### PR TITLE
ProjectionInitializeEntity now finishes off by firing the ResponsePip…

### DIFF
--- a/WCFDataService/Client/System/Data/Services/Client/Materialization/ODataEntityMaterializer.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Materialization/ODataEntityMaterializer.cs
@@ -519,6 +519,8 @@ namespace System.Data.Services.Client.Materialization
                 }
             }
 
+            materializer.MaterializerContext.ResponsePipeline.FireEndEntryEvents(entry);
+
             return result;
         }
 


### PR DESCRIPTION
### Issues
*This pull request fixes issue #677 .*  

### Description
*ProjectionInitializeEntity now finishes off by firing the ResponsePipeline's end entry events: OnEntityMaterialized (ATOM+JSON) and ReadingEntity (ATOM)..*

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
