### PR TITLE
ODataUriExtensions.BuildUri ignores $skiptoken and $deltatoken

### DIFF
--- a/src/Microsoft.OData.Core/Uri/ODataUriExtensions.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriExtensions.cs
@@ -80,6 +80,20 @@ namespace Microsoft.OData
                 queryOptions = string.Concat(queryOptions, "$search", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(nodeToStringBuilder.TranslateSearchClause(odataUri.Search)));
             }
 
+            if (odataUri.SkipToken != null)
+            {
+                queryOptions = WriteQueryPrefixOrSeparator(writeQueryPrefix, queryOptions);
+                writeQueryPrefix = false;
+                queryOptions = string.Concat(queryOptions, "$skiptoken", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(odataUri.SkipToken));
+            }
+
+            if (odataUri.DeltaToken != null)
+            {
+                queryOptions = WriteQueryPrefixOrSeparator(writeQueryPrefix, queryOptions);
+                writeQueryPrefix = false;
+                queryOptions = string.Concat(queryOptions, "$deltatoken", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(odataUri.DeltaToken));
+            }
+
             if (odataUri.ParameterAliasNodes != null && odataUri.ParameterAliasNodes.Count > 0)
             {
                 string aliasNode = nodeToStringBuilder.TranslateParameterAliasNodes(odataUri.ParameterAliasNodes);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/TopAndSkipBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/TopAndSkipBuilderTests.cs
@@ -63,6 +63,33 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Uri res = uri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(new Uri("http://gobbledygook/People?$top=5&$skip=4"), res);
         }
+
+        [Fact]
+        public void BuildUrlWithSkipTokenODataUri()
+        {
+            ODataUri uri = new ODataUri();
+            uri.ServiceRoot = new Uri("http://gobbledygook/");
+            uri.SkipToken = "MyToken";
+            uri.Top = 5;
+            uri.Path = new ODataPath(new EntitySetSegment(HardCodedTestModel.GetPeopleSet()));
+            Assert.Equal(uri.ParameterAliasNodes.Count, 0);
+
+            Uri res = uri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
+            Assert.Equal(new Uri("http://gobbledygook/People?$top=5&$skiptoken=MyToken"), res);
+        }
+
+        [Fact]
+        public void BuildUrlWithDeltaTokenODataUri()
+        {
+            ODataUri uri = new ODataUri();
+            uri.ServiceRoot = new Uri("http://gobbledygook/");
+            uri.DeltaToken = "MyToken";
+            uri.Path = new ODataPath(new EntitySetSegment(HardCodedTestModel.GetPeopleSet()));
+            Assert.Equal(uri.ParameterAliasNodes.Count, 0);
+
+            Uri res = uri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
+            Assert.Equal(new Uri("http://gobbledygook/People?$deltatoken=MyToken"), res);
+        }
         #endregion
 
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #949 .*

### Description

Fix ODataUriExtensions.BuildUri() to add the output for $skiptoken and $deltatoken to the uri.

### Checklist (Uncheck if it is not completed)

- [ x ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
