### PR TITLE
Allow Navigation Source be Null

### DIFF
--- a/src/Microsoft.OData.Core/ODataContextUriBuilder.cs
+++ b/src/Microsoft.OData.Core/ODataContextUriBuilder.cs
@@ -223,7 +223,7 @@ namespace Microsoft.OData.Core
             // at least requires EdmUnknownEntitySet to be present; otherwise validate its navigation
             // path as before.
             if (!contextUrlInfo.IsUnknownEntitySet && string.IsNullOrEmpty(contextUrlInfo.NavigationPath) ||
-                contextUrlInfo.IsUnknownEntitySet && string.IsNullOrEmpty(contextUrlInfo.NavigationSource))
+                contextUrlInfo.IsUnknownEntitySet && string.IsNullOrEmpty(contextUrlInfo.NavigationSource) && string.IsNullOrEmpty(contextUrlInfo.TypeName))
             {
                 throw new ODataException(Strings.ODataContextUriBuilder_NavigationSourceMissingForEntryAndFeed);
             }

--- a/src/Microsoft.OData.Core/ODataFeedAndEntrySerializationInfo.cs
+++ b/src/Microsoft.OData.Core/ODataFeedAndEntrySerializationInfo.cs
@@ -40,7 +40,6 @@ namespace Microsoft.OData.Core
 
             set
             {
-                ExceptionUtils.CheckArgumentStringNotNullOrEmpty(value, "NavigationSourceName");
                 this.navigationSourceName = value;
             }
         }
@@ -98,7 +97,10 @@ namespace Microsoft.OData.Core
         {
             if (serializationInfo != null)
             {
-                ExceptionUtils.CheckArgumentNotNull(serializationInfo.NavigationSourceName, "serializationInfo.NavigationSourceName");
+                if (serializationInfo.NavigationSourceKind != EdmNavigationSourceKind.UnknownEntitySet)
+                {
+                    ExceptionUtils.CheckArgumentNotNull(serializationInfo.NavigationSourceName, "serializationInfo.NavigationSourceName");
+                }
                 ExceptionUtils.CheckArgumentNotNull(serializationInfo.NavigationSourceEntityTypeName, "serializationInfo.NavigationSourceEntityTypeName");
             }
 

--- a/src/Microsoft.OData.Core/ODataFeedAndEntrySerializationInfo.cs
+++ b/src/Microsoft.OData.Core/ODataFeedAndEntrySerializationInfo.cs
@@ -101,6 +101,7 @@ namespace Microsoft.OData.Core
                 {
                     ExceptionUtils.CheckArgumentNotNull(serializationInfo.NavigationSourceName, "serializationInfo.NavigationSourceName");
                 }
+
                 ExceptionUtils.CheckArgumentNotNull(serializationInfo.NavigationSourceEntityTypeName, "serializationInfo.NavigationSourceEntityTypeName");
             }
 

--- a/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/OperationHandler.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/OperationHandler.cs
@@ -73,13 +73,14 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
                     ODataWriter resultWriter;
 
                     IEdmNavigationSource entitySource = this.QueryContext.OperationResultSource ?? this.QueryContext.Target.NavigationSource;
