### PR TITLE
V4 supports reading & writing undeclared property & its annotations

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -32,6 +32,27 @@ namespace Microsoft.OData.Client
     #endregion Namespaces
 
     /// <summary>
+    /// Indicates DataServiceContext's behavior on undeclared property in entity/complex value.
+    /// </summary>
+    public enum UndeclaredPropertyBehavior
+    {
+        /// <summary>
+        /// The default value, implies respecting existing DataServiceContext.IgnoreMissingProperties boolean.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// Sliently discard undeclared property.
+        /// </summary>
+        Discard = 1,
+
+        /// <summary>
+        /// Supports undeclared property.
+        /// </summary>
+        Support = 2,
+    }
+
+    /// <summary>
     /// The <see cref="T:Microsoft.OData.Client.DataServiceContext" /> represents the runtime context of the data service.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506", Justification = "Central class of the API, likely to have many cross-references")]
@@ -98,6 +119,9 @@ namespace Microsoft.OData.Client
 
         /// <summary>Options when deserializing properties to the target type.</summary>
         private bool ignoreMissingProperties = true;
+
+        /// <summary>Options that can overwrite ignoreMissingProperties.</summary>
+        private UndeclaredPropertyBehavior undeclaredPropertyBehavior;
 
         /// <summary>Used to specify a strategy to send entity parameter.</summary>
         private EntityParameterSendOption entityParameterSendOption;
@@ -433,6 +457,14 @@ namespace Microsoft.OData.Client
         {
             get { return this.ignoreMissingProperties; }
             set { this.ignoreMissingProperties = value; }
+        }
+
+        /// <summary>Gets or sets undeclaredPropertyBehaviorKinds.whether to respect IgnoreMissingProperties boolean, or directly ignore/support undeclared properties.</summary>
+        /// <returns>UndeclaredPropertyBehavior.</returns>
+        public UndeclaredPropertyBehavior UndeclaredPropertyBehavior
+        {
+            get { return this.undeclaredPropertyBehavior; }
+            set { this.undeclaredPropertyBehavior = value; }
         }
 
         /// <summary>Gets or sets a function to override the default type resolution strategy used by the client library when you send entities to a data service.</summary>

--- a/src/Microsoft.OData.Client/Materialization/ODataMaterializerContext.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataMaterializerContext.cs
@@ -8,6 +8,7 @@ namespace Microsoft.OData.Client.Materialization
 {
     using System;
     using Microsoft.OData.Client.Metadata;
+    using Microsoft.OData.Core;
     using Microsoft.OData.Edm;
 
     /// <summary>
@@ -37,7 +38,10 @@ namespace Microsoft.OData.Client.Materialization
         /// </summary>
         public bool IgnoreMissingProperties
         {
-            get { return this.ResponseInfo.IgnoreMissingProperties; }
+            get
+            {
+                return this.ResponseInfo.ShouldMaterializerIgnoreUndeclaredValueProperty;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/ODataMessageReadingHelper.cs
+++ b/src/Microsoft.OData.Client/ODataMessageReadingHelper.cs
@@ -54,12 +54,9 @@ namespace Microsoft.OData.Client
 
             settings.BaseUri = this.responseInfo.BaseUriResolver.BaseUriOrNull;
             settings.ODataSimplified = this.responseInfo.Context.ODataSimplified;
-            settings.UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.ReportUndeclaredLinkProperty;
             settings.MaxProtocolVersion = CommonUtil.ConvertToODataVersion(this.responseInfo.MaxProtocolVersion);
-            if (this.responseInfo.IgnoreMissingProperties)
-            {
-                settings.UndeclaredPropertyBehaviorKinds |= ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty;
-            }
+            settings.UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.ReportUndeclaredLinkProperty;
+            settings.UndeclaredPropertyBehaviorKinds |= this.responseInfo.UndeclaredPropertyBehaviorKinds;
 
             if (this.responseInfo.Context.UrlConventions == DataServiceUrlConventions.KeyAsSegment)
             {

--- a/src/Microsoft.OData.Client/ResponseInfo.cs
+++ b/src/Microsoft.OData.Client/ResponseInfo.cs
@@ -66,11 +66,27 @@ namespace Microsoft.OData.Client
         {
             get
             {
-                return this.Context.IgnoreMissingProperties
-                    ?
-                    ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty
-                    :
-                    ODataUndeclaredPropertyBehaviorKinds.None;
+                // DsContxt.UndeclaredPropertyBehavior    DsContxt.IgnoreMissingProperty    ODL behavior ODL UndeclaredPropertyBehaviorKinds    Materializer behavior
+                // .None (let IgnoreMissingProperty decide)    True    Read&write    .SupportUndeclaredValueProperty    Silently ignore
+                // .None (let IgnoreMissingProperty decide)    False    Throw exception    .None    Throw exception
+                // .Ignore    ignore    .IgnoreUndeclaredValueProperty    Silently ignore
+                // .Support    Read&write    .SupportUndeclaredValueProperty    Silently ignore
+                if (this.Context.UndeclaredPropertyBehavior == UndeclaredPropertyBehavior.None)
+                {
+                    return this.Context.IgnoreMissingProperties
+                        ?
+                        ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty
+                        :
+                        ODataUndeclaredPropertyBehaviorKinds.None;
+                }
+                else if (this.Context.UndeclaredPropertyBehavior == UndeclaredPropertyBehavior.Discard)
+                {
+                    return ODataUndeclaredPropertyBehaviorKinds.DiscardUndeclaredValueProperty;
+                }
+                else
+                {
+                    return ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty;
+                }
             }
         }
 

--- a/src/Microsoft.OData.Client/ResponseInfo.cs
+++ b/src/Microsoft.OData.Client/ResponseInfo.cs
@@ -9,6 +9,7 @@ namespace Microsoft.OData.Client
     using System;
     using System.Diagnostics;
     using Microsoft.OData.Client.Metadata;
+    using Microsoft.OData.Core;
 
     /// <summary>
     /// Wrappers the context and only exposes information required for
@@ -60,10 +61,30 @@ namespace Microsoft.OData.Client
             get { return this.mergeOption; }
         }
 
-        /// <summary>Whether to ignore extra properties in the response payload.</summary>
-        internal bool IgnoreMissingProperties
+        /// <summary>Gets the value of UndeclaredPropertyBehaviorKinds.</summary>
+        internal ODataUndeclaredPropertyBehaviorKinds UndeclaredPropertyBehaviorKinds
         {
-            get { return this.Context.IgnoreMissingProperties; }
+            get
+            {
+                return this.Context.IgnoreMissingProperties
+                    ?
+                    ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty
+                    :
+                    ODataUndeclaredPropertyBehaviorKinds.None;
+            }
+        }
+
+        /// <summary>True if materializer should ignore undeclared value property. 
+        /// False if materializer should throw exception on that.</summary>
+        internal bool ShouldMaterializerIgnoreUndeclaredValueProperty
+        {
+            get
+            {
+                return this.UndeclaredPropertyBehaviorKinds.HasFlag(
+                            ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty)
+                    || this.UndeclaredPropertyBehaviorKinds.HasFlag(
+                            ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty);
+            }
         }
 
         /// <summary>Returns the instance of entity tracker class which tracks all the entities and links for the context.</summary>
@@ -143,9 +164,9 @@ namespace Microsoft.OData.Client
         /// <param name="entityDescriptor">Entity whose property is being loaded.</param>
         /// <param name="property">Property which is being loaded.</param>
         internal LoadPropertyResponseInfo(
-            RequestInfo requestInfo, 
-            MergeOption mergeOption, 
-            EntityDescriptor entityDescriptor, 
+            RequestInfo requestInfo,
+            MergeOption mergeOption,
+            EntityDescriptor entityDescriptor,
             ClientPropertyAnnotation property)
             : base(requestInfo, mergeOption)
         {

--- a/src/Microsoft.OData.Core/Atom/ODataAtomEntryAndFeedSerializer.cs
+++ b/src/Microsoft.OData.Core/Atom/ODataAtomEntryAndFeedSerializer.cs
@@ -299,7 +299,7 @@ namespace Microsoft.OData.Core.Atom
                 this.WriteFeedLink(
                     feed,
                     AtomConstants.AtomNextRelationAttributeValue,
-                    nextPageLink, 
+                    nextPageLink,
                     (feedMetadata) => feedMetadata == null ? null : feedMetadata.NextPageLink);
             }
         }
@@ -317,9 +317,9 @@ namespace Microsoft.OData.Core.Atom
             {
                 // <atom:link rel="http://docs.oasis-open.org/odata/ns/delta" href="delta-link" />
                 this.WriteFeedLink(
-                    feed, 
-                    AtomConstants.AtomDeltaRelationAttributeValue, 
-                    deltaLink, 
+                    feed,
+                    AtomConstants.AtomDeltaRelationAttributeValue,
+                    deltaLink,
                     (feedMetadata) => feedMetadata == null ? null : feedMetadata.Links.FirstOrDefault(link => link.Relation == AtomConstants.AtomDeltaRelationAttributeValue));
             }
         }
@@ -368,7 +368,7 @@ namespace Microsoft.OData.Core.Atom
 
             WriterValidationUtils.ValidatePropertyName(propertyName);
             duplicatePropertyNamesChecker.CheckForDuplicatePropertyNames(streamProperty);
-            IEdmProperty edmProperty = WriterValidationUtils.ValidatePropertyDefined(streamProperty.Name, owningType);
+            IEdmProperty edmProperty = WriterValidationUtils.ValidatePropertyDefined(streamProperty.Name, owningType, this.MessageWriterSettings);
             WriterValidationUtils.ValidateStreamReferenceProperty(streamProperty, edmProperty, this.WritingResponse);
             ODataStreamReferenceValue streamReferenceValue = (ODataStreamReferenceValue)streamProperty.Value;
             WriterValidationUtils.ValidateStreamReferenceValue(streamReferenceValue, false /*isDefaultStream*/);

--- a/src/Microsoft.OData.Core/Atom/ODataAtomPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/Atom/ODataAtomPropertyAndValueDeserializer.cs
@@ -89,7 +89,7 @@ namespace Microsoft.OData.Core.Atom
                 expectedPropertyTypeReference,
                 /*nullValueReadBehaviorKind*/ ODataNullValueBehaviorKind.Default);
             this.AssertRecursionDepthIsZero();
-        
+
             Debug.Assert(property != null, "If we don't ignore null values the property must not be null.");
 
             this.ReadPayloadEnd();
@@ -367,7 +367,7 @@ namespace Microsoft.OData.Core.Atom
                     case EdmTypeKind.Collection:
                         IEdmCollectionTypeReference collectionTypeReference = ValidationUtils.ValidateCollectionType(targetTypeReference);
                         result = this.ReadCollectionValue(
-                            collectionTypeReference, 
+                            collectionTypeReference,
                             payloadTypeName,
                             serializationTypeNameAnnotation);
                         break;
