### PR TITLE
Updating build script regarding Windows Store test solution

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -503,11 +503,11 @@ Function BuildProcess
     {
         RunBuild ('Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln') -vsToolVersion '12.0'
     }
-	else
-	{
-		Write-Host 'Skipping Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln because VS2013 not installed or `
-		missing Microsoft.Windows.UI.Xaml.CSharp.targets for VS2013'
-	}
+    else
+    {
+        Write-Host 'Skipping Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln because VS2013 not installed or `
+        missing Microsoft.Windows.UI.Xaml.CSharp.targets for VS2013'
+    }
     RunBuild ('Microsoft.OData.CodeGen.sln')
     RunBuild ('Microsoft.OData.E2E.sln')
     

--- a/build.ps1
+++ b/build.ps1
@@ -46,11 +46,14 @@ $LOGDIR = $ENLISTMENT_ROOT + "\bin"
 
 # Default to use Visual Studio 2015 since the upgrade to .Net Core.
 $VS14MSBUILD=$PROGRAMFILESX86 + "\MSBuild\14.0\Bin\MSBuild.exe"
-$MSBUILD = $VS14MSBUILD
 $VSTEST = $PROGRAMFILESX86 + "\Microsoft Visual Studio 14.0\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
 $FXCOPDIR = $PROGRAMFILESX86 + "\Microsoft Visual Studio 14.0\Team Tools\Static Analysis Tools\FxCop"
 $SN = $PROGRAMFILESX86 + "\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\sn.exe"
 $SNx64 = $PROGRAMFILESX86 + "\Microsoft SDKs\Windows\v8.1A\bin\NETFX 4.5.1 Tools\x64\sn.exe"
+
+# Use Visual Studio 2013 compiler for older apps, such as Windows Store for 8.0 (as needed for PCL111/.NET Standard 1.1)
+$VS12MSBUILD=$PROGRAMFILESX86 + "\MSBuild\12.0\Bin\MSBuild.exe"
+$VS12XAMLTARGETFILE=$PROGRAMFILESX86 + "\MSBuild\Microsoft\WindowsXaml\v12.0\Microsoft.Windows.UI.Xaml.CSharp.targets"
 
 $FXCOP = $FXCOPDIR + "\FxCopCmd.exe"
 $BUILDLOG = $LOGDIR + "\msbuild.log"
@@ -270,6 +273,14 @@ Function RunBuild ($sln, $vsToolVersion)
     $slnpath = $ENLISTMENT_ROOT + "\sln\$sln"
     $Conf = "/p:Configuration=" + "$Configuration"
 
+    # Default to VS2015
+    $MSBUILD = $VS14MSBUILD
+    
+    if($vsToolVersion -eq '12.0')
+    {
+        $MSBUILD=$VS12MSBUILD
+    }
+    
     & $MSBUILD $slnpath /t:$Build /m /nr:false /fl "/p:Platform=Any CPU" $Conf /p:Desktop=true `
         /flp:LogFile=$LOGDIR/msbuild.log /flp:Verbosity=Normal 1>$null 2>$null
     if($LASTEXITCODE -eq 0)
@@ -486,12 +497,22 @@ Function BuildProcess
     RunBuild ('Microsoft.OData.E2E.Portable.sln')
     RunBuild ('Microsoft.Test.OData.Tests.Client.Portable.Desktop.sln')
     RunBuild ('Microsoft.Test.OData.Tests.Client.Portable.WindowsPhone.sln')
-    RunBuild ('Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln')
+    # Windows Store builds 8.0 apps which is needed to meet PCL111/.NET Standard 1.1 criteria
+    # Because VS2015 doesn't support 8.0 apps, we need to use VS2013. Skip if VS2013 not installed.
+    if([System.IO.File]::Exists($VS12MSBUILD) -And [System.IO.File]::Exists($VS12XAMLTARGETFILE))
+    {
+        RunBuild ('Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln') -vsToolVersion '12.0'
+    }
+	else
+	{
+		Write-Host 'Skipping Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln because VS2013 not installed or `
+		missing Microsoft.Windows.UI.Xaml.CSharp.targets for VS2013'
+	}
     RunBuild ('Microsoft.OData.CodeGen.sln')
     RunBuild ('Microsoft.OData.E2E.sln')
     
