### PR TITLE
Provide a better exception when a PrimitiveValue is encountered when …

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -739,6 +739,45 @@ namespace Microsoft.OData.Core.JsonLight
         /// <summary>
         /// Reads a complex value.
         /// </summary>
+        /// <param name="insideJsonObjectValue">true if the reader is positioned on the first property of the value which is a JSON Object 
+        ///     (or the second property if the first one was odata.type).</param>
+        /// <param name="insideComplexValue">true if we are reading a complex value and the reader is already positioned inside the complex value; otherwise false.</param>
+        /// <param name="propertyName">The name of the property whose value is being read, if applicable (used for error reporting).</param>
+        /// <param name="complexValueTypeReference">The expected type reference of the value.</param>
+        /// <param name="payloadTypeName">The type name read from the payload.</param>
+        /// <param name="serializationTypeNameAnnotation">The serialization type name for the collection value (possibly null).</param>
+        /// <param name="duplicatePropertyNamesChecker">The duplicate property names checker to use - this is always initialized as necessary, do not clear.</param>
+        /// <returns>The value of the complex value.</returns>
+        /// <remarks>
+        /// Pre-Condition:  JsonNodeType.Property - the first property of the complex value object, or the second one if the first one was odata.type.
+        ///                 JsonNodeType.EndObject - the end object of the complex value object.
+        /// Post-Condition: almost anything - the node after the complex value (after the EndObject)
+        /// </remarks>
+        private ODataComplexValue ReadComplexValue(
+            bool insideJsonObjectValue,
+            bool insideComplexValue,
+            string propertyName,
+            IEdmComplexTypeReference complexValueTypeReference,
+            string payloadTypeName,
+            SerializationTypeNameAnnotation serializationTypeNameAnnotation,
+            DuplicatePropertyNamesChecker duplicatePropertyNamesChecker)
+        {
+            if (!insideJsonObjectValue && !insideComplexValue)
+            {
+                if (this.JsonReader.NodeType != JsonNodeType.StartObject)
+                {
+                    string typeName = complexValueTypeReference != null ? complexValueTypeReference.FullName() : payloadTypeName;
+                    throw new ODataException(Strings.ODataJsonLightPropertyAndValueDeserializer_PrimitiveValueFoundForComplexType(propertyName, this.JsonReader.NodeType, typeName));
+                }
+                this.JsonReader.Read();
+            }
+
+            return this.ReadComplexValue(complexValueTypeReference, payloadTypeName, serializationTypeNameAnnotation, duplicatePropertyNamesChecker);
+        }
+
+        /// <summary>
+        /// Reads a complex value.
+        /// </summary>
         /// <param name="complexValueTypeReference">The expected type reference of the value.</param>
         /// <param name="payloadTypeName">The type name read from the payload.</param>
         /// <param name="serializationTypeNameAnnotation">The serialization type name for the collection value (possibly null).</param>
@@ -1045,12 +1084,10 @@ namespace Microsoft.OData.Core.JsonLight
                             throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ComplexValueWithPropertyTypeAnnotation(ODataAnnotationNames.ODataType));
                         }
 
-                        if (!valueIsJsonObject && !insideComplexValue)
-                        {
-                            this.JsonReader.ReadStartObject();
-                        }
-
                         result = this.ReadComplexValue(
+                            valueIsJsonObject,
+                            insideComplexValue,
+                            propertyName,
                             targetTypeReference == null ? null : targetTypeReference.AsComplex(),
                             payloadTypeName,
                             serializationTypeNameAnnotation,

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -547,6 +547,7 @@ namespace Microsoft.OData.Core {
         internal const string ODataJsonLightPropertyAndValueDeserializer_TopLevelPropertyWithPrimitiveNullValue = "ODataJsonLightPropertyAndValueDeserializer_TopLevelPropertyWithPrimitiveNullValue";
         internal const string ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty = "ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty";
         internal const string ODataJsonLightPropertyAndValueDeserializer_NoPropertyAndAnnotationAllowedInNullPayload = "ODataJsonLightPropertyAndValueDeserializer_NoPropertyAndAnnotationAllowedInNullPayload";
+        internal const string ODataJsonLightPropertyAndValueDeserializer_PrimitiveValueFoundForComplexType = "ODataJsonLightPropertyAndValueDeserializer_PrimitiveValueFoundForComplexType";
         internal const string ODataJsonReaderCoreUtils_CannotReadSpatialPropertyValue = "ODataJsonReaderCoreUtils_CannotReadSpatialPropertyValue";
         internal const string ODataJsonLightReaderUtils_AnnotationWithNullValue = "ODataJsonLightReaderUtils_AnnotationWithNullValue";
         internal const string ODataJsonLightReaderUtils_InvalidValueForODataNullAnnotation = "ODataJsonLightReaderUtils_InvalidValueForODataNullAnnotation";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -581,6 +581,7 @@ ODataJsonLightPropertyAndValueDeserializer_ODataTypeAnnotationInPrimitiveValue=A
 ODataJsonLightPropertyAndValueDeserializer_TopLevelPropertyWithPrimitiveNullValue=A top-level property with an invalid primitive null value was found. In OData, top-level properties with null value have to be serialized as JSON object with an '{0}' annotation that has the value '{1}'.
 ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty=Encountered a metadata reference property '{0}' in a scope other than an entry. In OData, a property name with a '#' character indicates a reference into the metadata and is only supported for describing operations bound to an entry.
 ODataJsonLightPropertyAndValueDeserializer_NoPropertyAndAnnotationAllowedInNullPayload=The property with name '{0}' was found in a null payload. In OData, no properties or OData annotations can appear in a null payload.
+ODataJsonLightPropertyAndValueDeserializer_PrimitiveValueFoundForComplexType=The property with name '{0}' was found with a value node of type '{1}'; however, a complex value of type '{2}' was expected.
 
 ODataJsonReaderCoreUtils_CannotReadSpatialPropertyValue=The value specified for the spatial property was not valid. You must specify a valid spatial value.
 

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -3728,6 +3728,13 @@ namespace Microsoft.OData.Core {
         }
 
         /// <summary>
+        /// A string like "The property with name '{0}' was found with a value node of type '{1}'; however, a complex value of type '{2}' was expected."
+        /// </summary>
+        internal static string ODataJsonLightPropertyAndValueDeserializer_PrimitiveValueFoundForComplexType(object p0, object p1, object p2) {
+            return Microsoft.OData.Core.TextRes.GetString(Microsoft.OData.Core.TextRes.ODataJsonLightPropertyAndValueDeserializer_PrimitiveValueFoundForComplexType, p0, p1, p2);
+        }
+
+        /// <summary>
         /// A string like "The value specified for the spatial property was not valid. You must specify a valid spatial value."
         /// </summary>
         internal static string ODataJsonReaderCoreUtils_CannotReadSpatialPropertyValue {


### PR DESCRIPTION
…trying to read a ComplexType

Currently, when we parse the JSON for a ComplexType property, if we
encounter a PrimitiveValue, we get back an exception that is mostly
useless to a client:

An unexpected 'PrimitiveValue' node was found when reading from the JSON
reader. A 'StartObject' node was expected.

This change makes the exception provide the property name and a
description of what was expected, including the type name.

Resolves #487
Fix #487