### PR TITLE
Undeclared properties should be allowed on Open Types

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/UriHelper.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriHelper.cs
@@ -180,7 +180,7 @@ namespace Microsoft.OData.Client
             }
             else
             {
-                return context.ResolveNameFromTypeInternal(type) ?? ClientTypeUtil.GetServerDefinedlTypeFullName(type);
+                return context.ResolveNameFromTypeInternal(type) ?? ClientTypeUtil.GetServerDefinedTypeFullName(type);
             }
         }
 
@@ -207,7 +207,7 @@ namespace Microsoft.OData.Client
             // Raise the uriVersion each time we write the type segment on the uri.
             WebUtil.RaiseVersion(ref uriVersion, Util.ODataVersion4);
 
-            return context.ResolveNameFromTypeInternal(type) ?? ClientTypeUtil.GetServerDefinedlTypeFullName(type);
+            return context.ResolveNameFromTypeInternal(type) ?? ClientTypeUtil.GetServerDefinedTypeFullName(type);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -48,9 +48,6 @@ namespace Microsoft.OData.Client
         /// <summary>Referenced core model.</summary>
         private readonly IEnumerable<IEdmModel> coreModel = new IEdmModel[] { EdmCoreModel.Instance };
 
-        /// <summary>The state of whether the edm structured schema elements have been set.</summary>
-        private bool edmStructuredSchemaElementsSet;
-
         /// <summary>The edm structured types from the TypeResolver's service model schema elements.</summary>
         private IEnumerable<IEdmSchemaElement> edmStructuredSchemaElements;
 
@@ -117,11 +114,15 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Gets the state of whether the edm structured schema elements have been set.
         /// </summary>
-        public bool EdmStructuredSchemaElementsSet
+        internal IEnumerable<IEdmSchemaElement> EdmStructuredSchemaElements
         {
             get
             {
-                return edmStructuredSchemaElementsSet;
+                return edmStructuredSchemaElements;
+            }
+            set
+            {
+                edmStructuredSchemaElements = value;
             }
         }
 
@@ -285,16 +286,6 @@ namespace Microsoft.OData.Client
             return this.GetClientTypeAnnotation(result);
         }
 
-        /// <summary>
-        /// Sets the edm structured type schema elements for use in determining open types.
-        /// </summary>
-        /// <param name="serviceModel">The service model.</param>
-        internal void SetEdmStructuredSchemaElements(IEnumerable<IEdmSchemaElement> edmStructuredSchemaElements)
-        {
-            this.edmStructuredSchemaElements = edmStructuredSchemaElements;
-            edmStructuredSchemaElementsSet = true;
-        }
-
         /// <summary>Returns <paramref name="type"/> and its base types, in the order of most base type first and <paramref name="type"/> last.</summary>
         /// <param name="type">Type instance in question.</param>
         /// <param name="keyProperties">Returns the list of key properties if <paramref name="type"/> is an entity type; null otherwise.</param>