+                    // IEdmNavigationSource entitySource = this.QueryContext.OperationResultSource;
 
                     if (this.QueryContext.Target.TypeKind == EdmTypeKind.Collection)
                     {
                         IEdmEntitySetBase entitySet = (IEdmEntitySetBase)entitySource;
 
                         resultWriter = messageWriter.CreateODataFeedWriter(entitySet, (IEdmEntityType)this.QueryContext.Target.ElementType);
-                        ResponseWriter.WriteFeed(resultWriter, result as IEnumerable, entitySet, ODataVersion.V4, this.QueryContext.QuerySelectExpandClause, this.QueryContext.TotalCount, null, this.QueryContext.NextLink, this.RequestHeaders);
+                        ResponseWriter.WriteFeed(resultWriter, (IEdmEntityType)this.QueryContext.Target.ElementType, result as IEnumerable, entitySet, ODataVersion.V4, this.QueryContext.QuerySelectExpandClause, this.QueryContext.TotalCount, null, this.QueryContext.NextLink, this.RequestHeaders);
                     }
                     else
                     {
@@ -151,48 +152,48 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
                     switch (parameterReader.State)
                     {
                         case ODataParameterReaderState.Value:
-                        {
-                            object clrValue = ODataObjectModelConverter.ConvertPropertyValue(parameterReader.Value);
-                            parameterValues.Add(Expression.Constant(clrValue));
-                            break;
-                        }
-                        case ODataParameterReaderState.Collection:
-                        {
-                            ODataCollectionReader collectionReader = parameterReader.CreateCollectionReader();
-                            object clrValue = ODataObjectModelConverter.ConvertPropertyValue(ODataObjectModelConverter.ReadCollectionParameterValue(collectionReader));
-                            parameterValues.Add(Expression.Constant(clrValue, clrValue.GetType()));
-                            break;
-                        }
-                        case ODataParameterReaderState.Entry:
-                        {
-                            var entryReader = parameterReader.CreateEntryReader();
-                            object clrValue = ODataObjectModelConverter.ConvertPropertyValue(ODataObjectModelConverter.ReadEntryParameterValue(entryReader));
-                            parameterValues.Add(Expression.Constant(clrValue, clrValue.GetType()));
-                            break;
-                        }
-                        case ODataParameterReaderState.Feed:
-                        {
-                            IList collectionList = null;
-                            var feedReader = parameterReader.CreateFeedReader();
-                            while (feedReader.Read())
                             {
-                                if (feedReader.State == ODataReaderState.EntryEnd)
-                                {
-                                    object clrItem = ODataObjectModelConverter.ConvertPropertyValue(feedReader.Item);
-                                    if (collectionList == null)
-                                    {
-                                        Type itemType = clrItem.GetType();
-                                        Type listType = typeof(List<>).MakeGenericType(new[] {itemType});
-                                        collectionList = (IList)Utility.QuickCreateInstance(listType);
-                                    }
-
-                                    collectionList.Add(clrItem);
-                                }
+                                object clrValue = ODataObjectModelConverter.ConvertPropertyValue(parameterReader.Value);
+                                parameterValues.Add(Expression.Constant(clrValue));
+                                break;
                             }
+                        case ODataParameterReaderState.Collection:
+                            {
+                                ODataCollectionReader collectionReader = parameterReader.CreateCollectionReader();
+                                object clrValue = ODataObjectModelConverter.ConvertPropertyValue(ODataObjectModelConverter.ReadCollectionParameterValue(collectionReader));
+                                parameterValues.Add(Expression.Constant(clrValue, clrValue.GetType()));
+                                break;
+                            }
+                        case ODataParameterReaderState.Entry:
+                            {
+                                var entryReader = parameterReader.CreateEntryReader();
+                                object clrValue = ODataObjectModelConverter.ConvertPropertyValue(ODataObjectModelConverter.ReadEntryParameterValue(entryReader));
+                                parameterValues.Add(Expression.Constant(clrValue, clrValue.GetType()));
+                                break;
+                            }
+                        case ODataParameterReaderState.Feed:
+                            {
+                                IList collectionList = null;
+                                var feedReader = parameterReader.CreateFeedReader();
+                                while (feedReader.Read())
+                                {
+                                    if (feedReader.State == ODataReaderState.EntryEnd)
+                                    {
+                                        object clrItem = ODataObjectModelConverter.ConvertPropertyValue(feedReader.Item);
+                                        if (collectionList == null)
+                                        {
+                                            Type itemType = clrItem.GetType();
+                                            Type listType = typeof(List<>).MakeGenericType(new[] { itemType });
+                                            collectionList = (IList)Utility.QuickCreateInstance(listType);
+                                        }
 
-                            parameterValues.Add(Expression.Constant(collectionList, collectionList.GetType()));
-                            break;
-                        }
+                                        collectionList.Add(clrItem);
+                                    }
+                                }
+
+                                parameterValues.Add(Expression.Constant(collectionList, collectionList.GetType()));
+                                break;
+                            }
                     }
                 }
 

