### PR TITLE
Preference Header Exception Handling

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -869,6 +869,7 @@ namespace Microsoft.OData.Core {
         internal const string JsonReaderExtensions_CannotReadValueAsString = "JsonReaderExtensions_CannotReadValueAsString";
         internal const string JsonReaderExtensions_CannotReadValueAsDouble = "JsonReaderExtensions_CannotReadValueAsDouble";
         internal const string JsonReaderExtensions_UnexpectedInstanceAnnotationName = "JsonReaderExtensions_UnexpectedInstanceAnnotationName";
+        internal const string PreferenceHeader_IntegerExpected = "PreferenceHeader_IntegerExpected";
 
         static TextRes loader = null;
         ResourceManager resources;

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -980,3 +980,5 @@ JsonReaderExtensions_CannotReadPropertyValueAsString=Cannot read the value '{0}'
 JsonReaderExtensions_CannotReadValueAsString=Cannot read the value '{0}' as a quoted JSON string value.
 JsonReaderExtensions_CannotReadValueAsDouble=Cannot read the value '{0}' as a double numeric value.
 JsonReaderExtensions_UnexpectedInstanceAnnotationName=An unexpected instance annotation name '{0}' was found when reading from the JSON reader, In OData, Instance annotation name must start with @.
+
+PreferenceHeader_IntegerExpected=Invalid value '{0}' for {1} preference header found. The {1} preference header requires an integer value.

--- a/src/Microsoft.OData.Core/ODataPreferenceHeader.cs
+++ b/src/Microsoft.OData.Core/ODataPreferenceHeader.cs
@@ -286,7 +286,13 @@ namespace Microsoft.OData.Core
 
                 if (wait != null)
                 {
-                    return int.Parse(wait.Value, CultureInfo.InvariantCulture);
+                    int value;
+                    if (int.TryParse(wait.Value, out value))
+                    {
+                        return value;
+                    }
+
+                    throw new ODataException(Strings.PreferenceHeader_IntegerExpected(wait.Value, ODataPreferenceHeader.WaitPreferenceTokenName));
                 }
 
                 return null;
@@ -346,12 +352,15 @@ namespace Microsoft.OData.Core
             {
                 var maxPageSizeHttpHeaderValueElement = this.Get(ODataMaxPageSizePreferenceToken);
 
-                // Should check maxPageSizeHttpHeaderValueElement.Value != null.
-                // Should do int.TryParse.
-                // If either of the above fail, should throw an ODataException for parsing, not a System.Exception (such as FormatException, etc.).
                 if (maxPageSizeHttpHeaderValueElement != null)
                 {
-                    return int.Parse(maxPageSizeHttpHeaderValueElement.Value, CultureInfo.InvariantCulture);
+                    int value;
+                    if (int.TryParse(maxPageSizeHttpHeaderValueElement.Value, out value))
+                    {
+                        return value;
+                    }
+
+                    throw new ODataException(Strings.PreferenceHeader_IntegerExpected(maxPageSizeHttpHeaderValueElement.Value, ODataPreferenceHeader.ODataMaxPageSizePreferenceToken));
                 }
 
                 return null;

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -6131,6 +6131,13 @@ namespace Microsoft.OData.Core {
             return Microsoft.OData.Core.TextRes.GetString(Microsoft.OData.Core.TextRes.JsonReaderExtensions_UnexpectedInstanceAnnotationName, p0);
         }
 
+        /// <summary>
+        /// A string like "Invalid value '{0}' for {1} preference header found. The {1} preference header requires an integer value."
+        /// </summary>
+        internal static string PreferenceHeader_IntegerExpected(object p0, object p1) {
+            return Microsoft.OData.Core.TextRes.GetString(Microsoft.OData.Core.TextRes.PreferenceHeader_IntegerExpected, p0, p1);
+        }
+
     }
 
     /// <summary>


### PR DESCRIPTION
This change adds some protection around invalid integers being passed in
for integer preference headers.  If a client specifies null /
non-integer to "wait", for example, the current code would throw an
ArgumentNullException or FormatException.  By properly throwing an
ODataException, service implementations can catch and return a correct
error to the client.

This resolves #92.