### PR TITLE
Improved support for contained entity sets

### DIFF
--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -1336,10 +1336,35 @@ namespace Microsoft.OData.Core
                                 case EdmNavigationSourceKind.ContainedEntitySet:
                                     if (odataUri.Path == null)
                                     {
-                                        throw new ODataException(Strings.ODataWriterCore_PathInODataUriMustBeSetWhenWritingContainedElement);
+                                        odataUri.Path = new ODataPath();
+                                        var segmentStack = new Stack<ODataPathSegment>();
+                                        object navigationSourceHandle = navigationSource;
+
+                                        do
+                                        {
+                                            var containedNavigationSource = navigationSourceHandle as IEdmContainedEntitySet;
+
+                                            if (containedNavigationSource != null)
+                                            {
+                                                segmentStack.Push(new NavigationPropertySegment(containedNavigationSource.NavigationProperty, containedNavigationSource.ParentNavigationSource));
+                                                navigationSourceHandle = containedNavigationSource.ParentNavigationSource;
+                                            }
+                                            else 
+                                            {
+                                                segmentStack.Push(new EntitySetSegment(navigationSourceHandle as IEdmEntitySet));
+                                                navigationSourceHandle = null;
+                                            }
+                                        }
+                                        while (navigationSourceHandle != null);
+
+                                        foreach (var segment in segmentStack)
+                                        {
+                                            odataUri.Path.Add(segment);
+                                        }
                                     }
 
                                     odataPath = odataUri.Path;
+
                                     if (ShouldAppendKey(currentNavigationSource))
                                     {
                                         ODataItem odataItem = this.CurrentScope.Item;


### PR DESCRIPTION
Related to an issue report for WebApi OData: https://github.com/OData/WebApi/issues/255.

ODataWriterCore now supports contained entity sets when returning their types as function results.

Important: I'm not fully aware of the internal mechanics of the complex ODataWriterCore class, so please consider this pull request more just as a highlight of the problem area... :-)

The proposed code solves the reported problem, but I'm not persuaded that it generates the correct path segments (e.g. entity key segments are missing).