@@ -445,6 +445,7 @@ namespace Microsoft.OData.Core.Atom
                                 {
                                     // Lookup the property in metadata
                                     edmProperty = ReaderValidationUtils.ValidateValuePropertyDefined(this.XmlReader.LocalName, structuredType, this.MessageReaderSettings, out ignoreProperty);
+
                                     if (edmProperty != null && edmProperty.PropertyKind == EdmPropertyKind.Navigation)
                                     {
                                         throw new ODataException(ODataErrorStrings.ODataAtomPropertyAndValueDeserializer_NavigationPropertyInProperties(edmProperty.Name, structuredType));
@@ -462,13 +463,13 @@ namespace Microsoft.OData.Core.Atom
                                 {
                                     // EdmLib bridge marks all key properties as non-nullable, but Astoria allows them to be nullable.
                                     // If the property has an annotation to ignore null values, we need to omit the property in requests.
-                                    ODataNullValueBehaviorKind nullValueReadBehaviorKind = this.ReadingResponse || edmProperty == null 
-                                        ? ODataNullValueBehaviorKind.Default 
+                                    ODataNullValueBehaviorKind nullValueReadBehaviorKind = this.ReadingResponse || edmProperty == null
+                                        ? ODataNullValueBehaviorKind.Default
                                         : this.Model.NullValueReadBehaviorKind(edmProperty);
                                     ODataProperty property = this.ReadProperty(
                                         false,
                                         edmProperty == null ? null : edmProperty.Name,
-                                        edmProperty == null ? null : edmProperty.Type, 
+                                        edmProperty == null ? null : edmProperty.Type,
                                         nullValueReadBehaviorKind);
                                     Debug.Assert(
                                         property != null || nullValueReadBehaviorKind == ODataNullValueBehaviorKind.IgnoreValue,
@@ -522,8 +523,8 @@ namespace Microsoft.OData.Core.Atom
         /// </remarks>
         private ODataProperty ReadProperty(
             bool isTop,
-            string expectedPropertyName, 
-            IEdmTypeReference expectedPropertyTypeReference, 
+            string expectedPropertyName,
+            IEdmTypeReference expectedPropertyTypeReference,
             ODataNullValueBehaviorKind nullValueReadBehaviorKind)
         {
             Debug.Assert(
@@ -545,8 +546,8 @@ namespace Microsoft.OData.Core.Atom
             property.Name = propertyName;
 
             object propertyValue = this.ReadNonEntityValueImplementation(
-                expectedPropertyTypeReference, 
-                /*duplicatePropertyNamesChecker*/ null, 
+                expectedPropertyTypeReference,
+                /*duplicatePropertyNamesChecker*/ null,
                 /*collectionValidator*/ null,
                 nullValueReadBehaviorKind == ODataNullValueBehaviorKind.Default,
                 propertyName);
@@ -627,8 +628,8 @@ namespace Microsoft.OData.Core.Atom
         /// Note that this method will not read null values, those should be handled by the caller already.
         /// </remarks>
         private ODataComplexValue ReadComplexValue(
-            IEdmComplexTypeReference complexTypeReference, 
-            string payloadTypeName, 
+            IEdmComplexTypeReference complexTypeReference,
+            string payloadTypeName,
             SerializationTypeNameAnnotation serializationTypeNameAnnotation,
             DuplicatePropertyNamesChecker duplicatePropertyNamesChecker)
         {
@@ -687,7 +688,7 @@ namespace Microsoft.OData.Core.Atom
         /// Note that this method will not read null values, those should be handled by the caller already.
         /// </remarks>
         private ODataCollectionValue ReadCollectionValue(
-            IEdmCollectionTypeReference collectionTypeReference, 
+            IEdmCollectionTypeReference collectionTypeReference,
             string payloadTypeName,
             SerializationTypeNameAnnotation serializationTypeNameAnnotation)
         {
@@ -771,7 +772,7 @@ namespace Microsoft.OData.Core.Atom
                             }
                             else if (this.XmlReader.NamespaceEquals(this.XmlReader.ODataNamespace))
                             {
-                                throw new ODataException(ODataErrorStrings.ODataAtomPropertyAndValueDeserializer_InvalidCollectionElement(this.XmlReader.LocalName, this.XmlReader.ODataMetadataNamespace));  
+                                throw new ODataException(ODataErrorStrings.ODataAtomPropertyAndValueDeserializer_InvalidCollectionElement(this.XmlReader.LocalName, this.XmlReader.ODataMetadataNamespace));
                             }
                             else
                             {

--- a/src/Microsoft.OData.Core/Atom/ODataAtomPropertyAndValueSerializer.cs
+++ b/src/Microsoft.OData.Core/Atom/ODataAtomPropertyAndValueSerializer.cs
@@ -516,7 +516,7 @@ namespace Microsoft.OData.Core.Atom
 
             WriterValidationUtils.ValidatePropertyName(propertyName);
             duplicatePropertyNamesChecker.CheckForDuplicatePropertyNames(property);
-            IEdmProperty edmProperty = WriterValidationUtils.ValidatePropertyDefined(propertyName, owningType);
+            IEdmProperty edmProperty = WriterValidationUtils.ValidatePropertyDefined(propertyName, owningType, this.MessageWriterSettings);
             IEdmTypeReference propertyTypeReference = edmProperty == null ? null : edmProperty.Type;
 
             if (value is ODataStreamReferenceValue)

--- a/src/Microsoft.OData.Core/Atom/ODataAtomReader.cs
+++ b/src/Microsoft.OData.Core/Atom/ODataAtomReader.cs
@@ -36,9 +36,9 @@ namespace Microsoft.OData.Core.Atom
         /// <param name="expectedEntityType">The expected entity type for the entry to be read (in case of entry reader) or entries in the feed to be read (in case of feed reader).</param>
         /// <param name="readingFeed">true if the reader is created for reading a feed; false when it is created for reading an entry.</param>
         internal ODataAtomReader(
-            ODataAtomInputContext atomInputContext, 
-            IEdmNavigationSource navigationSource, 
-            IEdmEntityType expectedEntityType, 
+            ODataAtomInputContext atomInputContext,
+            IEdmNavigationSource navigationSource,
+            IEdmEntityType expectedEntityType,
             bool readingFeed)
             : base(atomInputContext, readingFeed, false /*readingDelta*/, null /*listener*/)
         {
@@ -412,21 +412,31 @@ namespace Microsoft.OData.Core.Atom
                     if (navigationProperty == null && this.atomInputContext.Model.IsUserModel() &&
                         this.atomInputContext.MessageReaderSettings.ReportUndeclaredLinkProperties)
                     {
-                        // Undeclared navigation link with content which we should read anyway.
-                        // If we are to ignore value properties, then skip the content and read the link only as deferred link, otherwise fail.
-                        if (this.atomInputContext.MessageReaderSettings.ShouldIgnoreUndeclaredProperty())
+                        if (this.atomInputContext.MessageReaderSettings.NeedRunLegacyPropertyHandling())
                         {
-                            // The reader is positioned on some element inside the link (either </m:inline> or <entry> or <feed>)
-                            // So we need to read until we find the end-element for the link and skip everything in between.
-                            this.atomEntryAndFeedDeserializer.SkipNavigationLinkContentOnExpansion();
+                            // Undeclared navigation link with content which we should read anyway.
+                            // If we are to ignore value properties, then skip the content and read the link only as deferred link, otherwise fail.
+                            if (this.atomInputContext.MessageReaderSettings.NeedIgnoreLegacyUndeclaredProperty())
+                            {
+                                // The reader is positioned on some element inside the link (either </m:inline> or <entry> or <feed>)
+                                // So we need to read until we find the end-element for the link and skip everything in between.
+                                this.atomEntryAndFeedDeserializer.SkipNavigationLinkContentOnExpansion();
 
-                            // And report it as a deferred link.
-                            this.ReadAtNonExpandedNavigationLinkStart();
-                            return true;
+                                // And report it as a deferred link.
+                                this.ReadAtNonExpandedNavigationLinkStart();
+                                return true;
+                            }
+                            else
+                            {
+                                throw new ODataException(ODataErrorStrings.ValidationUtils_PropertyDoesNotExistOnType(currentNavigationLink.Name, this.LinkParentEntityScope.EntityType.FullTypeName()));
+                            }
                         }
                         else
                         {
-                            throw new ODataException(ODataErrorStrings.ValidationUtils_PropertyDoesNotExistOnType(currentNavigationLink.Name, this.LinkParentEntityScope.EntityType.FullTypeName()));
+                            // ignore for atom
+                            this.atomEntryAndFeedDeserializer.SkipNavigationLinkContentOnExpansion();
+                            this.ReadAtNonExpandedNavigationLinkStart();
+                            return true;
                         }
                     }
                 }

--- a/src/Microsoft.OData.Core/Atom/ODataAtomReader.cs
+++ b/src/Microsoft.OData.Core/Atom/ODataAtomReader.cs
@@ -414,7 +414,7 @@ namespace Microsoft.OData.Core.Atom
                     {
                         // Undeclared navigation link with content which we should read anyway.
                         // If we are to ignore value properties, then skip the content and read the link only as deferred link, otherwise fail.
-                        if (this.atomInputContext.MessageReaderSettings.IgnoreUndeclaredValueProperties)
+                        if (this.atomInputContext.MessageReaderSettings.ShouldIgnoreUndeclaredProperty())
                         {
                             // The reader is positioned on some element inside the link (either </m:inline> or <entry> or <feed>)
                             // So we need to read until we find the end-element for the link and skip everything in between.

--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -1000,6 +1000,9 @@
     <Compile Include="$(ODataCrossTargettingSourcePath)\ODataUndeclaredPropertyBehaviorKinds.cs">
       <Link>Microsoft\OData\Core\ODataUndeclaredPropertyBehaviorKinds.cs</Link>
     </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\ODataUndeclaredPropertyValue.cs">
+      <Link>Microsoft\OData\Core\ODataUndeclaredPropertyValue.cs</Link>
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\ODataUntypedValue.cs">
       <Link>Microsoft\OData\Core\ODataUntypedValue.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -367,6 +367,9 @@
     <Compile Include="$(ODataCrossTargettingSourcePath)\IPrimitiveTypeConverter.cs">
       <Link>Microsoft\OData\Core\IPrimitiveTypeConverter.cs</Link>
     </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\IMessageValidationSetting.cs">
+      <Link>Microsoft\OData\Core\IMessageValidationSetting.cs</Link>
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\InstanceAnnotationWriteTracker.cs">
       <Link>Microsoft\OData\Core\InstanceAnnotationWriteTracker.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -487,6 +487,9 @@
     <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ODataJsonLightPropertySerializer.cs">
       <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightPropertySerializer.cs</Link>
     </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ODataJsonLightRawAnnotationSet.cs">
+      <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightRawAnnotationSet.cs</Link>
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ODataJsonLightReader.cs">
       <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightReader.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/IMessageValidationSetting.cs
+++ b/src/Microsoft.OData.Core/IMessageValidationSetting.cs
@@ -1,0 +1,35 @@
+//---------------------------------------------------------------------
+// <copyright file="IMessageValidationSetting.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Core
+{
+    #region Namespaces
+    using System;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using System.Linq;
+    using Microsoft.OData.Core.Metadata;
+    using Microsoft.OData.Edm;
+    #endregion Namespaces
+
+    /// <summary>
+    /// Settings for validating OData content (applicable for readers and writers).
+    /// </summary>
+    internal interface IMessageValidationSetting
+    {
+        /// <summary>
+        /// If set to true, all the validation would be enabled. Else some validation will be skipped.
+        /// Default to true.
+        /// </summary>
+        bool EnableFullValidation { get; set; }
+
+        /// <summary>
+        /// Gets or sets UndeclaredPropertyBehaviorKinds.
+        /// </summary>
+        ODataUndeclaredPropertyBehaviorKinds UndeclaredPropertyBehaviorKinds { get; set; }
+    }
+}

--- a/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
@@ -173,7 +173,6 @@ namespace Microsoft.OData.Core.Json
             }
         }
 
-#if DEBUG
         /// <summary>
         /// Flag indicating whether buffering is on or off; debug-only for use in asserts.
         /// </summary>
@@ -184,7 +183,7 @@ namespace Microsoft.OData.Core.Json
                 return this.isBuffering;
             }
         }
-#endif
+
         /// <summary>
         /// Reads the next node from the input.
         /// </summary>

--- a/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
@@ -103,6 +103,33 @@ namespace Microsoft.OData.Core.Json
         }
 
         /// <summary>
+        /// The raw value (string or char) of the last reported node.
+        /// </summary>
+        /// <remarks>
+        /// Depending on whether buffering is on or off this will return the node raw value of the last
+        /// buffered read or the node raw value of the last unbuffered read.
+        /// </remarks>
+        public override string RawValue
+        {
+            get
+            {
+                if (this.bufferedNodesHead != null)
+                {
+                    if (this.isBuffering)
+                    {
+                        Debug.Assert(this.currentBufferedNode != null, "this.currentBufferedNode != null");
+                        return this.currentBufferedNode.RawValue;
+                    }
+
+                    // in non-buffering mode if we have buffered nodes satisfy the request from the first node there
+                    return this.bufferedNodesHead.RawValue;
+                }
+
+                return base.RawValue;
+            }
+        }
+
+        /// <summary>
         /// The value of the last reported node.
         /// </summary>
         /// <remarks>
@@ -180,7 +207,7 @@ namespace Microsoft.OData.Core.Json
             if (this.bufferedNodesHead == null)
             {
                 // capture the current state of the reader as the first item in the buffer (if there are none)
-                this.bufferedNodesHead = new BufferedNode(base.NodeType, base.Value);
+                this.bufferedNodesHead = new BufferedNode(base.NodeType, base.Value, base.RawValue);
             }
             else
             {
@@ -270,7 +297,7 @@ namespace Microsoft.OData.Core.Json
                 return this.TryReadInStreamErrorPropertyValue(out error);
             }
             finally
-            { 
+            {
                 this.StopBuffering();
                 this.parsingInStreamError = false;
             }
@@ -315,7 +342,7 @@ namespace Microsoft.OData.Core.Json
                         result = base.Read();
 
                         // Add the new node to the end
-                        BufferedNode newNode = new BufferedNode(base.NodeType, base.Value);
+                        BufferedNode newNode = new BufferedNode(base.NodeType, base.Value, base.RawValue);
                         newNode.Previous = this.bufferedNodesHead.Previous;
                         newNode.Next = this.bufferedNodesHead;
                         this.bufferedNodesHead.Previous.Next = newNode;
@@ -566,7 +593,7 @@ namespace Microsoft.OData.Core.Json
 
                         error.Details = details;
                         break;
-                    
+
                     case JsonConstants.ODataErrorInnerErrorName:
                         if (!ODataJsonLightReaderUtils.ErrorPropertyNotFound(ref propertiesFoundBitmask, ODataJsonLightReaderUtils.ErrorPropertyBitMask.InnerError))
                         {
@@ -966,6 +993,9 @@ namespace Microsoft.OData.Core.Json
             /// <summary>The type of the node read.</summary>
             private readonly JsonNodeType nodeType;
 
+            /// <summary>The Json raw value of the node.</summary>
+            private readonly string nodeRawValue;
+
             /// <summary>The value of the node.</summary>
             private readonly object nodeValue;
 
@@ -974,9 +1004,11 @@ namespace Microsoft.OData.Core.Json
             /// </summary>
             /// <param name="nodeType">The type of the node read.</param>
             /// <param name="value">The value of the node.</param>
-            internal BufferedNode(JsonNodeType nodeType, object value)
+            /// <param name="rawValue">The Json raw string or char of the node.</param>
+            internal BufferedNode(JsonNodeType nodeType, object value, string rawValue)
             {
                 this.nodeType = nodeType;
+                this.nodeRawValue = rawValue;
                 this.nodeValue = value;
                 this.Previous = this;
                 this.Next = this;
@@ -990,6 +1022,17 @@ namespace Microsoft.OData.Core.Json
                 get
                 {
                     return this.nodeType;
+                }
+            }
+
+            /// <summary>
+            /// The raw value (string or char) of the node.
+            /// </summary>
+            internal string RawValue
+            {
+                get
+                {
+                    return this.nodeRawValue;
                 }
             }
 

--- a/src/Microsoft.OData.Core/Json/JsonReaderExtensions.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReaderExtensions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.OData.Core.Json
     #region Namespaces
     using System;
     using System.Diagnostics;
+    using System.Text;
     using Microsoft.OData.Core.JsonLight;
 
 #if SPATIAL
@@ -194,6 +195,16 @@ namespace Microsoft.OData.Core.Json
         /// </remarks>
         internal static void SkipValue(this JsonReader jsonReader)
         {
+            SkipValue(jsonReader, null);
+        }
+
+        /// <summary>
+        /// Skips over a JSON value (primitive, object or array), and append raw string to StringBuilder.
+        /// </summary>
+        /// <param name="jsonReader">The <see cref="JsonReader"/> to read from.</param>
+        /// <param name="jsonRawValueStringBuilder">The StringBuilder to receive JSON raw string.</param>
+        internal static void SkipValue(this JsonReader jsonReader, StringBuilder jsonRawValueStringBuilder)
+        {
             Debug.Assert(jsonReader != null, "jsonReader != null");
 
             int depth = 0;
@@ -217,6 +228,11 @@ namespace Microsoft.OData.Core.Json
                             jsonReader.NodeType != JsonNodeType.EndOfInput,
                             "We should not have reached end of input, since the scopes should be well formed. Otherwise JsonReader should have failed by now.");
                         break;
+                }
+
+                if (jsonRawValueStringBuilder != null)
+                {
+                    jsonRawValueStringBuilder.Append(jsonReader.RawValue);
                 }
 
                 jsonReader.ReadNext();

--- a/src/Microsoft.OData.Core/JsonLight/IODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/IODataJsonLightValueSerializer.cs
@@ -82,6 +82,13 @@ namespace Microsoft.OData.Core.JsonLight
             IEdmTypeReference expectedTypeReference);
 
         /// <summary>
+        /// Writes an undeclared property value.
+        /// </summary>
+        /// <param name="value">The undeclared property value to write.</param>
+        void WriteUndeclaredPropertyValue(
+            ODataUndeclaredPropertyValue value);
+
+        /// <summary>
         /// Writes an untyped value.
         /// </summary>
         /// <param name="value">The untyped value to write.</param>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightEntryAndFeedDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightEntryAndFeedDeserializer.cs
@@ -1382,7 +1382,7 @@ namespace Microsoft.OData.Core.JsonLight
                 {
                     StringBuilder builder = new StringBuilder();
                     this.JsonReader.SkipValue(builder);
-                    propertyValue = new ODataUntypedValue()
+                    propertyValue = new ODataUndeclaredPropertyValue()
                     {
                         RawValue = builder.ToString()
                     };
@@ -1402,7 +1402,7 @@ namespace Microsoft.OData.Core.JsonLight
             {
                 ValidationUtils.ValidateOpenPropertyValue(propertyName, propertyValue);
                 ODataProperty property = AddEntryProperty(entryState, propertyName, propertyValue);
-                bool isTruelyUndeclaredPropertyInOpenEntity = (propertyValue is ODataUntypedValue);
+                bool isTruelyUndeclaredPropertyInOpenEntity = (propertyValue is ODataUndeclaredPropertyValue);
                 if (isTruelyUndeclaredPropertyInOpenEntity && (entryState.DuplicatePropertyNamesChecker != null))
                 {
                     TryAttachRawAnnotationSetToPropertyValue(entryState.DuplicatePropertyNamesChecker.AnnotationCollector, property);

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightEntryAndFeedDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightEntryAndFeedDeserializer.cs
@@ -12,12 +12,12 @@ namespace Microsoft.OData.Core.JsonLight
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using System.Text;
     using Microsoft.OData.Core.Evaluation;
     using Microsoft.OData.Core.Json;
     using Microsoft.OData.Core.Metadata;
     using Microsoft.OData.Edm;
     using ODataErrorStrings = Microsoft.OData.Core.Strings;
-
     #endregion Namespaces
 
     /// <summary>
@@ -1252,6 +1252,8 @@ namespace Microsoft.OData.Core.JsonLight
         /// Read an open property.
         /// </summary>
         /// <param name="entryState">The state of the reader for entry to read.</param>
+        /// <param name="owningStructuredType">The owning type of the property with name <paramref name="propertyName"/> 
+        /// or null if no metadata is available.</param>
         /// <param name="propertyName">The name of the open property to read.</param>
         /// <param name="propertyWithValue">true if the property has a value, false if it doesn't.</param>
         /// <remarks>
@@ -1259,7 +1261,7 @@ namespace Microsoft.OData.Core.JsonLight
         /// Post-Condition: JsonNodeType.Property:    the next property of the entry
         ///                 JsonNodeType.EndObject:   the end-object node of the entry
         /// </remarks>
-        private void ReadOpenProperty(IODataJsonLightReaderEntryState entryState, string propertyName, bool propertyWithValue)
+        private void InnerReadOpenUndeclaredProperty(IODataJsonLightReaderEntryState entryState, IEdmStructuredType owningStructuredType, string propertyName, bool propertyWithValue)
         {
             Debug.Assert(entryState != null, "entryState != null");
             Debug.Assert(!string.IsNullOrEmpty(propertyName), "!string.IsNullOrEmpty(propertyName)");
@@ -1271,21 +1273,134 @@ namespace Microsoft.OData.Core.JsonLight
                 throw new ODataException(ODataErrorStrings.ODataJsonLightEntryAndFeedDeserializer_OpenPropertyWithoutValue(propertyName));
             }
 
-            string propertyTypeName = ValidateDataPropertyTypeNameAnnotation(entryState.DuplicatePropertyNamesChecker, propertyName);
+            object propertyValue = null;
+            bool needAddPropertyValue = false;
+            if (this.MessageReaderSettings.NeedRunLegacyPropertyHandling())
+            {
+                string propertyTypeName = ValidateDataPropertyTypeNameAnnotation(entryState.DuplicatePropertyNamesChecker, propertyName);
+                propertyValue = this.ReadNonEntityValue(
+                    propertyTypeName,
+                    /*expectedValueTypeReference*/ null,
+                    /*duplicatePropertyNamesChecker*/ null,
+                    /*collectionValidator*/ null,
+                    /*validateNullValue*/ true,
+                    /*isTopLevelPropertyValue*/ false,
+                    /*insideComplexValue*/ false,
+                    propertyName,
+                    true);
+                needAddPropertyValue = true;
+            }
+            else
+            {
+                // Now we know the property name is undeclared, but not sure if property value type is known/unknown.
+                // For any Property in OPEN complex / entity :
+                // Property name     Property value type     Deserialized result
+                // unknown     Known (including string/numeric)     Primitive/ODataValue
+                // unknown     Unknown(no/unrecognized odata.type)     ODataUntypedValue
+                // known     inconsistent with model     Throw exception
+                bool insideComplexValue = false;
+                string outterPayloadTypeName = ValidateDataPropertyTypeNameAnnotation(entryState.DuplicatePropertyNamesChecker, propertyName);
+                string payloadTypeName = TryReadOrPeekPayloadType(entryState.DuplicatePropertyNamesChecker, propertyName, insideComplexValue);
+                EdmTypeKind payloadTypeKind;
+                IEdmType payloadType = ReaderValidationUtils.ResolvePayloadTypeName(
+                    this.Model,
+                    null, // expectedTypeReference
+                    payloadTypeName,
+                    EdmTypeKind.Complex,
+                    this.MessageReaderSettings.ReaderBehavior,
+                    out payloadTypeKind);
+                IEdmTypeReference payloadTypeReference = null;
+                if (!string.IsNullOrEmpty(payloadTypeName) && payloadType != null)
+                {
+                    // only try resolving for known type (the below will throw on unknown type name) :
+                    SerializationTypeNameAnnotation serializationTypeNameAnnotation;
+                    EdmTypeKind targetTypeKind;
+                    payloadTypeReference = ReaderValidationUtils.ResolvePayloadTypeNameAndComputeTargetType(
+                        EdmTypeKind.None,
+                        /*defaultPrimitivePayloadType*/ null,
+                        null, // expectedTypeReference 
+                        payloadTypeName,
+                        this.Model,
+                        this.MessageReaderSettings,
+                        this.GetNonEntityValueKind,
+                        out targetTypeKind,
+                        out serializationTypeNameAnnotation);
+                }
 
-            object propertyValue = this.ReadNonEntityValue(
-                propertyTypeName,
-                /*expectedValueTypeReference*/ null,
-                /*duplicatePropertyNamesChecker*/ null,
-                /*collectionValidator*/ null,
-                /*validateNullValue*/ true,
-                /*isTopLevelPropertyValue*/ false,
-                /*insideComplexValue*/ false,
-                propertyName,
-                true);
+                bool isKnownValueType = IsKnownValueTypeForOpenEntityOrComplex(this.JsonReader.NodeType, this.JsonReader.Value, payloadTypeName, payloadTypeReference);
+                if (isKnownValueType)
+                {
+                    bool validateNullValue = true;
+                    if (ODataJsonReaderCoreUtils.TryReadNullValue(this.JsonReader, this.JsonLightInputContext, payloadTypeReference, validateNullValue, propertyName))
+                    {
+                        bool isTopLevelPropertyValue = false;
+                        if (isTopLevelPropertyValue)
+                        {
+                            // For a top-level property value a special null marker object has to be used to indicate  a null value.
+                            // If we find a null value for a property at the top-level, it is an invalid payload
+                            throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_TopLevelPropertyWithPrimitiveNullValue(ODataAnnotationNames.ODataNull, JsonLightConstants.ODataNullAnnotationTrueValue));
+                        }
 
-            ValidationUtils.ValidateOpenPropertyValue(propertyName, propertyValue);
-            AddEntryProperty(entryState, propertyName, propertyValue);
+                        propertyValue = null;
+                    }
+                    else
+                    {
+                        this.JsonReader.AssertNotBuffering();
+                        propertyValue = this.ReadNonEntityValue(
+                            outterPayloadTypeName,
+                            /*expectedValueTypeReference*/ null,
+                            /*duplicatePropertyNamesChecker*/ null,
+                            /*collectionValidator*/ null,
+                            /*validateNullValue*/ true,
+                            /*isTopLevelPropertyValue*/ false,
+                            /*insideComplexValue*/ false,
+                            propertyName);
+                    }
+
+                    needAddPropertyValue = true;
+                }
+                else if (this.MessageReaderSettings.ShouldThrowOnUndeclaredProperty())
+                {
+                    // throw specific exceptions for backward compatibility
+                    if (!string.IsNullOrEmpty(payloadTypeName) && payloadTypeReference == null)
+                    {
+                        throw new ODataException(ODataErrorStrings.ValidationUtils_UnrecognizedTypeName(payloadTypeName));
+                    }
+
+                    if (string.IsNullOrEmpty(payloadTypeName)
+                        && (this.JsonReader.NodeType == JsonNodeType.StartObject
+                            || this.JsonReader.NodeType == JsonNodeType.StartArray))
+                    {
+                        throw new ODataException(ODataErrorStrings.ReaderValidationUtils_ValueWithoutType);
+                    }
+
+                    throw new ODataException(ODataErrorStrings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, owningStructuredType.FullTypeName()));
+                }
+                else if (this.MessageReaderSettings.ShouldSupportUndeclaredProperty())
+                {
+                    StringBuilder builder = new StringBuilder();
+                    this.JsonReader.SkipValue(builder);
+                    propertyValue = new ODataUntypedValue()
+                    {
+                        RawValue = builder.ToString()
+                    };
+                    needAddPropertyValue = true;
+                }
+                else
+                {
+                    Debug.Assert(
+                        this.MessageReaderSettings.ShouldIgnoreUndeclaredProperty(),
+                        "this.MessageReaderSettings.ShouldIgnoreUndeclaredProperty()");
+                    this.JsonReader.SkipValue();
+                    needAddPropertyValue = false;
+                }
+            }
+
+            if (needAddPropertyValue)
+            {
+                ValidationUtils.ValidateOpenPropertyValue(propertyName, propertyValue);
+                AddEntryProperty(entryState, propertyName, propertyValue);
+            }
 
             this.JsonReader.AssertNotBuffering();
             Debug.Assert(
@@ -1330,7 +1445,7 @@ namespace Microsoft.OData.Core.JsonLight
                 if (entryState.EntityType.IsOpen)
                 {
                     // Open property - read it as such.
-                    this.ReadOpenProperty(entryState, propertyName, propertyWithValue);
+                    this.InnerReadOpenUndeclaredProperty(entryState, entryState.EntityType, propertyName, propertyWithValue);
                     return null;
                 }
             }
@@ -1360,7 +1475,8 @@ namespace Microsoft.OData.Core.JsonLight
                     // If the property is expanded, ignore the content if we're asked to do so.
                     if (propertyWithValue)
                     {
-                        if (this.MessageReaderSettings.ShouldThrowOnUndeclaredProperty())
+                        if ((this.MessageReaderSettings.NeedRunLegacyPropertyHandling() && !this.MessageReaderSettings.NeedIgnoreLegacyUndeclaredProperty())
+                            || this.MessageReaderSettings.ShouldThrowOnUndeclaredProperty())
                         {
                             throw new ODataException(ODataErrorStrings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, entryState.EntityType.FullTypeName()));
                         }
@@ -1404,7 +1520,7 @@ namespace Microsoft.OData.Core.JsonLight
             if (entryState.EntityType.IsOpen)
             {
                 // Open property - read it as such.
-                this.ReadOpenProperty(entryState, propertyName, propertyWithValue);
+                this.InnerReadOpenUndeclaredProperty(entryState, entryState.EntityType, propertyName, propertyWithValue);
                 return null;
             }
 
@@ -1415,7 +1531,8 @@ namespace Microsoft.OData.Core.JsonLight
             }
 
             // Property with value can only be ignored if we're asked to do so.
-            if (this.MessageReaderSettings.ShouldThrowOnUndeclaredProperty())
+            if ((this.MessageReaderSettings.NeedRunLegacyPropertyHandling() && !this.MessageReaderSettings.NeedIgnoreLegacyUndeclaredProperty())
+                || this.MessageReaderSettings.ShouldThrowOnUndeclaredProperty())
             {
                 throw new ODataException(ODataErrorStrings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, entryState.EntityType.FullTypeName()));
             }
@@ -1424,8 +1541,30 @@ namespace Microsoft.OData.Core.JsonLight
             // We ignore the type name since we might not have the full model and thus might not be able to resolve it correctly.
             ValidateDataPropertyTypeNameAnnotation(entryState.DuplicatePropertyNamesChecker, propertyName);
 
-            // Read it as such.
-            this.ReadOpenProperty(entryState, propertyName, propertyWithValue);
+            if (this.MessageReaderSettings.NeedRunLegacyPropertyHandling())
+            {
+                // legacy logic: 
+                // will read non-open entity's undeclared primitives as ODataValue instead of ODataUntypedValue.
+                this.InnerReadOpenUndeclaredProperty(entryState, entryState.EntityType, propertyName, propertyWithValue);
+            }
+            else if (this.MessageReaderSettings.ShouldSupportUndeclaredProperty())
+            {
+                bool isTopLevelPropertyValue = false; // for undeclared: least verification
+
+                // new logic: 
+                // will read non-open entity's undeclared primitives as *ODataUntypedValue* instead of ODataValue.
+                object propertyValue = this.InnerReadNonOpenUndeclaredProperty(entryState.DuplicatePropertyNamesChecker, propertyName, isTopLevelPropertyValue);
+                AddEntryProperty(entryState, propertyName, propertyValue);
+            }
+            else
+            {
+                // Ignore the property value
+                Debug.Assert(
+                    this.MessageReaderSettings.ShouldIgnoreUndeclaredProperty(),
+                    "this.MessageReaderSettings.ShouldIgnoreUndeclaredProperty()");
+                this.JsonReader.SkipValue();
+            }
+
             return null;
         }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightEntryAndFeedDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightEntryAndFeedDeserializer.cs
@@ -1360,7 +1360,7 @@ namespace Microsoft.OData.Core.JsonLight
                     // If the property is expanded, ignore the content if we're asked to do so.
                     if (propertyWithValue)
                     {
-                        if (!this.MessageReaderSettings.IgnoreUndeclaredValueProperties)
+                        if (this.MessageReaderSettings.ShouldThrowOnUndeclaredProperty())
                         {
                             throw new ODataException(ODataErrorStrings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, entryState.EntityType.FullTypeName()));
                         }
@@ -1415,7 +1415,7 @@ namespace Microsoft.OData.Core.JsonLight
             }
 
             // Property with value can only be ignored if we're asked to do so.
-            if (!this.MessageReaderSettings.IgnoreUndeclaredValueProperties)
+            if (this.MessageReaderSettings.ShouldThrowOnUndeclaredProperty())
             {
                 throw new ODataException(ODataErrorStrings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, entryState.EntityType.FullTypeName()));
             }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -358,7 +358,7 @@ namespace Microsoft.OData.Core.JsonLight
             {
                 StringBuilder builder = new StringBuilder();
                 this.JsonReader.SkipValue(builder);
-                ODataUntypedValue tmp = new ODataUntypedValue()
+                ODataUndeclaredPropertyValue tmp = new ODataUndeclaredPropertyValue()
                 {
                     RawValue = builder.ToString()
                 };
@@ -527,7 +527,7 @@ namespace Microsoft.OData.Core.JsonLight
                     annotationCollector.GetPropertyRawAnnotationSet(property.Name);
                 if (rawAnnotations != null)
                 {
-                    ODataUntypedValue untypedValue = property.Value as ODataUntypedValue;
+                    ODataUndeclaredPropertyValue untypedValue = property.Value as ODataUndeclaredPropertyValue;
                     ODataAnnotatable valueTmp = (ODataAnnotatable)untypedValue ?? (ODataAnnotatable)property.ODataValue;
                     if (valueTmp != null)
                     {

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -182,7 +182,7 @@ namespace Microsoft.OData.Core.JsonLight
                     return true;
                 }
 
-                if (!(property.Value is ODataUntypedValue))
+                if (!(property.Value is ODataUndeclaredPropertyValue))
                 {
                     return true;
                 }
@@ -271,13 +271,13 @@ namespace Microsoft.OData.Core.JsonLight
                 }
 
                 // handle ODataUntypedValue
-                ODataUntypedValue untypedValue = property.Value as ODataUntypedValue;
-                if (untypedValue != null)
+                ODataUndeclaredPropertyValue undeclaredValue = property.Value as ODataUndeclaredPropertyValue;
+                if (undeclaredValue != null)
                 {
                     if (this.MessageWriterSettings.ShouldSupportUndeclaredProperty())
                     {
                         this.JsonWriter.WriteName(wirePropertyName);
-                        this.jsonLightValueSerializer.WriteUntypedValue(untypedValue);
+                        this.jsonLightValueSerializer.WriteUndeclaredPropertyValue(undeclaredValue);
                     }
 
                     return;
@@ -359,6 +359,7 @@ namespace Microsoft.OData.Core.JsonLight
             }
 
             ODataCollectionValue collectionValue = value as ODataCollectionValue;
+            ODataUntypedValue untypedValue = null;
             if (collectionValue != null)
             {
                 if (!alreadyWroteODataType)
@@ -371,6 +372,11 @@ namespace Microsoft.OData.Core.JsonLight
 
                 // passing false for 'isTopLevel' because the outer wrapping object has already been written.
                 this.JsonLightValueSerializer.WriteCollectionValue(collectionValue, propertyTypeReference, isTopLevel, false /*isInUri*/, isOpenPropertyType);
+            }
+            else if ((untypedValue = value as ODataUntypedValue) != null)
+            {
+                this.JsonWriter.WriteName(wirePropertyName);
+                this.JsonLightValueSerializer.WriteUntypedValue(untypedValue);
             }
             else
             {
@@ -396,7 +402,7 @@ namespace Microsoft.OData.Core.JsonLight
         /// <returns>True if raw annotations have been written.</returns>
         private bool TryWriteRawAnnotations(ODataProperty property, out bool isODataTypeWritten)
         {
-            ODataUntypedValue untypedValueTmp = property.Value as ODataUntypedValue;
+            ODataUndeclaredPropertyValue untypedValueTmp = property.Value as ODataUndeclaredPropertyValue;
             ODataAnnotatable annotatableValue = (ODataAnnotatable)untypedValueTmp ?? (ODataAnnotatable)property.ODataValue;
             isODataTypeWritten = false;
             if (annotatableValue != null)

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -187,11 +187,11 @@ namespace Microsoft.OData.Core.JsonLight
                 }
             }
 
+            // !this.WritingResponse => null => to throw on undeclared property
             IEdmProperty edmProperty = WriterValidationUtils.ValidatePropertyDefined(
                 propertyName,
                 owningType,
-                !(this.bypassValidation || this.WritingResponse));
-
+                this.WritingResponse ? this.JsonLightOutputContext.MessageWriterSettings : null);
             IEdmTypeReference propertyTypeReference = edmProperty == null ? null : edmProperty.Type;
 
             ODataValue value = property.ODataValue;

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -11,10 +11,9 @@ namespace Microsoft.OData.Core.JsonLight
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
     using System.Linq;
-    using Microsoft.Spatial;
     using Microsoft.OData.Edm;
-    using Microsoft.OData.Core.Json;
     using Microsoft.OData.Core.Metadata;
     using ODataErrorStrings = Microsoft.OData.Core.Strings;
     #endregion Namespaces
@@ -151,9 +150,11 @@ namespace Microsoft.OData.Core.JsonLight
         /// <param name="owningType">The IEdmStructuredType</param>
         /// <param name="property">The ODataProperty to be written.</param>
         /// <param name="edmProperty">The found edm information in model.</param>
+        /// <param name="shouldWriteRawAnnotations">Outputs if should write raw annotations.</param>
         /// <returns>True if should write property.</returns>
-        private bool ShouldWriteProperty(IEdmStructuredType owningType, ODataProperty property, IEdmProperty edmProperty)
+        private bool ShouldWriteProperty(IEdmStructuredType owningType, ODataProperty property, IEdmProperty edmProperty, out bool shouldWriteRawAnnotations)
         {
+            shouldWriteRawAnnotations = false;
             if (owningType == null)
             {
                 return true; // for top level property
@@ -190,6 +191,7 @@ namespace Microsoft.OData.Core.JsonLight
             // for non-open owning type, or for open owning type where value type is unknown, like ODataUntypedValue.
             if (this.MessageWriterSettings.ShouldSupportUndeclaredProperty())
             {
+                shouldWriteRawAnnotations = true;
                 return true;
             }
 
@@ -254,11 +256,18 @@ namespace Microsoft.OData.Core.JsonLight
 
             string wirePropertyName = isTopLevel ? JsonLightConstants.ODataValuePropertyName : propertyName;
             IEdmTypeReference propertyTypeReference = edmProperty == null ? null : edmProperty.Type;
+            bool alreadyWroteODataType = false;
             if (!this.MessageWriterSettings.NeedRunLegacyPropertyHandling())
             {
-                if (!ShouldWriteProperty(owningType, property, edmProperty))
+                bool shouldWriteRawAnnotations = false;
+                if (!ShouldWriteProperty(owningType, property, edmProperty, out shouldWriteRawAnnotations))
                 {
                     return;
+                }
+
+                if (shouldWriteRawAnnotations)
+                {
+                    TryWriteRawAnnotations(property, out alreadyWroteODataType);
                 }
 
                 // handle ODataUntypedValue
@@ -333,13 +342,17 @@ namespace Microsoft.OData.Core.JsonLight
             ODataEnumValue enumValue = value as ODataEnumValue;
             if (enumValue != null)
             {
-                // This is a work around, needTypeOnWire always = true for client side: 
-                // ClientEdmModel's reflection can't know a property is open type even if it is, so here 
-                // make client side always write 'odata.type' for enum.
-                bool needTypeOnWire = string.Equals(this.JsonLightOutputContext.Model.GetType().Name, "ClientEdmModel", StringComparison.OrdinalIgnoreCase);
-                string typeNameToWrite = this.JsonLightOutputContext.TypeNameOracle.GetValueTypeNameForWriting(
-                    enumValue, propertyTypeReference, typeFromValue, needTypeOnWire ? true /* leverage this flag to write 'odata.type' */ : isOpenPropertyType);
-                this.WritePropertyTypeName(wirePropertyName, typeNameToWrite, isTopLevel);
+                if (!alreadyWroteODataType)
+                {
+                    // This is a work around, needTypeOnWire always = true for client side: 
+                    // ClientEdmModel's reflection can't know a property is open type even if it is, so here 
+                    // make client side always write 'odata.type' for enum.
+                    bool needTypeOnWire = string.Equals(this.JsonLightOutputContext.Model.GetType().Name, "ClientEdmModel", StringComparison.OrdinalIgnoreCase);
+                    string typeNameToWrite = this.JsonLightOutputContext.TypeNameOracle.GetValueTypeNameForWriting(
+                        enumValue, propertyTypeReference, typeFromValue, needTypeOnWire ? true /* leverage this flag to write 'odata.type' */ : isOpenPropertyType);
+                    this.WritePropertyTypeName(wirePropertyName, typeNameToWrite, isTopLevel);
+                }
+
                 this.JsonWriter.WriteName(wirePropertyName);
                 this.JsonLightValueSerializer.WriteEnumValue(enumValue, propertyTypeReference);
                 return;
@@ -348,8 +361,12 @@ namespace Microsoft.OData.Core.JsonLight
             ODataCollectionValue collectionValue = value as ODataCollectionValue;
             if (collectionValue != null)
             {
-                string collectionTypeNameToWrite = this.JsonLightOutputContext.TypeNameOracle.GetValueTypeNameForWriting(collectionValue, propertyTypeReference, typeFromValue, isOpenPropertyType);
-                this.WritePropertyTypeName(wirePropertyName, collectionTypeNameToWrite, isTopLevel);
+                if (!alreadyWroteODataType)
+                {
+                    string collectionTypeNameToWrite = this.JsonLightOutputContext.TypeNameOracle.GetValueTypeNameForWriting(collectionValue, propertyTypeReference, typeFromValue, isOpenPropertyType);
+                    this.WritePropertyTypeName(wirePropertyName, collectionTypeNameToWrite, isTopLevel);
+                }
+
                 this.JsonWriter.WriteName(wirePropertyName);
 
                 // passing false for 'isTopLevel' because the outer wrapping object has already been written.
@@ -360,12 +377,55 @@ namespace Microsoft.OData.Core.JsonLight
                 ODataPrimitiveValue primitiveValue = value as ODataPrimitiveValue;
                 Debug.Assert(primitiveValue != null, "primitiveValue != null");
 
-                string typeNameToWrite = this.JsonLightOutputContext.TypeNameOracle.GetValueTypeNameForWriting(primitiveValue, propertyTypeReference, typeFromValue, isOpenPropertyType);
-                this.WritePropertyTypeName(wirePropertyName, typeNameToWrite, isTopLevel);
+                if (!alreadyWroteODataType)
+                {
+                    string typeNameToWrite = this.JsonLightOutputContext.TypeNameOracle.GetValueTypeNameForWriting(primitiveValue, propertyTypeReference, typeFromValue, isOpenPropertyType);
+                    this.WritePropertyTypeName(wirePropertyName, typeNameToWrite, isTopLevel);
+                }
 
                 this.JsonWriter.WriteName(wirePropertyName);
                 this.JsonLightValueSerializer.WritePrimitiveValue(primitiveValue.Value, propertyTypeReference);
             }
+        }
+
+        /// <summary>
+        /// Write raw annotatoins if hte property value has any.
+        /// </summary>
+        /// <param name="property">The property.</param>
+        /// <param name="isODataTypeWritten">Outputs if odata.type annotation has been written to the wire.</param>
+        /// <returns>True if raw annotations have been written.</returns>
+        private bool TryWriteRawAnnotations(ODataProperty property, out bool isODataTypeWritten)
+        {
+            ODataUntypedValue untypedValueTmp = property.Value as ODataUntypedValue;
+            ODataAnnotatable annotatableValue = (ODataAnnotatable)untypedValueTmp ?? (ODataAnnotatable)property.ODataValue;
+            isODataTypeWritten = false;
+            if (annotatableValue != null)
+            {
+                ODataJsonLightRawAnnotationSet tmpSet = annotatableValue.GetAnnotation<ODataJsonLightRawAnnotationSet>();
+                if (tmpSet != null)
+                {
+                    foreach (KeyValuePair<string, string> kvp in tmpSet.Annotations)
+                    {
+                        bool isODataType =
+                            string.Equals(kvp.Key, ODataAnnotationNames.ODataType, StringComparison.OrdinalIgnoreCase);
+                        if (isODataType && (annotatableValue is ODataComplexValue))
+                        {
+                            continue; // skip odata.type for complex value
+                        }
+
+                        this.JsonWriter.WriteName(string.Format(CultureInfo.InvariantCulture, "{0}@{1}", property.Name, kvp.Key));
+                        this.JsonWriter.WriteRawValue(kvp.Value);
+                        if (isODataType)
+                        {
+                            isODataTypeWritten = true;
+                        }
+                    }
+
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightRawAnnotationSet.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightRawAnnotationSet.cs
@@ -1,0 +1,41 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataJsonLightRawAnnotationSet.cs" company="Microsoft">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Core
+{
+    #region Namespaces
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    #endregion Namespaces
+
+    /// <summary>
+    /// Class representing a property's raw annotations in the JSON Light format.
+    /// </summary>
+    internal sealed class ODataJsonLightRawAnnotationSet
+    {
+        /// <summary>The (instance and property) annotations included in this annotation group.</summary>
+        private IDictionary<string, string> annotations;
+
+        /// <summary>
+        /// The (instance and property) annotations included in this annotation group.
+        /// </summary>
+        /// <remarks>The keys in the dictionary are the names of the annotations, the values are their values.</remarks>
+        [SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly", Justification = "We allow setting of all properties on public ODataLib OM classes.")]
+        public IDictionary<string, string> Annotations
+        {
+            get
+            {
+                return this.annotations;
+            }
+
+            set
+            {
+                this.annotations = value;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -371,6 +371,23 @@ namespace Microsoft.OData.Core.JsonLight
         }
 
         /// <summary>
+        /// Writes an undeclared property value.
+        /// </summary>
+        /// <param name="value">The undeclared property value to write.</param>
+        public void WriteUndeclaredPropertyValue(
+            ODataUndeclaredPropertyValue value)
+        {
+            Debug.Assert(value != null, "value != null");
+
+            if (string.IsNullOrEmpty(value.RawValue))
+            {
+                throw new ODataException(ODataErrorStrings.ODataJsonLightValueSerializer_MissingRawValueOnUntyped);
+            }
+
+            this.JsonWriter.WriteRawValue(value.RawValue);
+        }
+
+        /// <summary>
         /// Writes an untyped value.
         /// </summary>
         /// <param name="value">The untyped value to write.</param>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.Net45.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.Net45.csproj
@@ -223,6 +223,7 @@
     <Compile Include="Json\ODataJsonWriterUtils.cs" />
     <Compile Include="Json\TextWriterWrapper.cs" />
     <Compile Include="ODataErrorDetail.cs" />
+    <Compile Include="ODataUndeclaredPropertyValue.cs" />
     <Compile Include="ODataUntypedValue.cs" />
     <Compile Include="ODataMediaType.cs" />
     <Compile Include="ODataMediaTypeResolver.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.Net45.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.Net45.csproj
@@ -149,6 +149,7 @@
     <Compile Include="IODataResponseMessageAsync.cs" />
     <Compile Include="IODataUrlResolver.cs" />
     <Compile Include="IPrimitiveTypeConverter.cs" />
+    <Compile Include="IMessageValidationSetting.cs" />
     <Compile Include="InstanceAnnotationWriteTracker.cs" />
     <Compile Include="InternalErrorCodes.cs" />
     <Compile Include="InternalErrorCodesCommon.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.Net45.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.Net45.csproj
@@ -189,6 +189,7 @@
     <Compile Include="JsonLight\ODataJsonLightPayloadKindDetectionDeserializer.cs" />
     <Compile Include="JsonLight\ODataJsonLightPropertyAndValueDeserializer.cs" />
     <Compile Include="JsonLight\ODataJsonLightPropertySerializer.cs" />
+    <Compile Include="JsonLight\ODataJsonLightRawAnnotationSet.cs" />
     <Compile Include="JsonLight\ODataJsonLightReader.cs" />
     <Compile Include="JsonLight\ODataJsonLightReaderNavigationLinkInfo.cs" />
     <Compile Include="JsonLight\ODataJsonLightReaderUtils.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
@@ -222,6 +222,7 @@
     <Compile Include="Json\ODataJsonWriterUtils.cs" />
     <Compile Include="Json\TextWriterWrapper.cs" />
     <Compile Include="ODataErrorDetail.cs" />
+    <Compile Include="ODataUndeclaredPropertyValue.cs" />
     <Compile Include="ODataUntypedValue.cs" />
     <Compile Include="ODataMediaType.cs" />
     <Compile Include="ODataMediaTypeResolver.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
@@ -148,6 +148,7 @@
     <Compile Include="IODataResponseMessageAsync.cs" />
     <Compile Include="IODataUrlResolver.cs" />
     <Compile Include="IPrimitiveTypeConverter.cs" />
+    <Compile Include="IMessageValidationSetting.cs" />
     <Compile Include="InstanceAnnotationWriteTracker.cs" />
     <Compile Include="InternalErrorCodes.cs" />
     <Compile Include="InternalErrorCodesCommon.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
@@ -617,7 +617,7 @@
     <Compile Include="UriParser\Extensions\SyntacticAst\AggregateToken.cs" />
     <Compile Include="UriParser\Extensions\SyntacticAst\ApplyTransformationToken.cs" />
     <Compile Include="UriParser\Extensions\SyntacticAst\GroupByToken.cs" />
-	<Compile Include="UriParser\Extensions\TreeNodeKinds\TransformationNodeKind.cs" />
+    <Compile Include="UriParser\Extensions\TreeNodeKinds\TransformationNodeKind.cs" />
     <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs">
       <Link>EdmValueParser.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.Portable45.csproj
@@ -188,6 +188,7 @@
     <Compile Include="JsonLight\ODataJsonLightPayloadKindDetectionDeserializer.cs" />
     <Compile Include="JsonLight\ODataJsonLightPropertyAndValueDeserializer.cs" />
     <Compile Include="JsonLight\ODataJsonLightPropertySerializer.cs" />
+    <Compile Include="JsonLight\ODataJsonLightRawAnnotationSet.cs" />
     <Compile Include="JsonLight\ODataJsonLightReader.cs" />
     <Compile Include="JsonLight\ODataJsonLightReaderNavigationLinkInfo.cs" />
     <Compile Include="JsonLight\ODataJsonLightReaderUtils.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -221,6 +221,7 @@
     <Compile Include="Json\ODataJsonWriterUtils.cs" />
     <Compile Include="Json\TextWriterWrapper.cs" />
     <Compile Include="ODataErrorDetail.cs" />
+    <Compile Include="ODataUndeclaredPropertyValue.cs" />
     <Compile Include="ODataUntypedValue.cs" />
     <Compile Include="ODataMediaType.cs" />
     <Compile Include="ODataMediaTypeResolver.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -600,6 +600,7 @@
     <Compile Include="UriParser\Visitors\SyntacticTreeVisitor.cs" />
     <Compile Include="UriUtils.cs" />
     <Compile Include="Utils.cs" />
+    <Compile Include="IMessageValidationSetting.cs" />
     <Compile Include="ValidationUtils.cs" />
     <Compile Include="WriterUtils.cs" />
     <Compile Include="WriterValidationUtils.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -187,6 +187,7 @@
     <Compile Include="JsonLight\ODataJsonLightPayloadKindDetectionDeserializer.cs" />
     <Compile Include="JsonLight\ODataJsonLightPropertyAndValueDeserializer.cs" />
     <Compile Include="JsonLight\ODataJsonLightPropertySerializer.cs" />
+    <Compile Include="JsonLight\ODataJsonLightRawAnnotationSet.cs" />
     <Compile Include="JsonLight\ODataJsonLightReader.cs" />
     <Compile Include="JsonLight\ODataJsonLightReaderNavigationLinkInfo.cs" />
     <Compile Include="JsonLight\ODataJsonLightReaderUtils.cs" />

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -203,15 +203,15 @@ namespace Microsoft.OData.Core
             Debug.Assert(typeContext != null, "typeContext != null");
 
             return new ODataContextUrlInfo()
-                {
-                    isContained = typeContext.NavigationSourceKind == EdmNavigationSourceKind.ContainedEntitySet,
-                    IsUnknownEntitySet = typeContext.NavigationSourceKind == EdmNavigationSourceKind.UnknownEntitySet,
-                    navigationSource = typeContext.NavigationSourceName,
-                    TypeCast = typeContext.NavigationSourceEntityTypeName == typeContext.ExpectedEntityTypeName ? null : typeContext.ExpectedEntityTypeName,
-                    TypeName = typeContext.NavigationSourceFullTypeName,
-                    IncludeFragmentItemSelector = isSingle && typeContext.NavigationSourceKind != EdmNavigationSourceKind.Singleton,
-                    odataUri = odataUri
-                };
+            {
+                isContained = typeContext.NavigationSourceKind == EdmNavigationSourceKind.ContainedEntitySet,
+                IsUnknownEntitySet = typeContext.NavigationSourceKind == EdmNavigationSourceKind.UnknownEntitySet,
+                navigationSource = typeContext.NavigationSourceName,
+                TypeCast = typeContext.NavigationSourceEntityTypeName == typeContext.ExpectedEntityTypeName ? null : typeContext.ExpectedEntityTypeName,
+                TypeName = typeContext.NavigationSourceFullTypeName,
+                IncludeFragmentItemSelector = isSingle && typeContext.NavigationSourceKind != EdmNavigationSourceKind.Singleton,
+                odataUri = odataUri
+            };
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OData.Core
     /// <summary>
     /// Configuration settings for OData message readers.
     /// </summary>
-    public sealed class ODataMessageReaderSettings : ODataMessageReaderSettingsBase
+    public sealed class ODataMessageReaderSettings : ODataMessageReaderSettingsBase, IMessageValidationSetting
     {
         /// <summary>
         /// A instance representing any knobs that control the behavior of the readers
@@ -299,17 +299,6 @@ namespace Microsoft.OData.Core
             get
             {
                 return this.UndeclaredPropertyBehaviorKinds.HasFlag(ODataUndeclaredPropertyBehaviorKinds.ReportUndeclaredLinkProperty);
-            }
-        }
-
-        /// <summary>
-        /// Whether or not to ignore any undeclared value properties in the payload. Computed from the UndeclaredPropertyBehaviorKinds enum property.
-        /// </summary>
-        internal bool IgnoreUndeclaredValueProperties
-        {
-            get
-            {
-                return this.UndeclaredPropertyBehaviorKinds.HasFlag(ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty);
             }
         }
 

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OData.Core
     /// <summary>
     /// Configuration settings for OData message writers.
     /// </summary>
-    public sealed class ODataMessageWriterSettings : ODataMessageWriterSettingsBase
+    public sealed class ODataMessageWriterSettings : ODataMessageWriterSettingsBase, IMessageValidationSetting
     {
         /// <summary>
         /// The acceptable charsets used to the determine the encoding of the message.
@@ -106,6 +106,7 @@ namespace Microsoft.OData.Core
             this.AutoComputePayloadMetadataInJson = other.AutoComputePayloadMetadataInJson;
             this.UseKeyAsSegment = other.UseKeyAsSegment;
             this.alwaysUseDefaultXmlNamespaceForRootElement = other.alwaysUseDefaultXmlNamespaceForRootElement;
+            this.UndeclaredPropertyBehaviorKinds = other.UndeclaredPropertyBehaviorKinds;
             this.ODataUri = other.ODataUri;
 
             // NOTE: writer behavior is immutable; copy by reference is ok.
@@ -147,6 +148,15 @@ namespace Microsoft.OData.Core
         {
             get { return this.odataUri ?? (this.odataUri = new ODataUri()); }
             set { this.odataUri = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets UndeclaredPropertyBehaviorKinds.
+        /// </summary>
+        public ODataUndeclaredPropertyBehaviorKinds UndeclaredPropertyBehaviorKinds
+        {
+            get;
+            set;
         }
 
         /// <summary>Gets or sets a value that indicates whether the message stream will not be disposed after finishing writing with the message.</summary>

--- a/src/Microsoft.OData.Core/ODataProperty.cs
+++ b/src/Microsoft.OData.Core/ODataProperty.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData.Core
         /// <summary>
         /// The value of this property, accessed and set by both <seealso cref="Value"/> and <seealso cref="ODataValue"/>.
         /// </summary>
-        private ODataValue odataOrUntypedValue; // normal ODataValue or ODataUntypedValue
+        private ODataAnnotatable odataOrUndeclaredValue;
 
         /// <summary>
         /// Provides additional serialization information to the <see cref="ODataWriter"/> for this <see cref="ODataProperty"/>.
@@ -38,30 +38,30 @@ namespace Microsoft.OData.Core
         {
             get
             {
-                if (this.odataOrUntypedValue == null)
+                if (this.odataOrUndeclaredValue == null)
                 {
                     return null;
                 }
 
-                ODataUntypedValue tmpValue = this.odataOrUntypedValue as ODataUntypedValue;
+                ODataUndeclaredPropertyValue tmpValue = this.odataOrUndeclaredValue as ODataUndeclaredPropertyValue;
                 if (tmpValue != null)
                 {
                     return tmpValue;
                 }
 
-                return ((ODataValue)this.odataOrUntypedValue).FromODataValue();
+                return ((ODataValue)this.odataOrUndeclaredValue).FromODataValue();
             }
 
             set
             {
-                ODataUntypedValue tmpValue = value as ODataUntypedValue;
+                ODataUndeclaredPropertyValue tmpValue = value as ODataUndeclaredPropertyValue;
                 if (tmpValue != null)
                 {
-                    this.odataOrUntypedValue = tmpValue;
+                    this.odataOrUndeclaredValue = tmpValue;
                 }
                 else
                 {
-                    this.odataOrUntypedValue = value.ToODataValue();
+                    this.odataOrUndeclaredValue = value.ToODataValue();
                 }
             }
         }
@@ -88,7 +88,7 @@ namespace Microsoft.OData.Core
         {
             get
             {
-                return (ODataValue)this.odataOrUntypedValue;
+                return (ODataValue)this.odataOrUndeclaredValue;
             }
         }
 

--- a/src/Microsoft.OData.Core/ODataProperty.cs
+++ b/src/Microsoft.OData.Core/ODataProperty.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData.Core
         /// <summary>
         /// The value of this property, accessed and set by both <seealso cref="Value"/> and <seealso cref="ODataValue"/>.
         /// </summary>
-        private ODataValue odataValue;
+        private ODataValue odataOrUntypedValue; // normal ODataValue or ODataUntypedValue
 
         /// <summary>
         /// Provides additional serialization information to the <see cref="ODataWriter"/> for this <see cref="ODataProperty"/>.
@@ -26,10 +26,10 @@ namespace Microsoft.OData.Core
 
         /// <summary>Gets or sets the property name.</summary>
         /// <returns>The property name.</returns>
-        public string Name 
-        { 
-            get; 
-            set; 
+        public string Name
+        {
+            get;
+            set;
         }
 
         /// <summary>Gets or sets the property value.</summary>
@@ -38,19 +38,34 @@ namespace Microsoft.OData.Core
         {
             get
             {
-                if (this.odataValue == null)
+                if (this.odataOrUntypedValue == null)
                 {
                     return null;
                 }
 
-                return this.odataValue.FromODataValue();
+                ODataUntypedValue tmpValue = this.odataOrUntypedValue as ODataUntypedValue;
+                if (tmpValue != null)
+                {
+                    return tmpValue;
+                }
+
+                return ((ODataValue)this.odataOrUntypedValue).FromODataValue();
             }
 
             set
             {
-                this.odataValue = value.ToODataValue();
+                ODataUntypedValue tmpValue = value as ODataUntypedValue;
+                if (tmpValue != null)
+                {
+                    this.odataOrUntypedValue = tmpValue;
+                }
+                else
+                {
+                    this.odataOrUntypedValue = value.ToODataValue();
+                }
             }
         }
+
 
         /// <summary>
         /// Collection of custom instance annotations.
@@ -73,7 +88,7 @@ namespace Microsoft.OData.Core
         {
             get
             {
-                return this.odataValue;
+                return (ODataValue)this.odataOrUntypedValue;
             }
         }
 

--- a/src/Microsoft.OData.Core/ODataUndeclaredPropertyBehaviorKinds.cs
+++ b/src/Microsoft.OData.Core/ODataUndeclaredPropertyBehaviorKinds.cs
@@ -45,9 +45,22 @@ namespace Microsoft.OData.Core
         /// </remarks>
         ReportUndeclaredLinkProperty = 2,
 
+        #region For 6.15~ release
         /// <summary>
         /// Reading/writing undeclared properties will be supported.
         /// </summary>
-        SupportUndeclaredValueProperty = 4,
+        SupportUndeclaredValueProperty = 128,
+
+        /// <summary>
+        /// Truely ignore undeclared property.
+        /// (Since IgnoreUndeclaredValueProperty is already interpreted as supporting undeclared property)
+        /// </summary>
+        DiscardUndeclaredValueProperty = 256,
+
+        /// <summary>
+        /// Throw exception on undeclared value property.
+        /// </summary>
+        ThrowOnUndeclaredValueProperty = 512,
+        #endregion
     }
 }

--- a/src/Microsoft.OData.Core/ODataUndeclaredPropertyBehaviorKinds.cs
+++ b/src/Microsoft.OData.Core/ODataUndeclaredPropertyBehaviorKinds.cs
@@ -44,5 +44,10 @@ namespace Microsoft.OData.Core
         /// - Stream properties
         /// </remarks>
         ReportUndeclaredLinkProperty = 2,
+
+        /// <summary>
+        /// Reading/writing undeclared properties will be supported.
+        /// </summary>
+        SupportUndeclaredValueProperty = 4,
     }
 }

--- a/src/Microsoft.OData.Core/ODataUndeclaredPropertyValue.cs
+++ b/src/Microsoft.OData.Core/ODataUndeclaredPropertyValue.cs
@@ -1,0 +1,24 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataUndeclaredPropertyValue.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Core
+{
+    /// <summary>
+    /// OData representation of an undeclared property value.
+    /// </summary>
+    /// <remarks>ODataUndeclaredPropertyValue and ODataUntypedValue may look similar 
+    /// but ODataUntypedValue represents a declared Edm.Untyped value.</remarks>
+    public sealed class ODataUndeclaredPropertyValue : ODataValue
+    {
+        /// <summary>Gets or sets the raw string value.</summary>
+        /// <returns>The raw string value.</returns>
+        public string RawValue
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/ODataUntypedValue.cs
+++ b/src/Microsoft.OData.Core/ODataUntypedValue.cs
@@ -9,6 +9,8 @@ namespace Microsoft.OData.Core
     /// <summary>
     /// OData representation of an untyped value.
     /// </summary>
+    /// <remarks>ODataUndeclaredPropertyValue and ODataUntypedValue may look similar 
+    /// but ODataUntypedValue represents a declared Edm.Untyped value.</remarks>
     public sealed class ODataUntypedValue : ODataValue
     {
         /// <summary>Gets or sets the raw untyped value.</summary>

--- a/src/Microsoft.OData.Core/Query/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Query/ODataUriConversionUtils.cs
@@ -224,13 +224,13 @@ namespace Microsoft.OData.Core.UriParser
             ExceptionUtils.CheckArgumentNotNull(model, "model");
 
             return ConverToJsonLightLiteral(
-                model, 
+                model,
                 context =>
-            {
-                ODataWriter writer = context.CreateODataEntryWriter(null, null);
-                writer.WriteStart(entry);
-                writer.WriteEnd();
-            });
+                {
+                    ODataWriter writer = context.CreateODataEntryWriter(null, null);
+                    writer.WriteStart(entry);
+                    writer.WriteEnd();
+                });
         }
 
         /// <summary>
@@ -245,20 +245,20 @@ namespace Microsoft.OData.Core.UriParser
             ExceptionUtils.CheckArgumentNotNull(model, "model");
 
             return ConverToJsonLightLiteral(
-                model, 
+                model,
                 context =>
-            {
-                ODataWriter writer = context.CreateODataFeedWriter(null, null);
-                writer.WriteStart(new ODataFeed());
-
-                foreach (var entry in entries)
                 {
-                    writer.WriteStart(entry);
-                    writer.WriteEnd();
-                }
+                    ODataWriter writer = context.CreateODataFeedWriter(null, null);
+                    writer.WriteStart(new ODataFeed());
 
-                writer.WriteEnd();
-            });
+                    foreach (var entry in entries)
+                    {
+                        writer.WriteStart(entry);
+                        writer.WriteEnd();
+                    }
+
+                    writer.WriteEnd();
+                });
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ReaderValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ReaderValidationUtils.cs
@@ -182,13 +182,30 @@ namespace Microsoft.OData.Core
             IEdmProperty property = FindDefinedProperty(propertyName, owningStructuredType);
             if (property == null && !owningStructuredType.IsOpen)
             {
-                if (messageReaderSettings.ShouldIgnoreUndeclaredProperty())
+                if (messageReaderSettings.NeedRunLegacyPropertyHandling())
+                {
+                    if (messageReaderSettings.NeedIgnoreLegacyUndeclaredProperty())
+                    {
+                        ignoreProperty = true;
+                    }
+                    else
+                    {
+                        throw new ODataException(Strings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, owningStructuredType.FullTypeName()));
+                    }
+                }
+                else if (messageReaderSettings.ShouldIgnoreUndeclaredProperty())
                 {
                     ignoreProperty = true;
                 }
-                else
+                else if (messageReaderSettings.ShouldThrowOnUndeclaredProperty())
                 {
                     throw new ODataException(Strings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, owningStructuredType.FullTypeName()));
+                }
+                else
+                {
+                    Debug.Assert(
+                        messageReaderSettings.ShouldSupportUndeclaredProperty(),
+                        "messageReaderSettings.ShouldSupportUndeclaredProperty()");
                 }
             }
 

--- a/src/Microsoft.OData.Core/ReaderValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ReaderValidationUtils.cs
@@ -182,7 +182,7 @@ namespace Microsoft.OData.Core
             IEdmProperty property = FindDefinedProperty(propertyName, owningStructuredType);
             if (property == null && !owningStructuredType.IsOpen)
             {
-                if (messageReaderSettings.IgnoreUndeclaredValueProperties)
+                if (messageReaderSettings.ShouldIgnoreUndeclaredProperty())
                 {
                     ignoreProperty = true;
                 }

--- a/src/Microsoft.OData.Core/TypeNameOracle.cs
+++ b/src/Microsoft.OData.Core/TypeNameOracle.cs
@@ -71,7 +71,7 @@ namespace Microsoft.OData.Core
         /// <param name="value">The value in question to resolve the type for.</param>
         /// <param name="isOpenProperty">true if the type name belongs to an open property, false otherwise.</param>
         /// <returns>A type for the <paramref name="value"/> or null if no metadata is available.</returns>
-        internal static IEdmTypeReference ResolveAndValidateTypeNameForValue(IEdmModel model, IEdmTypeReference typeReferenceFromMetadata, ODataValue value, bool isOpenProperty)
+        internal static IEdmTypeReference ResolveAndValidateTypeNameForValue(IEdmModel model, IEdmTypeReference typeReferenceFromMetadata, ODataAnnotatable value, bool isOpenProperty)
         {
             Debug.Assert(model != null, "model != null");
             Debug.Assert(value != null, "value != null");

--- a/src/Microsoft.OData.Core/ValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ValidationUtils.cs
@@ -31,6 +31,33 @@ namespace Microsoft.OData.Core
         #region undeclared property setting logic
 
         /// <summary>
+        /// Retuns if should run legacy property handling logic of ~ 6.14 release.
+        /// </summary>
+        /// <param name="messageValidationSetting">The IMessageValidationSetting.</param>
+        /// <remarks>The legacy handling is for backward compatability, 
+        /// should be cleaned up in next breaking change release.</remarks>
+        /// <returns>True if if should run legacy property handling logic.</returns>
+        internal static bool NeedRunLegacyPropertyHandling(this IMessageValidationSetting messageValidationSetting)
+        {
+            // ignore messageValidationSetting.EnableFullValidation
+            return !ShouldIgnoreUndeclaredProperty(messageValidationSetting)
+                && !ShouldSupportUndeclaredProperty(messageValidationSetting)
+                && !ShouldThrowOnUndeclaredProperty(messageValidationSetting);
+        }
+
+        /// <summary>
+        /// Retuns if should run legacy property handling logic of ~ 6.14 release.
+        /// </summary>
+        /// <param name="messageValidationSetting">The IMessageValidationSetting.</param>
+        /// <returns>True if if should run legacy property handling logic.</returns>
+        internal static bool NeedIgnoreLegacyUndeclaredProperty(this IMessageValidationSetting messageValidationSetting)
+        {
+            // ignore messageValidationSetting.EnableFullValidation
+            return messageValidationSetting.UndeclaredPropertyBehaviorKinds.HasFlag(
+                ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty);
+        }
+
+        /// <summary>
         /// Retuns if undeclared property should be ignored.
         /// </summary>
         /// <param name="messageValidationSetting">The IMessageValidationSetting.</param>
@@ -39,11 +66,11 @@ namespace Microsoft.OData.Core
         {
             // ignore messageValidationSetting.EnableFullValidation
             return messageValidationSetting.UndeclaredPropertyBehaviorKinds.HasFlag(
-                ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty);
+                ODataUndeclaredPropertyBehaviorKinds.DiscardUndeclaredValueProperty);
         }
 
         /// <summary>
-        /// Retuns if undeclared property should be supported.
+        /// Retuns if undeclared property should be supported: read undeclared prmitive value into ODataUntypdValue.
         /// </summary>
         /// <param name="messageValidationSetting">The IMessageValidationSetting.</param>
         /// <returns>True if undeclared property should be supported.</returns>
@@ -62,12 +89,8 @@ namespace Microsoft.OData.Core
         internal static bool ShouldThrowOnUndeclaredProperty(this IMessageValidationSetting messageValidationSetting)
         {
             // ignore messageValidationSetting.EnableFullValidation
-            // exception can only be thrown when setting is .None / .ReportUndeclaredLinkProperty / ...
-            bool throwErr = !messageValidationSetting.UndeclaredPropertyBehaviorKinds.HasFlag(
-                                ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty)
-                   && !messageValidationSetting.UndeclaredPropertyBehaviorKinds.HasFlag(
-                          ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty);
-            return throwErr;
+            return messageValidationSetting.UndeclaredPropertyBehaviorKinds.HasFlag(
+                          ODataUndeclaredPropertyBehaviorKinds.ThrowOnUndeclaredValueProperty);
         }
         #endregion
 

--- a/src/Microsoft.OData.Core/ValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ValidationUtils.cs
@@ -28,6 +28,49 @@ namespace Microsoft.OData.Core
         /// <summary>Maximum batch boundary length supported (not includeding leading CRLF or '-').</summary>
         private const int MaxBoundaryLength = 70;
 
+        #region undeclared property setting logic
+
+        /// <summary>
+        /// Retuns if undeclared property should be ignored.
+        /// </summary>
+        /// <param name="messageValidationSetting">The IMessageValidationSetting.</param>
+        /// <returns>True if undeclared property should be ignored.</returns>
+        internal static bool ShouldIgnoreUndeclaredProperty(this IMessageValidationSetting messageValidationSetting)
+        {
+            // ignore messageValidationSetting.EnableFullValidation
+            return messageValidationSetting.UndeclaredPropertyBehaviorKinds.HasFlag(
+                ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty);
+        }
+
+        /// <summary>
+        /// Retuns if undeclared property should be supported.
+        /// </summary>
+        /// <param name="messageValidationSetting">The IMessageValidationSetting.</param>
+        /// <returns>True if undeclared property should be supported.</returns>
+        internal static bool ShouldSupportUndeclaredProperty(this IMessageValidationSetting messageValidationSetting)
+        {
+            // ignore messageValidationSetting.EnableFullValidation
+            return messageValidationSetting.UndeclaredPropertyBehaviorKinds.HasFlag(
+                ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty);
+        }
+
+        /// <summary>
+        /// Retuns if undeclared property should lead to an exception.
+        /// </summary>
+        /// <param name="messageValidationSetting">The IMessageValidationSetting.</param>
+        /// <returns>True if undeclared property should cause exception.</returns>
+        internal static bool ShouldThrowOnUndeclaredProperty(this IMessageValidationSetting messageValidationSetting)
+        {
+            // ignore messageValidationSetting.EnableFullValidation
+            // exception can only be thrown when setting is .None / .ReportUndeclaredLinkProperty / ...
+            bool throwErr = !messageValidationSetting.UndeclaredPropertyBehaviorKinds.HasFlag(
+                                ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty)
+                   && !messageValidationSetting.UndeclaredPropertyBehaviorKinds.HasFlag(
+                          ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty);
+            return throwErr;
+        }
+        #endregion
+
         /// <summary>
         /// Validates that an open property value is supported.
         /// </summary>

--- a/src/Microsoft.OData.Core/WriterValidationUtils.cs
+++ b/src/Microsoft.OData.Core/WriterValidationUtils.cs
@@ -79,13 +79,13 @@ namespace Microsoft.OData.Core
         /// <param name="propertyName">The name of the property to validate.</param>
         /// <param name="owningStructuredType">The owning type of the property with name <paramref name="propertyName"/> 
         /// or null if no metadata is available.</param>
-        /// <param name="throwOnMissingProperty">Whether throw exception on missing property.</param>
+        /// <param name="messageValidationSetting">The message validation setting, null: expects exception on missing property.</param>
         /// <returns>The <see cref="IEdmProperty"/> instance representing the property with name <paramref name="propertyName"/> 
         /// or null if no metadata is available.</returns>
         internal static IEdmProperty ValidatePropertyDefined(
             string propertyName,
             IEdmStructuredType owningStructuredType,
-            bool throwOnMissingProperty = true)
+            IMessageValidationSetting messageValidationSetting)
         {
             Debug.Assert(!string.IsNullOrEmpty(propertyName), "!string.IsNullOrEmpty(propertyName)");
 
@@ -97,7 +97,8 @@ namespace Microsoft.OData.Core
             IEdmProperty property = owningStructuredType.FindProperty(propertyName);
 
             // verify that the property is declared if the type is not an open type.
-            if (throwOnMissingProperty && !owningStructuredType.IsOpen && property == null)
+            if (((messageValidationSetting == null) || messageValidationSetting.ShouldThrowOnUndeclaredProperty())
+                && !owningStructuredType.IsOpen && property == null)
             {
                 throw new ODataException(Strings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, owningStructuredType.FullTypeName()));
             }
@@ -122,7 +123,7 @@ namespace Microsoft.OData.Core
                 return null;
             }
 
-            IEdmProperty property = ValidatePropertyDefined(propertyName, owningEntityType);
+            IEdmProperty property = ValidatePropertyDefined(propertyName, owningEntityType, null);
             if (property == null)
             {
                 // We don't support open navigation properties
@@ -460,7 +461,7 @@ namespace Microsoft.OData.Core
             {
                 return;
             }
-            
+
             if (expectedPropertyTypeReference != null)
             {
                 if (expectedPropertyTypeReference.IsNonEntityCollectionType())

--- a/src/Microsoft.OData.Core/WriterValidationUtils.cs
+++ b/src/Microsoft.OData.Core/WriterValidationUtils.cs
@@ -95,12 +95,23 @@ namespace Microsoft.OData.Core
             }
 
             IEdmProperty property = owningStructuredType.FindProperty(propertyName);
-
-            // verify that the property is declared if the type is not an open type.
-            if (((messageValidationSetting == null) || messageValidationSetting.ShouldThrowOnUndeclaredProperty())
-                && !owningStructuredType.IsOpen && property == null)
+            if ((messageValidationSetting == null)
+                || messageValidationSetting.NeedRunLegacyPropertyHandling())
             {
-                throw new ODataException(Strings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, owningStructuredType.FullTypeName()));
+                if (((messageValidationSetting == null) || messageValidationSetting.EnableFullValidation)
+                    && !owningStructuredType.IsOpen && property == null)
+                {
+                    throw new ODataException(Strings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, owningStructuredType.FullTypeName()));
+                }
+            }
+            else
+            {
+                // verify that the property is declared if the type is not an open type.
+                if (((messageValidationSetting == null) || messageValidationSetting.ShouldThrowOnUndeclaredProperty())
+                    && !owningStructuredType.IsOpen && property == null)
+                {
+                    throw new ODataException(Strings.ValidationUtils_PropertyDoesNotExistOnType(propertyName, owningStructuredType.FullTypeName()));
+                }
             }
 
             return property;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonLightValueSerializer.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonLightValueSerializer.cs
@@ -66,6 +66,12 @@ namespace Microsoft.OData.Core.Tests.Json
             this.WritePrimitiveVerifier(value, expectedTypeReference);
         }
 
+        public void WriteUndeclaredPropertyValue(ODataUndeclaredPropertyValue value)
+        {
+            this.WritePrimitiveVerifier.Should().NotBeNull("WriteUntypedValue was called.");
+            this.WritePrimitiveVerifier(value, null);
+        }
+
         public void WriteUntypedValue(ODataUntypedValue value)
         {
             this.WritePrimitiveVerifier.Should().NotBeNull("WriteUntypedValue was called.");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerSkipUndeclaredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerSkipUndeclaredTests.cs
@@ -1,0 +1,406 @@
+﻿namespace Microsoft.OData.Core.Tests.JsonLight
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using FluentAssertions;
+    // ReSharper disable RedundantUsingDirective
+    using ErrorStrings = Microsoft.OData.Core.Strings;
+    using Xunit;
+    using Microsoft.OData.Edm.Library;
+    using Microsoft.OData.Core;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Core.Tests;
+    using Microsoft.OData.Core.Atom;
+    using Microsoft.OData.Core.JsonLight;
+    using Microsoft.OData.Core.Tests.JsonLight;
+    using Microsoft.OData.Core.Json;
+    // ReSharper restore RedundantUsingDirective
+
+    public class ODataJsonLightEntryAndFeedDeserializerSkipUndeclaredTests
+    {
+        private ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings()
+        {
+            UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.DiscardUndeclaredValueProperty
+        };
+
+        // ----------- begin of edm for entry reader -----------
+        private EdmModel serverModel;
+        private EdmEntityType serverEntityType;
+        private EdmEntityType serverOpenEntityType;
+        private EdmEntitySet serverEntitySet;
+        private EdmEntitySet serverOpenEntitySet;
+
+        public ODataJsonLightEntryAndFeedDeserializerSkipUndeclaredTests()
+        {
+            this.serverModel = new EdmModel();
+            var addressType = new EdmComplexType("Server.NS", "Address");
+            addressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+            this.serverModel.AddElement(addressType);
+
+            // non-open entity type
+            this.serverEntityType = new EdmEntityType("Server.NS", "ServerEntityType");
+            this.serverModel.AddElement(this.serverEntityType);
+            this.serverEntityType.AddKeys(this.serverEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            // open entity type
+            this.serverOpenEntityType = new EdmEntityType("Server.NS", "ServerOpenEntityType",
+                baseType: null, isAbstract: false, isOpen: true);
+            this.serverModel.AddElement(this.serverOpenEntityType);
+            this.serverOpenEntityType.AddKeys(this.serverOpenEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverOpenEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            EdmEntityContainer container = new EdmEntityContainer("Server.NS", "container1");
+            this.serverEntitySet = container.AddEntitySet("serverEntitySet", this.serverEntityType);
+            this.serverOpenEntitySet = container.AddEntitySet("serverOpenEntitySet", this.serverOpenEntityType);
+            this.serverModel.AddElement(container);
+        }
+        // ----------- end of edm for entry reader ----------- 
+
+        private void ReadEntryPayload(string payload, EdmEntitySet entitySet, EdmEntityType entityType, Action<ODataReader> action)
+        {
+            var message = new InMemoryMessage() { Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload)) };
+            message.SetHeader("Content-Type", "application/json");
+            using (var msgReader = new ODataMessageReader((IODataResponseMessage)message, readerSettings, this.serverModel))
+            {
+                var reader = msgReader.CreateODataEntryReader(entitySet, entityType);
+                while (reader.Read())
+                {
+                    action(reader);
+                }
+            }
+        }
+
+        #region non-open entity's property unknown name + known value type
+
+        [Fact]
+        public void ReadNonOpenNullTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"null}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadNonOpenknownTypeBoolTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredBool"":false}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadNonOpenknownTypeStringTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet@odata.type"":""Edm.String"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .FirstOrDefault(s => string.Equals("UndeclaredStreet", s.Name)).Should().BeNull();
+        }
+
+        [Fact]
+        public void ReadNonOpenknownTypeNumericTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreetNo@odata.type"":""Edm.Double"",""UndeclaredStreetNo"":""12""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .FirstOrDefault(s => string.Equals("UndeclaredStreetNo", s.Name)).Should().BeNull();
+        }
+
+        [Fact]
+        public void ReadNonOpenKnownTypeComplexTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":{""@odata.type"":""Server.NS.Address"",""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadNonOpenKnownTypeCollectionTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                UndeclaredCollection1@odata.type:""Collection(Edm.String)"",UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+        }
+        #endregion
+
+        #region non-open entity's property unknown name + unknown value type
+
+        [Fact]
+        public void ReadNonOpenUnknownNullTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"null,""UndeclaredAddress1@odata.type"":""Server.NS.UndefComplex1""}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypePrimitiveTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.FirstOrDefault(s => string.Equals("UndeclaredFloatId", s.Name)).Should().BeNull();
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .FirstOrDefault(s => string.Equals("UndeclaredStreet", s.Name)).Should().BeNull();
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypeInvalidComplexTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"{""@odata.type"":""Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypeInvalidComplexNestedTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"{""@odata.type"":""Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""innerComplex1"":{""innerProp1"":null,""inerProp2"":'abc'},""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypeCollectionTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.FirstOrDefault(s => string.Equals(s.Name, "UndeclaredCollection1")).Should().BeNull();
+        }
+
+        #endregion
+
+        #region open entity's property unknown name + known value type
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredPropertiesWithNullValueTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""UndeclaredType1"":null}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredFloatId")).ODataValue.FromODataValue().Should().Be(12.3d);
+            Assert.True(entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredType1")).ODataValue.IsNullValue);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredComplexPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""undeclaredComplex1"":{""@odata.type"":""Server.NS.Address"",""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).ODataValue.As<ODataComplexValue>()
+                .Properties.Count().Should().Be(1);
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).ODataValue.As<ODataComplexValue>()
+                .TypeName.Should().Be("Server.NS.Address");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredCollectionPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                UndeclaredCollection1@odata.type:""Collection(Edm.String)"",UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).ODataValue.As<ODataCollectionValue>().Items
+                .Cast<string>().Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+        }
+        #endregion
+
+        #region open entity's property unknown name + unknown value type
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredComplexPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                  ""undeclaredComplex1"":{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.FirstOrDefault(s => string.Equals(s.Name, "undeclaredComplex1")).Should().BeNull();
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredComplexInvalidTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""undeclaredComplex1"":{""@odata.type"":""Server.NS.AddressUndeclared"",""Street"":""No.999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.Should().Be(12.3d);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredEmptyComplexPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""undeclaredComplex1"":{}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.Should().Be(12.3d);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredCollectionPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                                                          UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.FirstOrDefault(s => string.Equals(s.Name, "UndeclaredCollection1")).Should().BeNull();
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredEmptyCollectionPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                                                          UndeclaredCollection1:[],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.FirstOrDefault(s => string.Equals(s.Name, "UndeclaredCollection1")).Should().BeNull();
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(1);
+        }
+
+        #endregion
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
@@ -94,7 +94,7 @@
                 .ODataValue as ODataComplexValue;
             undeclaredComplex1Val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Should().BeNull(); // normal dynamic property in open entity has no raw ODataJsonLightRawAnnotationSet.
 
-            ODataUntypedValue undeclaredComplex1Innerstr = undeclaredComplex1Val.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value as ODataUntypedValue;
+            ODataUndeclaredPropertyValue undeclaredComplex1Innerstr = undeclaredComplex1Val.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value as ODataUndeclaredPropertyValue;
             undeclaredComplex1Innerstr.RawValue.Should().Be("\"hello this is a string.\"");
             undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(4);
             undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"od unkown value _234\"");
@@ -143,7 +143,7 @@
             undeclaredComplex1Val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"od unkown value 1\"");
             undeclaredComplex1Val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"custom annotation value 1\"");
 