--- a/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/QueryHandler.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/QueryHandler.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
 
                     ODataWriter resultWriter = messageWriter.CreateODataFeedWriter(entitySet, entityType);
 
-                    ResponseWriter.WriteFeed(resultWriter, iEnumerableResults, entitySet, ODataVersion.V4, this.QueryContext.QuerySelectExpandClause, this.QueryContext.TotalCount, this.QueryContext.DeltaLink, this.QueryContext.NextLink, this.RequestHeaders);
+                    ResponseWriter.WriteFeed(resultWriter, entityType, iEnumerableResults, entitySet, ODataVersion.V4, this.QueryContext.QuerySelectExpandClause, this.QueryContext.TotalCount, this.QueryContext.DeltaLink, this.QueryContext.NextLink, this.RequestHeaders);
                     resultWriter.Flush();
                 }
                 else if (this.QueryContext.Target.NavigationSource != null && this.QueryContext.Target.TypeKind == EdmTypeKind.Entity)

--- a/test/EndToEndTests/Services/ODataWCFLibrary/ODataObjectModelConverter.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/ODataObjectModelConverter.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
             entry.TypeName = element.GetType().Namespace + "." + typeName;
 
             // TODO: work around for now
-            if (!(entitySource is IEdmContainedEntitySet))
+            if (!(entitySource is IEdmContainedEntitySet) && entitySource != null)
             {
                 Uri entryUri = BuildEntryUri(element, entitySource, targetVersion);
                 if (element.GetType().BaseType != null && entitySource.EntityType().Name != typeName)

--- a/test/EndToEndTests/Services/ODataWCFLibrary/ResponseWriter.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/ResponseWriter.cs
@@ -105,14 +105,25 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
         /// <param name="entitySet">The entity set in the model that the feed belongs to.</param>
         /// <param name="targetVersion">The OData version this segment is targeting.</param>
         /// <param name="selectExpandClause">The SelectExpandClause.</param>
-        public static void WriteFeed(ODataWriter writer, IEnumerable entries, IEdmEntitySetBase entitySet, ODataVersion targetVersion, SelectExpandClause selectExpandClause, long? count, Uri deltaLink, Uri nextPageLink, Dictionary<string, string> incomingHeaders = null)
+        public static void WriteFeed(ODataWriter writer, IEdmEntityType entityType, IEnumerable entries, IEdmEntitySetBase entitySet, ODataVersion targetVersion, SelectExpandClause selectExpandClause, long? count, Uri deltaLink, Uri nextPageLink, Dictionary<string, string> incomingHeaders = null)
         {
             var feed = new ODataFeed
             {
-                Id = new Uri(ServiceConstants.ServiceBaseUri, entitySet.Name),
+                Id = entitySet == null ? null : new Uri(ServiceConstants.ServiceBaseUri, entitySet.Name),
                 DeltaLink = deltaLink,
                 NextPageLink = nextPageLink
             };
+
+            if (entitySet == null)
+            {
+                feed.SetSerializationInfo(new ODataFeedAndEntrySerializationInfo()
+                {
+                    NavigationSourceEntityTypeName = entityType.FullTypeName(),
+                    NavigationSourceName = null,
+                    NavigationSourceKind = EdmNavigationSourceKind.UnknownEntitySet,
+                    IsFromCollection = true
+                });
+            }
 
             if (count.HasValue)
             {
@@ -185,8 +196,8 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
                                 }
                                 else
                                 {
-                                    
-                                    WriteFeed(writer, collectionValue, targetSource as IEdmEntitySetBase, targetVersion, ((ExpandedNavigationSelectItem)expandedItem).SelectAndExpand, count, null, null);
+
+                                    WriteFeed(writer, null, collectionValue, targetSource as IEdmEntitySetBase, targetVersion, ((ExpandedNavigationSelectItem)expandedItem).SelectAndExpand, count, null, null);
                                 }
                             }
                             else
@@ -197,7 +208,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
                                 }
                                 else
                                 {
-                                    WriteEntry(writer, propertyValue, targetSource, targetVersion, ((ExpandedNavigationSelectItem)expandedItem).SelectAndExpand);                                   
+                                    WriteEntry(writer, propertyValue, targetSource, targetVersion, ((ExpandedNavigationSelectItem)expandedItem).SelectAndExpand);
                                 }
                             }
                         }
