### PR TITLE
DataServiceContext.SaveChanges performance when it's tracked by a DataServiceCollection #101

### DIFF
--- a/src/Microsoft.OData.Client/Binding/BindingGraph.cs
+++ b/src/Microsoft.OData.Client/Binding/BindingGraph.cs
@@ -402,7 +402,7 @@ namespace Microsoft.OData.Client
         public void RemoveNonTrackedEntities()
         {
             // Cleanup all untracked entities
-            foreach (var entity in this.graph.Select(o => BindingEntityInfo.IsEntityType(o.GetType(), this.observer.Context.Model) && !this.observer.IsContextTrackingEntity(o)))
+            foreach (var entity in this.graph.Select(o => !this.observer.IsContextTrackingEntity(o) && BindingEntityInfo.IsEntityType(o.GetType(), this.observer.Context.Model)))
             {
                 this.graph.ClearEdgesForVertex(this.graph.LookupVertex(entity));
             }


### PR DESCRIPTION
I've tried to improve the performance of the RemoveNonTrackedEntities method.
I've changed the order of the conditions applied to the query for retrieving the untracked entities of the graph. It seems the execution is much faster in this way.