### PR TITLE
Fix for Odata.net issue # 349

### DIFF
--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/Microsoft.Test.Taupo.OData.Scenario.Tests.csproj
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/Microsoft.Test.Taupo.OData.Scenario.Tests.csproj
@@ -235,6 +235,9 @@
     <None Include="UriParser\Path\PathTests.PathTypeSegmentToNavigation.approved.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="UriParser\Path\PathTests.PathTypeSegmentWithKeyAsSegmentEnabled.approved.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="UriParser\SelectTests\Select.SelectAll.approved.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/Path/PathTests.PathTypeSegmentWithKeyAsSegmentEnabled.approved.txt
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/Path/PathTests.PathTypeSegmentWithKeyAsSegmentEnabled.approved.txt
@@ -1,0 +1,1 @@
+Path[(EntitySet: People)/(Key: PersonID = 1)/(Type: Microsoft.Test.Taupo.OData.WCFService.Customer)]

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/Path/PathTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/Path/PathTests.cs
@@ -311,6 +311,15 @@ namespace Microsoft.Test.Taupo.OData.Scenario.Tests.UriParser.Path
 
         [TestMethod]
         [MethodImplAttribute(MethodImplOptions.NoOptimization)]
+        public void PathTypeSegmentWithKeyAsSegmentEnabled()
+        {
+            ODataUriParser parser = new ODataUriParser(model, new Uri("http://www.potato.com/"), new Uri("http://www.potato.com/People(1)/Microsoft.Test.Taupo.OData.WCFService.Customer")) { UrlConventions = ODataUrlConventions.KeyAsSegment };
+            var result = parser.ParsePath();
+            ApprovalVerify(QueryNodeToStringVisitor.ToString(result));
+        }
+
+        [TestMethod]
+        [MethodImplAttribute(MethodImplOptions.NoOptimization)]
         public void PathCollection()
         {
             ODataUriParser parser = new ODataUriParser(model, new Uri("http://www.potato.com/"), new Uri("http://www.potato.com/People(1)/Numbers"));


### PR DESCRIPTION
Parser conflict between UrlConventions KeyAsSegment and last segment ==
TypeSegment

This change identifies type segments higher up in the processing, so we
can elect to NOT try to handle it as a key segment if we know it's a
type.