### PR TITLE
Enable CodeGen to retrieve metadata from services with self-signed certificates

### DIFF
--- a/src/CodeGen/ODataT4CodeGenerator.tt
+++ b/src/CodeGen/ODataT4CodeGenerator.tt
@@ -24,6 +24,10 @@ public static class Configuration
 	// This flag indicates whether to ignore unexpected elements and attributes in the metadata document and generate
 	// the client code if any. The value must be set to true or false.
 	public const bool IgnoreUnexpectedElementsAndAttributes = true;
+	
+	// If the server is using self-signed SSL/TLS certificates this flag enables the T4 template to
+	// ignore this error when retrieving the metadata document
+	public const bool IgnoreInvalidTlsCertificate = false;
 }
 
 public static class Customization

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -317,6 +317,9 @@ private void ApplyParametersFromConfigurationClass()
     this.ValidateAndSetTargetLanguageFromString(Configuration.TargetLanguage);
     this.EnableNamingAlias = Configuration.EnableNamingAlias;
     this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
+    
+	if(Configuration.IgnoreInvalidTlsCertificates)
+		ServicePointManager.ServerCertificateValidationCallback += (sender, cert, chain, error) => true;
 }
 
 /// <summary>


### PR DESCRIPTION
A small patch from our local use-case. 

In the dev-env. we use self-signed certificates that the CodeGen considers invalid. I added a generator configuration flag that makes it ignore certificate error.
