### PR TITLE
Expose UriQueryExpressionParser.ParseFilter as a public API

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -21,7 +21,8 @@ namespace Microsoft.OData.Client
     using Microsoft.OData;
     using Microsoft.OData.UriParser;
     using Microsoft.OData.Edm;
-
+    using PathSegmentToken = Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken;
+    using NonSystemToken = Microsoft.OData.Client.ALinq.UriParser.NonSystemToken;
     #endregion Namespaces
 
     /// <summary>

--- a/src/Microsoft.OData.Client/Build.Portable/Microsoft.OData.Client.Portable.csproj
+++ b/src/Microsoft.OData.Client/Build.Portable/Microsoft.OData.Client.Portable.csproj
@@ -160,8 +160,8 @@
     <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\UriParser\SyntacticAst\QueryToken.cs">
       <Link>ALinq\UriParser\SyntacticAst\QueryToken.cs</Link>
     </Compile>
-    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\UriParser\TreeNodeKinds\QueryTokenKind.cs">
-      <Link>ALinq\UriParser\TreeNodeKinds\QueryTokenKind.cs</Link>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\UriParser\SyntacticAst\QueryTokenKind.cs">
+      <Link>ALinq\UriParser\SyntacticAst\QueryTokenKind.cs</Link>
     </Compile>
     <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\UriParser\SyntacticAst\RangeVariableToken.cs">
       <Link>ALinq\UriParser\SyntacticAst\RangeVariableToken.cs</Link>

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -166,8 +166,8 @@
     <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\UriParser\SyntacticAst\QueryToken.cs">
       <Link>ALinq\UriParser\SyntacticAst\QueryToken.cs</Link>
     </Compile>
-    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\UriParser\TreeNodeKinds\QueryTokenKind.cs">
-      <Link>ALinq\UriParser\TreeNodeKinds\QueryTokenKind.cs</Link>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\UriParser\SyntacticAst\QueryTokenKind.cs">
+      <Link>ALinq\UriParser\SyntacticAst\QueryTokenKind.cs</Link>
     </Compile>
     <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\UriParser\SyntacticAst\RangeVariableToken.cs">
       <Link>ALinq\UriParser\SyntacticAst\RangeVariableToken.cs</Link>

--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -1312,6 +1312,9 @@
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\SyntacticAst\QueryToken.cs">
       <Link>Microsoft\OData\Core\UriParser\SyntacticAst\QueryToken.cs</Link>
     </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\SyntacticAst\QueryTokenKind.cs">
+      <Link>Microsoft\OData\Core\UriParser\SyntacticAst\QueryTokenKind.cs</Link>
+    </Compile>	
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\SyntacticAst\RangeVariableToken.cs">
       <Link>Microsoft\OData\Core\UriParser\SyntacticAst\RangeVariableToken.cs</Link>
     </Compile>
@@ -1338,9 +1341,6 @@
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\TreeNodeKinds\QueryNodeKind.cs">
       <Link>Microsoft\OData\Core\UriParser\TreeNodeKinds\QueryNodeKind.cs</Link>
-    </Compile>
-    <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\TreeNodeKinds\QueryTokenKind.cs">
-      <Link>Microsoft\OData\Core\UriParser\TreeNodeKinds\QueryTokenKind.cs</Link>
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\TreeNodeKinds\RequestTargetKind.cs">
       <Link>Microsoft\OData\Core\UriParser\TreeNodeKinds\RequestTargetKind.cs</Link>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -542,7 +542,7 @@
     <Compile Include="UriParser\TreeNodeKinds\BinaryOperatorKind.cs" />
     <Compile Include="UriParser\TreeNodeKinds\ExpressionTokenKind.cs" />
     <Compile Include="UriParser\TreeNodeKinds\QueryNodeKind.cs" />
-    <Compile Include="UriParser\TreeNodeKinds\QueryTokenKind.cs" />
+    <Compile Include="UriParser\SyntacticAst\QueryTokenKind.cs" />
     <Compile Include="UriParser\TreeNodeKinds\RequestTargetKind.cs" />
     <Compile Include="UriParser\TreeNodeKinds\UnaryOperatorKind.cs" />
     <Compile Include="UriParser\TypePromotionUtils.cs" />

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpressionToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpressionToken.cs
@@ -14,7 +14,10 @@ namespace Microsoft.OData.UriParser.Aggregation
 #endif
     using Microsoft.OData.UriParser;
 
