### PR TITLE
Add Compute to ParseUri.

### DIFF
--- a/src/Microsoft.OData.Core/Uri/ODataUri.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUri.cs
@@ -54,6 +54,7 @@ namespace Microsoft.OData
         /// <param name="skip">Any $skip option for this uri. Can be null.</param>
         /// <param name="top">Any $top option for this uri. Can be null.</param>
         /// <param name="queryCount">Any query $count option for this uri. Can be null.</param>
+        /// <param name="compute">Any query $compute option for this uri. Can be null.</param>
         internal ODataUri(
             ParameterAliasValueAccessor parameterAliasValueAccessor,
             ODataPath path,
@@ -65,7 +66,8 @@ namespace Microsoft.OData
             ApplyClause apply,
             long? skip,
             long? top,
-            bool? queryCount)
+            bool? queryCount,
+            ComputeClause compute = null)
         {
             this.ParameterAliasValueAccessor = parameterAliasValueAccessor;
             this.Path = path;
@@ -78,6 +80,7 @@ namespace Microsoft.OData
             this.Skip = skip;
             this.Top = top;
             this.QueryCount = queryCount;
+            this.Compute = compute;
         }
 
         /// <summary>
@@ -164,6 +167,11 @@ namespace Microsoft.OData
         /// Gets or sets any $apply option for this uri.
         /// </summary>
         public ApplyClause Apply { get; set; }
+
+        /// <summary>
+        /// Gets or sets any $compute option for this uri.
+        /// </summary>
+        public ComputeClause Compute { get; set; }
 
         /// <summary>
         /// Gets or sets any $skip option for this uri.

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
@@ -449,6 +449,7 @@ namespace Microsoft.OData.UriParser
             OrderByClause orderBy = this.ParseOrderBy();
             SearchClause search = this.ParseSearch();
             ApplyClause apply = this.ParseApply();
+            ComputeClause compute = this.ParseCompute();
             long? top = this.ParseTop();
             long? skip = this.ParseSkip();
             bool? count = this.ParseCount();
@@ -458,7 +459,7 @@ namespace Microsoft.OData.UriParser
             // TODO:  check it shouldn't be empty
             List<QueryNode> boundQueryOptions = new List<QueryNode>();
 
-            ODataUri odataUri = new ODataUri(this.ParameterAliasValueAccessor, path, boundQueryOptions, selectExpand, filter, orderBy, search, apply, skip, top, count);
+            ODataUri odataUri = new ODataUri(this.ParameterAliasValueAccessor, path, boundQueryOptions, selectExpand, filter, orderBy, search, apply, skip, top, count, compute);
             odataUri.ServiceRoot = this.serviceRoot;
             odataUri.SkipToken = skipToken;
             odataUri.DeltaToken = deltaToken;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FullUriFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FullUriFunctionalTests.cs
@@ -54,7 +54,15 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             equalOperator.Right.ShouldBeConstantQueryNode("Bob");
         }
 
-       [Fact]
+        [Fact]
+        public void ParseCompute()
+        {
+            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://www.odata.com/OData"), new Uri("http://www.odata.com/OData/People?$compute=tolower(Name) as Name"));
+            ODataUri parsedUri = parser.ParseUri();
+            parsedUri.Compute.ComputedItems.Single().Expression.ShouldBeSingleValueFunctionCallQueryNode();
+        }
+
+        [Fact]
         public void ParseOrderby()
         {
             ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://www.odata.com/OData"), new Uri("http://www.odata.com/OData/People?$orderby=Name asc"));

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5079,6 +5079,7 @@ public sealed class Microsoft.OData.ODataUri {
 	public ODataUri ()
 
 	Microsoft.OData.UriParser.Aggregation.ApplyClause Apply  { public get; public set; }
+	Microsoft.OData.UriParser.ComputeClause Compute  { public get; public set; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.QueryNode]] CustomQueryOptions  { public get; public set; }
 	string DeltaToken  { public get; public set; }
 	Microsoft.OData.UriParser.FilterClause Filter  { public get; public set; }


### PR DESCRIPTION
Need to give some added exposure of the $compute option within the parser by adding it to the ODataUri general parse method.