-            ODataUntypedValue undeclaredComplex1Innerstr = undeclaredComplex1Val.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value as ODataUntypedValue;
+            ODataUndeclaredPropertyValue undeclaredComplex1Innerstr = undeclaredComplex1Val.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value as ODataUndeclaredPropertyValue;
             undeclaredComplex1Innerstr.RawValue.Should().Be("\"hello this is a string.\"");
             undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(4);
             undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"od unkown value _234\"");
@@ -176,7 +176,7 @@
             });
 
             entry.Properties.Count().Should().Be(2);
-            ODataUntypedValue val = entry.Properties.Last().Value.As<ODataUntypedValue>();
+            ODataUndeclaredPropertyValue val = entry.Properties.Last().Value.As<ODataUndeclaredPropertyValue>();
             val.Should().NotBeNull();
             val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(3);
             val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"NS1.unknownTypeName123\"");
@@ -305,7 +305,7 @@
             UndeclaredAddress1Value.TypeName.Should().Be("Server.NS.Address");
             UndeclaredAddress1Value.Properties.Count().Should().Be(2);
             UndeclaredAddress1Value.Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>()
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUndeclaredPropertyValue>()
                 .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
 
             UndeclaredAddress1Value.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(2);
@@ -370,7 +370,7 @@
             });
 
             entry.Properties.Count().Should().Be(2);
