### PR TITLE
Support no-$ for system query parameters in OData library

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -554,7 +554,7 @@ namespace Microsoft.OData.Core.UriParser
             }
 
             throw new ODataException(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce(
-                isNoDollarQueryOptionsEnabled ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", noDollarQueryOptionName ?? string.Empty) : trimmedQueryOptionName));
+                isNoDollarQueryOptionsEnabled ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", noDollarQueryOptionName ?? trimmedQueryOptionName) : trimmedQueryOptionName));
         }
         #endregion private methods
     }

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -510,37 +510,37 @@ namespace Microsoft.OData.Core.UriParser
         /// Gets query options according to case sensitivity and 
         /// whether no dollar query options is enabled.
         /// </summary>
-        /// <param name="queryOptionName">The query option name.</param>
+        /// <param name="name">The query option name.</param>
         /// <param name="value">The value of the query option.</param>
         /// <returns>Whether value successfully retrived.</returns>
-        private bool TryGetQueryOption(string queryOptionName, out string value)
+        private bool TryGetQueryOption(string name, out string value)
         {
             value = null;
-            if (queryOptionName == null)
+            if (name == null)
             {
                 return false;
             }
 
-            // Trim queryOptionName to prevent caller from passing in untrimmed name for comparison with 
+            // Trim name to prevent caller from passing in untrimmed name for comparison with 
             // already trimmed keys in queryOptions dictionary.
-            string trimmedQueryOptionName = queryOptionName.Trim();
+            string trimmedName = name.Trim();
 
             bool isCaseInsensitiveEnabled = this.Resolver.EnableCaseInsensitive;
             bool isNoDollarQueryOptionsEnabled = this.Configuration.EnableNoDollarQueryOptions;
 
             if (!isCaseInsensitiveEnabled && !isNoDollarQueryOptionsEnabled)
             {
-                return this.queryOptions.TryGetValue(trimmedQueryOptionName, out value);
+                return this.queryOptions.TryGetValue(trimmedName, out value);
             }
 
             StringComparison stringComparison = isCaseInsensitiveEnabled ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 
-            string noDollarQueryOptionName = (isNoDollarQueryOptionsEnabled && trimmedQueryOptionName.StartsWith(UriQueryConstants.DollarSign)) ?
-                trimmedQueryOptionName.Substring(1) : null;
+            string nameWithoutDollarPrefix = (isNoDollarQueryOptionsEnabled && trimmedName.StartsWith(UriQueryConstants.DollarSign, StringComparison.Ordinal)) ?
+                trimmedName.Substring(1) : null;
 
             var list = this.queryOptions
-                .Where(pair => string.Equals(trimmedQueryOptionName, pair.Key, stringComparison)
-                || (noDollarQueryOptionName != null && string.Equals(noDollarQueryOptionName, pair.Key, stringComparison)))
+                .Where(pair => string.Equals(trimmedName, pair.Key, stringComparison)
+                || (nameWithoutDollarPrefix != null && string.Equals(nameWithoutDollarPrefix, pair.Key, stringComparison)))
                 .ToList();
 
             if (list.Count == 0)
@@ -554,7 +554,7 @@ namespace Microsoft.OData.Core.UriParser
             }
 
             throw new ODataException(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce(
-                isNoDollarQueryOptionsEnabled ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", noDollarQueryOptionName ?? trimmedQueryOptionName) : trimmedQueryOptionName));
+                isNoDollarQueryOptionsEnabled ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", nameWithoutDollarPrefix ?? trimmedName) : trimmedName));
         }
         #endregion private methods
     }

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -9,6 +9,7 @@ namespace Microsoft.OData.Core.UriParser
     #region namespaces
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using Microsoft.OData.Core.Metadata;
     using Microsoft.OData.Core.UriParser.Aggregation;
@@ -506,21 +507,40 @@ namespace Microsoft.OData.Core.UriParser
         }
 
         /// <summary>
-        /// Get query options according to case insensitive.
+        /// Gets query options according to case sensitivity and 
+        /// whether no dollar query options is enabled.
         /// </summary>
