### PR TITLE
Rename net45 to dnx451; portable-net45 to dnxcore50

### DIFF
--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Debug.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Debug.nuspec
@@ -20,18 +20,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     </dependencies>
   </metadata>
   <files>
-    <file src="Net45\Microsoft.OData.Core.dll" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Core.pdb" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Core.xml" target="lib\net45" />
-    <file src="Net45\1041\Microsoft.OData.Core.resources.dll" target="lib\net45\ja" />
+    <file src="Net45\Microsoft.OData.Core.dll" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Core.pdb" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Core.xml" target="lib\dnx451" />
+    <file src="Net45\1041\Microsoft.OData.Core.resources.dll" target="lib\dnx451\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.dll" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1041\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ja" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Core\**\*.cs" target="src\Microsoft.OData.Core" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" target="src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\Csdl\EdmValueWriter.cs" target="src\Microsoft.OData.Edm\Csdl\EdmValueWriter.cs" />

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
@@ -20,18 +20,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     </dependencies>
   </metadata>
   <files>
-    <file src="Net45\Microsoft.OData.Core.dll" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Core.pdb" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Core.xml" target="lib\net45" />
-    <file src="Net45\2052\Microsoft.OData.Core.resources.dll" target="lib\net45\zh-Hans" />
-    <file src="Net45\1028\Microsoft.OData.Core.resources.dll" target="lib\net45\zh-Hant" />
-    <file src="Net45\1031\Microsoft.OData.Core.resources.dll" target="lib\net45\de" />
-    <file src="Net45\3082\Microsoft.OData.Core.resources.dll" target="lib\net45\es" />
-    <file src="Net45\1036\Microsoft.OData.Core.resources.dll" target="lib\net45\fr" />
-    <file src="Net45\1040\Microsoft.OData.Core.resources.dll" target="lib\net45\it" />
-    <file src="Net45\1041\Microsoft.OData.Core.resources.dll" target="lib\net45\ja" />
-    <file src="Net45\1042\Microsoft.OData.Core.resources.dll" target="lib\net45\ko" />
-    <file src="Net45\1049\Microsoft.OData.Core.resources.dll" target="lib\net45\ru" />
+    <file src="Net45\Microsoft.OData.Core.dll" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Core.pdb" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Core.xml" target="lib\dnx451" />
+    <file src="Net45\2052\Microsoft.OData.Core.resources.dll" target="lib\dnx451\zh-Hans" />
+    <file src="Net45\1028\Microsoft.OData.Core.resources.dll" target="lib\dnx451\zh-Hant" />
+    <file src="Net45\1031\Microsoft.OData.Core.resources.dll" target="lib\dnx451\de" />
+    <file src="Net45\3082\Microsoft.OData.Core.resources.dll" target="lib\dnx451\es" />
+    <file src="Net45\1036\Microsoft.OData.Core.resources.dll" target="lib\dnx451\fr" />
+    <file src="Net45\1040\Microsoft.OData.Core.resources.dll" target="lib\dnx451\it" />
+    <file src="Net45\1041\Microsoft.OData.Core.resources.dll" target="lib\dnx451\ja" />
+    <file src="Net45\1042\Microsoft.OData.Core.resources.dll" target="lib\dnx451\ko" />
+    <file src="Net45\1049\Microsoft.OData.Core.resources.dll" target="lib\dnx451\ru" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.dll" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
@@ -44,18 +44,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1041\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1042\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1049\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\2052\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1028\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1031\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\3082\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1036\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1040\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1042\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1049\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\2052\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1028\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1031\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\3082\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1036\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1040\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1042\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1049\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ru" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Core\**\*.cs" target="src\Microsoft.OData.Core" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" target="src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\Csdl\EdmValueWriter.cs" target="src\Microsoft.OData.Edm\Csdl\EdmValueWriter.cs" />

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
@@ -20,18 +20,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     </dependencies>
   </metadata>
   <files>