-            ODataUntypedValue val = entry.Properties.Last().Value.As<ODataUntypedValue>();
+            ODataUndeclaredPropertyValue val = entry.Properties.Last().Value.As<ODataUndeclaredPropertyValue>();
             val.RawValue.Should().Be("null");
             val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(3);
             val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"unknown odata.xxx value1\"");
@@ -399,10 +399,10 @@
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name)).Value.As<ODataUntypedValue>().RawValue.Should().Be("12.3"); // numeric
+            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name)).Value.As<ODataUndeclaredPropertyValue>().RawValue.Should().Be("12.3"); // numeric
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>() // string
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUndeclaredPropertyValue>() // string
                 .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
         }
 
@@ -419,7 +419,7 @@
             });
 
             entry.Properties.Count().Should().Be(2);
-            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Last().Value.As<ODataUndeclaredPropertyValue>().RawValue
                 .Should().Be(@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}");
         }
 
@@ -436,7 +436,7 @@
             });
 
             entry.Properties.Count().Should().Be(2);
-            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Last().Value.As<ODataUndeclaredPropertyValue>().RawValue
                 .Should().Be(@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""innerComplex1"":{""innerProp1"":null,""inerProp2"":'abc'},""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}");
         }
 
@@ -452,7 +452,7 @@
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUndeclaredPropertyValue>().RawValue
               .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
         }
