### PR TITLE
Added property 'AutoNullPropagation' to DataServiceContext. If set to…

### DIFF
--- a/WCFDataService/Client/System/Data/Services/Client/DataServiceContext.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/DataServiceContext.cs
@@ -598,6 +598,12 @@ namespace System.Data.Services.Client
             set { this.ignoreMissingProperties = value; }
         }
 
+        /// <summary>Gets or sets whether query projection will handle null propagation automatically. If set to true null propagation checks can be omitted from queries.</summary>
+        /// <remarks>
+        /// Default is false.
+        /// </remarks>
+        public bool AutoNullPropagation { get; set; }
+
         /// <summary>Gets or sets whether to respect IgnoreMissingProperties boolean, or directly ignore/support undeclared properties.</summary>
         /// <remarks>
         /// This also affects responses during SaveChanges.

--- a/WCFDataService/Client/System/Data/Services/Client/Materialization/IODataMaterializerContext.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Materialization/IODataMaterializerContext.cs
@@ -61,5 +61,7 @@ namespace System.Data.Services.Client.Materialization
         /// <param name="clientClrType">The client side CLR type.</param>
         /// <returns>The resolved EDM type to provide to ODataLib.</returns>
         IEdmType ResolveExpectedTypeForReading(Type clientClrType);
+
+        bool AutoNullPropagation { get; }
     }
 }

--- a/WCFDataService/Client/System/Data/Services/Client/Materialization/MaterializerEntry.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Materialization/MaterializerEntry.cs
@@ -275,7 +275,7 @@ namespace System.Data.Services.Client.Materialization
         /// <returns>The materializer entry</returns>
         public static MaterializerEntry GetEntry(ODataEntry entry)
         {
-            return entry.GetAnnotation<MaterializerEntry>();
+            return entry == null ? null : entry.GetAnnotation<MaterializerEntry>();
         }
 
         /// <summary>
@@ -341,7 +341,7 @@ namespace System.Data.Services.Client.Materialization
                     {
                         throw DSClient.Error.InvalidOperation(DSClient.Strings.Deserialize_MissingIdElement);
                     }
-
+                    
                     this.EntityDescriptor.Identity = this.entry.Id;
                     this.EntityDescriptor.EditLink = this.entry.EditLink;
                     this.EntityDescriptor.SelfLink = this.entry.ReadLink;

--- a/WCFDataService/Client/System/Data/Services/Client/Materialization/ODataEntityMaterializerInvoker.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Materialization/ODataEntityMaterializerInvoker.cs
@@ -113,6 +113,16 @@ namespace System.Data.Services.Client.Materialization
             return ODataEntityMaterializer.ProjectionGetEntry(MaterializerEntry.GetEntry((ODataEntry)entry), name);
         }
 
+        /// <summary>Provides support for getting payload entries or null during projections.</summary>
+        /// <param name="entry">Entry to get sub-entry from.</param>
+        /// <param name="name">Name of sub-entry.</param>
+        /// <returns>The sub-entry or null.</returns>
+        internal static object ProjectionGetEntryOrNull(object entry, string name)
+        {
+            Debug.Assert(entry.GetType() == typeof(ODataEntry), "entry.GetType() == typeof(ODataEntry)");
+            return ODataEntityMaterializer.ProjectionGetEntryOrNull(MaterializerEntry.GetEntry((ODataEntry)entry), name);
+        }
+
         /// <summary>Initializes a projection-driven entry (with a specific type and specific properties).</summary>
         /// <param name="materializer">Materializer under which projection is taking place.</param>
         /// <param name="entry">Root entry for paths.</param>
@@ -130,8 +140,10 @@ namespace System.Data.Services.Client.Materialization
             Func<object, object, Type, object>[] propertyValues)
         {
             Debug.Assert(typeof(ODataEntityMaterializer).IsAssignableFrom(materializer.GetType()), "typeof(ODataEntityMaterializer).IsAssignableFrom(materializer.GetType())");
-            Debug.Assert(entry.GetType() == typeof(ODataEntry), "entry.GetType() == typeof(ODataEntry)");
-            return ODataEntityMaterializer.ProjectionInitializeEntity((ODataEntityMaterializer)materializer, MaterializerEntry.GetEntry((ODataEntry)entry), expectedType, resultType, properties, propertyValues);
+            ODataEntityMaterializer entityMaterializer = (ODataEntityMaterializer)materializer;
+            if (!entityMaterializer.MaterializerContext.AutoNullPropagation)
+                Debug.Assert(entry.GetType() == typeof(ODataEntry), "entry.GetType() == typeof(ODataEntry)");
+            return ODataEntityMaterializer.ProjectionInitializeEntity(entityMaterializer, MaterializerEntry.GetEntry((ODataEntry)entry), expectedType, resultType, properties, propertyValues);
         }
 
         /// <summary>Projects a simple value from the specified <paramref name="path"/>.</summary>

--- a/WCFDataService/Client/System/Data/Services/Client/Materialization/ODataMaterializerContext.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Materialization/ODataMaterializerContext.cs
@@ -75,6 +75,14 @@ namespace System.Data.Services.Client.Materialization
         /// </summary>
         protected ResponseInfo ResponseInfo { get; private set; }
 
+        public bool AutoNullPropagation
+        {
+            get
+            {
+                return this.ResponseInfo.AutoNullPropagation;
+            }
+        }
+
         /// <summary>
         /// Resolved the given edm type to clr type.
         /// </summary>

--- a/WCFDataService/Client/System/Data/Services/Client/ResponseInfo.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/ResponseInfo.cs
@@ -96,6 +96,11 @@ namespace System.Data.Services.Client
             get { return this.Context.IgnoreMissingProperties; }
         }
 
+        internal bool AutoNullPropagation
+        {
+            get { return this.Context.AutoNullPropagation; }
+        }
+
         /// <summary>Gets the value of UndeclaredPropertyBehaviorKinds.</summary>
         internal ODataUndeclaredPropertyBehaviorKinds UndeclaredPropertyBehaviorKinds
         {


### PR DESCRIPTION
### Issues

_This pull request fixes issue #669 ._  
_This pull request has a workaround for issue #379 ._  
### Description

_Added boolean property AutoNullPropagation to DataServiceContext. When set to true the projection plan compiler and the entity materializer will accept null values from server while projecting._
### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed
### Additional work necessary

_If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue._

… true you can write queries without explicit null propagation checks in the projection when performing implicit expands.
