### PR TITLE
Clean up codes related to Spatial type deseializer

### DIFF
--- a/src/Microsoft.OData.Core/GeographyTypeConverter.cs
+++ b/src/Microsoft.OData.Core/GeographyTypeConverter.cs
@@ -19,27 +19,6 @@ namespace Microsoft.OData
     internal sealed class GeographyTypeConverter : IPrimitiveTypeConverter
     {
         /// <summary>
-        /// Create a geography instance from the value in an Xml reader.
-        /// </summary>
-        /// <param name="reader">The Xml reader to use to read the value.</param>
-        /// <remarks>In order to be consistent with how we are reading other types of property values elsewhere in the product, the reader
-        /// is expected to be placed at the beginning of the element when entering this method. After this method call, the reader will be placed
-        /// at the EndElement, such that the next Element will be read in the next Read call. The deserializer that uses this value expects
-        /// the reader to be in these states when entering and leaving the method.
-        /// </remarks>
-        /// <returns>Geography instance that was read.</returns>
-        public object TokenizeFromXml(XmlReader reader)
-        {
-            Debug.Assert(reader.NodeType == XmlNodeType.Element, "reader at element");
-            reader.ReadStartElement(); // <d:Property>
-
-            Geography geography = GmlFormatter.Create().Read<Geography>(reader);
-            reader.SkipInsignificantNodes();
-            Debug.Assert(reader.NodeType == XmlNodeType.EndElement, "reader at end of current element");
-            return geography;
-        }
-
-        /// <summary>
         /// Write the Atom representation of an instance of a primitive type to an XmlWriter.
         /// </summary>
         /// <param name="instance">The instance to write.</param>

--- a/src/Microsoft.OData.Core/GeometryTypeConverter.cs
+++ b/src/Microsoft.OData.Core/GeometryTypeConverter.cs
@@ -23,27 +23,6 @@ namespace Microsoft.OData
     internal sealed class GeometryTypeConverter : IPrimitiveTypeConverter
     {
         /// <summary>
-        /// Create a Geometry instance from the value in an Xml reader.
-        /// </summary>
-        /// <param name="reader">The Xml reader to use to read the value.</param>
-        /// <remarks>In order to be consistent with how we are reading other types of property values elsewhere in the product, the reader
-        /// is expected to be placed at the beginning of the element when entering this method. After this method call, the reader will be placed
-        /// at the EndElement, such that the next Element will be read in the next Read call. The deserializer that uses this value expects
-        /// the reader to be in these states when entering and leaving the method.
-        /// </remarks>
-        /// <returns>Geometry instance that was read.</returns>
-        public object TokenizeFromXml(XmlReader reader)
-        {
-            Debug.Assert(reader.NodeType == XmlNodeType.Element, "reader at element");
-            reader.ReadStartElement(); // <d:Property>
-
-            Geometry geometry = GmlFormatter.Create().Read<Geometry>(reader);
-            reader.SkipInsignificantNodes();
-            Debug.Assert(reader.NodeType == XmlNodeType.EndElement, "reader at end of current element");
-            return geometry;
-        }
-
-        /// <summary>
         /// Write the Atom representation of an instance of a primitive type to an XmlWriter.
         /// </summary>
         /// <param name="instance">The instance to write.</param>

--- a/src/Microsoft.OData.Core/IPrimitiveTypeConverter.cs
+++ b/src/Microsoft.OData.Core/IPrimitiveTypeConverter.cs
@@ -19,13 +19,6 @@ namespace Microsoft.OData
     internal interface IPrimitiveTypeConverter
     {
         /// <summary>
-        /// Create an instance of a primitive type from the value in an Xml reader.
-        /// </summary>
-        /// <param name="reader">The Xml reader to use to read the value.</param>
-        /// <returns>An instance of the primitive type.</returns>
-        object TokenizeFromXml(XmlReader reader);
-
-        /// <summary>
         /// Write the Atom representation of an instance of a primitive type to an XmlWriter.
         /// </summary>
         /// <param name="instance">The instance to write.</param>

--- a/src/Microsoft.OData.Core/Metadata/XmlReaderExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/XmlReaderExtensions.cs
@@ -132,43 +132,6 @@ namespace Microsoft.OData.Metadata
         }
 
         /// <summary>
-        /// Reads from the XML reader skipping insignificant nodes.
-        /// </summary>
-        /// <param name="reader">The XML reader to read from.</param>
-        /// <remarks>Do not use MoveToContent since for backward compatibility reasons we skip over nodes reported as Text which have
-        /// whitespace only content (even though the XmlReader should report those as Whitespace).</remarks>
-        internal static void SkipInsignificantNodes(this XmlReader reader)
-        {
-            Debug.Assert(reader != null, "reader != null");
-
-            do
-            {
-                switch (reader.NodeType)
-                {
-                    case XmlNodeType.Element:
-                        return;
-                    case XmlNodeType.Comment:
-                    case XmlNodeType.None:
-                    case XmlNodeType.ProcessingInstruction:
-                    case XmlNodeType.XmlDeclaration:
-                    case XmlNodeType.Whitespace:
-                        break;
-                    case XmlNodeType.Text:
-                        if (IsNullOrWhitespace(reader.Value))
-                        {
-                            break;
-                        }
-
-                        return;
-
-                    default:
-                        return;
-                }
-            }
-            while (reader.Read());
-        }
-
-        /// <summary>
         /// Determines if the current node's namespace equals to the specified <paramref name="namespaceUri"/>
         /// </summary>
         /// <param name="reader">The XML reader to get the current node from.</param>
@@ -220,31 +183,6 @@ namespace Microsoft.OData.Metadata
             }
 
             return false;
-        }
-
-        /// <summary>
-        /// Checks whether the specifies string is null or blank.
-        /// </summary>
-        /// <param name="text">Text to check.</param>
-        /// <returns>true if text is null, empty, or all whitespace characters.</returns>
-        private static bool IsNullOrWhitespace(string text)
-        {
-            if (text == null)
-            {
-                return true;
-            }
-            else
-            {
-                foreach (char c in text)
-                {
-                    if (!char.IsWhiteSpace(c))
-                    {
-                        return false;
-                    }
-                }
-
-                return true;
-            }
         }
     }
 }

