### PR TITLE
Adding ODL 7.2.0 release notes

### DIFF
--- a/v7/_posts/release notes/2017-05-02-ODL-7.2.0.md
+++ b/v7/_posts/release notes/2017-05-02-ODL-7.2.0.md
@@ -1,0 +1,33 @@
+---
+layout: post
+title: "ODataLib 7.2.0"
+description: "ODataLib 7.2.0 release notes"
+category: "4. Release Notes"
+---
+
+## Changes in ODataLib 7.2.0 Release ##
+
+## Notes ##
+
+7.2.0 re-introduces .NET Standard 1.1 libraries of ODataLib (OData.Core, OData.Edm, and Microsoft.Spatial). The PCL versions remain in the packages and are shipped alongside the new .NET Standard libraries. Bug fixes and additional test validations are also included in this release.
+
+## Features ##
+
+[[Commit 0b54111ee7909e71263b83fc60268de0de817986](https://github.com/OData/odata.net/commit/0b54111ee7909e71263b83fc60268de0de817986)] Expose UriQueryExpressionParser.ParseFilter as a public API [[#805](https://github.com/OData/odata.net/issues/805)]
+
+## Fixed Bugs ##
+
+[[Issue #789](https://github.com/OData/odata.net/issues/789)] BUG? Exception when create EdmModel V7.1.0
+
+## Improvements ##
+
+[[Commit 072f6f7c9bc4c739e553f7fa0996618c621a6589](https://github.com/OData/odata.net/commit/072f6f7c9bc4c739e553f7fa0996618c621a6589)] Adding FxCop exclusion for CA3053:UseXmlSecureResolver in code that compiles under .Net portable framework.
+
+[[Commit 272c74afd1dda7a4a8e562c45dd9da9a9d74dd8b](https://github.com/OData/odata.net/commit/272c74afd1dda7a4a8e562c45dd9da9a9d74dd8b)] Fix suppression for CA3053 to reference proper category and checkid.
+
+[[Commit 170827a01f9141649a848aefb13531163dedd65e](https://github.com/OData/odata.net/commit/170827a01f9141649a848aefb13531163dedd65e)] This change fixes test failures in both local machine and in the lab
+
+[[Commit 66738741dbecad8e0dc32fa787a9f98898a2beda](https://github.com/OData/odata.net/commit/66738741dbecad8e0dc32fa787a9f98898a2beda)] Adding .NET Core unit tests that integrate .NET Standard Libraries (#803
+)
+
+This release delivers OData core libraries including ODataLib, EdmLib and Spatial. OData Client for .NET is not published in this release.

--- a/v7/_posts/release notes/2017-05-02-ODL-7.2.0.md
+++ b/v7/_posts/release notes/2017-05-02-ODL-7.2.0.md
@@ -27,7 +27,6 @@ category: "4. Release Notes"
 
 [[Commit 170827a01f9141649a848aefb13531163dedd65e](https://github.com/OData/odata.net/commit/170827a01f9141649a848aefb13531163dedd65e)] This change fixes test failures in both local machine and in the lab
 
-[[Commit 66738741dbecad8e0dc32fa787a9f98898a2beda](https://github.com/OData/odata.net/commit/66738741dbecad8e0dc32fa787a9f98898a2beda)] Adding .NET Core unit tests that integrate .NET Standard Libraries (#803
-)
+[[Commit 66738741dbecad8e0dc32fa787a9f98898a2beda](https://github.com/OData/odata.net/commit/66738741dbecad8e0dc32fa787a9f98898a2beda)] Adding .NET Core unit tests that integrate .NET Standard Libraries (#803)
 
 This release delivers OData core libraries including ODataLib, EdmLib and Spatial. OData Client for .NET is not published in this release.


### PR DESCRIPTION
### Issues
N/A

### Description
This PR corresponds to the release of OData libraries 7.2.0. Release summary: "7.2.0 re-introduces .NET Standard 1.1 libraries of ODataLib (OData.Core, OData.Edm, and Microsoft.Spatial). The PCL versions remain in the packages and are shipped alongside the new .NET Standard libraries. Bug fixes and additional test validations are also included in this release."

### Checklist (Uncheck if it is not completed)
N/A

### Additional work necessary
N/A
