### PR TITLE
Add NetStandard support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ obj/
 *.user
 *.vstemplate
 !src/CodeGen/ODataT4CodeGenerator.vstemplate
+*.lock.json
 
 # TFS files
 *.vspscc
@@ -17,7 +18,7 @@ sln/TestResults/
 
 # VS2015 IDE generated files
 sln/*.ide/
-sln/.vs/
+.vs/
 
 # StyleCop files
 StyleCop.Cache

--- a/NetStandard.Projects/src/Microsoft.OData.Client/Microsoft.OData.Client.xproj
+++ b/NetStandard.Projects/src/Microsoft.OData.Client/Microsoft.OData.Client.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>D1567C63-4A0D-4E18-A14E-79699B9BFFFF</ProjectGuid>
+    <RootNamespace>System</RootNamespace>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\sln</SolutionDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/NetStandard.Projects/src/Microsoft.OData.Client/project.json
+++ b/NetStandard.Projects/src/Microsoft.OData.Client/project.json
@@ -1,0 +1,99 @@
+{
+  "version": "6.15.0-*",
+
+  "buildOptions": {
+    "define": [
+      "ODATA_CLIENT",
+      "PORTABLELIB"
+    ],
+    "compile": {
+      "include": "../../../src/Microsoft.OData.Client/**/*.cs",
+      "includeFiles": [
+        "../../../src/AssemblyInfo/AssemblyKeys.cs",
+        "../../../src/Microsoft.OData.Edm/Csdl/EdmValueParser.cs",
+        "../../../src/Microsoft.OData.Edm/Csdl/EdmValueWriter.cs",
+        "../../../src/Microsoft.OData.Core/ExceptionUtils.cs",
+        "../../../src/Microsoft.OData.Core/InternalErrorCodesCommon.cs",
+        "../../../src/Microsoft.OData.Core/SimpleLazy.cs",
+        "../../../src/Microsoft.OData.Core/TaskUtils.cs",
+        "../../../src/Microsoft.OData.Core/Evaluation/EdmValueUtils.cs",
+        "../../../src/Microsoft.OData.Core/Evaluation/KeySerializer.cs",
+        "../../../src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs",
+        "../../../src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataBuilder.cs",
+        "../../../src/Microsoft.OData.Core/Evaluation/ODataUriBuilder.cs",
+        "../../../src/Microsoft.OData.Core/Evaluation/UrlConvention.cs",
+        "../../../src/Microsoft.OData.Core/Json/JsonSharedUtils.cs",
+        "../../../src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpressionToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/Aggregation/AggregateToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/Aggregation/ApplyTransformationToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/Aggregation/GroupByToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/AllToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/AnyToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/BinaryOperatorToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/CustomQueryOptionToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/DottedIdentifierToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/EndPathToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/ExpandTermToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/ExpandToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/FunctionCallToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/FunctionParameterAliasToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/FunctionParameterToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/InnerPathToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/LambdaToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/LiteralToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/NonSystemToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/OrderByToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/PathSegmentToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/PathToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/RangeVariableToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/SelectToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/StarToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/SystemToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/SyntacticAst/UnaryOperatorToken.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/TreeNodeKinds/QueryTokenKind.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/Visitors/IPathSegmentTokenVisitor.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/Visitors/ISyntacticTreeVisitor.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/NamedValue.cs",
+        "../../../src/Microsoft.OData.Core/UriParser/ReadOnlyEnumerableForUriParser.cs",
+        "../../../src/PlatformHelper.cs"
+      ],
+      "excludeFiles": [
+        "../../../src/Microsoft.OData.Client/AtomParser.cs",
+        "../../../src/Microsoft.OData.Client/DataServiceTransportInfo.cs",
+        "../../../src/Microsoft.OData.Client/ReadingWritingEntityEventArgs.cs",
+        "../../../src/Microsoft.OData.Client/Microsoft.OData.Client.cs",
+        "../../../src/Microsoft.OData.Client/Parameterized.Microsoft.OData.Client.cs",
+        "../../../src/Microsoft.OData.Client/ALinq/ParameterReplacerVisitor.cs",
+        "../../../src/Microsoft.OData.Client/Metadata/EdmEntitySetFacade.cs",
+        "../../../src/Microsoft.OData.Client/Metadata/EdmFunctionImportFacade.cs",
+        "../../../src/Microsoft.OData.Client/Metadata/EdmFunctionParameterFacade.cs",
+        "../../../src/Microsoft.OData.Client/Metadata/EdmNavigationPropertyFacade.cs"
+      ]
+    }
+  },
+
+  "dependencies": {
+    "Microsoft.OData.Core": {
+      "target": "project"
+    },
+    "Microsoft.OData.Edm": {
+      "target": "project"
+    },
+    "Microsoft.Spatial": {
+      "target": "project"
+    },
+    "System.ComponentModel.EventBasedAsync": "4.0.11",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Linq.Queryable": "4.0.1",
+    "System.Net.Requests": "4.0.11",
+    "System.Reflection.TypeExtensions": "4.1.0",
+    "System.Runtime": "4.1.0",
+    "System.Text.RegularExpressions": "4.1.0"
+  },
+
+  "frameworks": {
+    "netstandard1.3": { }
+  }
+}

