### PR TITLE
By default, make build.cmd run all tests as to ensure nothing is missed.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -11,25 +11,36 @@ if (($args.Count -eq 0) -or ($args[0] -match 'Nightly'))
     $TestType = 'Nightly'
     $Configuration = 'Release'
 }
+elseif ($args[0] -match 'Quick' -or ($args[0] -match '-q')) 
+{
+    $TestType = "Quick"
+}
 elseif ($args[0] -match 'Rolling')
 {
-    $TestType = "Rolling"
+    # Rolling is a legacy options - run all tests.
+    $TestType = "Nightly"
 }
 elseif ($args[0] -match 'E2E')
 {
-    $TestType = "E2E"
+    # Rolling is a legacy options - run all tests.
+    $TestType = "Nightly"
 }
 elseif ($args[0] -match 'DisableSkipStrongName')
 {
     $TestType = "DisableSkipStrongName"
 }
+elseif ($args[0] -match 'EnableSkipStrongName')
+{
+    $TestType = "EnableSkipStrongName"
+}
 elseif ($args[0] -match 'SkipStrongName')
 {
-    $TestType = "SkipStrongName"
+    # SkipStrongName is a legacy options.
+    $TestType = "EnableSkipStrongName"
 }
 else 
 {
-    Write-Host 'Please choose Nightly Test or Rolling Test!' -ForegroundColor $Err
+    Write-Host 'Please choose Nightly Test or Quick Test!' -ForegroundColor $Err
     exit
 }
 
@@ -73,15 +84,20 @@ $ProductDlls = "Microsoft.OData.Client.dll",
     "Microsoft.OData.Service.Design.T4.dll",
     "Microsoft.Spatial.dll"
 
-$TestDlls = "Microsoft.OData.Service.Design.T4.dll",
+$XUnitTestDlls = "Microsoft.OData.Core.Tests.dll",
+    "Microsoft.OData.Edm.Tests.dll",
+    "Microsoft.Spatial.Tests.dll",
+    "Microsoft.OData.Client.Tests.dll"
+
+$NetCoreXUnitTestDlls = "Microsoft.OData.Core.Tests.dll",
+    "Microsoft.OData.Edm.Tests.dll",
+    "Microsoft.Spatial.Tests.dll"
+
+$TestSupportDlls = "Microsoft.OData.Service.Design.T4.dll",
     "Microsoft.OData.Service.dll",
     "Microsoft.OData.Service.Test.Common.dll"
 
-$RollingTestDlls = "Microsoft.OData.Core.Tests.dll",
-    "Microsoft.OData.Edm.Tests.dll",
-    "Microsoft.Spatial.Tests.dll",
-    "Microsoft.OData.Client.Tests.dll",
-    "Microsoft.Test.Data.Services.DDBasics.dll",
+$NightlyTestDlls = "Microsoft.Test.Data.Services.DDBasics.dll",
     "Microsoft.OData.Client.Design.T4.UnitTests.dll",
     "AstoriaUnitTests.TDDUnitTests.dll",
     "EdmLibTests.dll",
@@ -96,36 +112,35 @@ $RollingTestDlls = "Microsoft.OData.Core.Tests.dll",
     "Microsoft.Data.ServerUnitTests1.UnitTests.dll",
     "Microsoft.Data.ServerUnitTests2.UnitTests.dll",
     "RegressionUnitTests.dll",
-    "Microsoft.Test.OData.PluggableFormat.Tests.dll"
-
-$RollingTestSuite = @()
-ForEach($dll in $RollingTestDlls)
-{
-    $RollingTestSuite += $TESTDIR + "\" + $dll
-}
-
-$AdditionalNightlyTestDlls = "Microsoft.Data.MetadataObjectModel.UnitTests.dll", 
+    "Microsoft.Test.OData.PluggableFormat.Tests.dll",
+    "Microsoft.Data.MetadataObjectModel.UnitTests.dll",
     "AstoriaUnitTests.dll",
-    "AstoriaClientUnitTests.dll",
-    "TestCategoryAttributeCheck.dll"
+    "AstoriaClientUnitTests.dll"
 
-ForEach($dll in $AdditionalNightlyTestDlls)
+$QuickTestSuite = @()
+$NightlyTestSuite = @()
+ForEach($dll in $XUnitTestDlls)
 {
-    $AdditionalNightlyTestSuite += $TESTDIR + "\" + $dll
+    $QuickTestSuite += $TESTDIR + "\" + $dll
+    $NightlyTestSuite += $TESTDIR + "\" + $dll
 }
 
-$NightlyTestSuite = $RollingTestSuite
-ForEach ($test in $AddtionalNightlyTestSuite)
+ForEach($dll in $NetCoreXUnitTestDlls)
 {
-    $NightlyTestSuite += $test
+    # Turn on once we migrate to VS 2017 as there are some technical difficulties
+    # with running .NET Core tests through script for VS 2015
+    # $NightlyTestSuite += $NETCORETESTDIR + "\" + $dll
+}
+
+ForEach($dll in $NightlyTestDlls)
+{
+    $NightlyTestSuite += $TESTDIR + "\" + $dll
 }
 
 $E2eTestDlls = @("Microsoft.Test.OData.Tests.Client.dll")