-        /// <param name="queryOptionName">The query option's name.</param>
-        /// <param name="value">The value for that query option.</param>
+        /// <param name="queryOptionName">The query option name.</param>
+        /// <param name="value">The value of the query option.</param>
         /// <returns>Whether value successfully retrived.</returns>
         private bool TryGetQueryOption(string queryOptionName, out string value)
         {
-            if (!this.Resolver.EnableCaseInsensitive)
+            value = null;
+            if (queryOptionName == null)
             {
-                return this.queryOptions.TryGetValue(queryOptionName, out value);
+                return false;
             }
 
-            value = null;
+            // Trim queryOptionName to prevent caller from passing in untrimmed name for comparison with 
+            // already trimmed keys in queryOptions dictionary.
+            string trimmedQueryOptionName = queryOptionName.Trim();
+
+            bool isCaseInsensitiveEnabled = this.Resolver.EnableCaseInsensitive;
+            bool isNoDollarQueryOptionsEnabled = this.Configuration.EnableNoDollarQueryOptions;
+
+            if (!isCaseInsensitiveEnabled && !isNoDollarQueryOptionsEnabled)
+            {
+                return this.queryOptions.TryGetValue(trimmedQueryOptionName, out value);
+            }
+
+            StringComparison stringComparison = isCaseInsensitiveEnabled ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+            string noDollarQueryOptionName = (isNoDollarQueryOptionsEnabled && trimmedQueryOptionName.StartsWith(UriQueryConstants.DollarSign)) ?
+                trimmedQueryOptionName.Substring(1) : null;
+
             var list = this.queryOptions
-                .Where(pair => string.Equals(queryOptionName, pair.Key, StringComparison.OrdinalIgnoreCase))
+                .Where(pair => string.Equals(trimmedQueryOptionName, pair.Key, stringComparison)
+                || (noDollarQueryOptionName != null && string.Equals(noDollarQueryOptionName, pair.Key, stringComparison)))
                 .ToList();
 
             if (list.Count == 0)
@@ -533,7 +553,8 @@ namespace Microsoft.OData.Core.UriParser
                 return true;
             }
 
-            throw new ODataException(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce(queryOptionName));
+            throw new ODataException(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce(
+                isNoDollarQueryOptionsEnabled ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", noDollarQueryOptionName ?? string.Empty) : trimmedQueryOptionName));
         }
         #endregion private methods
     }

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
@@ -145,6 +145,17 @@ namespace Microsoft.OData.Core.UriParser
         }
 
         /// <summary>
+        /// Whether no dollar query options is enabled. 
+        /// If it is enabled, the '$' prefix of system query options becomes optional.  
+        /// For example, "select" and "$select" are equivalent in this case.
+        /// </summary>
+        public bool EnableNoDollarQueryOptions
+        {
+            get { return this.configuration.EnableNoDollarQueryOptions; }
+            set { this.configuration.EnableNoDollarQueryOptions = value; }
+        }
+
+        /// <summary>
         /// Whether Uri template parsing is enabled. Uri template for keys and function parameters are supported.
         /// See <see cref="UriTemplateExpression"/> class for detail.
         /// </summary>

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParserConfiguration.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParserConfiguration.cs
@@ -97,6 +97,13 @@ namespace Microsoft.OData.Core.UriParser
         }
 
         /// <summary>
+        /// Whether no dollar query options is enabled. 
+        /// If it is enabled, the '$' prefix of system query options becomes optional.  
+        /// For example, "select" and "$select" are equivalent in this case.
+        /// </summary>
+        internal bool EnableNoDollarQueryOptions { get; set; }
+
+        /// <summary>
         /// Whether Uri template parsing is enabled. See <see cref="UriTemplateExpression"/> class for detail.
         /// </summary>
         internal bool EnableUriTemplateParsing { get; set; }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/ExpandOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ExpandOptionParser.cs
@@ -152,7 +152,7 @@ namespace Microsoft.OData.Core.UriParser.Parsers
                         : this.lexer.CurrentToken.Text;
 
                     // Prepend '$' prefix if needed.
-                    if (this.enableNoDollarQueryOptions && !text.StartsWith(UriQueryConstants.DollarSign))
+                    if (this.enableNoDollarQueryOptions && !text.StartsWith(UriQueryConstants.DollarSign, StringComparison.Ordinal))
                     {
                         text = string.Format(CultureInfo.InvariantCulture, "{0}{1}", UriQueryConstants.DollarSign, text);
                     }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/ExpandOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ExpandOptionParser.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.Core.UriParser.Parsers
         /// The parent entity type for expand option in case expand option is star, get all parent navigation properties
         /// </summary>
         private readonly IEdmStructuredType parentEntityType;
-        
+
         /// <summary>
         /// Max recursion depth. As we recurse, each new instance of this class will have this lowered by 1.
         /// </summary>
@@ -50,14 +50,24 @@ namespace Microsoft.OData.Core.UriParser.Parsers
         private bool enableCaseInsensitiveBuiltinIdentifier;
 
         /// <summary>
