### PR TITLE
Client: FeedAndEntryMaterializerAdapter now only adds navigation links if they were expanded.

### DIFF
--- a/WCFDataService/Client/System/Data/Services/Client/Materialization/FeedAndEntryMaterializerAdapter.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Materialization/FeedAndEntryMaterializerAdapter.cs
@@ -352,7 +352,9 @@ namespace System.Data.Services.Client.Materialization
                     {
                         case ODataReaderState.NavigationLinkStart:
                             // Cache the list of navigation links here but don't add them to the entry because all of the key properties may not be available yet.
-                            navigationLinks.Add(this.ReadNavigationLink());
+                            ODataNavigationLink link = this.ReadNavigationLink();
+                            if (link != null)
+                                navigationLinks.Add(link);
                             break;
                         case ODataReaderState.EntryEnd:
                             break;
@@ -405,7 +407,8 @@ namespace System.Data.Services.Client.Materialization
 
                 this.ReadAndExpectState(ODataReaderState.NavigationLinkEnd);
             }
-
+            else
+                link = null;
             this.ExpectState(ODataReaderState.NavigationLinkEnd);
 
             return link;


### PR DESCRIPTION
### Issues
*This pull request fixes issue #674 .*  

### Description
*FeedAndEntryMaterializerAdapter now only adds navigation links if they were expanded.*

*ODataJsonLightReader now only add association links if server send them or on V1.*

*Net result: even on ATOM and json odata=fullmetadata - we only generate LinkInfo's for properties that were actually expanded. This increases performance and lowers memory consumption especially for models with many navigation properties.*

*The change to FeedAndEntryMaterializerAdapter could be directly ported to V4 to fix the same issue there, The change to ODataJsonLightReader is not relevant for V4.*

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*