### PR TITLE
Support dynamic properties in $apply

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpression.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/AggregateExpression.cs
@@ -35,11 +35,11 @@ namespace Microsoft.OData.UriParser.Aggregation
         {
             ExceptionUtils.CheckArgumentNotNull(expression, "expression");
             ExceptionUtils.CheckArgumentNotNull(alias, "alias");
-            ExceptionUtils.CheckArgumentNotNull(typeReference, "typeReference");
 
             this.expression = expression;
             this.method = method;
             this.alias = alias;
+            // TypeRefrence is null for dynamic properties
             this.typeReference = typeReference;
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -134,7 +134,16 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         private IEdmTypeReference GetTypeReferenceByPropertyName(string name)
         {
-            return aggregateExpressionsCache.First(statement => statement.Alias.Equals(name)).TypeReference;
+            if (aggregateExpressionsCache != null)
+            {
+                var expression = aggregateExpressionsCache.FirstOrDefault(statement => statement.Alias.Equals(name));
+                if (expression != null)
+                {
+                    return expression.TypeReference;
+                }
+            }
+
+            return null;
         }
 
         private GroupByTransformationNode BindGroupByToken(GroupByToken token)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -102,11 +102,27 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
+        public void FeedContextUriWithApplyAggreagateOnDynamicProperty()
+        {
+            string applyClause = "aggregate(DynamicProperty with sum as DynamicPropertyTotal)";
+
+            this.CreateFeedContextUri(applyClause).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)");
+        }
+
+        [Fact]
         public void FeedContextUriWithApplyGroupBy()
         {
             string applyClause = "groupby((Name, Address/Street))";
 
             this.CreateFeedContextUri(applyClause).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Name,Address(Street))");
+        }
+
+        [Fact]
+        public void FeedContextUriWithApplyGroupByDynamicProperty()
+        {
+            string applyClause = "groupby((Name, DynamicProperty, Address/Street))";
+
+            this.CreateFeedContextUri(applyClause).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Name,DynamicProperty,Address(Street))");
         }
 
         [Fact]
@@ -615,7 +631,7 @@ namespace Microsoft.OData.Tests
             addressType.AddStructuralProperty("Street", EdmCoreModel.Instance.GetString(/*isNullable*/false));
             addressType.AddStructuralProperty("Zip", EdmCoreModel.Instance.GetString(/*isNullable*/false));
 
-            this.cityType = new EdmEntityType("TestModel", "City");
+            this.cityType = new EdmEntityType("TestModel", "City", baseType: null, isAbstract: false, isOpen: true);
             EdmStructuralProperty cityIdProperty = cityType.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(/*isNullable*/false));
             cityType.AddKeys(cityIdProperty);
             cityType.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(/*isNullable*/false));


### PR DESCRIPTION
### Issues
*This pull request fixes issue #760 for 7.X.*  

### Description
*Dynamic properties don't have type. Relaxed null check in AggregateExpression and related changes in ApplyBinder to allow usage of dynamic properties in groupby clause.*

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*Changes in WebApi repo is needed to finalize. PR for 6.X https://github.com/OData/odata.net/pull/798 *