### PR TITLE
Modify the official lib path for performance test

### DIFF
--- a/tools/PerfAnalysis.ps1
+++ b/tools/PerfAnalysis.ps1
@@ -103,7 +103,7 @@ Function AnalysisTestResult
     If($exitResult -eq $False)
     {
         # exit 1 # fail
-        throw "Performance regression found, please see result: $logFile"
+        throw $a | ConvertTo-json        
     }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

For the 7.x release, we only have the "portable-net45+win8+wpa81" profiles. 

### Description

In some performance solution, we have some dependencies based on the official release.
We should change them with the correct path because in 7.x, the old one is removed.

### Checklist (Uncheck if it is not completed)

- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed

