### PR TITLE
Throw fix

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -140,7 +140,7 @@ namespace Microsoft.OData.Core.UriParser.Parsers
                 ex.ParsedSegments = this.parsedSegments;
                 ex.CurrentSegment = segmentText;
                 ex.UnparsedSegments = this.segmentQueue.ToList();
-                throw ex;
+                throw;
             }
 
             List<ODataPathSegment> validatedSegments = new List<ODataPathSegment>(this.parsedSegments.Count);


### PR DESCRIPTION
Simple change from "throw ex" to "throw" to preserve call-stacks and get
proper exception messages up to callers.