### PR TITLE
Add Support for PrimitiveType casts

### DIFF
--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -1632,6 +1632,9 @@
     <Compile Include="..\UriParser\SemanticAst\SingleComplexNode.cs">
       <Link>Microsoft\OData\Core\UriParser\SemanticAst\SingleComplexNode.cs</Link>
     </Compile>
+    <Compile Include="..\UriParser\SemanticAst\SingleValueCastNode.cs">
+      <Link>Microsoft\OData\Core\UriParser\SemanticAst\SingleValueCastNode.cs</Link>
+    </Compile>
     <Compile Include="..\UriParser\SemanticAst\SingleResourceCastNode.cs">
       <Link>Microsoft\OData\Core\UriParser\SemanticAst\SingleResourceCastNode.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
+++ b/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
@@ -1457,6 +1457,9 @@
     <Compile Include="..\UriParser\SemanticAst\SingleNavigationNode.cs">
       <Link>UriParser\SemanticAst\SingleNavigationNode.cs</Link>
     </Compile>
+    <Compile Include="..\UriParser\SemanticAst\SingleValueCastNode.cs">
+      <Link>UriParser\SemanticAst\SingleValueCastNode.cs</Link>
+    </Compile>
     <Compile Include="..\UriParser\SemanticAst\SingleResourceCastNode.cs">
       <Link>UriParser\SemanticAst\SingleResourceCastNode.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -73,6 +73,7 @@
     <Compile Include="UriParser\SemanticAst\ComputeExpression.cs" />
     <Compile Include="UriParser\SemanticAst\CountVirtualPropertyNode.cs" />
     <Compile Include="UriParser\SemanticAst\SingleComplexNode.cs" />
+    <Compile Include="UriParser\SemanticAst\SingleValueCastNode.cs" />
     <Compile Include="UriParser\SemanticAst\SingleResourceNode.cs" />
     <Compile Include="UriParser\SyntacticAst\ComputeToken.cs" />
     <Compile Include="UriParser\SyntacticAst\ComputeExpressionToken.cs" />

--- a/src/Microsoft.OData.Core/UriParser/Binders/DottedIdentifierBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/DottedIdentifierBinder.cs
@@ -82,7 +82,15 @@ namespace Microsoft.OData.UriParser
                     IEdmTypeReference edmTypeReference = UriEdmHelpers.FindTypeFromModel(state.Model, dottedIdentifierToken.Identifier, this.Resolver).ToTypeReference();
                     if (edmTypeReference is IEdmPrimitiveTypeReference || edmTypeReference is IEdmEnumTypeReference)
                     {
-                        return new ConstantNode(dottedIdentifierToken.Identifier, dottedIdentifierToken.Identifier);
+                        IEdmPrimitiveType childPrimitiveType = childType as IEdmPrimitiveType;
+                        if (childPrimitiveType != null && dottedIdentifierToken.NextToken != null)
+                        {
+                            return new SingleValueCastNode(parent as SingleValueNode, childPrimitiveType);
+                        }
+                        else
+                        {
+                            return new ConstantNode(dottedIdentifierToken.Identifier, dottedIdentifierToken.Identifier);
+                        }
                     }
                     else
                     {

--- a/src/Microsoft.OData.Core/UriParser/Binders/InnerPathTokenBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InnerPathTokenBinder.cs
@@ -171,6 +171,10 @@ namespace Microsoft.OData.UriParser
                 state.ParsedSegments.Add(new PropertySegment(structuralProperty));
                 return new SingleComplexNode(singleValueParent as SingleResourceNode, property);
             }
