### PR TITLE
Add the GC Allocations measure for performance 

### DIFF
--- a/test/PerformanceTests/ComponentTests/ODataReader/ODataReaderFeedTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataReader/ODataReaderFeedTests.cs
@@ -20,48 +20,56 @@ namespace Microsoft.OData.Performance
         private static readonly IEdmEntityType TestEntityType = Model.FindDeclaredType("PerformanceServices.Edm.AdventureWorks.Product") as IEdmEntityType;
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeed()
         { 
             ReadFeedTestAndMeasure("Entry.json", 1000, true);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeedIncludeSpatial()
         {
             ReadFeedTestAndMeasure("EntryIncludeSpatial.json", 1000, true); 
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeedWithExpansions()
         {
             ReadFeedTestAndMeasure("EntryWithExpansions.json", 100, true);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeedIncludeSpatialWithExpansions()
         {
             ReadFeedTestAndMeasure("EntryIncludeSpatialWithExpansions.json", 100, true);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeed_NoValidation()
         {
             ReadFeedTestAndMeasure("Entry.json", 1000, false);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeedIncludeSpatial_NoValidation()
         {
             ReadFeedTestAndMeasure("EntryIncludeSpatial.json", 1000, false);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeedWithExpansions_NoValidation()
         {
             ReadFeedTestAndMeasure("EntryWithExpansions.json", 100, false);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeedIncludeSpatialWithExpansions_NoValidation()
         {
             ReadFeedTestAndMeasure("EntryIncludeSpatialWithExpansions.json", 100, false);

--- a/test/PerformanceTests/ComponentTests/ODataWriter/ODataWriterFeedTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataWriter/ODataWriterFeedTests.cs
@@ -24,48 +24,56 @@ namespace Microsoft.OData.Performance
         private static readonly Stream WriteStream = new MemoryStream(MaxStreamSize);
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeed()
         {
             WriteFeedTestAndMeasure(expandNavigationLinks: false, includeSpatial: false, entryCount: 1000, isFullValidation: true);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedIncludeSpatial()
         {
             WriteFeedTestAndMeasure(expandNavigationLinks: false, includeSpatial: true, entryCount: 1000, isFullValidation: true);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedWithExpansions()
         {
             WriteFeedTestAndMeasure(expandNavigationLinks: true, includeSpatial: false, entryCount: 100, isFullValidation: true);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedIncludeSpatialWithExpansions()
         {
             WriteFeedTestAndMeasure(expandNavigationLinks: true, includeSpatial: true, entryCount: 100, isFullValidation: true);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeed_NoValidation()
         {
             WriteFeedTestAndMeasure(expandNavigationLinks: false, includeSpatial: false, entryCount: 1000, isFullValidation: false);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedIncludeSpatial_NoValidation()
         {
             WriteFeedTestAndMeasure(expandNavigationLinks: false, includeSpatial: true, entryCount: 1000, isFullValidation: false);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedWithExpansions_NoValidation()
         {
             WriteFeedTestAndMeasure(expandNavigationLinks: true, includeSpatial: false, entryCount: 100, isFullValidation: false);
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedIncludeSpatialWithExpansions_NoValidation()
         {
             WriteFeedTestAndMeasure(expandNavigationLinks: true, includeSpatial: true, entryCount: 100, isFullValidation: false);

--- a/test/PerformanceTests/ComponentTests/ODataWriter/WriteFeedPropertyTypeTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataWriter/WriteFeedPropertyTypeTests.cs
@@ -22,42 +22,49 @@ namespace Microsoft.OData.Performance
         private static Stream WriteStream = new MemoryStream(MaxStreamSize);
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedWithStringSet()
         {
             TestAndMeasure("EntityStringSet");
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedWithInt32Set()
         {
             TestAndMeasure("EntityInt32Set");
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedWithInt64Set()
         {
             TestAndMeasure("EntityInt64Set");
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedWithDecimalSet()
         {
             TestAndMeasure("EntityDecimalSet");
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedWithDateTimeOffsetSet()
         {
             TestAndMeasure("EntityDateTimeOffsetSet");
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedWithGuidSet()
         {
             TestAndMeasure("EntityGuidSet");
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedWithMixedSet()
         {
             TestAndMeasure("EntityMixedSet");

--- a/test/PerformanceTests/ComponentTests/Scenario/BinaryDataScaleTests.cs
+++ b/test/PerformanceTests/ComponentTests/Scenario/BinaryDataScaleTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.OData.Performance
         private static Stream WriteStream = new MemoryStream(MaxStreamSize);
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedBinaryData_4MB()
         {
             Action<ODataWriter> writeEntry = (writer) => this.WriteEntry(writer, 4 * 1024);
@@ -40,6 +41,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeedBinaryData_4MB()
         {
             Action<ODataWriter> writeEntry = (writer) => this.WriteEntry(writer, 4 * 1024);

--- a/test/PerformanceTests/ComponentTests/Scenario/DataSizeScaleTests.cs
+++ b/test/PerformanceTests/ComponentTests/Scenario/DataSizeScaleTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.OData.Performance
         private static Stream WriteStream = new MemoryStream(MaxStreamSize);
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedDataSize_4MB()
         {
             long numberOfEntries = 0;
@@ -49,6 +50,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void WriteFeedDataSize_8MB()
         {
             long numberOfEntries = 0;
@@ -73,6 +75,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeedDataSize_4MB()
         {
             long numberOfEntries = 0;
@@ -99,6 +102,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ReadFeedDataSize_8MB()
         {
             long numberOfEntries = 0;

--- a/test/PerformanceTests/ComponentTests/UriParser/UriParserTests.cs
+++ b/test/PerformanceTests/ComponentTests/UriParser/UriParserTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.OData.Performance
         private static readonly Uri ServiceRoot = new Uri(@"http://odata.org/Perf.svc/");
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ParseUri()
         {
             string query = "Employee(1)/PurchaseOrderHeader/Vendor/ProductVendor/Product?" +
@@ -36,6 +37,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ParsePath()
         {
             string query = "Employee(1)/PurchaseOrderHeader/Vendor/ProductVendor/Product/ProductInventory(ProductID = 1,LocationID = 1)/Location/WorkOrderRouting/WorkOrder/Product/BillOfMaterials(1)/UnitMeasure/ModifiedDate";
@@ -46,6 +48,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ParseFilter()
         {
             string query = "Product?$filter=contains(Name, 'aaaa') and startswith(ProductNumber, '000') " +
@@ -58,6 +61,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ParseOrderBy()
         {
             string query = "Product?$orderby=Name,ProductNumber,MakeFlag,Color,SizeUnitMeasureCode desc,SellStartDate desc,ListPrice,StandardCost asc,ModifiedDate asc";
@@ -68,6 +72,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void ParseSelectAndExpand()
         {
             string query = "Product?$select=BillOfMaterials,ProductModel,ProductSubcategory,ProductCostHistory,ProductListPriceHistory" +

--- a/test/PerformanceTests/ServiceTests/QueryOptionTests.cs
+++ b/test/PerformanceTests/ServiceTests/QueryOptionTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void QueryOptionsWithoutExpand()
         {
             int RequestsPerIteration = 20;
@@ -38,6 +39,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void QueryOptionsWithExpand()
         {
             foreach (var iteration in Benchmark.Iterations)
@@ -50,6 +52,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void NestedQueryOptionsWithExpand()
         {
             foreach (var iteration in Benchmark.Iterations)

--- a/test/PerformanceTests/ServiceTests/SimpleQueryTests.cs
+++ b/test/PerformanceTests/ServiceTests/SimpleQueryTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void QuerySimpleEntitySet()
         {
             int RequestsPerIteration = 100;
@@ -38,6 +39,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void QueryLargeEntitySet()
         {
             foreach (var iteration in Benchmark.Iterations)
@@ -50,6 +52,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void QuerySingleEntity()
         {
             int RequestsPerIteration = 100;

--- a/test/PerformanceTests/ServiceTests/UpdateTests.cs
+++ b/test/PerformanceTests/ServiceTests/UpdateTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void PostEntity()
         {
             int RequestsPerIteration = 100;
@@ -76,6 +77,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void DeleteEntity()
         {
             int RequestsPerIteration = 100;
@@ -102,6 +104,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void PutEntity()
         {
             int RequestsPerIteration = 100;
@@ -146,6 +149,7 @@ namespace Microsoft.OData.Performance
         }
 
         [Benchmark]
+        [MeasureGCAllocations]
         public void PatchEntity()
         {
             int RequestsPerIteration = 100;


### PR DESCRIPTION
It's required to add the GC allocations measure for the performance test.
So, modify the performance tests to accept the [MeasureGCAllocations].

The performance test runner outputs the GC Allocations as below with "bytes" unit:

![image](https://user-images.githubusercontent.com/9426627/29085999-e8856a9c-7c25-11e7-8c5c-789489287b3c.png)

Meantime, to run the analysis will output the following:

![image](https://user-images.githubusercontent.com/9426627/29086043-161cfbf0-7c26-11e7-96db-27ac6fc64e3f.png)

### Checklist (Uncheck if it is not completed)

- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
