### PR TITLE
Cleanup Microsoft.Reliability in OData.Core, OData.Client

### DIFF
--- a/src/Microsoft.OData.Client/BaseAsyncResult.cs
+++ b/src/Microsoft.OData.Client/BaseAsyncResult.cs
@@ -117,7 +117,6 @@ namespace Microsoft.OData.Client
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         public System.Threading.WaitHandle AsyncWaitHandle
         {
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "WaitHandle is disposed during EndXXX(IAsyncResult) method")]
             get
             {
                 if (null == this.asyncWait)

--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -232,7 +232,6 @@ namespace Microsoft.OData.Client
         /// <param name="statusCode">status code</param>
         /// <returns>text</returns>
         [SuppressMessage("Microsoft.Design", "CA1031", Justification = "Cache exception so user can examine it later")]
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "underlying stream is disposed so wrapping StreamReader doesn't need to be disposed")]
         internal static DataServiceClientException GetResponseText(Func<Stream> getResponseStream, HttpStatusCode statusCode)
         {
             string message = null;

--- a/src/Microsoft.OData.Client/BatchSaveResult.cs
+++ b/src/Microsoft.OData.Client/BatchSaveResult.cs
@@ -783,7 +783,6 @@ namespace Microsoft.OData.Client
         /// <param name="batchReader">The batch reader to get the operation response from.</param>
         /// <param name="isChangesetOperation">True if the current operation is inside a changeset (implying CUD, not query)</param>
         /// <returns>An exception if the operation response is an error response, null for success response.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "We don't dispose the memory stream we create, but that's not necessary since it's just a memory stream and we need to keep it for the operation response to be processed.")]
         private Exception ProcessCurrentOperationResponse(ODataBatchReader batchReader, bool isChangesetOperation)
         {
             Debug.Assert(batchReader != null, "batchReader != null");

--- a/src/Microsoft.OData.Client/DataServiceRequest.cs
+++ b/src/Microsoft.OData.Client/DataServiceRequest.cs
@@ -62,7 +62,6 @@ namespace Microsoft.OData.Client
         /// <param name="message">the message</param>
         /// <param name="expectedPayloadKind">expected payload kind.</param>
         /// <returns>atom materializer</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Returning MaterializeAtom, caller will dispose")]
         internal static MaterializeAtom Materialize(
             ResponseInfo responseInfo,
             QueryComponents queryComponents,

--- a/src/Microsoft.OData.Client/LoadPropertyResult.cs
+++ b/src/Microsoft.OData.Client/LoadPropertyResult.cs
@@ -181,7 +181,6 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="property">The property being loaded</param>
         /// <returns>property values as IEnumerable.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Returning MaterializeAtom, caller will dispose")]
         private MaterializeAtom ReadPropertyFromAtom(ClientPropertyAnnotation property)
         {
             DataServiceContext context = (DataServiceContext)this.Source;
@@ -271,7 +270,6 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="property">The property being loaded</param>
         /// <returns>property values as IEnumerable.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Returning MaterializeAtom, caller will dispose")]
         private MaterializeAtom ReadPropertyFromRawData(ClientPropertyAnnotation property)
         {
             DataServiceContext context = (DataServiceContext)this.Source;

--- a/src/Microsoft.OData.Client/Materialization/ODataMaterializer.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataMaterializer.cs
@@ -185,7 +185,6 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="plan">The projection plan.</param>
         /// <param name="payloadKind">expected payload kind.</param>
         /// <returns>A materializer specialized for the given response.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2000", Justification = "ODataMaterializer is disposed by the caller.")]
         public static ODataMaterializer CreateMaterializerForMessage(
             IODataResponseMessage responseMessage,
             ResponseInfo responseInfo,
@@ -345,7 +344,6 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="responseInfo">The response context</param>
         /// <param name="payloadKind">Type of the message.</param>
         /// <returns>The message reader.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2000", Justification = "ODataMessageReader must be disposed by the caller")]
         protected static ODataMessageReader CreateODataMessageReader(IODataResponseMessage responseMessage, ResponseInfo responseInfo, ref ODataPayloadKind payloadKind)
         {
             ODataMessageReaderSettings settings = responseInfo.ReadHelper.CreateSettings();

--- a/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
+++ b/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
@@ -552,7 +552,6 @@ namespace Microsoft.OData.Client
             /// Gets the stream to be used to write the request payload.
             /// </summary>
             /// <returns>Stream to which the request payload needs to be written.</returns>
-            [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "We don't dispose the memory stream we create")]
             public Stream GetStream()
             {
                 if (this.cachedRequestStream == null)

--- a/src/Microsoft.OData.Client/Serialization/HttpWebRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpWebRequestMessage.cs
@@ -565,7 +565,6 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="webException">WebException instance.</param>
         /// <returns>an instance of DataServiceWebException that abstracts the WebException.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Caller will dispose the message later.")]
         private static DataServiceTransportException ConvertToDataServiceWebException(WebException webException)
         {
             HttpWebResponseMessage errorResponseMessage = null;

--- a/src/Microsoft.OData.Core/ODataMessage.cs
+++ b/src/Microsoft.OData.Core/ODataMessage.cs
@@ -133,7 +133,6 @@ namespace Microsoft.OData
         /// <param name="messageStreamFunc">A function that returns the stream backing the message.</param>
         /// <param name="isRequest">true if the message is a request message; false for a response message.</param>
         /// <returns>The <see cref="Stream"/> backing the message.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "We don't own the underlying stream, so we should not dispose the wrapper.")]
         protected internal Stream GetStream(Func<Stream> messageStreamFunc, bool isRequest)
         {
             // Check whether we have an existing buffering read stream when reading

--- a/src/Microsoft.OData.Core/ODataMessageReader.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReader.cs
@@ -1423,7 +1423,6 @@ namespace Microsoft.OData
         /// <param name="readFunc">The read function which will be called over the created input context.</param>
         /// <param name="payloadKinds">All possible kinds of payload to read.</param>
         /// <returns>A task which when completed return the read value from the input.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "Disposed by the caller.")]
         private Task<T> ReadFromInputAsync<T>(Func<ODataInputContext, Task<T>> readFunc, params ODataPayloadKind[] payloadKinds) where T : class
         {
             this.ProcessContentType(payloadKinds);

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -1259,7 +1259,6 @@ namespace Microsoft.OData
         /// <param name="payloadKind">The payload kind to write.</param>
         /// <param name="writeAsyncAction">The write operation to invoke on the output.</param>
         /// <returns>Task which represents the pending write operation.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The output context is disposed by Dispose on the writer.")]
         private Task WriteToOutputAsync(ODataPayloadKind payloadKind, Func<ODataOutputContext, Task> writeAsyncAction)
         {
             // Set the content type header here since all headers have to be set before getting the stream
@@ -1286,7 +1285,6 @@ namespace Microsoft.OData
         /// <param name="payloadKind">The payload kind to write.</param>
         /// <param name="writeFunc">The write operation to invoke on the output.</param>
         /// <returns>Task which represents the pending write operation.</returns>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "The output context is disposed by Dispose on the writer.")]
         private Task<TResult> WriteToOutputAsync<TResult>(ODataPayloadKind payloadKind, Func<ODataOutputContext, Task<TResult>> writeFunc)
         {
             // Set the content type header here since all headers have to be set before getting the stream

--- a/src/Microsoft.OData.Core/ODataRawOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawOutputContext.cs
@@ -294,7 +294,6 @@ namespace Microsoft.OData
         /// </summary>
         /// <remarks>This can only be called if the text writer was not yet initialized or it has been closed.
         /// It can be called several times with CloseWriter calls in between though.</remarks>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "We create a NonDisposingStream which doesn't need to be disposed, even though it's IDisposable.")]
         internal void InitializeRawValueWriter()
         {
             Debug.Assert(this.rawValueWriter == null, "The rawValueWriter has already been initialized.");

--- a/src/Microsoft.OData.Core/RawValueWriter.cs
+++ b/src/Microsoft.OData.Core/RawValueWriter.cs
@@ -159,7 +159,6 @@ namespace Microsoft.OData
         /// </summary>
         /// <remarks>This can only be called if the text writer was not yet initialized or it has been closed.
         /// It can be called several times with CloseWriter calls in between though.</remarks>
-        [SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope", Justification = "We create a NonDisposingStream which doesn't need to be disposed, even though it's IDisposable.")]
         private void InitializeTextWriter()
         {
             // We must create the text writer over a stream which will ignore Dispose, since we need to be able to Dispose


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request is to clean up Microsoft.Reliability suppressed warning for ODL.Core, OData.Client.

### Description

Cleaned up Microsoft.Reliability warning suppressions.

### Checklist (Uncheck if it is not completed)

- [  ] Test cases added
- [ x ] Build and test with one-click build and test script passed