+            else if (property.Type.IsPrimitive())
+            {
+                return new SingleValuePropertyAccessNode(singleValueParent, property);
+            }
 
             // Note - this means nonentity collection (primitive or complex)
             if (property.Type.IsNonEntityCollectionType())

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SingleValueCastNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SingleValueCastNode.cs
@@ -1,0 +1,76 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="SingleValueCastNode.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+
+namespace Microsoft.OData.UriParser
+{
+    /// <summary>
+    /// Node representing a type segment that casts a single primitive value node.
+    /// </summary>
+    public sealed class SingleValueCastNode : SingleValueNode
+    {
+        /// <summary>
+        /// The resource that we're casting to a different type.
+        /// </summary>
+        private readonly SingleValueNode source;
+
+        /// <summary>
+        /// The target type that the source is cast to.
+        /// </summary>
+        private readonly IEdmPrimitiveTypeReference primitiveTypeReference;
+
+        /// <summary>
+        /// Created a SingleValueCastNode with the given source node and the given type to cast to.
+        /// </summary>
+        /// <param name="source"> Source <see cref="SingleValueNode"/> that is being cast.</param>
+        /// <param name="primitiveType">Type to cast to.</param>
+        /// <exception cref="System.ArgumentNullException">Throws if the input primitiveType is null.</exception>
+        public SingleValueCastNode(SingleValueNode source, IEdmPrimitiveType primitiveType)
+        {
+            ExceptionUtils.CheckArgumentNotNull(source, "source");
+            ExceptionUtils.CheckArgumentNotNull(primitiveType, "primitiveType");
+            this.source = source;
+            this.primitiveTypeReference = new EdmPrimitiveTypeReference(primitiveType, true);
+        }
+
+        /// <summary>
+        /// Gets the property that we're casting to a different type.
+        /// </summary>
+        public SingleValueNode Source
+        {
+            get { return this.source; }
+        }
+
+        /// <summary>
+        /// Gets the target type that the source is cast to.
+        /// </summary>
+        public override IEdmTypeReference TypeReference
+        {
+            get { return this.primitiveTypeReference; }
+        }
+
+        /// <summary>
+        /// Gets the kind of this query node.
+        /// </summary>
+        internal override InternalQueryNodeKind InternalKind
+        {
+            get { return InternalQueryNodeKind.SingleValueCast; }
+        }
+
+        /// <summary>
+        /// Accept a <see cref="QueryNodeVisitor{T}"/> that walks a tree of <see cref="QueryNode"/>s.
+        /// </summary>
+        /// <typeparam name="T">Type that the visitor will return after visiting this token.</typeparam>
+        /// <param name="visitor">An implementation of the visitor interface.</param>
+        /// <returns>An object whose type is determined by the type parameter of the visitor.</returns>
+        public override T Accept<T>(QueryNodeVisitor<T> visitor)
+        {
+            ExceptionUtils.CheckArgumentNotNull(visitor, "visitor");
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/TreeNodeKinds/QueryNodeKind.cs
+++ b/src/Microsoft.OData.Core/UriParser/TreeNodeKinds/QueryNodeKind.cs
@@ -158,6 +158,11 @@ namespace Microsoft.OData.UriParser
         /// Count of a collection contains primitive or enum or complex or entity type.
         /// </summary>
         Count = InternalQueryNodeKind.Count,
+
+        /// <summary>
+        /// Cast on a single value.
+        /// </summary>
+        SingleValueCast = InternalQueryNodeKind.SingleValueCast,
     }
 
     /// <summary>
@@ -309,5 +314,10 @@ namespace Microsoft.OData.UriParser
         /// Node describing count of a collection contains primitive or enum or complex or entity type.
         /// </summary>
         Count = 28,
+
+        /// <summary>
+        /// Cast on a single value.
+        /// </summary>
+        SingleValueCast = 29,
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Visitors/QueryNodeVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/QueryNodeVisitor.cs
@@ -273,5 +273,15 @@ namespace Microsoft.OData.UriParser
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Visit a SingleValueCastNode
+        /// </summary>
+        /// <param name="nodeIn">the node to visit</param>
+        /// <returns>Defined by the implementer</returns>
+        public virtual T Visit(SingleValueCastNode nodeIn)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -157,6 +157,46 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void SelectWithCastProperty()
+        {
+            SelectExpandClause select = RunParseSelectExpand("Artist/Edm.String", null, HardCodedTestModel.GetPaintingType(), HardCodedTestModel.GetPaintingsSet());
+            List<SelectItem> items = select.SelectedItems.ToList();
+            items.Count.Should().Be(1);
+
+            ODataPathSegment[] segments = new ODataPathSegment[2];
+            segments[0] = new PropertySegment(HardCodedTestModel.GetPaintingArtistProp());
+            segments[1] = new TypeSegment(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.String), null);
+            items[0].ShouldBePathSelectionItem(new ODataPath(segments));
+        }
+
+        [Fact]
+        public void SelectWithCastOpenProperty()
+        {
+            SelectExpandClause select = RunParseSelectExpand("Assistant/Edm.String", null, HardCodedTestModel.GetPaintingType(), HardCodedTestModel.GetPaintingsSet());
+            List<SelectItem> items = select.SelectedItems.ToList();
+            items.Count.Should().Be(1);
+
+            ODataPathSegment[] segments = new ODataPathSegment[2];
+            segments[0] = new DynamicPathSegment("Assistant");
+            segments[1] = new TypeSegment(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.String), null);
+            items[0].ShouldBePathSelectionItem(new ODataPath(segments));
+        }
+
+        [Fact]
+        public void SelectWithCastOpenComplexProperty()
+        {
+            SelectExpandClause select = RunParseSelectExpand("Exhibit/Location/Edm.String", null, HardCodedTestModel.GetPaintingType(), HardCodedTestModel.GetPaintingsSet());
+            List<SelectItem> items = select.SelectedItems.ToList();
+            items.Count.Should().Be(1);
+
+            ODataPathSegment[] segments = new ODataPathSegment[3];
+            segments[0] = new DynamicPathSegment("Exhibit");
+            segments[1] = new DynamicPathSegment("Location");
+            segments[2] = new TypeSegment(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.String), null);
+            items[0].ShouldBePathSelectionItem(new ODataPath(segments));
+        }
+
+        [Fact]
         public void SelectActionMeansOperation()
         {
             ParseSingleSelectForDog("Fully.Qualified.Namespace.Walk", "Fully.Qualified.Namespace.Walk").ShouldBePathSelectionItem(new ODataPath(new OperationSegment(new List<IEdmOperation>() { HardCodedTestModel.GetDogWalkAction() }, null)));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/NodeAssertions.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/NodeAssertions.cs
@@ -315,9 +315,9 @@ namespace Microsoft.OData.Tests.UriParser
         public static AndConstraint<SingleResourceCastNode> ShouldBeSingleResourceCastNode(this QueryNode node, IEdmTypeReference expectedTypeReference)
         {
             node.Should().BeOfType<SingleResourceCastNode>();
-            var singlePropertyCastNode = node.As<SingleResourceCastNode>();
-            singlePropertyCastNode.TypeReference.ShouldBeEquivalentTo(expectedTypeReference);
-            return new AndConstraint<SingleResourceCastNode>(singlePropertyCastNode);
+            var singleValueCastNode = node.As<SingleResourceCastNode>();
+            singleValueCastNode.TypeReference.ShouldBeEquivalentTo(expectedTypeReference);
+            return new AndConstraint<SingleResourceCastNode>(singleValueCastNode);
         }
 
         public static AndConstraint<CollectionResourceCastNode> ShouldBeCollectionResourceCastNode(this QueryNode node, IEdmTypeReference expectedTypeReference)

--- a/test/FunctionalTests/Service/Microsoft/OData/Service/Parsing/NodeToExpressionTranslator.cs
+++ b/test/FunctionalTests/Service/Microsoft/OData/Service/Parsing/NodeToExpressionTranslator.cs
@@ -348,6 +348,27 @@ namespace Microsoft.OData.Service.Parsing
         }
 
         /// <summary>