@@ -213,7 +224,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
         /// <param name="writer">The ODataWriter that will write the ReferenceLink.</param>
         public static void WriteReferenceLink(ODataWriter writer, object element, IEdmNavigationSource entitySource, ODataVersion targetVersion, ODataNavigationLink navigationLink)
         {
-            ODataEntry entry = ODataObjectModelConverter.ConvertToODataEntityReferenceLink (element, entitySource, targetVersion);
+            ODataEntry entry = ODataObjectModelConverter.ConvertToODataEntityReferenceLink(element, entitySource, targetVersion);
             entry.InstanceAnnotations.Add(new ODataInstanceAnnotation("Link.AnnotationByEntry", new ODataPrimitiveValue(true)));
             writer.WriteStart(entry);
             writer.WriteEnd();
@@ -225,7 +236,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
         /// <param name="writer">The ODataWriter that will write the ReferenceLinks.</param>
         public static void WriteReferenceLinks(ODataWriter writer, IEnumerable element, IEdmNavigationSource entitySource, ODataVersion targetVersion, ODataNavigationLink navigationLink)
         {
-            IEnumerable<ODataEntry> links = ODataObjectModelConverter.ConvertToODataEntityReferenceLinks (element, entitySource, targetVersion);
+            IEnumerable<ODataEntry> links = ODataObjectModelConverter.ConvertToODataEntityReferenceLinks(element, entitySource, targetVersion);
             var feed = new ODataFeed { };
             writer.WriteStart(feed);
             foreach (var entry in links)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -247,6 +247,7 @@
     <Compile Include="ScenarioTests\UriParser\SpatialFuntionalTests.cs" />
     <Compile Include="ScenarioTests\UriParser\TopAndSkipFunctionalTests.cs" />
     <Compile Include="ScenarioTests\UriParser\VerificationHelpers.cs" />
+    <Compile Include="ScenarioTests\Writer\JsonLight\WriteFeedWithoutNavigationSourceTests.cs" />
     <Compile Include="UriParser\Binders\MetadataBindingUtilsTests.cs" />
     <Compile Include="UriParser\ExpressionLexerTests.cs" />
     <Compile Include="UriParser\LiteralUtilsTests.cs" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -14,6 +14,7 @@ using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Library;
 using Microsoft.Spatial;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Microsoft.OData.Core.Tests
 {
@@ -230,7 +231,7 @@ namespace Microsoft.OData.Core.Tests
         }
 
         [Fact]
-        public void ShouldThrowIfEntitySetIsMissingOnFeedResponse()
+        public void ShouldThrowIfEntitySetIsMissingWithoutSerializationInfoOnFeedResponse()
         {
             Action test = () => this.CreateFeedContextUri(ResponseTypeContextWithoutTypeInfo);
             test.ShouldThrow<ODataException>().WithMessage(Strings.ODataFeedAndEntryTypeContext_MetadataOrSerializationInfoMissing);
@@ -240,6 +241,26 @@ namespace Microsoft.OData.Core.Tests
         public void ShouldNotWriteContextUriIfEntitySetIsMissingOnFeedRequest()
         {
             this.CreateFeedContextUri(RequestTypeContextWithoutTypeInfo, false).Should().BeNull();
+        }
+
+        [Fact]
+        public void ShouldWriteIfSerializationInfoWithoutNavigationSourceButUnknownSetOnFeedResponse()
+        {
+            this.CreateFeedContextUri(ODataFeedAndEntryTypeContext.Create(
+                serializationInfo: new ODataFeedAndEntrySerializationInfo()
+                {
+                    ExpectedTypeName = "NS.Type",
+                    IsFromCollection = true,
+                    NavigationSourceEntityTypeName = "NS.Type",
+                    NavigationSourceKind = EdmNavigationSourceKind.UnknownEntitySet,
+                    NavigationSourceName = null
+                },
+                navigationSource: null,
+                navigationSourceEntityType: null,
+                expectedEntityType: null,
+                model: EdmCoreModel.Instance,
+                throwIfMissingTypeInfo: true),
+                isResponse: true);
         }
         #endregion feed context uri
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataFeedAndEntrySerializationInfoTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataFeedAndEntrySerializationInfoTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using FluentAssertions;
+using Microsoft.OData.Edm;
 using Xunit;
 
 namespace Microsoft.OData.Core.Tests
@@ -28,17 +29,17 @@ namespace Microsoft.OData.Core.Tests
         }
 
         [Fact]
-        public void SettingNullEntitySetNameShouldThrow()
+        public void SettingNullEntitySetNameShouldNotThrow()
         {
-            Action action = () => this.testSubject.NavigationSourceName = null;
-            action.ShouldThrow<ArgumentNullException>().WithMessage("NavigationSourceName", ComparisonMode.Substring);
+            this.testSubject.NavigationSourceName = null;
+            this.testSubject.NavigationSourceName.Should().Be(null);
         }
 
         [Fact]
-        public void SettingEmptyEntitySetNameShouldThrow()
+        public void SettingEmptyEntitySetNameShouldNotThrow()
         {
-            Action action = () => this.testSubject.NavigationSourceName = "";
-            action.ShouldThrow<ArgumentNullException>().WithMessage("NavigationSourceName", ComparisonMode.Substring);
+            this.testSubject.NavigationSourceName = string.Empty;
+            this.testSubject.NavigationSourceName.Should().Be(string.Empty);
         }
 
         [Fact]
@@ -120,7 +121,20 @@ namespace Microsoft.OData.Core.Tests
         [Fact]
         public void ValidatingSerializationInfoShouldAllowExpectedTypeNameNotSet()
         {
-            ODataFeedAndEntrySerializationInfo.Validate(new ODataFeedAndEntrySerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "EntitySetElementTypeName"}).Should().NotBeNull();
+            ODataFeedAndEntrySerializationInfo.Validate(new ODataFeedAndEntrySerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "EntitySetElementTypeName" }).Should().NotBeNull();
+        }
+
+        [Fact]
+        public void ValdatingSerializationInfoShouldAllowIfEntitySetNameNotSetWithEdmUnknownEntitySet()
+        {
+            ODataFeedAndEntrySerializationInfo.Validate(new ODataFeedAndEntrySerializationInfo()
+            {
+                ExpectedTypeName = "NS.Type",
+                IsFromCollection = true,
+                NavigationSourceEntityTypeName = "NS.Type",
+                NavigationSourceKind = EdmNavigationSourceKind.UnknownEntitySet,
+                NavigationSourceName = null
+            });
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataFeedAndEntryTypeContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataFeedAndEntryTypeContextTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using FluentAssertions;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Library;
 using Microsoft.OData.Edm.Library.Annotations;
 using Xunit;
@@ -18,7 +19,9 @@ namespace Microsoft.OData.Core.Tests
         private static readonly ODataFeedAndEntryTypeContext TypeContextWithModel;
         private static readonly ODataFeedAndEntryTypeContext BaseTypeContextThatThrows;
         private static readonly ODataFeedAndEntryTypeContext BaseTypeContextThatWillNotThrow;
+        private static readonly ODataFeedAndEntryTypeContext TypeContextWithEdmUnknowEntitySet;
         private static readonly ODataFeedAndEntrySerializationInfo SerializationInfo;
+        private static readonly ODataFeedAndEntrySerializationInfo SerializationInfoWithEdmUnknowEntitySet;
         private static readonly EdmEntitySet EntitySet;
         private static readonly EdmEntityType EntitySetElementType;
         private static readonly EdmEntityType ExpectedEntityType;
@@ -42,9 +45,11 @@ namespace Microsoft.OData.Core.Tests
             Model.AddElement(ActualEntityType);
             defaultContainer.AddElement(EntitySet);
 
-            SerializationInfo = new ODataFeedAndEntrySerializationInfo {NavigationSourceName = "MyCustomers", NavigationSourceEntityTypeName = "ns.MyCustomer", ExpectedTypeName = "ns.MyVipCustomer"};
+            SerializationInfo = new ODataFeedAndEntrySerializationInfo { NavigationSourceName = "MyCustomers", NavigationSourceEntityTypeName = "ns.MyCustomer", ExpectedTypeName = "ns.MyVipCustomer" };
+            SerializationInfoWithEdmUnknowEntitySet = new ODataFeedAndEntrySerializationInfo() { NavigationSourceName = null, NavigationSourceEntityTypeName = "ns.MyCustomer", ExpectedTypeName = "ns.MyVipCustomer", NavigationSourceKind = EdmNavigationSourceKind.UnknownEntitySet };
             TypeContextWithoutModel = ODataFeedAndEntryTypeContext.Create(SerializationInfo, navigationSource: null, navigationSourceEntityType: null, expectedEntityType: null, model: Model, throwIfMissingTypeInfo: true);
             TypeContextWithModel = ODataFeedAndEntryTypeContext.Create(/*serializationInfo*/null, EntitySet, EntitySetElementType, ExpectedEntityType, Model, throwIfMissingTypeInfo: true);
+            TypeContextWithEdmUnknowEntitySet = ODataFeedAndEntryTypeContext.Create(SerializationInfoWithEdmUnknowEntitySet, navigationSource: null, navigationSourceEntityType: null, expectedEntityType: null, model: Model, throwIfMissingTypeInfo: true);
             BaseTypeContextThatThrows = ODataFeedAndEntryTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedEntityType: null, model: Model, throwIfMissingTypeInfo: true);
             BaseTypeContextThatWillNotThrow = ODataFeedAndEntryTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedEntityType: null, model: Model, throwIfMissingTypeInfo: false);
         }