--- a/NetStandard.Projects/src/Microsoft.OData.Core/Microsoft.OData.Core.xproj
+++ b/NetStandard.Projects/src/Microsoft.OData.Core/Microsoft.OData.Core.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>786C830F-07A1-408B-BD7F-6EE04809D6DB</ProjectGuid>
+    <RootNamespace>Microsoft.OData.Core</RootNamespace>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\sln</SolutionDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/NetStandard.Projects/src/Microsoft.OData.Core/project.json
+++ b/NetStandard.Projects/src/Microsoft.OData.Core/project.json
@@ -1,0 +1,41 @@
+﻿{
+  "version": "6.15.0-*",
+
+  "buildOptions": {
+    "define": [
+      "CODE_ANALYSIS",
+      "ODATA_CORE",
+      "PORTABLELIB"
+    ],
+    "compile": {
+      "include": "../../../src/Microsoft.OData.Core/**/*.cs",
+      "includeFiles": [
+        "../../../src/AssemblyInfo/AssemblyKeys.cs",
+        "../../../src/Microsoft.OData.Edm/Csdl/EdmValueParser.cs",
+        "../../../src/Microsoft.OData.Edm/Csdl/EdmValueWriter.cs",
+        "../../../src/PlatformHelper.cs"
+      ],
+      "excludeFiles": [
+        "../../../src/Microsoft.OData.Core/PortabilityExtensionMethods.cs"
+      ]
+    }
+  },
+
+  "dependencies": {
+    "Microsoft.OData.Edm": {
+      "target": "project"
+    },
+    "Microsoft.Spatial": {
+      "target": "project"
+    },
+    "System.ComponentModel":  "4.0.1",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Reflection.TypeExtensions": "4.1.0",
+    "System.Runtime": "4.1.0",
+    "System.Text.RegularExpressions": "4.1.0"
+  },
+
+  "frameworks": {
+    "netstandard1.3": { }
+  }
+}

--- a/NetStandard.Projects/src/Microsoft.OData.Edm/Microsoft.OData.Edm.xproj
+++ b/NetStandard.Projects/src/Microsoft.OData.Edm/Microsoft.OData.Edm.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>7D921888-FE03-4C3F-80FE-2F624505461C</ProjectGuid>
+    <RootNamespace>Microsoft.OData.Edm</RootNamespace>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\sln</SolutionDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/NetStandard.Projects/src/Microsoft.OData.Edm/project.json
+++ b/NetStandard.Projects/src/Microsoft.OData.Edm/project.json
@@ -1,0 +1,34 @@
+﻿{
+  "version": "6.15.0-*",
+
+  "buildOptions": {
+    "define": [
+      "CODE_ANALYSIS",
+      "PORTABLELIB"
+    ],
+    "compile": {
+      "include": "../../../src/Microsoft.OData.Edm/**/*.cs",
+      "includeFiles": [
+        "../../../src/AssemblyInfo/AssemblyKeys.cs",
+        "../../../src/PlatformHelper.cs"
+      ],
+      "excludeFiles": [
+        "../../../src/Microsoft.OData.Edm/Csdl/Semantics/IEdmReferentialConstraint.cs"
+      ]
+    }
+  },
+
+  "dependencies": {
+    "Newtonsoft.Json": "9.0.1",
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Reflection.Metadata": "1.3.0",
+    "System.Reflection.TypeExtensions": "4.1.0",
+    "System.Runtime": "4.1.0",
+    "System.Runtime.Handles": "4.0.1",
+    "System.Xml.ReaderWriter": "4.0.11"
+  },
+
+  "frameworks": {
+    "netstandard1.3": { }
+  }
+}

