### PR TITLE
Support average for dynamic properties

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -110,6 +110,8 @@ namespace Microsoft.OData.UriParser.Aggregation
                             return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Double, expressionType.IsNullable);
                         case EdmPrimitiveTypeKind.Decimal:
                             return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Decimal, expressionType.IsNullable);
+                        case EdmPrimitiveTypeKind.None:
+                            return expressionType;
                         default:
                             throw new ODataException(
                                 ODataErrorStrings.ApplyBinder_AggregateExpressionIncompatibleTypeForMethod(expression,

--- a/src/Microsoft.OData.Edm/ExtensionMethods/EdmTypeSemantics.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/EdmTypeSemantics.cs
@@ -1108,7 +1108,10 @@ namespace Microsoft.OData.Edm
         /// <returns>The primitive kind of the definition of this reference.</returns>
         public static EdmPrimitiveTypeKind PrimitiveKind(this IEdmTypeReference type)
         {
-            EdmUtil.CheckArgumentNull(type, "type");
+            if (type == null)
+            {
+                return EdmPrimitiveTypeKind.None;
+            }
             IEdmType typeDefinition = type.Definition;
             if (typeDefinition.TypeKind != EdmTypeKind.Primitive)
             {

--- a/src/Microsoft.OData.Edm/ExtensionMethods/EdmTypeSemantics.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/EdmTypeSemantics.cs
@@ -1112,6 +1112,7 @@ namespace Microsoft.OData.Edm
             {
                 return EdmPrimitiveTypeKind.None;
             }
+
             IEdmType typeDefinition = type.Definition;
             if (typeDefinition.TypeKind != EdmTypeKind.Primitive)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -101,10 +101,15 @@ namespace Microsoft.OData.Tests
             this.CreateFeedContextUri(applyClause).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(TotalId)");
         }
 
-        [Fact]
-        public void FeedContextUriWithApplyAggreagateOnDynamicProperty()
+        [Theory]
+        [InlineData("sum")]
+        [InlineData("average")]
+        [InlineData("max")]
+        [InlineData("min")]
+        [InlineData("countdistinct")]
+        public void FeedContextUriWithApplyAggreagateOnDynamicProperty(string method)
         {
-            string applyClause = "aggregate(DynamicProperty with sum as DynamicPropertyTotal)";
+            string applyClause = "aggregate(DynamicProperty with " + method +" as DynamicPropertyTotal)";
 
             this.CreateFeedContextUri(applyClause).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)");
         }


### PR DESCRIPTION
### Issues
*This pull request fixes issue #760.*  

### Description
*Dynamic properties don't have type. PR https://github.com/OData/odata.net/pull/808 added support, but average aggregation method wasn't supported.*
It's port for https://github.com/OData/odata.net/pull/813

### Checklist (Uncheck if it is not completed)
- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