@@ -541,8 +541,8 @@
             });
 
             entry.Properties.Count().Should().Be(4);
-            ODataUntypedValue val = entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
-                .Value.As<ODataUntypedValue>();
+            ODataUndeclaredPropertyValue val = entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+                .Value.As<ODataUndeclaredPropertyValue>();
             val.RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
             val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(2);
             val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"unknown odata.xxx value1\"");
@@ -570,7 +570,7 @@
             {
                 entry = reader.Item as ODataEntry;
             });
-            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Last().Value.As<ODataUndeclaredPropertyValue>().RawValue
                 .Should().Be(@"{""@odata.type"":""#Server.NS.AddressUndeclared"",""Street"":""No.999,Zixing Rd Minhang""}");
         }
 
@@ -586,7 +586,7 @@
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value.As<ODataUntypedValue>()
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value.As<ODataUndeclaredPropertyValue>()
                 .RawValue.Should().Be(@"{}");
         }
 
@@ -602,7 +602,7 @@
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUndeclaredPropertyValue>().RawValue
                 .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
         }
@@ -619,10 +619,10 @@
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>()
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUndeclaredPropertyValue>()
                 .RawValue.Should().Be(@"[]");
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet"))
-                .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
+                .Value.As<ODataUndeclaredPropertyValue>().RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
         }
 
         #endregion
@@ -646,7 +646,7 @@
 
             entry.Properties.Count().Should().Be(4);
             entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