--- a/NetStandard.Projects/src/Microsoft.Spatial/Microsoft.Spatial.xproj
+++ b/NetStandard.Projects/src/Microsoft.Spatial/Microsoft.Spatial.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>5D921888-FE03-4C3F-40FE-2F624505461D</ProjectGuid>
+    <RootNamespace>Microsoft.Spatial</RootNamespace>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\sln</SolutionDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/NetStandard.Projects/src/Microsoft.Spatial/project.json
+++ b/NetStandard.Projects/src/Microsoft.Spatial/project.json
@@ -1,0 +1,31 @@
+﻿{
+  "version": "6.15.0-*",
+
+  "buildOptions": {
+    "define": [
+      "CODE_ANALYSIS",
+      "SPATIAL",
+      "PORTABLELIB"
+    ],
+    "compile": {
+      "include": "../../../src/Microsoft.Spatial/**/*.cs",
+      "includeFiles": [
+        "../../../src/AssemblyInfo/AssemblyKeys.cs",
+        "../../../src/PlatformHelper.cs"
+      ]
+    }
+  },
+
+  "dependencies": {
+    "System.Diagnostics.Tools": "4.0.1",
+    "System.Reflection.Metadata": "1.3.0",
+    "System.Reflection.TypeExtensions": "4.1.0",
+    "System.Runtime": "4.1.0",
+    "System.Text.RegularExpressions": "4.1.0",
+    "System.Xml.ReaderWriter": "4.0.11"
+  },
+
+  "frameworks": {
+    "netstandard1.3": { }
+  }
+}

--- a/NetStandard.Projects/test/EndToEndTests/Framework/Core/Microsoft.Test.OData.Framework.xproj
+++ b/NetStandard.Projects/test/EndToEndTests/Framework/Core/Microsoft.Test.OData.Framework.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>CEC8AF29-77BC-4C62-B79C-A9B22C311E3B</ProjectGuid>
+    <RootNamespace>Microsoft.Test.OData.Framework</RootNamespace>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\..\sln</SolutionDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/NetStandard.Projects/test/EndToEndTests/Framework/Core/project.json
+++ b/NetStandard.Projects/test/EndToEndTests/Framework/Core/project.json
@@ -1,0 +1,22 @@
+{
+  "version": "6.15.0-*",
+
+  "buildOptions": {
+    "define": [
+      "PORTABLELIB"
+    ],
+    "compile": {
+      "include": "../../../../../test/EndToEndTests/Framework/Core/**/*.cs"
+    }
+  },
+
+  "dependencies": {
+    "Microsoft.OData.Client": {
+      "target": "project"
+    }
+  },
+
+  "frameworks": {
+    "netstandard1.3": { }
+  }
+}

