### PR TITLE
Custom aggregation methods

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -609,7 +609,7 @@ namespace Microsoft.OData {
         internal const string UriQueryExpressionParser_RangeVariableAlreadyDeclared = "UriQueryExpressionParser_RangeVariableAlreadyDeclared";
         internal const string UriQueryExpressionParser_AsExpected = "UriQueryExpressionParser_AsExpected";
         internal const string UriQueryExpressionParser_WithExpected = "UriQueryExpressionParser_WithExpected";
-        internal const string UriQueryExpressionParser_UnrecognizedWithVerb = "UriQueryExpressionParser_UnrecognizedWithVerb";
+        internal const string UriQueryExpressionParser_UnrecognizedWithMethod = "UriQueryExpressionParser_UnrecognizedWithMethod";
         internal const string UriQueryExpressionParser_PropertyPathExpected = "UriQueryExpressionParser_PropertyPathExpected";
         internal const string UriQueryExpressionParser_KeywordOrIdentifierExpected = "UriQueryExpressionParser_KeywordOrIdentifierExpected";
         internal const string UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri = "UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -661,7 +661,7 @@ UriQueryExpressionParser_CannotCreateStarTokenFromNonStar=Expecting a Star token
 UriQueryExpressionParser_RangeVariableAlreadyDeclared=The range variable '{0}' has already been declared.
 UriQueryExpressionParser_AsExpected='as' expected at position {0} in '{1}'.
 UriQueryExpressionParser_WithExpected='with' expected at position {0} in '{1}'.
-UriQueryExpressionParser_UnrecognizedWithVerb=Unrecognized with '{0}' at '{1}' in '{2}'.
+UriQueryExpressionParser_UnrecognizedWithMethod=Unrecognized with '{0}' at '{1}' in '{2}'.
 UriQueryExpressionParser_PropertyPathExpected=Expression expected at position {0} in '{1}'.
 UriQueryExpressionParser_KeywordOrIdentifierExpected='{0}' expected at position {1} in '{2}'.
 

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -4154,8 +4154,8 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "Unrecognized with '{0}' at '{1}' in '{2}'."
         /// </summary>
-        internal static string UriQueryExpressionParser_UnrecognizedWithVerb(object p0, object p1, object p2) {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriQueryExpressionParser_UnrecognizedWithVerb, p0, p1, p2);
+        internal static string UriQueryExpressionParser_UnrecognizedWithMethod(object p0, object p1, object p2) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriQueryExpressionParser_UnrecognizedWithMethod, p0, p1, p2);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
+++ b/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
@@ -51,6 +51,9 @@ namespace Microsoft.OData
         /// <summary>',' constant to represent an value list separator.</summary>
         internal const string SymbolComma = ",";
 
+        /// <summary>'.' constant to represent the value of a dot separator.</summary>
+        internal const string SymbolDot = ".";
+
         /// <summary>'/' constant to represent the forward slash used in a query.</summary>
         internal const string SymbolForwardSlash = "/";
 

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpression.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpression.cs
@@ -16,6 +16,8 @@ namespace Microsoft.OData.UriParser.Aggregation
     {
         private readonly AggregationMethod method;
 
+        private readonly AggregationMethodDefinition methodDefinition;
+
         private readonly SingleValueNode expression;
 
         private readonly string alias;
@@ -42,6 +44,19 @@ namespace Microsoft.OData.UriParser.Aggregation
         }
 
         /// <summary>
+        /// Create a AggregateExpression.
+        /// </summary>
+        /// <param name="expression">The aggregation expression.</param>
+        /// <param name="methodDefinition">The <see cref="AggregationMethodDefinition"/>.</param>
+        /// <param name="alias">The aggregation alias.</param>
+        /// <param name="typeReference">The <see cref="IEdmTypeReference"/> of this aggregate expression.</param>
+        public AggregateExpression(SingleValueNode expression, AggregationMethodDefinition methodDefinition, string alias, IEdmTypeReference typeReference)
+            : this(expression, methodDefinition.MethodKind, alias, typeReference)
+        {
+            this.methodDefinition = methodDefinition;
+        }
+
+        /// <summary>
         /// Gets the aggregation expression.
         /// </summary>
         public SingleValueNode Expression
