### PR TITLE
Make DataServiceQuerySingle.GetValueAsync consistent with GetValue

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceQuerySingleOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQuerySingleOfT.cs
@@ -172,11 +172,11 @@ namespace Microsoft.OData.Client
             Util.CheckArgumentNull(asyncResult, "asyncResult");
             if (this.isFunction)
             {
-                return this.Context.EndExecute<TElement>(asyncResult).Single();
+                return this.Context.EndExecute<TElement>(asyncResult).SingleOrDefault();
             }
             else
             {
-                return this.Query.EndExecute(asyncResult).Single();
+                return this.Query.EndExecute(asyncResult).SingleOrDefault();
             }
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #698.*

### Description

Use `SingleOrDefault()` instead of `Single()` to get the consistent behavior in DataServiceQuerySingle.GetValueAsync and DataServiceQuerySingle.GetValue.

### Checklist

- [ ] Test cases added
- [ ] Build and test with one-click build and test script passed

### Additional work necessary

A test should be added, but this project is too huge for me to find where the test for this fix belongs.
