### PR TITLE
Update the package folders to use up-to-date names for the NuGet folders.

### DIFF
--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Debug.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Debug.nuspec
@@ -26,11 +26,11 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src="Desktop\Microsoft.OData.Client.dll" target="lib\net40" />
     <file src="Desktop\Microsoft.OData.Client.pdb" target="lib\net40" />
     <file src="Desktop\Microsoft.OData.Client.xml" target="lib\net40" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.dll" target="lib\portable-net45+wp8+win8+wpa" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.pdb" target="lib\portable-net45+wp8+win8+wpa" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.xml" target="lib\portable-net45+wp8+win8+wpa" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.dll" target="lib\netstandard1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.pdb" target="lib\netstandard1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.xml" target="lib\netstandard1.0" />
     <file src="Desktop\1041\Microsoft.OData.Client.resources.dll" target="lib\net40\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1041\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1041\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\ja" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Client\**\*.cs" target="src\Microsoft.OData.Client" />
     <!-- files imported from EdmLib -->
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" target="src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" />

--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Nightly.Release.nuspec
@@ -26,27 +26,27 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src="Desktop\Microsoft.OData.Client.dll" target="lib\net40" />
     <file src="Desktop\Microsoft.OData.Client.xml" target="lib\net40" />
     <file src="Desktop\Microsoft.OData.Client.pdb" target="lib\net40" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.dll" target="lib\portable-net45+wp8+win8+wpa" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.pdb" target="lib\portable-net45+wp8+win8+wpa" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.xml" target="lib\portable-net45+wp8+win8+wpa" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.dll" target="lib\netstandard1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.pdb" target="lib\netstandard1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.xml" target="lib\netstandard1.0" />
     <file src="Desktop\2052\Microsoft.OData.Client.resources.dll" target="lib\net40\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\2052\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\2052\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\zh-Hans" />
     <file src="Desktop\1028\Microsoft.OData.Client.resources.dll" target="lib\net40\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1028\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1028\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\zh-Hant" />
     <file src="Desktop\1031\Microsoft.OData.Client.resources.dll" target="lib\net40\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1031\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1031\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\de" />
     <file src="Desktop\3082\Microsoft.OData.Client.resources.dll" target="lib\net40\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\3082\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\3082\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\es" />
     <file src="Desktop\1036\Microsoft.OData.Client.resources.dll" target="lib\net40\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1036\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1036\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\fr" />
     <file src="Desktop\1040\Microsoft.OData.Client.resources.dll" target="lib\net40\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1040\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1040\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\it" />
     <file src="Desktop\1041\Microsoft.OData.Client.resources.dll" target="lib\net40\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1041\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1041\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\ja" />
     <file src="Desktop\1042\Microsoft.OData.Client.resources.dll" target="lib\net40\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1042\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1042\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\ko" />
     <file src="Desktop\1049\Microsoft.OData.Client.resources.dll" target="lib\net40\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1049\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1049\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\ru" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Client\**\*.cs" target="src\Microsoft.OData.Client" />
     <!-- files imported from EdmLib -->
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" target="src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" />