+        /// Whether to enable no dollar query options.
+        /// </summary>
+        private bool enableNoDollarQueryOptions;
+
+        /// <summary>
         /// Creates an instance of this class to parse options.
         /// </summary>
         /// <param name="maxRecursionDepth">Max recursion depth left.</param>
         /// <param name="enableCaseInsensitiveBuiltinIdentifier">Whether to allow case insensitive for builtin identifier.</param>
-        internal ExpandOptionParser(int maxRecursionDepth, bool enableCaseInsensitiveBuiltinIdentifier = false)
+        /// <param name="enableNoDollarQueryOptions">Whether to enable no dollar query options.</param>
+        internal ExpandOptionParser(
+            int maxRecursionDepth,
+            bool enableCaseInsensitiveBuiltinIdentifier = false,
+            bool enableNoDollarQueryOptions = false)
         {
             this.maxRecursionDepth = maxRecursionDepth;
             this.enableCaseInsensitiveBuiltinIdentifier = enableCaseInsensitiveBuiltinIdentifier;
+            this.enableNoDollarQueryOptions = enableNoDollarQueryOptions;
         }
 
         /// <summary>
@@ -67,8 +77,14 @@ namespace Microsoft.OData.Core.UriParser.Parsers
         /// <param name="parentEntityType">The parent entity type for expand option</param>
         /// <param name="maxRecursionDepth">Max recursion depth left.</param>
         /// <param name="enableCaseInsensitiveBuiltinIdentifier">Whether to allow case insensitive for builtin identifier.</param>
