### PR TITLE
DateTime Support on the Client Side Corresponding to the Server Side DateTime Support

### DIFF
--- a/src/Microsoft.OData.Client/Serialization/HttpWebRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpWebRequestMessage.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OData.Client
 
 #if PORTABLELIB
         /// <summary> Running on silverlight </summary>
-        internal static bool IsRunningOnSilverlight;
+        internal static bool IsRunningOnSilverlight = false;
 
         /// <summary>Cached method info that will be used to call to set the userAgent property if its not null. </summary>
         private static MethodInfo UserAgentMethodSetter;

--- a/src/Microsoft.OData.Client/Serialization/ODataPropertyConverter.cs
+++ b/src/Microsoft.OData.Client/Serialization/ODataPropertyConverter.cs
@@ -344,6 +344,10 @@ namespace Microsoft.OData.Client
             {
                 return primitiveType.TypeConverter.ToString(propertyValue);
             }
+            else if (propertyType == typeof(DateTime))
+            {
+                return (DateTimeOffset)(DateTime)propertyValue;
+            }
 #if !PORTABLELIB
             else if (propertyType.FullName == "System.Data.Linq.Binary")
             {

--- a/src/Microsoft.OData.Client/Serialization/PrimitiveType.cs
+++ b/src/Microsoft.OData.Client/Serialization/PrimitiveType.cs
@@ -340,6 +340,7 @@ namespace Microsoft.OData.Client
             RegisterKnownType(typeof(Byte), XmlConstants.EdmByteTypeName, EdmPrimitiveTypeKind.Byte, new ByteTypeConverter(), true);
             RegisterKnownType(typeof(Byte[]), XmlConstants.EdmBinaryTypeName, EdmPrimitiveTypeKind.Binary, new ByteArrayTypeConverter(), true);
             RegisterKnownType(typeof(DateTimeOffset), XmlConstants.EdmDateTimeOffsetTypeName, EdmPrimitiveTypeKind.DateTimeOffset, new DateTimeOffsetTypeConverter(), true);
+            RegisterKnownType(typeof(DateTime), XmlConstants.EdmDateTimeTypeName, EdmPrimitiveTypeKind.DateTimeOffset, new DateTimeTypeConverter(), true);
             RegisterKnownType(typeof(Decimal), XmlConstants.EdmDecimalTypeName, EdmPrimitiveTypeKind.Decimal, new DecimalTypeConverter(), true);
             RegisterKnownType(typeof(Double), XmlConstants.EdmDoubleTypeName, EdmPrimitiveTypeKind.Double, new DoubleTypeConverter(), true);
             RegisterKnownType(typeof(Guid), XmlConstants.EdmGuidTypeName, EdmPrimitiveTypeKind.Guid, new GuidTypeConverter(), true);

--- a/src/Microsoft.OData.Client/Serialization/PrimitiveXmlConverter.cs
+++ b/src/Microsoft.OData.Client/Serialization/PrimitiveXmlConverter.cs
@@ -643,6 +643,32 @@ namespace Microsoft.OData.Client
     /// <summary>
     /// Convert between primitive types to string and xml representation
     /// </summary>
+    internal sealed class DateTimeTypeConverter : PrimitiveTypeConverter
+    {
+        /// <summary>
+        /// Create an instance of primitive type from a string representation
+        /// </summary>
+        /// <param name="text">The string representation</param>
+        /// <returns>An instance of primitive type</returns>
+        internal override object Parse(String text)
+        {
+            return PlatformHelper.ConvertStringToDateTime(text);
+        }
+
+        /// <summary>
+        /// Convert an instance of primitive type to string
+        /// </summary>
+        /// <param name="instance">The instance</param>
+        /// <returns>The string representation of the instance</returns>
+        internal override string ToString(object instance)
+        {
+            return XmlConvert.ToString((DateTime)instance, XmlDateTimeSerializationMode.Utc);
+        }
+    }
+
+    /// <summary>
+    /// Convert between primitive types to string and xml representation
+    /// </summary>
     internal sealed class TimeSpanTypeConverter : PrimitiveTypeConverter
     {
         /// <summary>

--- a/src/Microsoft.OData.Client/XmlConstants.cs
+++ b/src/Microsoft.OData.Client/XmlConstants.cs
@@ -982,6 +982,9 @@ namespace Microsoft.OData.Service
         /// <summary>edm string primitive type name</summary>
         internal const string EdmDateTimeOffsetTypeName = "Edm.DateTimeOffset";
 
+        /// <summary>edm string primitive type name</summary>
+        internal const string EdmDateTimeTypeName = "Edm.DateTime";
+
         #endregion
 
         #region Astoria Constants

--- a/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
+++ b/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
@@ -226,6 +226,11 @@ namespace Microsoft.OData.Core.Evaluation
                 return XmlConvert.ToString((DateTimeOffset)value);
             }
 
+            if (value is DateTime)
+            {
+                return XmlConvert.ToString((DateTimeOffset)(DateTime)value);
+            }
+
             if (value is TimeOfDay)
             {
                 return value.ToString();
@@ -363,7 +368,7 @@ namespace Microsoft.OData.Core.Evaluation
             private static bool TryGetByteArrayFromBinary(object value, out byte[] array)
             {
                 // DEVNOTE: the client does not have a reference to System.Data.Linq, but the server does.
-                // So we need to interact with Binary differently.
+                // So we need to interact with Binary differently.            
 #if ASTORIA_SERVER
                 Binary binary = value as Binary;
                 if (binary != null)
@@ -455,17 +460,6 @@ namespace Microsoft.OData.Core.Evaluation
             {
                 Debug.Assert(value != null, "value != null. Null values need to be handled differently in some cases.");
 
-                var enumValue = value as ODataEnumValue;
-                if (enumValue != null)
-                {
-                    if (string.IsNullOrEmpty(enumValue.TypeName))
-                    {
-                        throw new ODataException(Strings.DefaultLiteralFormatter_EnumValueTypeNameShouldNotBeNullOrEmpty);
-                    }
-
-                    return enumValue.TypeName + "'" + this.FormatAndEscapeLiteral(enumValue.Value) + "'";
-                }
-
                 string result = this.FormatAndEscapeLiteral(value);
 
                 if (value is byte[])
@@ -499,7 +493,7 @@ namespace Microsoft.OData.Core.Evaluation
         }
 
         /// <summary>
-        /// Literal formatter for keys which are written as URI segments.
+        /// Literal formatter for keys which are written as URI segments. 
         /// Very similar to the default, but it never puts the type markers or single quotes around the value.
         /// </summary>
         private sealed class KeysAsSegmentsLiteralFormatter : LiteralFormatter

--- a/src/PlatformHelper.cs
+++ b/src/PlatformHelper.cs
@@ -450,6 +450,17 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Converts a string to a DateTimeOffset.
+        /// </summary>
+        /// <param name="text">String to be converted.</param>
+        /// <returns>See documentation for method being accessed in the body of the method.</returns>
+        internal static DateTime ConvertStringToDateTime(string text)
+        {
+            var offset = ConvertStringToDateTimeOffset(text);
+            return offset.DateTime;
+        }
+
+        /// <summary>
         /// Validates that the DateTimeOffset string contains the time zone information.
         /// </summary>
         /// <param name="text">String to be validated.</param>

--- a/test/EndToEndTests/Services/Astoria/PrimitiveKeys/AllTypes.cs
+++ b/test/EndToEndTests/Services/Astoria/PrimitiveKeys/AllTypes.cs
@@ -254,4 +254,21 @@ namespace Microsoft.Test.OData.Services.PrimitiveKeysService
             yield return new EdmDateTimeOffset { Id = CachedUtcNow };
         }
     }
+
+    [Key("Id")]
+    public class EdmDateTime
+    {
+        private static readonly DateTime CachedNow = DateTime.Now;
+        private static readonly DateTime CachedUtcNow = DateTime.UtcNow.AddDays(1);
+
+        public DateTime Id { get; set; }
+
+        public static IEnumerable<EdmDateTime> GetData()
+        {
+            yield return new EdmDateTime { Id = DateTime.MinValue };
+            yield return new EdmDateTime { Id = DateTime.MaxValue };
+            yield return new EdmDateTime { Id = CachedNow };
+            yield return new EdmDateTime { Id = CachedUtcNow };
+        }
+    }
 }