@@ -60,6 +75,17 @@ namespace Microsoft.OData.UriParser.Aggregation
             get
             {
                 return method;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="AggregationMethodDefinition"/>.
+        /// </summary>
+        public AggregationMethodDefinition MethodDefinition
+        {
+            get
+            {
+                return methodDefinition;
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpressionToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpressionToken.cs
@@ -20,16 +20,24 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         private readonly AggregationMethod method;
 
+        private readonly AggregationMethodDefinition methodDefinition;
+
         private readonly string alias;
 
-        public AggregateExpressionToken(QueryToken expression, AggregationMethod withVerb, string alias)
+        public AggregateExpressionToken(QueryToken expression, AggregationMethod method, string alias)
         {
             ExceptionUtils.CheckArgumentNotNull(expression, "expression");
             ExceptionUtils.CheckArgumentNotNull(alias, "alias");
 
             this.expression = expression;
-            this.method = withVerb;
+            this.method = method;
             this.alias = alias;
+        }
+
+        public AggregateExpressionToken(QueryToken expression, AggregationMethodDefinition methodDefinition, string alias)
+            : this(expression, methodDefinition.MethodKind, alias)
+        {
+            this.methodDefinition = methodDefinition;
         }
 
         public override QueryTokenKind Kind
@@ -40,6 +48,11 @@ namespace Microsoft.OData.UriParser.Aggregation
         public AggregationMethod Method
         {
             get { return this.method; }
+        }
+
+        public AggregationMethodDefinition MethodDefinition
+        {
+            get { return this.methodDefinition; }
         }
 
         public QueryToken Expression

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregationMethod.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregationMethod.cs
@@ -4,6 +4,8 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System.Diagnostics;
+
 namespace Microsoft.OData.UriParser.Aggregation
 {
     /// <summary>
@@ -11,35 +13,77 @@ namespace Microsoft.OData.UriParser.Aggregation
     /// </summary>
     public enum AggregationMethod
     {
-        /// <summary>
-        /// The aggregation method Sum.
-        /// </summary>
+        /// <summary>The aggregation method Sum.</summary>
         Sum,
 
-        /// <summary>
-        /// The aggregation method Min.
-        /// </summary>
+        /// <summary>The aggregation method Min.</summary>
         Min,
 
-        /// <summary>
-        /// The aggregation method Max.
-        /// </summary>
+        /// <summary>The aggregation method Max.</summary>
         Max,
 
-        /// <summary>
-        /// The aggregation method Average.
-        /// </summary>
+        /// <summary>The aggregation method Average.</summary>
         Average,
 
-        /// <summary>
-        /// The aggregation method CountDistinct.
-        /// </summary>
+        /// <summary>The aggregation method CountDistinct.</summary>
         CountDistinct,
 
-        /// <summary>
-        /// The aggregation method Count.
-        /// Used only internally to represent the virtual property $count.
-        /// </summary>
+        /// <summary>The aggregation method Count. Used only internally to represent the virtual property $count.</summary>
         VirtualPropertyCount,
+
+        /// <summary>A custom aggregation method.</summary>
+        Custom
+    }
+
+    /// <summary>
+    /// Class that encapsulates all the information needed to define a aggregation method.
+    /// </summary>
+    public sealed class AggregationMethodDefinition
+    {
+        /// <summary>Returns a definition for the sum aggregation method.</summary>
+        public static AggregationMethodDefinition Sum = new AggregationMethodDefinition(AggregationMethod.Sum);
+
+        /// <summary>Returns a definition for the min aggregation method.</summary>
+        public static AggregationMethodDefinition Min = new AggregationMethodDefinition(AggregationMethod.Min);
+
+        /// <summary>Returns a definition for the max aggregation method.</summary>
+        public static AggregationMethodDefinition Max = new AggregationMethodDefinition(AggregationMethod.Max);
+
+        /// <summary>Returns a definition for the average aggregation method.</summary>
+        public static AggregationMethodDefinition Average = new AggregationMethodDefinition(AggregationMethod.Average);
+
+        /// <summary>Returns a definition for the countdistinct aggregation method.</summary>
+        public static AggregationMethodDefinition CountDistinct = new AggregationMethodDefinition(AggregationMethod.CountDistinct);
+
+        /// <summary>Returns a definition for the aggregation method used to calculate $count.</summary>
+        public static AggregationMethodDefinition VirtualPropertyCount = new AggregationMethodDefinition(AggregationMethod.VirtualPropertyCount);
+
+        /// <summary>Private constructor. Instances should be aquired via static fields of via Custom method.</summary>
+        /// <param name="aggregationMethodType">The <see cref="AggregationMethod"/> of this method definition.</param>
+        private AggregationMethodDefinition(AggregationMethod aggregationMethodType)
+        {
+            this.MethodKind = aggregationMethodType;
+        }
+
+        /// <summary>Returns the <see cref="AggregationMethod"/> of this method definition.</summary>
+        public AggregationMethod MethodKind { get; private set; }
+
+        /// <summary>Returns the label of this method definition.</summary>
+        public string MethodLabel { get; private set; }
+
+        /// <summary>Creates a custom method definition from it's label.</summary>
+        /// <param name="customMethodLabel">The label to call the custom method definition.</param>
+        /// <returns>The custom method created.</returns>
+        public static AggregationMethodDefinition Custom(string customMethodLabel)
+        {
+            ExceptionUtils.CheckArgumentNotNull(customMethodLabel, "customMethodLabel");
+
+            // Custom aggregation methods MUST use a namespace-qualified name (see [OData-ABNF]), i.e. contain at least one dot.
+            Debug.Assert(customMethodLabel.Contains(OData.ExpressionConstants.SymbolDot));
+
+            var aggregationMethod = new AggregationMethodDefinition(AggregationMethod.Custom);
+            aggregationMethod.MethodLabel = customMethodLabel;
+            return aggregationMethod;
+        }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -80,13 +80,13 @@ namespace Microsoft.OData.UriParser.Aggregation
                 throw new ODataException(ODataErrorStrings.ApplyBinder_AggregateExpressionNotSingleValue(token.Expression));
             }
 
-            var typeReference = CreateAggregateExpressionTypeReference(expression, token.Method);
+            var typeReference = CreateAggregateExpressionTypeReference(expression, token.MethodDefinition);
 
             // TODO: Determine source
-            return new AggregateExpression(expression, token.Method, token.Alias, typeReference);
+            return new AggregateExpression(expression, token.MethodDefinition, token.Alias, typeReference);
         }
 
-        private IEdmTypeReference CreateAggregateExpressionTypeReference(SingleValueNode expression, AggregationMethod withVerb)
+        private IEdmTypeReference CreateAggregateExpressionTypeReference(SingleValueNode expression, AggregationMethodDefinition method)
         {
             var expressionType = expression.TypeReference;
             if (expressionType == null && aggregateExpressionsCache != null)
@@ -98,7 +98,7 @@ namespace Microsoft.OData.UriParser.Aggregation
                 }
             }
 
-            switch (withVerb)
+            switch (method.MethodKind)
             {
                 case AggregationMethod.Average:
                     var expressionPrimitiveKind = expressionType.PrimitiveKind();
@@ -125,7 +125,10 @@ namespace Microsoft.OData.UriParser.Aggregation
                 case AggregationMethod.Sum:
                     return expressionType;
                 default:
-                    throw new ODataException(ODataErrorStrings.ApplyBinder_UnsupportedAggregateMethod(withVerb));
+                    // Only the EdmModel knows which type the custom aggregation methods returns.
+                    // Since we do not have a reference for it, right now we are assuming that all custom aggregation methods returns Doubles
+                    // TODO: find a appropriate way of getting the return type.
+                    return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Double, expressionType.IsNullable);
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -285,13 +285,13 @@ namespace Microsoft.OData.UriParser
             // expression
             var expression = this.ParseExpression();
             var endPathExpression = expression as EndPathToken;
-            AggregationMethod verb;
+            AggregationMethodDefinition verb;
 
             // "with" verb
             if (endPathExpression != null && endPathExpression.Identifier == ExpressionConstants.QueryOptionCount)
             {
                 // e.g. aggregate($count as Count)
-                verb = AggregationMethod.VirtualPropertyCount;
+                verb = AggregationMethodDefinition.VirtualPropertyCount;
             }
             else
             {
@@ -981,7 +981,7 @@ namespace Microsoft.OData.UriParser
             return new InnerPathToken(propertyName, parent, null);
         }
 
-        private AggregationMethod ParseAggregateWith()
+        private AggregationMethodDefinition ParseAggregateWith()
         {
             if (!TokenIdentifierIs(ExpressionConstants.KeywordWith))
             {
@@ -990,30 +990,40 @@ namespace Microsoft.OData.UriParser
 
             lexer.NextToken();
 
-            AggregationMethod verb;
+            AggregationMethodDefinition verb;
+            int identifierStartPosition = lexer.CurrentToken.Position;
+            string methodLabel = lexer.ReadDottedIdentifier(false /* acceptStar */);
 
-            switch (lexer.CurrentToken.GetIdentifier())
+            switch (methodLabel)
             {
                 case ExpressionConstants.KeywordAverage:
-                    verb = AggregationMethod.Average;
+                    verb = AggregationMethodDefinition.Average;
                     break;
                 case ExpressionConstants.KeywordCountDistinct:
-                    verb = AggregationMethod.CountDistinct;
+                    verb = AggregationMethodDefinition.CountDistinct;
                     break;
                 case ExpressionConstants.KeywordMax:
-                    verb = AggregationMethod.Max;
+                    verb = AggregationMethodDefinition.Max;
                     break;
                 case ExpressionConstants.KeywordMin:
-                    verb = AggregationMethod.Min;
+                    verb = AggregationMethodDefinition.Min;
                     break;
                 case ExpressionConstants.KeywordSum:
-                    verb = AggregationMethod.Sum;
+                    verb = AggregationMethodDefinition.Sum;
                     break;
                 default:
-                    throw ParseError(ODataErrorStrings.UriQueryExpressionParser_UnrecognizedWithVerb(lexer.CurrentToken.GetIdentifier(), this.lexer.CurrentToken.Position, this.lexer.ExpressionText));
-            }
+                    if (!methodLabel.Contains(OData.ExpressionConstants.SymbolDot))
+                    {
+                        throw ParseError(
+                            ODataErrorStrings.UriQueryExpressionParser_UnrecognizedWithMethod(
+                                methodLabel,
+                                identifierStartPosition,
+                                this.lexer.ExpressionText));
+                    }
 
-            lexer.NextToken();
+                    verb = AggregationMethodDefinition.Custom(methodLabel);
+                    break;
+            }
 
             return verb;
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/SyntacticAst/AggregateExpressionTokenTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/SyntacticAst/AggregateExpressionTokenTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.SyntacticAst
         }
 
         [Fact]
-        public void WithVerbSetCorrectly()
+        public void WithMethodSetCorrectly()
         {
             var token = new AggregateExpressionToken(expressionToken, AggregationMethod.CountDistinct, "Alias");
             token.Method.Should().Be(AggregationMethod.CountDistinct);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Visitors/SyntacticTreeVisitorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Visitors/SyntacticTreeVisitorTests.cs
@@ -153,7 +153,7 @@ namespace Microsoft.OData.Tests.UriParser.Visitors
         public void AggregateExpressionOperatorNotImplemented()
         {
             FakeVisitor visitor = new FakeVisitor();
-            Action visitUnaryOperatorToken = () => visitor.Visit(new AggregateExpressionToken(new EndPathToken("Identifier", null), AggregationMethod.Sum, "Alias"));
+            Action visitUnaryOperatorToken = () => visitor.Visit(new AggregateExpressionToken(new EndPathToken("Identifier", null), AggregationMethodDefinition.Sum, "Alias"));
             visitUnaryOperatorToken.ShouldThrow<NotImplementedException>();
         }
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -6158,6 +6158,7 @@ public sealed class Microsoft.OData.UriParser.WildcardSelectItem : Microsoft.ODa
 public enum Microsoft.OData.UriParser.Aggregation.AggregationMethod : int {
 	Average = 3
 	CountDistinct = 4
+	Custom = 6
 	Max = 2
 	Min = 1
 	Sum = 0
@@ -6178,10 +6179,12 @@ public abstract class Microsoft.OData.UriParser.Aggregation.TransformationNode {
 
 public sealed class Microsoft.OData.UriParser.Aggregation.AggregateExpression {
 	public AggregateExpression (Microsoft.OData.UriParser.SingleValueNode expression, Microsoft.OData.UriParser.Aggregation.AggregationMethod method, string alias, Microsoft.OData.Edm.IEdmTypeReference typeReference)
+	public AggregateExpression (Microsoft.OData.UriParser.SingleValueNode expression, Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition methodDefinition, string alias, Microsoft.OData.Edm.IEdmTypeReference typeReference)
 
 	string Alias  { public get; }
 	Microsoft.OData.UriParser.SingleValueNode Expression  { public get; }
 	Microsoft.OData.UriParser.Aggregation.AggregationMethod Method  { public get; }
+	Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition MethodDefinition  { public get; }
 	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public get; }
 }
 
@@ -6190,6 +6193,20 @@ public sealed class Microsoft.OData.UriParser.Aggregation.AggregateTransformatio
 
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.Aggregation.AggregateExpression]] Expressions  { public get; }
 	Microsoft.OData.UriParser.Aggregation.TransformationNodeKind Kind  { public virtual get; }
+}
+
+public sealed class Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition {
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Average = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition CountDistinct = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Max = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Min = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Sum = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition VirtualPropertyCount = Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition
+
+	Microsoft.OData.UriParser.Aggregation.AggregationMethod MethodKind  { public get; }
+	string MethodLabel  { public get; }
+
+	public static Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition Custom (string customMethodLabel)
 }
 
 public sealed class Microsoft.OData.UriParser.Aggregation.ApplyClause {


### PR DESCRIPTION
### Description
*Enhancing AggregationMethod class and modifying UriQueryExpressionParser to support Custom Aggregation Methods according to OData 4.0 spec. Right now only methods that return doubles are supported. This change addresses issue [#873](https://github.com/OData/WebApi/issues/873) of WebAPI project.*

### Checklist (Uncheck if it is not completed)
- [x] Test cases added
- [x] Build and tests passing

### Observations 
*We need to find out the best way to address the TODOs in the code. In the return type of the aggregation methods: right now we are limited to methods that returns doubles, because the parsers don't have information about the methods registered.*