-$E2eTestSuite = @()
-
 ForEach ($dll in $E2eTestDlls)
 {
-    $E2eTestSuite += $TESTDIR + "\" + $dll
+    $NightlyTestSuite += $TESTDIR + "\" + $dll
 }
 
 $FxCopRulesOptions = "/rule:$FxCopDir\Rules\DesignRules.dll",
@@ -152,17 +167,22 @@ Function GetDlls
         $dlls += $PRODUCTDIR + "\" + $dll
     }
 
-    ForEach($dll in $TestDlls)
-    {
-        $dlls += $TESTDIR + "\" + $dll
-    }
-    
-    ForEach($dll in $RollingTestDlls)
+    ForEach($dll in $XUnitTestDlls)
     {
         $dlls += $TESTDIR + "\" + $dll
     }
 
-    ForEach($dll in $AdditionalNightlyTestDlls)
+    ForEach($dll in $NetCoreXUnitTestDlls)
+    {
+        $dlls += $TESTDIR + "\" + $dll
+    }
+
+    ForEach($dll in $TestSupportDlls)
+    {
+        $dlls += $TESTDIR + "\" + $dll
+    }
+
+    ForEach($dll in $NightlyTestDlls)
     {
         $dlls += $TESTDIR + "\" + $dll
     }
@@ -293,7 +313,7 @@ Function FailedTestLog ($playlist , $reruncmd , $failedtest1 ,$failedtest2)
     }
     else
     {
-        foreach ($dll in $RollingTestSuite) 
+        foreach ($dll in $QuickTestSuite) 
         {
             $rerun += " $dll" 
         }
@@ -361,6 +381,7 @@ Function TestSummary
     
     $file = Get-Content -Path $TESTLOG
     $pass = 0
+    $skipped = 0
     $fail = 0
     $trxfile = New-Object -TypeName System.Collections.ArrayList
     $failedtest1 = New-Object -TypeName System.Collections.ArrayList
@@ -372,6 +393,10 @@ Function TestSummary
         if ($line -match "^Passed.*") 
         {
             $pass = $pass + 1
+        }
+        elseif ($line -match "^Skipped.*") 
+        {
+            $skipped = $skipped + 1
         }
         elseif ($line -match "^Failed\s+(.*)")
         {
@@ -394,6 +419,12 @@ Function TestSummary
 
     Write-Host "Test summary:" -ForegroundColor $Success
     Write-Host "Passed :`t$pass"  -ForegroundColor $Success
+
+    if ($skipped -ne 0)
+    {
+        Write-Host "Skipped:`t$skipped"  -ForegroundColor $Warning
+    }
+
     $color = $Success
     if ($fail -ne 0)
     {
@@ -436,13 +467,18 @@ Function BuildProcess
         rm $BUILDLOG
     }
     RunBuild ('Microsoft.OData.Lite.sln')
-    RunBuild ('Microsoft.OData.Full.sln')
-    RunBuild ('Microsoft.OData.Net35.sln')
-    RunBuild ('Microsoft.OData.Net45.sln')
-    RunBuild ('Microsoft.OData.Portable45.sln')
-    RunBuild ('Microsoft.OData.Portable45.Profile111.sln')
-    RunBuild ('Microsoft.OData.CodeGen.sln')
-    RunBuild ('Microsoft.OData.E2E.sln')
+
+    if ($TestType -ne 'Quick')
+    {
+        RunBuild ('Microsoft.OData.Full.sln')
+        RunBuild ('Microsoft.OData.Net35.sln')
+        RunBuild ('Microsoft.OData.Net45.sln')
+        RunBuild ('Microsoft.OData.Portable45.sln')
+        RunBuild ('Microsoft.OData.Portable45.Profile111.sln')
+        RunBuild ('Microsoft.OData.CodeGen.sln')
+        RunBuild ('Microsoft.OData.E2E.sln')
+    }
+
     Write-Host "Build Done" -ForegroundColor $Success
     $script:BUILD_END_TIME = Get-Date
 }
@@ -460,13 +496,9 @@ Function TestProcess
     {
         RunTest -title 'NightlyTests' -testdir $NightlyTestSuite
     }
-    elseif ($TestType -eq 'Rolling')
+    elseif ($TestType -eq 'Quick')
     {
-        RunTest -title 'RollingTests' -testdir $RollingTestSuite
-    }
-    elseif ($TestType -eq 'E2E')
-    {
-        # E2E tests run below.
+        RunTest -title 'XUnitTests' -testdir $QuickTestSuite
     }
     else
     {
@@ -474,7 +506,7 @@ Function TestProcess
         Cleanup
         exit
     }
-    RunTest -title 'E2ETests' -testdir $E2eTestSuite
+
     Write-Host "Test Done" -ForegroundColor $Success
     TestSummary
     $script:TEST_END_TIME = Get-Date
@@ -504,7 +536,7 @@ if (! (Test-Path $LOGDIR))
     mkdir $LOGDIR 1>$null
 }
 
