### PR TITLE
Fix client test failures

### DIFF
--- a/test/EndToEndTests/Services/Astoria/Microsoft.Test.OData.Services.Astoria.csproj
+++ b/test/EndToEndTests/Services/Astoria/Microsoft.Test.OData.Services.Astoria.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Build.props))\Build.props" />
   <PropertyGroup>
-    <DefineConstants Condition=" '$(VisualStudioVersion)' == '14.0' ">$(DefineConstants);VS2015</DefineConstants>
+    <DefineConstants Condition=" '$(VisualStudioVersion)' == '14.0' and '$(BuildingInLab)' != 'true'">$(DefineConstants);USELOCALDB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/test/EndToEndTests/Services/Astoria/PublicProvider/DatabaseHelper.cs
+++ b/test/EndToEndTests/Services/Astoria/PublicProvider/DatabaseHelper.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Test.OData.Services.PublicProvider
         private static string GetConnectionString()
         {
             var connStr = ConfigurationManager.ConnectionStrings["AstoriaDefaultServiceDBEntities"].ConnectionString;
-#if VS2015
+#if USELOCALDB
             connStr = connStr.Replace(@".\SQLExpress", @"(LocalDB)\MSSQLLocalDB");
 #endif
             return connStr;

--- a/test/FunctionalTests/Framework/AstoriaTestFramework.csproj
+++ b/test/FunctionalTests/Framework/AstoriaTestFramework.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <Import Project="..\Build.props" />
   <PropertyGroup>
-    <DefineConstants Condition=" '$(VisualStudioVersion)' == '14.0' ">$(DefineConstants);VS2015</DefineConstants>
+    <DefineConstants Condition=" '$(VisualStudioVersion)' == '14.0' and '$(BuildingInLab)' != 'true'">$(DefineConstants);USELOCALDB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CustomMarshalers" />

--- a/test/FunctionalTests/Framework/TestExecutionLayer/AstoriaDatabase.cs
+++ b/test/FunctionalTests/Framework/TestExecutionLayer/AstoriaDatabase.cs
@@ -139,7 +139,7 @@ namespace System.Data.Test.Astoria.TestExecutionLayer
                             break;
 
                         case "Local":
-#if !VS2015
+#if !USELOCALDB
                             if (ServiceUtil.IsLocalSqlServerExpressRunning)
 #endif
                             {

--- a/test/FunctionalTests/Framework/Util/DataUtil.cs
+++ b/test/FunctionalTests/Framework/Util/DataUtil.cs
@@ -26,7 +26,7 @@ namespace System.Data.Test.Astoria
             [DebuggerStepThrough]
             get
             {
-#if VS2015
+#if USELOCALDB
                 return @"(LocalDB)\MSSQLLocalDB";
 #else
                 return @".\SQLEXPRESS";

--- a/test/FunctionalTests/Tests/DataServices/Models/EFFK/Astoria.EFFKModel.csproj
+++ b/test/FunctionalTests/Tests/DataServices/Models/EFFK/Astoria.EFFKModel.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Build.props))\Build.props" />
   <PropertyGroup>
-    <DefineConstants Condition=" '$(VisualStudioVersion)' == '14.0' ">$(DefineConstants);VS2015</DefineConstants>
+    <DefineConstants Condition=" '$(VisualStudioVersion)' == '14.0' and '$(BuildingInLab)' != 'true'">$(DefineConstants);USELOCALDB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/test/FunctionalTests/Tests/DataServices/Models/EFFK/PopulateData.cs
+++ b/test/FunctionalTests/Tests/DataServices/Models/EFFK/PopulateData.cs
@@ -18,7 +18,7 @@ namespace AstoriaUnitTests.EFFK
 
     public static class PopulateData
     {
-#if VS2015
+#if USELOCALDB
         private static string ConnectionString = @"server=(LocalDB)\MSSQLLocalDB;integrated security=true;";
 #else
         private static string ConnectionString = @"server=.\sqlexpress;integrated security=true;";

--- a/test/FunctionalTests/Tests/DataServices/ddbasics/Microsoft.Test.Data.Services.DDBasics.csproj
+++ b/test/FunctionalTests/Tests/DataServices/ddbasics/Microsoft.Test.Data.Services.DDBasics.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), Build.props))\Build.props" />
   <PropertyGroup>