--- a/NetStandard.Projects/test/EndToEndTests/Services/TestServices/Microsoft.Test.OData.Services.TestServices.xproj
+++ b/NetStandard.Projects/test/EndToEndTests/Services/TestServices/Microsoft.Test.OData.Services.TestServices.xproj
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>B8A072BE-5B90-4193-A289-6CC8750D0DAD</ProjectGuid>
+    <RootNamespace>Microsoft.Test.OData.Services.TestServices</RootNamespace>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\..\sln</SolutionDir>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">$(SolutionDir)\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">$(SolutionDir)\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/NetStandard.Projects/test/EndToEndTests/Services/TestServices/project.json
+++ b/NetStandard.Projects/test/EndToEndTests/Services/TestServices/project.json
@@ -1,0 +1,34 @@
+{
+  "version": "6.15.0-*",
+
+  "buildOptions": {
+    "define": [
+      "PORTABLELIB"
+    ],
+    "compile": {
+      "include": "../../../../../test/EndToEndTests/Services/TestServices/**/*.cs",
+      "includeFiles": [
+        "../../../../../test/EndToEndTests/Services/CSDSCReferences/Microsoft.Test.OData.Services.TestServices.AstoriaDefaultServiceReference.cs",
+        "../../../../../test/EndToEndTests/Services/CSDSCReferences/Microsoft.Test.OData.Services.TestServices.ActionOverloadingServiceReference.cs",
+        "../../../../../test/EndToEndTests/Services/CSDSCReferences/Microsoft.Test.OData.Services.TestServices.KeyAsSegmentServiceReference.cs",
+        "../../../../../test/EndToEndTests/Services/CSDSCReferences/Microsoft.Test.OData.Services.TestServices.ODataWriterDefaultServiceReference.cs",
+        "../../../../../test/EndToEndTests/Services/CSDSCReferences/Microsoft.Test.OData.Services.TestServices.PrimitiveKeysServiceReference.cs"
+      ],
+      "exclude": [
+        "../../../../../test/EndToEndTests/Services/TestServices/PublicProvider/**/*.cs",
+        "../../../../../test/EndToEndTests/Services/TestServices/T4Clients/**/*.cs"
+
+      ]
+    }
+  },
+
+  "dependencies": {
+    "Core": {
+      "target": "project"
+    }
+  },
+
+  "frameworks": {
+    "netstandard1.3": { }
+  }
+}

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "projects": [ "src", "test", "test/EndToEndTests/Framework", "NetStandard.Projects/src", "NetStandard.Projects/test/EndToEndTests/Framework" ],
+  "sdk": {
+    "version": "1.0.0-preview2-003121"
+  }
+}