--- a/test/EndToEndTests/Services/Astoria/PrimitiveKeys/TestContext.cs
+++ b/test/EndToEndTests/Services/Astoria/PrimitiveKeys/TestContext.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Test.OData.Services.PrimitiveKeysService
         public IQueryable<EdmString> EdmStringSet { get { return EdmString.GetData().AsQueryable(); } }
         public IQueryable<EdmTime> EdmTimeSet { get { return EdmTime.GetData().AsQueryable(); } }
         public IQueryable<EdmDateTimeOffset> EdmDateTimeOffsetSet { get { return EdmDateTimeOffset.GetData().AsQueryable(); } }
-
+        public IQueryable<EdmDateTime> EdmDateTimeSet { get { return EdmDateTime.GetData().AsQueryable(); } }
         public IQueryable<Folder> Folders { get { return Folder.GetData().AsQueryable(); } }
 
         #endregion

--- a/test/EndToEndTests/Services/CSDSCReferences/Microsoft.Test.OData.Services.TestServices.PrimitiveKeysServiceReference.cs
+++ b/test/EndToEndTests/Services/CSDSCReferences/Microsoft.Test.OData.Services.TestServices.PrimitiveKeysServiceReference.cs
@@ -281,6 +281,25 @@ namespace Microsoft.Test.OData.Services.TestServices.PrimitiveKeysServiceReferen
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
         private global::Microsoft.OData.Client.DataServiceQuery<EdmDateTimeOffset> _EdmDateTimeOffsetSet;
