### PR TITLE
CA exclusion analysis: MSInternal warnings: removing CA908.

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ReflectionUtil.cs
+++ b/src/Microsoft.OData.Client/ALinq/ReflectionUtil.cs
@@ -471,7 +471,6 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="method">Method to identify.</param>
         /// <returns>Canonical description of method (suitable for lookup)</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies")]
         internal static string GetCanonicalMethodDescription(MethodInfo method)
         {
             // retrieve all generic type arguments and assign them numbers based on order

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightCollectionReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightCollectionReader.cs
@@ -82,7 +82,6 @@ namespace Microsoft.OData.JsonLight
         /// Pre-Condition:  JsonNodeType.None:      assumes that the JSON reader has not been used yet when not reading a nested payload.
         /// Post-Condition: The reader is positioned on the first node of the first item or the EndArray node of an empty item array
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtStartImplementationAsync()
         {
             Debug.Assert(this.State == ODataCollectionReaderState.Start, "this.State == ODataCollectionReaderState.Start");
@@ -133,7 +132,6 @@ namespace Microsoft.OData.JsonLight
         ///                 JsonNodeType.PrimitiveValue: for a primitive value as first item
         /// Post-Condition: The reader is positioned on the first node of the second item or an EndArray node if there are no items in the collection
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtCollectionStartImplementationAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadAtCollectionStartImplementationSynchronously);
@@ -170,7 +168,6 @@ namespace Microsoft.OData.JsonLight
         ///                 JsonNodeType.PrimitiveValue: for a primitive item
         /// Post-Condition: The reader is positioned on the first node of the next item or an EndArray node if there are no items in the collection
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtValueImplementationAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadAtValueImplementationSynchronously);
@@ -199,7 +196,6 @@ namespace Microsoft.OData.JsonLight
         /// Pre-Condition: JsonNodeType.EndArray        the end of the item array of the collection
         /// Post-Condition: JsonNodeType.EndOfInput     nothing else to read when not reading a nested payload
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtCollectionEndImplementationAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadAtCollectionEndImplementationSynchronously);

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightParameterReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightParameterReader.cs
@@ -89,7 +89,6 @@ namespace Microsoft.OData.JsonLight
         ///                 When the new state is Resource, the reader is positioned at the starting '{' of the resource payload.
         ///                 When the new state is Resource Set or Collection, the reader is positioned at the starting '[' of the resource set or collection payload.
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtStartImplementationAsync()
         {
             Debug.Assert(this.State == ODataParameterReaderState.Start, "this.State == ODataParameterReaderState.Start");
@@ -137,7 +136,6 @@ namespace Microsoft.OData.JsonLight
         ///                 When the new state is Resource, the reader is positioned at the starting '{' of the resource payload.
         ///                 When the new state is Resource Set or Collection, the reader is positioned at the starting '[' of the resource set or collection payload.
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadNextParameterImplementationAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadNextParameterImplementationSynchronously);
@@ -160,7 +158,6 @@ namespace Microsoft.OData.JsonLight
         /// </summary>
         /// <param name="expectedResourceType">Expected entity type to read.</param>
         /// <returns>An <see cref="ODataReader"/> to read the resource value of type <paramref name="expectedResourceType"/>.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<ODataReader> CreateResourceReaderAsync(IEdmStructuredType expectedResourceType)
         {
             return TaskUtils.GetTaskForSynchronousOperation<ODataReader>(() => this.CreateResourceReaderSynchronously(expectedResourceType));
@@ -183,7 +180,6 @@ namespace Microsoft.OData.JsonLight
         /// </summary>
         /// <param name="expectedResourceType">Expected resource set element type to read.</param>
         /// <returns>An <see cref="ODataReader"/> to read the resource set value of type <paramref name="expectedResourceType"/>.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<ODataReader> CreateResourceSetReaderAsync(IEdmStructuredType expectedResourceType)
         {
             return TaskUtils.GetTaskForSynchronousOperation<ODataReader>(() => this.CreateResourceSetReaderSynchronously(expectedResourceType));
@@ -216,7 +212,6 @@ namespace Microsoft.OData.JsonLight
         /// Post-Condition: Any:    the reader should be on the start array node of the collection value; if it is not we let the collection reader fail.
         /// NOTE: this method does not move the reader.
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<ODataCollectionReader> CreateCollectionReaderAsync(IEdmTypeReference expectedItemTypeReference)
         {
             return TaskUtils.GetTaskForSynchronousOperation<ODataCollectionReader>(() => this.CreateCollectionReaderSynchronously(expectedItemTypeReference));

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -172,8 +172,6 @@ namespace Microsoft.OData.JsonLight
         ///                 when reading a resource:  the first node of the first nested resource info value, null for a null expanded link or an end object
         ///                                         node if there are no navigation links.
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies",
-            Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtStartImplementationAsync()
         {
             Debug.Assert(this.State == ODataReaderState.Start, "this.State == ODataReaderState.Start");
@@ -226,8 +224,6 @@ namespace Microsoft.OData.JsonLight
         /// Post-Condition: The reader is positioned over the StartObject node of the first resource in the resource set or
         ///                 on the node following the resource set end in case of an empty resource set
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies",
-            Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtResourceSetStartImplementationAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadAtResourceSetStartImplementationSynchronously);
@@ -266,8 +262,6 @@ namespace Microsoft.OData.JsonLight
         ///                 JsonNodeType.EndArray       end of expanded link in request, in this case the resource set doesn't actually own the array object and it won't read it.
         ///                 Any                         in case of expanded resource set in request, this might be the next item in the expanded array, which is not a resource
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies",
-            Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtResourceSetEndImplementationAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadAtResourceSetEndImplementationSynchronously);
@@ -312,8 +306,6 @@ namespace Microsoft.OData.JsonLight
         ///                 JsonNodeType.Property               The next property after a deferred link or entity reference link
         ///                 JsonNodeType.EndObject              If no (more) properties exist in the resource's content
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies",
-            Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtResourceStartImplementationAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadAtResourceStartImplementationSynchronously);
@@ -344,8 +336,6 @@ namespace Microsoft.OData.JsonLight
         ///                 JsonNodeType.PrimitiveValue (null)  end of null expanded resource
         /// Post-Condition: The reader is positioned on the first node after the resource's end-object node
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies",
-            Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtResourceEndImplementationAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadAtResourceEndImplementationSynchronously);
@@ -390,8 +380,6 @@ namespace Microsoft.OData.JsonLight
         ///                 JsonNodeType.Property               deferred link with more properties in owning resource
         ///                 JsonNodeType.EndObject              deferred link as last property of the owning resource
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies",
-            Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtNestedResourceInfoStartImplementationAsync()
         {
             return
@@ -432,8 +420,6 @@ namespace Microsoft.OData.JsonLight
         ///                 JsonNoteType.Property           property after deferred link or entity reference link
         ///                 JsonNodeType.EndObject          end of the parent resource
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies",
-            Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtNestedResourceInfoEndImplementationAsync()
         {
             return
@@ -474,8 +460,6 @@ namespace Microsoft.OData.JsonLight
         ///                 JsonNodeType.Property:          there are more properties after the expanded link property in the owning resource
         ///                 Any:                            expanded collection link - the node after the entity reference link.
         /// </remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies",
-            Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAtEntityReferenceLinkAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadAtEntityReferenceLinkSynchronously);

--- a/src/Microsoft.OData.Core/ODataBatchReader.cs
+++ b/src/Microsoft.OData.Core/ODataBatchReader.cs
@@ -125,7 +125,6 @@ namespace Microsoft.OData
 #if PORTABLELIB
         /// <summary>Asynchronously reads the next part from the batch message payload.</summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         public Task<bool> ReadAsync()
         {
             this.VerifyCanRead(false);
@@ -263,7 +262,6 @@ namespace Microsoft.OData
         /// Asynchronously reads the next part from the batch message payload.
         /// </summary>
         /// <returns>A task that when completed indicates whether more information was read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         private Task<bool> ReadAsynchronously()
         {
             // We are reading from the fully buffered read stream here; thus it is ok

--- a/src/Microsoft.OData.Core/ODataCollectionReader.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionReader.cs
@@ -44,7 +44,6 @@ namespace Microsoft.OData
 #if PORTABLELIB
         /// <summary>Asynchronously reads the next item from the message payload.</summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         public abstract Task<bool> ReadAsync();
 #endif
     }

--- a/src/Microsoft.OData.Core/ODataCollectionReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionReaderCore.cs
@@ -153,7 +153,6 @@ namespace Microsoft.OData
         /// Asynchronously reads the next item from the message payload.
         /// </summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         public override sealed Task<bool> ReadAsync()
         {
             this.VerifyCanRead(false);
@@ -232,7 +231,6 @@ namespace Microsoft.OData
         /// Asynchronously reads the next <see cref="ODataItem"/> from the message payload.
         /// </summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected virtual Task<bool> ReadAsynchronously()
         {
             // We are reading from the fully buffered read stream here; thus it is ok

--- a/src/Microsoft.OData.Core/ODataCollectionReaderCoreAsync.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionReaderCoreAsync.cs
@@ -39,28 +39,24 @@ namespace Microsoft.OData
         /// Implementation of the collection reader logic when in state 'Start'.
         /// </summary>
         /// <returns>Task which returns true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtStartImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'CollectionStart'.
         /// </summary>
         /// <returns>Task which returns true if more nodes can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtCollectionStartImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'Value'.
         /// </summary>
         /// <returns>Task which returns true if more nodes can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtValueImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'CollectionEnd'.
         /// </summary>
         /// <returns>Task which should return false since no more nodes can be read from the reader after the collection ends.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtCollectionEndImplementationAsync();
 
         /// <summary>
@@ -69,7 +65,6 @@ namespace Microsoft.OData
         /// <returns>A task that when completed indicates whether more items were read.</returns>
         /// <remarks>The base class already implements this but only for fully synchronous readers, the implementation here
         /// allows fully asynchronous readers.</remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAsynchronously()
         {
             switch (this.State)

--- a/src/Microsoft.OData.Core/ODataDeltaReader.cs
+++ b/src/Microsoft.OData.Core/ODataDeltaReader.cs
@@ -41,7 +41,6 @@ namespace Microsoft.OData
 #if PORTABLELIB
         /// <summary> Asynchronously reads the next <see cref="T:Microsoft.OData.ODataItem" /> from the message payload. </summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         public abstract Task<bool> ReadAsync();
 #endif
     }

--- a/src/Microsoft.OData.Core/ODataParameterReader.cs
+++ b/src/Microsoft.OData.Core/ODataParameterReader.cs
@@ -76,7 +76,6 @@ namespace Microsoft.OData
 #if PORTABLELIB
         /// <summary> Asynchronously reads the next item from the message payload. </summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         public abstract Task<bool> ReadAsync();
 #endif
     }

--- a/src/Microsoft.OData.Core/ODataParameterReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterReaderCore.cs
@@ -192,7 +192,6 @@ namespace Microsoft.OData
         /// Asynchronously reads the next item from the message payload.
         /// </summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         public override sealed Task<bool> ReadAsync()
         {
             this.VerifyCanRead(false);
@@ -426,7 +425,6 @@ this.State == ODataParameterReaderState.Collection,
         /// Asynchronously reads the next <see cref="ODataItem"/> from the message payload.
         /// </summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected virtual Task<bool> ReadAsynchronously()
         {
             // We are reading from the fully buffered read stream here; thus it is ok

--- a/src/Microsoft.OData.Core/ODataParameterReaderCoreAsync.cs
+++ b/src/Microsoft.OData.Core/ODataParameterReaderCoreAsync.cs
@@ -37,14 +37,12 @@ namespace Microsoft.OData
         /// Implementation of the parameter reader logic when in state 'Start'.
         /// </summary>
         /// <returns>true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtStartImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state Value, Resource, Resource Set or Collection state.
         /// </summary>
         /// <returns>true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadNextParameterImplementationAsync();
 
         /// <summary>
@@ -52,7 +50,6 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="expectedResourceType">Expected entity type to read.</param>
         /// <returns>An <see cref="ODataReader"/> to read the resource value of type <paramref name="expectedResourceType"/>.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<ODataReader> CreateResourceReaderAsync(IEdmStructuredType expectedResourceType);
 
         /// <summary>
@@ -60,7 +57,6 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="expectedResourceType">Expected resource set element type to read.</param>
         /// <returns>An <see cref="ODataReader"/> to read the resource set value of type <paramref name="expectedResourceType"/>.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<ODataReader> CreateResourceSetReaderAsync(IEdmStructuredType expectedResourceType);
 
         /// <summary>
@@ -68,7 +64,6 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="expectedItemTypeReference">Expected item type reference of the collection to read.</param>
         /// <returns>An <see cref="ODataCollectionReader"/> to read the collection with type <paramref name="expectedItemTypeReference"/>.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<ODataCollectionReader> CreateCollectionReaderAsync(IEdmTypeReference expectedItemTypeReference);
 
         /// <summary>
@@ -77,7 +72,6 @@ namespace Microsoft.OData
         /// <returns>A task that when completed indicates whether more items were read.</returns>
         /// <remarks>The base class already implements this but only for fully synchronous readers, the implementation here
         /// allows fully asynchronous readers.</remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAsynchronously()
         {
             switch (this.State)

--- a/src/Microsoft.OData.Core/ODataReader.cs
+++ b/src/Microsoft.OData.Core/ODataReader.cs
@@ -33,7 +33,6 @@ namespace Microsoft.OData
 #if PORTABLELIB
         /// <summary> Asynchronously reads the next <see cref="T:Microsoft.OData.ODataItem" /> from the message payload. </summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         public abstract Task<bool> ReadAsync();
 #endif
     }

--- a/src/Microsoft.OData.Core/ODataReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataReaderCore.cs
@@ -326,7 +326,6 @@ namespace Microsoft.OData
         /// Asynchronously reads the next <see cref="ODataItem"/> from the message payload.
         /// </summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         public override sealed Task<bool> ReadAsync()
         {
             this.VerifyCanRead(false);
@@ -537,7 +536,6 @@ namespace Microsoft.OData
         /// Asynchronously reads the next <see cref="ODataItem"/> from the message payload.
         /// </summary>
         /// <returns>A task that when completed indicates whether more items were read.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected virtual Task<bool> ReadAsynchronously()
         {
             // We are reading from the fully buffered read stream here; thus it is ok

--- a/src/Microsoft.OData.Core/ODataReaderCoreAsync.cs
+++ b/src/Microsoft.OData.Core/ODataReaderCoreAsync.cs
@@ -40,56 +40,48 @@ namespace Microsoft.OData
         /// Implementation of the reader logic when in state 'Start'.
         /// </summary>
         /// <returns>A task which returns true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtStartImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'ResourceSetStart'.
         /// </summary>
         /// <returns>A task which returns true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtResourceSetStartImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'ResourceSetEnd'.
         /// </summary>
         /// <returns>A task which returns true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtResourceSetEndImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'EntryStart'.
         /// </summary>
         /// <returns>A task which returns true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtResourceStartImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'EntryEnd'.
         /// </summary>
         /// <returns>A task which returns true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtResourceEndImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'NestedResourceInfoStart'.
         /// </summary>
         /// <returns>A task which returns true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtNestedResourceInfoStartImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'NestedResourceInfoEnd'.
         /// </summary>
         /// <returns>A task which returns true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtNestedResourceInfoEndImplementationAsync();
 
         /// <summary>
         /// Implementation of the reader logic when in state 'EntityReferenceLink'.
         /// </summary>
         /// <returns>A task which returns true if more items can be read from the reader; otherwise false.</returns>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected abstract Task<bool> ReadAtEntityReferenceLinkAsync();
 
         /// <summary>
@@ -98,7 +90,6 @@ namespace Microsoft.OData
         /// <returns>A task that when completed indicates whether more items were read.</returns>
         /// <remarks>The base class already implements this but only for fully synchronous readers, the implementation here
         /// allows fully asynchronous readers.</remarks>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         protected override Task<bool> ReadAsynchronously()
         {
             Task<bool> result;

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/KeySegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/KeySegment.cs
@@ -24,7 +24,6 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// The set of key property names and the values to be used in searching for the given item.
         /// </summary>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "Using key value pair is exactly what we want here.")]
         private readonly ReadOnlyCollection<KeyValuePair<string, object>> keys;
 
         /// <summary>
@@ -44,7 +43,6 @@ namespace Microsoft.OData.UriParser
         /// <param name="edmType">The type of the item this key returns.</param>
         /// <param name="navigationSource">The navigation source that this key is used to search.</param>
         /// <exception cref="ODataException">Throws if the input entity set is not related to the input type.</exception>
-        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "Using key value pair is exactly what we want here.")]
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Using key value pair is exactly what we want here.")]
         public KeySegment(IEnumerable<KeyValuePair<string, object>> keys, IEdmEntityType edmType, IEdmNavigationSource navigationSource)
         {
@@ -84,7 +82,6 @@ namespace Microsoft.OData.UriParser
         [SuppressMessage("Microsoft.Design", "CA1006:DoNotNestGenericTypesInMemberSignatures", Justification = "Using key value pair is exactly what we want here.")]
         public IEnumerable<KeyValuePair<string, object>> Keys
         {
-            [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "Using key value pair is exactly what we want here.")]
             get { return this.keys.AsEnumerable(); }
         }
 

--- a/src/Microsoft.OData.Core/Utils.cs
+++ b/src/Microsoft.OData.Core/Utils.cs
@@ -57,7 +57,6 @@ namespace Microsoft.OData
         /// <param name="array">The array to sort.</param>
         /// <param name="comparison">The comparison to use to compare items in the array</param>
         /// <returns>Array of KeyValuePairs where the sequence of Values is the sorted representation of <paramref name="array"/>.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "Array.Sort is causing this, but it is needed in order to sort the KeyValuePairs using our own comparer.")]
         internal static KeyValuePair<int, T>[] StableSort<T>(this T[] array, Comparison<T> comparison)
         {
             ExceptionUtils.CheckArgumentNotNull(array, "array");

--- a/src/Microsoft.Spatial/CoordinateSystem.cs
+++ b/src/Microsoft.Spatial/CoordinateSystem.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Spatial
 
         /// <summary>Initializes a static instance of the <see cref="T:Microsoft.Spatial.CoordinateSystem" /> class.</summary>
         [SuppressMessage("Microsoft.Performance", "CA1810", Justification = "Static Constructor required")]
-        [SuppressMessage("Microsoft.MSInternal", "CA908", Justification = "generic of int required")]
         static CoordinateSystem()
         {
             References = new Dictionary<CompositeKey<int, Topology>, CoordinateSystem>(EqualityComparer<CompositeKey<int, Topology>>.Default);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request is for cleaning up CA9xx(MSInternal) warning category.*

### Description

*Remove CA908 warnings.*

### Checklist (Uncheck if it is not completed)

- [ ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