-                .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
+                .Value.As<ODataUndeclaredPropertyValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
@@ -1,0 +1,704 @@
+﻿namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using FluentAssertions;
+    using Microsoft.OData.Core;
+    using Microsoft.OData.Core.Json;
+    using Microsoft.OData.Core.Tests;
+    using Microsoft.OData.Core.Tests.JsonLight;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Edm.Library;
+    using Xunit;
+
+    public class ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests
+    {
+        private ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings()
+        {
+            UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty
+        };
+
+        private ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings
+        {
+            UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty
+        };
+
+        // ----------- begin of edm for entry reader -----------
+        private EdmModel serverModel;
+        private EdmEntityType serverEntityType;
+        private EdmEntityType serverOpenEntityType;
+        private EdmEntitySet serverEntitySet;
+        private EdmEntitySet serverOpenEntitySet;
+
+        public ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests()
+        {
+            this.serverModel = new EdmModel();
+            var addressType = new EdmComplexType("Server.NS", "Address");
+            addressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+            this.serverModel.AddElement(addressType);
+
+            // non-open entity type
+            this.serverEntityType = new EdmEntityType("Server.NS", "ServerEntityType");
+            this.serverModel.AddElement(this.serverEntityType);
+            this.serverEntityType.AddKeys(this.serverEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            // open entity type
+            this.serverOpenEntityType = new EdmEntityType("Server.NS", "ServerOpenEntityType",
+                baseType: null, isAbstract: false, isOpen: true);
+            this.serverModel.AddElement(this.serverOpenEntityType);
+            this.serverOpenEntityType.AddKeys(this.serverOpenEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverOpenEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            EdmEntityContainer container = new EdmEntityContainer("Server.NS", "container1");
+            this.serverEntitySet = container.AddEntitySet("serverEntitySet", this.serverEntityType);
+            this.serverOpenEntitySet = container.AddEntitySet("serverOpenEntitySet", this.serverOpenEntityType);
+            this.serverModel.AddElement(container);
+
+            this.writerSettings.SetContentType(ODataFormat.Json);
+            this.writerSettings.SetServiceDocumentUri(new Uri("http://www.sampletest.com/"));
+        }
+        // ----------- end of edm for entry reader ----------- 
+
+        #region test nested annotations for open & non-open entity: property unknown name + known value type
+
+        /// <summary>
+        /// For open entity
+        /// </summary>
+        [Fact]
+        public void ReadNestedAnnotationInOpenEntryUndeclaredComplexTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                  ""@instance.AnnotationName_"":""instance value_"",
+                                  ""undeclaredComplex1@odata.unknownname1"":""od unkown value 1"",
+                                  ""undeclaredComplex1@my.Annotation1"":""my custom value 1"",
+                                  ""undeclaredComplex1@instanceAnnotation1"":""custom annotation value 1"",
+                                ""undeclaredComplex1"":{  ""@odata.type"":""#Server.NS.Address"",
+                                                              ""@instance.AnnotationName_"":""instance value_234"",
+                                                              ""undeclaredComplex1@odata.unknownname1"":""od unkown value _234"",
+                                                              ""undeclaredComplex1@my.Annotation1"":""my custom value _234"",
+                                                              ""undeclaredComplex1@instanceAnnotation1"":""custom annotation value _234"",
+                                                              ""undeclaredComplex1@odata.type"":""Server.NS.UnknownType1"",
+                                                              ""undeclaredComplex1"":""hello this is a string."", 
+                                                              ""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            ODataComplexValue undeclaredComplex1Val = entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+                .ODataValue as ODataComplexValue;
+            undeclaredComplex1Val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Should().BeNull(); // normal dynamic property in open entity has no raw ODataJsonLightRawAnnotationSet.
+
+            ODataUntypedValue undeclaredComplex1Innerstr = undeclaredComplex1Val.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value as ODataUntypedValue;
+            undeclaredComplex1Innerstr.RawValue.Should().Be("\"hello this is a string.\"");
+            undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(4);
+            undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"od unkown value _234\"");
+            undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"custom annotation value _234\"");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"undeclaredComplex1\":{\"@odata.type\":\"#Server.NS.Address\",\"undeclaredComplex1@odata.unknownname1\":\"od unkown value _234\",\"undeclaredComplex1@odata.type\":\"Server.NS.UnknownType1\",\"undeclaredComplex1@my.Annotation1\":\"my custom value _234\",\"undeclaredComplex1@instanceAnnotation1\":\"custom annotation value _234\",\"undeclaredComplex1\":\"hello this is a string.\",\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+        }
+
+        /// <summary>
+        /// For non-open entity
+        /// </summary>
+        [Fact]
+        public void ReadNestedAnnotationInNonOpenEntryUndeclaredComplexTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                  ""@instance.AnnotationName_"":""instance value_"",
+                                  ""undeclaredComplex1@odata.unknownname1"":""od unkown value 1"",
+                                  ""undeclaredComplex1@my.Annotation1"":""my custom value 1"",
+                                  ""undeclaredComplex1@instanceAnnotation1"":""custom annotation value 1"",
+                                ""undeclaredComplex1"":{  ""@odata.type"":""#Server.NS.Address"",
+                                                              ""@instance.AnnotationName_"":""instance value_234"",
+                                                              ""undeclaredComplex1@odata.unknownname1"":""od unkown value _234"",
+                                                              ""undeclaredComplex1@my.Annotation1"":""my custom value _234"",
+                                                              ""undeclaredComplex1@instanceAnnotation1"":""custom annotation value _234"",
+                                                              ""undeclaredComplex1@odata.type"":""Server.NS.UnknownType1"",
+                                                              ""undeclaredComplex1"":""hello this is a string."", 
+                                                              ""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            ODataComplexValue undeclaredComplex1Val = entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+                .ODataValue as ODataComplexValue;
+            undeclaredComplex1Val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(3);
+            undeclaredComplex1Val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"od unkown value 1\"");
+            undeclaredComplex1Val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"custom annotation value 1\"");
+
+            ODataUntypedValue undeclaredComplex1Innerstr = undeclaredComplex1Val.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value as ODataUntypedValue;
+            undeclaredComplex1Innerstr.RawValue.Should().Be("\"hello this is a string.\"");
+            undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(4);
+            undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"od unkown value _234\"");
+            undeclaredComplex1Innerstr.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"custom annotation value _234\"");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"undeclaredComplex1@odata.unknownname1\":\"od unkown value 1\",\"undeclaredComplex1@my.Annotation1\":\"my custom value 1\",\"undeclaredComplex1@instanceAnnotation1\":\"custom annotation value 1\",\"undeclaredComplex1\":{\"undeclaredComplex1@odata.unknownname1\":\"od unkown value _234\",\"undeclaredComplex1@odata.type\":\"Server.NS.UnknownType1\",\"undeclaredComplex1@my.Annotation1\":\"my custom value _234\",\"undeclaredComplex1@instanceAnnotation1\":\"custom annotation value _234\",\"undeclaredComplex1\":\"hello this is a string.\",\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+        }
+
+        #endregion
+
+        #region non-open entity's property unknown name + known value type
+
+        [Fact]
+        public void ReadNonOpenNullTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1@odata.type"":""NS1.unknownTypeName123"",""UndeclaredAddress1@odata.unknownName1"":""uknown odata.xxx value1"",""UndeclaredAddress1@abcdefg"":""uknown abcdefghijk value2"",""UndeclaredAddress1"":null}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            ODataUntypedValue val = entry.Properties.Last().Value.As<ODataUntypedValue>();
+            val.Should().NotBeNull();
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(3);
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"NS1.unknownTypeName123\"");
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"uknown abcdefghijk value2\"");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(payload);
+        }
+
+        [Fact]
+        public void ReadNonOpenknownTypeBoolTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredBool@odata.unknownName1"":""unknown odata.xxx value1"",""UndeclaredBool@abcdefg"":""unknown abcdefghijk value2"",""UndeclaredBool"":false}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+            ODataValue val = entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .First(s => string.Equals("UndeclaredBool", s.Name)).ODataValue;
+            val.FromODataValue().Should().Be(false);
+
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(2);
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"unknown odata.xxx value1\"");
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"unknown abcdefghijk value2\"");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(payload);
+        }
+
+        [Fact]
+        public void ReadNonOpenknownTypeStringTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet@odata.type"":""Edm.String"",""UndeclaredStreet@odata.unknownName1"":""unknown odata.xxx value1"",""UndeclaredStreet@abcdefg"":""unknown abcdefghijk value2"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+            ODataValue val = entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).ODataValue;
+            val.FromODataValue().Should().Be("No.10000000999,Zixing Rd Minhang");
+
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(3);
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"Edm.String\"");
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"unknown abcdefghijk value2\"");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet@odata.type\":\"Edm.String\",\"UndeclaredStreet@odata.unknownName1\":\"unknown odata.xxx value1\",\"UndeclaredStreet@abcdefg\":\"unknown abcdefghijk value2\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+        }
+
+        [Fact]
+        public void ReadNonOpenknownTypeNumericTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreetNo@odata.type"":""Edm.Double"",""UndeclaredStreetNo@odata.unknownName1"":""unknown odata.xxx value1"",""UndeclaredStreetNo@abcdefg"":""unknown abcdefghijk value2"",""UndeclaredStreetNo"":""12""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+            ODataValue val = entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .First(s => string.Equals("UndeclaredStreetNo", s.Name)).ODataValue;
+            val.FromODataValue().Should().Be(12d);
+
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(3);
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"Edm.Double\"");
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"unknown abcdefghijk value2\"");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreetNo@odata.type\":\"Edm.Double\",\"UndeclaredStreetNo@odata.unknownName1\":\"unknown odata.xxx value1\",\"UndeclaredStreetNo@abcdefg\":\"unknown abcdefghijk value2\",\"UndeclaredStreetNo\":12.0}}");
+        }
+
+        [Fact]
+        public void ReadNonOpenKnownTypeComplexTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1@odata.unknownName1"":""unknown odata.xxx value1"",""UndeclaredAddress1@abcdefg"":""unknown abcdefghijk value2"",""UndeclaredAddress1"":{""@odata.type"":""#Server.NS.Address"",""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            ODataComplexValue UndeclaredAddress1Value = entry.Properties.Last().Value.As<ODataComplexValue>();
+            UndeclaredAddress1Value.TypeName.Should().Be("Server.NS.Address");
+            UndeclaredAddress1Value.Properties.Count().Should().Be(2);
+            UndeclaredAddress1Value.Properties
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>()
+                .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
+
+            UndeclaredAddress1Value.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(2);
+            UndeclaredAddress1Value.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"unknown odata.xxx value1\"");
+            UndeclaredAddress1Value.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"unknown abcdefghijk value2\"");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1@odata.unknownName1\":\"unknown odata.xxx value1\",\"UndeclaredAddress1@abcdefg\":\"unknown abcdefghijk value2\",\"UndeclaredAddress1\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+        }
+
+        [Fact]
+        public void ReadNonOpenKnownTypeCollectionTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                UndeclaredCollection1@odata.type:""Collection(Edm.String)"",""UndeclaredCollection1@odata.unknownName1"":""unknown odata.xxx value1"",""UndeclaredCollection1@abcdefg"":""unknown abcdefghijk value2"",UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            ODataValue val = entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).ODataValue;
+            val.As<ODataCollectionValue>().Items.Cast<string>().Count().Should().Be(3);
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(3);
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"Collection(Edm.String)\"");
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"unknown abcdefghijk value2\"");
+
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"UndeclaredCollection1@odata.type\":\"Collection(Edm.String)\",\"UndeclaredCollection1@odata.unknownName1\":\"unknown odata.xxx value1\",\"UndeclaredCollection1@abcdefg\":\"unknown abcdefghijk value2\",\"UndeclaredCollection1\":[\"email1@163.com\",\"email2@gmail.com\",\"email3@gmail2.com\"],\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+        }
+        #endregion
+
+        #region non-open entity's property unknown name + unknown value type
+
+        [Fact]
+        public void ReadNonOpenUnknownNullTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1@odata.unknownName1"":""unknown odata.xxx value1"",""UndeclaredAddress1@abcdefg"":""unknown abcdefghijk value2"",""UndeclaredAddress1"":"
+                + @"null,""UndeclaredAddress1@odata.type"":""Server.NS.UndefComplex1""}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            ODataUntypedValue val = entry.Properties.Last().Value.As<ODataUntypedValue>();
+            val.RawValue.Should().Be("null");
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(3);
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"unknown odata.xxx value1\"");
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"unknown abcdefghijk value2\"");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1@odata.unknownName1\":\"unknown odata.xxx value1\",\"UndeclaredAddress1@odata.type\":\"Server.NS.UndefComplex1\",\"UndeclaredAddress1@abcdefg\":\"unknown abcdefghijk value2\",\"UndeclaredAddress1\":null}");
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypePrimitiveTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId@odata.unknownName1"":""unknown odata.xxx value1"",""UndeclaredFloatId@abcdefg"":""unknown abcdefghijk value2"",""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name)).Value.As<ODataUntypedValue>().RawValue.Should().Be("12.3"); // numeric
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>() // string
+                .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypeInvalidComplexTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+                .Should().Be(@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}");
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypeInvalidComplexNestedTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""innerComplex1"":{""innerProp1"":null,""inerProp2"":'abc'},""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+                .Should().Be(@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""innerComplex1"":{""innerProp1"":null,""inerProp2"":'abc'},""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}");
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypeCollectionTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+              .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        #endregion
+
+        #region open entity's property unknown name + known value type
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredPropertiesWithNullValueTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""UndeclaredType1"":null}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            Assert.True(entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredType1")).ODataValue.IsNullValue);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredComplexPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""undeclaredComplex1"":{""@odata.type"":""#Server.NS.Address"",""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            var tmp = entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"));
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).ODataValue.As<ODataComplexValue>()
+                .Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredCollectionPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                UndeclaredCollection1@odata.type:""Collection(Edm.String)"",UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).ODataValue.As<ODataCollectionValue>().Items
+                .Cast<string>().Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+        #endregion
+
+        #region open entity's property unknown name + unknown value type
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredComplexPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                  ""undeclaredComplex1@odata.unknownName1"":""unknown odata.xxx value1"",""undeclaredComplex1@abcdefg"":""unknown abcdefghijk value2"",
+                                  ""undeclaredComplex1"":{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            ODataUntypedValue val = entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+                .Value.As<ODataUntypedValue>();
+            val.RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Count().Should().Be(2);
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.First().Value.Should().Be("\"unknown odata.xxx value1\"");
+            val.GetAnnotation<ODataJsonLightRawAnnotationSet>().Annotations.Last().Value.Should().Be("\"unknown abcdefghijk value2\"");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"undeclaredComplex1@odata.unknownName1\":\"unknown odata.xxx value1\",\"undeclaredComplex1@abcdefg\":\"unknown abcdefghijk value2\",\"undeclaredComplex1\":{\"MyProp1\":\"aaaaaaaaa\",\"UndeclaredProp1\":\"bbbbbbb\"},\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredComplexInvalidTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""undeclaredComplex1"":{""@odata.type"":""#Server.NS.AddressUndeclared"",""Street"":""No.999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+                .Should().Be(@"{""@odata.type"":""#Server.NS.AddressUndeclared"",""Street"":""No.999,Zixing Rd Minhang""}");
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredEmptyComplexPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""undeclaredComplex1"":{}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value.As<ODataUntypedValue>()
+                .RawValue.Should().Be(@"{}");
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredCollectionPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                                                          UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+                .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredEmptyCollectionPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                                                          UndeclaredCollection1:[],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>()
+                .RawValue.Should().Be(@"[]");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet"))
+                .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
+        }
+
+        #endregion
+
+        #region annotation for open entity's property unknown name + unknown value type
+
+        [Fact]
+        public void ReadAnnotationInOpenEntryUndeclaredComplexPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                    ""@instance.AnnotationName_"":""instance value_"",
+                                  ""undeclaredComplex1@odata.unknownname1"":""od unkown value 1"",
+                                  ""undeclaredComplex1@my.Annotation1"":""my custom value 1"",
+                                  ""undeclaredComplex1@instanceAnnotation1"":""custom annotation value 1"",
+                                  ""undeclaredComplex1@odata.type"":""Server.NS.UnknownType1"",""undeclaredComplex1"":{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+                .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        #endregion
+        private static void AdvanceReaderToFirstProperty(BufferingJsonReader bufferingJsonReader)
+        {
+            // Read start and then over the object start.
+            bufferingJsonReader.Read();
+            bufferingJsonReader.Read();
+            bufferingJsonReader.NodeType.Should().Be(JsonNodeType.Property);
+        }
+
+        private static void AdvanceReaderToFirstPropertyValue(BufferingJsonReader bufferingJsonReader)
+        {
+            AdvanceReaderToFirstProperty(bufferingJsonReader);
+
+            // Read over property name
+            bufferingJsonReader.Read();
+        }
+
+        private void ReadEntryPayload(string payload, EdmEntitySet entitySet, EdmEntityType entityType, Action<ODataReader> action)
+        {
+            var message = new InMemoryMessage() { Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload)) };
+            message.SetHeader("Content-Type", "application/json");
+            using (var msgReader = new ODataMessageReader((IODataResponseMessage)message, readerSettings, this.serverModel))
+            {
+                var reader = msgReader.CreateODataEntryReader(entitySet, entityType);
+                while (reader.Read())
+                {
+                    action(reader);
+                }
+            }
+        }
+        #region writer methods for roundtrip testing
+
+        private string WriteEntryPayload(EdmEntitySet entitySet, EdmEntityType entityType, Action<ODataWriter> action)
+        {
+            MemoryStream stream = new MemoryStream();
+            IODataResponseMessage message = new InMemoryMessage() { Stream = stream };
+            message.SetHeader("Content-Type", "application/json");
+            writerSettings.SetServiceDocumentUri(new Uri("http://www.sampletest.com"));
+            using (var msgReader = new ODataMessageWriter((IODataResponseMessage)message, writerSettings, this.serverModel))
+            {
+                var writer = msgReader.CreateODataEntryWriter(entitySet, entityType);
+                action(writer);
+
+                stream.Seek(0, SeekOrigin.Begin);
+                string payload = (new StreamReader(stream)).ReadToEnd();
+                return payload;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
@@ -204,7 +204,7 @@
             UndeclaredAddress1Value.TypeName.Should().Be("Server.NS.Address");
             UndeclaredAddress1Value.Properties.Count().Should().Be(2);
             UndeclaredAddress1Value.Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>()
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUndeclaredPropertyValue>()
                 .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
 
             // roundtrip test: writer
@@ -261,7 +261,7 @@
             });
 
             entry.Properties.Count().Should().Be(2);
-            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue.Should().Be("null");
+            entry.Properties.Last().Value.As<ODataUndeclaredPropertyValue>().RawValue.Should().Be("null");
 
             // roundtrip test: writer
             entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
@@ -286,10 +286,10 @@
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name)).Value.As<ODataUntypedValue>().RawValue.Should().Be("12.3"); // numeric
+            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name)).Value.As<ODataUndeclaredPropertyValue>().RawValue.Should().Be("12.3"); // numeric
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>() // string
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUndeclaredPropertyValue>() // string
                 .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
         }
 
@@ -306,7 +306,7 @@
             });
 
             entry.Properties.Count().Should().Be(2);
-            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Last().Value.As<ODataUndeclaredPropertyValue>().RawValue
                 .Should().Be(@"{""@odata.type"":""Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}");
         }
 
@@ -323,7 +323,7 @@
             });
 
             entry.Properties.Count().Should().Be(2);
-            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Last().Value.As<ODataUndeclaredPropertyValue>().RawValue
                 .Should().Be(@"{""@odata.type"":""Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""innerComplex1"":{""innerProp1"":null,""inerProp2"":'abc'},""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}");
         }
 
@@ -339,7 +339,7 @@
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUndeclaredPropertyValue>().RawValue
               .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
         }
@@ -428,7 +428,7 @@
 
             entry.Properties.Count().Should().Be(4);
             entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
-                .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
+                .Value.As<ODataUndeclaredPropertyValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
         }
 
@@ -442,7 +442,7 @@
             {
                 entry = reader.Item as ODataEntry;
             });
-            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Last().Value.As<ODataUndeclaredPropertyValue>().RawValue
                 .Should().Be(@"{""@odata.type"":""Server.NS.AddressUndeclared"",""Street"":""No.999,Zixing Rd Minhang""}");
         }
 
@@ -458,7 +458,7 @@
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value.As<ODataUntypedValue>()
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value.As<ODataUndeclaredPropertyValue>()
                 .RawValue.Should().Be(@"{}");
         }
 
@@ -474,7 +474,7 @@
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUndeclaredPropertyValue>().RawValue
                 .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
         }
@@ -491,10 +491,10 @@
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>()
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUndeclaredPropertyValue>()
                 .RawValue.Should().Be(@"[]");
             entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet"))
-                .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
+                .Value.As<ODataUndeclaredPropertyValue>().RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
         }
 
         #endregion

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
@@ -1,0 +1,522 @@
+﻿namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
+{
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using FluentAssertions;
+    // ReSharper disable RedundantUsingDirective
+    using Microsoft.OData.Core.Tests.JsonLight;
+    using Xunit;
+    using Microsoft.OData.Core;
+    using Microsoft.OData.Edm.Library;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Core.Tests;
+    // ReSharper restore RedundantUsingDirective
+
+    public class ODataJsonLightEntryAndFeedDeserializerUndeclaredTests
+    {
+        private ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings()
+        {
+            UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty
+        };
+
+        private ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings
+        {
+            UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty
+        };
+
+        // ----------- begin of edm for entry reader -----------
+        private EdmModel serverModel;
+        private EdmEntityType serverEntityType;
+        private EdmEntityType serverOpenEntityType;
+        private EdmEntitySet serverEntitySet;
+        private EdmEntitySet serverOpenEntitySet;
+
+        public ODataJsonLightEntryAndFeedDeserializerUndeclaredTests()
+        {
+            this.serverModel = new EdmModel();
+            var addressType = new EdmComplexType("Server.NS", "Address");
+            addressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+            this.serverModel.AddElement(addressType);
+
+            // non-open entity type
+            this.serverEntityType = new EdmEntityType("Server.NS", "ServerEntityType");
+            this.serverModel.AddElement(this.serverEntityType);
+            this.serverEntityType.AddKeys(this.serverEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            // open entity type
+            this.serverOpenEntityType = new EdmEntityType("Server.NS", "ServerOpenEntityType",
+                baseType: null, isAbstract: false, isOpen: true);
+            this.serverModel.AddElement(this.serverOpenEntityType);
+            this.serverOpenEntityType.AddKeys(this.serverOpenEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverOpenEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            EdmEntityContainer container = new EdmEntityContainer("Server.NS", "container1");
+            this.serverEntitySet = container.AddEntitySet("serverEntitySet", this.serverEntityType);
+            this.serverOpenEntitySet = container.AddEntitySet("serverOpenEntitySet", this.serverOpenEntityType);
+            this.serverModel.AddElement(container);
+
+            this.writerSettings.SetContentType(ODataFormat.Json);
+            this.writerSettings.SetServiceDocumentUri(new Uri("http://www.sampletest.com/"));
+        }
+        // ----------- end of edm for entry reader ----------- 
+
+        private void ReadEntryPayload(string payload, EdmEntitySet entitySet, EdmEntityType entityType, Action<ODataReader> action)
+        {
+            var message = new InMemoryMessage() { Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload)) };
+            message.SetHeader("Content-Type", "application/json");
+            using (var msgReader = new ODataMessageReader((IODataResponseMessage)message, readerSettings, this.serverModel))
+            {
+                var reader = msgReader.CreateODataEntryReader(entitySet, entityType);
+                while (reader.Read())
+                {
+                    action(reader);
+                }
+            }
+        }
+
+        #region non-open entity's property unknown name + known value type
+
+        [Fact]
+        public void ReadNonOpenNullTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"null}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().ODataValue.As<ODataNullValue>().Should().NotBeNull();
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(payload);
+        }
+
+        [Fact]
+        public void ReadNonOpenknownTypeBoolTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredBool"":false}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .First(s => string.Equals("UndeclaredBool", s.Name)).Value.Should().Be(false);
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(payload);
+        }
+
+        [Fact]
+        public void ReadNonOpenknownTypeStringTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet@odata.type"":""Edm.String"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+        }
+
+        [Fact]
+        public void ReadNonOpenknownTypeNumericTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreetNo@odata.type"":""Edm.Double"",""UndeclaredStreetNo"":""12""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .First(s => string.Equals("UndeclaredStreetNo", s.Name)).Value.Should().Be(12d);
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreetNo\":12.0}}");
+        }
+
+        [Fact]
+        public void ReadNonOpenKnownTypeComplexTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":{""@odata.type"":""Server.NS.Address"",""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            ODataComplexValue UndeclaredAddress1Value = entry.Properties.Last().Value.As<ODataComplexValue>();
+            UndeclaredAddress1Value.TypeName.Should().Be("Server.NS.Address");
+            UndeclaredAddress1Value.Properties.Count().Should().Be(2);
+            UndeclaredAddress1Value.Properties
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>()
+                .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+        }
+
+        [Fact]
+        public void ReadNonOpenKnownTypeCollectionTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                UndeclaredCollection1@odata.type:""Collection(Edm.String)"",UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).ODataValue.As<ODataCollectionValue>().Items
+                .Cast<string>().Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"UndeclaredCollection1\":[\"email1@163.com\",\"email2@gmail.com\",\"email3@gmail2.com\"],\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+        }
+        #endregion
+
+        #region non-open entity's property unknown name + unknown value type
+
+        [Fact]
+        public void ReadNonOpenUnknownNullTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"null,""UndeclaredAddress1@odata.type"":""Server.NS.UndefComplex1""}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue.Should().Be("null");
+
+            // roundtrip test: writer
+            entry.MetadataBuilder = new Microsoft.OData.Core.Evaluation.NoOpEntityMetadataBuilder(entry);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1\":null}");
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypePrimitiveTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name)).Value.As<ODataUntypedValue>().RawValue.Should().Be("12.3"); // numeric
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties
+                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>() // string
+                .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypeInvalidComplexTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"{""@odata.type"":""Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+                .Should().Be(@"{""@odata.type"":""Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}");
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypeInvalidComplexNestedTest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"{""@odata.type"":""Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""innerComplex1"":{""innerProp1"":null,""inerProp2"":'abc'},""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+                .Should().Be(@"{""@odata.type"":""Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""innerComplex1"":{""innerProp1"":null,""inerProp2"":'abc'},""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}");
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownTypeCollectionTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+              .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        #endregion
+
+        #region open entity's property unknown name + known value type
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredPropertiesWithNullValueTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""UndeclaredType1"":null}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            Assert.True(entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredType1")).ODataValue.IsNullValue);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredComplexPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""undeclaredComplex1"":{""@odata.type"":""Server.NS.Address"",""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            var tmp = entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"));
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).ODataValue.As<ODataComplexValue>()
+                .Properties.Count().Should().Be(2);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredCollectionPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                UndeclaredCollection1@odata.type:""Collection(Edm.String)"",UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).ODataValue.As<ODataCollectionValue>().Items
+                .Cast<string>().Count().Should().Be(3);
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+        #endregion
+
+        #region open entity's property unknown name + unknown value type
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredComplexPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                  ""undeclaredComplex1"":{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+                .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredComplexInvalidTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""undeclaredComplex1"":{""@odata.type"":""Server.NS.AddressUndeclared"",""Street"":""No.999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+            entry.Properties.Last().Value.As<ODataUntypedValue>().RawValue
+                .Should().Be(@"{""@odata.type"":""Server.NS.AddressUndeclared"",""Street"":""No.999,Zixing Rd Minhang""}");
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredEmptyComplexPropertiesTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""undeclaredComplex1"":{}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(3);
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value.As<ODataUntypedValue>()
+                .RawValue.Should().Be(@"{}");
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredCollectionPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                                                          UndeclaredCollection1:[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+                .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Count().Should().Be(2);
+        }
+
+        [Fact]
+        public void ReadOpenEntryUndeclaredEmptyCollectionPropertiesWithoutODataTypeTest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                                                                          UndeclaredCollection1:[],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataEntry entry = null;
+            this.ReadEntryPayload(payload, this.serverOpenEntitySet, this.serverOpenEntityType, reader =>
+            {
+                entry = reader.Item as ODataEntry;
+            });
+
+            entry.Properties.Count().Should().Be(4);
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>()
+                .RawValue.Should().Be(@"[]");
+            entry.Properties.Last().Value.As<ODataComplexValue>().Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet"))
+                .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
+        }
+
+        #endregion
+
+        #region writer methods for roundtrip testing
+
+        private string WriteEntryPayload(EdmEntitySet entitySet, EdmEntityType entityType, Action<ODataWriter> action)
+        {
+            MemoryStream stream = new MemoryStream();
+            IODataResponseMessage message = new InMemoryMessage() { Stream = stream };
+            message.SetHeader("Content-Type", "application/json");
+            using (var msgReader = new ODataMessageWriter((IODataResponseMessage)message, writerSettings, this.serverModel))
+            {
+                var writer = msgReader.CreateODataEntryWriter(entitySet, entityType);
+                action(writer);
+
+                stream.Seek(0, SeekOrigin.Begin);
+                string payload = (new StreamReader(stream)).ReadToEnd();
+                return payload;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
@@ -158,7 +158,7 @@
                 writer.WriteEnd();
             });
 
-            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet@odata.type\":\"Edm.String\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
         }
 
         [Fact]
@@ -185,7 +185,7 @@
                 writer.WriteEnd();
             });
 
-            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreetNo\":12.0}}");
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreetNo@odata.type\":\"Edm.Double\",\"UndeclaredStreetNo\":12.0}}");
         }
 
         [Fact]
@@ -242,7 +242,7 @@
                 writer.WriteEnd();
             });
 
-            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"UndeclaredCollection1\":[\"email1@163.com\",\"email2@gmail.com\",\"email3@gmail2.com\"],\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"UndeclaredCollection1@odata.type\":\"Collection(Edm.String)\",\"UndeclaredCollection1\":[\"email1@163.com\",\"email2@gmail.com\",\"email3@gmail2.com\"],\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\"}}");
         }
         #endregion
 
@@ -271,7 +271,7 @@
                 writer.WriteEnd();
             });
 
