### PR TITLE
Assert DateTimeOffset equality on DateTimeOffset object

### DIFF
--- a/test/EndToEndTests/Tests/Client/Build.Desktop/SingletonTests/SingletonQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/SingletonTests/SingletonQueryTests.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Test.OData.Tests.Client.SingletonTests
                 ODataProperty property = this.QueryProperty("VipCustomer/Orders(8)/OrderDate", mimeType);
                 if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
                 {
-                    Assert.AreEqual("3/4/2011 4:03:57 PM -08:00", property.Value.ToString());
+                    Assert.AreEqual(new DateTimeOffset(2011, 3, 4, 16, 3, 57, TimeSpan.FromHours(-8)), property.Value);
                 }
             }
         }


### PR DESCRIPTION
This will make the test pass even on systems configured with a non-US culture