### PR TITLE
Remove unreachable code block for collection reader.

### DIFF
--- a/src/Microsoft.OData.Core/ODataCollectionReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionReaderCore.cs
@@ -208,11 +208,6 @@ namespace Microsoft.OData
                     result = this.ReadAtCollectionEndImplementation();
                     break;
 
-                case ODataCollectionReaderState.Exception:    // fall through
-                case ODataCollectionReaderState.Completed:
-                    Debug.Assert(false, "This case should have been caught earlier.");
-                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataCollectionReaderCore_ReadImplementation));
-
                 default:
                     Debug.Assert(false, "Unsupported collection reader state " + this.State + " detected.");
                     throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataCollectionReaderCore_ReadImplementation));

--- a/src/Microsoft.OData.Core/ODataCollectionReaderCoreAsync.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionReaderCoreAsync.cs
@@ -86,11 +86,6 @@ namespace Microsoft.OData
                 case ODataCollectionReaderState.CollectionEnd:
                     return this.ReadAtCollectionEndImplementationAsync();
 
-                case ODataCollectionReaderState.Exception:    // fall through
-                case ODataCollectionReaderState.Completed:
-                    Debug.Assert(false, "This case should have been caught earlier.");
-                    return TaskUtils.GetFaultedTask<bool>(new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataCollectionReaderCoreAsync_ReadAsynchronously)));
-
                 default:
                     Debug.Assert(false, "Unsupported collection reader state " + this.State + " detected.");
                     return TaskUtils.GetFaultedTask<bool>(new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataCollectionReaderCoreAsync_ReadAsynchronously)));


### PR DESCRIPTION
### Issues
*Improve test code coverage.*  

### Description
*ReadImplmentation() or ReadAsynchronously() has some unreachable code blocked by ODataCollectionReaderCore.VerifyCanRead() processing. Approach here is to remove the unreachable code from the src; another alternative is to add test along with src code change to circumvent internal processing of VerifyCanReader so that ReadImplementation/ReadAsynchronously can be unblocked.*
*The first approach is preferred, since the second approach also needs src code change which is hacky. I can share the second approach as needed.*

### Checklist (Uncheck if it is not completed)
- [  ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
