### PR TITLE
Use single quotes for string collections in uri

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -322,7 +322,19 @@ namespace Microsoft.OData.Core.JsonLight
                             }
                             else if (item != null)
                             {
-                                this.WritePrimitiveValue(item, expectedItemTypeReference);
+                                if (isInUri && PlatformHelper.GetTypeCode(item.GetType()) == TypeCode.String)
+                                {
+                                    string text = (string) item;
+                                    //escape single quote by two single quotes
+                                    text = text.Replace("'", "''");
+                                    //use single quotes in uri
+                                    text = String.Format("'{0}'", text);
+                                    this.JsonWriter.WriteRawValue(text);
+                                }
+                                else
+                                {
+                                    this.WritePrimitiveValue(item, expectedItemTypeReference);
+                                }
                             }
                             else
                             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriConversionUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriConversionUtilsTests.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Microsoft.OData.Core.Tests.Query
 {
-    public class ODataUriConvesionUtilsTests
+    public class ODataUriConversionUtilsTests
     {
         [Fact]
         public void DoubleLiteralShouldNotHaveDecimalPointForScientificNotation()
@@ -46,6 +46,18 @@ namespace Microsoft.OData.Core.Tests.Query
         {
             PrimitiveLiteral(100D).Should().Be("100.0");
             PrimitiveLiteral(-100D).Should().Be("-100.0");
+        }
+
+        [Fact]
+        public void StringCollectionShouldHaveSingleQuotes()
+        {
+            ODataCollectionValue value = new ODataCollectionValue
+            {
+                Items = new string[] { "123", "abc" },
+                TypeName = "Collection(Edm.String)"
+            };
+            var collectionString = ODataUriConversionUtils.ConvertToUriCollectionLiteral(value, Microsoft.OData.Edm.Library.EdmCoreModel.Instance, ODataVersion.V4);
+            collectionString.Should().Be("['123','abc']");
         }
 
         private static string PrimitiveLiteral(object value)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
@@ -153,6 +153,31 @@ namespace Microsoft.OData.Core.Tests.Query
             action.ShouldThrow<ODataException>().WithMessage(Strings.UriQueryExpressionParser_UnrecognizedLiteral("Edm.Binary", "binary'AwEEAQUJAgYFAwUJ='", "0", "binary'AwEEAQUJAgYFAwUJ='"));
         }
 
+        [Fact]
+        public void TestStringConvertToUriLiteral()
+        {
+            string stringString = ODataUriUtils.ConvertToUriLiteral(String.Empty, ODataVersion.V4);
+            stringString.Should().Be("''");
+
+            stringString = ODataUriUtils.ConvertToUriLiteral("abc", ODataVersion.V4);
+            stringString.Should().Be("'abc'");
+
+            stringString = ODataUriUtils.ConvertToUriLiteral("a'bc", ODataVersion.V4);
+            stringString.Should().Be("'a''bc'");
+        }
+
+        [Fact]
+        public void TestStringCollectionConvertToUriLiteral()
+        {
+            ODataCollectionValue value = new ODataCollectionValue
+            {
+                Items = new string[] {"123", "abc", "a'bc"},
+                TypeName = "Collection(Edm.String)"
+            };
+            string collectionString = ODataUriUtils.ConvertToUriLiteral(value, ODataVersion.V4);
+            collectionString.Should().Be("['123','abc','a''bc']");
+        }
+
         #region enum testings
         [Fact]
         public void TestEnumConvertFromUriLiteral_EnumName()


### PR DESCRIPTION
### Description
When hosting an OData Service on Windows behind an nginx reverse proxy on different urls HTTPAPI returns a "400 Bad Request" for function calls with a parameter of type "Collection(Edm.String)".

There are several issues:

- nginx "normalizes" the uri https://serverfault.com/a/463932/13348
- ODataUriUtils quotes strings in Collection with the default Json-QuoteCharacter (")
- Microsoft-HTTPAPI/2.0 refuses requests with unescaped double quotes
- according to OData spec, strings should be quoted with single quotes

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [   ] Build and test with one-click build and test script passed