-        internal ExpandOptionParser(ODataUriResolver resolver, IEdmStructuredType parentEntityType, int maxRecursionDepth, bool enableCaseInsensitiveBuiltinIdentifier = false)
-            : this(maxRecursionDepth, enableCaseInsensitiveBuiltinIdentifier)
+        /// <param name="enableNoDollarQueryOptions">Whether to enable no dollar query options.</param>
+        internal ExpandOptionParser(
+            ODataUriResolver resolver,
+            IEdmStructuredType parentEntityType,
+            int maxRecursionDepth,
+            bool enableCaseInsensitiveBuiltinIdentifier = false,
+            bool enableNoDollarQueryOptions = false)
+            : this(maxRecursionDepth, enableCaseInsensitiveBuiltinIdentifier, enableNoDollarQueryOptions)
         {
             this.resolver = resolver;
             this.parentEntityType = parentEntityType;
@@ -134,6 +150,13 @@ namespace Microsoft.OData.Core.UriParser.Parsers
                     string text = this.enableCaseInsensitiveBuiltinIdentifier
                         ? this.lexer.CurrentToken.Text.ToLowerInvariant()
                         : this.lexer.CurrentToken.Text;
+
+                    // Prepend '$' prefix if needed.
+                    if (this.enableNoDollarQueryOptions && !text.StartsWith(UriQueryConstants.DollarSign))
+                    {
+                        text = string.Format(CultureInfo.InvariantCulture, "{0}{1}", UriQueryConstants.DollarSign, text);
+                    }
+
                     switch (text)
                     {
                         case ExpressionConstants.QueryOptionFilter:
@@ -261,14 +284,22 @@ namespace Microsoft.OData.Core.UriParser.Parsers
                                 {
                                     var parentProperty = this.resolver.ResolveProperty(parentEntityType, pathToken.Identifier) as IEdmNavigationProperty;
 
-                                    // it is a navigation property, need to find the type. Like $expand=Friends($expand=Trips($expand=*)), when expandText becomes "Trips($expand=*)", find navigation property Trips of Friends, then get Entity type of Trips.
+                                    // it is a navigation property, need to find the type. 
+                                    // Like $expand=Friends($expand=Trips($expand=*)), when expandText becomes "Trips($expand=*)", 
+                                    // find navigation property Trips of Friends, then get Entity type of Trips.
                                     if (parentProperty != null)
-                                    { 
+                                    {
                                         targetEntityType = parentProperty.ToEntityType();
                                     }
                                 }
 
-                                SelectExpandParser innerExpandParser = new SelectExpandParser(resolver, expandText, targetEntityType, this.maxRecursionDepth - 1, enableCaseInsensitiveBuiltinIdentifier);
+                                SelectExpandParser innerExpandParser = new SelectExpandParser(
+                                    resolver,
+                                    expandText,
+                                    targetEntityType,
+                                    this.maxRecursionDepth - 1,
+                                    this.enableCaseInsensitiveBuiltinIdentifier,
+                                    this.enableNoDollarQueryOptions);
                                 expandOption = innerExpandParser.ParseExpand();
                                 break;
                             }
@@ -347,8 +378,8 @@ namespace Microsoft.OData.Core.UriParser.Parsers
                     {
                         case ExpressionConstants.QueryOptionLevels:
                             {
-                                if (!isRefExpand) 
-                                { 
+                                if (!isRefExpand)
+                                {
                                     levelsOption = ResolveLevelOption();
                                 }
                                 else

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
@@ -56,13 +56,23 @@ namespace Microsoft.OData.Core.UriParser.Parsers
         private bool enableCaseInsensitiveBuiltinIdentifier;
 
         /// <summary>
+        /// Whether to enable no dollar query options.
+        /// </summary>
+        private bool enableNoDollarQueryOptions;
+
+        /// <summary>
         /// Build the SelectOption strategy.
         /// TODO: Really should not take the clauseToParse here. Instead it should be provided with a call to ParseSelect() or ParseExpand().
         /// </summary>
         /// <param name="clauseToParse">the clause to parse</param>
         /// <param name="maxRecursiveDepth">max recursive depth</param>
         /// <param name="enableCaseInsensitiveBuiltinIdentifier">Whether to allow case insensitive for builtin identifier.</param>
-        public SelectExpandParser(string clauseToParse, int maxRecursiveDepth, bool enableCaseInsensitiveBuiltinIdentifier = false)
+        /// <param name="enableNoDollarQueryOptions">Whether to enable no dollar query options.</param>
+        public SelectExpandParser(
+            string clauseToParse,
+            int maxRecursiveDepth,
+            bool enableCaseInsensitiveBuiltinIdentifier = false,
+            bool enableNoDollarQueryOptions = false)
         {
             this.maxRecursiveDepth = maxRecursiveDepth;
 
@@ -77,6 +87,8 @@ namespace Microsoft.OData.Core.UriParser.Parsers
             this.lexer = clauseToParse != null ? new ExpressionLexer(clauseToParse, false /*moveToFirstToken*/, false /*useSemicolonDelimiter*/) : null;
 
             this.enableCaseInsensitiveBuiltinIdentifier = enableCaseInsensitiveBuiltinIdentifier;
+
+            this.enableNoDollarQueryOptions = enableNoDollarQueryOptions;
         }
 
         /// <summary>
@@ -87,13 +99,20 @@ namespace Microsoft.OData.Core.UriParser.Parsers
         /// <param name="parentEntityType">the parent entity type for expand option</param>
         /// <param name="maxRecursiveDepth">max recursive depth</param>
         /// <param name="enableCaseInsensitiveBuiltinIdentifier">Whether to allow case insensitive for builtin identifier.</param>
-        public SelectExpandParser(ODataUriResolver resolver, string clauseToParse, IEdmStructuredType parentEntityType, int maxRecursiveDepth, bool enableCaseInsensitiveBuiltinIdentifier = false)
-            : this(clauseToParse, maxRecursiveDepth, enableCaseInsensitiveBuiltinIdentifier)
+        /// <param name="enableNoDollarQueryOptions">Whether to enable no dollar query options.</param>
+        public SelectExpandParser(
+            ODataUriResolver resolver,
+            string clauseToParse,
+            IEdmStructuredType parentEntityType,
+            int maxRecursiveDepth,
+            bool enableCaseInsensitiveBuiltinIdentifier = false,
+            bool enableNoDollarQueryOptions = false)
+            : this(clauseToParse, maxRecursiveDepth, enableCaseInsensitiveBuiltinIdentifier, enableNoDollarQueryOptions)
         {
             this.resolver = resolver;
             this.parentEntityType = parentEntityType;
         }
-        
+
         /// <summary>
         /// The maximum depth for path nested in $expand.
         /// </summary>
@@ -168,7 +187,12 @@ namespace Microsoft.OData.Core.UriParser.Parsers
 
             if (expandOptionParser == null)
             {
-                expandOptionParser = new ExpandOptionParser(this.resolver, this.parentEntityType, this.maxRecursiveDepth, enableCaseInsensitiveBuiltinIdentifier)
+                expandOptionParser = new ExpandOptionParser(
+                    this.resolver,
+                    this.parentEntityType,
+                    this.maxRecursiveDepth,
+                    this.enableCaseInsensitiveBuiltinIdentifier,
+                    this.enableNoDollarQueryOptions)
                 {
                     MaxFilterDepth = MaxFilterDepth,
                     MaxOrderByDepth = MaxOrderByDepth,

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandSyntacticParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandSyntacticParser.cs
@@ -37,7 +37,13 @@ namespace Microsoft.OData.Core.UriParser.Parsers
             };
             selectTree = selectParser.ParseSelect();
 
-            SelectExpandParser expandParser = new SelectExpandParser(configuration.Resolver, expandClause, parentEntityType, configuration.Settings.SelectExpandLimit, configuration.EnableCaseInsensitiveUriFunctionIdentifier)
+            SelectExpandParser expandParser = new SelectExpandParser(
+                configuration.Resolver,
+                expandClause,
+                parentEntityType,
+                configuration.Settings.SelectExpandLimit,
+                configuration.EnableCaseInsensitiveUriFunctionIdentifier,
+                configuration.EnableNoDollarQueryOptions)
             {
                 MaxPathDepth = configuration.Settings.PathLimit,
                 MaxFilterDepth = configuration.Settings.FilterLimit,

--- a/src/Microsoft.OData.Core/UriParser/UriQueryConstants.cs
+++ b/src/Microsoft.OData.Core/UriParser/UriQueryConstants.cs
@@ -76,5 +76,8 @@ namespace Microsoft.OData.Core.UriParser
 
         /// <summary>A search query option name.</summary>
         internal const string SearchQueryOption = "$search";
+
+        /// <summary>Dollar sign.</summary>
+        internal const string DollarSign = "$";
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -1,11 +1,12 @@
 ﻿//---------------------------------------------------------------------
-// <copyright file="ODataUriParserUnitTests.cs" company="Microsoft">
+// <copyright file="ODataUriParserTests.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
 //---------------------------------------------------------------------
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.OData.Core.UriParser;
@@ -26,10 +27,13 @@ namespace Microsoft.OData.Core.Tests.UriParser
         private readonly Uri ServiceRoot = new Uri("http://host");
         private readonly Uri FullUri = new Uri("http://host/People");
 
-        [Fact]
-        public void NoneQueryOptionShouldWork()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void NonQueryOptionShouldWork(bool enableNoDollarQueryOptions)
         {
             var uriParser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, FullUri);
+            uriParser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             var path = uriParser.ParsePath();
             path.Should().HaveCount(1);
             path.LastSegment.ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
@@ -44,10 +48,14 @@ namespace Microsoft.OData.Core.Tests.UriParser
             uriParser.ParseDeltaToken().Should().BeNull();
         }
 
-        [Fact]
-        public void EmptyValueQueryOptionShouldWork()
+        [Theory]
+        [InlineData("?filter=&select=&expand=&orderby=&top=&skip=&count=&search=&unknown=&$unknownvalue&skiptoken=&deltatoken=", true)]
+        [InlineData("?$filter=&$select=&$expand=&$orderby=&$top=&$skip=&$count=&$search=&$unknown=&$unknownvalue&$skiptoken=&$deltatoken=", true)]
+        [InlineData("?$filter=&$select=&$expand=&$orderby=&$top=&$skip=&$count=&$search=&$unknown=&$unknownvalue&$skiptoken=&$deltatoken=", false)]
+        public void EmptyValueQueryOptionShouldWork(string relativeUriString, bool enableNoDollarQueryOptions)
         {
-            var uriParser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(FullUri, "?$filter=&$select=&$expand=&$orderby=&$top=&$skip=&$count=&$search=&$unknow=&$unknowvalue&$skiptoken=&$deltatoken="));
+            var uriParser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(FullUri, relativeUriString));
+            uriParser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             var path = uriParser.ParsePath();
             path.Should().HaveCount(1);
             path.LastSegment.ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
@@ -126,18 +134,26 @@ namespace Microsoft.OData.Core.Tests.UriParser
             parser.Settings.FilterLimit.Should().Be(3);
         }
 
-        [Fact]
-        public void FilterLimitIsRespectedForFilter()
+        [Theory]
+        [InlineData("http://host/People?filter=1 eq 1", true)]
+        [InlineData("http://host/People?$filter=1 eq 1", true)]
+        [InlineData("http://host/People?$filter=1 eq 1", false)]
+        public void FilterLimitIsRespectedForFilter(string fullUriString, bool enableNoDollarQueryOptions)
         {
-            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri("http://host/People?$filter=1 eq 1")) { Settings = { FilterLimit = 0 } };
+            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(fullUriString)) { Settings = { FilterLimit = 0 } };
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             Action parseWithLimit = () => parser.ParseFilter();
             parseWithLimit.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.UriQueryExpressionParser_TooDeep);
         }
 
-        [Fact]
-        public void FilterLimitWithInterestingTreeStructures()
+        [Theory]
+        [InlineData("http://host/People?filter=MyDog/Color eq 'Brown' or MyDog/Color eq 'White'", true)]
+        [InlineData("http://host/People?$filter=MyDog/Color eq 'Brown' or MyDog/Color eq 'White'", true)]
+        [InlineData("http://host/People?$filter=MyDog/Color eq 'Brown' or MyDog/Color eq 'White'", false)]
+        public void FilterLimitWithInterestingTreeStructures(string fullUriString, bool enableNoDollarQueryOptions)
         {
-            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri("http://host/People?$filter=MyDog/Color eq 'Brown' or MyDog/Color eq 'White'")) { Settings = { FilterLimit = 5 } };
+            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(fullUriString)) { Settings = { FilterLimit = 5 } };
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             Action parseWithLimit = () => parser.ParseFilter();
             parseWithLimit.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.UriQueryExpressionParser_TooDeep);
         }