@@ -430,9 +421,9 @@ namespace Microsoft.OData.Client
             {
                 Type collectionType;
                 bool isOpen = false;
-                if (edmStructuredSchemaElements != null && edmStructuredSchemaElements.Any())
+                if (EdmStructuredSchemaElements != null && EdmStructuredSchemaElements.Any())
                 {
-                    IEdmSchemaElement edmStructuredSchemaElement = edmStructuredSchemaElements.FirstOrDefault(et => et.Name == ClientTypeUtil.GetServerDefinedTypeName(type));
+                    IEdmSchemaElement edmStructuredSchemaElement = EdmStructuredSchemaElements.FirstOrDefault(et => et.Name == ClientTypeUtil.GetServerDefinedTypeName(type));
                     if (edmStructuredSchemaElement != null)
                     {
                         IEdmStructuredType edmStructuredType = edmStructuredSchemaElement as IEdmStructuredType;

--- a/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
+++ b/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
@@ -535,12 +535,12 @@ namespace Microsoft.OData.Client.Metadata
         /// <returns>The server defined name.</returns>
         internal static string GetServerDefinedTypeFullName(Type type)
         {
-            OriginalNameAttribute originalNameAttribute = (OriginalNameAttribute)type.GetCustomAttributes(typeof(OriginalNameAttribute), false).SingleOrDefault();
-            if (originalNameAttribute != null)
+            string typeName = GetServerDefinedTypeName(type);
+            if (!string.IsNullOrEmpty(typeName))
             {
-                return type.Namespace + "." + originalNameAttribute.OriginalName;
+                return type.Namespace + "." + typeName;
             }
-
+        
             return type.FullName;
         }
 

--- a/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
+++ b/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
@@ -519,7 +519,21 @@ namespace Microsoft.OData.Client.Metadata
         /// <summary>Gets the server defined name in <see cref="OriginalNameAttribute"/> of the specified <paramref name="type"/>.</summary>
         /// <param name="type">Member to get server defined name of.</param>
         /// <returns>The server defined name.</returns>
-        internal static string GetServerDefinedlTypeFullName(Type type)
+        internal static string GetServerDefinedTypeName(Type type)
+        {
+            OriginalNameAttribute originalNameAttribute = (OriginalNameAttribute)type.GetCustomAttributes(typeof(OriginalNameAttribute), false).SingleOrDefault();
+            if (originalNameAttribute != null)
+            {
+                return originalNameAttribute.OriginalName;
+            }
+
+            return type.Name;
+        }
+
+        /// <summary>Gets the full server defined name in <see cref="OriginalNameAttribute"/> of the specified <paramref name="type"/>.</summary>
+        /// <param name="type">Member to get server defined name of.</param>
+        /// <returns>The server defined name.</returns>
+        internal static string GetServerDefinedTypeFullName(Type type)
         {
             OriginalNameAttribute originalNameAttribute = (OriginalNameAttribute)type.GetCustomAttributes(typeof(OriginalNameAttribute), false).SingleOrDefault();
             if (originalNameAttribute != null)

--- a/src/Microsoft.OData.Client/TypeResolver.cs
+++ b/src/Microsoft.OData.Client/TypeResolver.cs
@@ -58,8 +58,9 @@ namespace Microsoft.OData.Client
             Debug.Assert(resolveNameFromType != null, "resolveNameFromType != null");
             this.resolveTypeFromName = resolveTypeFromName;
             this.resolveNameFromType = resolveNameFromType;
-            this.clientEdmModel = model;
             this.serviceModel = serviceModel;
+            this.clientEdmModel = model;
+            this.clientEdmModel.SetEdmEntitySets(serviceModel.EntityContainer.EntitySets());
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/TypeResolver.cs
+++ b/src/Microsoft.OData.Client/TypeResolver.cs
@@ -60,7 +60,12 @@ namespace Microsoft.OData.Client
             this.resolveNameFromType = resolveNameFromType;
             this.serviceModel = serviceModel;
             this.clientEdmModel = model;
-            this.clientEdmModel.SetEdmEntitySets(serviceModel.EntityContainer.EntitySets());
+
+            if (serviceModel != null && clientEdmModel != null && !clientEdmModel.EdmStructuredSchemaElementsSet)
+            {
+                var edmStructuredSchemaElements = serviceModel.SchemaElements.Where(se => se is IEdmStructuredType).Cast<IEdmSchemaElement>();
+                this.clientEdmModel.SetEdmStructuredSchemaElements(edmStructuredSchemaElements);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/TypeResolver.cs
+++ b/src/Microsoft.OData.Client/TypeResolver.cs
@@ -61,10 +61,9 @@ namespace Microsoft.OData.Client
             this.serviceModel = serviceModel;
             this.clientEdmModel = model;
 
-            if (serviceModel != null && clientEdmModel != null && !clientEdmModel.EdmStructuredSchemaElementsSet)
+            if (serviceModel != null && clientEdmModel != null && clientEdmModel.EdmStructuredSchemaElements == null)
             {
-                var edmStructuredSchemaElements = serviceModel.SchemaElements.Where(se => se is IEdmStructuredType).Cast<IEdmSchemaElement>();
-                this.clientEdmModel.SetEdmStructuredSchemaElements(edmStructuredSchemaElements);
+                clientEdmModel.EdmStructuredSchemaElements = serviceModel.SchemaElements.Where(se => se is IEdmStructuredType);
             }
         }
 

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientOpenTypeUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientOpenTypeUpdateTests.cs
@@ -1,5 +1,5 @@
 ﻿//---------------------------------------------------------------------
-// <copyright file="ClientUpdateTests.cs" company="Microsoft">
+// <copyright file="ClientOpenTypeUpdateTests.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
 //---------------------------------------------------------------------
@@ -37,7 +37,6 @@ namespace Microsoft.Test.OData.Tests.Client
             contextWrapper.MergeOption = MergeOption.PreserveChanges;
             contextWrapper.Configurations.RequestPipeline.OnEntryStarting(ea => EntryStarting(ea));
             var row = contextWrapper.Context.Row.Where(r => r.Id == Guid.Parse("814d505b-6b6a-45a0-9de0-153b16149d56")).First();
-            Assert.IsNotNull(row);
 
             // In practice, transient property data would be mutated here in the partial companion to the client proxy.
 

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientOpenTypeUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientOpenTypeUpdateTests.cs
@@ -1,0 +1,70 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ClientUpdateTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.Test.OData.Tests.Client
+{
+    using Microsoft.OData.Client;
+    using System.Linq;
+    using Microsoft.Test.OData.Framework;
+    using Microsoft.Test.OData.Framework.Client;
+    using Microsoft.Test.OData.Services.TestServices;
+	using Microsoft.Test.OData.Services.TestServices.OpenTypesServiceReference;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+	using System.Collections.Generic;
+	using Microsoft.OData.Core;
+	using System;
+
+    /// <summary>
+    /// Generic client update test cases.
+    /// </summary>
+    [TestClass]
+    public class ClientOpenTypeUpdateTests : EndToEndTestBase
+    {
+		private DataServiceContextWrapper<DefaultContainer> contextWrapper;
+
+		public ClientOpenTypeUpdateTests()
+            : base(ServiceDescriptors.OpenTypesService)
+        {
+        }
+
+        [TestMethod]
+        public void UpdateOpenTypeWithUndeclaredProperties()
+        {
+            SetContextWrapper();
+            contextWrapper.MergeOption = MergeOption.PreserveChanges;
+            contextWrapper.Configurations.RequestPipeline.OnEntryStarting(ea => EntryStarting(ea));
+            var row = contextWrapper.Context.Row.Where(r => r.Id == Guid.Parse("814d505b-6b6a-45a0-9de0-153b16149d56")).First();
+            
+            // In practice, transient property data would be mutated here in the partial companion to the client proxy.
+
+            contextWrapper.UpdateObject(row);
+            contextWrapper.SaveChanges();
+        }
+
+		private void EntryStarting(WritingEntryArgs ea)
+		{
+            var odataProps = ea.Entry.Properties as List<ODataProperty>;
+            var entityState = contextWrapper.Context.Entities.First(e => e.Entity == ea.Entity).State;
+
+            // Send up an undeclared property on an Open Type.
+            if (entityState == EntityStates.Modified || entityState == EntityStates.Added)
+            {
+                if (ea.Entity.GetType() == typeof(Row))
+                {
+                    // In practice, the data from this undeclared property would probably be stored in a transient property of the partial companion class to the client proxy.
+                    var undeclaredOdataProperty = new ODataProperty() { Name = "dynamicPropertyKey", Value = "dynamicPropertyValue" };
+                    odataProps.Add(undeclaredOdataProperty);
+                }
+            }
+
+            ea.Entry.Properties = odataProps;
+		}
+		private void SetContextWrapper()
+        {
+            contextWrapper = this.CreateWrappedContext<DefaultContainer>();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientOpenTypeUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientOpenTypeUpdateTests.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Test.OData.Tests.Client
             contextWrapper.MergeOption = MergeOption.PreserveChanges;
             contextWrapper.Configurations.RequestPipeline.OnEntryStarting(ea => EntryStarting(ea));
             var row = contextWrapper.Context.Row.Where(r => r.Id == Guid.Parse("814d505b-6b6a-45a0-9de0-153b16149d56")).First();
-            
+            Assert.IsNotNull(row);
+
             // In practice, transient property data would be mutated here in the partial companion to the client proxy.
 
             contextWrapper.UpdateObject(row);

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ComplexTypeTests/ComplexTypeTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ComplexTypeTests/ComplexTypeTests.cs
@@ -939,9 +939,6 @@ namespace Microsoft.Test.OData.Tests.Client.ComplexTypeTests
             TestClientContext.Configurations.RequestPipeline.OnEntryStarting(ea => EntryStarting(ea, TestClientContext));
             var account = TestClientContext.Accounts.Where(a => a.AccountID == 101).First();
 
-            Assert.IsNotNull(account);
-            Assert.IsNotNull(account.AccountInfo);
-
             // In practice, transient property data would be mutated here in the partial companion to the client proxy.
 
             TestClientContext.UpdateObject(account);

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/Microsoft.Test.OData.Tests.Client.csproj
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/Microsoft.Test.OData.Tests.Client.csproj
@@ -103,6 +103,7 @@
     <Compile Include="AnnotationTests\InstanceAnnotationTests.cs" />
     <Compile Include="AsyncRequestTests\AsyncRequestTests.cs" />
     <Compile Include="ClientTests\ClientEntityDescripterTests.cs" />
+    <Compile Include="ClientTests\ClientOpenTypeUpdateTests.cs" />
     <Compile Include="ClientTests\ClientQueryTests.cs" />
     <Compile Include="ClientTests\ClientDeleteTests.cs" />
     <Compile Include="ClientWithoutTypeResolverTests\MismatchedClientModelWithoutTypeResolverTests.cs" />


### PR DESCRIPTION
Added support to ClientEdmModel to consult IEdmEntityType's IsOpen
property when instantiating EdmEntityTypeWithDelayLoadedProperties and
EdmComplexTypeWithDelayLoadedProperties.  ClientEdmModel was always
setting isOpen to false for these instances. This fixes an issue where
sending arbitrary/undeclared ODataProperty instances up would throw in
WriterValidationUtil.ValidatePropertyDefined().  This addresses
https://github.com/OData/odata.net/issues/143