### PR TITLE
add test cases for the ODataAtomErrorDeserializer coverage

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/MetadataReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/MetadataReaderTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -27,9 +28,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader
   <edmx:DataServices>
     <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""demo"">    
         <ComplexType Name=""C1"" BaseType=""demo.B1"">
-        </ComplexType>      
+        </ComplexType>
         <ComplexType Name=""B1"">
-        </ComplexType>    
+        </ComplexType>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>";
@@ -62,7 +63,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader
   <edmx:DataServices>
     <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""demo"">    
         <ComplexType Name=""C1"" BaseType=""demo.B1"">
-        </ComplexType>    
+        </ComplexType>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>";
@@ -74,7 +75,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader
   <edmx:DataServices>
     <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""demo"">    
         <ComplexType Name=""B1"">
-        </ComplexType>    
+        </ComplexType>
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>";
@@ -91,6 +92,114 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader
             var b1 = model.FindType("demo.B1").As<IEdmComplexType>();
             b1.Should().NotBeNull();
             b1.IsAssignableFrom(c1).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ReadErrorMetadataDocumentThrows()
+        {
+            string payload =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<m:error xmlns:m=""http://docs.oasis-open.org/odata/ns/metadata"">
+  <m:code>code42</m:code>
+  <m:message>message text</m:message>
+</m:error>";
+
+            Dictionary<string, string> map = new Dictionary<string, string>()
+            {
+                {"main", payload}
+            };
+
+            Action test = () => this.ReadMetadataDocument(map, "main");
+
+            var exception =
+                test.ShouldThrow<ODataErrorException>()
+                    .WithMessage("An error was read from the payload. See the 'Error' property for more details.");
+            exception.Subject.GetType().Should().Be<ODataErrorException>();
+            var odataErrorException = exception.Subject as ODataErrorException;
+            odataErrorException.Should().NotBeNull();
+            odataErrorException.Error.ErrorCode.Should().Be("code42");
+            odataErrorException.Error.Message.Should().Be("message text");
+        }
+
+        [Fact]
+        public void VerifyErrorElementNotFoundForErrorMetadataDocumentThrows()
+        {
+            string payload =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<m:error xmlns:m=""http://docs.oasis-open.org/odata/ns/metadata"">
+  <m:code>code42</m:code>
+  <m:code>code54</m:code>
+  <m:message>message text</m:message>
+</m:error>";
+
+            Dictionary<string, string> map = new Dictionary<string, string>()
+            {
+                {"main", payload}
+            };
+
+            Action test = () => this.ReadMetadataDocument(map, "main");
+            test.ShouldThrow<ODataException>()
+                .WithMessage(Strings.ODataAtomErrorDeserializer_MultipleErrorElementsWithSameName("code"));
+        }
+
+        [Fact]
+        public void ReadInnerErrorMetadataDocumentThrows()
+        {
+            string payload =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<m:error xmlns:m=""http://docs.oasis-open.org/odata/ns/metadata"">
+  <m:code>code42</m:code>
+  <m:message>message text</m:message>
+  <m:innererror>
+    <m:message>some inner error</m:message>
+    <m:type></m:type>
+    <m:stacktrace></m:stacktrace>
+    <m:internalexception></m:internalexception>
+  </m:innererror>
+</m:error>";
+
+            Dictionary<string, string> map = new Dictionary<string, string>()
+            {
+                {"main", payload}
+            };
+
+            Action test = () => this.ReadMetadataDocument(map, "main");
+
+            var exception =
+                test.ShouldThrow<ODataErrorException>()
+                    .WithMessage("An error was read from the payload. See the 'Error' property for more details.");
+            exception.Subject.GetType().Should().Be<ODataErrorException>();
+            var odataErrorException = exception.Subject as ODataErrorException;
+            odataErrorException.Should().NotBeNull();
+            odataErrorException.Error.ErrorCode.Should().Be("code42");
+            odataErrorException.Error.Message.Should().Be("message text");
+            odataErrorException.Error.InnerError.Message.Should().Be("some inner error");
+        }
+
+        [Fact]
+        public void VerifyInnerErrorElementNotFoundForErrorMetadataDocumentThrows()
+        {
+            string payload =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<m:error xmlns:m=""http://docs.oasis-open.org/odata/ns/metadata"">
+  <m:code>code42</m:code>
+  <m:message>message text</m:message>
+  <m:innererror>
+    <m:message>some inner error</m:message>
+    <m:type></m:type>
+    <m:stacktrace></m:stacktrace>
+    <m:stacktrace>my trackstrace</m:stacktrace>
+  </m:innererror>
+</m:error>";
+
+            Dictionary<string, string> map = new Dictionary<string, string>()
+            {
+                {"main", payload}
+            };
+
+            Action test = () => this.ReadMetadataDocument(map, "main");
+            test.ShouldThrow<ODataException>()
+                .WithMessage(Strings.ODataAtomErrorDeserializer_MultipleInnerErrorElementsWithSameName("stacktrace"));
         }
 
         private IEdmModel ReadMetadataDocument(Dictionary<string, string> map, string mainUrl)


### PR DESCRIPTION


### Issues

Related to MQ/QP.

### Description

* Originally, there are 113/100% codes missing. We should to add test cases to cover most of codes in it.
* After added, 

![image](https://user-images.githubusercontent.com/9426627/27346238-626ba1ec-55a1-11e7-9697-90418e3495af.png)


### Checklist (Uncheck if it is not completed)

- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary
* None
