### PR TITLE
Fix for "Id" not working as Key Property

### DIFF
--- a/src/Client/Build.Silverlight/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
+++ b/src/Client/Build.Silverlight/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
@@ -43,15 +43,21 @@ namespace Microsoft.OData.Client.Metadata
         {
             /// <summary>If this is not a key </summary>
             NotKey = 0,
+			
+			/// <summary> If the key property name was equal to Id</summary>
+			LowerId = 1,
 
             /// <summary> If the key property name was equal to ID </summary>
-            Id = 1,
+            Id = 2,
+			
+			/// <summary> If the key property name was equal to TypeName+Id </summary>
+			LowerTypeNameId = 3,
 
             /// <summary> If the key property name was equal to TypeName+ID </summary>
-            TypeNameId = 2,
+            TypeNameId = 4,
 
             /// <summary> if the key property was attributed </summary>
-            AttributedKey = 3,
+            AttributedKey = 5
         }
 
         /// <summary>
@@ -653,6 +659,20 @@ namespace Microsoft.OData.Client.Metadata
                 {
                     // matched "ID" pattern
                     keyKind = KeyKind.Id;
+                }
+            }
+			else if (propertyName.EndsWith("Id", StringComparison.Ordinal))
+            {
+                string declaringTypeName = propertyInfo.DeclaringType.Name;
+                if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.Ordinal))
+                {
+                    // matched "DeclaringType.Name+Id" pattern
+                    keyKind = KeyKind.LowerTypeNameId;
+                }
+                else if (2 == propertyName.Length)
+                {
+                    // matched "Id" pattern
+                    keyKind = KeyKind.LowerId;
                 }
             }
 

--- a/src/Client/Build.Silverlight/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
+++ b/src/Client/Build.Silverlight/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
@@ -43,15 +43,15 @@ namespace Microsoft.OData.Client.Metadata
         {
             /// <summary>If this is not a key </summary>
             NotKey = 0,
-			
-			/// <summary> If the key property name was equal to Id</summary>
-			LowerId = 1,
+
+            /// <summary> If the key property name was equal to Id</summary>
+            LowerId = 1,
 
             /// <summary> If the key property name was equal to ID </summary>
             Id = 2,
-			
-			/// <summary> If the key property name was equal to TypeName+Id </summary>
-			LowerTypeNameId = 3,
+	
+            /// <summary> If the key property name was equal to TypeName+Id </summary>
+            LowerTypeNameId = 3,
 
             /// <summary> If the key property name was equal to TypeName+ID </summary>
             TypeNameId = 4,
@@ -661,7 +661,7 @@ namespace Microsoft.OData.Client.Metadata
                     keyKind = KeyKind.Id;
                 }
             }
-			else if (propertyName.EndsWith("Id", StringComparison.Ordinal))
+            else if (propertyName.EndsWith("Id", StringComparison.Ordinal))
             {
                 string declaringTypeName = propertyInfo.DeclaringType.Name;
                 if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.Ordinal))

--- a/src/Client/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
+++ b/src/Client/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
@@ -44,14 +44,14 @@ namespace Microsoft.OData.Client.Metadata
             /// <summary>If this is not a key </summary>
             NotKey = 0,
 			
-			/// <summary> If the key property name was equal to Id</summary>
-			LowerId = 1,
+	    /// <summary> If the key property name was equal to Id</summary>
+	    LowerId = 1,
 
             /// <summary> If the key property name was equal to ID </summary>
             Id = 2,
 			
-			/// <summary> If the key property name was equal to TypeName+Id </summary>
-			LowerTypeNameId = 3,
+	    /// <summary> If the key property name was equal to TypeName+Id </summary>
+	    LowerTypeNameId = 3,
 
             /// <summary> If the key property name was equal to TypeName+ID </summary>
             TypeNameId = 4,
@@ -661,17 +661,17 @@ namespace Microsoft.OData.Client.Metadata
                     keyKind = KeyKind.Id;
                 }
             }