@@ -156,18 +172,26 @@ namespace Microsoft.OData.Core.Tests.UriParser
             parser.Settings.OrderByLimit.Should().Be(3);
         }
 
-        [Fact]
-        public void OrderByLimitIsRespectedForOrderby()
+        [Theory]
+        [InlineData("http://host/People?orderby= 1 eq 1", true)]
+        [InlineData("http://host/People?$orderby= 1 eq 1", true)]
+        [InlineData("http://host/People?$orderby= 1 eq 1", false)]
+        public void OrderByLimitIsRespectedForOrderby(string fullUriString, bool enableNoDollarQueryOptions)
         {
-            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri("http://host/People?$orderby= 1 eq 1")) { Settings = { OrderByLimit = 0 } };
+            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(fullUriString)) { Settings = { OrderByLimit = 0 } };
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             Action parseWithLimit = () => parser.ParseOrderBy();
             parseWithLimit.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.UriQueryExpressionParser_TooDeep);
         }
 
-        [Fact]
-        public void OrderByLimitWithInterestingTreeStructures()
+        [Theory]
+        [InlineData("http://host/People?orderby=MyDog/MyPeople/MyDog/MyPeople/MyPaintings asc", true)]
+        [InlineData("http://host/People?$orderby=MyDog/MyPeople/MyDog/MyPeople/MyPaintings asc", true)]
+        [InlineData("http://host/People?$orderby=MyDog/MyPeople/MyDog/MyPeople/MyPaintings asc", false)]
+        public void OrderByLimitWithInterestingTreeStructures(string fullUriString, bool enableNoDollarQueryOptions)
         {
-            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri("http://host/People?$orderby=MyDog/MyPeople/MyDog/MyPeople/MyPaintings asc")) { Settings = { OrderByLimit = 5 } };
+            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(fullUriString)) { Settings = { OrderByLimit = 5 } };
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             Action parseWithLimit = () => parser.ParseOrderBy();
             parseWithLimit.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.UriQueryExpressionParser_TooDeep);
         }
