### PR TITLE
Preference Header Extensibility

### DIFF
--- a/src/Microsoft.OData.Core/HttpHeaderValueElement.cs
+++ b/src/Microsoft.OData.Core/HttpHeaderValueElement.cs
@@ -13,10 +13,10 @@ namespace Microsoft.OData.Core
     /// <summary>
     /// Class to represent a HTTP header value element.
     /// </summary>
-    internal sealed class HttpHeaderValueElement
+    public sealed class HttpHeaderValueElement
     {
         /// <summary>
-        /// Internal constructor to create a new instance of <see cref="HttpHeaderValueElement"/>.
+        /// Initializes a new instance of the <see cref="HttpHeaderValueElement"/> class.
         /// </summary>
         /// <param name="name">The name of the preference.</param>
         /// <param name="value">The value of the preference.</param>

--- a/src/Microsoft.OData.Core/ODataPreferenceHeader.cs
+++ b/src/Microsoft.OData.Core/ODataPreferenceHeader.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData.Core
     /// Class to set the "Prefer" header on an <see cref="IODataRequestMessage"/> or 
     /// the "Preference-Applied" header on an <see cref="IODataResponseMessage"/>.
     /// </summary>
-    public sealed class ODataPreferenceHeader
+    public class ODataPreferenceHeader
     {
         /// <summary>
         /// The return preference token.
@@ -420,7 +420,7 @@ namespace Microsoft.OData.Core
         /// the "Preference-Applied" header on the underlying IODataResponseMessage.
         /// </summary>
         /// <param name="preference">The preference to clear.</param>
-        private void Clear(string preference)
+        protected void Clear(string preference)
         {
             Debug.Assert(!string.IsNullOrEmpty(preference), "!string.IsNullOrEmpty(preference)");
             if (this.Preferences.Remove(preference))
@@ -437,7 +437,7 @@ namespace Microsoft.OData.Core
         /// <remarks>
         /// If <paramref name="preference"/> is already on the header, this method does a replace rather than adding another instance of the same preference.
         /// </remarks>
-        private void Set(HttpHeaderValueElement preference)
+        protected void Set(HttpHeaderValueElement preference)
         {
             Debug.Assert(preference != null, "preference != null");
             this.Preferences[preference.Name] = preference;
@@ -451,7 +451,7 @@ namespace Microsoft.OData.Core
         /// <param name="preferenceName">The preference to get.</param>
         /// <returns>Returns a key value pair of the <paramref name="preferenceName"/> and its value. The Value property of the key value pair may be null since not
         /// all preferences have value. If the <paramref name="preferenceName"/> is missing from the header, null is returned.</returns>
-        private HttpHeaderValueElement Get(string preferenceName)
+        protected HttpHeaderValueElement Get(string preferenceName)
         {
             Debug.Assert(!string.IsNullOrEmpty(preferenceName), "!string.IsNullOrEmpty(preferenceName)");
             HttpHeaderValueElement value;


### PR DESCRIPTION
Makes ODataPreferenceHeader extensible by removing the "sealed" keyword
and making the private methods used to get / set / clear values
protected.  Makes HttpHeaderValueElement public.

Resolves issue #484