+
+        /// <summary>
+        /// There are no comments for EdmDateTimeSet in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
+        public global::Microsoft.OData.Client.DataServiceQuery<EdmDateTime> EdmDateTimeSet
+        {
+            get
+            {
+                if ((this._EdmDateTimeSet == null))
+                {
+                    this._EdmDateTimeSet = base.CreateQuery<EdmDateTime>("EdmDateTimeSet");
+                }
+                return this._EdmDateTimeSet;
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
+        private global::Microsoft.OData.Client.DataServiceQuery<EdmDateTime> _EdmDateTimeSet;
+
         /// <summary>
         /// There are no comments for Folders in the schema.
         /// </summary>
@@ -402,6 +421,16 @@ namespace Microsoft.Test.OData.Services.TestServices.PrimitiveKeysServiceReferen
         {
             base.AddObject("EdmDateTimeOffsetSet", edmDateTimeOffset);
         }
+        
+        /// <summary>
+        /// There are no comments for EdmDateTimeOffsetSet in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
+        public void AddToEdmDateTimeOffsetSet(EdmDateTime edmDateTime)
+        {
+            base.AddObject("EdmDateTimeSet", edmDateTime);
+        }
+        
         /// <summary>
         /// There are no comments for Folders in the schema.
         /// </summary>
@@ -497,6 +526,12 @@ namespace Microsoft.Test.OData.Services.TestServices.PrimitiveKeysServiceReferen
         </Key>
         <Property Name=""Id"" Type=""Edm.DateTimeOffset"" Nullable=""false"" />
       </EntityType>
+      <EntityType Name=""EdmDateTime"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.DateTimeOffset"" Nullable=""false"" />
+      </EntityType>
       <EntityType Name=""Folder"">
         <Key>
           <PropertyRef Name=""Id"" />
@@ -519,6 +554,7 @@ namespace Microsoft.Test.OData.Services.TestServices.PrimitiveKeysServiceReferen
         <EntitySet Name=""EdmStringSet"" EntityType=""Microsoft.Test.OData.Services.PrimitiveKeysService.EdmString"" />
         <EntitySet Name=""EdmTimeSet"" EntityType=""Microsoft.Test.OData.Services.PrimitiveKeysService.EdmTime"" />
         <EntitySet Name=""EdmDateTimeOffsetSet"" EntityType=""Microsoft.Test.OData.Services.PrimitiveKeysService.EdmDateTimeOffset"" />
+        <EntitySet Name=""EdmDateTimeSet"" EntityType=""Microsoft.Test.OData.Services.PrimitiveKeysService.EdmDateTime"" />
         <EntitySet Name=""Folders"" EntityType=""Microsoft.Test.OData.Services.PrimitiveKeysService.Folder"">
           <NavigationPropertyBinding Path=""Parent"" Target=""Folders"" />
         </EntitySet>
@@ -1659,6 +1695,97 @@ namespace Microsoft.Test.OData.Services.TestServices.PrimitiveKeysServiceReferen
             }
         }
     }