-    internal sealed class AggregateExpressionToken : QueryToken
+    /// <summary>
+    /// Query token representing an Aggregate expression.
+    /// </summary>
+    public sealed class AggregateExpressionToken : QueryToken
     {
         private readonly QueryToken expression;
 
@@ -24,6 +27,12 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         private readonly string alias;
 
+        /// <summary>
+        /// Create an AggregateExpressionToken.
+        /// </summary>
+        /// <param name="expression">The aggregate expression.</param>
+        /// <param name="method">The aggregation method.</param>
+        /// <param name="alias">The alias for this query token.</param>
         public AggregateExpressionToken(QueryToken expression, AggregationMethod method, string alias)
         {
             ExceptionUtils.CheckArgumentNotNull(expression, "expression");
@@ -34,32 +43,53 @@ namespace Microsoft.OData.UriParser.Aggregation
             this.alias = alias;
         }
 
+        /// <summary>
+        /// Create an AggregateExpressionToken.
+        /// </summary>
+        /// <param name="expression">The aggregate expression.</param>
+        /// <param name="methodDefinition">The aggregate method definition.</param>
+        /// <param name="alias">The alias for this query token.</param>
         public AggregateExpressionToken(QueryToken expression, AggregationMethodDefinition methodDefinition, string alias)
             : this(expression, methodDefinition.MethodKind, alias)
         {
             this.methodDefinition = methodDefinition;
         }
 
+        /// <summary>
+        /// Gets the kind of this token.
+        /// </summary>
         public override QueryTokenKind Kind
         {
             get { return QueryTokenKind.AggregateExpression; }
         }
 
+        /// <summary>
+        /// Gets the AggregationMethod of this token.
+        /// </summary>
         public AggregationMethod Method
         {
             get { return this.method; }
         }
 
+        /// <summary>
+        /// Gets the aggregate method definition.
+        /// </summary>
         public AggregationMethodDefinition MethodDefinition
         {
             get { return this.methodDefinition; }
         }
 
+        /// <summary>
+        /// Gets the expression.
+        /// </summary>
         public QueryToken Expression
         {
             get { return this.expression; }
         }
 
+        /// <summary>
+        /// Gets the alias.
+        /// </summary>
         public string Alias
         {
             get { return this.alias; }

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateToken.cs
@@ -13,21 +13,34 @@ namespace Microsoft.OData.UriParser.Aggregation
     using System.Collections.Generic;
     using Microsoft.OData.UriParser;
 
-    internal sealed class AggregateToken : ApplyTransformationToken
+    /// <summary>
+    /// Query token representing an Aggregate token.
+    /// </summary>
+    public sealed class AggregateToken : ApplyTransformationToken
     {
         private readonly IEnumerable<AggregateExpressionToken> expressions;
 
+        /// <summary>
+        /// Create an AggregateToken.
+        /// </summary>
+        /// <param name="expressions">The list of AggregateExpressionToken.</param>
         public AggregateToken(IEnumerable<AggregateExpressionToken> expressions)
         {
             ExceptionUtils.CheckArgumentNotNull(expressions, "expressions");
             this.expressions = expressions;
         }
 
+        /// <summary>
+        /// Gets the kind of this token.
+        /// </summary>
         public override QueryTokenKind Kind
         {
             get { return QueryTokenKind.Aggregate; }
         }
 
+        /// <summary>
+        /// Gets the list of AggregateExpressionToken.
+        /// </summary>
         public IEnumerable<AggregateExpressionToken> Expressions
         {
             get

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyTransformationToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyTransformationToken.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.UriParser.Aggregation
     /// <summary>
     /// Base class for Apply transformation tokens
     /// </summary>
-    internal abstract class ApplyTransformationToken : QueryToken
+    public abstract class ApplyTransformationToken : QueryToken
     {
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/GroupByToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/GroupByToken.cs
@@ -13,12 +13,20 @@ namespace Microsoft.OData.UriParser.Aggregation
     using System.Collections.Generic;
     using Microsoft.OData.UriParser;
 
-    internal sealed class GroupByToken : ApplyTransformationToken
+    /// <summary>
+    /// Query token representing a GroupBy token.
+    /// </summary>
+    public sealed class GroupByToken : ApplyTransformationToken
     {
         private readonly IEnumerable<EndPathToken> properties;
 
         private readonly ApplyTransformationToken child;
 
+        /// <summary>
+        /// Create a GroupByToken.
+        /// </summary>
+        /// <param name="properties">The list of group by properties.</param>
+        /// <param name="child">The child of this token.</param>
         public GroupByToken(IEnumerable<EndPathToken> properties, ApplyTransformationToken child)
         {
             ExceptionUtils.CheckArgumentNotNull(properties, "properties");
@@ -28,18 +36,24 @@ namespace Microsoft.OData.UriParser.Aggregation
         }
 
         /// <summary>
-        /// The kind of the query token.
+        /// Gets the kind of this token.
         /// </summary>
         public override QueryTokenKind Kind
         {
             get { return QueryTokenKind.AggregateGroupBy; }
         }
 
+        /// <summary>
+        /// Gets the list of group by properties.
+        /// </summary>
         public IEnumerable<EndPathToken> Properties
         {
             get { return this.properties; }
         }
 
+        /// <summary>
+        /// Gets the child of this token.
+        /// </summary>
         public ApplyTransformationToken Child
         {
             get { return this.child; }

--- a/src/Microsoft.OData.Core/UriParser/Binders/ExpandTreeNormalizer.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/ExpandTreeNormalizer.cs
@@ -44,7 +44,7 @@ namespace Microsoft.OData.UriParser
             foreach (ExpandTermToken term in treeToInvert.ExpandTerms)
             {
                 PathReverser pathReverser = new PathReverser();
-                PathSegmentToken reversedPath = term.PathToNavProp.Accept(pathReverser);
+                PathSegmentToken reversedPath = term.PathToNavigationProp.Accept(pathReverser);
 
                 // we also need to call the select token normalizer for this level to reverse the select paths
                 SelectToken newSelectToken = term.SelectOption;
@@ -86,7 +86,7 @@ namespace Microsoft.OData.UriParser
                 {
                     ExpandToken newSubExpand = CombineTerms(termToken.ExpandOption);
                     finalTermToken = new ExpandTermToken(
-                                                              termToken.PathToNavProp,
+                                                              termToken.PathToNavigationProp,
                                                               termToken.FilterOption,
                                                               termToken.OrderByOptions,
                                                               termToken.TopOption,
@@ -112,12 +112,12 @@ namespace Microsoft.OData.UriParser
         /// <returns>the combined token, or, if the two are mutually exclusive, the same tokens</returns>
         public ExpandTermToken CombineTerms(ExpandTermToken existingToken, ExpandTermToken newToken)
         {
-            Debug.Assert(new PathSegmentTokenEqualityComparer().Equals(existingToken.PathToNavProp, newToken.PathToNavProp), "Paths should be equal.");
+            Debug.Assert(new PathSegmentTokenEqualityComparer().Equals(existingToken.PathToNavigationProp, newToken.PathToNavigationProp), "Paths should be equal.");
 
             List<ExpandTermToken> childNodes = CombineChildNodes(existingToken, newToken).ToList();
             SelectToken combinedSelects = CombineSelects(existingToken, newToken);
             return new ExpandTermToken(
-                    existingToken.PathToNavProp,
+                    existingToken.PathToNavigationProp,
                     existingToken.FilterOption,
                     existingToken.OrderByOptions,
                     existingToken.TopOption,
@@ -177,13 +177,13 @@ namespace Microsoft.OData.UriParser
         private void AddOrCombine(IDictionary<PathSegmentToken, ExpandTermToken> combinedTerms, ExpandTermToken expandedTerm)
         {
             ExpandTermToken existingTerm;
-            if (combinedTerms.TryGetValue(expandedTerm.PathToNavProp, out existingTerm))
+            if (combinedTerms.TryGetValue(expandedTerm.PathToNavigationProp, out existingTerm))
             {
-                combinedTerms[expandedTerm.PathToNavProp] = CombineTerms(expandedTerm, existingTerm);
+                combinedTerms[expandedTerm.PathToNavigationProp] = CombineTerms(expandedTerm, existingTerm);
             }
             else
             {
-                combinedTerms.Add(expandedTerm.PathToNavProp, expandedTerm);
+                combinedTerms.Add(expandedTerm.PathToNavigationProp, expandedTerm);
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -180,7 +180,7 @@ namespace Microsoft.OData.UriParser
         {
             ExceptionUtils.CheckArgumentNotNull(tokenIn, "tokenIn");
 
-            PathSegmentToken currentToken = tokenIn.PathToNavProp;
+            PathSegmentToken currentToken = tokenIn.PathToNavigationProp;
 
             IEdmStructuredType currentLevelEntityType = this.EdmType;
             List<ODataPathSegment> pathSoFar = new List<ODataPathSegment>();

--- a/src/Microsoft.OData.Core/UriParser/NamedValue.cs
+++ b/src/Microsoft.OData.Core/UriParser/NamedValue.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Class representing a single named value (name and value pair).
     /// </summary>
-    internal sealed class NamedValue
+    public sealed class NamedValue
     {
         /// <summary>
         /// The name of the value. Or null if the name was not used for this value.

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
@@ -270,7 +270,7 @@ namespace Microsoft.OData.UriParser
                 List<string> explicitedTokens = new List<string>();
                 foreach (var tmpTokens in termTokens)
                 {
-                    var pathToNav = tmpTokens.PathToNavProp;
+                    var pathToNav = tmpTokens.PathToNavigationProp;
                     if (pathToNav.Identifier != UriQueryConstants.RefSegment)
                     {
                         explicitedTokens.Add(pathToNav.Identifier);
@@ -284,7 +284,7 @@ namespace Microsoft.OData.UriParser
                 // Add navigation path if it is not in list yet
                 foreach (var tmpTokens in starTermTokens)
                 {
-                    var pathToNav = tmpTokens.PathToNavProp;
+                    var pathToNav = tmpTokens.PathToNavigationProp;
                     if (pathToNav.Identifier != UriQueryConstants.RefSegment && !explicitedTokens.Contains(pathToNav.Identifier))
                     {
                         termTokens.Add(tmpTokens);

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Parser which consumes the query expression ($filter, $orderby) and produces the lexical object model.
     /// </summary>
-    internal sealed class UriQueryExpressionParser
+    public sealed class UriQueryExpressionParser
     {
         /// <summary>
         /// The maximum number of recursion nesting allowed.
@@ -54,6 +54,15 @@ namespace Microsoft.OData.UriParser
         /// Whether to allow case insensitive for builtin identifier.
         /// </summary>
         private bool enableCaseInsensitiveBuiltinIdentifier = false;
+
+        /// <summary>
+        /// Creates a UriQueryExpressionParser.
+        /// </summary>
+        /// <param name="maxDepth">The maximum depth of each part of the query - a recursion limit.</param>
+        public UriQueryExpressionParser(int maxDepth)
+            : this(maxDepth, false)
+        {
+        }
 
         /// <summary>
         /// Constructor.
@@ -93,6 +102,16 @@ namespace Microsoft.OData.UriParser
         internal ExpressionLexer Lexer
         {
             get { return this.lexer; }
+        }
+
+        /// <summary>
+        /// Parses the $filter expression.
+        /// </summary>
+        /// <param name="filter">The $filter expression string to parse.</param>
+        /// <returns>The lexical token representing the filter.</returns>
+        public QueryToken ParseFilter(string filter)
+        {
+            return this.ParseExpressionText(filter);
         }
 
         /// <summary>
@@ -184,16 +203,6 @@ namespace Microsoft.OData.UriParser
                 default:
                     return edmTypeReference.Definition.FullTypeName();
             }
-        }
-
-        /// <summary>
-        /// Parses the $filter expression.
-        /// </summary>
-        /// <param name="filter">The $filter expression string to parse.</param>
-        /// <returns>The lexical token representing the filter.</returns>
-        internal QueryToken ParseFilter(string filter)
-        {
-            return this.ParseExpressionText(filter);
         }
 
         internal IEnumerable<QueryToken> ParseApply(string apply)

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/AllToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/AllToken.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing the All Query
     /// </summary>
-    internal sealed class AllToken : LambdaToken
+    public sealed class AllToken : LambdaToken
     {
         /// <summary>
         /// Create a AllToken given the expression, parameter, and parent

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/AnyToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/AnyToken.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing the Any Query
     /// </summary>
-    internal sealed class AnyToken : LambdaToken
+    public sealed class AnyToken : LambdaToken
     {
         /// <summary>
         /// Create a AnyToken given the expression, parameter, and parent

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/BinaryOperatorToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/BinaryOperatorToken.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing a binary operator.
     /// </summary>
-    internal sealed class BinaryOperatorToken : QueryToken
+    public sealed class BinaryOperatorToken : QueryToken
     {
         /// <summary>
         /// The operator represented by this node.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/CustomQueryOptionToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/CustomQueryOptionToken.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing a query option.
     /// </summary>
-    internal sealed class CustomQueryOptionToken : QueryToken
+    public sealed class CustomQueryOptionToken : QueryToken
     {
         /// <summary>
         /// The name of the query option.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/DottedIdentifierToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/DottedIdentifierToken.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing a type segment.
     /// </summary>
-    internal sealed class DottedIdentifierToken : PathToken
+    public sealed class DottedIdentifierToken : PathToken
     {
         /// <summary>
         /// The Identifier of the type segment.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/EndPathToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/EndPathToken.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing the last segment in a path.
     /// </summary>
-    internal sealed class EndPathToken : PathToken
+    public sealed class EndPathToken : PathToken
     {
         /// <summary>
         /// The Identifier of the property to access.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/ExpandTermToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/ExpandTermToken.cs
@@ -18,12 +18,12 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing an expand operation.
     /// </summary>
-    internal sealed class ExpandTermToken : QueryToken
+    public sealed class ExpandTermToken : QueryToken
     {
         /// <summary>
         /// The nav prop path for this ExpandTerm
         /// </summary>
-        private readonly PathSegmentToken pathToNavProp;
+        private readonly PathSegmentToken pathToNavigationProp;
 
         /// <summary>
         /// the filter option for this expand term
@@ -73,27 +73,27 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Create an expand term token using only a property
         /// </summary>
-        /// <param name="pathToNavProp">the path to the navigation property</param>
-        public ExpandTermToken(PathSegmentToken pathToNavProp)
-            : this(pathToNavProp, null, null)
+        /// <param name="pathToNavigationProp">the path to the navigation property</param>
+        public ExpandTermToken(PathSegmentToken pathToNavigationProp)
+            : this(pathToNavigationProp, null, null)
         {
         }
 
         /// <summary>
         /// Create an expand term using only the property and its subexpand/select
         /// </summary>
-        /// <param name="pathToNavProp">the path to the navigation property for this expand term</param>
+        /// <param name="pathToNavigationProp">the path to the navigation property for this expand term</param>
         /// <param name="selectOption">the sub select for this token</param>
         /// <param name="expandOption">the sub expand for this token</param>
-        public ExpandTermToken(PathSegmentToken pathToNavProp, SelectToken selectOption, ExpandToken expandOption)
-            : this(pathToNavProp, null, null, null, null, null, null, null, selectOption, expandOption)
+        public ExpandTermToken(PathSegmentToken pathToNavigationProp, SelectToken selectOption, ExpandToken expandOption)
+            : this(pathToNavigationProp, null, null, null, null, null, null, null, selectOption, expandOption)
         {
         }
 
         /// <summary>
         /// Create an expand term token
         /// </summary>
-        /// <param name="pathToNavProp">the nav prop for this expand term</param>
+        /// <param name="pathToNavigationProp">the nav prop for this expand term</param>
         /// <param name="filterOption">the filter option for this expand term</param>
         /// <param name="orderByOptions">the orderby options for this expand term</param>
         /// <param name="topOption">the top option for this expand term</param>
@@ -103,11 +103,11 @@ namespace Microsoft.OData.UriParser
         /// <param name="searchOption">the search option for this expand term</param>
         /// <param name="selectOption">the select option for this expand term</param>
         /// <param name="expandOption">the expand option for this expand term</param>
-        public ExpandTermToken(PathSegmentToken pathToNavProp, QueryToken filterOption, IEnumerable<OrderByToken> orderByOptions, long? topOption, long? skipOption, bool? countQueryOption, long? levelsOption, QueryToken searchOption, SelectToken selectOption, ExpandToken expandOption)
+        public ExpandTermToken(PathSegmentToken pathToNavigationProp, QueryToken filterOption, IEnumerable<OrderByToken> orderByOptions, long? topOption, long? skipOption, bool? countQueryOption, long? levelsOption, QueryToken searchOption, SelectToken selectOption, ExpandToken expandOption)
         {
-            ExceptionUtils.CheckArgumentNotNull(pathToNavProp, "property");
+            ExceptionUtils.CheckArgumentNotNull(pathToNavigationProp, "property");
 
-            this.pathToNavProp = pathToNavProp;
+            this.pathToNavigationProp = pathToNavigationProp;
             this.filterOption = filterOption;
             this.orderByOptions = orderByOptions;
             this.topOption = topOption;
@@ -122,9 +122,9 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// the nav property for this expand term
         /// </summary>
-        public PathSegmentToken PathToNavProp
+        public PathSegmentToken PathToNavigationProp
         {
-            get { return this.pathToNavProp; }
+            get { return this.pathToNavigationProp; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/ExpandToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/ExpandToken.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing an expand operation.
     /// </summary>
-    internal sealed class ExpandToken : QueryToken
+    public sealed class ExpandToken : QueryToken
     {
         /// <summary>
         /// The properties according to which to expand in the results.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/FunctionCallToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/FunctionCallToken.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing a function call.
     /// </summary>
-    internal sealed class FunctionCallToken : QueryToken
+    public sealed class FunctionCallToken : QueryToken
     {
         /// <summary>
         /// The name of the function to call.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/FunctionParameterToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/FunctionParameterToken.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// A token to represent a parameter to a function call.
     /// </summary>
-    internal sealed class FunctionParameterToken : QueryToken
+    public sealed class FunctionParameterToken : QueryToken
     {
         /// <summary>
         /// get an empty list of parameters

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/InnerPathToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/InnerPathToken.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing a single nonroot segment in the query path.
     /// </summary>
-    internal sealed class InnerPathToken : PathToken
+    public sealed class InnerPathToken : PathToken
     {
         /// <summary>
         /// The Identifier of the segment.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/LambdaToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/LambdaToken.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing the Any/All Query
     /// </summary>
-    internal abstract class LambdaToken : QueryToken
+    public abstract class LambdaToken : QueryToken
     {
         /// <summary>
         /// The parent token.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/LiteralToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/LiteralToken.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing a literal value.
     /// </summary>
-    internal sealed class LiteralToken : QueryToken
+    public sealed class LiteralToken : QueryToken
     {
         /// <summary>
         /// The original text value of the literal.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/NonSystemToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/NonSystemToken.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.UriParser
     /// Lexical token representing a segment in a path.
     /// </summary>
     ///
-    internal sealed class NonSystemToken : PathSegmentToken
+    public sealed class NonSystemToken : PathSegmentToken
     {
         /// <summary>
         /// Any named values for this NonSystemToken

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/OrderByToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/OrderByToken.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing an order by operation.
     /// </summary>
-    internal sealed class OrderByToken : QueryToken
+    public sealed class OrderByToken : QueryToken
     {
         /// <summary>
         /// The direction of the ordering.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathSegmentToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathSegmentToken.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData.UriParser
     /// Lexical token representing a segment in a path.
     /// </summary>
     ///
-    internal abstract class PathSegmentToken
+    public abstract class PathSegmentToken
     {
         /// <summary>
         /// the next token in the path

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathToken.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData.UriParser
     /// Lexical token representing a segment in a path.
     /// </summary>
     ///
-    internal abstract class PathToken : QueryToken
+    public abstract class PathToken : QueryToken
     {
         /// <summary>
         /// The NextToken in the path(can either be the parent or the child depending on whether the tree has

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryToken.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Base class for all lexical tokens of OData query.
     /// </summary>
-    internal abstract class QueryToken
+    public abstract class QueryToken
     {
         /// <summary>
         /// Empty list of arguments.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryTokenKind.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryTokenKind.cs
@@ -13,7 +13,8 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Enumeration of kinds of query tokens.
     /// </summary>
-    internal enum QueryTokenKind
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1008:EnumsShouldHaveZeroValue")]
+    public enum QueryTokenKind
     {
         /// <summary>
         /// The binary operator.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/RangeVariableToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/RangeVariableToken.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing the parameter for an Any/All query.
     /// </summary>
-    internal sealed class RangeVariableToken : QueryToken
+    public sealed class RangeVariableToken : QueryToken
     {
         /// <summary>
         /// The name of the Any/All parameter.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/SelectToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/SelectToken.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing a select operation.
     /// </summary>
-    internal sealed class SelectToken : QueryToken
+    public sealed class SelectToken : QueryToken
     {
         /// <summary>
         /// The properties according to which to select the results.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/StarToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/StarToken.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing an all-properties access.
     /// </summary>
-    internal sealed class StarToken : PathToken
+    public sealed class StarToken : PathToken
     {
         /// <summary>
         /// The NextToken token to access the property on.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/SystemToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/SystemToken.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OData.UriParser
     /// Lexical token representing a System token such as $count
     /// </summary>
     ///
-    internal sealed class SystemToken : PathSegmentToken
+    public sealed class SystemToken : PathSegmentToken
     {
         /// <summary>
         /// The identifier for this SystemToken

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/UnaryOperatorToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/UnaryOperatorToken.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Lexical token representing a unary operator.
     /// </summary>
-    internal sealed class UnaryOperatorToken : QueryToken
+    public sealed class UnaryOperatorToken : QueryToken
     {
         /// <summary>
         /// The operator represented by this node.

--- a/src/Microsoft.OData.Core/UriParser/Visitors/IPathSegmentTokenVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/IPathSegmentTokenVisitor.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData.UriParser
     /// Visitor interface for walking the Path Tree.
     /// </summary>
     /// <typeparam name="T">Return type for the visitor methods on this visitor.</typeparam>
-    internal interface IPathSegmentTokenVisitor<T>
+    public interface IPathSegmentTokenVisitor<T>
     {
         /// <summary>
         /// Visit an SystemToken
@@ -34,7 +34,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// Visitor interface for walking the Path Tree.
     /// </summary>
-    internal interface IPathSegmentTokenVisitor
+    public interface IPathSegmentTokenVisitor
     {
         /// <summary>
         /// Visit an SystemToken

--- a/src/Microsoft.OData.Core/UriParser/Visitors/ISyntacticTreeVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/ISyntacticTreeVisitor.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.UriParser
     /// Visitor interface for walking the Syntactic Tree.
     /// </summary>
     /// <typeparam name="T">Return type for the visitor methods on this visitor.</typeparam>
-    internal interface ISyntacticTreeVisitor<T>
+    public interface ISyntacticTreeVisitor<T>
     {
         /// <summary>
         /// Visit an AllToken

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/ExpandTreeNormalizerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/ExpandTreeNormalizerTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             ExpandTreeNormalizer expandTreeNormalizer = new ExpandTreeNormalizer();
             ExpandToken normalizedExpand = expandTreeNormalizer.NormalizeExpandTree(expand);
             normalizedExpand.ExpandTerms.Single().ShouldBeExpandTermToken("1", true)
-                .And.PathToNavProp.As<NonSystemToken>().NamedValues.Single().ShouldBeNamedValue("name", "value");
+                .And.PathToNavigationProp.As<NonSystemToken>().NamedValues.Single().ShouldBeNamedValue("name", "value");
             normalizedExpand.ExpandTerms.Single().ExpandOption.Should().BeNull();
         }
 
@@ -65,8 +65,8 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             ExpandTreeNormalizer expandTreeNormalizer = new ExpandTreeNormalizer();
             ExpandToken combinedExpand = expandTreeNormalizer.CombineTerms(expand);
             combinedExpand.ExpandTerms.Single().ShouldBeExpandTermToken("1", true);
-            combinedExpand.ExpandTerms.ElementAt(0).ExpandOption.ExpandTerms.Should().Contain(t => t.PathToNavProp == token2);
-            combinedExpand.ExpandTerms.ElementAt(0).ExpandOption.ExpandTerms.Should().Contain(t => t.PathToNavProp == token3);
+            combinedExpand.ExpandTerms.ElementAt(0).ExpandOption.ExpandTerms.Should().Contain(t => t.PathToNavigationProp == token2);
+            combinedExpand.ExpandTerms.ElementAt(0).ExpandOption.ExpandTerms.Should().Contain(t => t.PathToNavigationProp == token3);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             ExpandTreeNormalizer expandTreeNormalizer = new ExpandTreeNormalizer();
             ExpandToken invertedPaths = expandTreeNormalizer.NormalizePaths(expand);
             invertedPaths.ExpandTerms.Single().ShouldBeExpandTermToken("1", false)
-                .And.PathToNavProp.NextToken.ShouldBeNonSystemToken("2");
+                .And.PathToNavigationProp.NextToken.ShouldBeNonSystemToken("2");
         }
 
         [Fact]
@@ -196,10 +196,10 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             ExpandTreeNormalizer expandTreeNormalizer = new ExpandTreeNormalizer();
             var addedToken = expandTreeNormalizer.CombineTerms(outerExpandTerm1, outerExpandTerm2);
             addedToken.ShouldBeExpandTermToken("1", true).And.ExpandOption.ExpandTerms.Should().Contain(innerExpandTerm2);
-            ExpandTermToken twoToken = addedToken.ExpandOption.ExpandTerms.FirstOrDefault(x => x.PathToNavProp.Identifier == "2");
+            ExpandTermToken twoToken = addedToken.ExpandOption.ExpandTerms.FirstOrDefault(x => x.PathToNavigationProp.Identifier == "2");
             twoToken.ShouldBeExpandTermToken("2", true);
-            ExpandTermToken fiveToken = twoToken.ExpandOption.ExpandTerms.FirstOrDefault(x => x.PathToNavProp.Identifier == "5");
-            ExpandTermToken zeroToken = twoToken.ExpandOption.ExpandTerms.FirstOrDefault(x => x.PathToNavProp.Identifier == "0");
+            ExpandTermToken fiveToken = twoToken.ExpandOption.ExpandTerms.FirstOrDefault(x => x.PathToNavigationProp.Identifier == "5");
+            ExpandTermToken zeroToken = twoToken.ExpandOption.ExpandTerms.FirstOrDefault(x => x.PathToNavigationProp.Identifier == "0");
             fiveToken.ShouldBeExpandTermToken("5", true);
             zeroToken.ShouldBeExpandTermToken("0", true);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ExpandOptionParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ExpandOptionParserTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             ExpandOptionParser optionParser = new ExpandOptionParser(5);
             var termToken = optionParser.BuildExpandTermToken(pathToken, "");
 
-            termToken.ElementAt(0).PathToNavProp.Should().Be(pathToken);
+            termToken.ElementAt(0).PathToNavigationProp.Should().Be(pathToken);
         }
 
         [Fact]
@@ -116,7 +116,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             var result = this.ParseExpandOptions("($expand=two)");
             ExpandTermToken two = result.ExpandOption.ExpandTerms.Single();
-            two.PathToNavProp.ShouldBeNonSystemToken("two");
+            two.PathToNavigationProp.ShouldBeNonSystemToken("two");
         }
 
         [Fact]
@@ -124,9 +124,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             var result = this.ParseExpandOptions("($expand=two($expand=three))");
             ExpandTermToken two = result.ExpandOption.ExpandTerms.Single();
-            two.PathToNavProp.ShouldBeNonSystemToken("two");
+            two.PathToNavigationProp.ShouldBeNonSystemToken("two");
             ExpandTermToken three = two.ExpandOption.ExpandTerms.Single();
-            three.PathToNavProp.ShouldBeNonSystemToken("three");
+            three.PathToNavigationProp.ShouldBeNonSystemToken("three");
         }
 
         [Fact]
@@ -134,9 +134,9 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             var result = this.ParseExpandOptions("($expand=two($expand=three;);)");
             ExpandTermToken two = result.ExpandOption.ExpandTerms.Single();
-            two.PathToNavProp.ShouldBeNonSystemToken("two");
+            two.PathToNavigationProp.ShouldBeNonSystemToken("two");
             ExpandTermToken three = two.ExpandOption.ExpandTerms.Single();
-            three.PathToNavProp.ShouldBeNonSystemToken("three");
+            three.PathToNavigationProp.ShouldBeNonSystemToken("three");
         }
 
         [Fact(Skip = "This test currently fails.")]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
@@ -217,8 +217,8 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             var results = this.StarExpandTesting("*/$ref,CityHall", "Cities");
             results.ExpandTerms.Should().HaveCount(3);
-            results.ExpandTerms.First().PathToNavProp.Identifier.ShouldBeEquivalentTo("CityHall");
-            results.ExpandTerms.Last().PathToNavProp.Identifier.ShouldBeEquivalentTo("$ref");
+            results.ExpandTerms.First().PathToNavigationProp.Identifier.ShouldBeEquivalentTo("CityHall");
+            results.ExpandTerms.Last().PathToNavigationProp.Identifier.ShouldBeEquivalentTo("$ref");
         }
 
         [Fact]
@@ -226,8 +226,8 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             var results = this.StarExpandTesting("CityHall($levels=2),*/$ref,PoliceStation($select=Id, Address)", "Cities");
             results.ExpandTerms.Should().HaveCount(3);
-            results.ExpandTerms.First().PathToNavProp.Identifier.ShouldBeEquivalentTo("CityHall");
-            results.ExpandTerms.Last().PathToNavProp.Identifier.ShouldBeEquivalentTo("$ref");
+            results.ExpandTerms.First().PathToNavigationProp.Identifier.ShouldBeEquivalentTo("CityHall");
+            results.ExpandTerms.Last().PathToNavigationProp.Identifier.ShouldBeEquivalentTo("$ref");
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SyntacticAst/ExpandTermTokenTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SyntacticAst/ExpandTermTokenTests.cs
@@ -58,10 +58,10 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
             ExpandTermToken expandTerm1 = new ExpandTermToken(new NonSystemToken("stuff", null, null),
                                                              null /*selectOption*/,
                                                              null /*expandOption*/);
-            expandTerm1.PathToNavProp.ShouldBeNonSystemToken("stuff");
+            expandTerm1.PathToNavigationProp.ShouldBeNonSystemToken("stuff");
 
             ExpandTermToken expandTerm2 = new ExpandTermToken(new NonSystemToken("stuff", null, null));
-            expandTerm2.PathToNavProp.ShouldBeNonSystemToken("stuff");
+            expandTerm2.PathToNavigationProp.ShouldBeNonSystemToken("stuff");
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/TokenAssertions.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/TokenAssertions.cs
@@ -126,10 +126,10 @@ namespace Microsoft.OData.Tests.UriParser
             token.Should().BeOfType<ExpandTermToken>();
             ExpandTermToken expandTermToken = token.As<ExpandTermToken>();
             expandTermToken.Kind.Should().Be(QueryTokenKind.ExpandTerm);
-            expandTermToken.PathToNavProp.Identifier.Should().Be(propertyName);
+            expandTermToken.PathToNavigationProp.Identifier.Should().Be(propertyName);
             if (checkNullParent)
             {
-                expandTermToken.PathToNavProp.NextToken.Should().BeNull();
+                expandTermToken.PathToNavigationProp.NextToken.Should().BeNull();
             }
             return new AndConstraint<ExpandTermToken>(expandTermToken);
         }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5166,9 +5166,69 @@ public enum Microsoft.OData.UriParser.QueryNodeKind : int {
 	UnaryOperator = 5
 }
 
+public enum Microsoft.OData.UriParser.QueryTokenKind : int {
+	Aggregate = 24
+	AggregateExpression = 25
+	AggregateGroupBy = 26
+	All = 19
+	Any = 15
+	BinaryOperator = 3
+	CustomQueryOption = 9
+	DottedIdentifier = 17
+	EndPath = 7
+	Expand = 13
+	ExpandTerm = 20
+	FunctionCall = 6
+	FunctionParameter = 21
+	FunctionParameterAlias = 22
+	InnerPath = 16
+	Literal = 5
+	OrderBy = 8
+	RangeVariable = 18
+	Select = 10
+	Star = 11
+	StringLiteral = 23
+	TypeSegment = 14
+	UnaryOperator = 4
+}
+
 public enum Microsoft.OData.UriParser.UnaryOperatorKind : int {
 	Negate = 0
 	Not = 1
+}
+
+public interface Microsoft.OData.UriParser.IPathSegmentTokenVisitor {
+	void Visit (Microsoft.OData.UriParser.NonSystemToken tokenIn)
+	void Visit (Microsoft.OData.UriParser.SystemToken tokenIn)
+}
+
+public interface Microsoft.OData.UriParser.IPathSegmentTokenVisitor`1 {
+	T Visit (Microsoft.OData.UriParser.NonSystemToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.SystemToken tokenIn)
+}
+
+public interface Microsoft.OData.UriParser.ISyntacticTreeVisitor`1 {
+	T Visit (Microsoft.OData.UriParser.Aggregation.AggregateExpressionToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.Aggregation.AggregateToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.Aggregation.GroupByToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.AllToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.AnyToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.BinaryOperatorToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.CustomQueryOptionToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.DottedIdentifierToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.EndPathToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.ExpandTermToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.ExpandToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.FunctionCallToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.FunctionParameterToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.InnerPathToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.LambdaToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.LiteralToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.OrderByToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.RangeVariableToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.SelectToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.StarToken tokenIn)
+	T Visit (Microsoft.OData.UriParser.UnaryOperatorToken tokenIn)
 }
 
 public interface Microsoft.OData.UriParser.IUriLiteralParser {
@@ -5198,6 +5258,16 @@ public abstract class Microsoft.OData.UriParser.LambdaNode : Microsoft.OData.Uri
 	Microsoft.OData.UriParser.RangeVariable CurrentRangeVariable  { public get; }
 	System.Collections.ObjectModel.Collection`1[[Microsoft.OData.UriParser.RangeVariable]] RangeVariables  { public get; }
 	Microsoft.OData.UriParser.CollectionNode Source  { public get; public set; }
+}
+
+public abstract class Microsoft.OData.UriParser.LambdaToken : Microsoft.OData.UriParser.QueryToken {
+	protected LambdaToken (Microsoft.OData.UriParser.QueryToken expression, string parameter, Microsoft.OData.UriParser.QueryToken parent)
+
+	Microsoft.OData.UriParser.QueryToken Expression  { public get; }
+	string Parameter  { public get; }
+	Microsoft.OData.UriParser.QueryToken Parent  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public abstract class Microsoft.OData.UriParser.ODataPathSegment {
@@ -5233,6 +5303,18 @@ public abstract class Microsoft.OData.UriParser.PathSegmentHandler {
 	public virtual void Handle (Microsoft.OData.UriParser.ValueSegment segment)
 }
 
+public abstract class Microsoft.OData.UriParser.PathSegmentToken {
+	protected PathSegmentToken (Microsoft.OData.UriParser.PathSegmentToken nextToken)
+
+	string Identifier  { public abstract get; }
+	bool IsStructuralProperty  { public get; public set; }
+	Microsoft.OData.UriParser.PathSegmentToken NextToken  { public get; }
+
+	public abstract T Accept (IPathSegmentTokenVisitor`1 visitor)
+	public abstract void Accept (Microsoft.OData.UriParser.IPathSegmentTokenVisitor visitor)
+	public abstract bool IsNamespaceOrContainerQualified ()
+}
+
 public abstract class Microsoft.OData.UriParser.PathSegmentTranslator`1 {
 	protected PathSegmentTranslator`1 ()
 
@@ -5252,6 +5334,13 @@ public abstract class Microsoft.OData.UriParser.PathSegmentTranslator`1 {
 	public virtual T Translate (Microsoft.OData.UriParser.SingletonSegment segment)
 	public virtual T Translate (Microsoft.OData.UriParser.TypeSegment segment)
 	public virtual T Translate (Microsoft.OData.UriParser.ValueSegment segment)
+}
+
+public abstract class Microsoft.OData.UriParser.PathToken : Microsoft.OData.UriParser.QueryToken {
+	protected PathToken ()
+
+	string Identifier  { public abstract get; }
+	Microsoft.OData.UriParser.QueryToken NextToken  { public abstract get; public abstract set; }
 }
 
 public abstract class Microsoft.OData.UriParser.QueryNode {
@@ -5291,6 +5380,16 @@ public abstract class Microsoft.OData.UriParser.QueryNodeVisitor`1 {
 	public virtual T Visit (Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode nodeIn)
 	public virtual T Visit (Microsoft.OData.UriParser.SingleValuePropertyAccessNode nodeIn)
 	public virtual T Visit (Microsoft.OData.UriParser.UnaryOperatorNode nodeIn)
+}
+
+public abstract class Microsoft.OData.UriParser.QueryToken {
+	public static readonly Microsoft.OData.UriParser.QueryToken[] EmptyTokens = Microsoft.OData.UriParser.QueryToken[]
+
+	protected QueryToken ()
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public abstract get; }
+
+	public abstract T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public abstract class Microsoft.OData.UriParser.RangeVariable {
@@ -5525,6 +5624,14 @@ public sealed class Microsoft.OData.UriParser.AllNode : Microsoft.OData.UriParse
 	public virtual T Accept (QueryNodeVisitor`1 visitor)
 }
 
+public sealed class Microsoft.OData.UriParser.AllToken : Microsoft.OData.UriParser.LambdaToken {
+	public AllToken (Microsoft.OData.UriParser.QueryToken expression, string parameter, Microsoft.OData.UriParser.QueryToken parent)
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
 public sealed class Microsoft.OData.UriParser.AlternateKeysODataUriResolver : Microsoft.OData.UriParser.ODataUriResolver {
 	public AlternateKeysODataUriResolver (Microsoft.OData.Edm.IEdmModel model)
 
@@ -5538,6 +5645,14 @@ public sealed class Microsoft.OData.UriParser.AnyNode : Microsoft.OData.UriParse
 	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public virtual get; }
 
 	public virtual T Accept (QueryNodeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.UriParser.AnyToken : Microsoft.OData.UriParser.LambdaToken {
+	public AnyToken (Microsoft.OData.UriParser.QueryToken expression, string parameter, Microsoft.OData.UriParser.QueryToken parent)
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.BatchReferenceSegment : Microsoft.OData.UriParser.ODataPathSegment {
@@ -5569,6 +5684,17 @@ public sealed class Microsoft.OData.UriParser.BinaryOperatorNode : Microsoft.ODa
 	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public virtual get; }
 
 	public virtual T Accept (QueryNodeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.UriParser.BinaryOperatorToken : Microsoft.OData.UriParser.QueryToken {
+	public BinaryOperatorToken (Microsoft.OData.UriParser.BinaryOperatorKind operatorKind, Microsoft.OData.UriParser.QueryToken left, Microsoft.OData.UriParser.QueryToken right)
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.UriParser.QueryToken Left  { public get; }
+	Microsoft.OData.UriParser.BinaryOperatorKind OperatorKind  { public get; }
+	Microsoft.OData.UriParser.QueryToken Right  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.CollectionFunctionCallNode : Microsoft.OData.UriParser.CollectionNode {
@@ -5695,11 +5821,31 @@ public sealed class Microsoft.OData.UriParser.CountVirtualPropertyNode : Microso
 	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public virtual get; }
 }
 
+public sealed class Microsoft.OData.UriParser.CustomQueryOptionToken : Microsoft.OData.UriParser.QueryToken {
+	public CustomQueryOptionToken (string name, string value)
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	string Name  { public get; }
+	string Value  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
 public sealed class Microsoft.OData.UriParser.CustomUriLiteralParsers : IUriLiteralParser {
 	public static void AddCustomUriLiteralParser (Microsoft.OData.UriParser.IUriLiteralParser customUriLiteralParser)
 	public static void AddCustomUriLiteralParser (Microsoft.OData.Edm.IEdmTypeReference edmTypeReference, Microsoft.OData.UriParser.IUriLiteralParser customUriLiteralParser)
 	public virtual object ParseUriStringToType (string text, Microsoft.OData.Edm.IEdmTypeReference targetType, out Microsoft.OData.UriParser.UriLiteralParsingException& parsingException)
 	public static bool RemoveCustomUriLiteralParser (Microsoft.OData.UriParser.IUriLiteralParser customUriLiteralParser)
+}
+
+public sealed class Microsoft.OData.UriParser.DottedIdentifierToken : Microsoft.OData.UriParser.PathToken {
+	public DottedIdentifierToken (string identifier, Microsoft.OData.UriParser.QueryToken nextToken)
+
+	string Identifier  { public virtual get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.UriParser.QueryToken NextToken  { public virtual get; public virtual set; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.DynamicPathSegment : Microsoft.OData.UriParser.ODataPathSegment {
@@ -5710,6 +5856,16 @@ public sealed class Microsoft.OData.UriParser.DynamicPathSegment : Microsoft.ODa
 
 	public virtual void HandleWith (Microsoft.OData.UriParser.PathSegmentHandler handler)
 	public virtual T TranslateWith (PathSegmentTranslator`1 translator)
+}
+
+public sealed class Microsoft.OData.UriParser.EndPathToken : Microsoft.OData.UriParser.PathToken {
+	public EndPathToken (string identifier, Microsoft.OData.UriParser.QueryToken nextToken)
+
+	string Identifier  { public virtual get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.UriParser.QueryToken NextToken  { public virtual get; public virtual set; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.EntityIdSegment {
@@ -5737,6 +5893,35 @@ public sealed class Microsoft.OData.UriParser.ExpandedNavigationSelectItem : Mic
 	public virtual T TranslateWith (SelectItemTranslator`1 translator)
 }
 
+public sealed class Microsoft.OData.UriParser.ExpandTermToken : Microsoft.OData.UriParser.QueryToken {
+	public ExpandTermToken (Microsoft.OData.UriParser.PathSegmentToken pathToNavigationProp)
+	public ExpandTermToken (Microsoft.OData.UriParser.PathSegmentToken pathToNavigationProp, Microsoft.OData.UriParser.SelectToken selectOption, Microsoft.OData.UriParser.ExpandToken expandOption)
+	public ExpandTermToken (Microsoft.OData.UriParser.PathSegmentToken pathToNavigationProp, Microsoft.OData.UriParser.QueryToken filterOption, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.OrderByToken]] orderByOptions, System.Nullable`1[[System.Int64]] topOption, System.Nullable`1[[System.Int64]] skipOption, System.Nullable`1[[System.Boolean]] countQueryOption, System.Nullable`1[[System.Int64]] levelsOption, Microsoft.OData.UriParser.QueryToken searchOption, Microsoft.OData.UriParser.SelectToken selectOption, Microsoft.OData.UriParser.ExpandToken expandOption)
+
+	System.Nullable`1[[System.Boolean]] CountQueryOption  { public get; }
+	Microsoft.OData.UriParser.ExpandToken ExpandOption  { public get; }
+	Microsoft.OData.UriParser.QueryToken FilterOption  { public get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	System.Nullable`1[[System.Int64]] LevelsOption  { public get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.OrderByToken]] OrderByOptions  { public get; }
+	Microsoft.OData.UriParser.PathSegmentToken PathToNavigationProp  { public get; }
+	Microsoft.OData.UriParser.QueryToken SearchOption  { public get; }
+	Microsoft.OData.UriParser.SelectToken SelectOption  { public get; }
+	System.Nullable`1[[System.Int64]] SkipOption  { public get; }
+	System.Nullable`1[[System.Int64]] TopOption  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.UriParser.ExpandToken : Microsoft.OData.UriParser.QueryToken {
+	public ExpandToken (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ExpandTermToken]] expandTerms)
+
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ExpandTermToken]] ExpandTerms  { public get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
 public sealed class Microsoft.OData.UriParser.FilterClause {
 	public FilterClause (Microsoft.OData.UriParser.SingleValueNode expression, Microsoft.OData.UriParser.RangeVariable rangeVariable)
 
@@ -5745,11 +5930,46 @@ public sealed class Microsoft.OData.UriParser.FilterClause {
 	Microsoft.OData.UriParser.RangeVariable RangeVariable  { public get; }
 }
 
+public sealed class Microsoft.OData.UriParser.FunctionCallToken : Microsoft.OData.UriParser.QueryToken {
+	public FunctionCallToken (string name, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.QueryToken]] argumentValues)
+	public FunctionCallToken (string name, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.FunctionParameterToken]] arguments, Microsoft.OData.UriParser.QueryToken source)
+
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.FunctionParameterToken]] Arguments  { public get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	string Name  { public get; }
+	Microsoft.OData.UriParser.QueryToken Source  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.UriParser.FunctionParameterToken : Microsoft.OData.UriParser.QueryToken {
+	public static Microsoft.OData.UriParser.FunctionParameterToken[] EmptyParameterList = Microsoft.OData.UriParser.FunctionParameterToken[]
+
+	public FunctionParameterToken (string parameterName, Microsoft.OData.UriParser.QueryToken valueToken)
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	string ParameterName  { public get; }
+	Microsoft.OData.UriParser.QueryToken ValueToken  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
 public sealed class Microsoft.OData.UriParser.FunctionSignatureWithReturnType {
 	public FunctionSignatureWithReturnType (Microsoft.OData.Edm.IEdmTypeReference returnType, Microsoft.OData.Edm.IEdmTypeReference[] argumentTypes)
 
 	Microsoft.OData.Edm.IEdmTypeReference[] ArgumentTypes  { public get; }
 	Microsoft.OData.Edm.IEdmTypeReference ReturnType  { public get; }
+}
+
+public sealed class Microsoft.OData.UriParser.InnerPathToken : Microsoft.OData.UriParser.PathToken {
+	public InnerPathToken (string identifier, Microsoft.OData.UriParser.QueryToken nextToken, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.NamedValue]] namedValues)
+
+	string Identifier  { public virtual get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.NamedValue]] NamedValues  { public get; }
+	Microsoft.OData.UriParser.QueryToken NextToken  { public virtual get; public virtual set; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.KeySegment : Microsoft.OData.UriParser.ODataPathSegment {
@@ -5771,6 +5991,15 @@ public sealed class Microsoft.OData.UriParser.LevelsClause {
 	long Level  { public get; }
 }
 
+public sealed class Microsoft.OData.UriParser.LiteralToken : Microsoft.OData.UriParser.QueryToken {
+	public LiteralToken (object value)
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	object Value  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
 public sealed class Microsoft.OData.UriParser.MetadataSegment : Microsoft.OData.UriParser.ODataPathSegment {
 	public static readonly Microsoft.OData.UriParser.MetadataSegment Instance = Microsoft.OData.UriParser.MetadataSegment
 
@@ -5778,6 +6007,13 @@ public sealed class Microsoft.OData.UriParser.MetadataSegment : Microsoft.OData.
 
 	public virtual void HandleWith (Microsoft.OData.UriParser.PathSegmentHandler handler)
 	public virtual T TranslateWith (PathSegmentTranslator`1 translator)
+}
+
+public sealed class Microsoft.OData.UriParser.NamedValue {
+	public NamedValue (string name, Microsoft.OData.UriParser.LiteralToken value)
+
+	string Name  { public get; }
+	Microsoft.OData.UriParser.LiteralToken Value  { public get; }
 }
 
 public sealed class Microsoft.OData.UriParser.NamespaceQualifiedWildcardSelectItem : Microsoft.OData.UriParser.SelectItem {
@@ -5828,6 +6064,17 @@ public sealed class Microsoft.OData.UriParser.NonResourceRangeVariableReferenceN
 	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public virtual get; }
 
 	public virtual T Accept (QueryNodeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.UriParser.NonSystemToken : Microsoft.OData.UriParser.PathSegmentToken {
+	public NonSystemToken (string identifier, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.NamedValue]] namedValues, Microsoft.OData.UriParser.PathSegmentToken nextToken)
+
+	string Identifier  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.NamedValue]] NamedValues  { public get; }
+
+	public virtual T Accept (IPathSegmentTokenVisitor`1 visitor)
+	public virtual void Accept (Microsoft.OData.UriParser.IPathSegmentTokenVisitor visitor)
+	public virtual bool IsNamespaceOrContainerQualified ()
 }
 
 [
@@ -5931,6 +6178,16 @@ public sealed class Microsoft.OData.UriParser.OrderByClause {
 	Microsoft.OData.UriParser.OrderByClause ThenBy  { public get; }
 }
 
+public sealed class Microsoft.OData.UriParser.OrderByToken : Microsoft.OData.UriParser.QueryToken {
+	public OrderByToken (Microsoft.OData.UriParser.QueryToken expression, Microsoft.OData.UriParser.OrderByDirection direction)
+
+	Microsoft.OData.UriParser.OrderByDirection Direction  { public get; }
+	Microsoft.OData.UriParser.QueryToken Expression  { public get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
 public sealed class Microsoft.OData.UriParser.ParseDynamicPathSegment : System.MulticastDelegate, ICloneable, ISerializable {
 	public ParseDynamicPathSegment (object object, System.IntPtr method)
 
@@ -5966,6 +6223,15 @@ public sealed class Microsoft.OData.UriParser.PropertySegment : Microsoft.OData.
 
 	public virtual void HandleWith (Microsoft.OData.UriParser.PathSegmentHandler handler)
 	public virtual T TranslateWith (PathSegmentTranslator`1 translator)
+}
+
+public sealed class Microsoft.OData.UriParser.RangeVariableToken : Microsoft.OData.UriParser.QueryToken {
+	public RangeVariableToken (string name)
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	string Name  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.ResourceRangeVariable : Microsoft.OData.UriParser.RangeVariable {
@@ -6012,6 +6278,15 @@ public sealed class Microsoft.OData.UriParser.SelectExpandClause {
 
 	bool AllSelected  { public get; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.SelectItem]] SelectedItems  { public get; }
+}
+
+public sealed class Microsoft.OData.UriParser.SelectToken : Microsoft.OData.UriParser.QueryToken {
+	public SelectToken (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.PathSegmentToken]] properties)
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.PathSegmentToken]] Properties  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.SingleNavigationNode : Microsoft.OData.UriParser.SingleEntityNode {
@@ -6098,6 +6373,16 @@ public sealed class Microsoft.OData.UriParser.SingleValuePropertyAccessNode : Mi
 	public virtual T Accept (QueryNodeVisitor`1 visitor)
 }
 
+public sealed class Microsoft.OData.UriParser.StarToken : Microsoft.OData.UriParser.PathToken {
+	public StarToken (Microsoft.OData.UriParser.QueryToken nextToken)
+
+	string Identifier  { public virtual get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.UriParser.QueryToken NextToken  { public virtual get; public virtual set; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
 public sealed class Microsoft.OData.UriParser.StringAsEnumResolver : Microsoft.OData.UriParser.ODataUriResolver {
 	public StringAsEnumResolver ()
 
@@ -6105,6 +6390,16 @@ public sealed class Microsoft.OData.UriParser.StringAsEnumResolver : Microsoft.O
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.KeyValuePair`2[[System.String],[System.Object]]]] ResolveKeys (Microsoft.OData.Edm.IEdmEntityType type, System.Collections.Generic.IDictionary`2[[System.String],[System.String]] namedValues, System.Func`3[[Microsoft.OData.Edm.IEdmTypeReference],[System.String],[System.Object]] convertFunc)
 	public virtual System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.KeyValuePair`2[[System.String],[System.Object]]]] ResolveKeys (Microsoft.OData.Edm.IEdmEntityType type, System.Collections.Generic.IList`1[[System.String]] positionalValues, System.Func`3[[Microsoft.OData.Edm.IEdmTypeReference],[System.String],[System.Object]] convertFunc)
 	public virtual System.Collections.Generic.IDictionary`2[[Microsoft.OData.Edm.IEdmOperationParameter],[Microsoft.OData.UriParser.SingleValueNode]] ResolveOperationParameters (Microsoft.OData.Edm.IEdmOperation operation, System.Collections.Generic.IDictionary`2[[System.String],[Microsoft.OData.UriParser.SingleValueNode]] input)
+}
+
+public sealed class Microsoft.OData.UriParser.SystemToken : Microsoft.OData.UriParser.PathSegmentToken {
+	public SystemToken (string identifier, Microsoft.OData.UriParser.PathSegmentToken nextToken)
+
+	string Identifier  { public virtual get; }
+
+	public virtual T Accept (IPathSegmentTokenVisitor`1 visitor)
+	public virtual void Accept (Microsoft.OData.UriParser.IPathSegmentTokenVisitor visitor)
+	public virtual bool IsNamespaceOrContainerQualified ()
 }
 
 public sealed class Microsoft.OData.UriParser.TypeSegment : Microsoft.OData.UriParser.ODataPathSegment {
@@ -6128,6 +6423,16 @@ public sealed class Microsoft.OData.UriParser.UnaryOperatorNode : Microsoft.ODat
 	public virtual T Accept (QueryNodeVisitor`1 visitor)
 }
 
+public sealed class Microsoft.OData.UriParser.UnaryOperatorToken : Microsoft.OData.UriParser.QueryToken {
+	public UnaryOperatorToken (Microsoft.OData.UriParser.UnaryOperatorKind operatorKind, Microsoft.OData.UriParser.QueryToken operand)
+
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.UriParser.QueryToken Operand  { public get; }
+	Microsoft.OData.UriParser.UnaryOperatorKind OperatorKind  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
 [
 DebuggerDisplayAttribute(),
 ]
@@ -6135,6 +6440,12 @@ public sealed class Microsoft.OData.UriParser.UriLiteralParsingException : Micro
 	public UriLiteralParsingException ()
 	public UriLiteralParsingException (string message)
 	public UriLiteralParsingException (string message, System.Exception innerException)
+}
+
+public sealed class Microsoft.OData.UriParser.UriQueryExpressionParser {
+	public UriQueryExpressionParser (int maxDepth)
+
+	public Microsoft.OData.UriParser.QueryToken ParseFilter (string filter)
 }
 
 public sealed class Microsoft.OData.UriParser.UriTemplateExpression {
@@ -6176,6 +6487,10 @@ public enum Microsoft.OData.UriParser.Aggregation.TransformationNodeKind : int {
 	GroupBy = 1
 }
 
+public abstract class Microsoft.OData.UriParser.Aggregation.ApplyTransformationToken : Microsoft.OData.UriParser.QueryToken {
+	protected ApplyTransformationToken ()
+}
+
 public abstract class Microsoft.OData.UriParser.Aggregation.TransformationNode {
 	protected TransformationNode ()
 
@@ -6191,6 +6506,28 @@ public sealed class Microsoft.OData.UriParser.Aggregation.AggregateExpression {
 	Microsoft.OData.UriParser.Aggregation.AggregationMethod Method  { public get; }
 	Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition MethodDefinition  { public get; }
 	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public get; }
+}
+
+public sealed class Microsoft.OData.UriParser.Aggregation.AggregateExpressionToken : Microsoft.OData.UriParser.QueryToken {
+	public AggregateExpressionToken (Microsoft.OData.UriParser.QueryToken expression, Microsoft.OData.UriParser.Aggregation.AggregationMethod method, string alias)
+	public AggregateExpressionToken (Microsoft.OData.UriParser.QueryToken expression, Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition methodDefinition, string alias)
+
+	string Alias  { public get; }
+	Microsoft.OData.UriParser.QueryToken Expression  { public get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.UriParser.Aggregation.AggregationMethod Method  { public get; }
+	Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition MethodDefinition  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.UriParser.Aggregation.AggregateToken : Microsoft.OData.UriParser.Aggregation.ApplyTransformationToken {
+	public AggregateToken (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.Aggregation.AggregateExpressionToken]] expressions)
+
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.Aggregation.AggregateExpressionToken]] Expressions  { public get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.Aggregation.AggregateTransformationNode : Microsoft.OData.UriParser.Aggregation.TransformationNode {
@@ -6235,6 +6572,16 @@ public sealed class Microsoft.OData.UriParser.Aggregation.GroupByPropertyNode {
 	Microsoft.OData.UriParser.SingleValueNode Expression  { public get; }
 	string Name  { public get; }
 	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public get; }
+}
+
+public sealed class Microsoft.OData.UriParser.Aggregation.GroupByToken : Microsoft.OData.UriParser.Aggregation.ApplyTransformationToken {
+	public GroupByToken (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.EndPathToken]] properties, Microsoft.OData.UriParser.Aggregation.ApplyTransformationToken child)
+
+	Microsoft.OData.UriParser.Aggregation.ApplyTransformationToken Child  { public get; }
+	Microsoft.OData.UriParser.QueryTokenKind Kind  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.EndPathToken]] Properties  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.Aggregation.GroupByTransformationNode : Microsoft.OData.UriParser.Aggregation.TransformationNode {
@@ -7119,5 +7466,346 @@ public sealed class Microsoft.OData.Client.WritingNestedResourceInfoArgs {
 	Microsoft.OData.ODataNestedResourceInfo Link  { public get; }
 	object Source  { public get; }
 	object Target  { public get; }
+}
+
+public enum Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind : int {
+	Aggregate = 24
+	AggregateExpression = 25
+	AggregateGroupBy = 26
+	All = 19
+	Any = 15
+	BinaryOperator = 3
+	CustomQueryOption = 9
+	DottedIdentifier = 17
+	EndPath = 7
+	Expand = 13
+	ExpandTerm = 20
+	FunctionCall = 6
+	FunctionParameter = 21
+	FunctionParameterAlias = 22
+	InnerPath = 16
+	Literal = 5
+	OrderBy = 8
+	RangeVariable = 18
+	Select = 10
+	Star = 11
+	StringLiteral = 23
+	TypeSegment = 14
+	UnaryOperator = 4
+}
+
+public interface Microsoft.OData.Client.ALinq.UriParser.IPathSegmentTokenVisitor {
+	void Visit (Microsoft.OData.Client.ALinq.UriParser.NonSystemToken tokenIn)
+	void Visit (Microsoft.OData.Client.ALinq.UriParser.SystemToken tokenIn)
+}
+
+public interface Microsoft.OData.Client.ALinq.UriParser.IPathSegmentTokenVisitor`1 {
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.NonSystemToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.SystemToken tokenIn)
+}
+
+public interface Microsoft.OData.Client.ALinq.UriParser.ISyntacticTreeVisitor`1 {
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.AggregateExpressionToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.AggregateToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.AllToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.AnyToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.BinaryOperatorToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.CustomQueryOptionToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.DottedIdentifierToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.EndPathToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.ExpandTermToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.ExpandToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.FunctionCallToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.FunctionParameterToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.GroupByToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.InnerPathToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.LambdaToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.LiteralToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.OrderByToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.RangeVariableToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.SelectToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.StarToken tokenIn)
+	T Visit (Microsoft.OData.Client.ALinq.UriParser.UnaryOperatorToken tokenIn)
+}
+
+public abstract class Microsoft.OData.Client.ALinq.UriParser.ApplyTransformationToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	protected ApplyTransformationToken ()
+}
+
+public abstract class Microsoft.OData.Client.ALinq.UriParser.LambdaToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	protected LambdaToken (Microsoft.OData.Client.ALinq.UriParser.QueryToken expression, string parameter, Microsoft.OData.Client.ALinq.UriParser.QueryToken parent)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken Expression  { public get; }
+	string Parameter  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken Parent  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public abstract class Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken {
+	protected PathSegmentToken (Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken nextToken)
+
+	string Identifier  { public abstract get; }
+	bool IsStructuralProperty  { public get; public set; }
+	Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken NextToken  { public get; }
+
+	public abstract T Accept (IPathSegmentTokenVisitor`1 visitor)
+	public abstract void Accept (Microsoft.OData.Client.ALinq.UriParser.IPathSegmentTokenVisitor visitor)
+	public abstract bool IsNamespaceOrContainerQualified ()
+}
+
+public abstract class Microsoft.OData.Client.ALinq.UriParser.PathToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	protected PathToken ()
+
+	string Identifier  { public abstract get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken NextToken  { public abstract get; public abstract set; }
+}
+
+public abstract class Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public static readonly Microsoft.OData.Client.ALinq.UriParser.QueryToken[] EmptyTokens = Microsoft.OData.Client.ALinq.UriParser.QueryToken[]
+
+	protected QueryToken ()
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public abstract get; }
+
+	public abstract T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.AggregateExpressionToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public AggregateExpressionToken (Microsoft.OData.Client.ALinq.UriParser.QueryToken expression, Microsoft.OData.UriParser.Aggregation.AggregationMethod method, string alias)
+	public AggregateExpressionToken (Microsoft.OData.Client.ALinq.UriParser.QueryToken expression, Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition methodDefinition, string alias)
+
+	string Alias  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken Expression  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.UriParser.Aggregation.AggregationMethod Method  { public get; }
+	Microsoft.OData.UriParser.Aggregation.AggregationMethodDefinition MethodDefinition  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.AggregateToken : Microsoft.OData.Client.ALinq.UriParser.ApplyTransformationToken {
+	public AggregateToken (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.AggregateExpressionToken]] expressions)
+
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.AggregateExpressionToken]] Expressions  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.AllToken : Microsoft.OData.Client.ALinq.UriParser.LambdaToken {
+	public AllToken (Microsoft.OData.Client.ALinq.UriParser.QueryToken expression, string parameter, Microsoft.OData.Client.ALinq.UriParser.QueryToken parent)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.AnyToken : Microsoft.OData.Client.ALinq.UriParser.LambdaToken {
+	public AnyToken (Microsoft.OData.Client.ALinq.UriParser.QueryToken expression, string parameter, Microsoft.OData.Client.ALinq.UriParser.QueryToken parent)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.BinaryOperatorToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public BinaryOperatorToken (Microsoft.OData.UriParser.BinaryOperatorKind operatorKind, Microsoft.OData.Client.ALinq.UriParser.QueryToken left, Microsoft.OData.Client.ALinq.UriParser.QueryToken right)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken Left  { public get; }
+	Microsoft.OData.UriParser.BinaryOperatorKind OperatorKind  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken Right  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.CustomQueryOptionToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public CustomQueryOptionToken (string name, string value)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	string Name  { public get; }
+	string Value  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.DottedIdentifierToken : Microsoft.OData.Client.ALinq.UriParser.PathToken {
+	public DottedIdentifierToken (string identifier, Microsoft.OData.Client.ALinq.UriParser.QueryToken nextToken)
+
+	string Identifier  { public virtual get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken NextToken  { public virtual get; public virtual set; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.EndPathToken : Microsoft.OData.Client.ALinq.UriParser.PathToken {
+	public EndPathToken (string identifier, Microsoft.OData.Client.ALinq.UriParser.QueryToken nextToken)
+
+	string Identifier  { public virtual get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken NextToken  { public virtual get; public virtual set; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.ExpandTermToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public ExpandTermToken (Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken pathToNavigationProp)
+	public ExpandTermToken (Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken pathToNavigationProp, Microsoft.OData.Client.ALinq.UriParser.SelectToken selectOption, Microsoft.OData.Client.ALinq.UriParser.ExpandToken expandOption)
+	public ExpandTermToken (Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken pathToNavigationProp, Microsoft.OData.Client.ALinq.UriParser.QueryToken filterOption, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.OrderByToken]] orderByOptions, System.Nullable`1[[System.Int64]] topOption, System.Nullable`1[[System.Int64]] skipOption, System.Nullable`1[[System.Boolean]] countQueryOption, System.Nullable`1[[System.Int64]] levelsOption, Microsoft.OData.Client.ALinq.UriParser.QueryToken searchOption, Microsoft.OData.Client.ALinq.UriParser.SelectToken selectOption, Microsoft.OData.Client.ALinq.UriParser.ExpandToken expandOption)
+
+	System.Nullable`1[[System.Boolean]] CountQueryOption  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.ExpandToken ExpandOption  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken FilterOption  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	System.Nullable`1[[System.Int64]] LevelsOption  { public get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.OrderByToken]] OrderByOptions  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken PathToNavigationProp  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken SearchOption  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.SelectToken SelectOption  { public get; }
+	System.Nullable`1[[System.Int64]] SkipOption  { public get; }
+	System.Nullable`1[[System.Int64]] TopOption  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.ExpandToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public ExpandToken (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.ExpandTermToken]] expandTerms)
+
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.ExpandTermToken]] ExpandTerms  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.FunctionCallToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public FunctionCallToken (string name, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.QueryToken]] argumentValues)
+	public FunctionCallToken (string name, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.FunctionParameterToken]] arguments, Microsoft.OData.Client.ALinq.UriParser.QueryToken source)
+
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.FunctionParameterToken]] Arguments  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	string Name  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken Source  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.FunctionParameterToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public static Microsoft.OData.Client.ALinq.UriParser.FunctionParameterToken[] EmptyParameterList = Microsoft.OData.Client.ALinq.UriParser.FunctionParameterToken[]
+
+	public FunctionParameterToken (string parameterName, Microsoft.OData.Client.ALinq.UriParser.QueryToken valueToken)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	string ParameterName  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken ValueToken  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.GroupByToken : Microsoft.OData.Client.ALinq.UriParser.ApplyTransformationToken {
+	public GroupByToken (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.EndPathToken]] properties, Microsoft.OData.Client.ALinq.UriParser.ApplyTransformationToken child)
+
+	Microsoft.OData.Client.ALinq.UriParser.ApplyTransformationToken Child  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.EndPathToken]] Properties  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.InnerPathToken : Microsoft.OData.Client.ALinq.UriParser.PathToken {
+	public InnerPathToken (string identifier, Microsoft.OData.Client.ALinq.UriParser.QueryToken nextToken, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.NamedValue]] namedValues)
+
+	string Identifier  { public virtual get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.NamedValue]] NamedValues  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken NextToken  { public virtual get; public virtual set; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.LiteralToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public LiteralToken (object value)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	object Value  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.NamedValue {
+	public NamedValue (string name, Microsoft.OData.Client.ALinq.UriParser.LiteralToken value)
+
+	string Name  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.LiteralToken Value  { public get; }
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.NonSystemToken : Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken {
+	public NonSystemToken (string identifier, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.NamedValue]] namedValues, Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken nextToken)
+
+	string Identifier  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.NamedValue]] NamedValues  { public get; }
+
+	public virtual T Accept (IPathSegmentTokenVisitor`1 visitor)
+	public virtual void Accept (Microsoft.OData.Client.ALinq.UriParser.IPathSegmentTokenVisitor visitor)
+	public virtual bool IsNamespaceOrContainerQualified ()
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.OrderByToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public OrderByToken (Microsoft.OData.Client.ALinq.UriParser.QueryToken expression, Microsoft.OData.UriParser.OrderByDirection direction)
+
+	Microsoft.OData.UriParser.OrderByDirection Direction  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken Expression  { public get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.RangeVariableToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public RangeVariableToken (string name)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	string Name  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.SelectToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public SelectToken (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken]] properties)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken]] Properties  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.StarToken : Microsoft.OData.Client.ALinq.UriParser.PathToken {
+	public StarToken (Microsoft.OData.Client.ALinq.UriParser.QueryToken nextToken)
+
+	string Identifier  { public virtual get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken NextToken  { public virtual get; public virtual set; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.SystemToken : Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken {
+	public SystemToken (string identifier, Microsoft.OData.Client.ALinq.UriParser.PathSegmentToken nextToken)
+
+	string Identifier  { public virtual get; }
+
+	public virtual T Accept (IPathSegmentTokenVisitor`1 visitor)
+	public virtual void Accept (Microsoft.OData.Client.ALinq.UriParser.IPathSegmentTokenVisitor visitor)
+	public virtual bool IsNamespaceOrContainerQualified ()
+}
+
+public sealed class Microsoft.OData.Client.ALinq.UriParser.UnaryOperatorToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {
+	public UnaryOperatorToken (Microsoft.OData.UriParser.UnaryOperatorKind operatorKind, Microsoft.OData.Client.ALinq.UriParser.QueryToken operand)
+
+	Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind Kind  { public virtual get; }
+	Microsoft.OData.Client.ALinq.UriParser.QueryToken Operand  { public get; }
+	Microsoft.OData.UriParser.UnaryOperatorKind OperatorKind  { public get; }
+
+	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 }
 


### PR DESCRIPTION
-The main change is exposing UriQueryExpressionParser.ParseFilter as a public API this requires QueryToken object model to be public as well.
-Move QueryTokenKind.cs to  /src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryTokenKind.cs