-    <DefineConstants Condition=" '$(VisualStudioVersion)' == '14.0' ">$(DefineConstants);VS2015</DefineConstants>
+    <DefineConstants Condition=" '$(VisualStudioVersion)' == '14.0' and '$(BuildingInLab)' != 'true'">$(DefineConstants);USELOCALDB</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />

--- a/test/FunctionalTests/Tests/DataServices/ddbasics/Util/DataUtil.cs
+++ b/test/FunctionalTests/Tests/DataServices/ddbasics/Util/DataUtil.cs
@@ -26,7 +26,7 @@ namespace System.Data.Test.Astoria
             [DebuggerStepThrough]
             get
             {
-#if VS2015
+#if USELOCALDB
                 return @"(LocalDB)\MSSQLLocalDB";
 #else
                 return @".\SQLEXPRESS";

--- a/tools/Scripts/artdbclean.js
+++ b/tools/Scripts/artdbclean.js
@@ -17,9 +17,9 @@ function OpenResultSet(connection, queryText)
 
 // Opens an ADO SQL Server driver connection to the specified.
 function OpenSqlServerConnection(serverName, initialCatalog, useTrustedConnection,
-  username, password)
+  username, password, provider)
 {
-  var connectionString = "Provider='sqloledb';Data Source=" + serverName + ";";
+  var connectionString = "Provider='" + provider + "';Data Source=" + serverName + ";";
   if (initialCatalog != null && initialCatalog != "")
   {
     connectionString += "Initial Catalog='" + initialCatalog + "';";
@@ -38,12 +38,12 @@ function OpenSqlServerConnection(serverName, initialCatalog, useTrustedConnectio
   return result;
 }
 
-function DropDatabasesForServer(serverName, path)
+function DropDatabasesForServer(serverName, path, provider)
 {
   var connection;
   try
   {
-    connection = OpenSqlServerConnection(serverName, null, true, null, null);
+    connection = OpenSqlServerConnection(serverName, null, true, null, null, provider);
   } catch (e) {
     //WScript.Echo("Continuing after failing to connect to server '" + serverName + "' with error: " + e.message);
     return;
@@ -85,9 +85,17 @@ if (enlistmentRoot == null || enlistmentRoot == "")
   WScript.Quit(1);
 }
 
-var serverNames = ["(local)", ".\\SQLEXPRESS", "(localdb)\\MSSQLLocalDB"];
-for (var i in serverNames) {
-  DropDatabasesForServer(serverNames[i], enlistmentRoot);
+var oledbServerNames = ["(local)", ".\\SQLEXPRESS"];
+for (var i in oledbServerNames)
+{
+  DropDatabasesForServer(oledbServerNames[i], enlistmentRoot, "sqloledb");
+}
+
+var sqlncliServerNames = ["(localdb)\\MSSQLLocalDB"];
+for (var i in sqlncliServerNames)
+{
+  // Use Sql native client for localDB.
+  DropDatabasesForServer(sqlncliServerNames[i], enlistmentRoot, "sqlncli11");
 }
 
 WScript.Quit(0);


### PR DESCRIPTION
This change fixes test failures in both local machine and in the lab
because of the switch to VS2015. Switching to VS2015 changed the testing
database engine from SQL Express to LocalDb. Since VS2015 installs LocalDb,
this is a change that make sense to keep.

For local tests, some client tests were failing due to a failure to
clean up local database entries in LocalDB. The change to artdbclean.js
uses SQL Native Client for LocalDB to fix a connection issue, allowing the
script to properly clean up after the tests.

For lab tests, the machine configuration is a bit different and LocalDb is not
available; therefore, use SQL Express when building the lab. Since the current
VS2015 symbol was only used for test DB selection, I renamed the symbol to
reflect its usage.

- [   ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Issues
*This pull request fixes issue #xxx.*  

### Description
*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