@@ -223,5 +228,37 @@ namespace Microsoft.OData.Core.Tests
             BaseTypeContextThatWillNotThrow.UrlConvention.GenerateKeyAsSegment.Should().BeFalse();
         }
         #endregion BaseTypeContextThatWillNotThrow
+
+        #region TypeContextWithEdmUnknowEntitySet
+        [Fact]
+        public void TypeContextWithEdmUnknowEntitySetShouldReturnNullEntitySetName()
+        {
+            TypeContextWithEdmUnknowEntitySet.NavigationSourceName.Should().Be(null);
+        }
+
+        [Fact]
+        public void TypeContextWithEdmUnknowEntitySetShouldReturnEntitySetElementTypeName()
+        {
+            TypeContextWithEdmUnknowEntitySet.NavigationSourceEntityTypeName.Should().Be("ns.MyCustomer");
+        }
+
+        [Fact]
+        public void TypeContextWithEdmUnknowEntitySetShouldReturnExpectedEntityTypeName()
+        {
+            TypeContextWithEdmUnknowEntitySet.ExpectedEntityTypeName.Should().Be("ns.MyVipCustomer");
+        }
+
+        [Fact]
+        public void TypeContextWithEdmUnknowEntitySetShouldReturnFalseForIsMediaLinkEntry()
+        {
+            TypeContextWithEdmUnknowEntitySet.IsMediaLinkEntry.Should().BeFalse();
+        }
+
+        [Fact]
+        public void TypeContextWithEdmUnknowEntitySetShouldReturnDefaultUrlConvention()
+        {
+            TypeContextWithEdmUnknowEntitySet.UrlConvention.GenerateKeyAsSegment.Should().BeFalse();
+        }
+        #endregion TypeContextWithEdmUnknowEntitySet
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataFeedTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataFeedTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using FluentAssertions;
+using Microsoft.OData.Edm;
 using Xunit;
 
 namespace Microsoft.OData.Core.Tests
