### PR TITLE
Fix for "The type initializer for 'CoreVocabularyModel' threw an exception.

### DIFF
--- a/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
+++ b/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
@@ -1484,15 +1484,15 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
-    <Content Include="..\Vocabularies\AlternateKeysVocabularies.xml">
+    <EmbeddedResource Include="..\Vocabularies\AlternateKeysVocabularies.xml">
       <Link>Vocabularies\AlternateKeysVocabularies.xml</Link>
-    </Content>
-    <Content Include="..\Vocabularies\CapabilitiesVocabularies.xml">
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\Vocabularies\CapabilitiesVocabularies.xml">
       <Link>Vocabularies\CapabilitiesVocabularies.xml</Link>
-    </Content>
-    <Content Include="..\Vocabularies\CoreVocabularies.xml">
+    </EmbeddedResource>
+    <EmbeddedResource Include="..\Vocabularies\CoreVocabularies.xml">
       <Link>Vocabularies\CoreVocabularies.xml</Link>
-    </Content>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(BuildExtensionsPath)\Portable.targets" />
 </Project>

--- a/src/Microsoft.OData.Edm/Vocabularies/AlternateKeysVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/AlternateKeysVocabularyModel.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Xml;
 using Microsoft.OData.Edm.Csdl;
@@ -52,7 +53,12 @@ namespace Microsoft.OData.Edm.Vocabularies.Community.V1
         {
             Assembly assembly = typeof(AlternateKeysVocabularyModel).GetAssembly();
 
-            using (Stream stream = assembly.GetManifestResourceStream("AlternateKeysVocabularies.xml"))
+            // Resource name has leading namespace and folder in .NetStandard dll.
+            string[] allResources = assembly.GetManifestResourceNames();
+            string alternateKeysVocabularies = allResources.Where(x => x.Contains("AlternateKeysVocabularies.xml")).FirstOrDefault();
+            Debug.Assert(alternateKeysVocabularies != null, "AlternateKeysVocabularies.xml: not found.");
+
+            using (Stream stream = assembly.GetManifestResourceStream(alternateKeysVocabularies))
             {
                 IEnumerable<EdmError> errors;
                 Debug.Assert(stream != null, "AlternateKeysVocabularies.xml: stream!=null");

--- a/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularyModel.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Xml;
 using Microsoft.OData.Edm.Csdl;
@@ -38,7 +39,12 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
         {
             Assembly assembly = typeof(CapabilitiesVocabularyModel).GetAssembly();
 
-            using (Stream stream = assembly.GetManifestResourceStream("CapabilitiesVocabularies.xml"))
+            // Resource name has leading namespace and folder in .NetStandard dll.
+            string[] allResources = assembly.GetManifestResourceNames();
+            string capabilitiesVocabularies = allResources.Where(x => x.Contains("CapabilitiesVocabularies.xml")).FirstOrDefault();
+            Debug.Assert(capabilitiesVocabularies != null, "CapabilitiesVocabularies.xml: not found.");
+
+            using (Stream stream = assembly.GetManifestResourceStream(capabilitiesVocabularies))
             {
                 IEnumerable<EdmError> errors;
                 Debug.Assert(stream != null, "CapabilitiesVocabularies.xml: stream!=null");

--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyModel.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Xml;
 using Microsoft.OData.Edm.Csdl;
@@ -128,7 +129,12 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
             IsInitializing = true;
             Assembly assembly = typeof(CoreVocabularyModel).GetAssembly();
 
-            using (Stream stream = assembly.GetManifestResourceStream("CoreVocabularies.xml"))
+            // Resource name has leading namespace and folder in .NetStandard dll.
+            string[] allResources = assembly.GetManifestResourceNames();
+            string coreVocabularies = allResources.Where(x => x.Contains("CoreVocabularies.xml")).FirstOrDefault();
+            Debug.Assert(coreVocabularies != null, "CoreVocabularies.xml: not found.");
+
+            using (Stream stream = assembly.GetManifestResourceStream(coreVocabularies))
             {
                 IEnumerable<EdmError> errors;
                 Debug.Assert(stream != null, "CoreVocabularies.xml: stream!=null");


### PR DESCRIPTION
### Issues
This pull request fixes issue #789   

### Description
The EdmModel constructor was failing with System.TypeInitializationException:“The type initializer
for 'Microsoft.OData.Edm.Vocabularies.V1.CoreVocabularyModel' threw an exception.”

This was caused by the construction of the CoreVocabularyModel looking for embedded resources
that are not present in the .NetStandard version of Edm.

In addition to adding the embedded resources, the resource name are fully qualified
in NetStandard so addition code is added to find the proper name for the resource before
loading it.

### Checklist (Uncheck if it is not completed)
- [   ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
The fix was tested by temporarily adding a unit test to validate the EdmModel constructor
as well as the unit test validation for CoreVocabularyModel and AlternateKeysVocabularyModel.
These tests are not included in this change as we need to invest in more than just these tests.
A future change will introduce a test suite for the NetStandard binary.