### PR TITLE
Issues #315 and #317: ODataUntypedValue

### DIFF
--- a/src/Microsoft.OData.Core/Json/IJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriter.cs
@@ -154,6 +154,12 @@ namespace Microsoft.OData.Core.Json
         void WriteValue(TimeOfDay value);
 
         /// <summary>
+        /// Write a raw value.
+        /// </summary>
+        /// <param name="rawValue">Raw value to be written.</param>
+        void WriteRawValue(string rawValue);
+
+        /// <summary>
         /// Clears all buffers for the current writer.
         /// </summary>
         void Flush();

--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -370,6 +370,16 @@ namespace Microsoft.OData.Core.Json
         }
 
         /// <summary>
+        /// Write a raw value.
+        /// </summary>
+        /// <param name="rawValue">Raw value to be written.</param>
+        public void WriteRawValue(string rawValue)
+        {
+            this.WriteValueSeparator();
+            this.writer.Write(rawValue);
+        }
+
+        /// <summary>
         /// Clears all buffers for the current writer.
         /// </summary>
         public void Flush()

--- a/src/Microsoft.OData.Core/JsonLight/IODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/IODataJsonLightValueSerializer.cs
@@ -82,6 +82,13 @@ namespace Microsoft.OData.Core.JsonLight
             IEdmTypeReference expectedTypeReference);
 
         /// <summary>
+        /// Writes an untyped value.
+        /// </summary>
+        /// <param name="value">The untyped value to write.</param>
+        void WriteUntypedValue(
+            ODataUntypedValue value);
+
+        /// <summary>
         /// Creates a <see cref="DuplicatePropertyNamesChecker"/> for checking duplication properties inside complex values.
         /// </summary>
         /// <returns>A new <see cref="DuplicatePropertyNamesChecker"/> instance.</returns>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -274,6 +274,14 @@ namespace Microsoft.OData.Core.JsonLight
 
                 // passing false for 'isTopLevel' because the outer wrapping object has already been written.
                 this.JsonLightValueSerializer.WriteCollectionValue(collectionValue, propertyTypeReference, isTopLevel, false /*isInUri*/, isOpenPropertyType);
