### PR TITLE
Issue #200: Enable unqualified functions on open types.

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/FunctionOverloadResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/FunctionOverloadResolver.cs
@@ -127,7 +127,8 @@ namespace Microsoft.OData.Core.UriParser.Parsers
             if (bindingType != null)
             {
                 // TODO: look up actual container names here?
-                if (bindingType.IsOpenType() && !identifier.Contains("."))
+                // When using extension, there may be function call with unqualified name. So loose the restriction here.
+                if (bindingType.IsOpenType() && !identifier.Contains(".") && resolver.GetType() == typeof(ODataUriResolver))
                 {
                     matchingOperation = null;
                     return false;

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.TDD.Tests/Metadata/OpenTypeExtensionTestBase.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.TDD.Tests/Metadata/OpenTypeExtensionTestBase.cs
@@ -1,0 +1,236 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="OpenTypeExtensionTestBase.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.Test.OData.Query.TDD.Tests
+{
+    using System;
+    using FluentAssertions;
+    using Microsoft.OData.Core;
+    using Microsoft.OData.Core.UriParser;
+    using Microsoft.OData.Core.UriParser.Metadata;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Edm.Library;
+    using Microsoft.OData.Edm.Library.Values;
+
+    public class OpenTypeExtensionTestBase
+    {
+        #region Test init
+        protected readonly Uri ServiceRoot = new Uri("http://host");
+        protected static IEdmModel Model;
+        protected static IEdmStructuralProperty PersonNameProp;
+        protected static IEdmProperty PersonPen;
+        protected static IEdmNavigationProperty PersonNavPen;
+        protected static IEdmNavigationProperty PersonNavPen2;
+        protected static IEdmStructuralProperty AddrProperty;
+        protected static IEdmStructuralProperty ZipCodeProperty;
+        protected static IEdmStructuralProperty PencilId;
+        protected static IEdmComplexType AddrType;
+        protected static IEdmEntityType PersonType;
+        protected static IEdmEntityType StarPencil;
+        protected static IEdmEntitySet PeopleSet;
+        protected static IEdmOperation FindPencil2P;
+        protected static IEdmOperation FindPencil1P;
+        protected static IEdmOperation FindPencilsCon;
+        protected static IEdmOperation FindPencilsConNT;
+        protected static EdmAction ChangeZip;
+        protected static EdmFunction GetZip;
+        protected static IEdmEntitySet PencilSet;
+
+        static OpenTypeExtensionTestBase()
+        {
+            var model = new EdmModel();
+            Model = model;
+
+            var person = new EdmEntityType("TestNS", "Person", null, false, true);
+            var personId = person.AddStructuralProperty("ID", EdmPrimitiveTypeKind.Int32);
+            PersonNameProp = person.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            PersonPen = person.AddStructuralProperty("pen", EdmPrimitiveTypeKind.Binary);
+            person.AddKeys(personId);
+            PersonType = person;
+
+            var address = new EdmComplexType("TestNS", "Address", null, false, true);
+            AddrType = address;
+            ZipCodeProperty = address.AddStructuralProperty("ZipCode", EdmPrimitiveTypeKind.String);
+            AddrProperty = person.AddStructuralProperty("Addr", new EdmComplexTypeReference(address, false));
+
+            var pencil = new EdmEntityType("TestNS", "Pencil");
+            var pencilId = pencil.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32);
+            PencilId = pencilId;
+            var pid = pencil.AddStructuralProperty("Pid", EdmPrimitiveTypeKind.Int32);
+            pencil.AddKeys(pencilId);
+
+            var starPencil = new EdmEntityType("TestNS", "StarPencil", pencil);
+            model.AddElement(starPencil);
+            var starPencilUpper = new EdmEntityType("TestNS", "STARPENCIL");
+            model.AddElement(starPencilUpper);
+            StarPencil = starPencil;
+
+            var navInfo = new EdmNavigationPropertyInfo()
+            {
+                Name = "Pen",
+                ContainsTarget = false,
+                Target = pencil,
+                TargetMultiplicity = EdmMultiplicity.One
+            };
+
+            PersonNavPen = person.AddUnidirectionalNavigation(navInfo);
+
+            var navInfo2 = new EdmNavigationPropertyInfo()
+            {
+                Name = "Pen2",
+                ContainsTarget = true,
+                Target = pencil,
+                TargetMultiplicity = EdmMultiplicity.One
+            };
+
+            PersonNavPen2 = person.AddUnidirectionalNavigation(navInfo2);
+
+            var container = new EdmEntityContainer("Default", "Con1");
+            var personSet = container.AddEntitySet("People", person);
+            PencilSet = container.AddEntitySet("PencilSet", pencil);
+            personSet.AddNavigationTarget(PersonNavPen, PencilSet);
+            PeopleSet = personSet;
+
+            var pencilRef = new EdmEntityTypeReference(pencil, false);
+            EdmFunction findPencil1 = new EdmFunction("TestNS", "FindPencil", pencilRef, true, null, false);
+            findPencil1.AddParameter("qid", new EdmEntityTypeReference(PersonType, false));
+            model.AddElement(findPencil1);
+            FindPencil1P = findPencil1;
+
+            EdmFunction findPencil = new EdmFunction("TestNS", "FindPencil", pencilRef, true, null, false);
+            findPencil.AddParameter("qid", new EdmEntityTypeReference(PersonType, false));
+            findPencil.AddParameter("pid", EdmCoreModel.Instance.GetInt32(false));
+            model.AddElement(findPencil);
+            FindPencil2P = findPencil;
+
+            EdmFunction findPencilsCon = new EdmFunction("TestNS", "FindPencilsCon", new EdmCollectionTypeReference(new EdmCollectionType(pencilRef)), true, null, false);
+            FindPencilsCon = findPencilsCon;
+            findPencilsCon.AddParameter("qid", new EdmEntityTypeReference(PersonType, false));
+            model.AddElement(findPencilsCon);
+
+            EdmFunction findPencilsConNT = new EdmFunction("TestNT", "FindPencilsCon", new EdmCollectionTypeReference(new EdmCollectionType(pencilRef)), true, null, false);
+            FindPencilsConNT = findPencilsConNT;
+            findPencilsConNT.AddParameter("qid", new EdmEntityTypeReference(PersonType, false));
+            model.AddElement(findPencilsConNT);
+
+            ChangeZip = new EdmAction("TestNS", "ChangeZip", null, true, null);
+            ChangeZip.AddParameter("address", new EdmComplexTypeReference(address, false));
+            ChangeZip.AddParameter("newZip", EdmCoreModel.Instance.GetString(false));
+            model.AddElement(ChangeZip);
+
+            GetZip = new EdmFunction("TestNS", "GetZip", EdmCoreModel.Instance.GetString(false), true, null, true);
+            GetZip.AddParameter("address", new EdmComplexTypeReference(address, false));
+            model.AddElement(GetZip);
+
+            model.AddElement(person);
+            model.AddElement(address);
+            model.AddElement(pencil);
+            model.AddElement(container);
+        }
+        #endregion
+
+        #region TestMethod
+        protected void TestUriParserExtension<TResult>(
+            string originalStr,
+            string caseInsensitiveStr,
+            Func<ODataUriParser, TResult> parse,
+            Action<TResult> verify,
+            string errorMessage,
+            IEdmModel model,
+            Action<ODataUriParser> parserSet)
+        {
+            Uri originalCase = new Uri(originalStr, UriKind.Relative);
+            Uri caseInsensitiveCase = new Uri(caseInsensitiveStr, UriKind.Relative);
+            TestExtension(
+                () => new ODataUriParser(model, originalCase),
+                () => new ODataUriParser(model, caseInsensitiveCase),
+                parse,
+                verify,
+                errorMessage,
+                model,
+                parserSet);
+        }
+
+        protected void TestExtension<TParser, TResult>(
+            Func<TParser> getOriginalParser,
+            Func<TParser> getCaseInsensitiveParser,
+            Func<TParser, TResult> parse,
+            Action<TResult> verify,
+            string errorMessage,
+            IEdmModel model,
+            Action<TParser> parserSet)
+        {
+            // Original case should pass
+            TParser parser = getOriginalParser();
+            verify(parse(parser));
+
+            // Original case should pass with CaseInsensitive parser
+            parser = getOriginalParser();
+            parserSet(parser);
+            verify(parse(parser));
+
+            // CaseInsensitive case should fail with original parser, or null result excepted when error message be null.
+            if (errorMessage != null)
+            {
+                Action action = () => parse(getCaseInsensitiveParser());
+                action.ShouldThrow<ODataException>().WithMessage(errorMessage);
+            }
+            else
+            {
+                parse(getCaseInsensitiveParser());
+            }
+
+            // CaseInsensitive case should pass with CaseInsensitive parser
+            parser = getCaseInsensitiveParser();
+            parserSet(parser);
+            verify(parse(parser));
+        }
+
+        protected void TestConflict<TResult>(
+            string originalStr,
+            Func<ODataUriParser, TResult> parse,
+            Action<TResult> verify,
+            string conflictMessage,
+            IEdmModel model,
+            ODataUriResolver resolver)
+        {
+            Uri originalCase = new Uri(originalStr, UriKind.Relative);
+
+            if (verify != null)
+            {
+                // Original case should pass
+                ODataUriParser parser = new ODataUriParser(model, originalCase);
+                verify(parse(parser));
+            }
+
+            // Original case should fail with CaseInsensitive parser with errorMessage
+            Action action = () => parse(new ODataUriParser(model, originalCase) { Resolver = resolver });
+            action.ShouldThrow<ODataException>().WithMessage(conflictMessage);
+        }
+
+        protected void TestNotExist<TResult>(
+            string originalStr,
+            Func<ODataUriParser, TResult> parse,
+            string message,
+            IEdmModel model,
+            Action<ODataUriParser> parserSet)
+        {
+            Uri originalCase = new Uri(originalStr, UriKind.Relative);
+
+            // Original case should fail with message
+            ODataUriParser parser = new ODataUriParser(model, originalCase);
+            Action action = () => parse(parser);
+            action.ShouldThrow<ODataException>().WithMessage(message);
+
+            // Original case should fail with CaseInsensitive parser with same errorMessage
+            parser = new ODataUriParser(model, originalCase);
+            parserSet(parser);
+            action = () => parse(parser);
+            action.ShouldThrow<ODataException>().WithMessage(message);
+        }
+        #endregion
+    }
+}

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.TDD.Tests/Metadata/OpenTypeUnqualifiedExtensionUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.TDD.Tests/Metadata/OpenTypeUnqualifiedExtensionUnitTests.cs
@@ -1,0 +1,207 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="OpenTypeUnqualifiedExtensionUnitTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.Test.OData.Query.TDD.Tests
+{
+    using System;
+    using Microsoft.OData.Core.UriParser;
+    using Microsoft.OData.Core.UriParser.Metadata;
+    using Microsoft.Test.OData.Query.TDD.Tests.TestUtilities;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Strings = Microsoft.OData.Core.Strings;
+
+    // Select unqualified Function not supported.
+    [TestClass]
+    public class OpenTypeUnqualifiedExtensionUnitTests
+        : OpenTypeExtensionTestBase
+    {
+        [TestMethod]
+        public void OpenTypeUnqualifiedFunctionInPathTest()
+        {
+            this.TestUnqualified(
+                "People(1)/TestNS.FindPencil(pid=2)",
+                "People(1)/FindPencil(pid=2)",
+                parser => parser.ParsePath(),
+                path => path.LastSegment.ShouldBeOperationSegment(FindPencil2P),
+                Strings.OpenNavigationPropertiesNotSupportedOnOpenTypes("FindPencil"));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedFunctionWithNoParameterInPathTest()
+        {
+            this.TestUnqualified(
+                "People(1)/TestNS.FindPencil",
+                "People(1)/FindPencil",
+                parser => parser.ParsePath(),
+                path => path.LastSegment.ShouldBeOperationSegment(FindPencil1P),
+                null);
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedFunctionWithNoParameterWithParenthesisInPathTest()
+        {
+            this.TestUnqualified(
+                "People(1)/TestNS.FindPencil()",
+                "People(1)/FindPencil()",
+                parser => parser.ParsePath(),
+                path => path.LastSegment.ShouldBeOperationSegment(FindPencil1P),
+                Strings.OpenNavigationPropertiesNotSupportedOnOpenTypes("FindPencil"));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedActionOnComplexTypeInPathTest()
+        {
+            this.TestUnqualified(
+                "People(1)/Addr/TestNS.ChangeZip",
+                "People(1)/Addr/ChangeZip",
+                parser => parser.ParsePath(),
+                path => path.LastSegment.ShouldBeOperationSegment(ChangeZip),
+                null);
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedActionWithParenthesisOnComplexTypeInPathTest()
+        {
+            this.TestUnqualified(
+                "People(1)/Addr/TestNS.ChangeZip()",
+                "People(1)/Addr/ChangeZip()",
+                parser => parser.ParsePath(),
+                path => path.LastSegment.ShouldBeOperationSegment(ChangeZip),
+                Strings.OpenNavigationPropertiesNotSupportedOnOpenTypes("ChangeZip"));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedOperationWithParenthesisNonexistInPath()
+        {
+            this.TestCaseUnqualifiedNotExist(
+                "People(1)/Addr/ChangeZipEE()",
+                parser => parser.ParsePath(),
+                Strings.OpenNavigationPropertiesNotSupportedOnOpenTypes("ChangeZipEE"));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedOperationConflictsInPath()
+        {
+            this.TestCaseUnqualifiedConflict(
+                "People(1)/FindPencilsCon",
+                parser => parser.ParsePath(),
+                Strings.FunctionOverloadResolver_NoSingleMatchFound("FindPencilsCon", ""));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedOperationWithParenthesisConflictsInPath()
+        {
+            this.TestCaseUnqualifiedConflict(
+                "People(1)/FindPencilsCon()",
+                parser => parser.ParsePath(),
+                Strings.FunctionOverloadResolver_NoSingleMatchFound("FindPencilsCon", ""));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedFunctionInQueryTest()
+        {
+            this.TestUnqualified(
+                "People?$orderby=TestNS.FindPencil(pid=2)/Id",
+                "People?$orderby=FindPencil(pid=2)/Id",
+                parser => parser.ParseOrderBy(),
+                clause => clause.Expression.ShouldBeSingleValuePropertyAccessQueryNode(PencilId).And.Source.ShouldBeSingleEntityFunctionCallNode("TestNS.FindPencil"),
+                Strings.MetadataBinder_UnknownFunction("FindPencil"));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedFunctionWithNoParameterInQueryTest()
+        {
+            this.TestUnqualified(
+                "People?$orderby=TestNS.FindPencil/Id",
+                "People?$orderby=FindPencil/Id",
+                parser => parser.ParseOrderBy(),
+                clause => clause.Expression.ShouldBeSingleValuePropertyAccessQueryNode(PencilId).And.Source.ShouldBeSingleEntityFunctionCallNode("TestNS.FindPencil"),
+                null);
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedFunctionWithNoParameterWithParenthesisInQueryTest()
+        {
+            this.TestUnqualified(
+                "People?$orderby=TestNS.FindPencil()/Id",
+                "People?$orderby=FindPencil()/Id",
+                parser => parser.ParseOrderBy(),
+                clause => clause.Expression.ShouldBeSingleValuePropertyAccessQueryNode(PencilId).And.Source.ShouldBeSingleEntityFunctionCallNode("TestNS.FindPencil"),
+                Strings.MetadataBinder_UnknownFunction("FindPencil"));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedFunctionOnComplexTypeInQueryTest()
+        {
+            this.TestUnqualified(
+                "People?$orderby=Addr/TestNS.GetZip",
+                "People?$orderby=Addr/GetZip",
+                parser => parser.ParseOrderBy(),
+                clause => clause.Expression.ShouldBeSingleValueFunctionCallQueryNode("TestNS.GetZip").And.Source.ShouldBeSingleValuePropertyAccessQueryNode(AddrProperty),
+                null);
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedFunctionWithParenthesisOnComplexTypeInQueryTest()
+        {
+            this.TestUnqualified(
+                "People?$orderby=Addr/TestNS.GetZip()",
+                "People?$orderby=Addr/GetZip()",
+                parser => parser.ParseOrderBy(),
+                clause => clause.Expression.ShouldBeSingleValueFunctionCallQueryNode("TestNS.GetZip").And.Source.ShouldBeSingleValuePropertyAccessQueryNode(AddrProperty),
+                Strings.FunctionCallBinder_BuiltInFunctionMustHaveHaveNullParent("GetZip"));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedOperationWithParenthesisNonexistInOrderBy()
+        {
+            this.TestCaseUnqualifiedNotExist(
+                "People?$orderby=FindPencilEE()/Id",
+                parser => parser.ParseOrderBy(),
+                Strings.MetadataBinder_UnknownFunction("FindPencilEE"));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedOperationConflictsInOrderby()
+        {
+            // Actually not a valid orderby cause, but use it to test pre-thrown exceptions.
+            this.TestCaseUnqualifiedConflict(
+                "People?$orderby=FindPencilsCon",
+                parser => parser.ParseOrderBy(),
+                Strings.FunctionOverloadResolver_NoSingleMatchFound("FindPencilsCon", ""));
+        }
+
+        [TestMethod]
+        public void OpenTypeUnqualifiedOperationWithParenthesisConflictsInOrderby()
+        {
+            // Actually not a valid orderby cause, but use it to test pre-thrown exceptions.
+            this.TestCaseUnqualifiedConflict(
+                "People?$orderby=FindPencilsCon()",
+                parser => parser.ParseOrderBy(),
+                Strings.FunctionOverloadResolver_NoSingleMatchFound("FindPencilsCon", ""));
+        }
+
+        private void TestUnqualified<TResult>(
+            string originalStr,
+            string caseInsensitiveStr,
+            Func<ODataUriParser, TResult> parse,
+            Action<TResult> verify,
+            string errorMessage)
+        {
+            this.TestUriParserExtension(originalStr, caseInsensitiveStr, parse, verify, errorMessage, Model, parser => parser.Resolver = new UnqualifiedODataUriResolver());
+        }
+
+        private void TestCaseUnqualifiedConflict<TResult>(string originalStr, Func<ODataUriParser, TResult> parse, string conflictMessage)
+        {
+            this.TestConflict(originalStr, parse, null, conflictMessage, Model, new UnqualifiedODataUriResolver());
+        }
+
+        private void TestCaseUnqualifiedNotExist<TResult>(string originalStr, Func<ODataUriParser, TResult> parse, string message)
+        {
+            this.TestNotExist(originalStr, parse, message, Model, parser => parser.Resolver = new UnqualifiedODataUriResolver());
+        }
+    }
+}

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.TDD.Tests/Microsoft.Test.OData.Query.TDD.Tests.csproj
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.TDD.Tests/Microsoft.Test.OData.Query.TDD.Tests.csproj
@@ -54,6 +54,8 @@
     <Compile Include="Metadata\CaseInsensitiveResolverUnitTests.cs" />
     <Compile Include="Metadata\ExtensionTestBase.cs" />
     <Compile Include="Metadata\ODataUriResolverUnitTests.cs" />
+    <Compile Include="Metadata\OpenTypeExtensionTestBase.cs" />
+    <Compile Include="Metadata\OpenTypeUnqualifiedExtensionUnitTests.cs" />
     <Compile Include="Metadata\UnqualifiedExtensionUnitTests.cs" />
     <Compile Include="ODataQueryOptionParserUnitTests.cs" />
     <Compile Include="ODataUriParserUnitTests.cs" />


### PR DESCRIPTION
Loose validation for non-default UriResolver according to https://github.com/OData/odata.net/issues/200#issuecomment-111011495.

For open types, each unqualified operation name should be followed with parenthesis (with or without parameters).