-    # Requires VS2015 (14.0) ($MSBUILD = $VS14MSBUILD)
-    RunBuild -sln 'Microsoft.Test.OData.DotNetStandard.sln' -vsToolVersion '14.0'
+    # Requires VS2015 (14.0) due to .NET Core test projects
+    RunBuild ('Microsoft.Test.OData.DotNetStandard.sln')
     
     Write-Host "Build Done" -ForegroundColor $Success
     $script:BUILD_END_TIME = Get-Date

--- a/sln/.nuget/packages.config
+++ b/sln/.nuget/packages.config
@@ -9,6 +9,9 @@
   <package id="Microsoft.Extensions.DependencyInjection.Abstractions" version="1.0.0" />
   <package id="Microsoft.Hadoop.Avro" version="1.4.0.0" />
   <package id="Microsoft.MadMan" version="3.1.112712.0" />
+  <package id="Microsoft.NETCore.App" version="1.0.0" />
+  <package id="Microsoft.NETCore.Jit" version="1.0.2" />
+  <package id="Microsoft.NETCore.Runtime.CoreCLR" version="1.0.2" />
   <package id="Microsoft.OData.StyleCop" version="1.0.0" />
   <package id="Newtonsoft.Json" version="6.0.5" />
   <package id="System.Text.Encoding.Extensions" version="4.0.11" />

