### PR TITLE
Standardize on EntityFramework 5.0 for tests to reduce race conditions

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -297,12 +297,6 @@ Function RunBuild ($sln, $vsToolVersion)
     }
 }
 
-Function RestoringFile ($file , $target)
-{
-    Write-Host "Restoring $file"
-    Copy-Item -Path $file -Destination $target -Force
-}
-
 Function FailedTestLog ($playlist , $reruncmd , $failedtest1 ,$failedtest2)
 {    
     Write-Output "<Playlist Version=`"1.0`">" | Out-File $playlist
@@ -338,8 +332,6 @@ Function FailedTestLog ($playlist , $reruncmd , $failedtest1 ,$failedtest2)
     if ($failedtest1.count -gt 0)
     {
         $rerun += " " + $XUNITADAPTER
-        Write-Output "copy /y $NUGETPACK\EntityFramework.4.3.1\lib\net40\EntityFramework.dll ." | Out-File -Append `
-            -Encoding ascii $reruncmd
         Write-Output $rerun | Out-File -Append -Encoding ascii $reruncmd
     }
     $rerun = "`"$VSTEST`""
@@ -361,8 +353,6 @@ Function FailedTestLog ($playlist , $reruncmd , $failedtest1 ,$failedtest2)
     # build the command only if failed tests exist
     if ($failedtest2.count -gt 0)
     {
-        Write-Output "copy /y $NUGETPACK\EntityFramework.5.0.0\lib\net40\EntityFramework.dll ." | Out-File -Append `
-            -Encoding ascii $reruncmd
         Write-Output $rerun | Out-File -Append -Encoding ascii $reruncmd
     }
     Write-Output "cd $LOGDIR" | Out-File -Append -Encoding ascii $reruncmd
@@ -527,7 +517,6 @@ Function TestProcess
     }
     $script:TEST_START_TIME = Get-Date
     cd $TESTDIR
-    RestoringFile -file "$NUGETPACK\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" -target $TESTDIR
     if ($TestType -eq 'Nightly')
     {
         RunTest -title 'NightlyTests' -testdir $NightlyTestSuite
@@ -546,7 +535,6 @@ Function TestProcess
         Cleanup
         exit
     }
-    RestoringFile -file "$NUGETPACK\EntityFramework.5.0.0\lib\net40\EntityFramework.dll" -target $TESTDIR
     RunTest -title 'E2ETests' -testdir $E2eTestSuite
     Write-Host "Test Done" -ForegroundColor $Success
     TestSummary

--- a/sln/.nuget/packages.config
+++ b/sln/.nuget/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="ApprovalTests" version="1.6" />
-  <package id="EntityFramework" version="4.3.1" />
   <package id="EntityFramework" version="5.0.0"/>
   <package id="FluentAssertions" version="2.0.0.1" />
   <package id="FluentAssertions" version="4.19.2" />

