### PR TITLE
Make ClientEdmModel.EdmStructuredSchemaElements thread-safe

### DIFF
--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -24,6 +24,7 @@ namespace Microsoft.OData.Client
     using Microsoft.OData.Edm.Library.Annotations;
     using Microsoft.OData.Edm.Library.Values;
     using c = Microsoft.OData.Client;
+    using System.Collections.Concurrent;
 
     #endregion Namespaces.
 
@@ -109,13 +110,12 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
-        /// Gets the state of whether the edm structured schema elements have been set.
+        /// Gets the state of edm structured schema elements keyed by their Name.
         /// </summary>
-        internal List<IEdmSchemaElement> EdmStructuredSchemaElements
+        internal ConcurrentDictionary<string, IEdmSchemaElement> EdmStructuredSchemaElements
         {
-            get;
-            set;
-        }
+            get; 
+        } = new ConcurrentDictionary<string, IEdmSchemaElement>();
 
         /// <summary>
         /// Gets the max protocol version of the model.
@@ -411,11 +411,10 @@ namespace Microsoft.OData.Client
             {
                 Type collectionType;
                 bool isOpen = false;
-                if (EdmStructuredSchemaElements != null && EdmStructuredSchemaElements.Any())
+                IEdmSchemaElement edmSchemaElement = null;
+                if (EdmStructuredSchemaElements.TryGetValue(ClientTypeUtil.GetServerDefinedTypeName(type), out edmSchemaElement))
                 {
-                    IEdmStructuredType edmStructuredType =
-                        EdmStructuredSchemaElements.FirstOrDefault(
-                            et => (et != null && et.Name == ClientTypeUtil.GetServerDefinedTypeName(type))) as IEdmStructuredType;
+                    var edmStructuredType = edmSchemaElement as IEdmStructuredType;
                     if (edmStructuredType != null)
                     {
                         isOpen = edmStructuredType.IsOpen;

--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -56,6 +56,7 @@ namespace Microsoft.OData.Client
         internal ClientEdmModel(ODataProtocolVersion maxProtocolVersion)
         {
             this.maxProtocolVersion = maxProtocolVersion;
+            this.EdmStructuredSchemaElements = new ConcurrentDictionary<string, IEdmSchemaElement>();
         }
 
         /// <summary>
@@ -114,8 +115,9 @@ namespace Microsoft.OData.Client
         /// </summary>
         internal ConcurrentDictionary<string, IEdmSchemaElement> EdmStructuredSchemaElements
         {
-            get; 
-        } = new ConcurrentDictionary<string, IEdmSchemaElement>();
+            get;
+            private set;
+        }
 
         /// <summary>
         /// Gets the max protocol version of the model.

--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -24,7 +24,13 @@ namespace Microsoft.OData.Client
     using Microsoft.OData.Edm.Library.Annotations;
     using Microsoft.OData.Edm.Library.Values;
     using c = Microsoft.OData.Client;
-    using System.Collections.Concurrent;
+
+#if PORTABLELIB
+    // Windows Phone 8.0 doesn't support ConcurrentDictionary
+    using ConcurrentEdmSchemaDictionary = System.Collections.Generic.Dictionary<string, Edm.IEdmSchemaElement>;
+#else
+    using ConcurrentEdmSchemaDictionary = System.Collections.Concurrent.ConcurrentDictionary<string, Edm.IEdmSchemaElement>;
+#endif
 
     #endregion Namespaces.
 
@@ -56,7 +62,7 @@ namespace Microsoft.OData.Client
         internal ClientEdmModel(ODataProtocolVersion maxProtocolVersion)
         {
             this.maxProtocolVersion = maxProtocolVersion;
-            this.EdmStructuredSchemaElements = new ConcurrentDictionary<string, IEdmSchemaElement>();
+            this.EdmStructuredSchemaElements = new ConcurrentEdmSchemaDictionary();
         }
 
         /// <summary>
@@ -113,7 +119,7 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Gets the state of edm structured schema elements keyed by their Name.
         /// </summary>
-        internal ConcurrentDictionary<string, IEdmSchemaElement> EdmStructuredSchemaElements
+        internal ConcurrentEdmSchemaDictionary EdmStructuredSchemaElements
         {
             get;
             private set;

--- a/src/Microsoft.OData.Client/DictionaryExtensions.cs
+++ b/src/Microsoft.OData.Client/DictionaryExtensions.cs
@@ -54,5 +54,38 @@ namespace Microsoft.OData.Client
                 dictionary[item.Key] = item.Value;
             }
         }
+
+#if PORTABLELIB
+        /// <summary>
+        /// Try to add a key/value pair to the dictionary and returns true if the key was added, false if it was already present.
+        /// The difference with Add is that it will not throw <see cref="ArgumentException"/> if the key is already present. 
+        /// </summary>
+        /// <remarks>
+        /// This provides a shim for ConcurrentDictionary.TryAdd that isn't supported in Windows Phone 8.0. 
+        /// </remarks>
+        /// <typeparam name="TKey">The type of the key.</typeparam>
+        /// <typeparam name="TValue">The type of the value.</typeparam>
+        /// <param name="dict">The dictionary to try to add the value to.</param>
+        /// <param name="key">The key to add if not already present.</param>
+        /// <param name="value">The value to add.</param>
+        /// <returns>True if the key was added or false if the key is already present.</returns>
+        internal static bool TryAdd<TKey, TValue>(this IDictionary<TKey, TValue> dict, TKey key, TValue value)
+        {
+            try
+            {
+                TValue val;
+                if (!dict.TryGetValue(key, out val))
+                {
+                    dict.Add(key, value);
+                    return true;
+                }
+            }
+            catch (ArgumentException)
+            {
+            }
+
+            return false;
+        }
+#endif
     }
 }

--- a/src/Microsoft.OData.Client/TypeResolver.cs
+++ b/src/Microsoft.OData.Client/TypeResolver.cs
@@ -63,19 +63,9 @@ namespace Microsoft.OData.Client
 
             if (serviceModel != null && clientEdmModel != null)
             {
-                if (clientEdmModel.EdmStructuredSchemaElements == null)
+                foreach (var element in serviceModel.SchemaElements.Where(se => se is IEdmStructuredType))
                 {
-                    clientEdmModel.EdmStructuredSchemaElements = serviceModel.SchemaElements.Where(se => se is IEdmStructuredType).ToList();
-                }
-                else
-                {
-                    foreach (var element in serviceModel.SchemaElements.Where(se => se is IEdmStructuredType))
-                    {
-                        if (!clientEdmModel.EdmStructuredSchemaElements.Contains(element))
-                        {
-                            clientEdmModel.EdmStructuredSchemaElements.Add(element);
-                        }
-                    }
+                    clientEdmModel.EdmStructuredSchemaElements.TryAdd(element.Name, element);
                 }
             }
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #898 

### Description

Change structure of `ClientEdmModel.EdmStructuredSchemaElements` from `List<IEdmSchemaElement>` to `ConcurrentDictionary<string,IEdmSchemaElement>` where the key is the `Name` property.

This should make the property thread-safe while at the same time improve performance for large number of schema elements.

The reason this property should be made thread-safe is because the `ClientEdmModel` instances are shared through the [ClientEdmModelCache](https://github.com/OData/odata.net/blob/c0389b23b383cf9f6b9009b23b9c2bff98fa660f/src/Microsoft.OData.Client/DataServiceContext.cs#L3462) while the property gets updated by `TypeResolver` when sending requests / processing responses.

### Checklist (Uncheck if it is not completed)

- [x] Build and test with one-click build and test script passed
