### PR TITLE
Allow for intented printing to include newline character seperators

### DIFF
--- a/src/OData/Microsoft/OData/Core/Json/JsonWriter.cs
+++ b/src/OData/Microsoft/OData/Core/Json/JsonWriter.cs
@@ -188,6 +188,7 @@ namespace Microsoft.OData.Core.Json
             Scope currentScope = this.scopes.Peek();
             if (currentScope.ObjectCount != 0)
             {
+                this.writer.WriteLine();
                 this.writer.Write(JsonConstants.ObjectMemberSeparator);
             }
 

--- a/src/OData/Microsoft/OData/Core/Json/JsonWriter.cs
+++ b/src/OData/Microsoft/OData/Core/Json/JsonWriter.cs
@@ -188,8 +188,8 @@ namespace Microsoft.OData.Core.Json
             Scope currentScope = this.scopes.Peek();
             if (currentScope.ObjectCount != 0)
             {
-                this.writer.WriteLine();
                 this.writer.Write(JsonConstants.ObjectMemberSeparator);
+                this.writer.WriteLine();
             }
 
             currentScope.ObjectCount++;
@@ -409,6 +409,7 @@ namespace Microsoft.OData.Core.Json
                 if (currentScope.ObjectCount != 0)
                 {
                     this.writer.Write(JsonConstants.ArrayElementSeparator);
+                    this.writer.WriteLine();
                 }
 
                 currentScope.ObjectCount++;
@@ -428,6 +429,7 @@ namespace Microsoft.OData.Core.Json
                     (currentScope.ObjectCount != 0))
                 {
                     this.writer.Write(JsonConstants.ArrayElementSeparator);
+                    this.writer.WriteLine();
                 }
 
                 currentScope.ObjectCount++;


### PR DESCRIPTION
Looks like even though there is a line intender that will do a good job lining up subsequent lines, there is a missing write line where the member objects will not be on a fresh line.  This should enhance the unaided readability quite a bit.