--- a/test/EndToEndTests/Services/Astoria/Microsoft.Test.OData.Services.Astoria.csproj
+++ b/test/EndToEndTests/Services/Astoria/Microsoft.Test.OData.Services.Astoria.csproj
@@ -40,7 +40,7 @@
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(EnlistmentRoot)\src\Microsoft.OData.Core\Microsoft.OData.Core.csproj">

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/CodeGenerationTests/T4CodeGenerationTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/CodeGenerationTests/T4CodeGenerationTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Test.OData.Tests.Client.CodeGenerationTests
     [DeploymentItem(@"VBDSCReferences\", "VBDSCReferences")]
     [DeploymentItem(@"VBReferences\", "VBReferences")]
 #if !WIN8 && !WINDOWSPHONE
-    [DeploymentItem(@"EntityFramework.5.0.0\lib\net40\EntityFramework.dll")]
+    [DeploymentItem(@"EntityFramework.dll")]
 #endif
     [TestClass]
     public class T4CodeGenerationTests

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/Microsoft.Test.OData.Tests.Client.csproj
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/Microsoft.Test.OData.Tests.Client.csproj
@@ -230,65 +230,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">
-    <CreateItem Condition="Exists('$(NugetPack)\EntityFramework.5.0.0\EntityFramework.5.0.0.nuspec')"
-         Include="$(NugetPack)\EntityFramework.5.0.0\EntityFramework.5.0.0.nuspec" AdditionalMetadata="TargetPath=">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Condition="Exists('$(NugetPack)\EntityFramework.5.0.0\EntityFramework.nuspec')"
-         Include="$(NugetPack)\EntityFramework.5.0.0\EntityFramework.nuspec" AdditionalMetadata="TargetPath=">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\Content\App.config.transform" AdditionalMetadata="TargetPath=Content">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\Content\Web.config.transform" AdditionalMetadata="TargetPath=Content">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\lib\net40\EntityFramework.dll" AdditionalMetadata="TargetPath=lib\net40">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\lib\net40\EntityFramework.xml" AdditionalMetadata="TargetPath=lib\net40">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" AdditionalMetadata="TargetPath=lib\net45">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.xml" AdditionalMetadata="TargetPath=lib\net45">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\about_EntityFramework.help.txt" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\EntityFramework.PowerShell.dll" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\EntityFramework.PowerShell.Utility.dll" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\EntityFramework.PS3.psd1" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\EntityFramework.psd1" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\EntityFramework.psm1" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\init.ps1" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\install.ps1" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\migrate.exe" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\Redirect.config" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
-    <CreateItem Include="$(NugetPack)\EntityFramework.5.0.0\tools\Redirect.VS11.config" AdditionalMetadata="TargetPath=tools">
-      <Output TaskParameter="Include" ItemName="EF5" />
-    </CreateItem>
     <CreateItem Include="$(EnlistmentRoot)\test\EndToEndTests\Services\CSDSCReferences\Microsoft.Test.OData.Services.TestServices.ActionOverloadingServiceReference.cs">
       <Output TaskParameter="Include" ItemName="CSDSCReferences" />
     </CreateItem>
@@ -349,7 +290,6 @@
     <CreateItem Include="$(EnlistmentRoot)\test\EndToEndTests\Services\VBReferences\Microsoft.Test.OData.Services.TestServices.PrimitiveKeysServiceReference.vb">
       <Output TaskParameter="Include" ItemName="VBReferences" />
     </CreateItem>
-    <Copy SourceFiles="@(EF5)" DestinationFiles="@(EF5->'$(OutDir)EntityFramework.5.0.0\%(TargetPath)\%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(CSDSCReferences)" DestinationFiles="@(CSDSCReferences->'$(OutDir)CSDSCReferences\%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(CSReferences)" DestinationFiles="@(CSReferences->'$(OutDir)CSReferences\%(Filename)%(Extension)')" />
     <Copy SourceFiles="@(VBDSCReferences)" DestinationFiles="@(VBReferences->'$(OutDir)VBDSCReferences\%(Filename)%(Extension)')" />

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTestsBase.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTestsBase.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Test.OData.Tests.Client
     /// Base class for tests that use the service implemented using ODataLib and EDMLib.
     /// </summary>
 #if !WIN8 && !WINDOWSPHONE
-    [DeploymentItem(@"EntityFramework.5.0.0\lib\net40\EntityFramework.dll")]
+    [DeploymentItem(@"EntityFramework.dll")]
 #endif
 #if !PORTABLELIB
     [DeploymentItem(@"Microsoft.VisualStudio.QualityTools.Common.dll")]

--- a/test/EndToEndTests/Tests/Client/EndToEndTestBase.cs
+++ b/test/EndToEndTests/Tests/Client/EndToEndTestBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Test.OData.Tests.Client
     /// </summary>
     [TestClass]
 #if !WIN8 && !WINDOWSPHONE
-    [DeploymentItem(@"EntityFramework.5.0.0\lib\net40\EntityFramework.dll")]
+    [DeploymentItem(@"EntityFramework.dll")]
 #endif
 #if !PORTABLELIB
     [DeploymentItem(@"Microsoft.VisualStudio.QualityTools.Common.dll")]

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/Microsoft.Data.WebClientCSharp.UnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/Microsoft.Data.WebClientCSharp.UnitTests.csproj
@@ -32,7 +32,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
-    <Reference Include="$(NugetPack)\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Numerics" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/Microsoft.Data.WebClient.UnitTests.vbproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/Microsoft.Data.WebClient.UnitTests.vbproj
@@ -31,7 +31,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
-    <Reference Include="$(NugetPack)\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net40\EntityFramework.dll" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/MetadataObjectModelTests/Microsoft.Data.MetadataObjectModel.UnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/MetadataObjectModelTests/Microsoft.Data.MetadataObjectModel.UnitTests.csproj
@@ -21,7 +21,7 @@
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.Entity" />
-    <Reference Include="$(NugetPack)\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ServerUnitTests\Microsoft.Data.Web.UnitTests.csproj">

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/NamedStreamTests/Microsoft.Data.NamedStream.UnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/NamedStreamTests/Microsoft.Data.NamedStream.UnitTests.csproj
@@ -24,7 +24,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
-    <Reference Include="$(NugetPack)\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Numerics" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/RegressionUnitTests/Microsoft.Data.Web.RegressionUnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/RegressionUnitTests/Microsoft.Data.Web.RegressionUnitTests.csproj
@@ -23,7 +23,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
-    <Reference Include="$(NugetPack)\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Runtime.Serialization" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Microsoft.Data.Web.UnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Microsoft.Data.Web.UnitTests.csproj
@@ -27,7 +27,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
-    <Reference Include="$(NugetPack)\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Numerics" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Stubs/DataServiceProvider/DSPUnitTestServiceDefinition.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Stubs/DataServiceProvider/DSPUnitTestServiceDefinition.cs
@@ -251,7 +251,7 @@ namespace AstoriaUnitTests.Stubs.DataServiceProvider
                     {
                         if (providerKind == DSPDataProviderKind.EF && IsPropertyKind(property, ResourcePropertyKind.Key))
                         {
-                            stringBuilder.AppendLine("[System.ComponentModel.DataAnnotations.DatabaseGenerated(System.ComponentModel.DataAnnotations.DatabaseGeneratedOption.None)]");
+                            stringBuilder.AppendLine("[System.ComponentModel.DataAnnotations.Schema.DatabaseGenerated(System.ComponentModel.DataAnnotations.Schema.DatabaseGeneratedOption.None)]");
                         }
 
                         // Entity Framework's spatial types are not currently the same as the type we use, so we need to use their type for the entity property
@@ -290,7 +290,14 @@ namespace AstoriaUnitTests.Stubs.DataServiceProvider
             }
 
             // compile the assembly
-            test.TestUtil.GenerateAssembly(stringBuilder.ToString(), assemblyFullPath, new string[] { Path.Combine(test.TestUtil.GreenBitsReferenceAssembliesDirectory, "System.ComponentModel.DataAnnotations.dll"), "EntityFramework.dll" });
+            string path = Path.GetDirectoryName(typeof(System.Data.Test.Astoria.TestUtil).Assembly.Location);
+            string[] dependentAssemblies = new string[]
+            {
+                    Path.Combine(test.TestUtil.GreenBitsReferenceAssembliesDirectory, "System.ComponentModel.DataAnnotations.dll"),
+                    Path.Combine(path,"EntityFramework.dll")
+            };
+
+            test.TestUtil.GenerateAssembly(stringBuilder.ToString(), assemblyFullPath, dependentAssemblies);
 
             Assembly assembly = Assembly.LoadFrom(assemblyFullPath);
             return assembly.GetType(contextTypeName);

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests1/Microsoft.Data.ServerUnitTests1.UnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests1/Microsoft.Data.ServerUnitTests1.UnitTests.csproj
@@ -28,7 +28,7 @@
       <Name>Microsoft.OData.Edm</Name>
     </ProjectReference>
     <Reference Include="System.Data.Entity" />
-    <Reference Include="$(NugetPack)\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Numerics" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests2/Microsoft.Data.ServerUnitTests2.UnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests2/Microsoft.Data.ServerUnitTests2.UnitTests.csproj
@@ -25,7 +25,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.Entity" />
-    <Reference Include="$(NugetPack)\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" />
     <Reference Include="System.DirectoryServices" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Numerics" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests2/Tests/DbContextTest.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests2/Tests/DbContextTest.cs
@@ -11,6 +11,7 @@ namespace AstoriaUnitTests.Tests
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations;
+    using System.ComponentModel.DataAnnotations.Schema;
     using System.Data.Entity;
     using System.Data.Entity.Infrastructure;
     using System.Data.SqlClient;

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/TDDUnitTests/Microsoft.OData.Service.TDDUnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/TDDUnitTests/Microsoft.OData.Service.TDDUnitTests.csproj
@@ -33,7 +33,7 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.Linq" />
     <Reference Include="$(NugetPack)\FluentAssertions.2.0.0.1\lib\net40\FluentAssertions.dll" />
-    <Reference Include="$(NugetPack)\EntityFramework.4.3.1\lib\net40\EntityFramework.dll" />
+    <Reference Include="$(NugetPack)\EntityFramework.5.0.0\lib\net45\EntityFramework.dll" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="$(EnlistmentRoot)\test\FunctionalTests\Service\Microsoft.OData.Service.csproj">


### PR DESCRIPTION
### Description
Standardize on EntityFramework 5.0 for tests to reduce race conditions
for EntityFramework dependent tests.
### Checklist (Uncheck if it is not completed)

- [   ] Test cases added
- [ x ] Build and test with one-click build and test script passed