@@ -208,10 +232,14 @@ namespace Microsoft.OData.Core.Tests.UriParser
             parser.Settings.SelectExpandLimit.Should().Be(3);
         }
 
-        [Fact]
-        public void SelectExpandLimitIsRespectedForSelectExpand()
+        [Theory]
+        [InlineData("http://host/People?select=MyDog&expand=MyDog(select=color)", true)]
+        [InlineData("http://host/People?$select=MyDog&$expand=MyDog($select=color)", true)]
+        [InlineData("http://host/People?$select=MyDog&$expand=MyDog($select=color)", false)]
+        public void SelectExpandLimitIsRespectedForSelectExpand(string fullUriString, bool enableNoDollarQueryOptions)
         {
-            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri("http://host/People?$select=MyDog&$expand=MyDog($select=color)")) { Settings = { SelectExpandLimit = 0 } };
+            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(fullUriString)) { Settings = { SelectExpandLimit = 0 } };
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             Action parseWithLimit = () => parser.ParseSelectAndExpand();
             parseWithLimit.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.UriQueryExpressionParser_TooDeep);
         }
@@ -258,10 +286,14 @@ namespace Microsoft.OData.Core.Tests.UriParser
         }
         #endregion
 
-        [Fact]
-        public void ParseSelectExpandForContainment()
+        [Theory]
+        [InlineData("http://host/People?select=MyContainedDog&expand=MyContainedDog", true)]
+        [InlineData("http://host/People?$select=MyContainedDog&$expand=MyContainedDog", true)]
+        [InlineData("http://host/People?$select=MyContainedDog&$expand=MyContainedDog", false)]
+        public void ParseSelectExpandForContainment(string fullUriString, bool enableNoDollarQueryOptions)
         {
-            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri("http://host/People?$select=MyContainedDog&$expand=MyContainedDog")) { Settings = { SelectExpandLimit = 5 } };
+            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(fullUriString)) { Settings = { SelectExpandLimit = 5 } };
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             SelectExpandClause containedSelectExpandClause = parser.ParseSelectAndExpand();
             IEnumerator<SelectItem> enumerator = containedSelectExpandClause.SelectedItems.GetEnumerator();
             enumerator.MoveNext();