-            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1\":null}");
+            result.Should().Be("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredAddress1@odata.type\":\"Server.NS.UndefComplex1\",\"UndeclaredAddress1\":null}");
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerSkipUndecalredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerSkipUndecalredTests.cs
@@ -300,14 +300,14 @@
                 Properties = new[]
                     {
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
-                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUntypedValue(){RawValue="12.3"}},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUndeclaredPropertyValue(){RawValue="12.3"}},
                         new ODataProperty{Name = "Address", Value = new ODataComplexValue()
                         {
                             TypeName = "Server.NS.Address",
                             Properties= new []
                             {
                                 new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
-                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUntypedValue(){RawValue="12.0"}},
+                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUndeclaredPropertyValue(){RawValue="12.0"}},
                             },
                         }},
                     },
@@ -337,7 +337,7 @@
                             Properties= new []
                             {
                                 new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
-                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUntypedValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUndeclaredPropertyValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
                             },
                         }},
                     },
@@ -362,7 +362,7 @@
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
                         new ODataProperty{Name = "UndeclaredAddress1", Value =
-                            new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
+                            new ODataUndeclaredPropertyValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
                         },
                     },
             };
@@ -386,7 +386,7 @@
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
                         new ODataProperty{Name = "UndeclaredCollection1", Value =
-                            new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
+                            new ODataUndeclaredPropertyValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
                         },
                     },
             };
@@ -615,14 +615,14 @@
                 Properties = new[]
                     {
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
-                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUntypedValue(){RawValue="12.3"}},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUndeclaredPropertyValue(){RawValue="12.3"}},
                         new ODataProperty{Name = "Address", Value = new ODataComplexValue()
                         {
                             TypeName = "Server.NS.Address",
                             Properties= new []
                             {
                                 new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
-                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUntypedValue(){RawValue="12.0"}},
+                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUndeclaredPropertyValue(){RawValue="12.0"}},
                             },
                         }},
                     },
@@ -652,7 +652,7 @@
                             Properties= new []
                             {
                                 new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
-                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUntypedValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUndeclaredPropertyValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
                             },
                         }},
                     },
@@ -677,7 +677,7 @@
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
                         new ODataProperty{Name = "UndeclaredAddress1", Value =
-                            new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
+                            new ODataUndeclaredPropertyValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
                         },
                     },
             };
@@ -701,7 +701,7 @@
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
                         new ODataProperty{Name = "UndeclaredCollection1", Value =
-                            new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
+                            new ODataUndeclaredPropertyValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
                         },
                     },
             };

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerSkipUndecalredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerSkipUndecalredTests.cs
@@ -19,9 +19,6 @@
         private EdmModel serverModel;
         private EdmEntityType serverEntityType;
         private EdmEntityType serverOpenEntityType;
-        private string serverEntityTypeName;
-        private string serverOpenEntityTypeName;
-        private string serverComplexTypeName;
         private EdmEntitySet serverEntitySet;
         private EdmEntitySet serverOpenEntitySet;
 
@@ -31,11 +28,9 @@
             var addressType = new EdmComplexType("Server.NS", "Address");
             addressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
             this.serverModel.AddElement(addressType);
-            this.serverComplexTypeName = "Server.NS.Address";
 
             // non-open entity type
             this.serverEntityType = new EdmEntityType("Server.NS", "ServerEntityType");
-            this.serverEntityTypeName = "Server.NS.ServerEntityType";
             this.serverModel.AddElement(this.serverEntityType);
             this.serverEntityType.AddKeys(this.serverEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
             this.serverEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
@@ -43,7 +38,6 @@
             // open entity type
             this.serverOpenEntityType = new EdmEntityType("Server.NS", "ServerOpenEntityType",
                 baseType: null, isAbstract: false, isOpen: true);
-            this.serverOpenEntityTypeName = "Server.NS.ServerOpenEntityType";
             this.serverModel.AddElement(this.serverOpenEntityType);
             this.serverOpenEntityType.AddKeys(this.serverOpenEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
             this.serverOpenEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
@@ -367,7 +361,7 @@
                     {
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
-                        new ODataProperty{Name = "UndeclaredAddress1", Value = 
+                        new ODataProperty{Name = "UndeclaredAddress1", Value =
                             new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
                         },
                     },
@@ -391,7 +385,7 @@
                     {
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
-                        new ODataProperty{Name = "UndeclaredCollection1", Value = 
+                        new ODataProperty{Name = "UndeclaredCollection1", Value =
                             new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
                         },
                     },
@@ -682,7 +676,7 @@
                     {
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
-                        new ODataProperty{Name = "UndeclaredAddress1", Value = 
+                        new ODataProperty{Name = "UndeclaredAddress1", Value =
                             new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
                         },
                     },
@@ -706,7 +700,7 @@
                     {
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
-                        new ODataProperty{Name = "UndeclaredCollection1", Value = 
+                        new ODataProperty{Name = "UndeclaredCollection1", Value =
                             new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
                         },
                     },

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerSkipUndecalredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerSkipUndecalredTests.cs
@@ -1,0 +1,767 @@
+﻿namespace Microsoft.Test.OData.TDD.Tests.Writer.JsonLight
+{
+    using FluentAssertions;
+    using Microsoft.OData.Core;
+    using Microsoft.OData.Core.JsonLight;
+    using Microsoft.OData.Core.Tests;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Edm.Library;
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using Xunit;
+
+    public class ODataJsonLightEntryAndFeedSerializerSkipUndeclaredTests
+    {
+        private Uri metadataDocumentUri = new Uri("http://odata.org/test/$metadata/");
+
+        private EdmModel serverModel;
+        private EdmEntityType serverEntityType;
+        private EdmEntityType serverOpenEntityType;
+        private string serverEntityTypeName;
+        private string serverOpenEntityTypeName;
+        private string serverComplexTypeName;
+        private EdmEntitySet serverEntitySet;
+        private EdmEntitySet serverOpenEntitySet;
+
+        public ODataJsonLightEntryAndFeedSerializerSkipUndeclaredTests()
+        {
+            this.serverModel = new EdmModel();
+            var addressType = new EdmComplexType("Server.NS", "Address");
+            addressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+            this.serverModel.AddElement(addressType);
+            this.serverComplexTypeName = "Server.NS.Address";
+
+            // non-open entity type
+            this.serverEntityType = new EdmEntityType("Server.NS", "ServerEntityType");
+            this.serverEntityTypeName = "Server.NS.ServerEntityType";
+            this.serverModel.AddElement(this.serverEntityType);
+            this.serverEntityType.AddKeys(this.serverEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            // open entity type
+            this.serverOpenEntityType = new EdmEntityType("Server.NS", "ServerOpenEntityType",
+                baseType: null, isAbstract: false, isOpen: true);
+            this.serverOpenEntityTypeName = "Server.NS.ServerOpenEntityType";
+            this.serverModel.AddElement(this.serverOpenEntityType);
+            this.serverOpenEntityType.AddKeys(this.serverOpenEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverOpenEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            EdmEntityContainer container = new EdmEntityContainer("Server.NS", "container1");
+            this.serverEntitySet = container.AddEntitySet("serverEntitySet", this.serverEntityType);
+            this.serverOpenEntitySet = container.AddEntitySet("serverOpenEntitySet", this.serverOpenEntityType);
+            this.serverModel.AddElement(container);
+        }
+
+        private ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings
+        {
+            Version = ODataVersion.V4,
+            UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.DiscardUndeclaredValueProperty
+        };
+
+        #region non-open entity's property unknown name + known value type
+
+        [Fact]
+        public void WriteEntryUndeclaredPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredPropertiesWithNullValueTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredType1", Value = null},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredComplexPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredComplexType1", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.1000,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.1001,Zixing Rd Minhang")},
+                            },
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredEmptyComplexPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredComplexType1", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new ODataProperty[]{},
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredCollectionPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = new ODataCollectionValue(){
+                            TypeName = "Collection(Edm.String)",
+                            Items = new[]
+                            {
+                                "mystr1",
+                                "mystr2",
+                                "mystr3"
+                            }}},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredEmptyCollectionPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = new ODataCollectionValue(){
+                            TypeName = "Collection(Edm.String)",
+                            Items = new string[]{},
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        #endregion
+
+        #region non-open entity's property unknown name + unknown value type
+        [Fact]
+        public void WriteEntryUntypedFloatDoubleTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUntypedValue(){RawValue="12.3"}},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUntypedValue(){RawValue="12.0"}},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteEntryUntypedStringTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUntypedValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteEntryUntypedComplexTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "UndeclaredAddress1", Value = 
+                            new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
+                        },
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128}");
+        }
+
+        [Fact]
+        public void WriteEntryUntypedCollectionTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = 
+                            new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
+                        },
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128}");
+        }
+        #endregion
+
+        #region open entity's property unknown name + known value type
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredPropertiesWithNullValueTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredType1", Value = null},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredType1"":null,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+        [Fact]
+        public void WriteOpenEntryUndeclaredComplexPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredComplexType1", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.1000,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.1001,Zixing Rd Minhang")},
+                            },
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredComplexType1"":{""@odata.type"":""#Server.NS.Address"",""Street"":""No.1000,Zixing Rd Minhang""},""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredEmptyComplexPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredComplexType1", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new ODataProperty[]{},
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredComplexType1"":{""@odata.type"":""#Server.NS.Address""},""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredCollectionPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = new ODataCollectionValue(){
+                            TypeName = "Collection(Edm.String)",
+                            Items = new[]
+                            {
+                                "mystr1",
+                                "mystr2",
+                                "mystr3"
+                            }}},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredCollection1@odata.type"":""#Collection(String)"",""UndeclaredCollection1"":[""mystr1"",""mystr2"",""mystr3""],""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredEmptyCollectionPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = new ODataCollectionValue(){
+                            TypeName = "Collection(Edm.String)",
+                            Items = new string[]{},
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredCollection1@odata.type"":""#Collection(String)"",""UndeclaredCollection1"":[],""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        #endregion
+
+        #region open entity's property unknown name + unknown value type
+        [Fact]
+        public void WriteOpenEntryUntypedFloatDoubleTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUntypedValue(){RawValue="12.3"}},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUntypedValue(){RawValue="12.0"}},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUntypedStringTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUntypedValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUntypedComplexTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "UndeclaredAddress1", Value = 
+                            new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
+                        },
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUntypedCollectionTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = 
+                            new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
+                        },
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3}");
+        }
+
+        #endregion
+
+        private string WriteEntryPayload(EdmEntitySet entitySet, EdmEntityType entityType, Action<ODataWriter> action)
+        {
+            MemoryStream stream = new MemoryStream();
+            IODataResponseMessage message = new InMemoryMessage() { Stream = stream };
+            message.SetHeader("Content-Type", "application/json");
+            writerSettings.SetServiceDocumentUri(new Uri("http://www.sampletest.com"));
+            using (var msgReader = new ODataMessageWriter((IODataResponseMessage)message, writerSettings, this.serverModel))
+            {
+                var writer = msgReader.CreateODataEntryWriter(entitySet, entityType);
+                action(writer);
+
+                stream.Seek(0, SeekOrigin.Begin);
+                string payload = (new StreamReader(stream)).ReadToEnd();
+                return payload;
+            }
+        }
+
+        private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream, bool writingResponse = true, bool setMetadataDocumentUri = true)
+        {
+            IEdmModel model = new EdmModel();
+
+            ODataMessageWriterSettings settings = new ODataMessageWriterSettings
+            {
+                Version = ODataVersion.V4
+            };
+            if (setMetadataDocumentUri)
+            {
+                settings.SetServiceDocumentUri(this.metadataDocumentUri);
+            }
+
+            return new ODataJsonLightOutputContext(
+                ODataFormat.Json,
+                new NonDisposingStream(stream),
+                new ODataMediaType("application", "json"),
+                Encoding.UTF8,
+                settings,
+                writingResponse,
+                /*synchronous*/ true,
+                model,
+                /*urlResolver*/ null);
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
@@ -298,14 +298,14 @@
                 Properties = new[]
                     {
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
-                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUntypedValue(){RawValue="12.3"}},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUndeclaredPropertyValue(){RawValue="12.3"}},
                         new ODataProperty{Name = "Address", Value = new ODataComplexValue()
                         {
                             TypeName = "Server.NS.Address",
                             Properties= new []
                             {
                                 new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
-                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUntypedValue(){RawValue="12.0"}},
+                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUndeclaredPropertyValue(){RawValue="12.0"}},
                             },
                         }},
                     },
@@ -335,7 +335,7 @@
                             Properties= new []
                             {
                                 new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
-                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUntypedValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUndeclaredPropertyValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
                             },
                         }},
                     },
@@ -360,7 +360,7 @@
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
                         new ODataProperty{Name = "UndeclaredAddress1", Value = 
-                            new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
+                            new ODataUndeclaredPropertyValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
                         },
                     },
             };
@@ -384,7 +384,7 @@
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
                         new ODataProperty{Name = "UndeclaredCollection1", Value = 
-                            new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
+                            new ODataUndeclaredPropertyValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
                         },
                     },
             };
@@ -613,14 +613,14 @@
                 Properties = new[]
                     {
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
-                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUntypedValue(){RawValue="12.3"}},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUndeclaredPropertyValue(){RawValue="12.3"}},
                         new ODataProperty{Name = "Address", Value = new ODataComplexValue()
                         {
                             TypeName = "Server.NS.Address",
                             Properties= new []
                             {
                                 new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
-                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUntypedValue(){RawValue="12.0"}},
+                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUndeclaredPropertyValue(){RawValue="12.0"}},
                             },
                         }},
                     },
@@ -650,7 +650,7 @@
                             Properties= new []
                             {
                                 new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
-                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUntypedValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUndeclaredPropertyValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
                             },
                         }},
                     },
@@ -675,7 +675,7 @@
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
                         new ODataProperty{Name = "UndeclaredAddress1", Value = 
-                            new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
+                            new ODataUndeclaredPropertyValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
                         },
                     },
             };
@@ -699,7 +699,7 @@
                         new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
                         new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
                         new ODataProperty{Name = "UndeclaredCollection1", Value = 
-                            new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
+                            new ODataUndeclaredPropertyValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
                         },
                     },
             };

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
@@ -1,0 +1,765 @@
+﻿namespace Microsoft.Test.OData.TDD.Tests.Writer.JsonLight
+{
+    using FluentAssertions;
+    using Microsoft.OData.Core;
+    using Microsoft.OData.Core.JsonLight;
+    using Microsoft.OData.Core.Tests;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Edm.Library;
+    using System;
+    using System.IO;
+    using System.Text;
+    using Xunit;
+
+    public class ODataJsonLightEntryAndFeedSerializerUndeclaredTests
+    {
+        private Uri metadataDocumentUri = new Uri("http://odata.org/test/$metadata/");
+
+        private EdmModel serverModel;
+        private EdmEntityType serverEntityType;
+        private EdmEntityType serverOpenEntityType;
+        private string serverEntityTypeName;
+        private string serverOpenEntityTypeName;
+        private string serverComplexTypeName;
+        private EdmEntitySet serverEntitySet;
+        private EdmEntitySet serverOpenEntitySet;
+
+        public ODataJsonLightEntryAndFeedSerializerUndeclaredTests()
+        {
+            this.serverModel = new EdmModel();
+            var addressType = new EdmComplexType("Server.NS", "Address");
+            addressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+            this.serverModel.AddElement(addressType);
+            this.serverComplexTypeName = "Server.NS.Address";
+
+            // non-open entity type
+            this.serverEntityType = new EdmEntityType("Server.NS", "ServerEntityType");
+            this.serverEntityTypeName = "Server.NS.ServerEntityType";
+            this.serverModel.AddElement(this.serverEntityType);
+            this.serverEntityType.AddKeys(this.serverEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            // open entity type
+            this.serverOpenEntityType = new EdmEntityType("Server.NS", "ServerOpenEntityType",
+                baseType: null, isAbstract: false, isOpen: true);
+            this.serverOpenEntityTypeName = "Server.NS.ServerOpenEntityType";
+            this.serverModel.AddElement(this.serverOpenEntityType);
+            this.serverOpenEntityType.AddKeys(this.serverOpenEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.serverOpenEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
+
+            EdmEntityContainer container = new EdmEntityContainer("Server.NS", "container1");
+            this.serverEntitySet = container.AddEntitySet("serverEntitySet", this.serverEntityType);
+            this.serverOpenEntitySet = container.AddEntitySet("serverOpenEntitySet", this.serverOpenEntityType);
+            this.serverModel.AddElement(container);
+        }
+
+        private ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings
+        {
+            UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty
+        };
+
+        #region non-open entity's property unknown name + known value type
+
+        [Fact]
+        public void WriteEntryUndeclaredPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredPropertiesWithNullValueTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredType1", Value = null},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredType1"":null,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredComplexPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredComplexType1", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.1000,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.1001,Zixing Rd Minhang")},
+                            },
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredComplexType1"":{""Street"":""No.1000,Zixing Rd Minhang"",""UndeclaredStreet"":""No.1001,Zixing Rd Minhang""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredEmptyComplexPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredComplexType1", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new ODataProperty[]{},
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredComplexType1"":{},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredCollectionPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = new ODataCollectionValue(){
+                            TypeName = "Collection(Edm.String)",
+                            Items = new[]
+                            {
+                                "mystr1",
+                                "mystr2",
+                                "mystr3"
+                            }}},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredCollection1"":[""mystr1"",""mystr2"",""mystr3""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteNonOpenEntryUndeclaredEmptyCollectionPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = new ODataCollectionValue(){
+                            TypeName = "Collection(Edm.String)",
+                            Items = new string[]{},
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredCollection1"":[],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        #endregion
+
+        #region non-open entity's property unknown name + unknown value type
+        [Fact]
+        public void WriteEntryUntypedFloatDoubleTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUntypedValue(){RawValue="12.3"}},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUntypedValue(){RawValue="12.0"}},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreetNo"":12.0}}");
+        }
+
+        [Fact]
+        public void WriteEntryUntypedStringTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUntypedValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteEntryUntypedComplexTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "UndeclaredAddress1", Value = 
+                            new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
+                        },
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""UndeclaredAddress1"":{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}}");
+        }
+
+        [Fact]
+        public void WriteEntryUntypedCollectionTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = 
+                            new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
+                        },
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""UndeclaredCollection1"":[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]}");
+        }
+        #endregion
+
+        #region open entity's property unknown name + known value type
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredPropertiesWithNullValueTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredType1", Value = null},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredType1"":null,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+        [Fact]
+        public void WriteOpenEntryUndeclaredComplexPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredComplexType1", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.1000,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.1001,Zixing Rd Minhang")},
+                            },
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredComplexType1"":{""@odata.type"":""#Server.NS.Address"",""Street"":""No.1000,Zixing Rd Minhang"",""UndeclaredStreet"":""No.1001,Zixing Rd Minhang""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredEmptyComplexPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredComplexType1", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new ODataProperty[]{},
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredComplexType1"":{""@odata.type"":""#Server.NS.Address""},""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredCollectionPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = new ODataCollectionValue(){
+                            TypeName = "Collection(Edm.String)",
+                            Items = new[]
+                            {
+                                "mystr1",
+                                "mystr2",
+                                "mystr3"
+                            }}},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredCollection1@odata.type"":""#Collection(String)"",""UndeclaredCollection1"":[""mystr1"",""mystr2"",""mystr3""],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUndeclaredEmptyCollectionPropertiesTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = new ODataCollectionValue(){
+                            TypeName = "Collection(Edm.String)",
+                            Items = new string[]{},
+                        }},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties = new[]
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataPrimitiveValue("No.10000000999,Zixing Rd Minhang")},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredCollection1@odata.type"":""#Collection(String)"",""UndeclaredCollection1"":[],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        #endregion
+
+        #region open entity's property unknown name + unknown value type
+        [Fact]
+        public void WriteOpenEntryUntypedFloatDoubleTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataUntypedValue(){RawValue="12.3"}},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreetNo", Value = new ODataUntypedValue(){RawValue="12.0"}},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreetNo"":12.0}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUntypedStringTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "Address", Value = new ODataComplexValue()
+                        {
+                            TypeName = "Server.NS.Address",
+                            Properties= new []
+                            {
+                                new ODataProperty{Name = "Street", Value = new ODataPrimitiveValue("No.999,Zixing Rd Minhang")},
+                                new ODataProperty{Name = "UndeclaredStreet", Value = new ODataUntypedValue(){RawValue=@"""No.10000000999,Zixing Rd Minhang"""}},
+                            },
+                        }},
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUntypedComplexTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "UndeclaredAddress1", Value = 
+                            new ODataUntypedValue(){RawValue=@"{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}"}
+                        },
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""UndeclaredAddress1"":{""@odata.type"":""#Server.NS.AddressInValid"",'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}}");
+        }
+
+        [Fact]
+        public void WriteOpenEntryUntypedCollectionTest()
+        {
+            var entry = new ODataEntry
+            {
+                TypeName = "Server.NS.ServerOpenEntityType",
+                Properties = new[]
+                    {
+                        new ODataProperty{Name = "Id", Value = new ODataPrimitiveValue(61880128)},
+                        new ODataProperty{Name = "UndeclaredFloatId", Value = new ODataPrimitiveValue(12.3D)},
+                        new ODataProperty{Name = "UndeclaredCollection1", Value = 
+                            new ODataUntypedValue(){RawValue=@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]"}
+                        },
+                    },
+            };
+            string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
+            {
+                writer.WriteStart(entry);
+                writer.WriteEnd();
+            });
+
+            result.Should().Be(@"{""@odata.context"":""http://www.sampletest.com/$metadata#serverOpenEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,""UndeclaredCollection1"":[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]}");
+        }
+
+        #endregion
+
+        private string WriteEntryPayload(EdmEntitySet entitySet, EdmEntityType entityType, Action<ODataWriter> action)
+        {
+            MemoryStream stream = new MemoryStream();
+            IODataResponseMessage message = new InMemoryMessage() { Stream = stream };
+            message.SetHeader("Content-Type", "application/json");
+            writerSettings.SetServiceDocumentUri(new Uri("http://www.sampletest.com"));
+            using (var msgReader = new ODataMessageWriter((IODataResponseMessage)message, writerSettings, this.serverModel))
+            {
+                var writer = msgReader.CreateODataEntryWriter(entitySet, entityType);
+                action(writer);
+
+                stream.Seek(0, SeekOrigin.Begin);
+                string payload = (new StreamReader(stream)).ReadToEnd();
+                return payload;
+            }
+        }
+
+        private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream, bool writingResponse = true, bool setMetadataDocumentUri = true)
+        {
+            IEdmModel model = new EdmModel();
+
+            ODataMessageWriterSettings settings = new ODataMessageWriterSettings
+            {
+                Version = ODataVersion.V4
+            };
+            if (setMetadataDocumentUri)
+            {
+                settings.SetServiceDocumentUri(this.metadataDocumentUri);
+            }
+
+            return new ODataJsonLightOutputContext(
+                ODataFormat.Json,
+                new NonDisposingStream(stream),
+                new ODataMediaType("application", "json"),
+                Encoding.UTF8,
+                settings,
+                writingResponse,
+                /*synchronous*/ true,
+                model,
+                /*urlResolver*/ null);
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
@@ -18,9 +18,6 @@
         private EdmModel serverModel;
         private EdmEntityType serverEntityType;
         private EdmEntityType serverOpenEntityType;
-        private string serverEntityTypeName;
-        private string serverOpenEntityTypeName;
-        private string serverComplexTypeName;
         private EdmEntitySet serverEntitySet;
         private EdmEntitySet serverOpenEntitySet;
 
@@ -30,11 +27,9 @@
             var addressType = new EdmComplexType("Server.NS", "Address");
             addressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
             this.serverModel.AddElement(addressType);
-            this.serverComplexTypeName = "Server.NS.Address";
 
             // non-open entity type
             this.serverEntityType = new EdmEntityType("Server.NS", "ServerEntityType");
-            this.serverEntityTypeName = "Server.NS.ServerEntityType";
             this.serverModel.AddElement(this.serverEntityType);
             this.serverEntityType.AddKeys(this.serverEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
             this.serverEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
@@ -42,7 +37,6 @@
             // open entity type
             this.serverOpenEntityType = new EdmEntityType("Server.NS", "ServerOpenEntityType",
                 baseType: null, isAbstract: false, isOpen: true);
-            this.serverOpenEntityTypeName = "Server.NS.ServerOpenEntityType";
             this.serverModel.AddElement(this.serverOpenEntityType);
             this.serverOpenEntityType.AddKeys(this.serverOpenEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
             this.serverOpenEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\..\sln\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="..\..\..\sln\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props" Condition="Exists('..\..\..\sln\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -14,7 +15,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\sln\</SolutionDir>
     <RestorePackages>true</RestorePackages>
-    <NuGetPackageImportStamp>a0f2c974</NuGetPackageImportStamp>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
     <NoWarn>;0618</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -113,8 +115,12 @@
     <Compile Include="JsonLight\ODataJsonLightDeltaReaderTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightDeltaWriterTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightDeserializerTests.cs" />
+    <Compile Include="JsonLight\ODataJsonLightEntryAndFeedDeserializerSkipUndeclaredTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightEntryAndFeedDeserializerTests.cs" />
+    <Compile Include="JsonLight\ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs" />
+    <Compile Include="JsonLight\ODataJsonLightEntryAndFeedSerializerSkipUndecalredTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightEntryAndFeedSerializerTests.cs" />
+    <Compile Include="JsonLight\ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightErrorDeserializerTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightOutputContextTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightParameterReaderTests.cs" />
@@ -450,6 +456,7 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
     <Error Condition="!Exists('..\..\..\sln\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\sln\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
+    <Error Condition="!Exists('..\..\..\sln\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\sln\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -117,6 +117,7 @@
     <Compile Include="JsonLight\ODataJsonLightDeserializerTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightEntryAndFeedDeserializerSkipUndeclaredTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightEntryAndFeedDeserializerTests.cs" />
+    <Compile Include="JsonLight\ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightEntryAndFeedSerializerSkipUndecalredTests.cs" />
     <Compile Include="JsonLight\ODataJsonLightEntryAndFeedSerializerTests.cs" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
@@ -921,11 +921,16 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Writer.JsonLight
 
             ODataItem[] itemsToWrite = { entry };
 
-            string expectedPayload =
-                                  "{\"" +
-                                    "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/$entity\"," +
-                                    "\"ID\":102,\"Name\":\"Bob\",\"Prop1\":\"Var1\"" +
-                                  "}";
+            Action action = () => this.GetWriterOutputForContentTypeAndKnobValue(
+                "application/json;odata.metadata=minimal",
+                true,
+                itemsToWrite,
+                Model,
+                EntitySet,
+                EntityType,
+                undeclaredPropertyBehaviorKinds: ODataUndeclaredPropertyBehaviorKinds.None);
+            action.ShouldThrow<ODataException>().WithMessage(
+                Strings.ValidationUtils_PropertyDoesNotExistOnType("Prop1", "Namespace.EntityType"));
 
             string result = this.GetWriterOutputForContentTypeAndKnobValue(
                 "application/json;odata.metadata=minimal",
@@ -934,17 +939,12 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Writer.JsonLight
                 Model,
                 EntitySet,
                 EntityType,
-                enableFullValidation: true);
-            result.Should().Be(expectedPayload);
-
-            result = this.GetWriterOutputForContentTypeAndKnobValue(
-                "application/json;odata.metadata=minimal",
-                true,
-                itemsToWrite,
-                Model,
-                EntitySet,
-                EntityType,
-                enableFullValidation: false);
+                undeclaredPropertyBehaviorKinds: ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty);
+            string expectedPayload =
+                                  "{\"" +
+                                    "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/$entity\"," +
+                                    "\"ID\":102,\"Name\":\"Bob\",\"Prop1\":\"Var1\"" +
+                                  "}";
             result.Should().Be(expectedPayload);
         }
 
@@ -993,7 +993,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Writer.JsonLight
             string selectClause = null,
             string expandClause = null,
             string resourcePath = null,
-            bool enableFullValidation = true)
+            ODataUndeclaredPropertyBehaviorKinds undeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.None)
         {
             MemoryStream outputStream = new MemoryStream();
             IODataResponseMessage message = new InMemoryMessage() { Stream = outputStream };
@@ -1001,7 +1001,8 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Writer.JsonLight
             ODataMessageWriterSettings settings = new ODataMessageWriterSettings()
             {
                 AutoComputePayloadMetadataInJson = autoComputePayloadMetadataInJson,
-                EnableFullValidation = enableFullValidation
+                EnableFullValidation = true,
+                UndeclaredPropertyBehaviorKinds = undeclaredPropertyBehaviorKinds
             };
 
             var result = new ODataQueryOptionParser(edmModel, edmEntityType, edmEntitySet, new Dictionary<string, string> { { "$expand", expandClause }, { "$select", selectClause } }).ParseSelectAndExpand();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
@@ -928,7 +928,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Writer.JsonLight
                 Model,
                 EntitySet,
                 EntityType,
-                undeclaredPropertyBehaviorKinds: ODataUndeclaredPropertyBehaviorKinds.None);
+                enableFullValidation: true);
             action.ShouldThrow<ODataException>().WithMessage(
                 Strings.ValidationUtils_PropertyDoesNotExistOnType("Prop1", "Namespace.EntityType"));
 