--- a/sln/Microsoft.OData.NetStandard.sln
+++ b/sln/Microsoft.OData.NetStandard.sln
@@ -1,0 +1,52 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.OData.Client", "..\NetStandard.Projects\src\Microsoft.OData.Client\Microsoft.OData.Client.xproj", "{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.OData.Core", "..\NetStandard.Projects\src\Microsoft.OData.Core\Microsoft.OData.Core.xproj", "{786C830F-07A1-408B-BD7F-6EE04809D6DB}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.OData.Edm", "..\NetStandard.Projects\src\Microsoft.OData.Edm\Microsoft.OData.Edm.xproj", "{7D921888-FE03-4C3F-80FE-2F624505461C}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Spatial", "..\NetStandard.Projects\src\Microsoft.Spatial\Microsoft.Spatial.xproj", "{5D921888-FE03-4C3F-40FE-2F624505461D}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Test.OData.Framework", "..\NetStandard.Projects\test\EndToEndTests\Framework\Core\Microsoft.Test.OData.Framework.xproj", "{CEC8AF29-77BC-4C62-B79C-A9B22C311E3B}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "Microsoft.Test.OData.Services.TestServices", "..\NetStandard.Projects\test\EndToEndTests\Services\TestServices\Microsoft.Test.OData.Services.TestServices.xproj", "{B8A072BE-5B90-4193-A289-6CC8750D0DAD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{786C830F-07A1-408B-BD7F-6EE04809D6DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{786C830F-07A1-408B-BD7F-6EE04809D6DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{786C830F-07A1-408B-BD7F-6EE04809D6DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{786C830F-07A1-408B-BD7F-6EE04809D6DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7D921888-FE03-4C3F-80FE-2F624505461C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7D921888-FE03-4C3F-80FE-2F624505461C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7D921888-FE03-4C3F-80FE-2F624505461C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7D921888-FE03-4C3F-80FE-2F624505461C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5D921888-FE03-4C3F-40FE-2F624505461D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5D921888-FE03-4C3F-40FE-2F624505461D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5D921888-FE03-4C3F-40FE-2F624505461D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5D921888-FE03-4C3F-40FE-2F624505461D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CEC8AF29-77BC-4C62-B79C-A9B22C311E3B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CEC8AF29-77BC-4C62-B79C-A9B22C311E3B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CEC8AF29-77BC-4C62-B79C-A9B22C311E3B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CEC8AF29-77BC-4C62-B79C-A9B22C311E3B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B8A072BE-5B90-4193-A289-6CC8750D0DAD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B8A072BE-5B90-4193-A289-6CC8750D0DAD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B8A072BE-5B90-4193-A289-6CC8750D0DAD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B8A072BE-5B90-4193-A289-6CC8750D0DAD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/src/Microsoft.OData.Client/ALinq/ALinqExpressionVisitor.cs
+++ b/src/Microsoft.OData.Client/ALinq/ALinqExpressionVisitor.cs
@@ -14,6 +14,9 @@ namespace Microsoft.OData.Client
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq.Expressions;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// base visitor class for walking an expression tree bottom up.

--- a/src/Microsoft.OData.Client/Binding/BindingEntityInfo.cs
+++ b/src/Microsoft.OData.Client/Binding/BindingEntityInfo.cs
@@ -15,6 +15,9 @@ namespace Microsoft.OData.Client
     using System.Linq;
     using System.Threading;
     using Microsoft.OData.Client.Metadata;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
     #endregion
 
     /// <summary>Type of property stored in BindingPropertyInfo.</summary>

--- a/src/Microsoft.OData.Client/Binding/BindingUtils.cs
+++ b/src/Microsoft.OData.Client/Binding/BindingUtils.cs
@@ -10,6 +10,9 @@ namespace Microsoft.OData.Client
 
     using System;
     using System.Diagnostics;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 #endregion
 
     /// <summary>Utilities for binding related operations</summary>

--- a/src/Microsoft.OData.Client/Binding/DataServiceCollectionOfT.cs
+++ b/src/Microsoft.OData.Client/Binding/DataServiceCollectionOfT.cs
@@ -15,6 +15,9 @@ namespace Microsoft.OData.Client
     using System.Diagnostics;
     using System.Threading;
     using Microsoft.OData.Client.Materialization;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     #endregion Namespaces
 

--- a/src/Microsoft.OData.Client/Build.Portable/Microsoft.OData.Client.Portable.cs
+++ b/src/Microsoft.OData.Client/Build.Portable/Microsoft.OData.Client.Portable.cs
@@ -275,11 +275,7 @@ namespace Microsoft.OData.Client {
         ResourceManager resources;
 
         internal TextRes() {
-#if !PORTABLELIB
-            resources = new System.Resources.ResourceManager("Microsoft.OData.Client", this.GetType().Assembly);
-#else
-            resources = new System.Resources.ResourceManager("Microsoft.OData.Client", this.GetType().GetTypeInfo().Assembly);
-#endif
+            resources = new System.Resources.ResourceManager("Microsoft.OData.Client", this.GetType().GetAssembly());
         }
 
         private static TextRes GetLoader() {

--- a/src/Microsoft.OData.Client/Common.cs
+++ b/src/Microsoft.OData.Client/Common.cs
@@ -21,6 +21,9 @@ namespace Microsoft.OData.Service
 #if !ODATA_CLIENT
     using Microsoft.OData.Client;
 #endif
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Common defintions and functions for the server and client lib

--- a/src/Microsoft.OData.Client/LoadPropertyResult.cs
+++ b/src/Microsoft.OData.Client/LoadPropertyResult.cs
@@ -15,6 +15,9 @@ namespace Microsoft.OData.Client
     using System.IO;
     using System.Text;
     using Microsoft.OData.Client.Metadata;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     #endregion Namespaces
 

--- a/src/Microsoft.OData.Client/Materialization/CollectionValueMaterializationPolicy.cs
+++ b/src/Microsoft.OData.Client/Materialization/CollectionValueMaterializationPolicy.cs
@@ -15,6 +15,9 @@ namespace Microsoft.OData.Client.Materialization
     using Microsoft.OData;
     using Microsoft.OData.Edm;
     using DSClient = Microsoft.OData.Client;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Use this class to materialize objects provided from an <see cref="ODataMessageReader"/>.

--- a/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
+++ b/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
@@ -15,6 +15,9 @@ namespace Microsoft.OData.Client.Materialization
     using Microsoft.OData.Client;
     using Microsoft.OData.Client.Metadata;
     using DSClient = Microsoft.OData.Client;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Used to materialize entities from an <see cref="ODataResource"/> to an object.

--- a/src/Microsoft.OData.Client/Materialization/ODataCollectionMaterializer.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataCollectionMaterializer.cs
@@ -15,6 +15,9 @@ namespace Microsoft.OData.Client.Materialization
     using Microsoft.OData;
     using Microsoft.OData.Edm;
     using DSClient = Microsoft.OData.Client;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Used to materialize a collection of primitive or complex values from an <see cref="ODataCollectionMaterializer"/>.

--- a/src/Microsoft.OData.Client/Materialization/ODataEntityMaterializerInvoker.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataEntityMaterializerInvoker.cs
@@ -11,6 +11,9 @@ namespace Microsoft.OData.Client.Materialization
     using System.Collections.Generic;
     using System.Diagnostics;
     using Microsoft.OData;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Use this class to invoke projection methods from <see cref="ODataEntityMaterializer"/>.

--- a/src/Microsoft.OData.Client/Materialization/ODataPropertyMaterializer.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataPropertyMaterializer.cs
@@ -13,6 +13,9 @@ namespace Microsoft.OData.Client.Materialization
     using Microsoft.OData.Client.Metadata;
     using Microsoft.OData;
     using Microsoft.OData.Edm;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Used to materialize a property from an <see cref="ODataMessageReader"/>.

--- a/src/Microsoft.OData.Client/Materialization/PrimitivePropertyConverter.cs
+++ b/src/Microsoft.OData.Client/Materialization/PrimitivePropertyConverter.cs
@@ -11,6 +11,9 @@ namespace Microsoft.OData.Client.Materialization
     using System.Globalization;
     using System.Xml.Linq;
     using Microsoft.Spatial;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Converter for primitive values which do not match the client property types. This can happen for two reasons:

--- a/src/Microsoft.OData.Client/MaterializeFromAtom.cs
+++ b/src/Microsoft.OData.Client/MaterializeFromAtom.cs
@@ -16,6 +16,9 @@ namespace Microsoft.OData.Client
     using System.Diagnostics;
     using System.Xml;
     using Microsoft.OData;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     #endregion Namespaces
 

--- a/src/Microsoft.OData.Client/Serialization/ODataPropertyConverter.cs
+++ b/src/Microsoft.OData.Client/Serialization/ODataPropertyConverter.cs
@@ -16,6 +16,9 @@ namespace Microsoft.OData.Client
     using Microsoft.OData.Metadata;
     using Microsoft.OData.Client.Metadata;
     using Microsoft.OData.Edm;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Component for converting properties on client types into instance of <see cref="ODataProperty"/> in order to serialize insert/update payloads.

--- a/src/Microsoft.OData.Client/TypeResolver.cs
+++ b/src/Microsoft.OData.Client/TypeResolver.cs
@@ -13,6 +13,9 @@ namespace Microsoft.OData.Client
     using System.Linq;
     using Microsoft.OData.Client.Metadata;
     using Microsoft.OData.Edm;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Class which contains all the logic for resolving the type from the wire name.

--- a/src/Microsoft.OData.Core/Evaluation/EdmValueUtils.cs
+++ b/src/Microsoft.OData.Core/Evaluation/EdmValueUtils.cs
@@ -15,7 +15,6 @@ using Microsoft.Spatial;
     using PlatformHelpers = Microsoft.OData.Client.PlatformHelper;
 #else
 using ErrorStrings = Microsoft.OData.Strings;
-using PlatformHelpers = Microsoft.OData.PlatformHelper;
 #endif
 
 #if ODATA_CLIENT

--- a/src/Microsoft.OData.Core/Json/IJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriter.cs
@@ -12,7 +12,9 @@ namespace Microsoft.OData.Json
     /// <summary>
     /// Interface for a class that can write arbitrary JSON.
     /// </summary>
+#if !NETSTANDARD1_3
     [CLSCompliant(false)]
+#endif
     public interface IJsonWriter
     {
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/IJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriterFactory.cs
@@ -12,7 +12,9 @@ namespace Microsoft.OData.Json
     /// <summary>
     /// Interface of the factory to create JSON writers.
     /// </summary>
+#if !NETSTANDARD1_3
     [CLSCompliant(false)]
+#endif
     public interface IJsonWriterFactory
     {
         /// <summary>

--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -28,6 +28,9 @@ namespace Microsoft.OData.Metadata
     using ErrorStrings = Microsoft.OData.Strings;
     using PlatformHelper = Microsoft.OData.PlatformHelper;
 #endif
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
     #endregion Namespaces
 
     /// <summary>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -875,11 +875,7 @@ namespace Microsoft.OData {
         ResourceManager resources;
 
         internal TextRes() {
-#if !PORTABLELIB
-            resources = new System.Resources.ResourceManager("Microsoft.OData.Core", this.GetType().Assembly);
-#else
-            resources = new System.Resources.ResourceManager("Microsoft.OData.Core", this.GetType().GetTypeInfo().Assembly);
-#endif
+            resources = new System.Resources.ResourceManager("Microsoft.OData.Core", this.GetType().GetAssembly());
         }
 
         private static TextRes GetLoader() {

--- a/src/Microsoft.OData.Core/PrimitiveConverter.cs
+++ b/src/Microsoft.OData.Core/PrimitiveConverter.cs
@@ -14,6 +14,9 @@ namespace Microsoft.OData
     using System.Xml;
     using Microsoft.OData.Json;
     using Microsoft.Spatial;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
     #endregion
 
     /// <summary>

--- a/src/Microsoft.OData.Core/TaskUtils.cs
+++ b/src/Microsoft.OData.Core/TaskUtils.cs
@@ -20,6 +20,9 @@ namespace Microsoft.OData.Client
 #if ODATA_CLIENT
     using ExceptionUtils = CommonUtil;
 #endif
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
     #endregion Namespaces
 
     /// <summary>

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -16,6 +16,9 @@ using Microsoft.OData.Evaluation;
 using Microsoft.OData.JsonLight;
 using Microsoft.OData.Metadata;
 using ODataErrorStrings = Microsoft.OData.Strings;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
 namespace Microsoft.OData
 {

--- a/src/Microsoft.OData.Core/UriParser/Parsers/LiteralParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/LiteralParser.cs
@@ -12,6 +12,9 @@ using System.Text;
 using System.Xml;
 using Microsoft.OData.Edm;
 using Microsoft.Spatial;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
 namespace Microsoft.OData.UriParser
 {

--- a/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
+++ b/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
@@ -10,6 +10,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using Microsoft.OData.Edm.Vocabularies;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
 namespace Microsoft.OData.Edm.Validation
 {

--- a/src/Microsoft.Spatial/GeoJsonObjectFormatterImplementation.cs
+++ b/src/Microsoft.Spatial/GeoJsonObjectFormatterImplementation.cs
@@ -7,6 +7,9 @@
 namespace Microsoft.Spatial
 {
     using System.Collections.Generic;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Formatter for Json Object

--- a/src/Microsoft.Spatial/SpatialFormatter.cs
+++ b/src/Microsoft.Spatial/SpatialFormatter.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Spatial
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>Represents the base class for all Spatial Formats.</summary>
         /// <typeparam name="TReaderStream">The type of reader to be read from.</typeparam>

--- a/src/Microsoft.Spatial/SpatialTreeBuilder.cs
+++ b/src/Microsoft.Spatial/SpatialTreeBuilder.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Spatial
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Tree based builder for spatial types

--- a/src/Microsoft.Spatial/Util.cs
+++ b/src/Microsoft.Spatial/Util.cs
@@ -7,6 +7,9 @@
 namespace Microsoft.Spatial
 {
     using System;
+#if NETSTANDARD1_3
+    using System.Reflection;
+#endif
 
     /// <summary>
     /// Util class

--- a/src/PlatformHelper.cs
+++ b/src/PlatformHelper.cs
@@ -36,12 +36,7 @@ namespace Microsoft.OData.Edm
     using System.Linq;
 #endif
     using System.Reflection;
-#if PORTABLELIB
-#endif
     using System.Xml;
-#if !SPATIAL
-
-#endif
 
     /// <summary>
     /// Helper methods that provide a common API surface on all platforms.
@@ -576,8 +571,7 @@ namespace Microsoft.OData.Edm
         {
 #if PORTABLELIB
             return GetInstanceConstructors(type, isPublic).SingleOrDefault(c => CheckTypeArgs(c, argTypes));
-#endif
-#if !PORTABLELIB
+#else
             BindingFlags bindingFlags = BindingFlags.Instance;
             bindingFlags |= isPublic ? BindingFlags.Public : BindingFlags.NonPublic;
             return type.GetConstructor(bindingFlags, null, argTypes, null);
@@ -737,6 +731,7 @@ namespace Microsoft.OData.Edm
         }
 
         #region Extension Methods to replace missing functionality (used for PORTABLELIB only, methods with these signatures already exist on other platforms)
+#if !NETSTANDARD1_3
         /// <summary>
         /// Replacement for Type.IsAssignableFrom(Type)
         /// </summary>
@@ -747,6 +742,7 @@ namespace Microsoft.OData.Edm
         {
             return thisType.GetTypeInfo().IsAssignableFrom(otherType.GetTypeInfo());
         }
+#endif
 
         /// <summary>
         /// Replacement for Type.IsSubclassOf(Type).
@@ -943,6 +939,7 @@ namespace Microsoft.OData.Edm
             return type.GetTypeInfo().GetCustomAttributes(inherit);
         }
 
+#if !NETSTANDARD1_3
         /// <summary>
         /// Replacement for Type.GetGenericArguments().
         /// </summary>
@@ -959,6 +956,7 @@ namespace Microsoft.OData.Edm
                 return type.GenericTypeArguments;
             }
         }
+#endif
 
         /// <summary>
         /// Replacement for Type.GetInterfaces().

--- a/test/EndToEndTests/Framework/Core/Common/ToStringConverter.cs
+++ b/test/EndToEndTests/Framework/Core/Common/ToStringConverter.cs
@@ -204,7 +204,7 @@ namespace Microsoft.Test.OData.Framework.Common
         /// <returns>See documentation for property being accessed in the body of the method.</returns>
         internal static bool IsEnum(this Type type)
         {
-#if DNXCORE50
+#if PORTABLELIB
             return type.GetTypeInfo().IsEnum;
 #else
             return type.IsEnum;
@@ -218,7 +218,7 @@ namespace Microsoft.Test.OData.Framework.Common
         /// <returns>See documentation for property being accessed in the body of the method.</returns>
         internal static Type GetBaseType(this Type type)
         {
-#if DNXCORE50
+#if PORTABLELIB
             return type.GetTypeInfo().BaseType;
 #else
             return type.BaseType;


### PR DESCRIPTION
Addresses #568.

This delta adds a solution file, `sln/Microsoft.OData.NetStandard.sln`,
which references six `.xproj` files in the following directories:
- NetStandard.Projects/src/Microsoft.OData.Client
- NetStandard.Projects/src/Microsoft.OData.Core
- NetStandard.Projects/src/Microsoft.OData.Edm
- NetStandard.Projects/src/Microsoft.Spatial
- NetStandard.Projects/test/EndToEndTests/Framework
- NetStandard.Projects/test/EndToEndTests/Services/TestServices

(basically all the project covered by
`sln/Microsoft.OData.E2E.Portable.sln`)

To build this project with VS 2015 and dotnet CLI Preview 1, open the
`sln/Microsoft.OData.NetStandard.sln` and build (`Ctrl+Shift+B`).

To build via command line on Windows or Unix, installed dotnet CLI
Preview 1 (from https://dot.net/) and run the following commands:

``` sh

git clone https://github.com/am11/odata.net -b feature/netstd-port
cd odata.net

dotnet restore
dotnet build NetStandard.Projects/test/EndToEndTests/Services/TestServices
```

Building `test/EndToEndTests/Services/TestServices` will trigger the
build on other five projects as TestServices is the most dependent one
in the given set.

The third way is to use latest msbuild (v14.0 or xplat for Unix:
https://github.com/microsoft/msbuild/tree/xplat) and execute:

``` sh
git clone https://github.com/am11/odata.net -b feature/netstd-port
cd odata.net

dotnet restore
msbuild sln/Microsoft.OData.NetStandard.sln
```