@@ -337,10 +369,14 @@ namespace Microsoft.OData.Core.Tests.UriParser
             path.LastSegment.ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
         }
 
-        [Fact]
-        public void ParseQueryOptionsShouldWork()
+        [Theory]
+        [InlineData("People?filter=MyDog/Color eq 'Brown'&select=ID&expand=MyDog&orderby=ID&top=1&skip=2&count=true&search=FA&$unknown=&$unknownvalue&skiptoken=abc&deltatoken=def", true)]
+        [InlineData("People?$filter=MyDog/Color eq 'Brown'&$select=ID&$expand=MyDog&$orderby=ID&$top=1&$skip=2&$count=true&$search=FA&$unknown=&$unknownvalue&$skiptoken=abc&$deltatoken=def", true)]
+        [InlineData("People?$filter=MyDog/Color eq 'Brown'&$select=ID&$expand=MyDog&$orderby=ID&$top=1&$skip=2&$count=true&$search=FA&$unknown=&$unknownvalue&$skiptoken=abc&$deltatoken=def", false)]
+        public void ParseQueryOptionsShouldWork(string relativeUriString, bool enableNoDollarQueryOptions)
         {
-            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("People?$filter=MyDog/Color eq 'Brown'&$select=ID&$expand=MyDog&$orderby=ID&$top=1&$skip=2&$count=true&$search=FA&$unknow=&$unknowvalue&$skiptoken=abc&$deltatoken=def", UriKind.Relative));
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri(relativeUriString, UriKind.Relative));
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             parser.ParseSelectAndExpand().Should().NotBeNull();
             parser.ParseFilter().Should().NotBeNull();
             parser.ParseOrderBy().Should().NotBeNull();
@@ -353,9 +389,84 @@ namespace Microsoft.OData.Core.Tests.UriParser
         }
 
         [Fact]
