### PR TITLE
Fix VerifyKeyPredicates issue

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -98,7 +98,7 @@ namespace Microsoft.OData.Client
                     return true;
                 }
 
-                if (re.Source != null)
+                if (re.Source != null && !re.IsOperationInvocation)
                 {
                     ResourceSetExpression rse = re.Source as ResourceSetExpression;
                     if ((rse != null) && !rse.HasKeyPredicate)
@@ -239,7 +239,7 @@ namespace Microsoft.OData.Client
                 List<Expression> clauses = predicates.Value;
                 List<Expression> nonKeyPredicates;
                 List<Expression> keyPredicates = ExtractKeyPredicate(target, clauses, model, out nonKeyPredicates);
-                if (keyPredicates == null || 
+                if (keyPredicates == null ||
                     (nonKeyPredicates != null && nonKeyPredicates.Count > 0))
                 {
                     // UNSUPPORTED: Only key predicates may be applied to earlier path components
@@ -979,7 +979,7 @@ namespace Microsoft.OData.Client
             {
                 obj = StripConvert(mce.Object, mce.Method.ReturnType);
             }
-            
+
             ResourceExpression re = obj as ResourceExpression;
             if (re == null)
             {
@@ -1486,7 +1486,7 @@ namespace Microsoft.OData.Client
                     {
                         t = typeof(DataServiceQuery<>).MakeGenericType(mce.Method.GetParameters()[0].ParameterType.GetGenericArguments()[0]);
                     }
-                    
+
                     if (mce.Method.Name == ExpandMethodName && mce.Method.DeclaringType == t)
                     {
                         return AnalyzeExpand(mce, this.context);
@@ -1641,7 +1641,7 @@ namespace Microsoft.OData.Client
                     if (MatchNonPrivateReadableProperty(me, out pi, out boundTarget))
                     {
                         string propertyName = ClientTypeUtil.GetServerDefinedName(pi);
-                        
+
                         NonSystemToken newPropertyToAdd = new NonSystemToken(propertyName, null, null);
                         if (propertyPath == null)
                         {
@@ -1660,7 +1660,7 @@ namespace Microsoft.OData.Client
                             NonSystemToken subPropertyToAdd = new NonSystemToken(UriHelper.GetEntityTypeNameForUriAndValidateMaxProtocolVersion(convertedType, context, ref uriVersion), null, null);
                             subPropertyToAdd.SetNextToken(propertyPath);
                             propertyPath = subPropertyToAdd;
-                       }
+                        }
                     }
                     else
                     {

--- a/test/EndToEndTests/Services/ODataDefaultService/DefaultInMemoryModel.cs
+++ b/test/EndToEndTests/Services/ODataDefaultService/DefaultInMemoryModel.cs
@@ -536,7 +536,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
             //Bound Function : Bound to CollectionOfEntity, Return Entity
             var getSeniorEmployees = new EdmFunction(ns, "GetSeniorEmployees",
                 new EdmEntityTypeReference(employeeType, true),
-                true, new EdmPathExpression("People"), true);
+                true, new EdmPathExpression("employees"), true);
             getSeniorEmployees.AddParameter("employees", new EdmCollectionTypeReference(new EdmCollectionType(new EdmEntityTypeReference(employeeType, false))));
             model.AddElement(getSeniorEmployees);
 

--- a/test/EndToEndTests/Services/ODataOperationService/OperationServiceOperationProvider.cs
+++ b/test/EndToEndTests/Services/ODataOperationService/OperationServiceOperationProvider.cs
@@ -15,7 +15,7 @@ using Microsoft.Test.OData.Services.ODataWCFService.DataSource;
 
 namespace Microsoft.Test.OData.Services.ODataOperationService
 {
-    
+
     public class OperationServiceOperationProvider : ODataReflectionOperationProvider
     {
         public void ResetDataSource()
@@ -77,7 +77,8 @@ namespace Microsoft.Test.OData.Services.ODataOperationService
 
         public Order GetOrderByNote(IEnumerable<Order> orders, IEnumerable<string> notes)
         {
-            return orders.SingleOrDefault(order => order.Notes.Intersect(notes).Any());
+            return orders.SingleOrDefault(order => order.Notes.Intersect(notes).Count() == order.Notes.Count
+                && order.Notes.Count == notes.Count());
         }
 
         public IEnumerable<Customer> GetCustomersByOrders(IEnumerable<Customer> customers, IEnumerable<Order> orders)


### PR DESCRIPTION
This is to fix the issue https://github.com/OData/odata.net/issues/357. Reason is that VerifyKeyPredicates will check the source of the function expresion. Since function might bind to a collection of entity, so we should avode verifing the key predicates of the source.