### PR TITLE
Only append parameter when it was provided in the first place

### DIFF
--- a/WCFDataService/Service/System/Data/Services/Serializers/Serializer.cs
+++ b/WCFDataService/Service/System/Data/Services/Serializers/Serializer.cs
@@ -945,9 +945,13 @@ namespace System.Data.Services.Serializers
                         queryParametersBuilder.Append('&');
                     }
 
-                    queryParametersBuilder.Append(parameter.Name).Append('=');
-                    string escapedQueryStringItem = DataStringEscapeBuilder.EscapeDataString(this.service.OperationContext.RequestMessage.GetQueryStringItem(parameter.Name));
-                    queryParametersBuilder.Append(escapedQueryStringItem);
+                    string queryStringItem = this.service.OperationContext.RequestMessage.GetQueryStringItem(parameter.Name);
+                    if (!string.IsNullOrEmpty(queryStringItem)) {
+                        // Only append parameter when it was provided in the first place
+                        queryParametersBuilder.Append(parameter.Name).Append('=');
+                        string escapedQueryStringItem = DataStringEscapeBuilder.EscapeDataString(queryStringItem);
+                        queryParametersBuilder.Append(escapedQueryStringItem);
+                    }
                 }
             }
 


### PR DESCRIPTION
This fixes the scenario described at https://social.msdn.microsoft.com/Forums/en-US/6cc0ef87-80ec-4331-8b41-efb22d8f1c60/odata-provider-with-wcf-40-paging-operations-with-null-parameters?forum=adodotnetdataservices.

We ran into it on building NuGet as well:

* https://github.com/NuGet/NuGetGallery/issues/1502
* https://github.com/NuGet/NuGetGallery/issues/1886
* https://github.com/NuGet/NuGetGallery/issues/1259

Long story short: when an OData service operation `Foo(string bar, string baz)` is called, but `baz` is not provided (`null`), the `GetNextPageQueryParametersForRootContainer()` method on `Serializer` was trying to escape a missing query string parameter, resulting in a `NullReferenceException`.

This pull request fixes this exception by not trying to escape non-existant query string parameters.