-			else if (propertyName.EndsWith("Id", StringComparison.Ordinal))
+	    else if (propertyName.EndsWith("Id", StringComparison.Ordinal))
             {
                 string declaringTypeName = propertyInfo.DeclaringType.Name;
                 if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.Ordinal))
                 {
-                    // matched "DeclaringType.Name+ID" pattern
+                    // matched "DeclaringType.Name+Id" pattern
                     keyKind = KeyKind.LowerTypeNameId;
                 }
                 else if (2 == propertyName.Length)
                 {
-                    // matched "ID" pattern
+                    // matched "Id" pattern
                     keyKind = KeyKind.LowerId;
                 }
             }

--- a/src/Client/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
+++ b/src/Client/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
@@ -43,15 +43,15 @@ namespace Microsoft.OData.Client.Metadata
         {
             /// <summary>If this is not a key </summary>
             NotKey = 0,
-			
-	    /// <summary> If the key property name was equal to Id</summary>
-	    LowerId = 1,
+	
+            /// <summary> If the key property name was equal to Id</summary>
+            LowerId = 1,
 
             /// <summary> If the key property name was equal to ID </summary>
             Id = 2,
-			
-	    /// <summary> If the key property name was equal to TypeName+Id </summary>
-	    LowerTypeNameId = 3,
+	
+            /// <summary> If the key property name was equal to TypeName+Id </summary>
+            LowerTypeNameId = 3,
 
             /// <summary> If the key property name was equal to TypeName+ID </summary>
             TypeNameId = 4,
@@ -661,7 +661,7 @@ namespace Microsoft.OData.Client.Metadata
                     keyKind = KeyKind.Id;
                 }
             }
-	    else if (propertyName.EndsWith("Id", StringComparison.Ordinal))
+            else if (propertyName.EndsWith("Id", StringComparison.Ordinal))
             {
                 string declaringTypeName = propertyInfo.DeclaringType.Name;
                 if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.Ordinal))

--- a/src/Client/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
+++ b/src/Client/Microsoft/OData/Client/Metadata/ClientTypeUtil.cs
@@ -43,15 +43,21 @@ namespace Microsoft.OData.Client.Metadata
         {
             /// <summary>If this is not a key </summary>
             NotKey = 0,
+			
+			/// <summary> If the key property name was equal to Id</summary>
+			LowerId = 1,
 
             /// <summary> If the key property name was equal to ID </summary>
-            Id = 1,
+            Id = 2,
+			
+			/// <summary> If the key property name was equal to TypeName+Id </summary>
+			LowerTypeNameId = 3,
 
             /// <summary> If the key property name was equal to TypeName+ID </summary>
-            TypeNameId = 2,
+            TypeNameId = 4,
 
             /// <summary> if the key property was attributed </summary>
-            AttributedKey = 3,
+            AttributedKey = 5
         }
 
         /// <summary>
@@ -653,6 +659,20 @@ namespace Microsoft.OData.Client.Metadata
                 {
                     // matched "ID" pattern
                     keyKind = KeyKind.Id;
+                }
+            }
+			else if (propertyName.EndsWith("Id", StringComparison.Ordinal))
+            {
+                string declaringTypeName = propertyInfo.DeclaringType.Name;
+                if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.Ordinal))
+                {
+                    // matched "DeclaringType.Name+ID" pattern
+                    keyKind = KeyKind.LowerTypeNameId;
+                }
+                else if (2 == propertyName.Length)
+                {
+                    // matched "ID" pattern
+                    keyKind = KeyKind.LowerId;
                 }
             }
 


### PR DESCRIPTION
Small change to allow properties named "Id" or "PropertyNameId" to be identified as keys. This change will allow the same objects to be used client and server side (server allows "Id"). Change was made to not break any existing users. Any properties named "ID" will supersede any properties named "Id" thus preventing any breaking changes.