+
+    /// <summary>
+    /// There are no comments for EdmDateTimeOffsetSingle in the schema.
+    /// </summary>
+    public partial class EdmDateTimeSingle : global::Microsoft.OData.Client.DataServiceQuerySingle<EdmDateTime>
+    {
+        /// <summary>
+        /// Initialize a new EdmDateTimeSingle object.
+        /// </summary>
+        public EdmDateTimeSingle(global::Microsoft.OData.Client.DataServiceContext context, string path)
+            : base(context, path)
+        { }
+
+        /// <summary>
+        /// Initialize a new EdmDateTimeSingle object.
+        /// </summary>
+        public EdmDateTimeSingle(global::Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
+            : base(context, path, isComposable)
+        { }
+
+        /// <summary>
+        /// Initialize a new EdmDateTimeSingle object.
+        /// </summary>
+        public EdmDateTimeSingle(global::Microsoft.OData.Client.DataServiceQuerySingle<EdmDateTime> query)
+            : base(query)
+        { }
+
+    }
+
+    /// <summary>
+    /// There are no comments for EdmDateTime in the schema.
+    /// </summary>
+    /// <KeyProperties>
+    /// Id
+    /// </KeyProperties>
+    [global::Microsoft.OData.Client.Key("Id")]
+    [global::Microsoft.OData.Client.EntitySet("EdmDateTimeSet")]
+    public partial class EdmDateTime : global::Microsoft.OData.Client.BaseEntityType, global::System.ComponentModel.INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Create a new EdmDateTime object.
+        /// </summary>
+        /// <param name="ID">Initial value of Id.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
+        public static EdmDateTime CreateEdmDateTime(global::System.DateTime ID)
+        {
+            EdmDateTime edmDateTime = new EdmDateTime();
+            edmDateTime.Id = ID;
+            return edmDateTime;
+        }
+        /// <summary>
+        /// There are no comments for Property Id in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
+        public global::System.DateTime Id
+        {
+            get
+            {
+                return this._Id;
+            }
+            set
+            {
+                this.OnIdChanging(value);
+                this._Id = value;
+                this.OnIdChanged();
+                this.OnPropertyChanged("Id");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
+        private global::System.DateTime _Id;
+        partial void OnIdChanging(global::System.DateTime value);
+        partial void OnIdChanged();
+        /// <summary>
+        /// This event is raised when the value of the property is changed
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
+        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        /// <summary>
+        /// The value of the property is changed
+        /// </summary>
+        /// <param name="property">property name</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "2.2.0")]
+        protected virtual void OnPropertyChanged(string property)
+        {
+            if ((this.PropertyChanged != null))
+            {
+                this.PropertyChanged(this, new global::System.ComponentModel.PropertyChangedEventArgs(property));
+            }
+        }
+    }
+
     /// <summary>
     /// There are no comments for FolderSingle in the schema.
     /// </summary>

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/KeyAsSegmentTests/PrimitiveKeyValuesTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/KeyAsSegmentTests/PrimitiveKeyValuesTests.cs
@@ -57,6 +57,20 @@ namespace Microsoft.Test.OData.Tests.Client.KeyAsSegmentTests
         }
 
         [TestMethod]
+        public void DateTimeTest()
+        {
+            var contextWrapper = this.CreateWrappedContext();
+            foreach (var entry in contextWrapper.Context.EdmDateTimeSet)
+            {
+                var queryResult = contextWrapper.CreateQuery<EdmDateTime>("EdmDateTimeSet").Where(e
+                    => 
+                e.Id.Equals(entry.Id)
+                    ).ToArray();
+                Assert.AreEqual(1, queryResult.Count(), "Expected a single result for key value {0}", entry.Id.ToString());
+            }
+        }
+
+        [TestMethod]
         public void DecimalTest()
         {
             var contextWrapper = this.CreateWrappedContext();


### PR DESCRIPTION
### Issues
*This pull request fixes issue #473.*  

### Description
Our team has encountered the same blocking issue when trying to upgrade from OData v3 to v4. Our existing base object already uses DateTime in production, therefore it would be a breaking change during the upgrade if there is no DateTime support. It would be great to find a workaround on the client side without changing the odata V4 protocol.

from OData/WebApi#136 and also http://odata.github.io/WebApi/datetime-support, seems DateTime is officially supported by the OData server side while still maintain the compatibility with the OData v4 protocol, why we could not do the same for client side?

In other words, for the EDM model and over the wire, still use DateTimeOffset to be compatible with OData v4 protocol, while internally convert the DateTimeOffset from/to DateTime, to allow the actual C# object used in client side still be DateTime.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