+        /// Translates a <see cref="SingleValueCastNode"/> into a corresponding <see cref="Expression"/>.
+        /// </summary>
+        /// <param name="node">The node to translate.</param>
+        /// <returns>The translated expression.</returns>
+        public override Expression Visit(SingleValueCastNode node)
+        {
+            WebUtil.CheckArgumentNull(node, "node");
+
+            // Whenever we encounter the type segment, we need to only verify that the MPV is set to 4.0 or higher.
+            // There is no need to check for request DSV, request MaxDSV since there are no protocol changes in
+            // the payload for uri's with type identifier.
+            this.verifyProtocolVersion(ODataProtocolVersion.V4);
+
+            Expression source = this.TranslateNode(node.Source);
+            ResourceType resourceType = MetadataProviderUtils.GetResourceType(node.TypeReference.Definition);
+            Debug.Assert(resourceType != null, "resourceType != null");
+
+            return ExpressionGenerator.GenerateTypeAs(source, resourceType);
+        }
+
+        /// <summary>
         /// Translates a <see cref="SingleNavigationNode"/> into a corresponding <see cref="Expression"/>.
         /// </summary>
         /// <param name="node">The node to translate.</param>

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5175,6 +5175,7 @@ public enum Microsoft.OData.UriParser.QueryNodeKind : int {
 	SingleNavigationNode = 11
 	SingleResourceCast = 13
 	SingleResourceFunctionCall = 17
+	SingleValueCast = 29
 	SingleValueFunctionCall = 8
 	SingleValueOpenPropertyAccess = 12
 	SingleValuePropertyAccess = 6
@@ -5393,6 +5394,7 @@ public abstract class Microsoft.OData.UriParser.QueryNodeVisitor`1 {
 	public virtual T Visit (Microsoft.OData.UriParser.SingleNavigationNode nodeIn)
 	public virtual T Visit (Microsoft.OData.UriParser.SingleResourceCastNode nodeIn)
 	public virtual T Visit (Microsoft.OData.UriParser.SingleResourceFunctionCallNode nodeIn)
+	public virtual T Visit (Microsoft.OData.UriParser.SingleValueCastNode nodeIn)
 	public virtual T Visit (Microsoft.OData.UriParser.SingleValueFunctionCallNode nodeIn)
 	public virtual T Visit (Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode nodeIn)
 	public virtual T Visit (Microsoft.OData.UriParser.SingleValuePropertyAccessNode nodeIn)
@@ -6395,6 +6397,15 @@ public sealed class Microsoft.OData.UriParser.SingletonSegment : Microsoft.OData
 
 	public virtual void HandleWith (Microsoft.OData.UriParser.PathSegmentHandler handler)
 	public virtual T TranslateWith (PathSegmentTranslator`1 translator)
+}
+
+public sealed class Microsoft.OData.UriParser.SingleValueCastNode : Microsoft.OData.UriParser.SingleValueNode {
+	public SingleValueCastNode (Microsoft.OData.UriParser.SingleValueNode source, Microsoft.OData.Edm.IEdmPrimitiveType primitiveType)
+
+	Microsoft.OData.UriParser.SingleValueNode Source  { public get; }
+	Microsoft.OData.Edm.IEdmTypeReference TypeReference  { public virtual get; }
+
+	public virtual T Accept (QueryNodeVisitor`1 visitor)
 }
 
 public sealed class Microsoft.OData.UriParser.SingleValueFunctionCallNode : Microsoft.OData.UriParser.SingleValueNode {


### PR DESCRIPTION
### Issues

This pull request fixes issue #801 and #747 

### Description

Modify the binding operations so that type casts and dynamic properties on dynamic complex properties can be successfully bound to Nodes during the parsing process.

### Checklist (Uncheck if it is not completed)

- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

No documentation changes needed.