-    <file src="Net45\Microsoft.OData.Core.dll" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Core.pdb" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Core.xml" target="lib\net45" />
-    <file src="Net45\2052\Microsoft.OData.Core.resources.dll" target="lib\net45\zh-Hans" />
-    <file src="Net45\1028\Microsoft.OData.Core.resources.dll" target="lib\net45\zh-Hant" />
-    <file src="Net45\1031\Microsoft.OData.Core.resources.dll" target="lib\net45\de" />
-    <file src="Net45\3082\Microsoft.OData.Core.resources.dll" target="lib\net45\es" />
-    <file src="Net45\1036\Microsoft.OData.Core.resources.dll" target="lib\net45\fr" />
-    <file src="Net45\1040\Microsoft.OData.Core.resources.dll" target="lib\net45\it" />
-    <file src="Net45\1041\Microsoft.OData.Core.resources.dll" target="lib\net45\ja" />
-    <file src="Net45\1042\Microsoft.OData.Core.resources.dll" target="lib\net45\ko" />
-    <file src="Net45\1049\Microsoft.OData.Core.resources.dll" target="lib\net45\ru" />
+    <file src="Net45\Microsoft.OData.Core.dll" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Core.pdb" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Core.xml" target="lib\dnx451" />
+    <file src="Net45\2052\Microsoft.OData.Core.resources.dll" target="lib\dnx451\zh-Hans" />
+    <file src="Net45\1028\Microsoft.OData.Core.resources.dll" target="lib\dnx451\zh-Hant" />
+    <file src="Net45\1031\Microsoft.OData.Core.resources.dll" target="lib\dnx451\de" />
+    <file src="Net45\3082\Microsoft.OData.Core.resources.dll" target="lib\dnx451\es" />
+    <file src="Net45\1036\Microsoft.OData.Core.resources.dll" target="lib\dnx451\fr" />
+    <file src="Net45\1040\Microsoft.OData.Core.resources.dll" target="lib\dnx451\it" />
+    <file src="Net45\1041\Microsoft.OData.Core.resources.dll" target="lib\dnx451\ja" />
+    <file src="Net45\1042\Microsoft.OData.Core.resources.dll" target="lib\dnx451\ko" />
+    <file src="Net45\1049\Microsoft.OData.Core.resources.dll" target="lib\dnx451\ru" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.dll" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
@@ -44,18 +44,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1041\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1042\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1049\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\2052\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1028\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1031\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\3082\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1036\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1040\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1042\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1049\Microsoft.OData.Core.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\2052\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1028\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1031\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\3082\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1036\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1040\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1042\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1049\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ru" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Core\**\*.cs" target="src\Microsoft.OData.Core" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" target="src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\Csdl\EdmValueWriter.cs" target="src\Microsoft.OData.Edm\Csdl\EdmValueWriter.cs" />

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Debug.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Debug.nuspec
@@ -16,18 +16,18 @@
 OData .NET library is open source at http://github.com/OData/odata.net</description>
   </metadata>
   <files>
-    <file src="Net45\Microsoft.OData.Edm.dll" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Edm.pdb" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Edm.xml" target="lib\net45" />
-    <file src="Net45\1041\Microsoft.OData.Edm.resources.dll" target="lib\net45\ja" />
+    <file src="Net45\Microsoft.OData.Edm.dll" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Edm.pdb" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Edm.xml" target="lib\dnx451" />
+    <file src="Net45\1041\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.dll" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1041\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ja" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\**\*.cs" target="src\Microsoft.OData.Edm" />
     <file src="$SourcesRoot$\src\PlatformHelper.cs" target="src\PlatformHelper.cs" />
     <file src="$SourcesRoot$\src\AssemblyInfo\AssemblyMetadataAttribute.cs" target="src\AssemblyMetadataAttribute.cs" />

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Nightly.Release.nuspec
@@ -16,18 +16,18 @@
 OData .NET library is open source at http://github.com/OData/odata.net</description>
   </metadata>
   <files>
-    <file src="Net45\Microsoft.OData.Edm.dll" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Edm.pdb" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Edm.xml" target="lib\net45" />
-    <file src="Net45\2052\Microsoft.OData.Edm.resources.dll" target="lib\net45\zh-Hans" />
-    <file src="Net45\1028\Microsoft.OData.Edm.resources.dll" target="lib\net45\zh-Hant" />
-    <file src="Net45\1031\Microsoft.OData.Edm.resources.dll" target="lib\net45\de" />
-    <file src="Net45\3082\Microsoft.OData.Edm.resources.dll" target="lib\net45\es" />
-    <file src="Net45\1036\Microsoft.OData.Edm.resources.dll" target="lib\net45\fr" />
-    <file src="Net45\1040\Microsoft.OData.Edm.resources.dll" target="lib\net45\it" />
-    <file src="Net45\1041\Microsoft.OData.Edm.resources.dll" target="lib\net45\ja" />
-    <file src="Net45\1042\Microsoft.OData.Edm.resources.dll" target="lib\net45\ko" />
-    <file src="Net45\1049\Microsoft.OData.Edm.resources.dll" target="lib\net45\ru" />
+    <file src="Net45\Microsoft.OData.Edm.dll" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Edm.pdb" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Edm.xml" target="lib\dnx451" />
+    <file src="Net45\2052\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\zh-Hans" />
+    <file src="Net45\1028\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\zh-Hant" />
+    <file src="Net45\1031\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\de" />
+    <file src="Net45\3082\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\es" />
+    <file src="Net45\1036\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\fr" />
+    <file src="Net45\1040\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\it" />
+    <file src="Net45\1041\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\ja" />
+    <file src="Net45\1042\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\ko" />
+    <file src="Net45\1049\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\ru" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.dll" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
@@ -40,18 +40,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1041\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1042\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1049\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\2052\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1028\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1031\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\3082\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1036\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1040\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1042\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1049\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\2052\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1028\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1031\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\3082\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1036\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1040\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1042\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1049\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ru" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\**\*.cs" target="src\Microsoft.OData.Edm\" />
     <file src="$SourcesRoot$\src\PlatformHelper.cs" target="src\PlatformHelper.cs" />
     <file src="$SourcesRoot$\src\AssemblyInfo\AssemblyMetadataAttribute.cs" target="src\AssemblyMetadataAttribute.cs" />

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
@@ -16,18 +16,18 @@
 OData .NET library is open source at http://github.com/OData/odata.net</description>
   </metadata>
   <files>
-    <file src="Net45\Microsoft.OData.Edm.dll" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Edm.pdb" target="lib\net45" />
-    <file src="Net45\Microsoft.OData.Edm.xml" target="lib\net45" />
-    <file src="Net45\2052\Microsoft.OData.Edm.resources.dll" target="lib\net45\zh-Hans" />
-    <file src="Net45\1028\Microsoft.OData.Edm.resources.dll" target="lib\net45\zh-Hant" />
-    <file src="Net45\1031\Microsoft.OData.Edm.resources.dll" target="lib\net45\de" />
-    <file src="Net45\3082\Microsoft.OData.Edm.resources.dll" target="lib\net45\es" />
-    <file src="Net45\1036\Microsoft.OData.Edm.resources.dll" target="lib\net45\fr" />
-    <file src="Net45\1040\Microsoft.OData.Edm.resources.dll" target="lib\net45\it" />
-    <file src="Net45\1041\Microsoft.OData.Edm.resources.dll" target="lib\net45\ja" />
-    <file src="Net45\1042\Microsoft.OData.Edm.resources.dll" target="lib\net45\ko" />
-    <file src="Net45\1049\Microsoft.OData.Edm.resources.dll" target="lib\net45\ru" />
+    <file src="Net45\Microsoft.OData.Edm.dll" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Edm.pdb" target="lib\dnx451" />
+    <file src="Net45\Microsoft.OData.Edm.xml" target="lib\dnx451" />
+    <file src="Net45\2052\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\zh-Hans" />
+    <file src="Net45\1028\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\zh-Hant" />
+    <file src="Net45\1031\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\de" />
+    <file src="Net45\3082\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\es" />
+    <file src="Net45\1036\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\fr" />
+    <file src="Net45\1040\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\it" />
+    <file src="Net45\1041\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\ja" />
+    <file src="Net45\1042\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\ko" />
+    <file src="Net45\1049\Microsoft.OData.Edm.resources.dll" target="lib\dnx451\ru" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.dll" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
@@ -40,18 +40,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1041\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1042\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1049\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\2052\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1028\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1031\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\3082\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1036\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1040\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1042\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1049\Microsoft.OData.Edm.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\2052\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1028\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1031\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\3082\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1036\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1040\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1042\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1049\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ru" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\**\*.cs" target="src\Microsoft.OData.Edm" />
     <file src="$SourcesRoot$\src\PlatformHelper.cs" target="src\PlatformHelper.cs" />
     <file src="$SourcesRoot$\src\AssemblyInfo\AssemblyMetadataAttribute.cs" target="src\AssemblyMetadataAttribute.cs" />

