### PR TITLE
V3 client detect properties for post

### DIFF
--- a/WCFDataService/Client/System/Data/Services/Client/AtomMaterializerLog.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/AtomMaterializerLog.cs
@@ -216,7 +216,7 @@ namespace System.Data.Services.Client
                     {
                         // we should always reset descriptor's state to Unchanged (old v1 behaviour)
                         descriptor.State = EntityStates.Unchanged;
-                        descriptor.PropertiesToSerialize.Clear();
+                        descriptor.ClearPropertiesToSerialize();
                     }
                 }
             }

--- a/WCFDataService/Client/System/Data/Services/Client/AtomMaterializerLog.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/AtomMaterializerLog.cs
@@ -216,6 +216,7 @@ namespace System.Data.Services.Client
                     {
                         // we should always reset descriptor's state to Unchanged (old v1 behaviour)
                         descriptor.State = EntityStates.Unchanged;
+                        descriptor.PropertiesToSerialize.Clear();
                     }
                 }
             }

--- a/WCFDataService/Client/System/Data/Services/Client/BaseSaveResult.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/BaseSaveResult.cs
@@ -1209,7 +1209,7 @@ namespace System.Data.Services.Client
                 {
                     entityDescriptor.ETag = etag;
                     entityDescriptor.State = EntityStates.Unchanged;
-                    entityDescriptor.PropertiesToSerialize.Clear();
+                    entityDescriptor.ClearPropertiesToSerialize();
                 }
 
                 if (entityDescriptor.StreamState != EntityStates.Added)
@@ -1281,7 +1281,7 @@ namespace System.Data.Services.Client
                         Debug.Assert(entityDescriptor.State == EntityStates.Modified, "descriptor.State == EntityStates.Modified");
                         entityDescriptor.ETag = etag;
                         entityDescriptor.State = EntityStates.Unchanged;
-                        entityDescriptor.PropertiesToSerialize.Clear();
+                        entityDescriptor.ClearPropertiesToSerialize();
                     }
                 }
             }

--- a/WCFDataService/Client/System/Data/Services/Client/BaseSaveResult.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/BaseSaveResult.cs
@@ -98,7 +98,7 @@ namespace System.Data.Services.Client
         {
             this.RequestInfo = new RequestInfo(context);
             this.Options = options;
-            this.SerializerInstance = new Serializer(this.RequestInfo);
+            this.SerializerInstance = new Serializer(this.RequestInfo, options);
 
             if (null == queries)
             {
@@ -1209,6 +1209,7 @@ namespace System.Data.Services.Client
                 {
                     entityDescriptor.ETag = etag;
                     entityDescriptor.State = EntityStates.Unchanged;
+                    entityDescriptor.PropertiesToSerialize.Clear();
                 }
 
                 if (entityDescriptor.StreamState != EntityStates.Added)
@@ -1280,6 +1281,7 @@ namespace System.Data.Services.Client
                         Debug.Assert(entityDescriptor.State == EntityStates.Modified, "descriptor.State == EntityStates.Modified");
                         entityDescriptor.ETag = etag;
                         entityDescriptor.State = EntityStates.Unchanged;
+                        entityDescriptor.PropertiesToSerialize.Clear();
                     }
                 }
             }

--- a/WCFDataService/Client/System/Data/Services/Client/Binding/BindingObserver.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Binding/BindingObserver.cs
@@ -560,6 +560,8 @@ namespace System.Data.Services.Client
                         // be added to the context. We need to call AddRelatedObject,
                         // which adds via the parent (for e.g. POST Customers(0)/Orders).
                         this.Context.AddRelatedObject(source, sourceProperty, target);
+                        if (this.Context.UsePartialPost)
+                            DetectChangedProperties(target);
                     }
                     else
                     if (targetDescriptor.State != EntityStates.Deleted && !this.IsContextTrackingLink(source, sourceProperty, target))