-if ($TestType -eq 'SkipStrongName')
+if ($TestType -eq 'EnableSkipStrongName')
 {
     CleanBeforeScorch 
     BuildProcess

--- a/sln/Microsoft.OData.Full.sln
+++ b/sln/Microsoft.OData.Full.sln
@@ -52,8 +52,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Commander.Common", "..\test
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KoKoMo", "..\tools\KoKoMo\KoKoMo.csproj", "{EB4C9641-0452-4E7F-AA38-3EBD871914A3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestCategoryAttributeCheck.UnitTest", "..\test\FunctionalTests\Tests\DataServices\UnitTests\TestCategoryAttributeCheck\TestCategoryAttributeCheck.UnitTest.csproj", "{10F2E291-BCCC-488B-8788-6EF6451DAC98}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.MetadataObjectModel.UnitTests", "..\test\FunctionalTests\Tests\DataServices\UnitTests\MetadataObjectModelTests\Microsoft.Data.MetadataObjectModel.UnitTests.csproj", "{69A5EB3B-5AE5-49AD-B4F3-025D087A4647}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Data.Web.UnitTests", "..\test\FunctionalTests\Tests\DataServices\UnitTests\ServerUnitTests\Microsoft.Data.Web.UnitTests.csproj", "{BB7D22CB-7003-4AF6-9035-B369B00EA95E}"
@@ -561,24 +559,6 @@ Global
 		{EB4C9641-0452-4E7F-AA38-3EBD871914A3}.Release|x64.Build.0 = Release|x64
 		{EB4C9641-0452-4E7F-AA38-3EBD871914A3}.Release|x86.ActiveCfg = Release|x86
 		{EB4C9641-0452-4E7F-AA38-3EBD871914A3}.Release|x86.Build.0 = Release|x86
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Cover|Any CPU.ActiveCfg = Cover|Any CPU
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Cover|Any CPU.Build.0 = Cover|Any CPU
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Cover|x64.ActiveCfg = Cover|x64
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Cover|x64.Build.0 = Cover|x64
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Cover|x86.ActiveCfg = Cover|x86
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Cover|x86.Build.0 = Cover|x86
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Debug|x64.ActiveCfg = Debug|x64
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Debug|x64.Build.0 = Debug|x64
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Debug|x86.ActiveCfg = Debug|x86
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Debug|x86.Build.0 = Debug|x86
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Release|Any CPU.Build.0 = Release|Any CPU
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Release|x64.ActiveCfg = Release|x64
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Release|x64.Build.0 = Release|x64
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Release|x86.ActiveCfg = Release|x86
-		{10F2E291-BCCC-488B-8788-6EF6451DAC98}.Release|x86.Build.0 = Release|x86
 		{69A5EB3B-5AE5-49AD-B4F3-025D087A4647}.Cover|Any CPU.ActiveCfg = Cover|Any CPU
 		{69A5EB3B-5AE5-49AD-B4F3-025D087A4647}.Cover|Any CPU.Build.0 = Cover|Any CPU
 		{69A5EB3B-5AE5-49AD-B4F3-025D087A4647}.Cover|x64.ActiveCfg = Cover|x64

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Annotation/ClientAnnotationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Annotation/ClientAnnotationTests.cs
@@ -1085,7 +1085,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests.Annotation
         }
 
         [TestMethod]
-        public void TesDuplicateAnnotationsOnPropertyThrows()
+        public void TestDuplicateAnnotationsOnPropertyThrows()
         {
             string response = @"{
     ""@odata.context"":""http://odataService/$metadata#People('Adrian')/Location"",

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Tests/HttpContextServiceHostTest.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Tests/HttpContextServiceHostTest.cs
@@ -483,7 +483,7 @@ namespace AstoriaUnitTests.Tests
         {
             CombinatorialEngine engine = CombinatorialEngine.FromDimensions(
                 new Dimension("WebServerLocation", new WebServerLocation[] { WebServerLocation.InProcessWcf }),
-                new Dimension("LocalHostName", new string[] { "127.0.0.1" }));
+                new Dimension("LocalHostName", new string[] { "localhost" }));
             TestUtil.RunCombinatorialEngineFail(engine, delegate(Hashtable values)
             {
                 WebServerLocation location = (WebServerLocation)values["WebServerLocation"];

--- a/tools/Scripts/TestStartup.cmd
+++ b/tools/Scripts/TestStartup.cmd
@@ -1,0 +1,2 @@
+@echo off
+set ENLISTMENT_ROOT=%1


### PR DESCRIPTION
### Description
By default, make build.cmd run all tests as to ensure nothing is missed.
Optionally, run build.cmd quick to run only the unit tests.
Add TestStartup.cmd to prepare for test runs in the build environment.
Remove TestCategoryAttributeCheck.csproj from the solution as it provides little value.
Changed HttpContextServiceHostRequestNameTest to run against localhost.
Rename a misspelled test.

### Checklist (Uncheck if it is not completed)

- [   ] Test cases added
- [ x ] Build and test with one-click build and test script passed