--- a/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Debug.nuspec
+++ b/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Debug.nuspec
@@ -16,18 +16,18 @@
 OData .NET library is open source at http://github.com/OData/odata.net</description>
   </metadata>
   <files>
-    <file src="Net45\Microsoft.Spatial.dll" target="lib\net45" />
-    <file src="Net45\Microsoft.Spatial.pdb" target="lib\net45" />
-    <file src="Net45\Microsoft.Spatial.xml" target="lib\net45" />
-    <file src="Net45\1041\Microsoft.Spatial.resources.dll" target="lib\net45\ja" />
+    <file src="Net45\Microsoft.Spatial.dll" target="lib\dnx451" />
+    <file src="Net45\Microsoft.Spatial.pdb" target="lib\dnx451" />
+    <file src="Net45\Microsoft.Spatial.xml" target="lib\dnx451" />
+    <file src="Net45\1041\Microsoft.Spatial.resources.dll" target="lib\dnx451\ja" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.dll" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1041\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ja" />
     <file src="$SourcesRoot$\src\Microsoft.Spatial\**\*.cs" target="src\Microsoft.Spatial" />
     <file src="$SourcesRoot$\src\PlatformHelper.cs" target="src\PlatformHelper.cs" />
     <file src="$SourcesRoot$\src\AssemblyInfo\AssemblyMetadataAttribute.cs" target="src\AssemblyMetadataAttribute.cs" />

--- a/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Nightly.Release.nuspec
+++ b/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Nightly.Release.nuspec
@@ -16,18 +16,18 @@
 OData .NET library is open source at http://github.com/OData/odata.net</description>
   </metadata>
   <files>
-    <file src="Net45\Microsoft.Spatial.dll" target="lib\net45" />
-    <file src="Net45\Microsoft.Spatial.pdb" target="lib\net45" />
-    <file src="Net45\Microsoft.Spatial.xml" target="lib\net45" />
-    <file src="Net45\2052\Microsoft.Spatial.resources.dll" target="lib\net45\zh-Hans" />
-    <file src="Net45\1028\Microsoft.Spatial.resources.dll" target="lib\net45\zh-Hant" />
-    <file src="Net45\1031\Microsoft.Spatial.resources.dll" target="lib\net45\de" />
-    <file src="Net45\3082\Microsoft.Spatial.resources.dll" target="lib\net45\es" />
-    <file src="Net45\1036\Microsoft.Spatial.resources.dll" target="lib\net45\fr" />
-    <file src="Net45\1040\Microsoft.Spatial.resources.dll" target="lib\net45\it" />
-    <file src="Net45\1041\Microsoft.Spatial.resources.dll" target="lib\net45\ja" />
-    <file src="Net45\1042\Microsoft.Spatial.resources.dll" target="lib\net45\ko" />
-    <file src="Net45\1049\Microsoft.Spatial.resources.dll" target="lib\net45\ru" />
+    <file src="Net45\Microsoft.Spatial.dll" target="lib\dnx451" />
+    <file src="Net45\Microsoft.Spatial.pdb" target="lib\dnx451" />
+    <file src="Net45\Microsoft.Spatial.xml" target="lib\dnx451" />
+    <file src="Net45\2052\Microsoft.Spatial.resources.dll" target="lib\dnx451\zh-Hans" />
+    <file src="Net45\1028\Microsoft.Spatial.resources.dll" target="lib\dnx451\zh-Hant" />
+    <file src="Net45\1031\Microsoft.Spatial.resources.dll" target="lib\dnx451\de" />
+    <file src="Net45\3082\Microsoft.Spatial.resources.dll" target="lib\dnx451\es" />
+    <file src="Net45\1036\Microsoft.Spatial.resources.dll" target="lib\dnx451\fr" />
+    <file src="Net45\1040\Microsoft.Spatial.resources.dll" target="lib\dnx451\it" />
+    <file src="Net45\1041\Microsoft.Spatial.resources.dll" target="lib\dnx451\ja" />
+    <file src="Net45\1042\Microsoft.Spatial.resources.dll" target="lib\dnx451\ko" />
+    <file src="Net45\1049\Microsoft.Spatial.resources.dll" target="lib\dnx451\ru" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.dll" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
@@ -40,18 +40,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1041\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1042\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1049\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\2052\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1028\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1031\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\3082\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1036\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1040\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1042\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1049\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\2052\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1028\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1031\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\de" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\3082\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\es" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1036\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1040\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\it" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1042\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1049\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ru" />
     <file src="$SourcesRoot$\src\Microsoft.Spatial\**\*.cs" target="src\Microsoft.Spatial" />
     <file src="$SourcesRoot$\src\PlatformHelper.cs" target="src\PlatformHelper.cs" />
     <file src="$SourcesRoot$\src\AssemblyInfo\AssemblyMetadataAttribute.cs" target="src\AssemblyMetadataAttribute.cs" />

