### PR TITLE
Prevent the OData Client to throw on annotations that were misintepreted as duplicate

### DIFF
--- a/src/Microsoft.OData.Core/DuplicatePropertyNamesChecker.cs
+++ b/src/Microsoft.OData.Core/DuplicatePropertyNamesChecker.cs
@@ -385,12 +385,7 @@ namespace Microsoft.OData.Core
             {
                 return null;
             }
-
-            // TODO: Refactor the duplicate property names checker and use different implementations for JSON Light
-            //      and the other formats (most of the logic is not needed for JSON Light).
-            //      Once we create a JSON Light specific duplicate property names checker, we will check for duplicates in
-            //      the ParseProperty method and thus detect duplicates before we get here.
-            ThrowIfPropertyIsProcessed(propertyName, duplicationRecord);
+            
             return duplicationRecord.PropertyODataAnnotations;
         }
 


### PR DESCRIPTION

### Issues
This pull request fixes issue #739.

### Description
The `DuplicatePropertyNamesChecker` calls the function `ThrowIfPropertyIsProcessed` when it tries to add a property annotation. Unfortunately, when an entity annotation has been processed, annotations on properties with the same name are considered to be equal (erroneously).

However, a comment was saying that this call should not be needed with a new implementation of the Json Light deserializer, and I think this new deserializer has been correctly implemented because the test scenarios pass as expected without this call. So this commit simply removes the call to this function.

### Checklist (Uncheck if it is not completed)
- [x] Test cases added
- [x] Build and test with one-click build and test script passed
