### PR TITLE
Add support for parsng attributes AnnotationPath (#525) and IncludeInServiceDocument (#526)

### DIFF
--- a/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
+++ b/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
@@ -683,11 +683,17 @@
     <Compile Include="..\Csdl\CsdlWriter.cs">
       <Link>Microsoft\OData\Edm\Csdl\CsdlWriter.cs</Link>
     </Compile>
+    <Compile Include="..\Csdl\Parsing\Ast\CsdlAnnotationPathExpression.cs">
+      <Link>Microsoft\OData\Edm\Csdl\Parsing\Ast\CsdlAnnotationPathExpression.cs</Link>
+    </Compile>
     <Compile Include="..\Csdl\SchemaReader.cs">
       <Link>Microsoft\OData\Edm\Csdl\SchemaReader.cs</Link>
     </Compile>
     <Compile Include="..\Csdl\SchemaWriter.cs">
       <Link>Microsoft\OData\Edm\Csdl\SchemaWriter.cs</Link>
+    </Compile>
+    <Compile Include="..\Csdl\Semantics\CsdlSemanticsAnnotationPathExpression.cs">
+      <Link>Microsoft\OData\Edm\Csdl\Semantics\CsdlSemanticsAnnotationPathExpression.cs</Link>
     </Compile>
     <Compile Include="..\Csdl\Semantics\CsdlSemanticsTerm.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\CsdlSemanticsTerm.cs</Link>

--- a/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
@@ -51,6 +51,7 @@ namespace Microsoft.OData.Edm.Csdl
         internal const string Attribute_Abstract = "Abstract";
         internal const string Attribute_Action = "Action";
         internal const string Attribute_Alias = "Alias";
+        internal const string Attribute_AnnotationPath = "AnnotationPath";
         internal const string Attribute_AppliesTo = "AppliesTo";
         internal const string Attribute_BaseType = "BaseType";
         internal const string Attribute_Binary = "Binary";

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAnnotationPathExpression.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAnnotationPathExpression.cs
@@ -1,0 +1,23 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CsdlAnnotationPathExpression.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
+{
+    /// <summary>
+    /// Represents a CSDL annotation Path expression.
+    /// </summary>
+    internal class CsdlAnnotationPathExpression : CsdlPathExpression
+    {
+        public CsdlAnnotationPathExpression(string path, CsdlLocation location) : base(path, location)
+        {
+        }
+
+        public override EdmExpressionKind ExpressionKind
+        {
+            get { return EdmExpressionKind.AnnotationPath; }
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlEntitySet.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlEntitySet.cs
@@ -16,14 +16,22 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         private readonly string elementType;
 
         public CsdlEntitySet(string name, string elementType, IEnumerable<CsdlNavigationPropertyBinding> navigationPropertyBindings, CsdlDocumentation documentation, CsdlLocation location)
+            : this(name, elementType, navigationPropertyBindings, documentation, location, true)
+        {
+        }
+
+        public CsdlEntitySet(string name, string elementType, IEnumerable<CsdlNavigationPropertyBinding> navigationPropertyBindings, CsdlDocumentation documentation, CsdlLocation location, bool includeInServiceDocument)
             : base(name, navigationPropertyBindings, documentation, location)
         {
             this.elementType = elementType;
+            this.IncludeInServiceDocument = includeInServiceDocument;
         }
 
         public string ElementType
         {
             get { return this.elementType; }
         }
+
+        public bool IncludeInServiceDocument { get; private set; }
     }
 }

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
@@ -794,6 +794,12 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
                 return new CsdlEnumMemberExpression(this.ValidateEnumMembersPath(enumMemberValue), element.Location);
             }
 
+            string annotationPath = Optional(CsdlConstants.Attribute_AnnotationPath);
+            if (annotationPath != null)
+            {
+                return new CsdlAnnotationPathExpression(annotationPath, element.Location);
+            }
+
             EdmValueKind kind;
 
             string value = Optional(CsdlConstants.Attribute_String);
@@ -1210,8 +1216,16 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
         {
             string name = Required(CsdlConstants.Attribute_Name);
             string entityType = RequiredQualifiedName(CsdlConstants.Attribute_EntityType);
+            bool? includeInServiceDocument = OptionalBoolean(CsdlConstants.Attribute_IncludeInServiceDocument);
 
-            return new CsdlEntitySet(name, entityType, childValues.ValuesOfType<CsdlNavigationPropertyBinding>(), Documentation(childValues), element.Location);
+            if (includeInServiceDocument == null)
+            {
+                return new CsdlEntitySet(name, entityType, childValues.ValuesOfType<CsdlNavigationPropertyBinding>(), Documentation(childValues), element.Location);
+            }
+            else
+            {
+                return new CsdlEntitySet(name, entityType, childValues.ValuesOfType<CsdlNavigationPropertyBinding>(), Documentation(childValues), element.Location, (bool)includeInServiceDocument);
+            }
         }
 
         private CsdlSingleton OnSingletonElement(XmlElementInfo element, XmlElementValueCollection childValues)

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsAnnotationPathExpression.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsAnnotationPathExpression.cs
@@ -1,0 +1,25 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CsdlSemanticsAnnotationPathExpression.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm.Csdl.Parsing.Ast;
+
+namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
+{
+    /// <summary>
+    /// Provides semantics for a Csdl Annotation Path expression.
+    /// </summary>
+    internal class CsdlSemanticsAnnotationPathExpression : CsdlSemanticsPathExpression
+    {
+        public CsdlSemanticsAnnotationPathExpression(CsdlPathExpression expression, IEdmEntityType bindingContext, CsdlSemanticsSchema schema) : base(expression, bindingContext, schema)
+        {
+        }
+
+        public override EdmExpressionKind ExpressionKind
+        {
+            get { return EdmExpressionKind.AnnotationPath; }
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEntitySet.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEntitySet.cs
@@ -29,6 +29,11 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             get { return EdmContainerElementKind.EntitySet; }
         }
 
+        public bool IncludeInServiceDocument
+        {
+            get { return ((CsdlEntitySet)this.navigationSource).IncludeInServiceDocument; }
+        }
+
         protected override IEdmEntityType ComputeElementType()
         {
             string type = ((CsdlEntitySet)this.navigationSource).ElementType;

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
@@ -393,6 +393,8 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                         return new CsdlSemanticsDateConstantExpression((CsdlConstantExpression)expression, schema);
                     case EdmExpressionKind.TimeOfDayConstant:
                         return new CsdlSemanticsTimeOfDayConstantExpression((CsdlConstantExpression)expression, schema);
+                    case EdmExpressionKind.AnnotationPath:
+                        return new CsdlSemanticsAnnotationPathExpression((CsdlAnnotationPathExpression)expression, bindingContext, schema);
                 }
             }
 

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -38,7 +38,9 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Csdl\EdmEnumValueParser.cs" />
+    <Compile Include="Csdl\Parsing\Ast\CsdlAnnotationPathExpression.cs" />
     <Compile Include="Csdl\Parsing\Ast\CsdlUntypedTypeReference.cs" />
+    <Compile Include="Csdl\Semantics\CsdlSemanticsAnnotationPathExpression.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsTypeDefinitionReference.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsUntypedTypeReference.cs" />
     <Compile Include="GlobalSuppressions.cs" />

--- a/src/Microsoft.OData.Edm/Schema/AmbiguousEntitySetBinding.cs
+++ b/src/Microsoft.OData.Edm/Schema/AmbiguousEntitySetBinding.cs
@@ -41,6 +41,11 @@ namespace Microsoft.OData.Edm
             get { return new EdmCollectionType(new EdmEntityTypeReference(new BadEntityType(String.Empty, this.Errors), false)); }
         }
 
+        public bool IncludeInServiceDocument
+        {
+            get { return true; }
+        }
+
         public IEnumerable<IEdmNavigationPropertyBinding> NavigationPropertyBindings
         {
             get { return Enumerable.Empty<IEdmNavigationPropertyBinding>(); }

--- a/src/Microsoft.OData.Edm/Schema/BadEntitySet.cs
+++ b/src/Microsoft.OData.Edm/Schema/BadEntitySet.cs
@@ -56,6 +56,11 @@ namespace Microsoft.OData.Edm
             get { return new EdmCollectionType(new EdmEntityTypeReference(new BadEntityType(String.Empty, this.Errors), false)); }
         }
 
+        public bool IncludeInServiceDocument
+        {
+            get { return true; }
+        }
+
         public IEdmNavigationSource FindNavigationTarget(IEdmNavigationProperty property)
         {
             return null;

--- a/src/Microsoft.OData.Edm/Schema/EdmEntityContainer.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmEntityContainer.cs
@@ -112,6 +112,20 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Creates and adds an entity set to this entity container.
+        /// </summary>
+        /// <param name="name">Name of the entity set.</param>
+        /// <param name="elementType">The entity type of the elements in this entity set.</param>
+        /// <param name="includeInServiceDocument">Indicates whether the entity set is advertised in the service document.</param>
+        /// <returns>Created entity set.</returns>
+        public virtual EdmEntitySet AddEntitySet(string name, IEdmEntityType elementType, bool includeInServiceDocument)
+        {
+            EdmEntitySet entitySet = new EdmEntitySet(this, name, elementType, includeInServiceDocument);
+            this.AddElement(entitySet);
+            return entitySet;
+        }
+
+        /// <summary>
         /// Creates and adds an singleton to this entity container.
         /// </summary>
         /// <param name="name">Name of the singleton.</param>

--- a/src/Microsoft.OData.Edm/Schema/EdmEntitySet.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmEntitySet.cs
@@ -14,6 +14,7 @@ namespace Microsoft.OData.Edm
         private readonly IEdmEntityContainer container;
         private readonly IEdmCollectionType type;
         private IEdmPathExpression path;
+        private bool includeInServiceDocument;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmEntitySet"/> class.
@@ -22,13 +23,26 @@ namespace Microsoft.OData.Edm
         /// <param name="name">Name of the entity set.</param>
         /// <param name="elementType">The entity type of the elements in this entity set.</param>
         public EdmEntitySet(IEdmEntityContainer container, string name, IEdmEntityType elementType)
-            : base(name, elementType)
+            : this(container, name, elementType, true)
         {
             EdmUtil.CheckArgumentNull(container, "container");
 
             this.container = container;
             this.type = new EdmCollectionType(new EdmEntityTypeReference(elementType, false));
             this.path = new EdmPathExpression(this.container.FullName() + "." + this.Name);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmEntitySet"/> class.
+        /// </summary>
+        /// <param name="container">An <see cref="IEdmEntityContainer"/> containing this entity set.</param>
+        /// <param name="name">Name of the entity set.</param>
+        /// <param name="elementType">The entity type of the elements in this entity set.</param>
+        /// <param name="includeInServiceDocument">Indicates whether the entity set is advertised in the service document.</param>
+        public EdmEntitySet(IEdmEntityContainer container, string name, IEdmEntityType elementType, bool includeInServiceDocument)
+            : base(name, elementType)
+        {
+            this.includeInServiceDocument = includeInServiceDocument;
         }
 
         /// <summary>
@@ -61,6 +75,14 @@ namespace Microsoft.OData.Edm
         public override IEdmPathExpression Path
         {
             get { return this.path; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the entity set is included in the service document.
+        /// </summary>
+        public bool IncludeInServiceDocument
+        {
+            get { return includeInServiceDocument; }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmEntitySet.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmEntitySet.cs
@@ -11,5 +11,9 @@ namespace Microsoft.OData.Edm
     /// </summary>
     public interface IEdmEntitySet : IEdmEntitySetBase, IEdmEntityContainerElement
     {
+        /// <summary>
+        /// Gets a value indicating whether the entity set is included in the service document.
+        /// </summary>
+        bool IncludeInServiceDocument { get; }
     }
 }

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmExpression.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmExpression.cs
@@ -136,7 +136,12 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Represents an expression implementing <see cref="IEdmEnumMemberExpression"/>.
         /// </summary>
-        EnumMember
+        EnumMember,
+
+        /// <summary>
+        /// Represents an expression implementing <see cref="IEdmPathExpression"/>.
+        /// </summary>
+        AnnotationPath
     }
 
     /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
@@ -1018,6 +1018,11 @@ namespace Microsoft.OData.Edm.Tests.Validation
                 get { return type; }
                 set { type = value; }
             }
+
+            public bool IncludeInServiceDocument
+            {
+                get; set;
+            }
         }
 
         private sealed class CustomSingleton : EdmNamedElement, IEdmSingleton

--- a/test/FunctionalTests/Service/Microsoft/OData/Service/Providers/MetadataProviderEdmEntitySet.cs
+++ b/test/FunctionalTests/Service/Microsoft/OData/Service/Providers/MetadataProviderEdmEntitySet.cs
@@ -120,6 +120,11 @@ namespace Microsoft.OData.Service.Providers
             get { return null; }
         }
 
+        public bool IncludeInServiceDocument
+        {
+            get; internal set;
+        }
+
         /// <summary>
         /// Finds the entity set that this navigation property refers to.
         /// </summary>

--- a/test/FunctionalTests/Taupo/Source/Taupo.Edmlib/StubEdm/StubEdmEntitySet.cs
+++ b/test/FunctionalTests/Taupo/Source/Taupo.Edmlib/StubEdm/StubEdmEntitySet.cs
@@ -73,12 +73,20 @@ namespace Microsoft.Test.Taupo.Edmlib.StubEdm
             get { return null; }
         }
 