+                return;
+            }
+
+            ODataUntypedValue untypedValue = value as ODataUntypedValue;
+            if (untypedValue != null)
+            {
+                this.JsonWriter.WriteName(wirePropertyName);
+                this.JsonLightValueSerializer.WriteUntypedValue(untypedValue);
             }
             else
             {

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -305,7 +305,12 @@ namespace Microsoft.OData.Core.JsonLight
                         }
                         else
                         {
-                            if (item != null)
+                            ODataUntypedValue untypedValue = item as ODataUntypedValue;
+                            if (untypedValue != null)
+                            {
+                                this.WriteUntypedValue(untypedValue);
+                            }
+                            else if (item != null)
                             {
                                 this.WritePrimitiveValue(item, expectedItemTypeReference);
                             }
@@ -363,6 +368,23 @@ namespace Microsoft.OData.Core.JsonLight
             {
                 this.JsonWriter.WritePrimitiveValue(value);
             }
+        }
+
+        /// <summary>
+        /// Writes an untyped value.
+        /// </summary>
+        /// <param name="value">The untyped value to write.</param>
+        public void WriteUntypedValue(
+            ODataUntypedValue value)
+        {
+            Debug.Assert(value != null, "value != null");
+
+            if (string.IsNullOrEmpty(value.RawValue))
+            {
+                throw new ODataException(ODataErrorStrings.ODataJsonLightValueSerializer_MissingRawValueOnUntyped);
+            }
+
+            this.JsonWriter.WriteRawValue(value.RawValue);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.Net45.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.Net45.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Json\ODataJsonWriterUtils.cs" />
     <Compile Include="Json\TextWriterWrapper.cs" />
     <Compile Include="ODataErrorDetail.cs" />
+    <Compile Include="ODataUntypedValue.cs" />
     <Compile Include="ODataMediaType.cs" />
     <Compile Include="ODataMediaTypeResolver.cs" />
     <Compile Include="MediaTypeUtils.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Json\ODataJsonWriterUtils.cs" />
     <Compile Include="Json\TextWriterWrapper.cs" />
     <Compile Include="ODataErrorDetail.cs" />
+    <Compile Include="ODataUntypedValue.cs" />
     <Compile Include="ODataMediaType.cs" />
     <Compile Include="ODataMediaTypeResolver.cs" />
     <Compile Include="MediaTypeUtils.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -645,6 +645,7 @@ namespace Microsoft.OData.Core {
         internal const string ODataInstanceAnnotation_ValueCannotBeODataStreamReferenceValue = "ODataInstanceAnnotation_ValueCannotBeODataStreamReferenceValue";
         internal const string ODataJsonLightValueSerializer_MissingTypeNameOnComplex = "ODataJsonLightValueSerializer_MissingTypeNameOnComplex";
         internal const string ODataJsonLightValueSerializer_MissingTypeNameOnCollection = "ODataJsonLightValueSerializer_MissingTypeNameOnCollection";
+        internal const string ODataJsonLightValueSerializer_MissingRawValueOnUntyped = "ODataJsonLightValueSerializer_MissingRawValueOnUntyped";
         internal const string AtomInstanceAnnotation_MissingTermAttributeOnAnnotationElement = "AtomInstanceAnnotation_MissingTermAttributeOnAnnotationElement";
         internal const string AtomInstanceAnnotation_AttributeValueNotationUsedWithIncompatibleType = "AtomInstanceAnnotation_AttributeValueNotationUsedWithIncompatibleType";
         internal const string AtomInstanceAnnotation_AttributeValueNotationUsedOnNonEmptyElement = "AtomInstanceAnnotation_AttributeValueNotationUsedOnNonEmptyElement";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -220,6 +220,7 @@
     <Compile Include="Json\ODataJsonWriterUtils.cs" />
     <Compile Include="Json\TextWriterWrapper.cs" />
     <Compile Include="ODataErrorDetail.cs" />
+    <Compile Include="ODataUntypedValue.cs" />
     <Compile Include="ODataMediaType.cs" />
     <Compile Include="ODataMediaTypeResolver.cs" />
     <Compile Include="MediaTypeUtils.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -700,6 +700,7 @@ ODataInstanceAnnotation_ValueCannotBeODataStreamReferenceValue=The value of an i
 
 ODataJsonLightValueSerializer_MissingTypeNameOnComplex=A type name was not provided for an instance of ODataComplexValue.
 ODataJsonLightValueSerializer_MissingTypeNameOnCollection=A type name was not provided for an instance of ODataCollectionValue.
+ODataJsonLightValueSerializer_MissingRawValueOnUntyped=A raw value was not provided for an instance of ODataUntypedValue.
 
 AtomInstanceAnnotation_MissingTermAttributeOnAnnotationElement=Encountered an 'annotation' element without a 'term' attribute. All 'annotation' elements must have a 'term' attribute.
 AtomInstanceAnnotation_AttributeValueNotationUsedWithIncompatibleType=The value of the 'type' attribute on an 'annotation' element was '{0}', which is incompatible with the '{1}' attribute.

--- a/src/Microsoft.OData.Core/ODataConstants.cs
+++ b/src/Microsoft.OData.Core/ODataConstants.cs
@@ -176,6 +176,9 @@ namespace Microsoft.OData.Core
         /// <summary>The token that indicates the payload is a property with null value.</summary>
         internal const string ContextUriFragmentNull = "Edm.Null";
 
+        /// <summary>The token that indicates the payload is a property with an untyped value.</summary>
+        internal const string ContextUriFragmentUntyped = "Edm.Untyped";
+
         /// <summary>The $delta token indicates delta feed.</summary>
         internal const string ContextUriDeltaFeed = "/$delta";
 

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -310,6 +310,12 @@ namespace Microsoft.OData.Core
                 return enumValue.TypeName;
             }
 
