### PR TITLE
ODL-Spatial, ODL-Edm, ODL-Client: cleanup obsolete AC warnings suppresion

### DIFF
--- a/src/Microsoft.OData.Client/AtomMaterializerLog.cs
+++ b/src/Microsoft.OData.Client/AtomMaterializerLog.cs
@@ -96,7 +96,6 @@ namespace Microsoft.OData.Client
         /// <param name="entityDescriptorFromMaterializer">entityDescriptor that is returned by the materializer</param>
         /// <param name="mergeInfo">if true, we will need to merge all entity descriptor info, otherwise not.</param>
         /// <param name="mergeOption">merge option depending on which etag information needs to be merged.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Performance", "AC0008", Justification = "This self link call is intentional")]
         internal static void MergeEntityDescriptorInfo(EntityDescriptor trackedEntityDescriptor, EntityDescriptor entityDescriptorFromMaterializer, bool mergeInfo, MergeOption mergeOption)
         {
             Debug.Assert(trackedEntityDescriptor != null, "trackedEntityDescriptor != null");

--- a/src/Microsoft.OData.Client/BaseAsyncResult.cs
+++ b/src/Microsoft.OData.Client/BaseAsyncResult.cs
@@ -371,7 +371,6 @@ namespace Microsoft.OData.Client
         /// time limit.  Also then cancel the operation, to make sure its stopped, to avoid
         /// multi-threading if your wait time limit was just too short.
         /// </remarks>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         internal void HandleCompleted()
         {
             // TODO: even if background thread of async operation encounters
@@ -527,7 +526,6 @@ namespace Microsoft.OData.Client
         /// <summary>handle request.BeginGetRequestStream with request.EndGetRequestStream and then write out request stream</summary>
         /// <param name="asyncResult">async result</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "required for this feature")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         protected void AsyncEndGetRequestStream(IAsyncResult asyncResult)
         {
             Debug.Assert(asyncResult != null && asyncResult.IsCompleted, "asyncResult.IsCompleted");
@@ -737,7 +735,6 @@ namespace Microsoft.OData.Client
         /// and in case of synchronous also the next BeginRead.
         /// </summary>
         /// <param name="asyncResult">The asynchronous result associated with the completed operation.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         private void AsyncRequestContentEndRead(IAsyncResult asyncResult)
 #endif
         {
@@ -852,7 +849,6 @@ namespace Microsoft.OData.Client
         /// <summary>handle requestStream.BeginWrite with requestStream.EndWrite then BeginGetResponse.</summary>
         /// <param name="asyncResult">async result</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "required for this feature")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         private void AsyncEndWrite(IAsyncResult asyncResult)
 #endif
         {
@@ -1092,7 +1088,6 @@ namespace Microsoft.OData.Client
             /// <summary>
             /// dispose of the request object
             /// </summary>
-            [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
             internal void Dispose()
             {
                 if (this.isDisposed)

--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -431,7 +431,6 @@ namespace Microsoft.OData.Client
         /// <summary>handle request.BeginGetResponse with request.EndGetResponse and then copy response stream</summary>
         /// <param name="asyncResult">async result</param>
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "required for this feature")]
-        [SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         protected override void AsyncEndGetResponse(IAsyncResult asyncResult)
         {
             Debug.Assert(asyncResult != null && asyncResult.IsCompleted, "asyncResult.IsCompleted");
@@ -1056,8 +1055,6 @@ namespace Microsoft.OData.Client
         /// <param name="binding">The binding.</param>
         /// <param name="targetResource">The target's entity descriptor.</param>
         /// <returns>The original link uri or one with the target entity key appended.</returns>
-        [SuppressMessage("DataWeb.Usage", "AC0011:EntityDescriptorPublicPropertiesRule",
-             Justification = "This property has been limited by get/set")]
         private static Uri AppendTargetEntityKeyIfNeeded(Uri linkUri, LinkDescriptor binding, EntityDescriptor targetResource)
         {
             // To delete from a collection, we need to append the key.
@@ -1296,7 +1293,6 @@ namespace Microsoft.OData.Client
         /// <summary>handle responseStream.BeginRead with responseStream.EndRead</summary>
         /// <param name="asyncResult">async result</param>
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "required for this feature")]
-        [SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         private void AsyncEndRead(IAsyncResult asyncResult)
 #endif
         {

--- a/src/Microsoft.OData.Client/BatchSaveResult.cs
+++ b/src/Microsoft.OData.Client/BatchSaveResult.cs
@@ -102,7 +102,6 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>initial the async batch save changeset</summary>
-        [SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         internal void BatchBeginRequest()
         {
             PerRequest pereq = null;

--- a/src/Microsoft.OData.Client/Binding/DataServiceCollectionOfT.cs
+++ b/src/Microsoft.OData.Client/Binding/DataServiceCollectionOfT.cs
@@ -757,7 +757,6 @@ namespace Microsoft.OData.Client
         /// The method does not process the results of the <paramref name="endCall"/>, it just raises the <see cref="LoadCompleted"/>
         /// event as appropriate. If there's some processing to be done for the results it should all be done by the
         /// <paramref name="endCall"/> method before it returns.</remarks>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         private void BeginLoadAsyncOperation(
             Func<AsyncCallback, IAsyncResult> beginCall,
             Func<IAsyncResult, QueryOperationResponse> endCall)
@@ -804,7 +803,6 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="endCall">End method to complete the asynchronous query execution.</param>
         /// <param name="asyncResult">IAsyncResult to be passed to <paramref name="endCall"/>.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         private void EndLoadAsyncOperation(Func<IAsyncResult, QueryOperationResponse> endCall, IAsyncResult asyncResult)
         {
             try

--- a/src/Microsoft.OData.Client/Common.cs
+++ b/src/Microsoft.OData.Client/Common.cs
@@ -248,7 +248,6 @@ namespace Microsoft.OData.Service
         /// <param name="text">Text to read.</param>
         /// <param name="result">Parsed version and trailing text.</param>
         /// <returns>true if the version was read successfully; false otherwise.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         internal static bool TryReadVersion(string text, out KeyValuePair<Version, string> result)
         {
             Debug.Assert(text != null, "text != null");

--- a/src/Microsoft.OData.Client/DataServiceQueryContinuation.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryContinuation.cs
@@ -103,7 +103,6 @@ namespace Microsoft.OData.Client
 
         /// <summary>Returns the next link URI as a string.</summary>
         /// <returns>A string representation of the next link URI.  </returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0010", Justification = "ToString for display purpose is OK")]
         public override string ToString()
         {
             return this.NextLinkUri.ToString();
@@ -150,7 +149,6 @@ namespace Microsoft.OData.Client
         /// <summary>Initializes a new typed instance.</summary>
         /// <param name="nextLinkUri">URI to next page of data.</param>
         /// <param name="plan">Projection plan for results of next page.</param>
-        [SuppressMessage("DataWeb.Usage", "AC0003", Justification = "MethodCallNotAllowed: The constructor of DataServiceQueryContinuation<T> is the only place where we can call the constructor of DataServiceQueryContinuation.")]
         internal DataServiceQueryContinuation(Uri nextLinkUri, ProjectionPlan plan)
             : base(nextLinkUri, plan)
         {

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -354,7 +354,6 @@ namespace Microsoft.OData.Client
 
         /// <summary>Represents the URI of the query to the data service.</summary>
         /// <returns>A URI as string that represents the query to the data service for this <see cref="T:Microsoft.OData.Client.DataServiceQuery`1" /> instance.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0010", Justification = "ToString for display purpose is OK")]
         public override string ToString()
         {
             try

--- a/src/Microsoft.OData.Client/DataServiceRequestOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceRequestOfT.cs
@@ -92,7 +92,6 @@ namespace Microsoft.OData.Client
 
         /// <summary>Represents the URI of the query to the data service. </summary>
         /// <returns>The requested URI as a <see cref="T:System.String" /> value.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0010", Justification = "ToString for display purpose is OK")]
         public override string ToString()
         {
             return this.requestUri.ToString();

--- a/src/Microsoft.OData.Client/GetReadStreamResult.cs
+++ b/src/Microsoft.OData.Client/GetReadStreamResult.cs
@@ -60,7 +60,6 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Begins the async request
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         internal void Begin()
         {
             try
@@ -111,7 +110,6 @@ namespace Microsoft.OData.Client
         /// <returns>
         /// The response object for this request.
         /// </returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         internal DataServiceStreamResponse Execute()
         {
             try
@@ -177,7 +175,6 @@ namespace Microsoft.OData.Client
         /// Async callback registered with the underlying HttpWebRequest object.
         /// </summary>
         /// <param name="asyncResult">The async result associated with the HttpWebRequest operation.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         protected override void AsyncEndGetResponse(IAsyncResult asyncResult)
         {
             try

--- a/src/Microsoft.OData.Client/GlobalSuppressions.cs
+++ b/src/Microsoft.OData.Client/GlobalSuppressions.cs
@@ -29,11 +29,6 @@ using System.Diagnostics.CodeAnalysis;
 [module: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.OData.Client.Strings.#ODataMetadataBuilder_MissingSegmentForEntitySetUriSuffix(System.Object,System.Object)")]
 [module: SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Scope = "member", Target = "Microsoft.OData.Client.Strings.#ODataMetadataBuilder_MissingEntityInstanceUri(System.Object)")]
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Performance", "AC0002:HashSetCtorRule", Scope = "member", Target = "Microsoft.OData.Client.DataServiceCollection`1.#Microsoft.OData.Client.ICollectionSerializationAppendix.GetAppendix()")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Performance", "AC0002:HashSetCtorRule", Scope = "member", Target = "Microsoft.OData.Client.DataServiceSerializationScope.#.cctor()")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Performance", "AC0002:HashSetCtorRule", Scope = "member", Target = "Microsoft.OData.Client.KnownTypeTable.#.ctor()")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Performance", "AC0002:HashSetCtorRule", Scope = "member", Target = "Microsoft.OData.Client.DataServiceSerializationAppendice.#.ctor(Microsoft.OData.Client.DataServiceContext,System.Collections.Generic.IEnumerable`1<System.Object>)")]
-
 // Since DataServiceClientRequestMessage is already a public API, suppress this issue until we decide to make breaking changes.
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1012:AbstractTypesShouldNotHaveConstructors", Scope = "type", Target = "Microsoft.OData.Client.DataServiceClientRequestMessage")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1034:NestedTypesShouldNotBeVisible", Scope = "type", Target = "Microsoft.OData.Client.DataServiceQuery`1+DataServiceOrderedQuery")]

--- a/src/Microsoft.OData.Client/Materialization/HttpWebResponseMessage.cs
+++ b/src/Microsoft.OData.Client/Materialization/HttpWebResponseMessage.cs
@@ -56,7 +56,6 @@ namespace Microsoft.OData.Client
         /// Constructor.
         /// </summary>
         /// <param name="httpResponse">HttpWebResponse instance.</param>
-        [SuppressMessage("DataWeb.Usage", "AC0013:HttpWebResponseMustBeEncapsulated", Justification = "Particular Silverlight stacks use HttpWebResponse others use XmlHttp.")]
         public HttpWebResponseMessage(HttpWebResponse httpResponse)
         {
             Util.CheckArgumentNull(httpResponse, "httpResponse");

--- a/src/Microsoft.OData.Client/Materialization/ODataMaterializer.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataMaterializer.cs
@@ -186,7 +186,6 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="payloadKind">expected payload kind.</param>
         /// <returns>A materializer specialized for the given response.</returns>
         [SuppressMessage("Microsoft.Reliability", "CA2000", Justification = "ODataMaterializer is disposed by the caller.")]
-        [SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         public static ODataMaterializer CreateMaterializerForMessage(
             IODataResponseMessage responseMessage,
             ResponseInfo responseInfo,

--- a/src/Microsoft.OData.Client/QueryResult.cs
+++ b/src/Microsoft.OData.Client/QueryResult.cs
@@ -169,7 +169,6 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>start the asynchronous request</summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         internal void BeginExecuteQuery()
         {
             IAsyncResult asyncResult = null;
@@ -216,7 +215,6 @@ namespace Microsoft.OData.Client
 
 #if !PORTABLELIB
         /// <summary>Synchronous web request</summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         internal void ExecuteQuery()
         {
             try
@@ -506,7 +504,6 @@ namespace Microsoft.OData.Client
         /// <summary>handle request.BeginGetResponse with request.EndGetResponse and then copy response stream</summary>
         /// <param name="asyncResult">async result</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "required for this feature")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         protected override void AsyncEndGetResponse(IAsyncResult asyncResult)
         {
             Debug.Assert(asyncResult != null && asyncResult.IsCompleted, "asyncResult.IsCompleted");
@@ -639,7 +636,6 @@ namespace Microsoft.OData.Client
         /// <summary>handle responseStream.BeginRead with responseStream.EndRead</summary>
         /// <param name="asyncResult">async result</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "required for this feature")]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         private void AsyncEndRead(IAsyncResult asyncResult)
 #endif
         {

--- a/src/Microsoft.OData.Client/SaveResult.cs
+++ b/src/Microsoft.OData.Client/SaveResult.cs
@@ -846,7 +846,6 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="responseMsg">httpwebresponse instance.</param>
         /// <param name="responseStream">stream containing the response payload.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0014", Justification = "Throws every time")]
         private void HandleOperationResponseData(IODataResponseMessage responseMsg, Stream responseStream)
         {
             Debug.Assert(this.entryIndex >= 0 && this.entryIndex < this.ChangedEntries.Count(), string.Format(System.Globalization.CultureInfo.InvariantCulture, "this.entryIndex = '{0}', this.ChangedEntries.Count() = '{1}'", this.entryIndex, this.ChangedEntries.Count()));

--- a/src/Microsoft.OData.Client/Serialization/DataStringEscapeBuilder.cs
+++ b/src/Microsoft.OData.Client/Serialization/DataStringEscapeBuilder.cs
@@ -71,7 +71,6 @@ namespace Microsoft.OData.Client
         /// Build a new escaped string
         /// </summary>
         /// <returns>The escaped string</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0018:SystemUriEscapeDataStringRule", Justification = "Method explicitly only escapes specific characters that we know need escaping.")]
         private string Build()
         {
             Debug.Assert(this.index == 0, "Expected this.index to be 0, because Build can only be called once for an instance of DataStringEscapeBuilder.");
@@ -101,7 +100,6 @@ namespace Microsoft.OData.Client
         /// Read quoted string
         /// </summary>
         /// <param name="quoteStart">The character that started the quote</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0018:SystemUriEscapeDataStringRule", Justification = "Method explicitly only escapes values inside the single quotes.")]
         private void ReadQuotedString(char quoteStart)
         {
             if (this.quotedDataBuilder == null)

--- a/src/Microsoft.OData.Client/Serialization/HttpWebRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpWebRequestMessage.cs
@@ -259,7 +259,6 @@ namespace Microsoft.OData.Client
         /// <param name="callback">The System.AsyncCallback delegate.</param>
         /// <param name="state">The state object for this request.</param>
         /// <returns>An System.IAsyncResult that references the asynchronous request.</returns>
-        [SuppressMessage("DataWeb.Usage", "AC0013:HttpWebResponseMustBeEncapsulated", Justification = "Particular Silverlight stacks use HttpWebResponse others use XmlHttp.")]
         public override IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state)
         {
             // Currently this method cannot get called from SendingRequest2 event - But if we expose these
@@ -277,7 +276,6 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="asyncResult">The pending request for a stream.</param>
         /// <returns>A System.IO.Stream to use to write request data.</returns>
-        [SuppressMessage("DataWeb.Usage", "AC0013:HttpWebResponseMustBeEncapsulated", Justification = "Particular Silverlight stacks use HttpWebResponse others use XmlHttp.")]
         public override Stream EndGetRequestStream(IAsyncResult asyncResult)
         {
             return this.httpRequest.EndGetRequestStream(asyncResult);
@@ -289,7 +287,6 @@ namespace Microsoft.OData.Client
         /// <param name="callback">The System.AsyncCallback delegate.</param>
         /// <param name="state">The state object for this request.</param>
         /// <returns>An System.IAsyncResult that references the asynchronous request for a response.</returns>
-        [SuppressMessage("DataWeb.Usage", "AC0013:HttpWebResponseMustBeEncapsulated", Justification = "Particular Silverlight stacks use HttpWebResponse others use XmlHttp.")]
         public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
         {
             return this.httpRequest.BeginGetResponse(callback, state);
@@ -300,7 +297,6 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="asyncResult">The pending request for a response.</param>
         /// <returns>A System.Net.WebResponse that contains the response from the Internet resource.</returns>
-        [SuppressMessage("DataWeb.Usage", "AC0013:HttpWebResponseMustBeEncapsulated", Justification = "Particular Silverlight stacks use HttpWebResponse others use XmlHttp.")]
         public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
         {
             Debug.Assert(this.httpRequest != null, "this.httpRequest != null");
@@ -326,7 +322,6 @@ namespace Microsoft.OData.Client
         /// Returns a response from an Internet resource.
         /// </summary>
         /// <returns>A System.Net.WebResponse that contains the response from the Internet resource.</returns>
-        [SuppressMessage("DataWeb.Usage", "AC0013:HttpWebResponseMustBeEncapsulated", Justification = "Particular Silverlight stacks use HttpWebResponse others use XmlHttp.")]
         public override IODataResponseMessage GetResponse()
         {
             try

--- a/src/Microsoft.OData.Client/Serialization/Serializer.cs
+++ b/src/Microsoft.OData.Client/Serialization/Serializer.cs
@@ -737,7 +737,6 @@ namespace Microsoft.OData.Client
         /// <param name="value">The value of the <see cref="UriOperationParameter"/>.</param>
         /// <param name="useEntityReference">If true, use entity reference, instead of entity to serialize the parameter.</param>
         /// <returns>A string representation of <paramref name="value"/> for use in a Url.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("DataWeb.Usage", "AC0018:SystemUriEscapeDataStringRule", Justification = "Values being escaped are known not to contain single quotes.")]
         private string ConvertToEscapedUriValue(string paramName, object value, bool useEntityReference = false)
         {
             Debug.Assert(!string.IsNullOrEmpty(paramName), "!string.IsNullOrEmpty(paramName)");

--- a/src/Microsoft.OData.Client/UriUtil.cs
+++ b/src/Microsoft.OData.Client/UriUtil.cs
@@ -34,7 +34,6 @@ namespace Microsoft.OData.Service
         /// </summary>
         /// <param name="uri">The uri instance</param>
         /// <returns>The string representation of the uri</returns>
-        [SuppressMessage("DataWeb.Usage", "AC0010", Justification = "Usage of OriginalString is safe in this context")]
         internal static string UriToString(Uri uri)
         {
             Debug.Assert(uri != null, "uri != null");

--- a/src/Microsoft.OData.Edm/Csdl/EdmValueWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/EdmValueWriter.cs
@@ -230,7 +230,6 @@ namespace Microsoft.OData.Edm.Csdl
         /// </summary>
         /// <param name="uri">The value to convert.</param>
         /// <returns>A string representation of the Uri.</returns>
-        [SuppressMessage("DataWeb.Usage", "AC0010", Justification = "Usage of OriginalString is safe in this context")]
         internal static string UriAsXml(Uri uri)
         {
             Debug.Assert(uri != null, "uri != null");

--- a/src/Microsoft.Spatial/ForwardingSegment.cs
+++ b/src/Microsoft.Spatial/ForwardingSegment.cs
@@ -122,7 +122,6 @@ namespace Microsoft.Spatial
         /// <param name="handlerReset">The handler reset.</param>
         /// <param name="delegation">what the rest of the pipeline should do</param>
         /// <param name="delegationReset">The delegation reset.</param>
-        [SuppressMessage("DataWeb.Usage", "AC0014:DoNotHandleProhibitedExceptionsRule", Justification = "We're calling this correctly")]
         private static void DoAction(Action handler, Action handlerReset, Action delegation, Action delegationReset)
         {
             try
@@ -164,7 +163,6 @@ namespace Microsoft.Spatial
         /// <param name="delegation">what the rest of the pipeline should do</param>
         /// <param name="delegationReset">The delegation reset.</param>
         /// <param name="argument">The argument to pass to both this node and the rest of the pipeline</param>
-        [SuppressMessage("DataWeb.Usage", "AC0014:DoNotHandleProhibitedExceptionsRule", Justification = "We're calling this correctly")]
         private static void DoAction<T>(Action<T> handler, Action handlerReset, Action<T> delegation, Action delegationReset, T argument)
         {
             try

--- a/src/Microsoft.Spatial/SpatialReader.cs
+++ b/src/Microsoft.Spatial/SpatialReader.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Spatial
         /// </summary>
         /// <exception cref = "ParseErrorException">Throws if the input is not valid. In that case, guarantees that it will not pass anything down the pipeline, or will clear the pipeline by passing down a Reset.</exception>
         /// <param name = "input">The input string</param>
-        [SuppressMessage("DataWeb.Usage", "AC0014:DoNotHandleProhibitedExceptionsRule", Justification = "We're calling this correctly")]
         public void ReadGeography(TSource input)
         {
             Util.CheckArgumentNull(input, "input");
@@ -62,7 +61,6 @@ namespace Microsoft.Spatial
         /// </summary>
         /// <exception cref = "ParseErrorException">Throws if the input is not valid. In that case, guarantees that it will not pass anything down the pipeline, or will clear the pipeline by passing down a Reset.</exception>
         /// <param name = "input">The input string</param>
-        [SuppressMessage("DataWeb.Usage", "AC0014:DoNotHandleProhibitedExceptionsRule", Justification = "We're calling this correctly")]
         public void ReadGeometry(TSource input)
         {
             Util.CheckArgumentNull(input, "input");


### PR DESCRIPTION
…ssions.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request is for cleaning up AC00xx (DataUsage) warning category that has become obsoleted.*

### Description

*Remove the AC warnings.*

### Checklist (Uncheck if it is not completed)

- [ ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