-        /// <summary>
-        /// Sets the navigation target for a particular navigation property.
-        /// </summary>
-        /// <param name="navigationProperty">The navigation property.</param>
-        /// <param name="target">The target entity set.</param>
-        public void SetNavigationTarget(IEdmNavigationProperty navigationProperty, IEdmEntitySet target)
+		/// <summary>
+		/// Sets or gets whether to include in the service document
+		/// </summary>
+		public bool IncludeInServiceDocument
+		{
+			get; set;
+		}
+
+		/// <summary>
+		/// Sets the navigation target for a particular navigation property.
+		/// </summary>
+		/// <param name="navigationProperty">The navigation property.</param>
+		/// <param name="target">The target entity set.</param>
+		public void SetNavigationTarget(IEdmNavigationProperty navigationProperty, IEdmEntitySet target)
         {
             this.navigationTargets[navigationProperty] = target;
 

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalUtilities/InterfaceCriticalModelBuilder.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalUtilities/InterfaceCriticalModelBuilder.cs
@@ -294,7 +294,7 @@ namespace EdmLibTests.FunctionalUtilities
             var badTypeRef = new EdmCollectionTypeReference(badType);
             var valueTerm = new EdmTerm("NS", "Note", badTypeRef);
             model.AddElement(valueTerm);
-            
+
             return model;
         }
 
