### PR TITLE
A HashSet<T> now keeps track of items in the DataServiceCollection - …

### DIFF
--- a/WCFDataService/Client/System/Data/Services/Client/Binding/DataServiceCollectionOfT.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Binding/DataServiceCollectionOfT.cs
@@ -48,7 +48,7 @@ namespace System.Data.Services.Client
     }
 
     /// <summary>Represents a dynamic entity collection that provides notifications when items get added, removed, or when the list is refreshed.</summary>
-        /// <typeparam name="T">An entity type.</typeparam>
+    /// <typeparam name="T">An entity type.</typeparam>
 #if WINDOWS_PHONE
     [CollectionDataContract(IsReference = true)]
     public class DataServiceCollection<T> : ObservableCollection<T>, ICollectionSerializationAppendix
@@ -113,6 +113,11 @@ namespace System.Data.Services.Client
         /// The async handle for the current LoadAsync Operation
         /// </summary>
         private IAsyncResult ongoingAsyncOperation;
+
+        /// <summary>
+        /// A hashed set of the entities in this DataServiceCollection. Optimization - used for faster detection of item prescense in the collection.
+        /// </summary>
+        private HashSet<T> hashedItems = new HashSet<T>(EqualityComparer<T>.Default);
 
         #endregion Private fields
 
@@ -534,10 +539,7 @@ namespace System.Data.Services.Client
             this.StartLoading();
             try
             {
-                if (!this.Contains(item))
-                {
-                    this.Add(item);
-                }
+                this.Add(item);
             }
             finally
             {
@@ -675,6 +677,8 @@ namespace System.Data.Services.Client
         /// </remarks>
         protected override void InsertItem(int index, T item)
         {
+            if (this.hashedItems.Contains(item))
+                return;
             if (this.trackingOnLoad)
             {
                 throw new InvalidOperationException(Strings.DataServiceCollection_InsertIntoTrackedButNotLoadedCollection);
@@ -690,6 +694,40 @@ namespace System.Data.Services.Client
             }
 
             base.InsertItem(index, item);
+            this.hashedItems.Add(item);
+        }
+
+        /// <summary>
+        /// Called from the ObservableCollection when the DataServiceCollection is cleared. Used to sync hasedItems with the  ObservableCollection.
+        /// </summary>
+        protected override void ClearItems()
+        {
+            this.hashedItems.Clear();
+            base.ClearItems();
+        }
+
+        /// <summary>
+        /// Called from the ObservableCollection when an item is removed from the DataServiceCollection. Used to sync hasedItems with the  ObservableCollection.
+        /// </summary>
+        /// <param name="index">The index of the item to be removed.</param>
+        protected override void RemoveItem(int index)
+        {
+            if (index < this.Count)
+                this.hashedItems.Remove(this[index]);
+            base.RemoveItem(index);
+        }
+
+        /// <summary>
+        /// Called from the ObservableCollection when an item at a given index is replaced with another. Used to sync hasedItems with the  ObservableCollection.
+        /// </summary>
+        /// <param name="index">Index at which to remove the old item and add the new item.</param>
+        /// <param name="item">The item to be added</param>
+        protected override void SetItem(int index, T item)
+        {
+            if (index < this.Count)
+                this.hashedItems.Remove(this[index]);
+            base.SetItem(index, item);
+            this.hashedItems.Add(item);
         }
 
         /// <summary>
@@ -760,12 +798,7 @@ namespace System.Data.Services.Client
 
             foreach (T item in items)
             {
-                // if this is too slow, consider hashing the set
-                // or just use LoadProperties                    
-                if (!this.Contains(item))
-                {
-                    this.Add(item);
-                }
+                this.Add(item);
             }
 
             QueryOperationResponse<T> response = items as QueryOperationResponse<T>;

--- a/WCFDataService/Client/System/Data/Services/Client/Binding/DataServiceCollectionOfT.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Binding/DataServiceCollectionOfT.cs
@@ -539,7 +539,10 @@ namespace System.Data.Services.Client
             this.StartLoading();
             try
             {
-                this.Add(item);
+                if (!this.hashedItems.Contains(item))
+                {
+                    this.Add(item);
+                }
             }
             finally
             {
@@ -677,8 +680,6 @@ namespace System.Data.Services.Client
         /// </remarks>
         protected override void InsertItem(int index, T item)
         {
-            if (this.hashedItems.Contains(item))
-                return;
             if (this.trackingOnLoad)
             {
                 throw new InvalidOperationException(Strings.DataServiceCollection_InsertIntoTrackedButNotLoadedCollection);
@@ -798,7 +799,10 @@ namespace System.Data.Services.Client
 
             foreach (T item in items)
             {
-                this.Add(item);
+                if (!this.hashedItems.Contains(item))
+                {
+                    this.Add(item);
+                }
             }
 
             QueryOperationResponse<T> response = items as QueryOperationResponse<T>;


### PR DESCRIPTION
### Issues
*This pull request fixes part of the performance issues reported in issue #662. Relates to PR #663 *  

### Description
*Without this change we won't see the performance gains reported/the performance issue will not be fixed.
This change fixes the scenarios "DataServiceCollection (mergeOption=NoTracking).". We need this change to get down to a sensible 5 seconds. Without - it will be 10 times more for 50.000 - and increasingly worse for larger collection sizes.

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

…detection for Contains is now MUCH faster for large collections.