--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
@@ -27,27 +27,27 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src="Desktop\Microsoft.OData.Client.dll" target="lib\net40" />
     <file src="Desktop\Microsoft.OData.Client.xml" target="lib\net40" />
     <file src="Desktop\Microsoft.OData.Client.pdb" target="lib\net40" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.dll" target="lib\portable-net45+wp8+win8+wpa" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.pdb" target="lib\portable-net45+wp8+win8+wpa" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.xml" target="lib\portable-net45+wp8+win8+wpa" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.dll" target="lib\netstandard1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.pdb" target="lib\netstandard1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\Microsoft.OData.Client.xml" target="lib\netstandard1.0" />
     <file src="Desktop\2052\Microsoft.OData.Client.resources.dll" target="lib\net40\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\2052\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\2052\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\zh-Hans" />
     <file src="Desktop\1028\Microsoft.OData.Client.resources.dll" target="lib\net40\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1028\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1028\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\zh-Hant" />
     <file src="Desktop\1031\Microsoft.OData.Client.resources.dll" target="lib\net40\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1031\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1031\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\de" />
     <file src="Desktop\3082\Microsoft.OData.Client.resources.dll" target="lib\net40\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\3082\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\3082\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\es" />
     <file src="Desktop\1036\Microsoft.OData.Client.resources.dll" target="lib\net40\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1036\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1036\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\fr" />
     <file src="Desktop\1040\Microsoft.OData.Client.resources.dll" target="lib\net40\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1040\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1040\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\it" />
     <file src="Desktop\1041\Microsoft.OData.Client.resources.dll" target="lib\net40\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1041\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1041\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\ja" />
     <file src="Desktop\1042\Microsoft.OData.Client.resources.dll" target="lib\net40\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1042\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1042\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\ko" />
     <file src="Desktop\1049\Microsoft.OData.Client.resources.dll" target="lib\net40\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1049\Microsoft.OData.Client.resources.dll" target="lib\portable-net45+wp8+win8+wpa\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Client.Portable\1049\Microsoft.OData.Client.resources.dll" target="lib\netstandard1.0\ru" />
     <file src="$SourcesRoot$\src\Microsoft.OData.Client\**\*.cs" target="src\Microsoft.OData.Client" />
     <!-- files imported from EdmLib -->
     <file src="$SourcesRoot$\src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" target="src\Microsoft.OData.Edm\Csdl\EdmValueParser.cs" />

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Debug.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Debug.nuspec
@@ -28,10 +28,10 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\Microsoft.OData.Core.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1041\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\ja" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45.Profile111\Microsoft.OData.Core.dll" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45.Profile111\Microsoft.OData.Core.pdb" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45.Profile111\Microsoft.OData.Core.xml" target="lib\portable-net45+win+wpa81" />

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
@@ -44,18 +44,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1041\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1042\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1049\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\2052\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1028\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1031\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\3082\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1036\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1040\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1042\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1049\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\2052\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1028\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1031\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\3082\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1036\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1040\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1042\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1049\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\ru" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45.Profile111\Microsoft.OData.Core.dll" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45.Profile111\Microsoft.OData.Core.pdb" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45.Profile111\Microsoft.OData.Core.xml" target="lib\portable-net45+win+wpa81" />

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
@@ -45,18 +45,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1041\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1042\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Core\1049\Microsoft.OData.Core.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\2052\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1028\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1031\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\3082\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1036\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1040\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1042\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1049\Microsoft.OData.Core.resources.dll" target="lib\dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.dll" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.pdb" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\Microsoft.OData.Core.xml" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\2052\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1028\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1031\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\3082\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1036\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1040\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1041\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1042\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45\1049\Microsoft.OData.Core.resources.dll" target="lib\netcoreapp1.0\ru" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45.Profile111\Microsoft.OData.Core.dll" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45.Profile111\Microsoft.OData.Core.pdb" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Core.Portable45.Profile111\Microsoft.OData.Core.xml" target="lib\portable-net45+win+wpa81" />

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Debug.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Debug.nuspec
@@ -24,10 +24,10 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\Microsoft.OData.Edm.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1041\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\ja" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45.Profile111\Microsoft.OData.Edm.dll" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45.Profile111\Microsoft.OData.Edm.pdb" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45.Profile111\Microsoft.OData.Edm.xml" target="lib\portable-net45+win+wpa81" />

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Nightly.Release.nuspec
@@ -40,18 +40,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1041\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1042\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1049\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\2052\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1028\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1031\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\3082\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1036\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1040\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1042\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1049\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\2052\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1028\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1031\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\3082\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1036\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1040\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1042\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1049\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\ru" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45.Profile111\Microsoft.OData.Edm.dll" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45.Profile111\Microsoft.OData.Edm.pdb" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45.Profile111\Microsoft.OData.Edm.xml" target="lib\portable-net45+win+wpa81" />

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
@@ -41,18 +41,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1041\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1042\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.OData.Edm\1049\Microsoft.OData.Edm.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\2052\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1028\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1031\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\3082\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1036\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1040\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1042\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1049\Microsoft.OData.Edm.resources.dll" target="lib\dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.dll" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.pdb" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\Microsoft.OData.Edm.xml" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\2052\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1028\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1031\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\de" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\3082\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\es" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1036\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1040\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\it" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1041\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1042\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45\1049\Microsoft.OData.Edm.resources.dll" target="lib\netcoreapp1.0\ru" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45.Profile111\Microsoft.OData.Edm.dll" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45.Profile111\Microsoft.OData.Edm.pdb" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.OData.Edm.Portable45.Profile111\Microsoft.OData.Edm.xml" target="lib\portable-net45+win+wpa81" />

--- a/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Debug.nuspec
+++ b/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Debug.nuspec
@@ -24,10 +24,10 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.pdb" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\Microsoft.Spatial.xml" target="lib\portable-net40+sl5+wp8+win8+wpa" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1041\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\ja" />
     <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45.Profile111\Microsoft.Spatial.dll" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45.Profile111\Microsoft.Spatial.pdb" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45.Profile111\Microsoft.Spatial.xml" target="lib\portable-net45+win+wpa81" />

--- a/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Nightly.Release.nuspec
+++ b/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Nightly.Release.nuspec
@@ -40,18 +40,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1041\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1042\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1049\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\2052\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1028\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1031\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\3082\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1036\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1040\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1042\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1049\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\2052\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1028\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1031\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\de" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\3082\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\es" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1036\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1040\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\it" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1042\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1049\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\ru" />
     <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45.Profile111\Microsoft.Spatial.dll" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45.Profile111\Microsoft.Spatial.pdb" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45.Profile111\Microsoft.Spatial.xml" target="lib\portable-net45+win+wpa81" />

--- a/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Release.nuspec
+++ b/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Release.nuspec
@@ -41,18 +41,18 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1041\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ja" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1042\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ko" />
     <file src=".NETPortable\v4.0\Microsoft.Spatial\1049\Microsoft.Spatial.resources.dll" target="lib\portable-net40+sl5+wp8+win8+wpa\ru" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\dnxcore50" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\2052\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\zh-Hans" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1028\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\zh-Hant" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1031\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\de" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\3082\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\es" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1036\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\fr" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1040\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\it" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ja" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1042\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ko" />
-    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1049\Microsoft.Spatial.resources.dll" target="lib\dnxcore50\ru" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.dll" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.pdb" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\Microsoft.Spatial.xml" target="lib\netcoreapp1.0" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\2052\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\zh-Hans" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1028\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\zh-Hant" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1031\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\de" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\3082\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\es" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1036\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\fr" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1040\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\it" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1041\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\ja" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1042\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\ko" />
+    <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45\1049\Microsoft.Spatial.resources.dll" target="lib\netcoreapp1.0\ru" />
     <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45.Profile111\Microsoft.Spatial.dll" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45.Profile111\Microsoft.Spatial.pdb" target="lib\portable-net45+win+wpa81" />
     <file src=".NETPortable\v4.5\Microsoft.Spatial.Portable45.Profile111\Microsoft.Spatial.xml" target="lib\portable-net45+win+wpa81" />


### PR DESCRIPTION
### Issues
Make these packages able to be consumed from .NET Core without additional changes to project.json

### Description
Rename the old folders for inside the NuGet package that have been deprecated for quite a while ago.