--- a/src/Microsoft.OData.Core/PrimitiveConverter.cs
+++ b/src/Microsoft.OData.Core/PrimitiveConverter.cs
@@ -78,32 +78,6 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Try to create an object of type <paramref name="targetType"/> from the value in <paramref name="reader" />.
-        /// </summary>
-        /// <param name="reader">XmlReader to use to read the value.</param>
-        /// <param name="targetType">Expected type of the value in the reader.</param>
-        /// <param name="tokenizedPropertyValue">Object of type <paramref name="targetType"/>, null if no object could be created.</param>
-        /// <returns>True if the value was converted to the specified type, otherwise false.</returns>
-        internal bool TryTokenizeFromXml(XmlReader reader, Type targetType, out object tokenizedPropertyValue)
-        {
-            tokenizedPropertyValue = null;
-
-            Debug.Assert(reader != null, "Expected a non-null XmlReader.");
-            Debug.Assert(reader.NodeType == XmlNodeType.Element, "Expected the reader to be at the start of an element.");
-            Debug.Assert(targetType != null, "Expected a valid type to convert value.");
-
-            IPrimitiveTypeConverter primitiveTypeConverter;
-            if (this.TryGetConverter(targetType, out primitiveTypeConverter))
-            {
-                tokenizedPropertyValue = primitiveTypeConverter.TokenizeFromXml(reader);
-                Debug.Assert(reader.NodeType == XmlNodeType.EndElement, "Expected reader to be at the end of an element");
-                return true;
-            }
-
-            return false;
-        }
-
-        /// <summary>
         /// Try to write the XML representation of <paramref name="instance"/> to the specified <paramref name="writer"/>
         /// </summary>
         /// <param name="instance">Object to convert to XML representation.</param>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Part of related to https://github.com/OData/odata.net/issues/846

### Description

The output of raw value of Spatial is JSON format. So, such codes are needless because they are assuming the xml format of Spatial date.

### Checklist (Uncheck if it is not completed)

- [    ] Test cases added
- [   ] Build and test with one-click build and test script passed

### Additional work necessary

It's part of code coverage related to Metadata subfolder.