@@ -96,8 +97,15 @@ namespace Microsoft.OData.Core.Tests
         [Fact]
         public void ShouldBeAbleToSetSerializationInfo()
         {
-            this.odataFeed.SerializationInfo = new ODataFeedAndEntrySerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.base", ExpectedTypeName = "ns.expected"};
+            this.odataFeed.SerializationInfo = new ODataFeedAndEntrySerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.base", ExpectedTypeName = "ns.expected" };
             this.odataFeed.SerializationInfo.NavigationSourceName.Should().Be("Set");
+        }
+
+        [Fact]
+        public void ShouldBeAbleToSetSerializationInfoWithEdmUnknowEntitySet()
+        {
+            this.odataFeed.SerializationInfo = new ODataFeedAndEntrySerializationInfo { NavigationSourceName = null, NavigationSourceKind = EdmNavigationSourceKind.UnknownEntitySet, NavigationSourceEntityTypeName = "ns.base", ExpectedTypeName = "ns.expected" };
+            this.odataFeed.SerializationInfo.NavigationSourceName.Should().BeNull();
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataOperationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataOperationTests.cs
@@ -47,7 +47,7 @@ namespace Microsoft.OData.Core.Tests
             var metadataContext = new TestMetadataContext();
             var entryMetadataContext = ODataEntryMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, SelectedPropertiesNode.EntireSubtree);
             var fullMetadataBuilder = new ODataConventionalEntityMetadataBuilder(entryMetadataContext, metadataContext, new ODataConventionalUriBuilder(ServiceUri, UrlConvention.CreateWithExplicitValue(false)));