--- a/sln/Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln
+++ b/sln/Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln
@@ -1,18 +1,48 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Test.OData.Tests.Client.Portable.WindowsStore", "..\test\EndToEndTests\Tests\Client\Build.PortableLibrary.WindowsStore\Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.csproj", "{D3F99EBE-1535-4F31-9C08-BEFEBF27CE2B}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Test.OData.Services.TestServices.Portable", "..\test\EndToEndTests\Services\TestServices\Build.PortableLibrary\Microsoft.Test.OData.Services.TestServices.Portable.csproj", "{4382D649-1A86-48D0-9156-AC37C3D568C0}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Test.OData.Framework.Portable", "..\test\EndToEndTests\Framework\Core\Build.PortableLibrary\Microsoft.Test.OData.Framework.Portable.csproj", "{134D2AD7-3C82-45C9-AC43-75F482081F8D}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.Client.Portable", "..\src\Microsoft.OData.Client\Build.Portable\Microsoft.OData.Client.Portable.csproj", "{AED0DC9D-76E5-4145-AF5E-9E2F856F4D18}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Spatial", "..\src\Microsoft.Spatial\Microsoft.Spatial.csproj", "{5D921888-FE03-4C3F-40FE-2F624505461D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.Core", "..\src\Microsoft.OData.Core\Microsoft.OData.Core.csproj", "{989A83CC-B864-4A75-8BF3-5EDA99203A86}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.Edm", "..\src\Microsoft.OData.Edm\Microsoft.OData.Edm.csproj", "{7D921888-FE03-4C3F-80FE-2F624505461C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.Core", "..\src\Microsoft.OData.Core\Microsoft.OData.Core.csproj", "{989A83CC-B864-4A75-8BF3-5EDA99203A86}"
+	ProjectSection(ProjectDependencies) = postProject
+		{5D921888-FE03-4C3F-40FE-2F624505461D} = {5D921888-FE03-4C3F-40FE-2F624505461D}
+		{7D921888-FE03-4C3F-80FE-2F624505461C} = {7D921888-FE03-4C3F-80FE-2F624505461C}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.OData.Client.Portable", "..\src\Microsoft.OData.Client\Build.Portable\Microsoft.OData.Client.Portable.csproj", "{AED0DC9D-76E5-4145-AF5E-9E2F856F4D18}"
+	ProjectSection(ProjectDependencies) = postProject
+		{5D921888-FE03-4C3F-40FE-2F624505461D} = {5D921888-FE03-4C3F-40FE-2F624505461D}
+		{7D921888-FE03-4C3F-80FE-2F624505461C} = {7D921888-FE03-4C3F-80FE-2F624505461C}
+		{989A83CC-B864-4A75-8BF3-5EDA99203A86} = {989A83CC-B864-4A75-8BF3-5EDA99203A86}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Test.OData.Framework.Portable", "..\test\EndToEndTests\Framework\Core\Build.PortableLibrary\Microsoft.Test.OData.Framework.Portable.csproj", "{134D2AD7-3C82-45C9-AC43-75F482081F8D}"
+	ProjectSection(ProjectDependencies) = postProject
+		{5D921888-FE03-4C3F-40FE-2F624505461D} = {5D921888-FE03-4C3F-40FE-2F624505461D}
+		{7D921888-FE03-4C3F-80FE-2F624505461C} = {7D921888-FE03-4C3F-80FE-2F624505461C}
+		{989A83CC-B864-4A75-8BF3-5EDA99203A86} = {989A83CC-B864-4A75-8BF3-5EDA99203A86}
+		{AED0DC9D-76E5-4145-AF5E-9E2F856F4D18} = {AED0DC9D-76E5-4145-AF5E-9E2F856F4D18}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Test.OData.Services.TestServices.Portable", "..\test\EndToEndTests\Services\TestServices\Build.PortableLibrary\Microsoft.Test.OData.Services.TestServices.Portable.csproj", "{4382D649-1A86-48D0-9156-AC37C3D568C0}"
+	ProjectSection(ProjectDependencies) = postProject
+		{5D921888-FE03-4C3F-40FE-2F624505461D} = {5D921888-FE03-4C3F-40FE-2F624505461D}
+		{7D921888-FE03-4C3F-80FE-2F624505461C} = {7D921888-FE03-4C3F-80FE-2F624505461C}
+		{989A83CC-B864-4A75-8BF3-5EDA99203A86} = {989A83CC-B864-4A75-8BF3-5EDA99203A86}
+		{AED0DC9D-76E5-4145-AF5E-9E2F856F4D18} = {AED0DC9D-76E5-4145-AF5E-9E2F856F4D18}
+		{134D2AD7-3C82-45C9-AC43-75F482081F8D} = {134D2AD7-3C82-45C9-AC43-75F482081F8D}
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Test.OData.Tests.Client.Portable.WindowsStore", "..\test\EndToEndTests\Tests\Client\Build.PortableLibrary.WindowsStore\Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.csproj", "{D3F99EBE-1535-4F31-9C08-BEFEBF27CE2B}"
+	ProjectSection(ProjectDependencies) = postProject
+		{5D921888-FE03-4C3F-40FE-2F624505461D} = {5D921888-FE03-4C3F-40FE-2F624505461D}
+		{7D921888-FE03-4C3F-80FE-2F624505461C} = {7D921888-FE03-4C3F-80FE-2F624505461C}
+		{989A83CC-B864-4A75-8BF3-5EDA99203A86} = {989A83CC-B864-4A75-8BF3-5EDA99203A86}
+		{AED0DC9D-76E5-4145-AF5E-9E2F856F4D18} = {AED0DC9D-76E5-4145-AF5E-9E2F856F4D18}
+		{134D2AD7-3C82-45C9-AC43-75F482081F8D} = {134D2AD7-3C82-45C9-AC43-75F482081F8D}
+		{4382D649-1A86-48D0-9156-AC37C3D568C0} = {4382D649-1A86-48D0-9156-AC37C3D568C0}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
### Issues
*This pull request fixes issue #810.*  

### Description
- Updating build.ps1 to skip building the Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln if VS2013 is not installed. This is due to the fact that Windows 8.0 apps are not supported with VS2015. We will not force users to install multiple versions of Visual Studio, but if they happen to have VS2013 installed, we'll build the solution as it provides additional local validation of code changes. We will have automation that will build the solution.
- Updating Microsoft.Test.OData.Tests.Client.Portable.WindowsStore.sln to build the projects in order in the event of race conditions during build.
- Adding .NET Core packages to nuget for the .NET Standard solution.

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added (N/A)
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
N/A