+            var untypedValue = value as ODataUntypedValue;
+            if (untypedValue != null)
+            {
+                return ODataConstants.ContextUriFragmentUntyped;
+            }
+
             ODataPrimitiveValue primitive = value as ODataPrimitiveValue;
             if (primitive == null)
             {

--- a/src/Microsoft.OData.Core/ODataUntypedValue.cs
+++ b/src/Microsoft.OData.Core/ODataUntypedValue.cs
@@ -1,0 +1,29 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataUntypedValue.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Core
+{
+    /// <summary>
+    /// OData representation of an untyped value.
+    /// </summary>
+    public sealed class ODataUntypedValue : ODataValue
+    {
+        /// <summary>Gets or sets the raw untyped value.</summary>
+        /// <returns>The raw untyped value.</returns>
+        /// <remarks>
+        /// The caller of the setter is responsible for formatting the value for the 
+        /// data transmission protocol it will be used in. 
+        /// For instance, if the protocol is JSON, the caller must format this value as JSON.
+        /// If the protocol is Atom, the caller must format this value as XML.
+        /// This libarary will not perform any formatting.
+        /// </remarks>
+        public string RawValue
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -4442,6 +4442,17 @@ namespace Microsoft.OData.Core {
         }
 
         /// <summary>
+        /// A string like "A raw value was not provided for an instance of ODataUntypedValue."
+        /// </summary>
+        internal static string ODataJsonLightValueSerializer_MissingRawValueOnUntyped
+        {
+            get
+            {
+                return Microsoft.OData.Core.TextRes.GetString(Microsoft.OData.Core.TextRes.ODataJsonLightValueSerializer_MissingRawValueOnUntyped);
+            }
+        }
+
+        /// <summary>
         /// A string like "Encountered an 'annotation' element without a 'term' attribute. All 'annotation' elements must have a 'term' attribute."
         /// </summary>
         internal static string AtomInstanceAnnotation_MissingTermAttributeOnAnnotationElement {

--- a/src/Microsoft.OData.Core/TypeNameOracle.cs
+++ b/src/Microsoft.OData.Core/TypeNameOracle.cs
@@ -95,6 +95,11 @@ namespace Microsoft.OData.Core
                 return ResolveAndValidateTypeFromNameAndMetadata(model, typeReferenceFromMetadata, enumValue.TypeName, EdmTypeKind.Enum, isOpenProperty);
             }
 
+            if (value is ODataUntypedValue)
+            {
+                return typeReferenceFromMetadata;
+            }
+
             ODataCollectionValue collectionValue = (ODataCollectionValue)value;
             return ResolveAndValidateTypeFromNameAndMetadata(model, typeReferenceFromMetadata, collectionValue.TypeName, EdmTypeKind.Collection, isOpenProperty);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonLightValueSerializer.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonLightValueSerializer.cs
@@ -66,6 +66,12 @@ namespace Microsoft.OData.Core.Tests.Json
             this.WritePrimitiveVerifier(value, expectedTypeReference);
         }
 
+        public void WriteUntypedValue(ODataUntypedValue value)
+        {
+            this.WritePrimitiveVerifier.Should().NotBeNull("WriteUntypedValue was called.");
+            this.WritePrimitiveVerifier(value, null);
+        }
+
         public DuplicatePropertyNamesChecker CreateDuplicatePropertyNamesChecker()
         {
             return new DuplicatePropertyNamesChecker(true /*allowDuplicateProperties*/, true /*isRepsonse*/);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
@@ -144,6 +144,12 @@ namespace Microsoft.OData.Core.Tests.Json
             this.WriteValueVerifier(Convert.ToBase64String(value));
         }
 
+        public void WriteRawValue(string rawValue)
+        {
+            this.WriteValueVerifier.Should().NotBeNull();
+            this.WriteValueVerifier(rawValue);
+        }
+
         public void Flush()
         {
             throw new System.NotImplementedException();

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -4866,6 +4866,12 @@ public sealed class Microsoft.OData.Core.ODataStreamReferenceValue : Microsoft.O
 	System.Uri ReadLink  { public get; public set; }
 }
 
+public sealed class Microsoft.OData.Core.ODataUntypedValue : Microsoft.OData.Core.ODataValue {
+	public ODataUntypedValue ()
+
+	string RawValue  { public get; public set; }
+}
+
 public sealed class Microsoft.OData.Core.ODataUri {
 	public ODataUri ()
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/JsonLight/JsonLightPropertyWriterTests.WriteUntypedValueTest.approved.txt
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/JsonLight/JsonLightPropertyWriterTests.WriteUntypedValueTest.approved.txt
@@ -1,0 +1,160 @@
+Combination: 1; TestConfiguration = Format: JsonLight, Request: True, Synchronous: True
+Model Present: true
+{"@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":null}
+
+Combination: 2; TestConfiguration = Format: JsonLight, Request: False, Synchronous: True
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":null
+}
+
+Combination: 3; TestConfiguration = Format: JsonLight, Request: True, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":null
+}
+
+Combination: 4; TestConfiguration = Format: JsonLight, Request: False, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":null
+}
+
+Combination: 5; TestConfiguration = Format: JsonLight, Request: True, Synchronous: True
+Model Present: true
+{"@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":42}
+
+Combination: 6; TestConfiguration = Format: JsonLight, Request: False, Synchronous: True
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":42
+}
+
+Combination: 7; TestConfiguration = Format: JsonLight, Request: True, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":42
+}
+
+Combination: 8; TestConfiguration = Format: JsonLight, Request: False, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":42
+}
+
+Combination: 9; TestConfiguration = Format: JsonLight, Request: True, Synchronous: True
+Model Present: true
+{"@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":3.1415}
+
+Combination: 10; TestConfiguration = Format: JsonLight, Request: False, Synchronous: True
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":3.1415
+}
+
+Combination: 11; TestConfiguration = Format: JsonLight, Request: True, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":3.1415
+}
+
+Combination: 12; TestConfiguration = Format: JsonLight, Request: False, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":3.1415
+}
+
+Combination: 13; TestConfiguration = Format: JsonLight, Request: True, Synchronous: True
+Model Present: true
+{"@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":"foo bar"}
+
+Combination: 14; TestConfiguration = Format: JsonLight, Request: False, Synchronous: True
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":"foo bar"
+}
+
+Combination: 15; TestConfiguration = Format: JsonLight, Request: True, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":"foo bar"
+}
+
+Combination: 16; TestConfiguration = Format: JsonLight, Request: False, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":"foo bar"
+}
+
+Combination: 17; TestConfiguration = Format: JsonLight, Request: True, Synchronous: True
+Model Present: true
+{"@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":[1, 2, "abc"]}
+
+Combination: 18; TestConfiguration = Format: JsonLight, Request: False, Synchronous: True
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":[1, 2, "abc"]
+}
+
+Combination: 19; TestConfiguration = Format: JsonLight, Request: True, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":[1, 2, "abc"]
+}
+
+Combination: 20; TestConfiguration = Format: JsonLight, Request: False, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":[1, 2, "abc"]
+}
+
+Combination: 21; TestConfiguration = Format: JsonLight, Request: True, Synchronous: True
+Model Present: true
+{"@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":[ [1, "abc"], [2, "def"], [[3],[4, 5]] ]}
+
+Combination: 22; TestConfiguration = Format: JsonLight, Request: False, Synchronous: True
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":[ [1, "abc"], [2, "def"], [[3],[4, 5]] ]
+}
+
+Combination: 23; TestConfiguration = Format: JsonLight, Request: True, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":[ [1, "abc"], [2, "def"], [[3],[4, 5]] ]
+}
+
+Combination: 24; TestConfiguration = Format: JsonLight, Request: False, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Edm.Untyped","value":[ [1, "abc"], [2, "def"], [[3],[4, 5]] ]
+}
+
+Combination: 29; TestConfiguration = Format: JsonLight, Request: True, Synchronous: True
+Model Present: true
+{"@odata.context":"http://odata.org/test/$metadata#Collection(TestModel.JsonType)","@odata.type":"#Collection(TestModel.JsonType)","value":["foo bar",[1, 2, "abc"],3.1415]}
+
+Combination: 30; TestConfiguration = Format: JsonLight, Request: False, Synchronous: True
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Collection(TestModel.JsonType)","value":[
+    "foo bar",[1, 2, "abc"],3.1415
+  ]
+}
+
+Combination: 31; TestConfiguration = Format: JsonLight, Request: True, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Collection(TestModel.JsonType)","@odata.type":"#Collection(TestModel.JsonType)","value":[
+    "foo bar",[1, 2, "abc"],3.1415
+  ]
+}
+
+Combination: 32; TestConfiguration = Format: JsonLight, Request: False, Synchronous: False
+Model Present: true
+{
+  "@odata.context":"http://odata.org/test/$metadata#Collection(TestModel.JsonType)","value":[
+    "foo bar",[1, 2, "abc"],3.1415
+  ]
+}
+

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Microsoft.Test.Taupo.OData.Writer.Tests.csproj
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Microsoft.Test.Taupo.OData.Writer.Tests.csproj
@@ -227,6 +227,9 @@
     <Content Include="JsonLight\JsonLightPropertyWriterTests.WritePropertyWithoutOwningType.approved.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="JsonLight\JsonLightPropertyWriterTests.WriteUntypedValueTest.approved.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Writer\WriterContentTypeTests.AppJsonContentComplexTypeVersioningTest.approved.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
This commit addresses:
#315 "Add ODataUntypedValue to object model."
#317 "Write untyped json property for entry."

The above are part of #248 "Support for unknown ComplexTypes within OpenType."