@@ -307,7 +307,7 @@ namespace EdmLibTests.FunctionalUtilities
 
             var badSet = new CustomEntitySet(entityContainer, "Set", null);
             entityContainer.AddElement(badSet);
-            
+
             return model;
         }
 
@@ -345,7 +345,7 @@ namespace EdmLibTests.FunctionalUtilities
 
             var entityContainer = new EdmEntityContainer("NS", "Container");
             model.AddElement(entityContainer);
-            
+
             var badSet = new CustomEntitySet(entityContainer, "BadSet", entity);
             badSet.AddNavigationTarget(nav, null);
             entityContainer.AddElement(badSet);
@@ -386,7 +386,7 @@ namespace EdmLibTests.FunctionalUtilities
 
             return model;
         }
-        
+
         public static IEdmModel AllInterfaceCriticalModel()
         {
             var model = new EdmModel();
@@ -407,7 +407,7 @@ namespace EdmLibTests.FunctionalUtilities
             };
 
             model.AddVocabularyAnnotation(mutableValueAnnotationueAnnotation);
-            
+
             var customEntity = new CustomEntityType(new List<IEdmProperty>() { null });
             model.AddElement(customEntity);
 
@@ -477,7 +477,8 @@ namespace EdmLibTests.FunctionalUtilities
 
             public EdmExpressionKind ExpressionKind { get; set; }
 
