### PR TITLE
Fix broken link to file InMemoryMessage.cs

### DIFF
--- a/_posts/core libraries/2015-04-29-01-02-read-payload.md
+++ b/_posts/core libraries/2015-04-29-01-02-read-payload.md
@@ -15,7 +15,7 @@ To construct an ODataMessageReader instance, you'll need to provide an IODataRes
 
 OData Core library provides no implementation of these two interfaces, because it is different in different scenario.
 
-In this tutoria, we'll still use the [InMemoryMessage.cs](https://github.com/OData/odata.net/blob/master/test/FunctionalTests/Tests/DataOData/Tests/OData.TDD.Tests/Common/InMemoryMessage.cs).
+In this tutoria, we'll still use the [InMemoryMessage.cs](https://github.com/OData/odata.net/blob/master/test/FunctionalTests/Microsoft.OData.Core.Tests/InMemoryMessage.cs).
 
 We'll still use the model set up in the EDMLIB section.
 {% highlight csharp %}


### PR DESCRIPTION
Fix broken link to file `InMemoryMessage.cs` in the ODataLib documentation.