--- a/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Release.nuspec
+++ b/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Release.nuspec
@@ -16,18 +16,18 @@
 OData .NET library is open source at http://github.com/OData/odata.net</description>
   </metadata>
   <files>
-    <file src="Net45\Microsoft.Spatial.dll" target="lib\net45" />
-    <file src="Net45\Microsoft.Spatial.pdb" target="lib\net45" />
-    <file src="Net45\Microsoft.Spatial.xml" target="lib\net45" />
-    <file src="Net45\2052\Microsoft.Spatial.resources.dll" target="lib\net45\zh-Hans" />
-    <file src="Net45\1028\Microsoft.Spatial.resources.dll" target="lib\net45\zh-Hant" />
-    <file src="Net45\1031\Microsoft.Spatial.resources.dll" target="lib\net45\de" />
-    <file src="Net45\3082\Microsoft.Spatial.resources.dll" target="lib\net45\es" />
-    <file src="Net45\1036\Microsoft.Spatial.resources.dll" target="lib\net45\fr" />
-    <file src="Net45\1040\Microsoft.Spatial.resources.dll" target="lib\net45\it" />
-    <file src="Net45\1041\Microsoft.Spatial.resources.dll" target="lib\net45\ja" />
-    <file src="Net45\1042\Microsoft.Spatial.resources.dll" target="lib\net45\ko" />
-    <file src="Net45\1049\Microsoft.Spatial.resources.dll" target="lib\net45\ru" />
+    <file src="Net45\Microsoft.Spatial.dll" target="lib\dnx451" />
+    <file src="Net45\Microsoft.Spatial.pdb" target="lib\dnx451" />
+    <file src="Net45\Microsoft.Spatial.xml" target="lib\dnx451" />
+    <file src="Net45\2052\Microsoft.Spatial.resources.dll" target="lib\dnx451\zh-Hans" />
+    <file src="Net45\1028\Microsoft.Spatial.resources.dll" target="lib\dnx451\zh-Hant" />
+    <file src="Net45\1031\Microsoft.Spatial.resources.dll" target="lib\dnx451\de" />
+    <file src="Net45\3082\Microsoft.Spatial.resources.dll" target="lib\dnx451\es" />
+    <file src="Net45\1036\Microsoft.Spatial.resources.dll" target="lib\dnx451\fr" />
+    <file src="Net45\1040\Microsoft.Spatial.resources.dll" target="lib\dnx451\it" />
+    <file src="Net45\1041\Microsoft.Spatial.resources.dll" target="lib\dnx451\ja" />
+    <file src="Net45\1042\Microsoft.Spatial.resources.dll" target="lib\dnx451\ko" />
+    <file src="Net45\1049\Microsoft.Spatial.resources.dll" target="lib\dnx451\ru" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.dll" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
@@ -40,18 +40,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1041\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1042\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1049\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\2052\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1028\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1031\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\3082\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1036\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1040\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1042\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1049\Microsoft.Spatial.resources.dll" target="lib\portable-net45+win8+wp8+wpa81+dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\dnxcore50" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\2052\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1028\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1031\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\de" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\3082\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\es" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1036\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1040\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\it" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1042\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1049\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ru" />
     <file src="$SourcesRoot$\src\Microsoft.Spatial\**\*.cs" target="src\Microsoft.Spatial" />
     <file src="$SourcesRoot$\src\PlatformHelper.cs" target="src\PlatformHelper.cs" />
     <file src="$SourcesRoot$\src\AssemblyInfo\AssemblyMetadataAttribute.cs" target="src\AssemblyMetadataAttribute.cs" />


### PR DESCRIPTION
Limit the impact scope of these two frameworks to ASP.NET 5 applications.