### PR TITLE
issue 556: Uri template parser doesn't work if the key is enum type.

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/SegmentArgumentParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SegmentArgumentParser.cs
@@ -236,6 +236,13 @@ namespace Microsoft.OData.Core.UriParser.Parsers
         /// <returns>true if the conversion was successful.</returns>
         private bool TryConvertValue(IEdmTypeReference typeReference, string valueText, out object convertedValue)
         {
+            UriTemplateExpression expression;
+            if (this.enableUriTemplateParsing && UriTemplateParser.TryParseLiteral(valueText, typeReference, out expression))
+            {
+                convertedValue = expression;
+                return true;
+            }
+
             if (typeReference.IsEnum())
             {
                 QueryNode enumNode = null;
@@ -250,13 +257,6 @@ namespace Microsoft.OData.Core.UriParser.Parsers
             }
 
             IEdmPrimitiveTypeReference primitiveType = typeReference.AsPrimitive();
-            UriTemplateExpression expression;
-            if (this.enableUriTemplateParsing && UriTemplateParser.TryParseLiteral(valueText, primitiveType, out expression))
-            {
-                convertedValue = expression;
-                return true;
-            }
-
             Type primitiveClrType = EdmLibraryExtensions.GetPrimitiveClrType((IEdmPrimitiveType)primitiveType.Definition, primitiveType.IsNullable);
             LiteralParser literalParser = LiteralParser.ForKeys(this.keysAsSegment);
             return literalParser.TryParseLiteral(primitiveClrType, valueText, out convertedValue);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -368,6 +368,10 @@ namespace Microsoft.OData.Core.Tests.UriParser
             FullyQualifiedNamespacePet6.AddKeys(FullyQualifiedNamespacePet6.AddStructuralProperty("ID", FullyQualifiedNamespaceIdTypeReference));
             FullyQualifiedNamespacePet6.AddStructuralProperty("Color", EdmPrimitiveTypeKind.String);
             model.AddElement(FullyQualifiedNamespacePet6);
+
+            // entity type with enum as key
+            var fullyQualifiedNamespaceShape = new EdmEntityType("Fully.Qualified.Namespace", "Shape", null, false, false);
+            fullyQualifiedNamespaceShape.AddKeys(fullyQualifiedNamespaceShape.AddStructuralProperty("Color", colorTypeReference));
             #endregion
 
             #region Operations
@@ -666,6 +670,8 @@ namespace Microsoft.OData.Core.Tests.UriParser
             var FullyQualifiedNamespaceContextPet6Set = FullyQualifiedNamespaceContext.AddEntitySet("Pet6Set", FullyQualifiedNamespacePet6);
             var FullyQualifiedNamespaceContextChimera = FullyQualifiedNamespaceContext.AddEntitySet("Chimeras", FullyQualifiedNamespaceChimera);
 
+            FullyQualifiedNamespaceContext.AddEntitySet("Shapes", fullyQualifiedNamespaceShape);
+
             FullyQualifiedNamespaceContextPeople.AddNavigationTarget(FullyQualifiedNamespacePerson_MyDog, FullyQualifiedNamespaceContextDogs);
             FullyQualifiedNamespaceContextPeople.AddNavigationTarget(FullyQualifiedNamespacePerson_MyRelatedDogs, FullyQualifiedNamespaceContextDogs);
             FullyQualifiedNamespaceContextPeople.AddNavigationTarget(FullyQualifiedNamespacePerson_MyLions, FullyQualifiedNamespaceContextLions);
@@ -812,6 +818,8 @@ namespace Microsoft.OData.Core.Tests.UriParser
           <NavigationPropertyBinding Path=""MyPeople"" Target=""People"" />
           <NavigationPropertyBinding Path=""FastestOwner"" Target=""People"" />
           <NavigationPropertyBinding Path=""LionsISaw"" Target=""Lions"" />
+        </EntitySet>
+        <EntitySet Name=""Shapes"" EntityType=""Fully.Qualified.Namespace.Shape"">
         </EntitySet>
         <EntitySet Name=""Lions"" EntityType=""Fully.Qualified.Namespace.Lion"">
           <NavigationPropertyBinding Path=""Friends"" Target=""Lions"" />
@@ -1002,6 +1010,12 @@ namespace Microsoft.OData.Core.Tests.UriParser
         <NavigationProperty Name=""FastestOwner"" Type=""Fully.Qualified.Namespace.Person"" />
         <NavigationProperty Name=""LionWhoAteMe"" Type=""Fully.Qualified.Namespace.Lion"" Nullable=""false"" Partner=""DogThatIAte"" />
         <NavigationProperty Name=""LionsISaw"" Type=""Collection(Fully.Qualified.Namespace.Lion)"" Nullable=""false"" Partner=""DogsSeenMe"" />
+      </EntityType>
+      <EntityType Name=""Shape"">
+        <Key>
+          <PropertyRef Name=""Color"" />
+        </Key>
+        <Property Name=""Color"" Type=""Fully.Qualified.Namespace.ColorPattern"" Nullable=""false"" />
       </EntityType>
       <ComplexType Name=""Heartbeat"">
         <Property Name=""Frequency"" Type=""Edm.Double"" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
@@ -124,6 +124,39 @@ namespace Microsoft.OData.Core.Tests.UriParser.Parsers
             keys[3].Key.Should().Be("Upgraded");
             keys[3].Value.As<UriTemplateExpression>().ShouldBeEquivalentTo(new UriTemplateExpression { LiteralText = "{UPGRADE}", ExpectedType = keyTypes[3].Type });
         }
+
+        [Fact]
+        public void ParseEnumKeyTemplateWithTemplateParser()
+        {
+            var uriParser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("Shapes({enumKey})", UriKind.Relative))
+            {
+                EnableUriTemplateParsing = true
+            };
+
+            var path = uriParser.ParsePath();
+
+            var keySegment = path.LastSegment.As<KeySegment>();
+            KeyValuePair<string, object> keypair = keySegment.Keys.Single();
+            keypair.Key.Should().Be("Color");
+
+            keypair.Value.As<UriTemplateExpression>().ShouldBeEquivalentTo(new UriTemplateExpression { LiteralText = "{enumKey}", ExpectedType = keySegment.EdmType.As<IEdmEntityType>().DeclaredKey.Single().Type });
+        }
+
+        [Fact]
+        public void ParseEnumKeyTemplateAsSegmentWithTemplateParser()
+        {
+            var uriParser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/Shapes/{enumKey}"))
+            {
+                EnableUriTemplateParsing = true,
+                UrlConventions = ODataUrlConventions.KeyAsSegment
+            };
+
+            var path = uriParser.ParsePath();
+            var keySegment = path.LastSegment.As<KeySegment>();
+            KeyValuePair<string, object> keypair = keySegment.Keys.Single();
+            keypair.Key.Should().Be("Color");
+            keypair.Value.As<UriTemplateExpression>().ShouldBeEquivalentTo(new UriTemplateExpression { LiteralText = "{enumKey}", ExpectedType = keySegment.EdmType.As<IEdmEntityType>().DeclaredKey.Single().Type });
+        }
         #endregion
 
         #region Parameter template tests


### PR DESCRIPTION
### Issues
*This pull request fixes issue #556.*  

### Description
*Make the enum key as uri template work.*
