### PR TITLE
Adding FxCop exclusion for CA3053:UseXmlSecureResolver in code that compiles under .Net portable framework.

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
@@ -651,6 +651,9 @@ namespace Microsoft.OData.Edm.Csdl
             this.edmReferences.Add(result);
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = "The XmlResolver property no longer exists in .NET portable framework.")]
         private void ParseSchemaElement()
         {
             Debug.Assert(this.reader.LocalName == CsdlConstants.Element_Schema, "Must call ParseCsdlSchemaElement on Schema Element");

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Common/EdmXmlDocumentParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Common/EdmXmlDocumentParser.cs
@@ -43,6 +43,9 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Common
             return attr;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = "The XmlResolver property no longer exists in .NET portable framework.")]
         protected override XmlReader InitializeReader(XmlReader reader)
         {
             XmlReaderSettings readerSettings = new XmlReaderSettings

--- a/src/Microsoft.OData.Edm/Validation/ValidationHelper.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationHelper.cs
@@ -73,6 +73,9 @@ namespace Microsoft.OData.Edm.Validation
             return true;
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = "The XmlResolver property no longer exists in .NET portable framework.")]
         internal static bool ValidateValueCanBeWrittenAsXmlElementAnnotation(IEdmValue value, string annotationNamespace, string annotationName, out EdmError error)
         {
             IEdmStringValue edmStringValue = value as IEdmStringValue;

--- a/src/Microsoft.OData.Edm/Vocabularies/AlternateKeysVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/AlternateKeysVocabularyModel.cs
@@ -47,6 +47,9 @@ namespace Microsoft.OData.Edm.Vocabularies.Community.V1
         /// <summary>
         /// Parse Alternate Keys Vocabulary Model from AlternateKeysVocabularies.xml
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = "The XmlResolver property no longer exists in .NET portable framework.")]
         static AlternateKeysVocabularyModel()
         {
             Assembly assembly = typeof(AlternateKeysVocabularyModel).GetAssembly();

--- a/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularyModel.cs
@@ -32,6 +32,9 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
         /// <summary>
         /// Parse Capabilities Vocabulary Model from CapabilitiesVocabularies.xml
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = "The XmlResolver property no longer exists in .NET portable framework.")]
         static CapabilitiesVocabularyModel()
         {
             Assembly assembly = typeof(CapabilitiesVocabularyModel).GetAssembly();

--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyModel.cs
@@ -122,6 +122,9 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
         /// <summary>
         /// Parse Core Vocabulary Model from CoreVocabularies.xml
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.FxCop.Rules.Security.Xml.SecurityXmlRules", "CA3053:UseXmlSecureResolver",
+            MessageId = "System.Xml.XmlReader.Create",
+            Justification = "The XmlResolver property no longer exists in .NET portable framework.")]
         static CoreVocabularyModel()
         {
             IsInitializing = true;


### PR DESCRIPTION
The XmlResolver property no longer exists in .NET portable framework. Now that the code compile
using VS2015 and uses the Code Analysis and FxCop rule associated with VS2015, add an exclusion 
for this rule in code that compiles under .Net portable framework.
