### PR TITLE
Raw Value serializer output json string for Spatial type

### DIFF
--- a/src/Microsoft.OData.Core/PrimitiveConverter.cs
+++ b/src/Microsoft.OData.Core/PrimitiveConverter.cs
@@ -78,34 +78,6 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Try to write the XML representation of <paramref name="instance"/> to the specified <paramref name="writer"/>
-        /// </summary>
-        /// <param name="instance">Object to convert to XML representation.</param>
-        /// <param name="writer">XmlWriter to use to write the converted value.</param>
-        /// <returns>True if the value was written, otherwise false.</returns>
-        internal bool TryWriteAtom(object instance, XmlWriter writer)
-        {
-            Debug.Assert(instance != null, "Expected a non-null instance to write.");
-            Debug.Assert(writer != null, "Expected a non-null XmlWriter.");
-
-            return this.TryWriteValue(instance, ptc => ptc.WriteAtom(instance, writer));
-        }
-
-        /// <summary>
-        /// Try to write the text representation of <paramref name="instance"/> to the specified <paramref name="writer"/>
-        /// </summary>
-        /// <param name="instance">Object to convert to text representation.</param>
-        /// <param name="writer">TextWriter to use to write the converted value.</param>
-        /// <returns>True if the value was written, otherwise false.</returns>
-        internal bool TryWriteAtom(object instance, TextWriter writer)
-        {
-            Debug.Assert(instance != null, "Expected a non-null instance to write.");
-            Debug.Assert(writer != null, "Expected a non-null TextWriter.");
-
-            return this.TryWriteValue(instance, ptc => ptc.WriteAtom(instance, writer));
-        }
-
-        /// <summary>
         /// Try to write the JSON Lite representation of <paramref name="instance"/> using a registered primitive type converter
         /// </summary>
         /// <param name="instance">Object to convert to JSON representation.</param>
@@ -120,26 +92,6 @@ namespace Microsoft.OData
             this.TryGetConverter(instanceType, out primitiveTypeConverter);
             Debug.Assert(primitiveTypeConverter != null, "primitiveTypeConverter != null");
             primitiveTypeConverter.WriteJsonLight(instance, jsonWriter);
-        }
-
-        /// <summary>
-        /// Tries to write the value of object instance using a registered primitive type converter.
-        /// </summary>
-        /// <param name="instance">Object to write.</param>
-        /// <param name="writeMethod">Method to use when writing the value, if a registered converter is found for the type.</param>
-        /// <returns>True if the value was written using a registered primitive type converter, otherwise false.</returns>
-        private bool TryWriteValue(object instance, Action<IPrimitiveTypeConverter> writeMethod)
-        {
-            Type instanceType = instance.GetType();
-
-            IPrimitiveTypeConverter primitiveTypeConverter;
-            if (this.TryGetConverter(instanceType, out primitiveTypeConverter))
-            {
-                writeMethod(primitiveTypeConverter);
-                return true;
-            }
-
-            return false;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/RawValueWriter.cs
+++ b/src/Microsoft.OData.Core/RawValueWriter.cs
@@ -40,6 +40,11 @@ namespace Microsoft.OData
         private TextWriter textWriter;
 
         /// <summary>
+        /// JsonWriter instance for writing values.
+        /// </summary>
+        private JsonWriter jsonWriter;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="RawValueWriter"/> class.
         /// Initializes the TextWriter.
         /// </summary>
@@ -59,10 +64,15 @@ namespace Microsoft.OData
         /// </summary>
         internal TextWriter TextWriter
         {
-            get
-            {
-                return this.textWriter;
-            }
+            get { return this.textWriter; }
+        }
+
+        /// <summary>
+        /// Gets the json writer.
+        /// </summary>
+        internal JsonWriter JsonWriter
+        {
+            get { return this.jsonWriter; }
         }
 
         /// <summary>
@@ -117,7 +127,7 @@ namespace Microsoft.OData
             }
             else if (value is Geometry || value is Geography)
             {
-                PrimitiveConverter.Instance.TryWriteAtom(value, textWriter);
+                PrimitiveConverter.Instance.WriteJsonLight(value, jsonWriter);
             }
             else if (ODataRawValueUtils.TryConvertPrimitiveToString(value, out valueAsString))
             {
@@ -166,6 +176,7 @@ namespace Microsoft.OData
             }
 
             this.textWriter = new StreamWriter(nonDisposingStream, this.encoding);
+            this.jsonWriter = new JsonWriter(this.textWriter, isIeee754Compatible: false);
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/ODataWCFServiceQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/ODataWCFServiceQueryTests.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
                 property = messageReader.ReadValue(new EdmStringTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.String), true));
             }
 
-            Assert.AreEqual("SRID=4326;POINT (23.1 32.1)", property);
+            Assert.AreEqual(@"{""type"":""Point"",""coordinates"":[23.1,32.1],""crs"":{""type"":""name"",""properties"":{""name"":""EPSG:4326""}}}", property);
         }
 
         [TestMethod]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/RawValueWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/RawValueWriterTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
 using System.IO;
 using System.Text;
 using FluentAssertions;
@@ -107,7 +108,7 @@ namespace Microsoft.OData.Tests
             RawValueWriter target = new RawValueWriter(this.settings, this.stream, new UTF32Encoding());
             var value = GeographyPoint.Create(22.2, 22.2);
             target.WriteRawValue(value);
-            this.StreamAsString(target).Should().Be("SRID=4326;POINT (22.2 22.2)");
+            this.StreamAsString(target).Should().Be(@"{""type"":""Point"",""coordinates"":[22.2,22.2],""crs"":{""type"":""name"",""properties"":{""name"":""EPSG:4326""}}}");
         }
 
         /// <summary>
@@ -117,9 +118,9 @@ namespace Microsoft.OData.Tests
         public void WriteRawValueWritesGeometryValue()
         {
             RawValueWriter target = new RawValueWriter(this.settings, this.stream, new UTF32Encoding());
-            var value2 = GeometryPoint.Create(1.2, 3.16);
-            target.WriteRawValue(value2);
-            this.StreamAsString(target).Should().Be("SRID=0;POINT (1.2 3.16)");
+            var value = GeometryPoint.Create(1.2, 3.16);
+            target.WriteRawValue(value);
+            this.StreamAsString(target).Should().Be(@"{""type"":""Point"",""coordinates"":[1.2,3.16],""crs"":{""type"":""name"",""properties"":{""name"":""EPSG:0""}}}");
         }
 
         private string StreamAsString(RawValueWriter target)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* #846 

### Description

In `RawValueWriter.cs`, There's a function named `WriteRawValue(object value)`, in which it has the following codes to write the Spatial object:

```C#
else if (value is Geometry || value is Geography)
{
   PrimitiveConverter.Instance.TryWriteAtom(value, textWriter);
}
```
However, it should call `WriteJsonLight`, not `TryWriteAtom`.

For example:
```C#
RawValueWriter target = new RawValueWriter(this.settings, this.stream, new UTF32Encoding());
var value2 = GeometryPoint.Create(1.2, 3.16);
target.WriteRawValue(value2);
```

Expected result

```json
{"type":"Point","coordinates":[1.2,3.16],"crs":{"type":"name","properties":{"name":"EPSG:4326"}}}
```
Actual result
```txt
RID=4326;POINT (1.2 3.16)
```
### Checklist (Uncheck if it is not completed)

- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary


