### PR TITLE
Remove extra ()s to generate correct url for tooling blog entry.

### DIFF
--- a/v6/_posts/tooling/2015-12-18-OData-Client-Code-Generation-Tool.md
+++ b/v6/_posts/tooling/2015-12-18-OData-Client-Code-Generation-Tool.md
@@ -14,7 +14,7 @@ OData provide two tools to generate client proxy file for an OData Service.
 	- Visual Studio 2013
 	- Visual Studio 2015
 
-	For full documentation, please refere to "[How to use odata client generator to generate client proxy file]((http://blogs.msdn.com/b/odatateam/archive/2014/03/12/how-to-use-odata-client-code-generator-to-generate-client-side-proxy-class.aspx))".
+	For full documentation, please refere to "[How to use odata client generator to generate client proxy file](http://blogs.msdn.com/b/odatateam/archive/2014/03/12/how-to-use-odata-client-code-generator-to-generate-client-side-proxy-class.aspx)".
 
 - [OData Connected Service](https://visualstudiogallery.msdn.microsoft.com/b343d0eb-6493-44c2-b558-13a0408d013f) lets app developers connect their applications to OData Services (both V3 & V4) and generate the client proxy files for the services. It supports following Visual Studio:
 


### PR DESCRIPTION
Doc change: Remove extra ()s to generate correct url for tooling blog entry.

Currently, the doc points to: http://odata.github.io/odata.net/(http://blogs.msdn.com/b/odatateam/archive/2014/03/12/how-to-use-odata-client-code-generator-to-generate-client-side-proxy-class.aspx)

After the change, the link points to: http://blogs.msdn.com/b/odatateam/archive/2014/03/12/how-to-use-odata-client-code-generator-to-generate-client-side-proxy-class.aspx