-            public override EdmValueKind ValueKind { 
+            public override EdmValueKind ValueKind
+            {
                 get { return this.valueKind; }
             }
         }
@@ -487,12 +488,12 @@ namespace EdmLibTests.FunctionalUtilities
             private EdmTypeKind typeKind;
             private List<IEdmProperty> declaredProperties;
 
-            public CustomEntityType(EdmTypeKind typeKind) : base("", "") 
+            public CustomEntityType(EdmTypeKind typeKind) : base("", "")
             {
                 this.typeKind = typeKind;
                 this.declaredProperties = new List<IEdmProperty>();
             }
-            
+
             public CustomEntityType(IEnumerable<IEdmProperty> properties) : base("", "")
             {
                 this.typeKind = EdmTypeKind.Entity;
@@ -705,6 +706,11 @@ namespace EdmLibTests.FunctionalUtilities
             private readonly List<IEdmNavigationPropertyBinding> navigationPropertyBindings = new List<IEdmNavigationPropertyBinding>();
 
             public CustomEntitySet(IEdmEntityContainer container, string name, IEdmEntityType elementType)
+                 : this(container, name, elementType, false)
+            {
+            }
+
+            public CustomEntitySet(IEdmEntityContainer container, string name, IEdmEntityType elementType, bool includeInServiceDocument)
                 : base(name)
             {
                 this.container = container;
@@ -712,6 +718,7 @@ namespace EdmLibTests.FunctionalUtilities
                 {
                     this.type = new EdmCollectionType(new EdmEntityTypeReference(elementType, false));
                 }
+                this.IncludeInServiceDocument = includeInServiceDocument;
             }
 
             public IEnumerable<IEdmNavigationPropertyBinding> NavigationPropertyBindings
@@ -757,6 +764,11 @@ namespace EdmLibTests.FunctionalUtilities
             public IEdmType Type
             {
                 get { return type; }
+            }
+
+            public bool IncludeInServiceDocument
+            {
+                get; internal set;
             }
         }
 

--- a/test/FunctionalTests/Tests/DataEdmLib/StubEdm/StubEdmEntitySet.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/StubEdm/StubEdmEntitySet.cs
@@ -74,6 +74,14 @@ namespace EdmLibTests.StubEdm
         public IEdmType Type { get; set; }
 
         /// <summary>
+        /// Gets or sets whether to include in service doucment
+        /// </summary>
+        public bool IncludeInServiceDocument
+        {
+            get; set;
+        }
+
+        /// <summary>
         /// Sets the navigation target for a particular navigation property.
         /// </summary>
         /// <param name="navigationProperty">The navigation property.</param>


### PR DESCRIPTION
### Issues
This pull request fixes issue #525 and #526

### Description
Added parsing of AnnotationPath attribute as an Expression and parsing of IncludeInServiceDocument attribute for EntitySet in CsdlDocumentParser
Updated classes and interfaces for supporting the new attributes
Added a functional test with a sample metadata document

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