@@ -586,6 +588,56 @@ namespace System.Data.Services.Client
                 {
                     // Add the target entity.
                     this.Context.AddObject(targetEntitySet, target);
+                    if (this.Context.UsePartialPost)
+                        DetectChangedProperties(target);
+                }
+            }
+        }
+
+        private void DetectChangedProperties(object entity)
+        {
+            Debug.Assert(entity != null, "entity != null");
+
+            EntityDescriptor resource = this.Context.GetEntityDescriptor(entity);
+            ClientTypeAnnotation entityType = resource.Model.GetClientTypeAnnotation(resource.Model.GetOrCreateEdmType(resource.Entity.GetType()));
+            Type clrEntityType = entity.GetType();
+
+            resource.EnsurePropertiesToSerializeIsInitialized();
+ 
+            var properties = entityType.PropertiesToSerialize();
+            foreach (var prop in properties)
+            {
+                Type propertyType = prop.PropertyType;
+                object value = prop.GetValue(entity); // TODO: If we get a mechanism for getting to the backing field to avoid lazy initialization here (see #663). This line should be changed to: proper.GetFieldOrPropertyValue(entity);
+                if (value != null && (!propertyType.IsValueType || !value.Equals(WebUtil.GetDefaultValue(propertyType))))
+                {
+                    // TODO: If we get a mechanism for getting to the backing field to avoid lazy initialization here (see #663). 
+                    //       The entire block of this if() clause can be removed and replaced with a single line:
+                    //       resource.AddPropertyToSerialize(prop.PropertyName);
+
+                    if (prop.IsKnownType) // Primitive types
+                        resource.AddPropertyToSerialize(prop.PropertyName);
+
+                    else if (prop.IsSpatialType) // Spatial types
+                        resource.AddPropertyToSerialize(prop.PropertyName);
+
+                    else if (prop.IsPrimitiveOrComplexCollection) // Collection
+                        resource.AddPropertyToSerialize(prop.PropertyName); // Assumption - if someone has given this a value we include it even if the IEnumerable might yield zero results.
+
+                    else if (!prop.IsEntityCollection && !ClientTypeUtil.TypeIsEntity(prop.PropertyType, resource.Model)) // Complex type
+                    {
+                        var propertiesOfComplexType = resource.Model.GetClientTypeAnnotation(resource.Model.GetOrCreateEdmType(prop.PropertyType)).PropertiesToSerialize();
+                        foreach (var propOnComplex in propertiesOfComplexType)
+                        {
+                            Type propOnComplexType = propOnComplex.PropertyType;
+                            object complexPropertyValue = propOnComplex.GetValue(value);
+                            if (complexPropertyValue != null && (!propOnComplexType.IsValueType || !complexPropertyValue.Equals(WebUtil.GetDefaultValue(propOnComplexType))))
+                            {
+                                resource.AddPropertyToSerialize(prop.PropertyName);
+                                break;
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -756,8 +808,10 @@ namespace System.Data.Services.Client
                     else
                     {
                         this.Context.AddObject(targetEntitySet, target);
+                        if (this.Context.UsePartialPost)
+                            DetectChangedProperties(target);
                     }
-                    
+
                     targetDescriptor = this.Context.GetEntityDescriptor(target);
                 }
 
@@ -827,10 +881,9 @@ namespace System.Data.Services.Client
                 return;
             }
 
-            HashSet<string> propertiesToSerialize = this.Context.GetEntityDescriptor(entity).PropertiesToSerialize;
             if (propertyName != null)
             {
-                propertiesToSerialize.Add(propertyName);
+                this.Context.GetEntityDescriptor(entity).AddPropertyToSerialize(propertyName);
             }
 
             // First give the user code a chance to handle Update operation.

--- a/WCFDataService/Client/System/Data/Services/Client/Binding/BindingObserver.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Binding/BindingObserver.cs
@@ -827,6 +827,12 @@ namespace System.Data.Services.Client
                 return;
             }
 
+            HashSet<string> propertiesToSerialize = this.Context.GetEntityDescriptor(entity).PropertiesToSerialize;
+            if (propertyName != null)
+            {
+                propertiesToSerialize.Add(propertyName);
+            }
+
             // First give the user code a chance to handle Update operation.
             if (this.EntityChanged != null)
             {

--- a/WCFDataService/Client/System/Data/Services/Client/DataServiceContext.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/DataServiceContext.cs
@@ -977,6 +977,11 @@ namespace System.Data.Services.Client
             get { return this.model; }
         }
 
+        /// <summary>
+        /// When set to true the DataServiceContext will detect properties with non default values for added entities and only POST the non default properties during SaveChanges.
+        /// </summary>
+        public bool UsePartialPost { get; set; }
+
         #region Entity and Link Tracking
 
         /// <summary>Gets the <see cref="T:System.Data.Services.Client.EntityDescriptor" /> for the supplied entity object.</summary>
@@ -1728,6 +1733,8 @@ namespace System.Data.Services.Client
         public IAsyncResult BeginSaveChanges(SaveChangesOptions options, AsyncCallback callback, object state)
         {
             this.ValidateSaveChangesOptions(options);
+            if (this.UsePartialPost)
+                options |= SaveChangesOptions.PostOnlySetProperties;
             BaseSaveResult result = BaseSaveResult.CreateSaveResult(this, Util.SaveChangesMethodName, null, options, callback, state);
             if (result.IsBatchRequest)
             {
@@ -1773,6 +1780,8 @@ namespace System.Data.Services.Client
         {
             DataServiceResponse errors = null;
             this.ValidateSaveChangesOptions(options);
+            if (this.UsePartialPost)
+                options |= SaveChangesOptions.PostOnlySetProperties;
 
             BaseSaveResult result = BaseSaveResult.CreateSaveResult(this, Util.SaveChangesMethodName, null, options, null, null);
             if (result.IsBatchRequest)

--- a/WCFDataService/Client/System/Data/Services/Client/DataServiceContext.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/DataServiceContext.cs
@@ -2744,7 +2744,8 @@ namespace System.Data.Services.Client
                 SaveChangesOptions.Batch |
                 SaveChangesOptions.BatchWithIndependentOperations |
                 SaveChangesOptions.ReplaceOnUpdate |
-                SaveChangesOptions.PatchOnUpdate;
+                SaveChangesOptions.PatchOnUpdate |
+                SaveChangesOptions.PostOnlySetProperties;
 
             // Make sure no higher order bits are set.
             if ((options | All) != All)

--- a/WCFDataService/Client/System/Data/Services/Client/EntityDescriptor.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/EntityDescriptor.cs
@@ -95,6 +95,7 @@ namespace System.Data.Services.Client
             : base(EntityStates.Unchanged)
         {
             this.Model = model;
+            this.PropertiesToSerialize = new HashSet<string>(StringComparer.Ordinal);
 #if WINDOWS_PHONE
             this.deserializing = false;
 #endif
@@ -556,6 +557,11 @@ namespace System.Data.Services.Client
         /// </summary>
         internal string EntitySetName { get; set; }
         
+        /// <summary> 
+        ///  The hash set contains names of changed properties in this entity. 
+        /// </summary> 
+        internal HashSet<string> PropertiesToSerialize { get; set; } 
+
         #endregion
 
         #region Internal Methods

--- a/WCFDataService/Client/System/Data/Services/Client/EntityDescriptor.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/EntityDescriptor.cs
@@ -95,7 +95,6 @@ namespace System.Data.Services.Client
             : base(EntityStates.Unchanged)
         {
             this.Model = model;
-            this.PropertiesToSerialize = new HashSet<string>(StringComparer.Ordinal);
 #if WINDOWS_PHONE
             this.deserializing = false;
 #endif
@@ -556,15 +555,40 @@ namespace System.Data.Services.Client
         /// The entity set name provided in either AttachTo or AddObject.
         /// </summary>
         internal string EntitySetName { get; set; }
-        
+
         /// <summary> 
         ///  The hash set contains names of changed properties in this entity. 
         /// </summary> 
-        internal HashSet<string> PropertiesToSerialize { get; set; } 
+        /// <remarks>Can be null</remarks>
+        internal IEnumerable<string> PropertiesToSerialize
+        {
+            get
+            {
+                return propertiesToSerialize;
+            }
+        }
+
+        private HashSet<string> propertiesToSerialize;
 
         #endregion
 
         #region Internal Methods
+
+        internal void EnsurePropertiesToSerializeIsInitialized()
+        {
+            if (this.propertiesToSerialize == null)
+                this.propertiesToSerialize = new HashSet<string>(StringComparer.Ordinal);
+        }
+        internal void AddPropertyToSerialize(string propertyName)
+        {
+            EnsurePropertiesToSerializeIsInitialized();
+            this.propertiesToSerialize.Add(propertyName);
+        }
+
+        internal void ClearPropertiesToSerialize()
+        {
+            this.propertiesToSerialize = null;
+        }
 
         /// <summary>
         /// returns the most recent identity of the entity

--- a/WCFDataService/Client/System/Data/Services/Client/EntityTracker.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/EntityTracker.cs
@@ -502,7 +502,7 @@ namespace System.Data.Services.Client
             trackedEntityDescriptor.Identity = entityDescriptorFromMaterializer.Identity; // always attach the identity
             AtomMaterializerLog.MergeEntityDescriptorInfo(trackedEntityDescriptor, entityDescriptorFromMaterializer, true /*mergeInfo*/, metadataMergeOption);
             trackedEntityDescriptor.State = EntityStates.Unchanged;
-            trackedEntityDescriptor.PropertiesToSerialize.Clear();
+            trackedEntityDescriptor.ClearPropertiesToSerialize();
 
             // scenario: sucessfully (1) delete an existing entity and (2) add a new entity where the new entity has the same identity as deleted entity
             // where the SaveChanges pass1 will now associate existing identity with new entity

--- a/WCFDataService/Client/System/Data/Services/Client/EntityTracker.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/EntityTracker.cs
@@ -502,6 +502,7 @@ namespace System.Data.Services.Client
             trackedEntityDescriptor.Identity = entityDescriptorFromMaterializer.Identity; // always attach the identity
             AtomMaterializerLog.MergeEntityDescriptorInfo(trackedEntityDescriptor, entityDescriptorFromMaterializer, true /*mergeInfo*/, metadataMergeOption);
             trackedEntityDescriptor.State = EntityStates.Unchanged;
+            trackedEntityDescriptor.PropertiesToSerialize.Clear();
 
             // scenario: sucessfully (1) delete an existing entity and (2) add a new entity where the new entity has the same identity as deleted entity
             // where the SaveChanges pass1 will now associate existing identity with new entity

--- a/WCFDataService/Client/System/Data/Services/Client/SaveChangesOptions.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/SaveChangesOptions.cs
@@ -44,6 +44,12 @@ namespace System.Data.Services.Client
 
         /// <summary>save each change independently in a batch request.</summary>
         BatchWithIndependentOperations = 16,
-    }    
+
+        /// <summary> 
+        /// Use partial payload when doing post. 
+        /// Note it can only be used when using <see cref="T:Microsoft.OData.Client.DataServiceCollection`1" /> 
+        /// </summary> 
+        PostOnlySetProperties = 32,
+    }
 }
 

--- a/WCFDataService/Client/System/Data/Services/Client/Serialization/Serializer.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Serialization/Serializer.cs
@@ -283,11 +283,11 @@ namespace System.Data.Services.Client
                 }
 
                 IEnumerable<ClientPropertyAnnotation> properties;
-                if ((!Util.IsFlagSet(this.options, SaveChangesOptions.ReplaceOnUpdate) &&
-                    entityDescriptor.State == EntityStates.Modified &&
-                    entityDescriptor.PropertiesToSerialize.Any()) ||
+                if (entityDescriptor.PropertiesToSerialize != null &&
+                    ((!Util.IsFlagSet(this.options, SaveChangesOptions.ReplaceOnUpdate) &&
+                    entityDescriptor.State == EntityStates.Modified) ||
                     (Util.IsFlagSet(this.options, SaveChangesOptions.PostOnlySetProperties) &&
-                    entityDescriptor.State == EntityStates.Added))
+                    entityDescriptor.State == EntityStates.Added)))
                 {
                     if (this.requestInfo.Format.ODataFormat != ODataFormat.Atom)
                         properties = entityType.PropertiesToSerialize().Where(prop => entityDescriptor.PropertiesToSerialize.Contains(prop.PropertyName));


### PR DESCRIPTION
### Issues
*This pull request fixes issue #685.*  

### Description
*BindingObserver now inspects the properties of newly added objects and properties with non null/non default values are added to the PropertiesToSerialize collection on the EntityDescriptor. Added a new Boolean property "UsePartialPost" to the DataServiceContext to enable or disable this on a global level. This PR builds upon my earlier PR #684. It should be easy to port this one to V4 if you decide to.*

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
