### PR TITLE
V3 ODL Split ODataConventionalEntityMetadataBuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/ODataLib/EdmLib/Desktop/.Net4.0/bin
+/ODataLib/EdmLib/Desktop/.Net4.0/obj
+/ODataLib/EdmLib/Desktop/.Net4.0/Microsoft.Data.Edm.resources
+/ODataLib/OData/Desktop/.Net4.0/bin
+/ODataLib/OData/Desktop/.Net4.0/obj
+/ODataLib/Spatial/Desktop/.Net4.0/bin
+/ODataLib/Spatial/Desktop/.Net4.0/obj
+/ODataLib/Spatial/Desktop/.Net4.0/System.Spatial.resources
+/ODataLib/OData/Desktop/.Net4.0/Microsoft.Data.OData.resources
+/WCFDataService/AdHocTest
+/WCFDataService/Client/.vs/System.Data.Services.Client/v14
+/WCFDataService/Client/bin
+/WCFDataService/Client/obj
+/WCFDataService/Client/packages
+/WCFDataService/Client/System.Data.Services.Client.resources
+/WCFDataService/Service/.vs/System.Data.Services/v14
+/WCFDataService/Service/bin/Debug
+/WCFDataService/Service/obj/Debug
+/WCFDataService/Service/System.Data.Services.resources

--- a/ODataLib/OData/Desktop/.Net4.0/Microsoft/Data/OData/Evaluation/ODataMetadataContext.cs
+++ b/ODataLib/OData/Desktop/.Net4.0/Microsoft/Data/OData/Evaluation/ODataMetadataContext.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Data.OData.Evaluation
 
                     UrlConvention urlConvention = UrlConvention.ForUserSettingAndTypeContext(/*keyAsSegment*/ null, typeContext);
                     ODataConventionalUriBuilder uriBuilder = new ODataConventionalUriBuilder(this.ServiceBaseUri, urlConvention);
-                    entryState.MetadataBuilder = new ODataConventionalEntityMetadataBuilder(entryMetadataContext, this, uriBuilder);
+                    entryState.MetadataBuilder = new ODataConventionalEntityMetadataBuilderReader(entryMetadataContext, this, uriBuilder);
                 }
                 else
                 {

--- a/ODataLib/OData/Desktop/.Net4.0/Microsoft/Data/OData/JsonLight/JsonFullMetadataLevel.cs
+++ b/ODataLib/OData/Desktop/.Net4.0/Microsoft/Data/OData/JsonLight/JsonFullMetadataLevel.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Data.OData.JsonLight
             ODataConventionalUriBuilder uriBuilder = new ODataConventionalUriBuilder(metadataContext.ServiceBaseUri, urlConvention);
             
             IODataEntryMetadataContext entryMetadataContext = ODataEntryMetadataContext.Create(entry, typeContext, serializationInfo, actualEntityType, metadataContext, selectedProperties);
-            return new ODataConventionalEntityMetadataBuilder(entryMetadataContext, metadataContext, uriBuilder);
+            return new ODataConventionalEntityMetadataBuilderWriter(entryMetadataContext, metadataContext, uriBuilder);
         }
 
         /// <summary>


### PR DESCRIPTION
### Issues
*This pull request fixes issue #674.*  

### Description
*During reading the data on the wire is now always the source for what navigation properties are generated. During writing it is still the model that is the source.*

*This is accomplished by splitting ODataConventionalEntityMetadataBuilder in a Reader and Writer part. GetNextUnprocessedNavigationLink is only valid during Write. During read we should not use the model to generate navigation links not present on the wire.*

*When reading unprojected payloads with odata=minimalmetadata - performance will be increased as no navigation links will be on the wire and now - we no longer generate them from the model.*

*I have another PR ( #697 ) open for this issue, they are both valid, but independent.

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