-        public void ParseDeltaTokenWithKindsofCharactorsShouldWork()
+        public void ParseNoDollarQueryOptionsShouldReturnNullIfNoDollarQueryOptionsIsNotEnabled()
         {
-            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("People?$deltatoken=Start@Next_Chunk:From%26$To=Here!?()*+%2B,1-._~;", UriKind.Relative));
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("People?filter=MyDog/Color eq 'Brown'&select=ID&expand=MyDog&orderby=ID&top=1&skip=2&count=true&search=FA&$unknown=&$unknownvalue&skiptoken=abc&deltatoken=def", UriKind.Relative));
+            parser.ParseFilter().Should().BeNull();
+            parser.ParseSelectAndExpand().Should().BeNull();
+            parser.ParseOrderBy().Should().BeNull();
+            parser.ParseTop().Should().Be(null);
+            parser.ParseSkip().Should().Be(null);
+            parser.ParseCount().Should().Be(null);
+            parser.ParseSearch().Should().BeNull();
+            parser.ParseSkipToken().Should().BeNull();
+            parser.ParseDeltaToken().Should().BeNull();
+        }
+
+        [Theory]
+        // Should not throw duplicate query options exception.
+        // 1. Case sensitive, No dollar enabled.
+        [InlineData("People?select=ID&$SELECT=Name", false, true, "select", false)]
+        [InlineData("People?SELECT=ID&$select=Name", false, true, "select", false)]
+        [InlineData("People?SELECT=ID&$SELECT=Name", false, true, "select", false)]
+        // 2. Case insensitive, No dollar not enabled.
+        [InlineData("People?$select=ID&select=Name", true, false, "$select", false)]
+        [InlineData("People?$select=ID&SELECT=Name", true, false, "$select", false)]
+
+        // Should throw duplicate query options exception.
+        [InlineData("People?select=ID&select=Name", false, false, "select", true)]
+        [InlineData("People?$select=ID&$select=Name", false, false, "$select", true)]
+        [InlineData("People?select=ID&$select=Name", false, true, "select", true)]
+        [InlineData("People?$select=ID&$SELECT=Name", true, false, "$select", true)]
+        [InlineData("People?$select=ID&$SELECT=Name", true, true, "select", true)]
+        [InlineData("People?select=ID&$SELECT=Name", true, true, "select", true)]
+        public void ParseShouldFailWithDuplicateQueryOptions(string relativeUriString, bool enableCaseInsensitive, bool enableNoDollarQueryOptions, string queryOptionName, bool shouldThrow)
+        {
+            Uri relativeUri = new Uri(relativeUriString, UriKind.Relative);
+            Action action = () => new ODataUriParser(HardCodedTestModel.TestModel, relativeUri)
+            {
+                Resolver = new ODataUriResolver()
+                {
+                    EnableCaseInsensitive = enableCaseInsensitive
+                },
+
+                EnableNoDollarQueryOptions = enableNoDollarQueryOptions
+
+            }.ParseSelectAndExpand();
+
+            if (shouldThrow)
+            {
+                action.ShouldThrow<ODataException>().WithMessage(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce(
+                    enableNoDollarQueryOptions ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", queryOptionName ?? string.Empty) : queryOptionName));
+            }
+            else
+            {
+                action.ShouldNotThrow<ODataException>();
+            }
+        }
+
+        [Theory]
+        [InlineData("People?expand=MyDog(select=ID,Color)")]
+        [InlineData("People?$expand=MyDog(select=ID,Color)")]
+        [InlineData("People?expand=MyDog(expand=MyPeople(select=Name))")]
+        [InlineData("People?expand=MyDog($expand=MyPeople($select=Name))")]
+        [InlineData("People?expand=MyDog(select=Color;expand=MyPeople(select=Name;count=true))")]
+        [InlineData("People?$expand=MyDog($select=Color;expand=MyPeople(select=Name;$count=true))")]
+        public void ParseNestedNoDollarQueryOptionsShouldWorkWhenNoDollarQueryOptionsIsEnabled(string relativeUriString)
+        {
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri(relativeUriString, UriKind.Relative));
+            parser.EnableNoDollarQueryOptions = true;
+            parser.ParseSelectAndExpand().Should().NotBeNull();
+        }
+
+        [Theory]
+        [InlineData("People?deltatoken=Start@Next_Chunk:From%26$To=Here!?()*+%2B,1-._~;", true)]
+        [InlineData("People?$deltatoken=Start@Next_Chunk:From%26$To=Here!?()*+%2B,1-._~;", true)]
+        [InlineData("People?$deltatoken=Start@Next_Chunk:From%26$To=Here!?()*+%2B,1-._~;", false)]
+        public void ParseDeltaTokenWithKindsofCharactorsShouldWork(string relativeUriString, bool enableNoDollarQueryOptions)
+        {
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri(relativeUriString, UriKind.Relative));
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
             parser.ParseDeltaToken().Should().Be("Start@Next_Chunk:From&$To=Here!?()* +,1-._~;");
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -437,7 +437,7 @@ namespace Microsoft.OData.Core.Tests.UriParser
             if (shouldThrow)
             {
                 action.ShouldThrow<ODataException>().WithMessage(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce(
-                    enableNoDollarQueryOptions ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", queryOptionName ?? string.Empty) : queryOptionName));
+                    enableNoDollarQueryOptions ? string.Format(CultureInfo.InvariantCulture, "${0}/{0}", queryOptionName) : queryOptionName));
             }
             else
             {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5172,6 +5172,7 @@ public sealed class Microsoft.OData.Core.UriParser.ODataUriParser {
 	public ODataUriParser (Microsoft.OData.Edm.IEdmModel model, System.Uri serviceRoot, System.Uri fullUri)
 
 	System.Func`2[[System.String],[Microsoft.OData.Core.UriParser.Semantic.BatchReferenceSegment]] BatchReferenceCallback  { public get; public set; }
+	bool EnableNoDollarQueryOptions  { public get; public set; }
 	bool EnableUriTemplateParsing  { public get; public set; }
 	Microsoft.OData.Edm.IEdmModel Model  { public get; }
 	System.Collections.Generic.IDictionary`2[[System.String],[Microsoft.OData.Core.UriParser.Semantic.SingleValueNode]] ParameterAliasNodes  { public get; }


### PR DESCRIPTION
### Issues
*This pull request fixes issue #637.*  

### Description
- Add configuration flag to enable no-$ system query options.
- Handle no-$ system query options at root and nested levels.
- Handle duplicate system query options caused by having both $ and no-$ equivalents.
- Add new test cases for no-$ support.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
Update the[ ODataUriParser tutorial ](http://odata.github.io/odata.net/#01-03-use-uri-parser) mentioning the added no-$ support.