### PR TITLE
Making navigation target is optional for non-containment navigation property

### DIFF
--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -49,15 +49,20 @@ namespace Microsoft.OData.Core
             get
             {
                 string navigationPath = null;
-                if (this.isContained && this.odataUri != null && this.odataUri.Path != null)
+                if (this.odataUri != null && this.odataUri.Path != null)
                 {
                     ODataPath odataPath = this.odataUri.Path.TrimEndingTypeSegment().TrimEndingKeySegment();
-                    if (!(odataPath.LastSegment is NavigationPropertySegment))
+                    if (odataPath.LastSegment is NavigationPropertySegment)
                     {
-                        throw new ODataException(Strings.ODataContextUriBuilder_ODataPathInvalidForContainedElement(odataPath.ToContextUrlPathString()));
+                        navigationPath = odataPath.ToContextUrlPathString();
                     }
-
-                    navigationPath = odataPath.ToContextUrlPathString();
+                    else
+                    {
+                        if (this.isContained)
+                        {
+                            throw new ODataException(Strings.ODataContextUriBuilder_ODataPathInvalidForContainedElement(odataPath.ToContextUrlPathString()));
+                        }
+                    }
                 }
 
                 return navigationPath ?? this.navigationSource;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -1183,13 +1183,6 @@ namespace Microsoft.OData.Core.UriParser.Parsers
                 var navigationProperty = (IEdmNavigationProperty)property;
                 IEdmNavigationSource navigationSource = previous.TargetEdmNavigationSource.FindNavigationTarget(navigationProperty);
 
-                // If we can't compute the target navigation source, then throw
-                if (navigationSource is IEdmUnknownEntitySet)
-                {
-                    // Specifically not throwing ODataUriParserException since it's more an an internal server error
-                    throw new ODataException(ODataErrorStrings.RequestUriProcessor_TargetEntitySetNotFound(property.Name));
-                }
-
                 segment = new NavigationPropertySegment(navigationProperty, navigationSource);
             }
             else

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.TDD.Tests/Semantic/Functional/PathFunctionalTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.TDD.Tests/Semantic/Functional/PathFunctionalTests.cs
@@ -570,9 +570,8 @@ namespace Microsoft.Test.OData.Query.TDD.Tests.Semantic.Functional
             var model = ModelBuildingHelpers.GetModelWithNavPropWithNoTargetSet();
 
             // We want a descriptive error message, and do NOT want a ODataUriParserException so the service implementor does not blindly surface this to users
-            Action parse = () => new ODataUriParser(model, new Uri("http://gobbldygook/"), new Uri("http://gobbldygook/Vegetables(1)/GenesModified")).ParsePath();
-            parse.ShouldThrow<ODataException>().WithMessage("The target Entity Set of Navigation Property 'GenesModified' could not be found. This is most likely an error in the IEdmModel.").
-                And.GetType().Should().Be<ODataException>();
+            var path = new ODataUriParser(model, new Uri("http://gobbldygook/"), new Uri("http://gobbldygook/Vegetables(1)/GenesModified")).ParsePath();
+            Assert.AreEqual(path.LastSegment.Identifier, "GenesModified");
         }
 
         [TestMethod]

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests1/Tests/ActionsTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests1/Tests/ActionsTests.cs
@@ -2022,7 +2022,7 @@ namespace AstoriaUnitTests.Tests.Server
                 {
                     RequestUri = "/Foo(1)/Bar",
                     Payload = "{ \"ID\" : 100 }",
-                    ExpectedResponse = "{\"@odata.context\":\"http://host/$metadata#Foo/$entity\",\"ID\":100}",
+                    ExpectedResponse = "{\"@odata.context\":\"http://host/$metadata#Foo(1)/Bar/$entity\",\"ID\":100}",
                     ExpectedStatusCode = 201,
                 }
             };


### PR DESCRIPTION
Allowing non-containment navigation property to not required to have navigation target set
https://github.com/OData/odata.net/issues/273