### PR TITLE
GetSelectedNavigationProperties now yields empty result sets for non …

### DIFF
--- a/ODataLib/OData/Desktop/.Net4.0/Microsoft/Data/OData/SelectedPropertiesNode.cs
+++ b/ODataLib/OData/Desktop/.Net4.0/Microsoft/Data/OData/SelectedPropertiesNode.cs
@@ -302,9 +302,9 @@ namespace Microsoft.Data.OData
                 return EmptyNavigationProperties;
             }
 
-            if (this.selectionType == SelectionType.EntireSubtree || this.hasWildcard)
+            if (this.selectionType == SelectionType.EntireSubtree)
             {
-                return entityType.NavigationProperties();
+                return EmptyNavigationProperties;
             }
 
             // Find all the selected navigation properties


### PR DESCRIPTION
### Issues
*This pull request fixes issue #674 .*  

### Description
*GetSelectedNavigationProperties now yields empty result sets for non projected queries. The correct set of LinkInfos will still be created elsewhere when explicit $expand is part of the query.*

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
