### PR TITLE
Fix to Issue #541

### DIFF
--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -668,8 +668,11 @@ namespace Microsoft.OData.Client
                     contentHeaders.TryGetHeader(XmlConstants.HttpResponseLocation, out location);
                     contentHeaders.TryGetHeader(XmlConstants.HttpODataEntityId, out odataEntityId);
 
-                    Debug.Assert(location == null || location == entityDescriptor.GetLatestEditLink().AbsoluteUri, "edit link must already be set to location header");
-                    Debug.Assert((location == null && odataEntityId == null) || (odataEntityId ?? location) == UriUtil.UriToString(entityDescriptor.GetLatestIdentity()), "Identity must already be set");
+                    Uri locationUri = null;
+                    bool isLocationValidUri = Uri.TryCreate(location, UriKind.Absolute, out locationUri);
+
+                    Debug.Assert(location == null || isLocationValidUri && locationUri == entityDescriptor.GetLatestEditLink(), "edit link must already be set to location header");
+                    Debug.Assert((location == null && odataEntityId == null) || odataEntityId != null ? odataEntityId == UriUtil.UriToString(entityDescriptor.GetLatestIdentity()) : locationUri == entityDescriptor.GetLatestIdentity(), "Identity must already be set");
                 }
 #endif
             }


### PR DESCRIPTION
### Issues
*This pull request fixes issue #541*  

### Description

There will be an assertion failure complaining "edit link must already be set to location header", if the location header in the OData response is an URI having no local path, e.g. https://graph.microsoft.com

Root cause:
 if the location header in the OData response is an URI having no local path, e.g. https://graph.microsoft.com, it will be added a tailing slash automatically when converted to an Uri object (i.e. https://graph.microsoft.com/ ). therefore, it will always fail, when comparing the location string to an Uri.AbsoluteUri, because of an extra tailing slash.

Fix: Convert the location string to a Uri first, when comparing it to an Uri

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

There will be an assertion failure complaining "edit link must already be set to location header", if the location header in the OData response is an URI having no local path, e.g. https://graph.microsoft.com

Root cause:
 if the location header in the OData response is an URI having no local path, e.g. https://graph.microsoft.com, it will be added a tailing slash automatically when converted to an Uri object (i.e. https://graph.microsoft.com/ ). therefore, it will always fail, when comparing the location string to an Uri.AbsoluteUri, because of an extra tailing slash.

Fix: Convert the location string to a Uri first, when comparing it to an Uri