@@ -939,7 +939,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Writer.JsonLight
                 Model,
                 EntitySet,
                 EntityType,
-                undeclaredPropertyBehaviorKinds: ODataUndeclaredPropertyBehaviorKinds.IgnoreUndeclaredValueProperty);
+                enableFullValidation: false);
             string expectedPayload =
                                   "{\"" +
                                     "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/$entity\"," +
@@ -993,7 +993,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Writer.JsonLight
             string selectClause = null,
             string expandClause = null,
             string resourcePath = null,
-            ODataUndeclaredPropertyBehaviorKinds undeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.None)
+            bool enableFullValidation = true)
         {
             MemoryStream outputStream = new MemoryStream();
             IODataResponseMessage message = new InMemoryMessage() { Stream = outputStream };
@@ -1001,8 +1001,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Writer.JsonLight
             ODataMessageWriterSettings settings = new ODataMessageWriterSettings()
             {
                 AutoComputePayloadMetadataInJson = autoComputePayloadMetadataInJson,
-                EnableFullValidation = true,
-                UndeclaredPropertyBehaviorKinds = undeclaredPropertyBehaviorKinds
+                EnableFullValidation = enableFullValidation
             };
 
             var result = new ODataQueryOptionParser(edmModel, edmEntityType, edmEntitySet, new Dictionary<string, string> { { "$expand", expandClause }, { "$select", selectClause } }).ParseSelectAndExpand();

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -4876,6 +4876,12 @@ public sealed class Microsoft.OData.Core.ODataStreamReferenceValue : Microsoft.O
 	System.Uri ReadLink  { public get; public set; }
 }
 
+public sealed class Microsoft.OData.Core.ODataUndeclaredPropertyValue : Microsoft.OData.Core.ODataValue {
+	public ODataUndeclaredPropertyValue ()
+
+	string RawValue  { public get; public set; }
+}
+
 public sealed class Microsoft.OData.Core.ODataUntypedValue : Microsoft.OData.Core.ODataValue {
 	public ODataUntypedValue ()
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -3851,6 +3851,7 @@ public enum Microsoft.OData.Core.ODataUndeclaredPropertyBehaviorKinds : int {
 	IgnoreUndeclaredValueProperty = 1
 	None = 0
 	ReportUndeclaredLinkProperty = 2
+	SupportUndeclaredValueProperty = 4
 }
 
 public enum Microsoft.OData.Core.ODataVersion : int {
@@ -4709,19 +4710,19 @@ public sealed class Microsoft.OData.Core.ODataMessageReader : IDisposable {
 	public System.Threading.Tasks.Task`1[[System.Object]] ReadValueAsync (Microsoft.OData.Edm.IEdmTypeReference expectedTypeReference)
 }
 
-public sealed class Microsoft.OData.Core.ODataMessageReaderSettings : Microsoft.OData.Core.ODataMessageReaderSettingsBase {
+public sealed class Microsoft.OData.Core.ODataMessageReaderSettings : Microsoft.OData.Core.ODataMessageReaderSettingsBase, IMessageValidationSetting {
 	public ODataMessageReaderSettings ()
 	public ODataMessageReaderSettings (Microsoft.OData.Core.ODataMessageReaderSettings other)
 
 	System.Uri BaseUri  { public get; public set; }
 	bool DisableMessageStreamDisposal  { public get; public set; }
 	bool DisablePrimitiveTypeConversion  { public get; public set; }
-	bool EnableFullValidation  { public get; public set; }
+	bool EnableFullValidation  { public virtual get; public virtual set; }
 	Microsoft.OData.Core.ODataVersion MaxProtocolVersion  { public get; public set; }
 	Microsoft.OData.Core.ODataMediaTypeResolver MediaTypeResolver  { public get; public set; }
 	bool ODataSimplified  { public get; public set; }
 	System.Uri PayloadBaseUri  { public get; public set; }
-	Microsoft.OData.Core.ODataUndeclaredPropertyBehaviorKinds UndeclaredPropertyBehaviorKinds  { public get; public set; }
+	Microsoft.OData.Core.ODataUndeclaredPropertyBehaviorKinds UndeclaredPropertyBehaviorKinds  { public virtual get; public virtual set; }
 	System.Nullable`1[[System.Boolean]] UseKeyAsSegment  { public get; public set; }
 
 	public void EnableDefaultBehavior ()
@@ -4777,18 +4778,19 @@ public sealed class Microsoft.OData.Core.ODataMessageWriter : IDisposable {
 	public System.Threading.Tasks.Task WriteValueAsync (object value)
 }
 
-public sealed class Microsoft.OData.Core.ODataMessageWriterSettings : Microsoft.OData.Core.ODataMessageWriterSettingsBase {
+public sealed class Microsoft.OData.Core.ODataMessageWriterSettings : Microsoft.OData.Core.ODataMessageWriterSettingsBase, IMessageValidationSetting {
 	public ODataMessageWriterSettings ()
 	public ODataMessageWriterSettings (Microsoft.OData.Core.ODataMessageWriterSettings other)
 
 	bool AutoComputePayloadMetadataInJson  { public get; public set; }
 	bool DisableMessageStreamDisposal  { public get; public set; }
-	bool EnableFullValidation  { public get; public set; }
+	bool EnableFullValidation  { public virtual get; public virtual set; }
 	string JsonPCallback  { public get; public set; }
 	Microsoft.OData.Core.ODataMediaTypeResolver MediaTypeResolver  { public get; public set; }
 	bool ODataSimplified  { public get; public set; }
 	Microsoft.OData.Core.ODataUri ODataUri  { public get; public set; }
 	System.Uri PayloadBaseUri  { public get; public set; }
+	Microsoft.OData.Core.ODataUndeclaredPropertyBehaviorKinds UndeclaredPropertyBehaviorKinds  { public virtual get; public virtual set; }
 	System.Nullable`1[[System.Boolean]] UseKeyAsSegment  { public get; public set; }
 	System.Nullable`1[[Microsoft.OData.Core.ODataVersion]] Version  { public get; public set; }
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -3848,10 +3848,12 @@ public enum Microsoft.OData.Core.ODataReaderState : int {
 FlagsAttribute(),
 ]
 public enum Microsoft.OData.Core.ODataUndeclaredPropertyBehaviorKinds : int {
+	DiscardUndeclaredValueProperty = 256
 	IgnoreUndeclaredValueProperty = 1
 	None = 0
 	ReportUndeclaredLinkProperty = 2
-	SupportUndeclaredValueProperty = 4
+	SupportUndeclaredValueProperty = 128
+	ThrowOnUndeclaredValueProperty = 512
 }
 
 public enum Microsoft.OData.Core.ODataVersion : int {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -6199,6 +6199,12 @@ public enum Microsoft.OData.Client.TrackingMode : int {
 	None = 0
 }
 
+public enum Microsoft.OData.Client.UndeclaredPropertyBehavior : int {
+	Discard = 1
+	None = 0
+	Support = 2
+}
+
 public abstract class Microsoft.OData.Client.DataServiceClientRequestMessage : IODataRequestMessage {
 	public DataServiceClientRequestMessage (string actualMethod)
 
@@ -6409,6 +6415,7 @@ public class Microsoft.OData.Client.DataServiceContext {
 	System.Func`2[[System.String],[System.Type]] ResolveType  { public get; public set; }
 	Microsoft.OData.Client.SaveChangesOptions SaveChangesDefaultOptions  { public get; public set; }
 	int Timeout  { public get; public set; }
+	Microsoft.OData.Client.UndeclaredPropertyBehavior UndeclaredPropertyBehavior  { public get; public set; }
 	Microsoft.OData.Client.DataServiceUrlConventions UrlConventions  { public get; public set; }
 	bool UsePostTunneling  { public get; public set; }
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/JsonLight/JsonLightPropertyWriterTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/JsonLight/JsonLightPropertyWriterTests.cs
@@ -48,9 +48,9 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
                 tc => new JsonWriterTestExpectedResults(this.ExpectedResultSettings)
                 {
                 })
-                {
-                    Model = model
-                };
+            {
+                Model = model
+            };
 
             this.CombinatorialEngineProvider.RunCombinations(
                 this.WriterTestConfigurationProvider.JsonLightFormatConfigurations,
@@ -108,7 +108,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
                         "\"type\":\"name\",\"properties\":{{",
                         "\"name\":\"EPSG:4326\"",
                         "}}",
-                        "}}", 
+                        "}}",
                         "}}",
                         "}}")
                 },
@@ -148,7 +148,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
                 (testDescriptor, testConfiguration) =>
                 {
                     TestWriterUtils.WriteAndVerifyTopLevelContent(
-                        testDescriptor, 
+                        testDescriptor,
                         testConfiguration,
                         (messageWriter) => messageWriter.WriteProperty(testDescriptor.PayloadItems.Single()),
                         this.Assert,
@@ -190,7 +190,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
                         "\"type\":\"name\",\"properties\":{{",
                         "\"name\":\"EPSG:4326\"",
                         "}}",
-                        "}}", 
+                        "}}",
                         "}}",
                         "}}")
                 },
@@ -210,7 +210,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
                         "\"type\":\"name\",\"properties\":{{",
                         "\"name\":\"EPSG:4326\"",
                         "}}",
-                        "}}", 
+                        "}}",
                         "}}",
                         "}}")
                 },
@@ -334,69 +334,69 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
             edmModel.AddElement(container);
 
             const string JsonFormat = "$(NL){{{0},\"Value\":{1}}}";
-                
+
             IEnumerable<PropertyPayloadTestCase> testCases = new[]
             {
                 new PropertyPayloadTestCase
                 {
                     DebugDescription = "Null.",
-                    Property = new ODataProperty 
+                    Property = new ODataProperty
                                 {
-                                    Name = "Value", 
+                                    Name = "Value",
                                     Value = new ODataUntypedValue() { RawValue = "null" }
                                 },
                 },
                 new PropertyPayloadTestCase
                 {
                     DebugDescription = "Integer.",
-                    Property = new ODataProperty 
+                    Property = new ODataProperty
                                 {
-                                    Name = "Value", 
+                                    Name = "Value",
                                     Value = new ODataUntypedValue() { RawValue = "42" }
                                 },
                 },
                 new PropertyPayloadTestCase
                 {
                     DebugDescription = "Float.",
-                    Property = new ODataProperty 
+                    Property = new ODataProperty
                                 {
-                                    Name = "Value", 
+                                    Name = "Value",
                                     Value = new ODataUntypedValue() { RawValue = "3.1415" }
                                 },
                 },
                 new PropertyPayloadTestCase
                 {
                     DebugDescription = "String.",
-                    Property = new ODataProperty 
+                    Property = new ODataProperty
                                 {
-                                    Name = "Value", 
+                                    Name = "Value",
                                     Value = new ODataUntypedValue() { RawValue = "\"foo bar\"" }
                                 },
                 },
                 new PropertyPayloadTestCase
                 {
                     DebugDescription = "Array of elements of mixed types.",
-                    Property = new ODataProperty 
+                    Property = new ODataProperty
                                 {
-                                    Name = "Value", 
+                                    Name = "Value",
                                     Value = new ODataUntypedValue() { RawValue = "[1, 2, \"abc\"]" }
                                 },
                 },
                 new PropertyPayloadTestCase
                 {
                     DebugDescription = "Array of arrays.",
-                    Property = new ODataProperty 
+                    Property = new ODataProperty
                                 {
-                                    Name = "Value", 
+                                    Name = "Value",
                                     Value = new ODataUntypedValue() { RawValue = "[ [1, \"abc\"], [2, \"def\"], [[3],[4, 5]] ]" }
                                 },
                 },
                 new PropertyPayloadTestCase
                 {
                     DebugDescription = "Negative - empty RawValue",
-                    Property = new ODataProperty 
+                    Property = new ODataProperty
                                 {
-                                    Name = "Value", 
+                                    Name = "Value",
                                     Value = new ODataUntypedValue() { RawValue = string.Empty },
                                 },
                     ExpectedException = ODataExpectedExceptions.ODataException(
@@ -405,17 +405,17 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
                 new PropertyPayloadTestCase
                 {
                     DebugDescription = "Collection of Edm.Untyped elements.",
-                    Property = new ODataProperty 
+                    Property = new ODataProperty
                                 {
-                                    Name = "CollectionValue", 
+                                    Name = "CollectionValue",
                                     Value = new ODataCollectionValue()
                                             {
                                                 TypeName = "Collection(TestModel.JsonType)",
                                                 Items = new object[]
                                                         {
                                                             new ODataUntypedValue()
-                                                            { 
-                                                                RawValue = "\"foo bar\"" 
+                                                            {
+                                                                RawValue = "\"foo bar\""
                                                             },
                                                             new ODataUntypedValue()
                                                             {
@@ -444,7 +444,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
                             GetExpectedJson(testCase.Property.Value)),
                         FragmentExtractor = (result) => result.RemoveAllAnnotations(false),
                         ExpectedException2 = testCase.ExpectedException,
-                     })
+                    })
                 {
                     DebugDescription = testCase.DebugDescription,
                     Model = edmModel,
@@ -458,7 +458,11 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
                     TestWriterUtils.WriteAndVerifyTopLevelContent(
                         testDescriptor,
                         testConfiguration,
-                        (messageWriter) => messageWriter.WriteProperty(testDescriptor.PayloadItems.Single()),
+                        (messageWriter) =>
+                        {
+                            messageWriter.PrivateSettings.UndeclaredPropertyBehaviorKinds = ODataUndeclaredPropertyBehaviorKinds.SupportUndeclaredValueProperty;
+                            messageWriter.WriteProperty(testDescriptor.PayloadItems.Single());
+                        },
                         this.Assert,
                         baselineLogger: this.Logger);
                 });
@@ -481,10 +485,10 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.JsonLight
             ODataCollectionValue collectionValue = value as ODataCollectionValue;
             if (collectionValue != null)
             {
-                return 
+                return
                     "[" +
                         string.Join<string>(
-                            ",", 
+                            ",",
                             collectionValue.Items.OfType<ODataUntypedValue>().Select(uv => uv.RawValue)) +
                      "]";
             }


### PR DESCRIPTION
it can be turned on by ODataUndeclaredPropertyBehaviorKinds.Discard-/Support-/ThrowOn-UndeclaredValueProperty, DataServiceContext.UndeclaredPropertyBehavior.