-            this.operationWithFullBuilder = new TestODataOperation { Metadata = ContextUri};
+            this.operationWithFullBuilder = new TestODataOperation { Metadata = ContextUri };
             this.operationWithFullBuilder.SetMetadataBuilder(fullMetadataBuilder, MetadataDocumentUri);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/WriteFeedWithoutNavigationSourceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/WriteFeedWithoutNavigationSourceTests.cs
@@ -1,0 +1,191 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="WriteFeedWithoutNavigationTargetTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using FluentAssertions;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Library;
+using Xunit;
+
+namespace Microsoft.OData.Core.Tests.ScenarioTests.Writer.JsonLight
+{
+    public class WriteFeedWithoutNavigationSourceTests
+    {
+        private EdmModel myModel;
+        private MemoryStream stream;
+
+        #region Entities
+
+        private static readonly ODataFeed feed = new ODataFeed();
+
+        private static readonly ODataEntry entry = new ODataEntry
+        {
+            TypeName = "NS.DeriviedTypeA",
+            Properties = new List<ODataProperty>
+            {
+                new ODataProperty { Name = "AId", Value = 1 }
+            },
+        };
+        #endregion
+
+        #region Test Cases
+        [Fact]
+        public void WriteFeedMissingNavigationSourceWithSerializationInfoWithModel()
+        {
+            this.TestInit();
+
+            feed.SerializationInfo = new ODataFeedAndEntrySerializationInfo()
+            {
+                IsFromCollection = true,
+                NavigationSourceEntityTypeName = "NS.BaseType",
+                NavigationSourceKind = EdmNavigationSourceKind.UnknownEntitySet,
+                NavigationSourceName = null,
+            };
+
+            using (var messageWriter = this.CreateMessageWriter(true))
+            {
+                var writer = messageWriter.CreateODataFeedWriter(entitySet: null, entityType: this.GetBaseType());
+                writer.WriteStart(feed);
+                writer.WriteStart(entry);
+                writer.WriteEnd(); // entry
+                writer.WriteEnd(); // feed
+                writer.Flush();
+            }
+
+            string payload = this.TestFinish();
+            payload.Should().Contain("\"@odata.context\":\"http://host/service/$metadata#Collection(NS.BaseType)\"");
+        }
+
+        [Fact]
+        public void WriteFeedMissingNavigationSourceWithSerializationInfoWithoutModel()
+        {
+            this.TestInit();
+
+            feed.SerializationInfo = new ODataFeedAndEntrySerializationInfo()
+            {
+                IsFromCollection = true,
+                NavigationSourceEntityTypeName = "NS.BaseType",
+                NavigationSourceKind = EdmNavigationSourceKind.UnknownEntitySet,
+                NavigationSourceName = null,
+            };
+
+            using (var messageWriter = this.CreateMessageWriter(false))
+            {
+                var writer = messageWriter.CreateODataFeedWriter(entitySet: null, entityType: this.GetBaseType());
+                writer.WriteStart(feed);
+                writer.WriteStart(entry);
+                writer.WriteEnd(); // entry
+                writer.WriteEnd(); // feed
+                writer.Flush();
+            }
+
+            string payload = this.TestFinish();
+            payload.Should().Contain("\"@odata.context\":\"http://host/service/$metadata#Collection(NS.BaseType)\"");
+        }
+        #endregion
+
+        #region Private Methods
+
+        private void TestInit()
+        {
+            this.stream = new MemoryStream();
+        }
+
+        private IEdmModel GetModel()
+        {
+            if (myModel == null)
+            {
+                myModel = new EdmModel();
+
+                var baseType = new EdmEntityType("NS", "BaseType", baseType: null, isAbstract: true, isOpen: false);
+                myModel.AddElement(baseType);
+
+                var deriviedTypeA = new EdmEntityType("NS", "DeriviedTypeA", baseType);
+                deriviedTypeA.AddKeys(deriviedTypeA.AddStructuralProperty("AId", EdmPrimitiveTypeKind.Int32));
+                myModel.AddElement(deriviedTypeA);
+
+                var deriviedTypeB = new EdmEntityType("NS", "DeriviedTypeB", baseType);
+                deriviedTypeB.AddKeys(deriviedTypeB.AddStructuralProperty("BId", EdmPrimitiveTypeKind.Int32));
+                myModel.AddElement(deriviedTypeB);
+
+                var container = new EdmEntityContainer("MyNS", "Default");
+                container.AddEntitySet("SetA", deriviedTypeA);
+                container.AddEntitySet("SetB", deriviedTypeB);
+                myModel.AddElement(container);
+            }
+
+            return myModel;
+        }
+
+        private string TestFinish()
+        {
+            this.stream.Seek(0, SeekOrigin.Begin);
+            using (var reader = new StreamReader(this.stream))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
+        private IEdmEntityType GetBaseType()
+        {
+            var model = this.GetModel();
+            return (IEdmEntityType)model.FindDeclaredType("NS.BaseType");
+        }
+
+        private ODataMessageWriter CreateMessageWriter(bool useModel)
+        {
+            var responseMessage = new TestResponseMessage(this.stream);
+            var writerSettings = new ODataMessageWriterSettings { DisableMessageStreamDisposal = true };
+            writerSettings.SetServiceDocumentUri(new Uri("http://host/service"));
+            var model = useModel ? this.GetModel() : null;
+            return new ODataMessageWriter(responseMessage, writerSettings, model);
+        }
+
+        private class TestResponseMessage : IODataResponseMessage
+        {
+            private readonly Dictionary<string, string> headers =
+                new Dictionary<string, string>();
+            private readonly Stream stream;
+
+            public TestResponseMessage(Stream stream)
+            {
+                this.stream = stream;
+            }
+
+            public IEnumerable<KeyValuePair<string, string>> Headers
+            {
+                get { return this.headers; }
+            }
+
+            public int StatusCode { get; set; }
+
+            public string GetHeader(string headerName)
+            {
+                string headerValue;
+                if (this.headers.TryGetValue(headerName, out headerValue))
+                {
+                    return headerValue;
+                }
+
+                return null;
+            }
+
+            public void SetHeader(string headerName, string headerValue)
+            {
+                this.headers[headerName] = headerValue;
+            }
+
+            public Stream GetStream()
+            {
+                return this.stream;
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
This PR is for Issue https://github.com/OData/odata.net/issues/69
The Navigation Source during serialization can be null when Passing SerializationInfo in ODataFeed.
