### PR TITLE
6.x to 7.x Porting : Batching refactor - Multipart mime only

### DIFF
--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -475,6 +475,15 @@
     <Compile Include="$(ODataCrossTargettingSourcePath)\ODataBatchReader.cs">
       <Link>Microsoft\OData\Core\ODataBatchReader.cs</Link>
     </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\MultipartMixed\ODataMultipartMixedBatchReader.cs">
+      <Link>Microsoft\OData\Core\MultipartMixed\ODataMultipartMixedBatchReader.cs</Link>
+    </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\MultipartMixed\ODataMultipartMixedBatchReaderStream.cs">
+      <Link>Microsoft\OData\Core\MultipartMixed\ODataMultipartMixedBatchReaderStream.cs</Link>
+    </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\MultipartMixed\ODataMultipartMixedBatchWriter.cs">
+      <Link>Microsoft\OData\Core\MultipartMixed\ODataMultipartMixedBatchWriter.cs</Link>
+    </Compile>  	
     <Compile Include="$(ODataCrossTargettingSourcePath)\ODataBatchReaderState.cs">
       <Link>Microsoft\OData\Core\ODataBatchReaderState.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
+++ b/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
@@ -521,6 +521,15 @@
     <Compile Include="..\ODataBatchReader.cs">
       <Link>ODataBatchReader.cs</Link>
     </Compile>
+    <Compile Include="..\MultipartMixed\ODataMultipartMixedBatchReader.cs">
+      <Link>ODataMultipartMixedBatchReader.cs</Link>
+    </Compile>
+    <Compile Include="..\MultipartMixed\ODataMultipartMixedBatchReaderStream.cs">
+      <Link>ODataMultipartMixedBatchReaderStream.cs</Link>
+    </Compile>
+    <Compile Include="..\MultipartMixed\ODataMultipartMixedBatchWriter.cs">
+      <Link>ODataMultipartMixedBatchWriter.cs</Link>
+    </Compile>  	
     <Compile Include="..\ODataBatchReaderState.cs">
       <Link>ODataBatchReaderState.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -47,6 +47,9 @@
     <Compile Include="ContainerBuilderExtensions.cs" />
     <Compile Include="EdmExtensionMethods.cs" />
     <Compile Include="Evaluation\ODataConventionalResourceMetadataBuilder.cs" />
+    <Compile Include="MultipartMixed\ODataMultipartMixedBatchReader.cs" />
+    <Compile Include="MultipartMixed\ODataMultipartMixedBatchReaderStream.cs" />
+    <Compile Include="MultipartMixed\ODataMultipartMixedBatchWriter.cs" />
     <Compile Include="UnknownEntitySet.cs" />
     <Compile Include="IContainerProvider.cs" />
     <Compile Include="IDuplicatePropertyNameChecker.cs" />

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -1,0 +1,472 @@
+//---------------------------------------------------------------------
+// <copyright file="ODataMultipartMixedBatchReader.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.MultipartMixed
+{
+    #region Namespaces
+    using System;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Text;
+
+#if PORTABLELIB
+    using System.Threading.Tasks;
+#endif
+    #endregion Namespaces
+
+    /// <summary>
+    /// Class for reading OData batch messages of MIME multipart/mixed type.
+    /// Also verifies the proper sequence of read calls on the reader.
+    /// </summary>
+    internal sealed class ODataMultipartMixedBatchReader : ODataBatchReader
+    {
+        /// <summary>The batch stream used by the batch reader to divide a batch payload into parts.</summary>
+        private readonly ODataMultipartMixedBatchReaderStream batchStream;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="inputContext">The input context to read the content from.</param>
+        /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
+        /// <param name="batchEncoding">The encoding to use to read from the batch stream.</param>
+        /// <param name="synchronous">true if the reader is created for synchronous operation; false for asynchronous.</param>
+        internal ODataMultipartMixedBatchReader(ODataInputContext inputContext, string batchBoundary, Encoding batchEncoding, bool synchronous)
+            : base(inputContext, synchronous)
+        {
+            Debug.Assert(inputContext != null, "inputContext != null");
+            Debug.Assert(this.RawInputContext != null, "this.RawInputContext != null");
+            Debug.Assert(!string.IsNullOrEmpty(batchBoundary), "!string.IsNullOrEmpty(batchBoundary)");
+
+            this.batchStream = new ODataMultipartMixedBatchReaderStream(this.RawInputContext, batchBoundary, batchEncoding);
+        }
+
+        /// <summary>
+        /// Gets the reader's input context as the real runtime type.
+        /// </summary>
+        internal ODataRawInputContext RawInputContext
+        {
+            get
+            {
+                return this.InputContext as ODataRawInputContext;
+            }
+        }
+
+        /// <summary>
+        /// Parses the request line of a batch operation request.
+        /// </summary>
+        /// <param name="requestLine">The request line as a string.</param>
+        /// <param name="httpMethod">The parsed HTTP method of the request.</param>
+        /// <param name="requestUri">The parsed <see cref="Uri"/> of the request.</param>
+        internal void ParseRequestLine(string requestLine, out string httpMethod, out Uri requestUri)
+        {
+            Debug.Assert(!this.RawInputContext.ReadingResponse, "Must only be called for requests.");
+
+            // Batch Request: POST /Customers HTTP/1.1
+            // Since the uri can contain spaces, the only way to read the request url, is to
+            // check for first space character and last space character and anything between
+            // them.
+            int firstSpaceIndex = requestLine.IndexOf(' ');
+
+            // Check whether there are enough characters after the first space for the 2nd and 3rd segments
+            // (and a whitespace in between)
+            if (firstSpaceIndex <= 0 || requestLine.Length - 3 <= firstSpaceIndex)
+            {
+                // only 1 segment or empty first segment or not enough left for 2nd and 3rd segments
+                throw new ODataException(Strings.ODataBatchReaderStream_InvalidRequestLine(requestLine));
+            }
+
+            int lastSpaceIndex = requestLine.LastIndexOf(' ');
+            if (lastSpaceIndex < 0 || lastSpaceIndex - firstSpaceIndex - 1 <= 0 || requestLine.Length - 1 <= lastSpaceIndex)
+            {
+                // only 2 segments or empty 2nd or 3rd segments
+                // only 1 segment or empty first segment or not enough left for 2nd and 3rd segments
+                throw new ODataException(Strings.ODataBatchReaderStream_InvalidRequestLine(requestLine));
+            }
+
+            httpMethod = requestLine.Substring(0, firstSpaceIndex);               // Request - Http method
+            string uriSegment = requestLine.Substring(firstSpaceIndex + 1, lastSpaceIndex - firstSpaceIndex - 1);      // Request - Request uri
+            string httpVersionSegment = requestLine.Substring(lastSpaceIndex + 1);             // Request - Http version
+
+            // Validate HttpVersion
+            if (string.CompareOrdinal(ODataConstants.HttpVersionInBatching, httpVersionSegment) != 0)
+            {
+                throw new ODataException(Strings.ODataBatchReaderStream_InvalidHttpVersionSpecified(httpVersionSegment, ODataConstants.HttpVersionInBatching));
+            }
+
+            // NOTE: this method will throw if the method is not recognized.
+            HttpUtils.ValidateHttpMethod(httpMethod);
+
+            // Validate the HTTP method when reading a request
+            if (this.batchStream.ChangeSetBoundary != null)
+            {
+                // allow all methods except for GET
+                if (HttpUtils.IsQueryMethod(httpMethod))
+                {
+                    throw new ODataException(Strings.ODataBatch_InvalidHttpMethodForChangeSetRequest(httpMethod));
+                }
+            }
+
+            requestUri = new Uri(uriSegment, UriKind.RelativeOrAbsolute);
+            requestUri = ODataBatchUtils.CreateOperationRequestUri(requestUri, this.RawInputContext.MessageReaderSettings.BaseUri, this.payloadUriConverter);
+        }
+
+        /// <summary>
+        /// Returns the cached <see cref="ODataBatchOperationRequestMessage"/> for reading the content of an operation
+        /// in a batch request.
+        /// </summary>
+        /// <returns>The message that can be used to read the content of the batch request operation from.</returns>
+        protected override ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation()
+        {
+            this.ReaderOperationState = OperationState.MessageCreated;
+
+            string requestLine = this.batchStream.ReadFirstNonEmptyLine();
+
+            string httpMethod;
+            Uri requestUri;
+            this.ParseRequestLine(requestLine, out httpMethod, out requestUri);
+
+            // Read all headers and create the request message
+            ODataBatchOperationHeaders headers = this.batchStream.ReadHeaders();
+
+            if (this.batchStream.ChangeSetBoundary != null)
+            {
+                if (this.AllowLegacyContentIdBehavior)
+                {
+                    // Add a potential Content-ID header to the URL resolver so that it will be available
+                    // to subsequent operations.
+                    string contentId;
+                    if (this.ContentIdToAddOnNextRead == null && headers.TryGetValue(ODataConstants.ContentIdHeader, out contentId))
+                    {
+                        if (contentId != null && this.payloadUriConverter.ContainsContentId(contentId))
+                        {
+                            throw new ODataException(Strings.ODataBatchReader_DuplicateContentIDsNotAllowed(contentId));
+                        }
+
+                        this.ContentIdToAddOnNextRead = contentId;
+                    }
+                }
+
+                if (this.ContentIdToAddOnNextRead == null)
+                {
+                    throw new ODataException(Strings.ODataBatchOperationHeaderDictionary_KeyNotFound(ODataConstants.ContentIdHeader));
+                }
+            }
+
+            ODataBatchOperationRequestMessage requestMessage = ODataBatchOperationRequestMessage.CreateReadMessage(
+                this.batchStream,
+                httpMethod,
+                requestUri,
+                headers,
+                /*operationListener*/ this,
+                this.ContentIdToAddOnNextRead,
+                this.payloadUriConverter,
+                this.container);
+
+            return requestMessage;
+        }
+
+        /// <summary>
+        /// Returns the cached <see cref="ODataBatchOperationRequestMessage"/> for reading the content of an operation
+        /// in a batch request.
+        /// </summary>
+        /// <returns>The message that can be used to read the content of the batch request operation from.</returns>
+        protected override ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation()
+        {
+            this.ReaderOperationState = OperationState.MessageCreated;
+
+            string responseLine = this.batchStream.ReadFirstNonEmptyLine();
+
+            int statusCode = this.ParseResponseLine(responseLine);
+
+            // Read all headers and create the response message
+            ODataBatchOperationHeaders headers = this.batchStream.ReadHeaders();
+
+            if (this.batchStream.ChangeSetBoundary != null)
+            {
+                if (this.AllowLegacyContentIdBehavior)
+                {
+                    // Add a potential Content-ID header to the URL resolver so that it will be available
+                    // to subsequent operations.
+                    string contentId;
+                    if (this.ContentIdToAddOnNextRead == null && headers.TryGetValue(ODataConstants.ContentIdHeader, out contentId))
+                    {
+                        if (contentId != null && this.payloadUriConverter.ContainsContentId(contentId))
+                        {
+                            throw new ODataException(Strings.ODataBatchReader_DuplicateContentIDsNotAllowed(contentId));
+                        }
+
+                        this.ContentIdToAddOnNextRead = contentId;
+                    }
+                }
+            }
+
+            // In responses we don't need to use our batch URL resolver, since there are no cross referencing URLs
+            // so use the URL resolver from the batch message instead.
+            ODataBatchOperationResponseMessage responseMessage = ODataBatchOperationResponseMessage.CreateReadMessage(
+                this.batchStream,
+                statusCode,
+                headers,
+                this.ContentIdToAddOnNextRead,
+                /*operationListener*/ this,
+                this.payloadUriConverter,
+                this.container);
+
+            //// NOTE: Content-IDs for cross referencing are only supported in request messages; in responses
+            ////       we allow a Content-ID header but don't process it (i.e., don't add the content ID to the URL resolver).
+
+            return responseMessage;
+        }
+
+        /// <summary>
+        /// Continues reading from the batch message payload.
+        /// </summary>
+        /// <returns>true if more items were read; otherwise false.</returns>
+        protected override bool ReadImplementation()
+        {
+            Debug.Assert(this.ReaderOperationState != OperationState.StreamRequested, "Should have verified that no operation stream is still active.");
+
+            switch (this.State)
+            {
+                case ODataBatchReaderState.Initial:
+                    // The stream should be positioned at the beginning of the batch content,
+                    // that is before the first boundary (or the preamble if there is one).
+                    this.State = this.SkipToNextPartAndReadHeaders();
+                    break;
+
+                case ODataBatchReaderState.Operation:
+                    // When reaching this state we already read the MIME headers of the operation.
+                    // Clients MUST call CreateOperationRequestMessage
+                    // or CreateOperationResponseMessage to read at least the headers of the operation.
+                    // This is important since we need to read the ContentId header (if present) and
+                    // add it to the URL resolver.
+                    if (this.ReaderOperationState == OperationState.None)
+                    {
+                        // No message was created; fail
+                        throw new ODataException(Strings.ODataBatchReader_NoMessageWasCreatedForOperation);
+                    }
+
+                    // Reset the operation state; the operation state only
+                    // tracks the state of a batch operation while in state Operation.
+                    this.ReaderOperationState = OperationState.None;
+
+                    // Also add a pending ContentId header to the URL resolver now. We ensured above
+                    // that a message has been created for this operation and thus the headers (incl.
+                    // a potential content ID header) have been read.
+                    if (this.ContentIdToAddOnNextRead != null)
+                    {
+                        this.payloadUriConverter.AddContentId(this.ContentIdToAddOnNextRead);
+                        this.ContentIdToAddOnNextRead = null;
+                    }
+
+                    // When we are done with an operation, we have to skip ahead to the next part
+                    // when Read is called again. Note that if the operation stream was never requested
+                    // and the content of the operation has not been read, we'll skip it here.
+                    Debug.Assert(this.ReaderOperationState == OperationState.None, "Operation state must be 'None' at the end of the operation.");
+                    this.State = this.SkipToNextPartAndReadHeaders();
+                    break;
+
+                case ODataBatchReaderState.ChangesetStart:
+                    // When at the start of a changeset, skip ahead to the first operation in the
+                    // changeset (or the end boundary of the changeset).
+                    Debug.Assert(this.batchStream.ChangeSetBoundary != null, "Changeset boundary must have been set by now.");
+                    this.State = this.SkipToNextPartAndReadHeaders();
+                    break;
+
+                case ODataBatchReaderState.ChangesetEnd:
+                    // When at the end of a changeset, reset the changeset boundary and the
+                    // changeset size and then skip to the next part.
+                    this.ResetChangesetSize();
+                    this.batchStream.ResetChangeSetBoundary();
+                    this.State = this.SkipToNextPartAndReadHeaders();
+                    break;
+
+                case ODataBatchReaderState.Exception:    // fall through
+                case ODataBatchReaderState.Completed:
+                    Debug.Assert(false, "Should have checked in VerifyCanRead that we are not in one of these states.");
+                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_ReadImplementation));
+
+                default:
+                    Debug.Assert(false, "Unsupported reader state " + this.State + " detected.");
+                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_ReadImplementation));
+            }
+
+            return this.State != ODataBatchReaderState.Completed && this.State != ODataBatchReaderState.Exception;
+        }
+
+
+        /// <summary>
+        /// Parses the response line of a batch operation response.
+        /// </summary>
+        /// <param name="responseLine">The response line as a string.</param>
+        /// <returns>The parsed status code from the response line.</returns>
+        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "'this' is used when built in debug")]
+        private int ParseResponseLine(string responseLine)
+        {
+            Debug.Assert(this.RawInputContext.ReadingResponse, "Must only be called for responses.");
+
+            // Batch Response: HTTP/1.1 200 Ok
+            // Since the http status code strings have spaces in them, we cannot use the same
+            // logic. We need to check for the second space and anything after that is the error
+            // message.
+            int firstSpaceIndex = responseLine.IndexOf(' ');
+            if (firstSpaceIndex <= 0 || responseLine.Length - 3 <= firstSpaceIndex)
+            {
+                // only 1 segment or empty first segment or not enough left for 2nd and 3rd segments
+                throw new ODataException(Strings.ODataBatchReaderStream_InvalidResponseLine(responseLine));
+            }
+
+            int secondSpaceIndex = responseLine.IndexOf(' ', firstSpaceIndex + 1);
+            if (secondSpaceIndex < 0 || secondSpaceIndex - firstSpaceIndex - 1 <= 0 || responseLine.Length - 1 <= secondSpaceIndex)
+            {
+                // only 2 segments or empty 2nd or 3rd segments
+                // only 1 segment or empty first segment or not enough left for 2nd and 3rd segments
+                throw new ODataException(Strings.ODataBatchReaderStream_InvalidResponseLine(responseLine));
+            }
+
+            string httpVersionSegment = responseLine.Substring(0, firstSpaceIndex);
+            string statusCodeSegment = responseLine.Substring(firstSpaceIndex + 1, secondSpaceIndex - firstSpaceIndex - 1);
+
+            // Validate HttpVersion
+            if (string.CompareOrdinal(ODataConstants.HttpVersionInBatching, httpVersionSegment) != 0)
+            {
+                throw new ODataException(Strings.ODataBatchReaderStream_InvalidHttpVersionSpecified(httpVersionSegment, ODataConstants.HttpVersionInBatching));
+            }
+
+            int intResult;
+            if (!Int32.TryParse(statusCodeSegment, out intResult))
+            {
+                throw new ODataException(Strings.ODataBatchReaderStream_NonIntegerHttpStatusCode(statusCodeSegment));
+            }
+
+            return intResult;
+        }
+
+        /// <summary>
+        /// Skips all data in the stream until the next part is detected; then reads the part's request/response line and headers.
+        /// </summary>
+        /// <returns>The next state of the batch reader after skipping to the next part and reading the part's beginning.</returns>
+        private ODataBatchReaderState SkipToNextPartAndReadHeaders()
+        {
+            bool isEndBoundary, isParentBoundary;
+            bool foundBoundary = this.batchStream.SkipToBoundary(out isEndBoundary, out isParentBoundary);
+
+            if (!foundBoundary)
+            {
+                // We did not find the expected boundary at all in the payload;
+                // we are done reading. Depending on where we are report changeset end or completed state
+                if (this.batchStream.ChangeSetBoundary == null)
+                {
+                    return ODataBatchReaderState.Completed;
+                }
+                else
+                {
+                    return ODataBatchReaderState.ChangesetEnd;
+                }
+            }
+
+            ODataBatchReaderState nextState;
+            if (isEndBoundary || isParentBoundary)
+            {
+                // We detected an end boundary or detected that the end boundary is missing
+                // because we found a parent boundary
+                nextState = this.GetEndBoundaryState();
+
+                if (nextState == ODataBatchReaderState.ChangesetEnd)
+                {
+                    // Reset the URL resolver at the end of a changeset; Content IDs are
+                    // unique within a given changeset.
+                    this.payloadUriConverter.Reset();
+                }
+            }
+            else
+            {
+                bool currentlyInChangeSet = this.batchStream.ChangeSetBoundary != null;
+                string contentId;
+
+                // If we did not find an end boundary, we found another part
+                bool isChangeSetPart = this.batchStream.ProcessPartHeader(out contentId);
+
+                // Compute the next reader state
+                if (currentlyInChangeSet)
+                {
+                    Debug.Assert(!isChangeSetPart, "Should have validated that nested changesets are not allowed.");
+                    nextState = ODataBatchReaderState.Operation;
+                    this.IncreaseChangesetSize();
+                }
+                else
+                {
+                    // We are at the top level (not inside a changeset)
+                    nextState = isChangeSetPart
+                        ? ODataBatchReaderState.ChangesetStart
+                        : ODataBatchReaderState.Operation;
+                    this.IncreaseBatchSize();
+                }
+
+                if (!isChangeSetPart)
+                {
+                    // Add a potential Content-ID header to the URL resolver so that it will be available
+                    // to subsequent operations.
+                    Debug.Assert(this.ContentIdToAddOnNextRead == null, "Must not have a content ID to be added to a part.");
+
+                    if (contentId != null && this.payloadUriConverter.ContainsContentId(contentId))
+                    {
+                        throw new ODataException(Strings.ODataBatchReader_DuplicateContentIDsNotAllowed(contentId));
+                    }
+
+                    this.ContentIdToAddOnNextRead = contentId;
+                }
+            }
+
+            return nextState;
+        }
+
+
+        /// <summary>
+        /// Returns the next state of the batch reader after an end boundary has been found.
+        /// </summary>
+        /// <returns>The next state of the batch reader.</returns>
+        private ODataBatchReaderState GetEndBoundaryState()
+        {
+            switch (this.State)
+            {
+                case ODataBatchReaderState.Initial:
+                    // If we find an end boundary when in state 'Initial' it means that we
+                    // have an empty batch. The next state will be 'Completed'.
+                    return ODataBatchReaderState.Completed;
+
+                case ODataBatchReaderState.Operation:
+                    // If we find an end boundary in state 'Operation' we have finished
+                    // processing an operation and found the end boundary of either the
+                    // current changeset or the batch.
+                    return this.batchStream.ChangeSetBoundary == null
+                        ? ODataBatchReaderState.Completed
+                        : ODataBatchReaderState.ChangesetEnd;
+
+                case ODataBatchReaderState.ChangesetStart:
+                    // If we find an end boundary when in state 'ChangeSetStart' it means that
+                    // we have an empty changeset. The next state will be 'ChangeSetEnd'
+                    return ODataBatchReaderState.ChangesetEnd;
+
+                case ODataBatchReaderState.ChangesetEnd:
+                    // If we are at the end of a changeset and find an end boundary
+                    // we reached the end of the batch
+                    return ODataBatchReaderState.Completed;
+
+                case ODataBatchReaderState.Completed:
+                    // We should never get here when in Completed state.
+                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_GetEndBoundary_Completed));
+
+                case ODataBatchReaderState.Exception:
+                    // We should never get here when in Exception state.
+                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_GetEndBoundary_Exception));
+
+                default:
+                    // Invalid enum value
+                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_GetEndBoundary_UnknownValue));
+            }
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReaderStream.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReaderStream.cs
@@ -1,0 +1,684 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataMultipartMixedBatchReaderStream.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.MultipartMixed
+{
+    #region Namespaces
+
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Text;
+
+    #endregion Namespaces
+
+    /// <summary>
+    /// Class used by the <see cref="ODataMultipartMixedBatchReader"/> to read the various pieces of a batch payload
+    /// in multipart/mixed format.
+    /// </summary>
+    /// <remarks>
+    /// This stream separates a batch payload into multiple parts by scanning ahead and matching
+    /// a boundary string against the current payload.
+    /// </remarks>
+    internal sealed class ODataMultipartMixedBatchReaderStream : ODataBatchReaderStream
+    {
+        /// <summary>
+        /// The default length for the line buffer byte array used to read lines; expecting lines to normally be less than 2000 bytes.
+        /// </summary>
+        private const int LineBufferLength = 2000;
+
+        /// <summary>
+        /// The byte array used for reading lines from the stream. We cache the byte array on the stream instance
+        /// rather than allocating a new one for each ReadLine call.
+        /// </summary>
+        private readonly byte[] lineBuffer;
+
+        /// <summary>
+        /// The boundary string for the batch structure itself.
+        /// </summary>
+        private readonly string batchBoundary;
+
+        /// <summary>
+        /// The boundary string for a changeset (or null if not in a changeset part).
+        /// </summary>
+        private string changesetBoundary;
+
+        /// <summary>
+        /// The raw input context used by the reader.
+        /// </summary>
+        private ODataRawInputContext rawInputContext;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="inputContext">The input context to read the content from.</param>
+        /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
+        /// <param name="batchEncoding">The encoding to use to read from the batch stream.</param>
+        internal ODataMultipartMixedBatchReaderStream(
+            ODataRawInputContext inputContext,
+            string batchBoundary,
+            Encoding batchEncoding)
+            : base(batchEncoding)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(batchBoundary), "!string.IsNullOrEmpty(batchBoundary)");
+
+            this.rawInputContext = inputContext;
+            this.batchBoundary = batchBoundary;
+
+            // When we allocate a batch reader stream we will in almost all cases also call ReadLine
+            // (to read the headers of the parts); so allocating it here.
+            this.lineBuffer = new byte[LineBufferLength];
+        }
+
+        /// <summary>
+        /// The boundary string for the batch structure itself.
+        /// </summary>
+        internal string BatchBoundary
+        {
+            get
+            {
+                return this.batchBoundary;
+            }
+        }
+
+        /// <summary>
+        /// The boundary string for the current changeset (only set when reading a changeset
+        /// or an operation in a changeset).
+        /// </summary>
+        /// <remarks>When not reading a changeset (or operation in a changeset) this field is null.</remarks>
+        internal string ChangeSetBoundary
+        {
+            get
+            {
+                return this.changesetBoundary;
+            }
+        }
+
+        /// <summary>
+        /// The current boundary string to be used for reading with delimiter.
+        /// </summary>
+        /// <remarks>This is the changeset boundary when reading a changeset or the batch boundary otherwise.</remarks>
+        private IEnumerable<string> CurrentBoundaries
+        {
+            get
+            {
+                if (this.changesetBoundary != null)
+                {
+                    yield return this.changesetBoundary;
+                }
+
+                yield return this.batchBoundary;
+            }
+        }
+
+        /// <summary>
+        /// Resets the changeset boundary at the end of the changeset.
+        /// </summary>
+        internal void ResetChangeSetBoundary()
+        {
+            Debug.Assert(this.changesetBoundary != null, "Only valid to reset a changeset boundary if one exists.");
+            this.changesetBoundary = null;
+            this.changesetEncoding = null;
+        }
+
+        /// <summary>
+        /// Skips all the data in the stream until a boundary is found.
+        /// </summary>
+        /// <param name="isEndBoundary">true if the boundary that was found is an end boundary; otherwise false.</param>
+        /// <param name="isParentBoundary">true if the detected boundary is a parent boundary (i.e., the expected boundary is missing).</param>
+        /// <returns>true if a boundary was found; otherwise false.</returns>
+        internal bool SkipToBoundary(out bool isEndBoundary, out bool isParentBoundary)
+        {
+            // Ensure we have a batch encoding; if not detect it on the first read/skip.
+            this.EnsureBatchEncoding(this.rawInputContext.Stream);
+
+            ODataBatchReaderStreamScanResult scanResult = ODataBatchReaderStreamScanResult.NoMatch;
+            while (scanResult != ODataBatchReaderStreamScanResult.Match)
+            {
+                int boundaryStartPosition, boundaryEndPosition;
+                scanResult = this.batchBuffer.ScanForBoundary(
+                    this.CurrentBoundaries,
+                    /*stopAfterIfNotFound*/int.MaxValue,
+                    out boundaryStartPosition,
+                    out boundaryEndPosition,
+                    out isEndBoundary,
+                    out isParentBoundary);
+                switch (scanResult)
+                {
+                    case ODataBatchReaderStreamScanResult.NoMatch:
+                        if (this.underlyingStreamExhausted)
+                        {
+                            // there is nothing else to load from the underlying stream; the requested boundary does not exist
+                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + this.batchBuffer.NumberOfBytesInBuffer);
+                            return false;
+                        }
+
+                        // skip everything in the buffer and refill it from the underlying stream; continue scanning
+                        this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.rawInputContext.Stream, /*preserveFrom*/ODataBatchReaderStreamBuffer.BufferLength);
+                        break;
+
+                    case ODataBatchReaderStreamScanResult.PartialMatch:
+                        if (this.underlyingStreamExhausted)
+                        {
+                            // there is nothing else to load from the underlying stream; the requested boundary does not exist
+                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + this.batchBuffer.NumberOfBytesInBuffer);
+                            return false;
+                        }
+
+                        this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.rawInputContext.Stream, /*preserveFrom*/boundaryStartPosition);
+                        break;
+
+                    case ODataBatchReaderStreamScanResult.Match:
+                        // If we found the expected boundary, position the reader on the position after the boundary end.
+                        // If we found a parent boundary, position the reader on the boundary start so we'll detect the boundary
+                        // again on the next Read call.
+                        this.batchBuffer.SkipTo(isParentBoundary ? boundaryStartPosition : boundaryEndPosition + 1);
+                        return true;
+
+                    default:
+                        throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStream_SkipToBoundary));
+                }
+            }
+
+            throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStream_SkipToBoundary));
+        }
+
+        /// <summary>
+        /// Reads from the batch stream while ensuring that we stop reading at each boundary.
+        /// </summary>
+        /// <param name="userBuffer">The byte array to read bytes into.</param>
+        /// <param name="userBufferOffset">The offset in the buffer where to start reading bytes into.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <returns>The number of bytes actually read.</returns>
+        internal override int ReadWithDelimiter(byte[] userBuffer, int userBufferOffset, int count)
+        {
+            Debug.Assert(userBuffer != null, "userBuffer != null");
+            Debug.Assert(userBufferOffset >= 0 && userBufferOffset < userBuffer.Length, "Offset must be within the range of the user buffer.");
+            Debug.Assert(count >= 0, "count >= 0");
+            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
+
+            if (count == 0)
+            {
+                // Nothing to read.
+                return 0;
+            }
+
+            int remainingNumberOfBytesToRead = count;
+            ODataBatchReaderStreamScanResult scanResult = ODataBatchReaderStreamScanResult.NoMatch;
+
+            while (remainingNumberOfBytesToRead > 0 && scanResult != ODataBatchReaderStreamScanResult.Match)
+            {
+                int boundaryStartPosition, boundaryEndPosition;
+                bool isEndBoundary, isParentBoundary;
+                scanResult = this.batchBuffer.ScanForBoundary(
+                    this.CurrentBoundaries,
+                    remainingNumberOfBytesToRead,
+                    out boundaryStartPosition,
+                    out boundaryEndPosition,
+                    out isEndBoundary,
+                    out isParentBoundary);
+
+                int bytesBeforeBoundaryStart;
+                switch (scanResult)
+                {
+                    case ODataBatchReaderStreamScanResult.NoMatch:
+                        // The boundary was not found in the buffer or after the required number of bytes to be read;
+                        // Check whether we can satisfy the full read request from the buffer
+                        // or whether we have to split the request and read more data into the buffer.
+                        if (this.batchBuffer.NumberOfBytesInBuffer >= remainingNumberOfBytesToRead)
+                        {
+                            // we can satisfy the full read request from the buffer
+                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, remainingNumberOfBytesToRead);
+                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + remainingNumberOfBytesToRead);
+                            return count;
+                        }
+                        else
+                        {
+                            // we can only partially satisfy the read request
+                            int availableBytesToRead = this.batchBuffer.NumberOfBytesInBuffer;
+                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, availableBytesToRead);
+                            remainingNumberOfBytesToRead -= availableBytesToRead;
+                            userBufferOffset += availableBytesToRead;
+
+                            // we exhausted the buffer; if the underlying stream is not exceeded, refill the buffer
+                            if (this.underlyingStreamExhausted)
+                            {
+                                // We cannot fully satisfy the read request since there are not enough bytes in the stream.
+                                // Return the number of bytes we read.
+                                this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + availableBytesToRead);
+                                return count - remainingNumberOfBytesToRead;
+                            }
+                            else
+                            {
+                                this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.rawInputContext.Stream, /*preserveFrom*/ ODataBatchReaderStreamBuffer.BufferLength);
+                            }
+                        }
+
+                        break;
+
+                    case ODataBatchReaderStreamScanResult.PartialMatch:
+                        // A partial match for the boundary was found at the end of the buffer.
+                        // If the underlying stream is not exceeded, refill the buffer. Otherwise return
+                        // the available bytes.
+                        if (this.underlyingStreamExhausted)
+                        {
+                            // We cannot fully satisfy the read request since there are not enough bytes in the stream.
+                            // Return the remaining bytes in the buffer independently of where a portentially boundary
+                            // start was detected since no full boundary can ever be detected if the stream is exhausted.
+                            int bytesToReturn = Math.Min(this.batchBuffer.NumberOfBytesInBuffer, remainingNumberOfBytesToRead);
+                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, bytesToReturn);
+                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + bytesToReturn);
+                            remainingNumberOfBytesToRead -= bytesToReturn;
+                            return count - remainingNumberOfBytesToRead;
+                        }
+                        else
+                        {
+                            // Copy the bytes prior to the potential boundary start into the user buffer, refill the buffer and continue.
+                            bytesBeforeBoundaryStart = boundaryStartPosition - this.batchBuffer.CurrentReadPosition;
+                            Debug.Assert(bytesBeforeBoundaryStart < remainingNumberOfBytesToRead, "When reporting a partial match we should never have read all the remaining bytes to read (or more).");
+
+                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, bytesBeforeBoundaryStart);
+                            remainingNumberOfBytesToRead -= bytesBeforeBoundaryStart;
+                            userBufferOffset += bytesBeforeBoundaryStart;
+
+                            this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.rawInputContext.Stream, /*preserveFrom*/ boundaryStartPosition);
+                        }
+
+                        break;
+
+                    case ODataBatchReaderStreamScanResult.Match:
+                        // We found the full boundary match; copy everything before the boundary to the buffer
+                        bytesBeforeBoundaryStart = boundaryStartPosition - this.batchBuffer.CurrentReadPosition;
+                        Debug.Assert(bytesBeforeBoundaryStart <= remainingNumberOfBytesToRead, "When reporting a full match we should never have read more than the remaining bytes to read.");
+                        Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, bytesBeforeBoundaryStart);
+                        remainingNumberOfBytesToRead -= bytesBeforeBoundaryStart;
+                        userBufferOffset += bytesBeforeBoundaryStart;
+
+                        // position the reader on the position of the boundary start
+                        this.batchBuffer.SkipTo(boundaryStartPosition);
+
+                        // return the number of bytes that were read
+                        return count - remainingNumberOfBytesToRead;
+
+                    default:
+                        break;
+                }
+            }
+
+            throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStream_ReadWithDelimiter));
+        }
+
+        /// <summary>
+        /// Reads from the batch stream without checking for a boundary delimiter since we
+        /// know the length of the stream.
+        /// </summary>
+        /// <param name="userBuffer">The byte array to read bytes into.</param>
+        /// <param name="userBufferOffset">The offset in the buffer where to start reading bytes into.</param>
+        /// <param name="count">The number of bytes to read.</param>
+        /// <returns>The number of bytes actually read.</returns>
+        internal override int ReadWithLength(byte[] userBuffer, int userBufferOffset, int count)
+        {
+            Debug.Assert(userBuffer != null, "userBuffer != null");
+            Debug.Assert(userBufferOffset >= 0, "userBufferOffset >= 0");
+            Debug.Assert(count >= 0, "count >= 0");
+            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
+
+            //// NOTE: if we have a stream with length we don't even check for boundaries but rely solely on the content length
+
+            int remainingNumberOfBytesToRead = count;
+            while (remainingNumberOfBytesToRead > 0)
+            {
+                // check whether we can satisfy the full read request from the buffer
+                // or whether we have to split the request and read more data into the buffer.
+                if (this.batchBuffer.NumberOfBytesInBuffer >= remainingNumberOfBytesToRead)
+                {
+                    // we can satisfy the full read request from the buffer
+                    Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, remainingNumberOfBytesToRead);
+                    this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + remainingNumberOfBytesToRead);
+                    remainingNumberOfBytesToRead = 0;
+                }
+                else
+                {
+                    // we can only partially satisfy the read request
+                    int availableBytesToRead = this.batchBuffer.NumberOfBytesInBuffer;
+                    Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, availableBytesToRead);
+                    remainingNumberOfBytesToRead -= availableBytesToRead;
+                    userBufferOffset += availableBytesToRead;
+
+                    // we exhausted the buffer; if the underlying stream is not exhausted, refill the buffer
+                    if (this.underlyingStreamExhausted)
+                    {
+                        // We cannot fully satisfy the read request since there are not enough bytes in the stream.
+                        // This means that the content length of the stream was incorrect; this should never happen
+                        // since the caller should already have checked this.
+                        throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStreamBuffer_ReadWithLength));
+                    }
+                    else
+                    {
+                        this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.rawInputContext.Stream, /*preserveFrom*/ ODataBatchReaderStreamBuffer.BufferLength);
+                    }
+                }
+            }
+
+            // return the number of bytes that were read
+            return count - remainingNumberOfBytesToRead;
+        }
+
+        /// <summary>
+        /// Reads the headers of a part.
+        /// </summary>
+        /// <param name="contentId">Content-ID read from operation part header, null if changeset part detected</param>
+        /// <returns>true if the start of a changeset part was detected; otherwise false.</returns>
+        internal bool ProcessPartHeader(out string contentId)
+        {
+            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
+
+            bool isChangeSetPart;
+            ODataBatchOperationHeaders headers = this.ReadPartHeaders(out isChangeSetPart);
+
+            contentId = null;
+
+            if (isChangeSetPart)
+            {
+                // determine the changeset boundary and the changeset encoding from the content type header
+                this.DetermineChangesetBoundaryAndEncoding(headers[ODataConstants.ContentTypeHeader]);
+
+                if (this.changesetEncoding == null)
+                {
+                    // NOTE: No changeset encoding was specified in the changeset's content type header.
+                    //       Determine the changeset encoding from the first bytes in the changeset.
+                    // NOTE: We do not have to skip over the potential preamble of the encoding
+                    //       because the batch reader will skip over everything (incl. the preamble)
+                    //       until it finds the first changeset (or batch) boundary
+                    this.changesetEncoding = this.DetectEncoding(this.rawInputContext.Stream);
+                }
+
+                // Verify that we only allow single byte encodings and UTF-8 for now.
+                ReaderValidationUtils.ValidateEncodingSupportedInBatch(this.changesetEncoding);
+            }
+            else if (this.ChangeSetBoundary != null)
+            {
+                headers.TryGetValue(ODataConstants.ContentIdHeader, out contentId);
+            }
+
+            return isChangeSetPart;
+        }
+
+        /// <summary>
+        /// Reads the headers of a batch part or an operation.
+        /// </summary>
+        /// <returns>A dictionary of header names to header values; never null.</returns>
+        internal ODataBatchOperationHeaders ReadHeaders()
+        {
+            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
+
+            // [Astoria-ODataLib-Integration] WCF DS Batch reader compares header names in batch part using case insensitive comparison, ODataLib is case sensitive
+            ODataBatchOperationHeaders headers = new ODataBatchOperationHeaders();
+
+            // Read all the headers
+            string headerLine = this.ReadLine();
+            while (headerLine != null && headerLine.Length > 0)
+            {
+                string headerName, headerValue;
+                ValidateHeaderLine(headerLine, out headerName, out headerValue);
+
+                if (headers.ContainsKeyOrdinal(headerName))
+                {
+                    throw new ODataException(Strings.ODataBatchReaderStream_DuplicateHeaderFound(headerName));
+                }
+
+                headers.Add(headerName, headerValue);
+                headerLine = this.ReadLine();
+            }
+
+            return headers;
+        }
+
+        /// <summary>
+        /// Read and return the next line from the batch stream, skipping all empty lines.
+        /// </summary>
+        /// <remarks>This method will throw if end-of-input was reached while looking for the next line.</remarks>
+        /// <returns>The text of the first non-empty line (not including any terminating newline characters).</returns>
+        internal string ReadFirstNonEmptyLine()
+        {
+            string line;
+            do
+            {
+                line = this.ReadLine();
+
+                // null indicates end of input, which is unexpected at this point.
+                if (line == null)
+                {
+                    throw new ODataException(Strings.ODataBatchReaderStream_UnexpectedEndOfInput);
+                }
+            }
+            while (line.Length == 0);
+
+            return line;
+        }
+
+        /// <summary>
+        /// Parses a header line and validates that it has the correct format.
+        /// </summary>
+        /// <param name="headerLine">The header line to validate.</param>
+        /// <param name="headerName">The name of the header.</param>
+        /// <param name="headerValue">The value of the header.</param>
+        private static void ValidateHeaderLine(string headerLine, out string headerName, out string headerValue)
+        {
+            Debug.Assert(headerLine != null && headerLine.Length > 0, "Expected non-empty header line.");
+
+            int colon = headerLine.IndexOf(':');
+            if (colon <= 0)
+            {
+                throw new ODataException(Strings.ODataBatchReaderStream_InvalidHeaderSpecified(headerLine));
+            }
+
+            headerName = headerLine.Substring(0, colon).Trim();
+            headerValue = headerLine.Substring(colon + 1).Trim();
+        }
+
+        /// <summary>
+        /// Reads a line (all bytes until a line feed) from the underlying stream.
+        /// </summary>
+        /// <returns>Returns the string that was read from the underyling stream (not including a terminating line feed), or null if the end of input was reached.</returns>
+        private string ReadLine()
+        {
+            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
+            Debug.Assert(this.lineBuffer != null && this.lineBuffer.Length == LineBufferLength, "Line buffer should have been created.");
+
+            // The number of bytes in the line buffer that make up the line.
+            int lineBufferSize = 0;
+
+            // Start with the pre-allocated line buffer array.
+            byte[] bytesForString = this.lineBuffer;
+
+            ODataBatchReaderStreamScanResult scanResult = ODataBatchReaderStreamScanResult.NoMatch;
+            while (scanResult != ODataBatchReaderStreamScanResult.Match)
+            {
+                int byteCount, lineEndStartPosition, lineEndEndPosition;
+                scanResult = this.batchBuffer.ScanForLineEnd(out lineEndStartPosition, out lineEndEndPosition);
+
+                switch (scanResult)
+                {
+                    case ODataBatchReaderStreamScanResult.NoMatch:
+                        // Copy all the bytes in the BatchBuffer into the result byte[] and then continue
+                        byteCount = this.batchBuffer.NumberOfBytesInBuffer;
+                        if (byteCount > 0)
+                        {
+                            // TODO: [Design] Consider security limits for data being read
+                            ODataBatchUtils.EnsureArraySize(ref bytesForString, lineBufferSize, byteCount);
+                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, bytesForString, lineBufferSize, byteCount);
+                            lineBufferSize += byteCount;
+                        }
+
+                        if (this.underlyingStreamExhausted)
+                        {
+                            if (lineBufferSize == 0)
+                            {
+                                // If there's nothing more to pull from the underlying stream, and we didn't read anything
+                                // in this invocation of ReadLine(), return null to indicate end of input.
+                                return null;
+                            }
+
+                            // Nothing more to read; stop looping
+                            scanResult = ODataBatchReaderStreamScanResult.Match;
+                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + byteCount);
+                        }
+                        else
+                        {
+                            this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.rawInputContext.Stream, /*preserveFrom*/ ODataBatchReaderStreamBuffer.BufferLength);
+                        }
+
+                        break;
+
+                    case ODataBatchReaderStreamScanResult.PartialMatch:
+                        // We found the start of a line end in the buffer but could not verify whether we saw all of it.
+                        // This can happen if a line end is represented as \r\n and we found \r at the very last position in the buffer.
+                        // In this case we copy the bytes into the result byte[] and continue at the start of the line end; this will guarantee
+                        // that the next scan will find the full line end, not find any additional bytes and then skip the full line end.
+                        // It is safe to copy the string right here because we will also accept \r as a line end; we are just not sure whether there
+                        // will be a subsequent \n.
+                        // This can also happen if the last byte in the stream is \r.
+                        byteCount = lineEndStartPosition - this.batchBuffer.CurrentReadPosition;
+                        if (byteCount > 0)
+                        {
+                            ODataBatchUtils.EnsureArraySize(ref bytesForString, lineBufferSize, byteCount);
+                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, bytesForString, lineBufferSize, byteCount);
+                            lineBufferSize += byteCount;
+                        }
+
+                        if (this.underlyingStreamExhausted)
+                        {
+                            // Nothing more to read; stop looping
+                            scanResult = ODataBatchReaderStreamScanResult.Match;
+                            this.batchBuffer.SkipTo(lineEndStartPosition + 1);
+                        }
+                        else
+                        {
+                            this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.rawInputContext.Stream, /*preserveFrom*/ lineEndStartPosition);
+                        }
+
+                        break;
+
+                    case ODataBatchReaderStreamScanResult.Match:
+                        // We found a line end in the buffer
+                        Debug.Assert(lineEndStartPosition >= this.batchBuffer.CurrentReadPosition, "Line end must be at or after current position.");
+                        Debug.Assert(lineEndEndPosition < this.batchBuffer.CurrentReadPosition + this.batchBuffer.NumberOfBytesInBuffer, "Line end must finish withing buffer range.");
+
+                        byteCount = lineEndStartPosition - this.batchBuffer.CurrentReadPosition;
+                        if (byteCount > 0)
+                        {
+                            ODataBatchUtils.EnsureArraySize(ref bytesForString, lineBufferSize, byteCount);
+                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, bytesForString, lineBufferSize, byteCount);
+                            lineBufferSize += byteCount;
+                        }
+
+                        this.batchBuffer.SkipTo(lineEndEndPosition + 1);
+                        break;
+
+                    default:
+                        throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStream_ReadLine));
+                }
+            }
+
+            Debug.Assert(bytesForString != null, "bytesForString != null");
+
+            return this.CurrentEncoding.GetString(bytesForString, 0, lineBufferSize);
+        }
+
+        /// <summary>
+        /// Reads and validates the headers of a batch part.
+        /// </summary>
+        /// <param name="isChangeSetPart">true if the headers indicate a changset part; otherwise false.</param>
+        /// <returns>A dictionary of header names to header values; never null.</returns>
+        private ODataBatchOperationHeaders ReadPartHeaders(out bool isChangeSetPart)
+        {
+            ODataBatchOperationHeaders partHeaders = this.ReadHeaders();
+            return this.ValidatePartHeaders(partHeaders, out isChangeSetPart);
+        }
+
+        /// <summary>
+        /// Validates the headers that have been read for a part.
+        /// </summary>
+        /// <param name="headers">The set of headers to validate.</param>
+        /// <param name="isChangeSetPart">true if the headers indicate a changset part; otherwise false.</param>
+        /// <returns>The set of validated headers.</returns>
+        /// <remarks>
+        /// An operation part is required to have content type 'application/http' and content transfer
+        /// encoding 'binary'. A changeset is required to have content type 'multipart/mixed'.
+        /// Note that we allow additional headers for batch parts; clients of the library can choose
+        /// to be more strict.
+        /// </remarks>
+        private ODataBatchOperationHeaders ValidatePartHeaders(ODataBatchOperationHeaders headers, out bool isChangeSetPart)
+        {
+            string contentType;
+            if (!headers.TryGetValue(ODataConstants.ContentTypeHeader, out contentType))
+            {
+                throw new ODataException(Strings.ODataBatchReaderStream_MissingContentTypeHeader);
+            }
+
+            if (MediaTypeUtils.MediaTypeAndSubtypeAreEqual(contentType, MimeConstants.MimeApplicationHttp))
+            {
+                isChangeSetPart = false;
+
+                // An operation part is required to have application/http content type and
+                // binary content transfer encoding.
+                string transferEncoding;
+                if (!headers.TryGetValue(ODataConstants.ContentTransferEncoding, out transferEncoding) ||
+                    string.Compare(transferEncoding, ODataConstants.BatchContentTransferEncoding, StringComparison.OrdinalIgnoreCase) != 0)
+                {
+                    throw new ODataException(Strings.ODataBatchReaderStream_MissingOrInvalidContentEncodingHeader(
+                        ODataConstants.ContentTransferEncoding,
+                        ODataConstants.BatchContentTransferEncoding));
+                }
+            }
+            else if (MediaTypeUtils.MediaTypeStartsWithTypeAndSubtype(contentType, MimeConstants.MimeMultipartMixed))
+            {
+                isChangeSetPart = true;
+
+                if (this.changesetBoundary != null)
+                {
+                    // Nested changesets are not supported
+                    throw new ODataException(Strings.ODataBatchReaderStream_NestedChangesetsAreNotSupported);
+                }
+            }
+            else
+            {
+                throw new ODataException(Strings.ODataBatchReaderStream_InvalidContentTypeSpecified(
+                    ODataConstants.ContentTypeHeader,
+                    contentType,
+                    MimeConstants.MimeMultipartMixed,
+                    MimeConstants.MimeApplicationHttp));
+            }
+
+            return headers;
+        }
+
+        /// <summary>
+        /// Parse the content type header value to retrieve the boundary and encoding of a changeset.
+        /// </summary>
+        /// <param name="contentType">The content type to parse.</param>
+        private void DetermineChangesetBoundaryAndEncoding(string contentType)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(contentType), "Should have validated that non-null, non-empty content type header exists.");
+
+            ODataMediaType mediaType;
+            ODataPayloadKind readerPayloadKind;
+            MediaTypeUtils.GetFormatFromContentType(
+                contentType,
+                new ODataPayloadKind[] { ODataPayloadKind.Batch },
+                new ODataMediaTypeResolver(),
+                out mediaType,
+                out this.changesetEncoding,
+                out readerPayloadKind,
+                out this.changesetBoundary);
+            Debug.Assert(readerPayloadKind == ODataPayloadKind.Batch, "Must find batch payload kind.");
+            Debug.Assert(this.changesetBoundary != null && this.changesetBoundary.Length > 0, "Boundary string should have been validated by now.");
+            Debug.Assert(HttpUtils.CompareMediaTypeNames(MimeConstants.MimeMultipartMixed, mediaType.FullTypeName), "Must be multipart/mixed media type.");
+        }
+    }
+}
+

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -1,0 +1,570 @@
+//---------------------------------------------------------------------
+// <copyright file="ODataMultipartMixedBatchWriter.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.MultipartMixed
+{
+    #region Namespaces
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+#if PORTABLELIB
+    using System.Threading.Tasks;
+#endif
+    #endregion Namespaces
+
+    /// <summary>
+    /// Class for writing OData batch messages of MIME multipart/mixed type.
+    /// </summary>
+    internal sealed class ODataMultipartMixedBatchWriter : ODataBatchWriter
+    {
+        /// <summary>The boundary string for the batch structure itself.</summary>
+        private readonly string batchBoundary;
+
+        /// <summary>
+        /// A flag to indicate whether the batch start boundary has been written or not; important to support writing of empty batches.
+        /// </summary>
+        private bool batchStartBoundaryWritten;
+
+        /// <summary>
+        /// A flags to indicate whether the current changeset start boundary has been written or not.
+        /// This is false if a changeset has been started but no changeset boundary was written, and true once the first changeset
+        /// boundary for the current changeset has been written.
+        /// </summary>
+        private bool changesetStartBoundaryWritten;
+
+        /// <summary>
+        /// The boundary string for the current changeset (only set when writing a changeset,
+        /// e.g., after WriteStartChangeSet has been called and before WriteEndChangeSet is called).
+        /// </summary>
+        /// <remarks>When not writing a changeset this field is null.</remarks>
+        private string changeSetBoundary;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="rawOutputContext">The output context to write to.</param>
+        /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
+        internal ODataMultipartMixedBatchWriter(ODataRawOutputContext rawOutputContext, string batchBoundary)
+            : base(rawOutputContext)
+        {
+            Debug.Assert(this.RawOutputContext != null, "this.RawOutputContext != null");
+
+            ExceptionUtils.CheckArgumentNotNull(batchBoundary, "batchBoundary is null");
+
+            this.batchBoundary = batchBoundary;
+            this.RawOutputContext.InitializeRawValueWriter();
+        }
+
+        /// <summary>
+        /// Gets the writer's output context as the real runtime type.
+        /// </summary>
+        internal ODataRawOutputContext RawOutputContext
+        {
+            get { return this.OutputContext as ODataRawOutputContext; }
+        }
+
+        /// <summary>Flushes the write buffer to the underlying stream.</summary>
+        public override void Flush()
+        {
+            this.VerifyCanFlush(true);
+
+            // make sure we switch to state FatalExceptionThrown if an exception is thrown during flushing.
+            try
+            {
+                this.RawOutputContext.Flush();
+            }
+            catch
+            {
+                this.SetState(BatchWriterState.Error);
+                throw;
+            }
+        }
+
+#if PORTABLELIB
+        /// <summary>Flushes the write buffer to the underlying stream asynchronously.</summary>
+        /// <returns>A task instance that represents the asynchronous operation.</returns>
+        public override Task FlushAsync()
+        {
+            this.VerifyCanFlush(false);
+
+            // make sure we switch to state FatalExceptionThrown if an exception is thrown during flushing.
+            return this.RawOutputContext.FlushAsync().FollowOnFaultWith(t => this.SetState(BatchWriterState.Error));
+        }
+#endif
+
+        /// <summary>
+        /// This method is called to notify that the content stream for a batch operation has been requested.
+        /// </summary>
+        public override void BatchOperationContentStreamRequested()
+        {
+            // Write any pending data and flush the batch writer to the async buffered stream
+            this.StartBatchOperationContent();
+
+            // Flush the async buffered stream to the underlying message stream (if there's any)
+            this.RawOutputContext.FlushBuffers();
+
+            // Dispose the batch writer (since we are now writing the operation content) and set the corresponding state.
+            this.DisposeBatchWriterAndSetContentStreamRequestedState();
+        }
+
+#if PORTABLELIB
+
+        /// <summary>
+        /// This method is called to notify that the content stream for a batch operation has been requested.
+        /// </summary>
+        /// <returns>
+        /// A task representing any action that is running as part of the status change of the operation;
+        /// null if no such action exists.
+        /// </returns>
+        public override Task BatchOperationContentStreamRequestedAsync()
+        {
+            // Write any pending data and flush the batch writer to the async buffered stream
+            this.StartBatchOperationContent();
+
+            // Asynchronously flush the async buffered stream to the underlying message stream (if there's any);
+            // then dispose the batch writer (since we are now writing the operation content) and set the corresponding state.
+            return this.RawOutputContext.FlushBuffersAsync()
+                .FollowOnSuccessWith(task => this.DisposeBatchWriterAndSetContentStreamRequestedState());
+        }
+#endif
+
+        /// <summary>
+        /// This method is called to notify that the content stream of a batch operation has been disposed.
+        /// </summary>
+        public override void BatchOperationContentStreamDisposed()
+        {
+            Debug.Assert(this.CurrentOperationMessage != null, "Expected non-null operation message!");
+
+            this.SetState(BatchWriterState.OperationStreamDisposed);
+            this.CurrentOperationRequestMessage = null;
+            this.CurrentOperationResponseMessage = null;
+            this.RawOutputContext.InitializeRawValueWriter();
+        }
+
+        /// <summary>
+        /// This method notifies the listener, that an in-stream error is to be written.
+        /// </summary>
+        /// <remarks>
+        /// This listener can choose to fail, if the currently written payload doesn't support in-stream error at this position.
+        /// If the listener returns, the writer should not allow any more writing, since the in-stream error is the last thing in the payload.
+        /// </remarks>
+        public override void OnInStreamError()
+        {
+            this.RawOutputContext.VerifyNotDisposed();
+            this.SetState(BatchWriterState.Error);
+            this.RawOutputContext.TextWriter.Flush();
+
+            // The OData protocol spec did not defined the behavior when an exception is encountered outside of a batch operation. The batch writer
+            // should not allow WriteError in this case. Note that WCF DS Server does serialize the error in XML format when it encounters one outside of a
+            // batch operation.
+            throw new ODataException(Strings.ODataBatchWriter_CannotWriteInStreamErrorForBatch);
+        }
+
+        /// <summary>
+        /// Ends a batch - implementation of the actual functionality.
+        /// </summary>
+        protected override void WriteEndBatchImplementation()
+        {
+            Debug.Assert(
+                this.batchStartBoundaryWritten || this.CurrentOperationMessage == null,
+                "If not batch boundary was written we must not have an active message.");
+
+            // write pending message data (headers, response line) for a previously unclosed message/request
+            this.WritePendingMessageData(true);
+
+            this.SetState(BatchWriterState.BatchCompleted);
+
+            // write the end boundary for the batch
+            ODataBatchWriterUtils.WriteEndBoundary(this.RawOutputContext.TextWriter, this.batchBoundary, !this.batchStartBoundaryWritten);
+
+            // For compatibility with WCF DS we write a newline after the end batch boundary.
+            // Technically it's not needed, but it doesn't violate anything either.
+            this.RawOutputContext.TextWriter.WriteLine();
+        }
+
+        /// <summary>
+        /// Starts a new changeset - implementation of the actual functionality.
+        /// </summary>
+        protected override void WriteStartChangesetImplementation()
+        {
+            // write pending message data (headers, response line) for a previously unclosed message/request
+            this.WritePendingMessageData(true);
+
+            // important to do this first since it will set up the change set boundary.
+            this.SetState(BatchWriterState.ChangesetStarted);
+            Debug.Assert(this.changeSetBoundary != null, "this.changeSetBoundary != null");
+
+            // reset the size of the current changeset and increase the size of the batch
+            this.ResetChangeSetSize();
+            this.InterceptException(this.IncreaseBatchSize);
+
+            // write the boundary string
+            ODataBatchWriterUtils.WriteStartBoundary(this.RawOutputContext.TextWriter, this.batchBoundary, !this.batchStartBoundaryWritten);
+            this.batchStartBoundaryWritten = true;
+
+            // write the change set headers
+            ODataBatchWriterUtils.WriteChangeSetPreamble(this.RawOutputContext.TextWriter, this.changeSetBoundary);
+            this.changesetStartBoundaryWritten = false;
+        }
+
+        /// <summary>
+        /// Ends an active changeset - implementation of the actual functionality.
+        /// </summary>
+        protected override void WriteEndChangesetImplementation()
+        {
+            // write pending message data (headers, response line) for a previously unclosed message/request
+            this.WritePendingMessageData(true);
+
+            string currentChangeSetBoundary = this.changeSetBoundary;
+
+            // change the state first so we validate the change set boundary before attempting to write it.
+            this.SetState(BatchWriterState.ChangesetCompleted);
+
+            // In the case of an empty changeset the start changeset boundary has not been written yet
+            // we will leave it like that, since we want the empty changeset to be represented only as
+            // the end changeset boundary.
+            // Due to WCF DS V2 compatiblity we must not write the start boundary in this case
+            // otherwise WCF DS V2 won't be able to read it (it fails on the start-end boundary empty changeset).
+
+            // write the end boundary for the change set
+            ODataBatchWriterUtils.WriteEndBoundary(this.RawOutputContext.TextWriter, currentChangeSetBoundary, !this.changesetStartBoundaryWritten);
+
+            // Reset the cache of content IDs here. As per spec, content IDs are only unique inside a change set.
+            this.payloadUriConverter.Reset();
+            this.CurrentOperationContentId = null;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ODataBatchOperationRequestMessage"/> for writing an operation of a batch request - implementation of the actual functionality.
+        /// </summary>
+        /// <param name="method">The Http method to be used for this request operation.</param>
+        /// <param name="uri">The Uri to be used for this request operation.</param>
+        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
+        /// <returns>The message that can be used to write the request operation.</returns>
+        protected override ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation(string method, Uri uri, string contentId,  BatchPayloadUriOption payloadUriOption)
+        {
+            if (this.changeSetBoundary == null)
+            {
+                this.InterceptException(this.IncreaseBatchSize);
+            }
+            else
+            {
+                this.InterceptException(this.IncreaseChangeSetSize);
+            }
+
+            // write pending message data (headers, request line) for a previously unclosed message/request
+            this.WritePendingMessageData(true);
+
+            // Add a potential Content-ID header to the URL resolver so that it will be available
+            // to subsequent operations.
+            // Note that what we add here is the Content-ID header of the previous operation (if any).
+            // This also means that the Content-ID of the last operation in a changeset will never get
+            // added to the cache which is fine since we cannot reference it anywhere.
+            if (this.CurrentOperationContentId != null)
+            {
+                this.payloadUriConverter.AddContentId(this.CurrentOperationContentId);
+            }
+
+            this.InterceptException(() => uri = ODataBatchUtils.CreateOperationRequestUri(uri, this.RawOutputContext.MessageWriterSettings.BaseUri, this.payloadUriConverter));
+
+            // create the new request operation
+            this.CurrentOperationRequestMessage = ODataBatchOperationRequestMessage.CreateWriteMessage(
+                this.RawOutputContext.OutputStream,
+                method,
+                uri,
+                /*operationListener*/ this,
+                this.payloadUriConverter,
+                this.container);
+
+            if (this.changeSetBoundary != null)
+            {
+                this.RememberContentIdHeader(contentId);
+            }
+
+            this.SetState(BatchWriterState.OperationCreated);
+
+            // write the operation's start boundary string
+            this.WriteStartBoundaryForOperation();
+
+            // write the headers and request line
+            ODataBatchWriterUtils.WriteRequestPreamble(this.RawOutputContext.TextWriter, method, uri, this.RawOutputContext.MessageWriterSettings.BaseUri, changeSetBoundary != null, contentId, payloadUriOption);
+
+            return this.CurrentOperationRequestMessage;
+        }
+
+        /// <summary>
+        /// Sets a new writer state; verifies that the transition from the current state into new state is valid.
+        /// </summary>
+        /// <param name="newState">The writer state to transition into.</param>
+        protected override void SetState(BatchWriterState newState)
+        {
+            this.InterceptException(() => this.ValidateTransition(
+                newState,
+                () => ValidateTransitionAgainstChangesetBoundary(newState, this.changeSetBoundary)));
+
+            switch (newState)
+            {
+                case BatchWriterState.BatchStarted:
+                    Debug.Assert(!this.batchStartBoundaryWritten, "The batch boundary must not be written before calling WriteStartBatch.");
+                    break;
+                case BatchWriterState.ChangesetStarted:
+                    Debug.Assert(this.changeSetBoundary == null, "this.changeSetBoundary == null");
+                    this.changeSetBoundary = ODataBatchWriterUtils.CreateChangeSetBoundary(this.OutputContext.WritingResponse);
+                    break;
+                case BatchWriterState.ChangesetCompleted:
+                    Debug.Assert(this.changeSetBoundary != null, "this.changeSetBoundary != null");
+                    this.changeSetBoundary = null;
+                    break;
+            }
+
+            this.State = newState;
+        }
+
+        /// <summary>
+        /// Creates an <see cref="ODataBatchOperationResponseMessage"/> for writing an operation of a batch response - implementation of the actual functionality.
+        /// </summary>
+        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
+        /// <returns>The message that can be used to write the response operation.</returns>
+        protected override ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation(string contentId)
+        {
+            this.WritePendingMessageData(true);
+
+            // In responses we don't need to use our batch URL resolver, since there are no cross referencing URLs
+            // so use the URL resolver from the batch message instead.
+            this.CurrentOperationResponseMessage = ODataBatchOperationResponseMessage.CreateWriteMessage(
+                this.RawOutputContext.OutputStream,
+                /*operationListener*/ this,
+                this.payloadUriConverter,
+                this.container);
+            this.SetState(BatchWriterState.OperationCreated);
+
+            Debug.Assert(this.CurrentOperationContentId == null, "The Content-ID header is only supported in request messages.");
+
+            // write the operation's start boundary string
+            this.WriteStartBoundaryForOperation();
+
+            // write the headers and request separator line
+            ODataBatchWriterUtils.WriteResponsePreamble(this.RawOutputContext.TextWriter, changeSetBoundary != null, contentId);
+
+            return this.CurrentOperationResponseMessage;
+        }
+
+        /// <summary>
+        /// Write any pending headers for the current operation message (if any).
+        /// </summary>
+        /// <param name="reportMessageCompleted">
+        /// A flag to control whether after writing the pending data we report writing the message to be completed or not.
+        /// </param>
+        protected override void WritePendingMessageData(bool reportMessageCompleted)
+        {
+            if (this.CurrentOperationMessage != null)
+            {
+                Debug.Assert(this.RawOutputContext.TextWriter != null, "Must have a batch writer if pending data exists.");
+
+                if (this.CurrentOperationResponseMessage != null)
+                {
+                    Debug.Assert(this.RawOutputContext.WritingResponse, "If the response message is available we must be writing response.");
+                    int statusCode = this.CurrentOperationResponseMessage.StatusCode;
+                    string statusMessage = HttpUtils.GetStatusMessage(statusCode);
+                    this.RawOutputContext.TextWriter.WriteLine("{0} {1} {2}", ODataConstants.HttpVersionInBatching, statusCode, statusMessage);
+                }
+
+                IEnumerable<KeyValuePair<string, string>> headers = this.CurrentOperationMessage.Headers;
+                if (headers != null)
+                {
+                    foreach (KeyValuePair<string, string> headerPair in headers)
+                    {
+                        string headerName = headerPair.Key;
+                        string headerValue = headerPair.Value;
+                        this.RawOutputContext.TextWriter.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}: {1}", headerName, headerValue));
+                    }
+                }
+
+                // write CRLF after the headers (or request/response line if there are no headers)
+                this.RawOutputContext.TextWriter.WriteLine();
+
+                if (reportMessageCompleted)
+                {
+                    this.CurrentOperationMessage.PartHeaderProcessingCompleted();
+                    this.CurrentOperationRequestMessage = null;
+                    this.CurrentOperationResponseMessage = null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes the start boundary for an operation. This is either the batch or the changeset boundary.
+        /// </summary>
+        protected override void WriteStartBoundaryForOperation()
+        {
+            if (this.changeSetBoundary == null)
+            {
+                ODataBatchWriterUtils.WriteStartBoundary(this.RawOutputContext.TextWriter, this.batchBoundary, !this.batchStartBoundaryWritten);
+                this.batchStartBoundaryWritten = true;
+            }
+            else
+            {
+                ODataBatchWriterUtils.WriteStartBoundary(this.RawOutputContext.TextWriter, this.changeSetBoundary, !this.changesetStartBoundaryWritten);
+                this.changesetStartBoundaryWritten = true;
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the writer is in correct state for the Flush operation.
+        /// </summary>
+        /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
+        protected override void VerifyCanFlush(bool synchronousCall)
+        {
+            this.RawOutputContext.VerifyNotDisposed();
+            this.VerifyCallAllowed(synchronousCall);
+            if (this.State == BatchWriterState.OperationStreamRequested)
+            {
+                this.ThrowODataException(Strings.ODataBatchWriter_FlushOrFlushAsyncCalledInStreamRequestedState);
+            }
+        }
+
+        /// <summary>
+        /// Validates that the batch writer is ready to process a new write request.
+        /// </summary>
+        protected override void ValidateWriterReady()
+        {
+            this.RawOutputContext.VerifyNotDisposed();
+
+            // If the operation stream was requested but not yet disposed, the writer can't be used to do anything.
+            if (this.State == BatchWriterState.OperationStreamRequested)
+            {
+                throw new ODataException(Strings.ODataBatchWriter_InvalidTransitionFromOperationContentStreamRequested);
+            }
+        }
+
+        /// <summary>
+        /// Writes all the pending headers and prepares the writer to write a content of the operation.
+        /// </summary>
+        protected override void StartBatchOperationContent()
+        {
+            Debug.Assert(this.CurrentOperationMessage != null, "Expected non-null operation message!");
+            Debug.Assert(this.RawOutputContext.TextWriter != null, "Must have a batch writer!");
+
+            // write the pending headers (if any)
+            this.WritePendingMessageData(false);
+
+            // flush the text writer to make sure all buffers of the text writer
+            // are flushed to the underlying async stream
+            this.RawOutputContext.TextWriter.Flush();
+        }
+
+        /// <summary>
+        /// Disposes the batch writer and set the 'OperationStreamRequested' batch writer state;
+        /// called after the flush operation(s) have completed.
+        /// </summary>
+        protected override void DisposeBatchWriterAndSetContentStreamRequestedState()
+        {
+            this.RawOutputContext.CloseWriter();
+
+            this.SetState(BatchWriterState.OperationStreamRequested);
+        }
+
+        /// <summary>
+        /// Verifies that calling CreateOperationRequestMessage is valid.
+        /// </summary>
+        /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
+        /// <param name="method">The Http method to be used for this request operation.</param>
+        /// <param name="uri">The Uri to be used for this request operation.</param>
+        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
+        protected override void VerifyCanCreateOperationRequestMessage(bool synchronousCall, string method, Uri uri, string contentId)
+        {
+            this.CanCreateOperationRequestMessageVerifierCommon(synchronousCall, method, uri, contentId);
+            VerifyCanCreateOperationRequestMessageAgainstChangeSetBoundary(method, contentId);
+        }
+
+        /// <summary>
+        /// Remember a non-null Content-ID header for change set request operations.
+        /// If a non-null content ID header is specified for a change set request operation, record it in the URL resolver.
+        /// </summary>
+        /// <param name="contentId">The Content-ID header value read from the message.</param>
+        /// <remarks>
+        /// Note that the content ID of this operation will only
+        /// become visible once this operation has been written
+        /// and OperationCompleted has been called on the URL resolver.
+        /// </remarks>
+        private void RememberContentIdHeader(string contentId)
+        {
+            // The Content-ID header is only supported in request messages and inside of changesets.
+            Debug.Assert(this.CurrentOperationRequestMessage != null, "this.CurrentOperationRequestMessage != null");
+            Debug.Assert(this.changeSetBoundary != null, "this.changeSetBoundary != null");
+
+            // Set the current content ID. If no Content-ID header is found in the message,
+            // the 'contentId' argument will be null and this will reset the current operation content ID field.
+            this.CurrentOperationContentId = contentId;
+
+            // Check for duplicate content IDs; we have to do this here instead of in the cache itself
+            // since the content ID of the last operation never gets added to the cache but we still
+            // want to fail on the duplicate.
+            if (contentId != null && this.payloadUriConverter.ContainsContentId(contentId))
+            {
+                throw new ODataException(Strings.ODataBatchWriter_DuplicateContentIDsNotAllowed(contentId));
+            }
+        }
+
+        /// <summary>
+        /// Verifies that, for the case within a changeset, CreateOperationRequestMessage is valid.
+        /// </summary>
+        /// <param name="method">The HTTP method to be validated.</param>
+        /// <param name="contentId">The content Id string to be validated.</param>
+        private void VerifyCanCreateOperationRequestMessageAgainstChangeSetBoundary(string method, string contentId)
+        {
+            if (this.changeSetBoundary != null)
+            {
+                if (HttpUtils.IsQueryMethod(method))
+                {
+                    this.ThrowODataException(Strings.ODataBatch_InvalidHttpMethodForChangeSetRequest(method));
+                }
+
+                if (string.IsNullOrEmpty(contentId))
+                {
+                    this.ThrowODataException(Strings.ODataBatchOperationHeaderDictionary_KeyNotFound(ODataConstants.ContentIdHeader));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Validates state transition is allowed if we are within a changeset.
+        /// </summary>
+        /// <param name="newState">Teh new writer state to transition into.</param>
+        /// <param name="changeSetBoundary">The changeset boundary string.</param>
+        private static void ValidateTransitionAgainstChangesetBoundary(BatchWriterState newState, string changeSetBoundary)
+        {
+            // make sure that we are not starting a changeset when one is already active
+            if (newState == BatchWriterState.ChangesetStarted)
+            {
+                if (changeSetBoundary != null)
+                {
+                    throw new ODataException(Strings.ODataBatchWriter_CannotStartChangeSetWithActiveChangeSet);
+                }
+            }
+
+            // make sure that we are not completing a changeset without an active changeset
+            if (newState == BatchWriterState.ChangesetCompleted)
+            {
+                if (changeSetBoundary == null)
+                {
+                    throw new ODataException(Strings.ODataBatchWriter_CannotCompleteChangeSetWithoutActiveChangeSet);
+                }
+            }
+
+            // make sure that we are not completing a batch while a changeset is still active
+            if (newState == BatchWriterState.BatchCompleted)
+            {
+                if (changeSetBoundary != null)
+                {
+                    throw new ODataException(Strings.ODataBatchWriter_CannotCompleteBatchWithActiveChangeSet);
+                }
+            }
+        }
+    }
+}
+

--- a/src/Microsoft.OData.Core/ODataBatchReader.cs
+++ b/src/Microsoft.OData.Core/ODataBatchReader.cs
@@ -17,24 +17,23 @@ namespace Microsoft.OData
     #endregion Namespaces
 
     /// <summary>
-    /// Class for reading OData batch messages; also verifies the proper sequence of read calls on the reader.
+    /// Abstract Class for reading OData batch messages; also verifies the proper sequence of read calls on the reader.
     /// </summary>
-    public sealed class ODataBatchReader : IODataBatchOperationListener
+    public abstract class ODataBatchReader : IODataBatchOperationListener
     {
         /// <summary>The input context to read the content from.</summary>
-        private readonly ODataRawInputContext inputContext;
+        private  ODataInputContext inputContext;
 
-        /// <summary>The batch stream used by the batch reader to devide a batch payload into parts.</summary>
-        private readonly ODataBatchReaderStream batchStream;
 
         /// <summary>True if the writer was created for synchronous operation; false for asynchronous.</summary>
         private readonly bool synchronous;
 
-        /// <summary>The batch-specific URL converter that stores the content IDs found in a changeset and supports resolving cross-referencing URLs.</summary>
-        private readonly ODataBatchPayloadUriConverter payloadUriConverter;
-
         /// <summary>The dependency injection container to get related services.</summary>
-        private readonly IServiceProvider container;
+        internal readonly IServiceProvider container;
+
+        /// <summary>The batch-specific URL converter that stores the content IDs found in a changeset and supports resolving cross-referencing URLs.</summary>
+        internal readonly ODataBatchPayloadUriConverter payloadUriConverter;
+
 
         /// <summary>The current state of the batch reader.</summary>
         private ODataBatchReaderState batchReaderState;
@@ -58,7 +57,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Internal switch for whether we support reading Content-ID header appear in HTTP head instead of ChangeSet head.
         /// </summary>
-        private bool allowLegacyContentIdBehaviour;
+        private bool allowLegacyContentIdBehavior;
 
         /// <summary>
         /// Constructor.
@@ -67,23 +66,21 @@ namespace Microsoft.OData
         /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
         /// <param name="batchEncoding">The encoding to use to read from the batch stream.</param>
         /// <param name="synchronous">true if the reader is created for synchronous operation; false for asynchronous.</param>
-        internal ODataBatchReader(ODataRawInputContext inputContext, string batchBoundary, Encoding batchEncoding, bool synchronous)
+        protected ODataBatchReader(ODataInputContext inputContext, bool synchronous)
         {
             Debug.Assert(inputContext != null, "inputContext != null");
-            Debug.Assert(!string.IsNullOrEmpty(batchBoundary), "!string.IsNullOrEmpty(batchBoundary)");
 
             this.inputContext = inputContext;
             this.container = inputContext.Container;
             this.synchronous = synchronous;
             this.payloadUriConverter = new ODataBatchPayloadUriConverter(inputContext.PayloadUriConverter);
-            this.batchStream = new ODataBatchReaderStream(inputContext, batchBoundary, batchEncoding);
-            this.allowLegacyContentIdBehaviour = true;
+            this.allowLegacyContentIdBehavior = true;
         }
 
         /// <summary>
         /// An enumeration to track the state of a batch operation.
         /// </summary>
-        private enum OperationState
+        protected enum OperationState
         {
             /// <summary>No action has been performed on the operation.</summary>
             None,
@@ -98,6 +95,41 @@ namespace Microsoft.OData
             StreamDisposed,
         }
 
+        /// <summary>
+        /// Reader's input context.
+        /// </summary>
+        protected ODataInputContext InputContext
+        {
+            get { return this.inputContext; }
+        }
+
+        /// <summary>
+        /// Previously cache contentId that should be applied to the next message read.
+        /// </summary>
+        protected string ContentIdToAddOnNextRead
+        {
+            get { return this.contentIdToAddOnNextRead; }
+            set { this.contentIdToAddOnNextRead = value; }
+        }
+
+        /// <summary>
+        /// The reader's Operation state
+        /// </summary>
+        protected OperationState ReaderOperationState
+        {
+            get { return this.operationState; }
+            set { this.operationState = value; }
+        }
+
+        /// <summary>
+        /// Boolean flag indicating whether legacy content Id behavior is used.
+        /// </summary>
+        protected bool AllowLegacyContentIdBehavior
+        {
+            get { return this.allowLegacyContentIdBehavior; }
+        }
+
+
         /// <summary>Gets the current state of the batch reader.</summary>
         /// <returns>The current state of the batch reader.</returns>
         public ODataBatchReaderState State
@@ -108,7 +140,7 @@ namespace Microsoft.OData
                 return this.batchReaderState;
             }
 
-            private set
+            set
             {
                 this.batchReaderState = value;
             }
@@ -204,49 +236,57 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Returns the next state of the batch reader after an end boundary has been found.
+        /// Increases the size of the current batch message; throws if the allowed limit is exceeded.
         /// </summary>
-        /// <returns>The next state of the batch reader.</returns>
-        private ODataBatchReaderState GetEndBoundaryState()
+        protected void IncreaseBatchSize()
         {
-            switch (this.batchReaderState)
+            this.currentBatchSize++;
+
+            if (this.currentBatchSize > this.inputContext.MessageReaderSettings.MessageQuotas.MaxPartsPerBatch)
             {
-                case ODataBatchReaderState.Initial:
-                    // If we find an end boundary when in state 'Initial' it means that we
-                    // have an empty batch. The next state will be 'Completed'.
-                    return ODataBatchReaderState.Completed;
-
-                case ODataBatchReaderState.Operation:
-                    // If we find an end boundary in state 'Operation' we have finished
-                    // processing an operation and found the end boundary of either the
-                    // current changeset or the batch.
-                    return this.batchStream.ChangeSetBoundary == null
-                        ? ODataBatchReaderState.Completed
-                        : ODataBatchReaderState.ChangesetEnd;
-
-                case ODataBatchReaderState.ChangesetStart:
-                    // If we find an end boundary when in state 'ChangeSetStart' it means that
-                    // we have an empty changeset. The next state will be 'ChangeSetEnd'
-                    return ODataBatchReaderState.ChangesetEnd;
-
-                case ODataBatchReaderState.ChangesetEnd:
-                    // If we are at the end of a changeset and find an end boundary
-                    // we reached the end of the batch
-                    return ODataBatchReaderState.Completed;
-
-                case ODataBatchReaderState.Completed:
-                    // We should never get here when in Completed state.
-                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_GetEndBoundary_Completed));
-
-                case ODataBatchReaderState.Exception:
-                    // We should never get here when in Exception state.
-                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_GetEndBoundary_Exception));
-
-                default:
-                    // Invalid enum value
-                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_GetEndBoundary_UnknownValue));
+                throw new ODataException(Strings.ODataBatchReader_MaxBatchSizeExceeded(this.inputContext.MessageReaderSettings.MessageQuotas.MaxPartsPerBatch));
             }
         }
+
+        /// <summary>
+        /// Increases the size of the current change set; throws if the allowed limit is exceeded.
+        /// </summary>
+        protected void IncreaseChangesetSize()
+        {
+            this.currentChangeSetSize++;
+
+            if (this.currentChangeSetSize > this.inputContext.MessageReaderSettings.MessageQuotas.MaxOperationsPerChangeset)
+            {
+                throw new ODataException(Strings.ODataBatchReader_MaxChangeSetSizeExceeded(this.inputContext.MessageReaderSettings.MessageQuotas.MaxOperationsPerChangeset));
+            }
+        }
+
+        /// <summary>
+        /// Resets the size of the current change set to 0.
+        /// </summary>
+        protected void ResetChangesetSize()
+        {
+            this.currentChangeSetSize = 0;
+        }
+        /// <summary>
+        /// Continues reading from the batch message payload.
+        /// </summary>
+        /// <returns>true if more items were read; otherwise false.</returns>
+        protected abstract bool ReadImplementation();
+        /// <summary>
+        /// Returns the cached <see cref="ODataBatchOperationRequestMessage"/> for reading the content of an operation
+        /// in a batch request.
+        /// </summary>
+        /// <returns>The message that can be used to read the content of the batch request operation from.</returns>
+
+        protected abstract ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation();
+
+        /// <summary>
+        /// Returns the cached <see cref="ODataBatchOperationResponseMessage"/> for reading the content of a
+        /// batch response.
+        /// </summary>
+        /// <returns>The message that can be used to read the content of the batch response from.</returns>
+        protected abstract ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation();
 
         /// <summary>
         /// Reads the next part from the batch message payload.
@@ -262,6 +302,7 @@ namespace Microsoft.OData
         /// Asynchronously reads the next part from the batch message payload.
         /// </summary>
         /// <returns>A task that when completed indicates whether more information was read.</returns>
+        [SuppressMessage("Microsoft.MSInternal", "CA908:AvoidTypesThatRequireJitCompilationInPrecompiledAssemblies", Justification = "API design calls for a bool being returned from the task here.")]
         private Task<bool> ReadAsynchronously()
         {
             // We are reading from the fully buffered read stream here; thus it is ok
@@ -270,374 +311,6 @@ namespace Microsoft.OData
             return TaskUtils.GetTaskForSynchronousOperation<bool>(this.ReadImplementation);
         }
 #endif
-
-        /// <summary>
-        /// Continues reading from the batch message payload.
-        /// </summary>
-        /// <returns>true if more items were read; otherwise false.</returns>
-        private bool ReadImplementation()
-        {
-            Debug.Assert(this.operationState != OperationState.StreamRequested, "Should have verified that no operation stream is still active.");
-
-            switch (this.State)
-            {
-                case ODataBatchReaderState.Initial:
-                    // The stream should be positioned at the beginning of the batch content,
-                    // that is before the first boundary (or the preamble if there is one).
-                    this.batchReaderState = this.SkipToNextPartAndReadHeaders();
-                    break;
-
-                case ODataBatchReaderState.Operation:
-                    // When reaching this state we already read the MIME headers of the operation.
-                    // Clients MUST call CreateOperationRequestMessage
-                    // or CreateOperationResponseMessage to read at least the headers of the operation.
-                    // This is important since we need to read the ContentId header (if present) and
-                    // add it to the URL resolver.
-                    if (this.operationState == OperationState.None)
-                    {
-                        // No message was created; fail
-                        throw new ODataException(Strings.ODataBatchReader_NoMessageWasCreatedForOperation);
-                    }
-
-                    // Reset the operation state; the operation state only
-                    // tracks the state of a batch operation while in state Operation.
-                    this.operationState = OperationState.None;
-
-                    // Also add a pending ContentId header to the URL resolver now. We ensured above
-                    // that a message has been created for this operation and thus the headers (incl.
-                    // a potential content ID header) have been read.
-                    if (this.contentIdToAddOnNextRead != null)
-                    {
-                        this.payloadUriConverter.AddContentId(this.contentIdToAddOnNextRead);
-                        this.contentIdToAddOnNextRead = null;
-                    }
-
-                    // When we are done with an operation, we have to skip ahead to the next part
-                    // when Read is called again. Note that if the operation stream was never requested
-                    // and the content of the operation has not been read, we'll skip it here.
-                    Debug.Assert(this.operationState == OperationState.None, "Operation state must be 'None' at the end of the operation.");
-                    this.batchReaderState = this.SkipToNextPartAndReadHeaders();
-                    break;
-
-                case ODataBatchReaderState.ChangesetStart:
-                    // When at the start of a changeset, skip ahead to the first operation in the
-                    // changeset (or the end boundary of the changeset).
-                    Debug.Assert(this.batchStream.ChangeSetBoundary != null, "Changeset boundary must have been set by now.");
-                    this.batchReaderState = this.SkipToNextPartAndReadHeaders();
-                    break;
-
-                case ODataBatchReaderState.ChangesetEnd:
-                    // When at the end of a changeset, reset the changeset boundary and the
-                    // changeset size and then skip to the next part.
-                    this.ResetChangeSetSize();
-                    this.batchStream.ResetChangeSetBoundary();
-                    this.batchReaderState = this.SkipToNextPartAndReadHeaders();
-                    break;
-
-                case ODataBatchReaderState.Exception:    // fall through
-                case ODataBatchReaderState.Completed:
-                    Debug.Assert(false, "Should have checked in VerifyCanRead that we are not in one of these states.");
-                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_ReadImplementation));
-
-                default:
-                    Debug.Assert(false, "Unsupported reader state " + this.State + " detected.");
-                    throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReader_ReadImplementation));
-            }
-
-            return this.batchReaderState != ODataBatchReaderState.Completed && this.batchReaderState != ODataBatchReaderState.Exception;
-        }
-
-        /// <summary>
-        /// Skips all data in the stream until the next part is detected; then reads the part's request/response line and headers.
-        /// </summary>
-        /// <returns>The next state of the batch reader after skipping to the next part and reading the part's beginning.</returns>
-        private ODataBatchReaderState SkipToNextPartAndReadHeaders()
-        {
-            bool isEndBoundary, isParentBoundary;
-            bool foundBoundary = this.batchStream.SkipToBoundary(out isEndBoundary, out isParentBoundary);
-
-            if (!foundBoundary)
-            {
-                // We did not find the expected boundary at all in the payload;
-                // we are done reading. Depending on where we are report changeset end or completed state
-                if (this.batchStream.ChangeSetBoundary == null)
-                {
-                    return ODataBatchReaderState.Completed;
-                }
-                else
-                {
-                    return ODataBatchReaderState.ChangesetEnd;
-                }
-            }
-
-            ODataBatchReaderState nextState;
-            if (isEndBoundary || isParentBoundary)
-            {
-                // We detected an end boundary or detected that the end boundary is missing
-                // because we found a parent boundary
-                nextState = this.GetEndBoundaryState();
-
-                if (nextState == ODataBatchReaderState.ChangesetEnd)
-                {
-                    // Reset the URL resolver at the end of a changeset; Content IDs are
-                    // unique within a given changeset.
-                    this.payloadUriConverter.Reset();
-                }
-            }
-            else
-            {
-                bool currentlyInChangeSet = this.batchStream.ChangeSetBoundary != null;
-                string contentId;
-
-                // If we did not find an end boundary, we found another part
-                bool isChangeSetPart = this.batchStream.ProcessPartHeader(out contentId);
-
-                // Compute the next reader state
-                if (currentlyInChangeSet)
-                {
-                    Debug.Assert(!isChangeSetPart, "Should have validated that nested changesets are not allowed.");
-                    nextState = ODataBatchReaderState.Operation;
-                    this.IncreaseChangeSetSize();
-                }
-                else
-                {
-                    // We are at the top level (not inside a changeset)
-                    nextState = isChangeSetPart
-                        ? ODataBatchReaderState.ChangesetStart
-                        : ODataBatchReaderState.Operation;
-                    this.IncreaseBatchSize();
-                }
-
-                if (!isChangeSetPart)
-                {
-                    // Add a potential Content-ID header to the URL resolver so that it will be available
-                    // to subsequent operations.
-                    Debug.Assert(this.contentIdToAddOnNextRead == null, "Must not have a content ID to be added to a part.");
-
-                    if (contentId != null && this.payloadUriConverter.ContainsContentId(contentId))
-                    {
-                        throw new ODataException(Strings.ODataBatchReader_DuplicateContentIDsNotAllowed(contentId));
-                    }
-
-                    this.contentIdToAddOnNextRead = contentId;
-                }
-            }
-
-            return nextState;
-        }
-
-        /// <summary>
-        /// Returns the cached <see cref="ODataBatchOperationRequestMessage"/> for reading the content of an operation
-        /// in a batch request.
-        /// </summary>
-        /// <returns>The message that can be used to read the content of the batch request operation from.</returns>
-        private ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation()
-        {
-            this.operationState = OperationState.MessageCreated;
-
-            string requestLine = this.batchStream.ReadFirstNonEmptyLine();
-
-            string httpMethod;
-            Uri requestUri;
-            this.ParseRequestLine(requestLine, out httpMethod, out requestUri);
-
-            // Read all headers and create the request message
-            ODataBatchOperationHeaders headers = this.batchStream.ReadHeaders();
-
-            if (this.batchStream.ChangeSetBoundary != null)
-            {
-                if (this.allowLegacyContentIdBehaviour)
-                {
-                    // Add a potential Content-ID header to the URL resolver so that it will be available
-                    // to subsequent operations.
-                    string contentId;
-                    if (this.contentIdToAddOnNextRead == null && headers.TryGetValue(ODataConstants.ContentIdHeader, out contentId))
-                    {
-                        if (contentId != null && this.payloadUriConverter.ContainsContentId(contentId))
-                        {
-                            throw new ODataException(Strings.ODataBatchReader_DuplicateContentIDsNotAllowed(contentId));
-                        }
-
-                        this.contentIdToAddOnNextRead = contentId;
-                    }
-                }
-
-                if (this.contentIdToAddOnNextRead == null)
-                {
-                    throw new ODataException(Strings.ODataBatchOperationHeaderDictionary_KeyNotFound(ODataConstants.ContentIdHeader));
-                }
-            }
-
-            ODataBatchOperationRequestMessage requestMessage = ODataBatchOperationRequestMessage.CreateReadMessage(
-                this.batchStream,
-                httpMethod,
-                requestUri,
-                headers,
-                /*operationListener*/ this,
-                this.contentIdToAddOnNextRead,
-                this.payloadUriConverter,
-                this.container);
-
-            return requestMessage;
-        }
-
-        /// <summary>
-        /// Returns the cached <see cref="ODataBatchOperationRequestMessage"/> for reading the content of an operation
-        /// in a batch request.
-        /// </summary>
-        /// <returns>The message that can be used to read the content of the batch request operation from.</returns>
-        private ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation()
-        {
-            this.operationState = OperationState.MessageCreated;
-
-            string responseLine = this.batchStream.ReadFirstNonEmptyLine();
-
-            int statusCode = this.ParseResponseLine(responseLine);
-
-            // Read all headers and create the response message
-            ODataBatchOperationHeaders headers = this.batchStream.ReadHeaders();
-
-            if (this.batchStream.ChangeSetBoundary != null)
-            {
-                if (this.allowLegacyContentIdBehaviour)
-                {
-                    // Add a potential Content-ID header to the URL resolver so that it will be available
-                    // to subsequent operations.
-                    string contentId;
-                    if (this.contentIdToAddOnNextRead == null && headers.TryGetValue(ODataConstants.ContentIdHeader, out contentId))
-                    {
-                        if (contentId != null && this.payloadUriConverter.ContainsContentId(contentId))
-                        {
-                            throw new ODataException(Strings.ODataBatchReader_DuplicateContentIDsNotAllowed(contentId));
-                        }
-
-                        this.contentIdToAddOnNextRead = contentId;
-                    }
-                }
-            }
-
-            // In responses we don't need to use our batch URL resolver, since there are no cross referencing URLs
-            // so use the URL resolver from the batch message instead.
-            ODataBatchOperationResponseMessage responseMessage = ODataBatchOperationResponseMessage.CreateReadMessage(
-                this.batchStream,
-                statusCode,
-                headers,
-                this.contentIdToAddOnNextRead,
-                /*operationListener*/ this,
-                this.payloadUriConverter.BatchMessagePayloadUriConverter,
-                this.container);
-
-            //// NOTE: Content-IDs for cross referencing are only supported in request messages; in responses
-            ////       we allow a Content-ID header but don't process it (i.e., don't add the content ID to the URL resolver).
-
-            return responseMessage;
-        }
-
-        /// <summary>
-        /// Parses the request line of a batch operation request.
-        /// </summary>
-        /// <param name="requestLine">The request line as a string.</param>
-        /// <param name="httpMethod">The parsed HTTP method of the request.</param>
-        /// <param name="requestUri">The parsed <see cref="Uri"/> of the request.</param>
-        private void ParseRequestLine(string requestLine, out string httpMethod, out Uri requestUri)
-        {
-            Debug.Assert(!this.inputContext.ReadingResponse, "Must only be called for requests.");
-
-            // Batch Request: POST /Customers HTTP/1.1
-            // Since the uri can contain spaces, the only way to read the request url, is to
-            // check for first space character and last space character and anything between
-            // them.
-            int firstSpaceIndex = requestLine.IndexOf(' ');
-
-            // Check whether there are enough characters after the first space for the 2nd and 3rd segments
-            // (and a whitespace in between)
-            if (firstSpaceIndex <= 0 || requestLine.Length - 3 <= firstSpaceIndex)
-            {
-                // only 1 segment or empty first segment or not enough left for 2nd and 3rd segments
-                throw new ODataException(Strings.ODataBatchReaderStream_InvalidRequestLine(requestLine));
-            }
-
-            int lastSpaceIndex = requestLine.LastIndexOf(' ');
-            if (lastSpaceIndex < 0 || lastSpaceIndex - firstSpaceIndex - 1 <= 0 || requestLine.Length - 1 <= lastSpaceIndex)
-            {
-                // only 2 segments or empty 2nd or 3rd segments
-                // only 1 segment or empty first segment or not enough left for 2nd and 3rd segments
-                throw new ODataException(Strings.ODataBatchReaderStream_InvalidRequestLine(requestLine));
-            }
-
-            httpMethod = requestLine.Substring(0, firstSpaceIndex);               // Request - Http method
-            string uriSegment = requestLine.Substring(firstSpaceIndex + 1, lastSpaceIndex - firstSpaceIndex - 1);      // Request - Request uri
-            string httpVersionSegment = requestLine.Substring(lastSpaceIndex + 1);             // Request - Http version
-
-            // Validate HttpVersion
-            if (string.CompareOrdinal(ODataConstants.HttpVersionInBatching, httpVersionSegment) != 0)
-            {
-                throw new ODataException(Strings.ODataBatchReaderStream_InvalidHttpVersionSpecified(httpVersionSegment, ODataConstants.HttpVersionInBatching));
-            }
-
-            // NOTE: this method will throw if the method is not recognized.
-            HttpUtils.ValidateHttpMethod(httpMethod);
-
-            // Validate the HTTP method when reading a request
-            if (this.batchStream.ChangeSetBoundary != null)
-            {
-                // allow all methods except for GET
-                if (HttpUtils.IsQueryMethod(httpMethod))
-                {
-                    throw new ODataException(Strings.ODataBatch_InvalidHttpMethodForChangeSetRequest(httpMethod));
-                }
-            }
-
-            requestUri = new Uri(uriSegment, UriKind.RelativeOrAbsolute);
-            requestUri = ODataBatchUtils.CreateOperationRequestUri(requestUri, this.inputContext.MessageReaderSettings.BaseUri, this.payloadUriConverter);
-        }
-
-        /// <summary>
-        /// Parses the response line of a batch operation response.
-        /// </summary>
-        /// <param name="responseLine">The response line as a string.</param>
-        /// <returns>The parsed status code from the response line.</returns>
-        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "'this' is used when built in debug")]
-        private int ParseResponseLine(string responseLine)
-        {
-            Debug.Assert(this.inputContext.ReadingResponse, "Must only be called for responses.");
-
-            // Batch Response: HTTP/1.1 200 Ok
-            // Since the http status code strings have spaces in them, we cannot use the same
-            // logic. We need to check for the second space and anything after that is the error
-            // message.
-            int firstSpaceIndex = responseLine.IndexOf(' ');
-            if (firstSpaceIndex <= 0 || responseLine.Length - 3 <= firstSpaceIndex)
-            {
-                // only 1 segment or empty first segment or not enough left for 2nd and 3rd segments
-                throw new ODataException(Strings.ODataBatchReaderStream_InvalidResponseLine(responseLine));
-            }
-
-            int secondSpaceIndex = responseLine.IndexOf(' ', firstSpaceIndex + 1);
-            if (secondSpaceIndex < 0 || secondSpaceIndex - firstSpaceIndex - 1 <= 0 || responseLine.Length - 1 <= secondSpaceIndex)
-            {
-                // only 2 segments or empty 2nd or 3rd segments
-                // only 1 segment or empty first segment or not enough left for 2nd and 3rd segments
-                throw new ODataException(Strings.ODataBatchReaderStream_InvalidResponseLine(responseLine));
-            }
-
-            string httpVersionSegment = responseLine.Substring(0, firstSpaceIndex);
-            string statusCodeSegment = responseLine.Substring(firstSpaceIndex + 1, secondSpaceIndex - firstSpaceIndex - 1);
-
-            // Validate HttpVersion
-            if (string.CompareOrdinal(ODataConstants.HttpVersionInBatching, httpVersionSegment) != 0)
-            {
-                throw new ODataException(Strings.ODataBatchReaderStream_InvalidHttpVersionSpecified(httpVersionSegment, ODataConstants.HttpVersionInBatching));
-            }
-
-            int intResult;
-            if (!Int32.TryParse(statusCodeSegment, out intResult))
-            {
-                throw new ODataException(Strings.ODataBatchReaderStream_NonIntegerHttpStatusCode(statusCodeSegment));
-            }
-
-            return intResult;
-        }
 
         /// <summary>
         /// Verifies that calling CreateOperationRequestMessage if valid.
@@ -742,40 +415,6 @@ namespace Microsoft.OData
                 Debug.Assert(false, "Async calls are not allowed in this build.");
 #endif
             }
-        }
-
-        /// <summary>
-        /// Increases the size of the current batch message; throws if the allowed limit is exceeded.
-        /// </summary>
-        private void IncreaseBatchSize()
-        {
-            this.currentBatchSize++;
-
-            if (this.currentBatchSize > this.inputContext.MessageReaderSettings.MessageQuotas.MaxPartsPerBatch)
-            {
-                throw new ODataException(Strings.ODataBatchReader_MaxBatchSizeExceeded(this.inputContext.MessageReaderSettings.MessageQuotas.MaxPartsPerBatch));
-            }
-        }
-
-        /// <summary>
-        /// Increases the size of the current change set; throws if the allowed limit is exceeded.
-        /// </summary>
-        private void IncreaseChangeSetSize()
-        {
-            this.currentChangeSetSize++;
-
-            if (this.currentChangeSetSize > this.inputContext.MessageReaderSettings.MessageQuotas.MaxOperationsPerChangeset)
-            {
-                throw new ODataException(Strings.ODataBatchReader_MaxChangeSetSizeExceeded(this.inputContext.MessageReaderSettings.MessageQuotas.MaxOperationsPerChangeset));
-            }
-        }
-
-        /// <summary>
-        /// Resets the size of the current change set to 0.
-        /// </summary>
-        private void ResetChangeSetSize()
-        {
-            this.currentChangeSetSize = 0;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataBatchReaderStream.cs
+++ b/src/Microsoft.OData.Core/ODataBatchReaderStream.cs
@@ -10,6 +10,7 @@ namespace Microsoft.OData
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.IO;
     using System.Text;
     #endregion Namespaces
 
@@ -17,48 +18,26 @@ namespace Microsoft.OData
     /// Class used by the <see cref="ODataBatchReader"/> to read the various pieces of a batch payload.
     /// </summary>
     /// <remarks>
-    /// This stream separates a batch payload into multiple parts by scanning ahead and matching
-    /// a boundary string against the current payload.
+    /// This is the base class for format-specific derived classes to process batch requests in different formats,
+    /// such as multipart/mixed format and applicatino/json format.
     /// </remarks>
-    internal sealed class ODataBatchReaderStream
+    internal abstract class ODataBatchReaderStream
     {
-        /// <summary>
-        /// The default length for the line buffer byte array used to read lines; expecting lines to normally be less than 2000 bytes.
-        /// </summary>
-        private const int LineBufferLength = 2000;
-
-        /// <summary>
-        /// The byte array used for reading lines from the stream. We cache the byte array on the stream instance
-        /// rather than allocating a new one for each ReadLine call.
-        /// </summary>
-        private readonly byte[] lineBuffer;
-
-        /// <summary>The input context to read the content from.</summary>
-        private readonly ODataRawInputContext inputContext;
-
-        /// <summary>The boundary string for the batch structure itself.</summary>
-        private readonly string batchBoundary;
 
         /// <summary>The buffer used by the batch reader stream to scan for boundary strings.</summary>
-        private readonly ODataBatchReaderStreamBuffer batchBuffer;
-
-        /// <summary>The media type resolver to use when interpreting the incoming content type.</summary>
-        private readonly ODataMediaTypeResolver mediaTypeResolver;
+        protected readonly ODataBatchReaderStreamBuffer batchBuffer;
 
         /// <summary>The encoding to use to read from the batch stream.</summary>
-        private Encoding batchEncoding;
-
-        /// <summary>The boundary string for a changeset (or null if not in a changeset part).</summary>
-        private string changesetBoundary;
+        protected Encoding batchEncoding;
 
         /// <summary>The encoding for a given changeset.</summary>
-        private Encoding changesetEncoding;
+        protected Encoding changesetEncoding;
 
         /// <summary>
         /// true if the underlying stream was exhausted during a read operation; we won't try to read from the
         /// underlying stream again once it was exhausted.
         /// </summary>
-        private bool underlyingStreamExhausted;
+        protected bool underlyingStreamExhausted;
 
         /// <summary>
         /// Constructor.
@@ -67,72 +46,18 @@ namespace Microsoft.OData
         /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
         /// <param name="batchEncoding">The encoding to use to read from the batch stream.</param>
         internal ODataBatchReaderStream(
-            ODataRawInputContext inputContext,
-            string batchBoundary,
             Encoding batchEncoding)
         {
-            Debug.Assert(inputContext != null, "inputContext != null");
-            Debug.Assert(!string.IsNullOrEmpty(batchBoundary), "!string.IsNullOrEmpty(batchBoundary)");
-
-            this.inputContext = inputContext;
-            this.batchBoundary = batchBoundary;
             this.batchEncoding = batchEncoding;
-
             this.batchBuffer = new ODataBatchReaderStreamBuffer();
-
-            // When we allocate a batch reader stream we will in almost all cases also call ReadLine
-            // (to read the headers of the parts); so allocating it here.
-            this.lineBuffer = new byte[LineBufferLength];
-
-            this.mediaTypeResolver = ODataMediaTypeResolver.GetMediaTypeResolver(inputContext.Container);
         }
 
-        /// <summary>
-        /// The boundary string for the batch structure itself.
-        /// </summary>
-        internal string BatchBoundary
-        {
-            get
-            {
-                return this.batchBoundary;
-            }
-        }
-
-        /// <summary>
-        /// The boundary string for the current changeset (only set when reading a changeset
-        /// or an operation in a changeset).
-        /// </summary>
-        /// <remarks>When not reading a changeset (or operation in a changeset) this field is null.</remarks>
-        internal string ChangeSetBoundary
-        {
-            get
-            {
-                return this.changesetBoundary;
-            }
-        }
-
-        /// <summary>
-        /// The current boundary string to be used for reading with delimiter.
-        /// </summary>
-        /// <remarks>This is the changeset boundary when reading a changeset or the batch boundary otherwise.</remarks>
-        private IEnumerable<string> CurrentBoundaries
-        {
-            get
-            {
-                if (this.changesetBoundary != null)
-                {
-                    yield return this.changesetBoundary;
-                }
-
-                yield return this.batchBoundary;
-            }
-        }
 
         /// <summary>
         /// The current encoding to use when reading from the stream.
         /// </summary>
         /// <remarks>This is the changeset encoding when reading a changeset or the batch encoding otherwise.</remarks>
-        private Encoding CurrentEncoding
+        protected Encoding CurrentEncoding
         {
             get
             {
@@ -140,77 +65,6 @@ namespace Microsoft.OData
             }
         }
 
-        /// <summary>
-        /// Resets the changeset boundary at the end of the changeset.
-        /// </summary>
-        internal void ResetChangeSetBoundary()
-        {
-            Debug.Assert(this.changesetBoundary != null, "Only valid to reset a changeset boundary if one exists.");
-            this.changesetBoundary = null;
-            this.changesetEncoding = null;
-        }
-
-        /// <summary>
-        /// Skips all the data in the stream until a boundary is found.
-        /// </summary>
-        /// <param name="isEndBoundary">true if the boundary that was found is an end boundary; otherwise false.</param>
-        /// <param name="isParentBoundary">true if the detected boundary is a parent boundary (i.e., the expected boundary is missing).</param>
-        /// <returns>true if a boundary was found; otherwise false.</returns>
-        internal bool SkipToBoundary(out bool isEndBoundary, out bool isParentBoundary)
-        {
-            // Ensure we have a batch encoding; if not detect it on the first read/skip.
-            this.EnsureBatchEncoding();
-
-            ODataBatchReaderStreamScanResult scanResult = ODataBatchReaderStreamScanResult.NoMatch;
-            while (scanResult != ODataBatchReaderStreamScanResult.Match)
-            {
-                int boundaryStartPosition, boundaryEndPosition;
-                scanResult = this.batchBuffer.ScanForBoundary(
-                    this.CurrentBoundaries,
-                    /*stopAfterIfNotFound*/int.MaxValue,
-                    out boundaryStartPosition,
-                    out boundaryEndPosition,
-                    out isEndBoundary,
-                    out isParentBoundary);
-                switch (scanResult)
-                {
-                    case ODataBatchReaderStreamScanResult.NoMatch:
-                        if (this.underlyingStreamExhausted)
-                        {
-                            // there is nothing else to load from the underlying stream; the requested boundary does not exist
-                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + this.batchBuffer.NumberOfBytesInBuffer);
-                            return false;
-                        }
-
-                        // skip everything in the buffer and refill it from the underlying stream; continue scanning
-                        this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.inputContext.Stream, /*preserveFrom*/ODataBatchReaderStreamBuffer.BufferLength);
-
-                        break;
-                    case ODataBatchReaderStreamScanResult.PartialMatch:
-                        if (this.underlyingStreamExhausted)
-                        {
-                            // there is nothing else to load from the underlying stream; the requested boundary does not exist
-                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + this.batchBuffer.NumberOfBytesInBuffer);
-                            return false;
-                        }
-
-                        this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.inputContext.Stream, /*preserveFrom*/boundaryStartPosition);
-
-                        break;
-                    case ODataBatchReaderStreamScanResult.Match:
-                        // If we found the expected boundary, position the reader on the position after the boundary end.
-                        // If we found a parent boundary, position the reader on the boundary start so we'll detect the boundary
-                        // again on the next Read call.
-                        this.batchBuffer.SkipTo(isParentBoundary ? boundaryStartPosition : boundaryEndPosition + 1);
-                        return true;
-
-                    default:
-                        throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStream_SkipToBoundary));
-                }
-            }
-
-            throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStream_SkipToBoundary));
-        }
 
         /// <summary>
         /// Reads from the batch stream while ensuring that we stop reading at each boundary.
@@ -219,121 +73,8 @@ namespace Microsoft.OData
         /// <param name="userBufferOffset">The offset in the buffer where to start reading bytes into.</param>
         /// <param name="count">The number of bytes to read.</param>
         /// <returns>The number of bytes actually read.</returns>
-        internal int ReadWithDelimiter(byte[] userBuffer, int userBufferOffset, int count)
-        {
-            Debug.Assert(userBuffer != null, "userBuffer != null");
-            Debug.Assert(userBufferOffset >= 0 && userBufferOffset < userBuffer.Length, "Offset must be within the range of the user buffer.");
-            Debug.Assert(count >= 0, "count >= 0");
-            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
+        internal abstract int ReadWithDelimiter(byte[] userBuffer, int userBufferOffset, int count);
 
-            if (count == 0)
-            {
-                // Nothing to read.
-                return 0;
-            }
-
-            int remainingNumberOfBytesToRead = count;
-            ODataBatchReaderStreamScanResult scanResult = ODataBatchReaderStreamScanResult.NoMatch;
-
-            while (remainingNumberOfBytesToRead > 0 && scanResult != ODataBatchReaderStreamScanResult.Match)
-            {
-                int boundaryStartPosition, boundaryEndPosition;
-                bool isEndBoundary, isParentBoundary;
-                scanResult = this.batchBuffer.ScanForBoundary(
-                    this.CurrentBoundaries,
-                    remainingNumberOfBytesToRead,
-                    out boundaryStartPosition,
-                    out boundaryEndPosition,
-                    out isEndBoundary,
-                    out isParentBoundary);
-
-                int bytesBeforeBoundaryStart;
-                switch (scanResult)
-                {
-                    case ODataBatchReaderStreamScanResult.NoMatch:
-                        // The boundary was not found in the buffer or after the required number of bytes to be read;
-                        // Check whether we can satisfy the full read request from the buffer
-                        // or whether we have to split the request and read more data into the buffer.
-                        if (this.batchBuffer.NumberOfBytesInBuffer >= remainingNumberOfBytesToRead)
-                        {
-                            // we can satisfy the full read request from the buffer
-                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, remainingNumberOfBytesToRead);
-                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + remainingNumberOfBytesToRead);
-                            return count;
-                        }
-                        else
-                        {
-                            // we can only partially satisfy the read request
-                            int availableBytesToRead = this.batchBuffer.NumberOfBytesInBuffer;
-                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, availableBytesToRead);
-                            remainingNumberOfBytesToRead -= availableBytesToRead;
-                            userBufferOffset += availableBytesToRead;
-
-                            // we exhausted the buffer; if the underlying stream is not exceeded, refill the buffer
-                            if (this.underlyingStreamExhausted)
-                            {
-                                // We cannot fully satisfy the read request since there are not enough bytes in the stream.
-                                // Return the number of bytes we read.
-                                this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + availableBytesToRead);
-                                return count - remainingNumberOfBytesToRead;
-                            }
-                            else
-                            {
-                                this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.inputContext.Stream, /*preserveFrom*/ ODataBatchReaderStreamBuffer.BufferLength);
-                            }
-                        }
-
-                        break;
-                    case ODataBatchReaderStreamScanResult.PartialMatch:
-                        // A partial match for the boundary was found at the end of the buffer.
-                        // If the underlying stream is not exceeded, refill the buffer. Otherwise return
-                        // the available bytes.
-                        if (this.underlyingStreamExhausted)
-                        {
-                            // We cannot fully satisfy the read request since there are not enough bytes in the stream.
-                            // Return the remaining bytes in the buffer independently of where a portentially boundary
-                            // start was detected since no full boundary can ever be detected if the stream is exhausted.
-                            int bytesToReturn = Math.Min(this.batchBuffer.NumberOfBytesInBuffer, remainingNumberOfBytesToRead);
-                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, bytesToReturn);
-                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + bytesToReturn);
-                            remainingNumberOfBytesToRead -= bytesToReturn;
-                            return count - remainingNumberOfBytesToRead;
-                        }
-                        else
-                        {
-                            // Copy the bytes prior to the potential boundary start into the user buffer, refill the buffer and continue.
-                            bytesBeforeBoundaryStart = boundaryStartPosition - this.batchBuffer.CurrentReadPosition;
-                            Debug.Assert(bytesBeforeBoundaryStart < remainingNumberOfBytesToRead, "When reporting a partial match we should never have read all the remaining bytes to read (or more).");
-
-                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, bytesBeforeBoundaryStart);
-                            remainingNumberOfBytesToRead -= bytesBeforeBoundaryStart;
-                            userBufferOffset += bytesBeforeBoundaryStart;
-
-                            this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.inputContext.Stream, /*preserveFrom*/ boundaryStartPosition);
-                        }
-
-                        break;
-                    case ODataBatchReaderStreamScanResult.Match:
-                        // We found the full boundary match; copy everything before the boundary to the buffer
-                        bytesBeforeBoundaryStart = boundaryStartPosition - this.batchBuffer.CurrentReadPosition;
-                        Debug.Assert(bytesBeforeBoundaryStart <= remainingNumberOfBytesToRead, "When reporting a full match we should never have read more than the remaining bytes to read.");
-                        Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, bytesBeforeBoundaryStart);
-                        remainingNumberOfBytesToRead -= bytesBeforeBoundaryStart;
-                        userBufferOffset += bytesBeforeBoundaryStart;
-
-                        // position the reader on the position of the boundary start
-                        this.batchBuffer.SkipTo(boundaryStartPosition);
-
-                        // return the number of bytes that were read
-                        return count - remainingNumberOfBytesToRead;
-
-                    default:
-                        break;
-                }
-            }
-
-            throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStream_ReadWithDelimiter));
-        }
 
         /// <summary>
         /// Reads from the batch stream without checking for a boundary delimiter since we
@@ -343,284 +84,33 @@ namespace Microsoft.OData
         /// <param name="userBufferOffset">The offset in the buffer where to start reading bytes into.</param>
         /// <param name="count">The number of bytes to read.</param>
         /// <returns>The number of bytes actually read.</returns>
-        internal int ReadWithLength(byte[] userBuffer, int userBufferOffset, int count)
-        {
-            Debug.Assert(userBuffer != null, "userBuffer != null");
-            Debug.Assert(userBufferOffset >= 0, "userBufferOffset >= 0");
-            Debug.Assert(count >= 0, "count >= 0");
-            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
-
-            //// NOTE: if we have a stream with length we don't even check for boundaries but rely solely on the content length
-
-            int remainingNumberOfBytesToRead = count;
-            while (remainingNumberOfBytesToRead > 0)
-            {
-                // check whether we can satisfy the full read request from the buffer
-                // or whether we have to split the request and read more data into the buffer.
-                if (this.batchBuffer.NumberOfBytesInBuffer >= remainingNumberOfBytesToRead)
-                {
-                    // we can satisfy the full read request from the buffer
-                    Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, remainingNumberOfBytesToRead);
-                    this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + remainingNumberOfBytesToRead);
-                    remainingNumberOfBytesToRead = 0;
-                }
-                else
-                {
-                    // we can only partially satisfy the read request
-                    int availableBytesToRead = this.batchBuffer.NumberOfBytesInBuffer;
-                    Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, userBuffer, userBufferOffset, availableBytesToRead);
-                    remainingNumberOfBytesToRead -= availableBytesToRead;
-                    userBufferOffset += availableBytesToRead;
-
-                    // we exhausted the buffer; if the underlying stream is not exhausted, refill the buffer
-                    if (this.underlyingStreamExhausted)
-                    {
-                        // We cannot fully satisfy the read request since there are not enough bytes in the stream.
-                        // This means that the content length of the stream was incorrect; this should never happen
-                        // since the caller should already have checked this.
-                        throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStreamBuffer_ReadWithLength));
-                    }
-                    else
-                    {
-                        this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.inputContext.Stream, /*preserveFrom*/ ODataBatchReaderStreamBuffer.BufferLength);
-                    }
-                }
-            }
-
-            // return the number of bytes that were read
-            return count - remainingNumberOfBytesToRead;
-        }
+        internal abstract int ReadWithLength(byte[] userBuffer, int userBufferOffset, int count);
 
         /// <summary>
-        /// Reads the headers of a part.
+        /// Dispose internal resource.
         /// </summary>
-        /// <param name="contentId">Content-ID read from changeset header, null if changeset part detected</param>
-        /// <returns>true if the start of a changeset part was detected; otherwise false.</returns>
-        internal bool ProcessPartHeader(out string contentId)
+        /// <remarks>
+        /// Default implementation at base level is no-op.
+        /// Derived types provide specific implementation as needed.
+        /// Note that, instead of defining IDisposable on the root level and causing ripples to handle IDisposable
+        /// in other related types, we use this out-of-band method and its overrides for disposing.
+        /// </remarks>
+        protected internal virtual void DisposeResources()
         {
-            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
-
-            bool isChangeSetPart;
-            ODataBatchOperationHeaders headers = this.ReadPartHeaders(out isChangeSetPart);
-
-            contentId = null;
-
-            if (isChangeSetPart)
-            {
-                // determine the changeset boundary and the changeset encoding from the content type header
-                this.DetermineChangesetBoundaryAndEncoding(headers[ODataConstants.ContentTypeHeader]);
-
-                if (this.changesetEncoding == null)
-                {
-                    // NOTE: No changeset encoding was specified in the changeset's content type header.
-                    //       Determine the changeset encoding from the first bytes in the changeset.
-                    // NOTE: We do not have to skip over the potential preamble of the encoding
-                    //       because the batch reader will skip over everything (incl. the preamble)
-                    //       until it finds the first changeset (or batch) boundary
-                    this.changesetEncoding = this.DetectEncoding();
-                }
-
-                // Verify that we only allow single byte encodings and UTF-8 for now.
-                ReaderValidationUtils.ValidateEncodingSupportedInBatch(this.changesetEncoding);
-            }
-            else if (this.ChangeSetBoundary != null)
-            {
-                headers.TryGetValue(ODataConstants.ContentIdHeader, out contentId);
-            }
-
-            return isChangeSetPart;
-        }
-
-        /// <summary>
-        /// Reads the headers of a batch part or an operation.
-        /// </summary>
-        /// <returns>A dictionary of header names to header values; never null.</returns>
-        internal ODataBatchOperationHeaders ReadHeaders()
-        {
-            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
-
-            // [Astoria-ODataLib-Integration] WCF DS Batch reader compares header names in batch part using case insensitive comparison, ODataLib is case sensitive
-            ODataBatchOperationHeaders headers = new ODataBatchOperationHeaders();
-
-            // Read all the headers
-            string headerLine = this.ReadLine();
-            while (headerLine != null && headerLine.Length > 0)
-            {
-                string headerName, headerValue;
-                ValidateHeaderLine(headerLine, out headerName, out headerValue);
-
-                if (headers.ContainsKeyOrdinal(headerName))
-                {
-                    throw new ODataException(Strings.ODataBatchReaderStream_DuplicateHeaderFound(headerName));
-                }
-
-                headers.Add(headerName, headerValue);
-                headerLine = this.ReadLine();
-            }
-
-            return headers;
-        }
-
-        /// <summary>
-        /// Read and return the next line from the batch stream, skipping all empty lines.
-        /// </summary>
-        /// <remarks>This method will throw if end-of-input was reached while looking for the next line.</remarks>
-        /// <returns>The text of the first non-empty line (not including any terminating newline characters).</returns>
-        internal string ReadFirstNonEmptyLine()
-        {
-            string line;
-            do
-            {
-                line = this.ReadLine();
-
-                // null indicates end of input, which is unexpected at this point.
-                if (line == null)
-                {
-                    throw new ODataException(Strings.ODataBatchReaderStream_UnexpectedEndOfInput);
-                }
-            }
-            while (line.Length == 0);
-
-            return line;
-        }
-
-        /// <summary>
-        /// Parses a header line and validates that it has the correct format.
-        /// </summary>
-        /// <param name="headerLine">The header line to validate.</param>
-        /// <param name="headerName">The name of the header.</param>
-        /// <param name="headerValue">The value of the header.</param>
-        private static void ValidateHeaderLine(string headerLine, out string headerName, out string headerValue)
-        {
-            Debug.Assert(headerLine != null && headerLine.Length > 0, "Expected non-empty header line.");
-
-            int colon = headerLine.IndexOf(':');
-            if (colon <= 0)
-            {
-                throw new ODataException(Strings.ODataBatchReaderStream_InvalidHeaderSpecified(headerLine));
-            }
-
-            headerName = headerLine.Substring(0, colon).Trim();
-            headerValue = headerLine.Substring(colon + 1).Trim();
-        }
-
-        /// <summary>
-        /// Reads a line (all bytes until a line resource set) from the underlying stream.
-        /// </summary>
-        /// <returns>Returns the string that was read from the underyling stream (not including a terminating line resource set), or null if the end of input was reached.</returns>
-        private string ReadLine()
-        {
-            Debug.Assert(this.batchEncoding != null, "Batch encoding should have been established on first call to SkipToBoundary.");
-            Debug.Assert(this.lineBuffer != null && this.lineBuffer.Length == LineBufferLength, "Line buffer should have been created.");
-
-            // The number of bytes in the line buffer that make up the line.
-            int lineBufferSize = 0;
-
-            // Start with the pre-allocated line buffer array.
-            byte[] bytesForString = this.lineBuffer;
-
-            ODataBatchReaderStreamScanResult scanResult = ODataBatchReaderStreamScanResult.NoMatch;
-            while (scanResult != ODataBatchReaderStreamScanResult.Match)
-            {
-                int byteCount, lineEndStartPosition, lineEndEndPosition;
-                scanResult = this.batchBuffer.ScanForLineEnd(out lineEndStartPosition, out lineEndEndPosition);
-
-                switch (scanResult)
-                {
-                    case ODataBatchReaderStreamScanResult.NoMatch:
-                        // Copy all the bytes in the batchBuffer into the result byte[] and then continue
-                        byteCount = this.batchBuffer.NumberOfBytesInBuffer;
-                        if (byteCount > 0)
-                        {
-                            // TODO: [Design] Consider security limits for data being read
-                            ODataBatchUtils.EnsureArraySize(ref bytesForString, lineBufferSize, byteCount);
-                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, bytesForString, lineBufferSize, byteCount);
-                            lineBufferSize += byteCount;
-                        }
-
-                        if (this.underlyingStreamExhausted)
-                        {
-                            if (lineBufferSize == 0)
-                            {
-                                // If there's nothing more to pull from the underlying stream, and we didn't read anything
-                                // in this invocation of ReadLine(), return null to indicate end of input.
-                                return null;
-                            }
-
-                            // Nothing more to read; stop looping
-                            scanResult = ODataBatchReaderStreamScanResult.Match;
-                            this.batchBuffer.SkipTo(this.batchBuffer.CurrentReadPosition + byteCount);
-                        }
-                        else
-                        {
-                            this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.inputContext.Stream, /*preserveFrom*/ ODataBatchReaderStreamBuffer.BufferLength);
-                        }
-
-                        break;
-                    case ODataBatchReaderStreamScanResult.PartialMatch:
-                        // We found the start of a line end in the buffer but could not verify whether we saw all of it.
-                        // This can happen if a line end is represented as \r\n and we found \r at the very last position in the buffer.
-                        // In this case we copy the bytes into the result byte[] and continue at the start of the line end; this will guarantee
-                        // that the next scan will find the full line end, not find any additional bytes and then skip the full line end.
-                        // It is safe to copy the string right here because we will also accept \r as a line end; we are just not sure whether there
-                        // will be a subsequent \n.
-                        // This can also happen if the last byte in the stream is \r.
-                        byteCount = lineEndStartPosition - this.batchBuffer.CurrentReadPosition;
-                        if (byteCount > 0)
-                        {
-                            ODataBatchUtils.EnsureArraySize(ref bytesForString, lineBufferSize, byteCount);
-                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, bytesForString, lineBufferSize, byteCount);
-                            lineBufferSize += byteCount;
-                        }
-
-                        if (this.underlyingStreamExhausted)
-                        {
-                            // Nothing more to read; stop looping
-                            scanResult = ODataBatchReaderStreamScanResult.Match;
-                            this.batchBuffer.SkipTo(lineEndStartPosition + 1);
-                        }
-                        else
-                        {
-                            this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.inputContext.Stream, /*preserveFrom*/ lineEndStartPosition);
-                        }
-
-                        break;
-                    case ODataBatchReaderStreamScanResult.Match:
-                        // We found a line end in the buffer
-                        Debug.Assert(lineEndStartPosition >= this.batchBuffer.CurrentReadPosition, "Line end must be at or after current position.");
-                        Debug.Assert(lineEndEndPosition < this.batchBuffer.CurrentReadPosition + this.batchBuffer.NumberOfBytesInBuffer, "Line end must finish withing buffer range.");
-
-                        byteCount = lineEndStartPosition - this.batchBuffer.CurrentReadPosition;
-                        if (byteCount > 0)
-                        {
-                            ODataBatchUtils.EnsureArraySize(ref bytesForString, lineBufferSize, byteCount);
-                            Buffer.BlockCopy(this.batchBuffer.Bytes, this.batchBuffer.CurrentReadPosition, bytesForString, lineBufferSize, byteCount);
-                            lineBufferSize += byteCount;
-                        }
-
-                        this.batchBuffer.SkipTo(lineEndEndPosition + 1);
-                        break;
-                    default:
-                        throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchReaderStream_ReadLine));
-                }
-            }
-
-            Debug.Assert(bytesForString != null, "bytesForString != null");
-
-            return this.CurrentEncoding.GetString(bytesForString, 0, lineBufferSize);
         }
 
         /// <summary>
         /// Ensure that a batch encoding exists; if not, detect it from the first couple of bytes of the stream.
         /// </summary>
-        private void EnsureBatchEncoding()
+        /// <param name="stream">The stream to read.</param>
+        protected void EnsureBatchEncoding(Stream stream)
         {
             // If no batch encoding is specified we detect it from the first bytes in the buffer.
             if (this.batchEncoding == null)
             {
                 // NOTE: The batch encoding will only ever be null on the first call to this method which
                 //       happens before the batch reader skips to the first boundary.
-                this.batchEncoding = this.DetectEncoding();
+                this.batchEncoding = this.DetectEncoding(stream);
             }
 
             // Verify that we only allow single byte encodings and UTF-8 for now.
@@ -628,19 +118,20 @@ namespace Microsoft.OData
         }
 
         /// <summary>Detect the encoding based data from the stream.</summary>
+        /// <param name="stream">The stream to read.</param>
         /// <returns>The encoding discovered from the bytes in the buffer or the fallback encoding.</returns>
         /// <remarks>
         /// We don't have to skip a potential preamble of the encoding since the batch reader
         /// will skip over everything (incl. the potential preamble) until it finds the first
         /// boundary.
         /// </remarks>
-        private Encoding DetectEncoding()
+        protected Encoding DetectEncoding(Stream stream)
         {
             // We need at most 4 bytes in the buffer to determine the encoding; if we have less than that,
             // refill the buffer.
             while (!this.underlyingStreamExhausted && this.batchBuffer.NumberOfBytesInBuffer < 4)
             {
-                this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(this.inputContext.Stream, this.batchBuffer.CurrentReadPosition);
+                this.underlyingStreamExhausted = this.batchBuffer.RefillFrom(stream, this.batchBuffer.CurrentReadPosition);
             }
 
             // Now we should have a full buffer unless the underlying stream did not have enough bytes.
@@ -714,95 +205,5 @@ namespace Microsoft.OData
             }
         }
 
-        /// <summary>
-        /// Reads and validates the headers of a batch part.
-        /// </summary>
-        /// <param name="isChangeSetPart">true if the headers indicate a changset part; otherwise false.</param>
-        /// <returns>A dictionary of header names to header values; never null.</returns>
-        private ODataBatchOperationHeaders ReadPartHeaders(out bool isChangeSetPart)
-        {
-            ODataBatchOperationHeaders partHeaders = this.ReadHeaders();
-            return this.ValidatePartHeaders(partHeaders, out isChangeSetPart);
-        }
-
-        /// <summary>
-        /// Validates the headers that have been read for a part.
-        /// </summary>
-        /// <param name="headers">The set of headers to validate.</param>
-        /// <param name="isChangeSetPart">true if the headers indicate a changset part; otherwise false.</param>
-        /// <returns>The set of validated headers.</returns>
-        /// <remarks>
-        /// An operation part is required to have content type 'application/http' and content transfer
-        /// encoding 'binary'. A changeset is required to have content type 'multipart/mixed'.
-        /// Note that we allow additional headers for batch parts; clients of the library can choose
-        /// to be more strict.
-        /// </remarks>
-        private ODataBatchOperationHeaders ValidatePartHeaders(ODataBatchOperationHeaders headers, out bool isChangeSetPart)
-        {
-            string contentType;
-            if (!headers.TryGetValue(ODataConstants.ContentTypeHeader, out contentType))
-            {
-                throw new ODataException(Strings.ODataBatchReaderStream_MissingContentTypeHeader);
-            }
-
-            if (MediaTypeUtils.MediaTypeAndSubtypeAreEqual(contentType, MimeConstants.MimeApplicationHttp))
-            {
-                isChangeSetPart = false;
-
-                // An operation part is required to have application/http content type and
-                // binary content transfer encoding.
-                string transferEncoding;
-                if (!headers.TryGetValue(ODataConstants.ContentTransferEncoding, out transferEncoding) ||
-                    string.Compare(transferEncoding, ODataConstants.BatchContentTransferEncoding, StringComparison.OrdinalIgnoreCase) != 0)
-                {
-                    throw new ODataException(Strings.ODataBatchReaderStream_MissingOrInvalidContentEncodingHeader(
-                        ODataConstants.ContentTransferEncoding,
-                        ODataConstants.BatchContentTransferEncoding));
-                }
-            }
-            else if (MediaTypeUtils.MediaTypeStartsWithTypeAndSubtype(contentType, MimeConstants.MimeMultipartMixed))
-            {
-                isChangeSetPart = true;
-
-                if (this.changesetBoundary != null)
-                {
-                    // Nested changesets are not supported
-                    throw new ODataException(Strings.ODataBatchReaderStream_NestedChangesetsAreNotSupported);
-                }
-            }
-            else
-            {
-                throw new ODataException(Strings.ODataBatchReaderStream_InvalidContentTypeSpecified(
-                    ODataConstants.ContentTypeHeader,
-                    contentType,
-                    MimeConstants.MimeMultipartMixed,
-                    MimeConstants.MimeApplicationHttp));
-            }
-
-            return headers;
-        }
-
-        /// <summary>
-        /// Parse the content type header value to retrieve the boundary and encoding of a changeset.
-        /// </summary>
-        /// <param name="contentType">The content type to parse.</param>
-        private void DetermineChangesetBoundaryAndEncoding(string contentType)
-        {
-            Debug.Assert(!string.IsNullOrEmpty(contentType), "Should have validated that non-null, non-empty content type header exists.");
-
-            ODataMediaType mediaType;
-            ODataPayloadKind readerPayloadKind;
-            MediaTypeUtils.GetFormatFromContentType(
-                contentType,
-                new ODataPayloadKind[] { ODataPayloadKind.Batch },
-                this.mediaTypeResolver,
-                out mediaType,
-                out this.changesetEncoding,
-                out readerPayloadKind,
-                out this.changesetBoundary);
-            Debug.Assert(readerPayloadKind == ODataPayloadKind.Batch, "Must find batch payload kind.");
-            Debug.Assert(this.changesetBoundary != null && this.changesetBoundary.Length > 0, "Boundary string should have been validated by now.");
-            Debug.Assert(HttpUtils.CompareMediaTypeNames(MimeConstants.MimeMultipartMixed, mediaType.FullTypeName), "Must be multipart/mixed media type.");
-        }
     }
 }

--- a/src/Microsoft.OData.Core/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/ODataBatchWriter.cs
@@ -18,43 +18,21 @@ namespace Microsoft.OData
     #endregion Namespaces
 
     /// <summary>
-    /// Class for writing OData batch messages; also verifies the proper sequence of write calls on the writer.
+    /// Abstract class for writing OData batch messages; also verifies the proper sequence of write calls on the writer.
     /// </summary>
-    public sealed class ODataBatchWriter : IODataBatchOperationListener, IODataOutputInStreamErrorListener
+    public abstract class ODataBatchWriter : IODataBatchOperationListener, IODataOutputInStreamErrorListener
     {
         /// <summary>The output context to write to.</summary>
-        private readonly ODataRawOutputContext rawOutputContext;
-
-        /// <summary>The boundary string for the batch structure itself.</summary>
-        private readonly string batchBoundary;
+        private ODataOutputContext outputContext;
 
         /// <summary>The batch-specific URL converter that stores the content IDs found in a changeset and supports resolving cross-referencing URLs.</summary>
-        private readonly ODataBatchPayloadUriConverter payloadUriConverter;
+        internal readonly ODataBatchPayloadUriConverter payloadUriConverter;
 
         /// <summary>The dependency injection container to get related services.</summary>
-        private readonly IServiceProvider container;
+        internal readonly IServiceProvider container;
 
         /// <summary>The state the writer currently is in.</summary>
         private BatchWriterState state;
-
-        /// <summary>
-        /// The boundary string for the current changeset (only set when writing a changeset,
-        /// e.g., after WriteStartChangeSet has been called and before WriteEndChangeSet is called).
-        /// </summary>
-        /// <remarks>When not writing a changeset this field is null.</remarks>
-        private string changeSetBoundary;
-
-        /// <summary>
-        /// A flag to indicate whether the batch start boundary has been written or not; important to support writing of empty batches.
-        /// </summary>
-        private bool batchStartBoundaryWritten;
-
-        /// <summary>
-        /// A flags to indicate whether the current changeset start boundary has been written or not.
-        /// This is false if a changeset has been started by no changeset boundary was written, and true once the first changeset
-        /// boundary for the current changeset has been written.
-        /// </summary>
-        private bool changesetStartBoundaryWritten;
 
         /// <summary>The request message for the operation that is currently written if it's a request;
         /// or null if no part is written right now or it's a response part.</summary>
@@ -82,28 +60,24 @@ namespace Microsoft.OData
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="rawOutputContext">The output context to write to.</param>
-        /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
-        internal ODataBatchWriter(ODataRawOutputContext rawOutputContext, string batchBoundary)
+        /// <param name="outputContext">The output context to write to.</param>
+        internal ODataBatchWriter(ODataOutputContext outputContext)
         {
-            Debug.Assert(rawOutputContext != null, "rawOutputContext != null");
+            Debug.Assert(outputContext != null, "rawOutputContext != null");
             Debug.Assert(
-                rawOutputContext.MessageWriterSettings.BaseUri == null || rawOutputContext.MessageWriterSettings.BaseUri.IsAbsoluteUri,
-                "We should have validated that baseUri is absolute.");
+                outputContext.MessageWriterSettings.BaseUri == null || outputContext.MessageWriterSettings.BaseUri.IsAbsoluteUri,
+                "We should have validated that PayloadBaseUri is absolute.");
 
-            ExceptionUtils.CheckArgumentNotNull(batchBoundary, "batchBoundary");
 
-            this.rawOutputContext = rawOutputContext;
-            this.container = rawOutputContext.Container;
-            this.batchBoundary = batchBoundary;
-            this.payloadUriConverter = new ODataBatchPayloadUriConverter(rawOutputContext.PayloadUriConverter);
-            this.rawOutputContext.InitializeRawValueWriter();
+            this.outputContext = outputContext;
+            this.container = outputContext.Container;
+            this.payloadUriConverter = new ODataBatchPayloadUriConverter(outputContext.PayloadUriConverter);
         }
 
         /// <summary>
         /// An enumeration representing the current state of the writer.
         /// </summary>
-        private enum BatchWriterState
+        protected internal enum BatchWriterState
         {
             /// <summary>The writer is in initial state; nothing has been written yet.</summary>
             Start,
@@ -112,7 +86,7 @@ namespace Microsoft.OData
             BatchStarted,
 
             /// <summary>WriteStartChangeSet has been called.</summary>
-            ChangeSetStarted,
+            ChangesetStarted,
 
             /// <summary>CreateOperationRequestMessage/CreateOperationResponseMessage has been called.</summary>
             OperationCreated,
@@ -127,7 +101,7 @@ namespace Microsoft.OData
             OperationStreamDisposed,
 
             /// <summary>WriteEndChangeSet has been called.</summary>
-            ChangeSetCompleted,
+            ChangesetCompleted,
 
             /// <summary>WriteEndBatch has been called.</summary>
             BatchCompleted,
@@ -136,19 +110,68 @@ namespace Microsoft.OData
             Error
         }
 
-        /// <summary>The request message for the operation that is currently written if it's a request; or null if no operation is written right now or it's a response operation.</summary>
-        private ODataBatchOperationRequestMessage CurrentOperationRequestMessage
+        /// <summary>The message for the operation that is currently written; or null if no operation is written right now.</summary>
+        internal ODataBatchOperationMessage CurrentOperationMessage
         {
             get
             {
-                Debug.Assert(this.currentOperationRequestMessage == null || !this.rawOutputContext.WritingResponse, "Request message can only be filled when writing request.");
+                Debug.Assert(this.currentOperationRequestMessage == null || this.currentOperationResponseMessage == null, "Only request or reponse message can be set, not both.");
+                if (this.currentOperationRequestMessage != null)
+                {
+                    Debug.Assert(!this.outputContext.WritingResponse, "Request message can only be set when writing request.");
+                    return this.currentOperationRequestMessage.OperationMessage;
+                }
+                else if (this.currentOperationResponseMessage != null)
+                {
+                    Debug.Assert(this.outputContext.WritingResponse, "Response message can only be set when writing response.");
+                    return this.currentOperationResponseMessage.OperationMessage;
+                }
+                else
+                {
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or Sets the content Id of the current operation.
+        /// </summary>
+        protected string CurrentOperationContentId
+        {
+            get { return this.currentOperationContentId; }
+            set { this.currentOperationContentId = value; }
+        }
+
+        /// <summary>
+        /// Gets or Sets the batch writer's state.
+        /// </summary>
+        protected BatchWriterState State
+        {
+            get { return this.state; }
+            set { this.state = value; }
+        }
+
+        /// <summary>
+        /// Gets the writer's output context.
+        /// </summary>
+        protected ODataOutputContext OutputContext
+        {
+            get { return this.outputContext; }
+        }
+
+        /// <summary>The request message for the operation that is currently written if it's a request; or null if no operation is written right now or it's a response operation.</summary>
+        protected ODataBatchOperationRequestMessage CurrentOperationRequestMessage
+        {
+            get
+            {
+                Debug.Assert(this.currentOperationRequestMessage == null || !this.outputContext.WritingResponse, "Request message can only be filled when writing request.");
                 Debug.Assert(this.currentOperationRequestMessage == null || this.currentOperationResponseMessage == null, "Only request or reponse message can be set, not both.");
                 return this.currentOperationRequestMessage;
             }
 
             set
             {
-                Debug.Assert(value == null || !this.rawOutputContext.WritingResponse, "Can only set the request message if we're writing a request.");
+                Debug.Assert(value == null || !this.outputContext.WritingResponse, "Can only set the request message if we're writing a request.");
                 Debug.Assert(this.currentOperationRequestMessage == null || this.currentOperationResponseMessage == null, "Only request or reponse message can be set, not both.");
                 this.currentOperationRequestMessage = value;
             }
@@ -156,43 +179,20 @@ namespace Microsoft.OData
 
         /// <summary>The response message for the operation that is currently written if it's a response;
         /// or null if no operation is written right now or it's a request operation.</summary>
-        private ODataBatchOperationResponseMessage CurrentOperationResponseMessage
+        protected ODataBatchOperationResponseMessage CurrentOperationResponseMessage
         {
             get
             {
-                Debug.Assert(this.currentOperationResponseMessage == null || this.rawOutputContext.WritingResponse, "Response message can only be filled when writing response.");
+                Debug.Assert(this.currentOperationResponseMessage == null || this.outputContext.WritingResponse, "Response message can only be filled when writing response.");
                 Debug.Assert(this.currentOperationRequestMessage == null || this.currentOperationResponseMessage == null, "Only request or reponse message can be set, not both.");
                 return this.currentOperationResponseMessage;
             }
 
             set
             {
-                Debug.Assert(value == null || this.rawOutputContext.WritingResponse, "Can only set the response message if we're writing a response.");
+                Debug.Assert(value == null || this.outputContext.WritingResponse, "Can only set the response message if we're writing a response.");
                 Debug.Assert(this.currentOperationRequestMessage == null || this.currentOperationResponseMessage == null, "Only request or reponse message can be set, not both.");
                 this.currentOperationResponseMessage = value;
-            }
-        }
-
-        /// <summary>The message for the operation that is currently written; or null if no operation is written right now.</summary>
-        private ODataBatchOperationMessage CurrentOperationMessage
-        {
-            get
-            {
-                Debug.Assert(this.currentOperationRequestMessage == null || this.currentOperationResponseMessage == null, "Only request or reponse message can be set, not both.");
-                if (this.currentOperationRequestMessage != null)
-                {
-                    Debug.Assert(!this.rawOutputContext.WritingResponse, "Request message can only be set when writing request.");
-                    return this.currentOperationRequestMessage.OperationMessage;
-                }
-                else if (this.currentOperationResponseMessage != null)
-                {
-                    Debug.Assert(this.rawOutputContext.WritingResponse, "Response message can only be set when writing response.");
-                    return this.currentOperationResponseMessage.OperationMessage;
-                }
-                else
-                {
-                    return null;
-                }
             }
         }
 
@@ -339,48 +339,18 @@ namespace Microsoft.OData
 #endif
 
         /// <summary>Flushes the write buffer to the underlying stream.</summary>
-        public void Flush()
-        {
-            this.VerifyCanFlush(true);
-
-            // make sure we switch to state FatalExceptionThrown if an exception is thrown during flushing.
-            try
-            {
-                this.rawOutputContext.Flush();
-            }
-            catch
-            {
-                this.SetState(BatchWriterState.Error);
-                throw;
-            }
-        }
+        public abstract void Flush();
 
 #if PORTABLELIB
         /// <summary>Flushes the write buffer to the underlying stream asynchronously.</summary>
         /// <returns>A task instance that represents the asynchronous operation.</returns>
-        public Task FlushAsync()
-        {
-            this.VerifyCanFlush(false);
-
-            // make sure we switch to state FatalExceptionThrown if an exception is thrown during flushing.
-            return this.rawOutputContext.FlushAsync().FollowOnFaultWith(t => this.SetState(BatchWriterState.Error));
-        }
+        public abstract Task FlushAsync();
 #endif
 
         /// <summary>
         /// This method is called to notify that the content stream for a batch operation has been requested.
         /// </summary>
-        void IODataBatchOperationListener.BatchOperationContentStreamRequested()
-        {
-            // Write any pending data and flush the batch writer to the async buffered stream
-            this.StartBatchOperationContent();
-
-            // Flush the async buffered stream to the underlying message stream (if there's any)
-            this.rawOutputContext.FlushBuffers();
-
-            // Dispose the batch writer (since we are now writing the operation content) and set the corresponding state.
-            this.DisposeBatchWriterAndSetContentStreamRequestedState();
-        }
+        public abstract void BatchOperationContentStreamRequested();
 
 #if PORTABLELIB
         /// <summary>
@@ -390,30 +360,13 @@ namespace Microsoft.OData
         /// A task representing any action that is running as part of the status change of the operation;
         /// null if no such action exists.
         /// </returns>
-        Task IODataBatchOperationListener.BatchOperationContentStreamRequestedAsync()
-        {
-            // Write any pending data and flush the batch writer to the async buffered stream
-            this.StartBatchOperationContent();
-
-            // Asynchronously flush the async buffered stream to the underlying message stream (if there's any);
-            // then dispose the batch writer (since we are now writing the operation content) and set the corresponding state.
-            return this.rawOutputContext.FlushBuffersAsync()
-                .FollowOnSuccessWith(task => this.DisposeBatchWriterAndSetContentStreamRequestedState());
-        }
+        public abstract Task BatchOperationContentStreamRequestedAsync();
 #endif
 
         /// <summary>
         /// This method is called to notify that the content stream of a batch operation has been disposed.
         /// </summary>
-        void IODataBatchOperationListener.BatchOperationContentStreamDisposed()
-        {
-            Debug.Assert(this.CurrentOperationMessage != null, "Expected non-null operation message!");
-
-            this.SetState(BatchWriterState.OperationStreamDisposed);
-            this.CurrentOperationRequestMessage = null;
-            this.CurrentOperationResponseMessage = null;
-            this.rawOutputContext.InitializeRawValueWriter();
-        }
+        public abstract void BatchOperationContentStreamDisposed();
 
         /// <summary>
         /// This method notifies the listener, that an in-stream error is to be written.
@@ -422,17 +375,220 @@ namespace Microsoft.OData
         /// This listener can choose to fail, if the currently written payload doesn't support in-stream error at this position.
         /// If the listener returns, the writer should not allow any more writing, since the in-stream error is the last thing in the payload.
         /// </remarks>
-        void IODataOutputInStreamErrorListener.OnInStreamError()
-        {
-            this.rawOutputContext.VerifyNotDisposed();
-            this.SetState(BatchWriterState.Error);
-            this.rawOutputContext.TextWriter.Flush();
+        public abstract void OnInStreamError();
 
-            // The OData protocol spec did not defined the behavior when an exception is encountered outside of a batch operation. The batch writer
-            // should not allow WriteError in this case. Note that WCF DS Server does serialize the error in XML format when it encounters one outside of a
-            // batch operation.
-            throw new ODataException(Strings.ODataBatchWriter_CannotWriteInStreamErrorForBatch);
+        /// <summary>
+        /// Verifies that calling CreateOperationRequestMessage is valid.
+        /// </summary>
+        /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
+        /// <param name="method">The Http method to be used for this request operation.</param>
+        /// <param name="uri">The Uri to be used for this request operation.</param>
+        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
+        internal void CanCreateOperationRequestMessageVerifierCommon(bool synchronousCall, string method, Uri uri, string contentId)
+        {
+            this.ValidateWriterReady();
+            this.VerifyCallAllowed(synchronousCall);
+
+            if (this.outputContext.WritingResponse)
+            {
+                this.ThrowODataException(Strings.ODataBatchWriter_CannotCreateRequestOperationWhenWritingResponse);
+            }
+
+            ExceptionUtils.CheckArgumentStringNotNullOrEmpty(method, "method");
+
+            ExceptionUtils.CheckArgumentNotNull(uri, "uri");
         }
+
+        /// <summary>
+        /// Verifies that a call is allowed to the writer.
+        /// </summary>
+        /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
+        internal void VerifyCallAllowed(bool synchronousCall)
+        {
+            if (synchronousCall)
+            {
+                if (!this.outputContext.Synchronous)
+                {
+                    throw new ODataException(Strings.ODataBatchWriter_SyncCallOnAsyncWriter);
+                }
+            }
+            else
+            {
+#if PORTABLELIB
+                if (this.outputContext.Synchronous)
+                {
+                    throw new ODataException(Strings.ODataBatchWriter_AsyncCallOnSyncWriter);
+                }
+#else
+                Debug.Assert(false, "Async calls are not allowed in this build.");
+#endif
+            }
+        }
+
+        /// <summary>
+        /// Catch any exception thrown by the action passed in; in the exception case move the writer into
+        /// state ExceptionThrown and then rethrow the exception.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        internal void InterceptException(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch
+            {
+                if (!IsErrorState(this.state))
+                {
+                    this.SetState(BatchWriterState.Error);
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Wrapper method to validate state transition with optional customized validation.
+        /// </summary>
+        /// <param name="newState">Teh new writer state to transition into.</param>
+        /// <param name="customizedValidationAction">Optional validation action.</param>
+        internal void ValidateTransition(BatchWriterState newState, Action customizedValidationAction)
+        {
+            if (customizedValidationAction != null)
+            {
+                customizedValidationAction();
+            }
+
+            CommonTransitionValidation(newState);
+        }
+
+        /// <summary>
+        /// Sets the 'Error' state and then throws an ODataException with the specified error message.
+        /// </summary>
+        /// <param name="errorMessage">The error message for the exception.</param>
+        internal void ThrowODataException(string errorMessage)
+        {
+            this.SetState(BatchWriterState.Error);
+            throw new ODataException(errorMessage);
+        }
+
+        /// <summary>
+        /// Increases the size of the current batch message; throws if the allowed limit is exceeded.
+        /// </summary>
+        internal void IncreaseBatchSize()
+        {
+            this.currentBatchSize++;
+
+            if (this.currentBatchSize > this.outputContext.MessageWriterSettings.MessageQuotas.MaxPartsPerBatch)
+            {
+                throw new ODataException(Strings.ODataBatchWriter_MaxBatchSizeExceeded(this.outputContext.MessageWriterSettings.MessageQuotas.MaxPartsPerBatch));
+            }
+        }
+
+        /// <summary>
+        /// Increases the size of the current change set; throws if the allowed limit is exceeded.
+        /// </summary>
+        internal void IncreaseChangeSetSize()
+        {
+            this.currentChangeSetSize++;
+
+            if (this.currentChangeSetSize > this.outputContext.MessageWriterSettings.MessageQuotas.MaxOperationsPerChangeset)
+            {
+                throw new ODataException(Strings.ODataBatchWriter_MaxChangeSetSizeExceeded(this.outputContext.MessageWriterSettings.MessageQuotas.MaxOperationsPerChangeset));
+            }
+        }
+
+        /// <summary>
+        /// Resets the size of the current change set to 0.
+        /// </summary>
+        internal void ResetChangeSetSize()
+        {
+            this.currentChangeSetSize = 0;
+        }
+
+        /// <summary>
+        /// Starts a new changeset - implementation of the actual functionality.
+        /// </summary>
+        protected abstract void WriteStartChangesetImplementation();
+
+        /// <summary>
+        /// Creates an <see cref="ODataBatchOperationRequestMessage"/> for writing an operation of a batch request - implementation of the actual functionality.
+        /// </summary>
+        /// <param name="method">The Http method to be used for this request operation.</param>
+        /// <param name="uri">The Uri to be used for this request operation.</param>
+        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
+        /// <returns>The message that can be used to write the request operation.</returns>
+        protected abstract ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation(string method,
+            Uri uri, string contentId, BatchPayloadUriOption payloadUriOption);
+
+        /// <summary>
+        /// Ends a batch.
+        /// </summary>
+        protected abstract void WriteEndBatchImplementation();
+
+        /// <summary>
+        /// Ends an active changeset.
+        /// </summary>
+        protected abstract void WriteEndChangesetImplementation();
+
+        /// <summary>
+        /// Verifies that calling CreateOperationRequestMessage is valid.
+        /// </summary>
+        /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
+        /// <param name="method">The Http method to be used for this request operation.</param>
+        /// <param name="uri">The Uri to be used for this request operation.</param>
+        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
+        protected abstract void VerifyCanCreateOperationRequestMessage(bool synchronousCall, string method, Uri uri,
+            string contentId);
+
+        /// <summary>
+        /// Creates an <see cref="ODataBatchOperationResponseMessage"/> for writing an operation of a batch response.
+        /// </summary>
+        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
+        /// <returns>The message that can be used to write the response operation.</returns>
+        protected abstract ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation(
+            string contentId);
+
+        /// <summary>
+        /// Writes all the pending headers and prepares the writer to write a content of the operation.
+        /// </summary>
+        protected abstract void StartBatchOperationContent();
+
+        /// <summary>
+        /// Disposes the batch writer and set the 'OperationStreamRequested' batch writer state;
+        /// called after the flush operation(s) have completed.
+        /// </summary>
+        protected abstract void DisposeBatchWriterAndSetContentStreamRequestedState();
+
+        /// <summary>
+        /// Verifies that the writer is in correct state for the Flush operation.
+        /// </summary>
+        /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
+        protected abstract void VerifyCanFlush(bool synchronousCall);
+
+        /// <summary>
+        /// Sets a new writer state; verifies that the transition from the current state into new state is valid.
+        /// </summary>
+        /// <param name="newState">The writer state to transition into.</param>
+        protected abstract void SetState(BatchWriterState newState);
+
+        /// <summary>
+        /// Validates that the batch writer is ready to process a new write request.
+        /// </summary>
+        protected abstract void ValidateWriterReady();
+
+        /// <summary>
+        /// Write any pending data for the current operation message (if any).
+        /// </summary>
+        /// <param name="reportMessageCompleted">
+        /// A flag to control whether after writing the pending data we report writing the message to be completed or not.
+        /// </param>
+        protected abstract void WritePendingMessageData(bool reportMessageCompleted);
+
+        /// <summary>
+        /// Writes the start boundary for an operation. This is either the batch or the changeset boundary.
+        /// </summary>
+        protected abstract void WriteStartBoundaryForOperation();
 
         /// <summary>
         /// Determines whether a given writer state is considered an error state.
@@ -455,7 +611,7 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Starts a new batch - implementation of the actual functionality.
+        /// Starts a new batch.
         /// </summary>
         private void WriteStartBatchImplementation()
         {
@@ -473,28 +629,6 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Ends a batch - implementation of the actual functionality.
-        /// </summary>
-        private void WriteEndBatchImplementation()
-        {
-            Debug.Assert(
-                this.batchStartBoundaryWritten || this.CurrentOperationMessage == null,
-                "If not batch boundary was written we must not have an active message.");
-
-            // write pending message data (headers, response line) for a previously unclosed message/request
-            this.WritePendingMessageData(true);
-
-            this.SetState(BatchWriterState.BatchCompleted);
-
-            // write the end boundary for the batch
-            ODataBatchWriterUtils.WriteEndBoundary(this.rawOutputContext.TextWriter, this.batchBoundary, !this.batchStartBoundaryWritten);
-
-            // For compatibility with WCF DS we write a newline after the end batch boundary.
-            // Technically it's not needed, but it doesn't violate anything either.
-            this.rawOutputContext.TextWriter.WriteLine();
-        }
-
-        /// <summary>
         /// Verifies that calling WriteStartChangeset is valid.
         /// </summary>
         /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
@@ -502,31 +636,6 @@ namespace Microsoft.OData
         {
             this.ValidateWriterReady();
             this.VerifyCallAllowed(synchronousCall);
-        }
-
-        /// <summary>
-        /// Starts a new changeset - implementation of the actual functionality.
-        /// </summary>
-        private void WriteStartChangesetImplementation()
-        {
-            // write pending message data (headers, response line) for a previously unclosed message/request
-            this.WritePendingMessageData(true);
-
-            // important to do this first since it will set up the change set boundary.
-            this.SetState(BatchWriterState.ChangeSetStarted);
-            Debug.Assert(this.changeSetBoundary != null, "this.changeSetBoundary != null");
-
-            // reset the size of the current changeset and increase the size of the batch
-            this.ResetChangeSetSize();
-            this.InterceptException(this.IncreaseBatchSize);
-
-            // write the boundary string
-            ODataBatchWriterUtils.WriteStartBoundary(this.rawOutputContext.TextWriter, this.batchBoundary, !this.batchStartBoundaryWritten);
-            this.batchStartBoundaryWritten = true;
-
-            // write the change set headers
-            ODataBatchWriterUtils.WriteChangeSetPreamble(this.rawOutputContext.TextWriter, this.changeSetBoundary);
-            this.changesetStartBoundaryWritten = false;
         }
 
         /// <summary>
@@ -539,127 +648,6 @@ namespace Microsoft.OData
             this.VerifyCallAllowed(synchronousCall);
         }
 
-        /// <summary>
-        /// Ends an active changeset - implementation of the actual functionality.
-        /// </summary>
-        private void WriteEndChangesetImplementation()
-        {
-            // write pending message data (headers, response line) for a previously unclosed message/request
-            this.WritePendingMessageData(true);
-
-            string currentChangeSetBoundary = this.changeSetBoundary;
-
-            // change the state first so we validate the change set boundary before attempting to write it.
-            this.SetState(BatchWriterState.ChangeSetCompleted);
-
-            // In the case of an empty changeset the start changeset boundary has not been written yet
-            // we will leave it like that, since we want the empty changeset to be represented only as
-            // the end changeset boundary.
-            // Due to WCF DS V2 compatiblity we must not write the start boundary in this case
-            // otherwise WCF DS V2 won't be able to read it (it fails on the start-end boundary empty changeset).
-
-            // write the end boundary for the change set
-            ODataBatchWriterUtils.WriteEndBoundary(this.rawOutputContext.TextWriter, currentChangeSetBoundary, !this.changesetStartBoundaryWritten);
-
-            // Reset the cache of content IDs here. As per spec, content IDs are only unique inside a change set.
-            this.payloadUriConverter.Reset();
-            this.currentOperationContentId = null;
-        }
-
-        /// <summary>
-        /// Verifies that calling CreateOperationRequestMessage if valid.
-        /// </summary>
-        /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
-        /// <param name="method">The Http method to be used for this request operation.</param>
-        /// <param name="uri">The Uri to be used for this request operation.</param>
-        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
-        private void VerifyCanCreateOperationRequestMessage(bool synchronousCall, string method, Uri uri, string contentId)
-        {
-            this.ValidateWriterReady();
-            this.VerifyCallAllowed(synchronousCall);
-
-            if (this.rawOutputContext.WritingResponse)
-            {
-                this.ThrowODataException(Strings.ODataBatchWriter_CannotCreateRequestOperationWhenWritingResponse);
-            }
-
-            ExceptionUtils.CheckArgumentStringNotNullOrEmpty(method, "method");
-            if (this.changeSetBoundary != null)
-            {
-                if (HttpUtils.IsQueryMethod(method))
-                {
-                    this.ThrowODataException(Strings.ODataBatch_InvalidHttpMethodForChangeSetRequest(method));
-                }
-
-                if (string.IsNullOrEmpty(contentId))
-                {
-                    this.ThrowODataException(Strings.ODataBatchOperationHeaderDictionary_KeyNotFound(ODataConstants.ContentIdHeader));
-                }
-            }
-
-            ExceptionUtils.CheckArgumentNotNull(uri, "uri");
-        }
-
-        /// <summary>
-        /// Creates an <see cref="ODataBatchOperationRequestMessage"/> for writing an operation of a batch request - implementation of the actual functionality.
-        /// </summary>
-        /// <param name="method">The Http method to be used for this request operation.</param>
-        /// <param name="uri">The Uri to be used for this request operation.</param>
-        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
-        /// <param name="payloadUriOption">The format of operation Request-URI, which could be AbsoluteUri, AbsoluteResourcePathAndHost, or RelativeResourcePath.</param>
-        /// <returns>The message that can be used to write the request operation.</returns>
-        private ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation(string method, Uri uri, string contentId, BatchPayloadUriOption payloadUriOption)
-        {
-            if (this.changeSetBoundary == null)
-            {
-                this.InterceptException(this.IncreaseBatchSize);
-            }
-            else
-            {
-                this.InterceptException(this.IncreaseChangeSetSize);
-            }
-
-            // write pending message data (headers, response line) for a previously unclosed message/request
-            this.WritePendingMessageData(true);
-
-            // Add a potential Content-ID header to the URL resolver so that it will be available
-            // to subsequent operations.
-            // Note that what we add here is the Content-ID header of the previous operation (if any).
-            // This also means that the Content-ID of the last operation in a changeset will never get
-            // added to the cache which is fine since we cannot reference it anywhere.
-            if (this.currentOperationContentId != null)
-            {
-                this.payloadUriConverter.AddContentId(this.currentOperationContentId);
-            }
-
-            this.InterceptException(() => uri = ODataBatchUtils.CreateOperationRequestUri(uri, this.rawOutputContext.MessageWriterSettings.BaseUri, this.payloadUriConverter));
-
-            // create the new request operation
-            this.CurrentOperationRequestMessage = ODataBatchOperationRequestMessage.CreateWriteMessage(
-                this.rawOutputContext.OutputStream,
-                method,
-                uri,
-                /*operationListener*/ this,
-                this.payloadUriConverter,
-                this.container);
-
-            if (this.changeSetBoundary != null)
-            {
-                this.RememberContentIdHeader(contentId);
-            }
-
-            this.SetState(BatchWriterState.OperationCreated);
-
-            // write the operation's start boundary string
-            this.WriteStartBoundaryForOperation();
-
-            // write the headers and request line
-            ODataBatchWriterUtils.WriteRequestPreamble(this.rawOutputContext.TextWriter, method, uri,
-                this.rawOutputContext.MessageWriterSettings.BaseUri, changeSetBoundary != null, contentId,
-                payloadUriOption);
-
-            return this.CurrentOperationRequestMessage;
-        }
 
         /// <summary>
         /// Verifies that calling CreateOperationResponseMessage is valid.
@@ -670,223 +658,24 @@ namespace Microsoft.OData
             this.ValidateWriterReady();
             this.VerifyCallAllowed(synchronousCall);
 
-            if (!this.rawOutputContext.WritingResponse)
+            if (!this.outputContext.WritingResponse)
             {
                 this.ThrowODataException(Strings.ODataBatchWriter_CannotCreateResponseOperationWhenWritingRequest);
             }
         }
 
-        /// <summary>
-        /// Creates an <see cref="ODataBatchOperationResponseMessage"/> for writing an operation of a batch response - implementation of the actual functionality.
-        /// </summary>
-        /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
-        /// <returns>The message that can be used to write the response operation.</returns>
-        private ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation(string contentId)
-        {
-            this.WritePendingMessageData(true);
-
-            // In responses we don't need to use our batch URL resolver, since there are no cross referencing URLs
-            // so use the URL resolver from the batch message instead.
-            this.CurrentOperationResponseMessage = ODataBatchOperationResponseMessage.CreateWriteMessage(
-                this.rawOutputContext.OutputStream,
-                /*operationListener*/ this,
-                this.payloadUriConverter.BatchMessagePayloadUriConverter,
-                this.container);
-            this.SetState(BatchWriterState.OperationCreated);
-
-            Debug.Assert(this.currentOperationContentId == null, "The Content-ID header is only supported in request messages.");
-
-            // write the operation's start boundary string
-            this.WriteStartBoundaryForOperation();
-
-            // write the headers and request separator line
-            ODataBatchWriterUtils.WriteResponsePreamble(this.rawOutputContext.TextWriter, changeSetBoundary != null, contentId);
-
-            return this.CurrentOperationResponseMessage;
-        }
 
         /// <summary>
-        /// Writes all the pending headers and prepares the writer to write a content of the operation.
-        /// </summary>
-        private void StartBatchOperationContent()
-        {
-            Debug.Assert(this.CurrentOperationMessage != null, "Expected non-null operation message!");
-            Debug.Assert(this.rawOutputContext.TextWriter != null, "Must have a batch writer!");
-
-            // write the pending headers (if any)
-            this.WritePendingMessageData(false);
-
-            // flush the text writer to make sure all buffers of the text writer
-            // are flushed to the underlying async stream
-            this.rawOutputContext.TextWriter.Flush();
-        }
-
-        /// <summary>
-        /// Disposes the batch writer and set the 'OperationStreamRequested' batch writer state;
-        /// called after the flush operation(s) have completed.
-        /// </summary>
-        private void DisposeBatchWriterAndSetContentStreamRequestedState()
-        {
-            this.rawOutputContext.CloseWriter();
-
-            this.SetState(BatchWriterState.OperationStreamRequested);
-        }
-
-        /// <summary>
-        /// Remember a non-null Content-ID header for change set request operations.
-        /// If a non-null content ID header is specified for a change set request operation, record it in the URL resolver.
-        /// </summary>
-        /// <param name="contentId">The Content-ID header value read from the message.</param>
-        /// <remarks>
-        /// Note that the content ID of this operation will only
-        /// become visible once this operation has been written
-        /// and OperationCompleted has been called on the URL resolver.
-        /// </remarks>
-        private void RememberContentIdHeader(string contentId)
-        {
-            // The Content-ID header is only supported in request messages and inside of changesets.
-            Debug.Assert(this.currentOperationRequestMessage != null, "this.currentOperationRequestMessage != null");
-            Debug.Assert(this.changeSetBoundary != null, "this.changeSetBoundary != null");
-
-            // Set the current content ID. If no Content-ID header is found in the message,
-            // the 'contentId' argument will be null and this will reset the current operation content ID field.
-            this.currentOperationContentId = contentId;
-
-            // Check for duplicate content IDs; we have to do this here instead of in the cache itself
-            // since the content ID of the last operation never gets added to the cache but we still
-            // want to fail on the duplicate.
-            if (contentId != null && this.payloadUriConverter.ContainsContentId(contentId))
-            {
-                throw new ODataException(Strings.ODataBatchWriter_DuplicateContentIDsNotAllowed(contentId));
-            }
-        }
-
-        /// <summary>
-        /// Verifies that the writer is in correct state for the Flush operation.
-        /// </summary>
-        /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
-        private void VerifyCanFlush(bool synchronousCall)
-        {
-            this.rawOutputContext.VerifyNotDisposed();
-            this.VerifyCallAllowed(synchronousCall);
-            if (this.state == BatchWriterState.OperationStreamRequested)
-            {
-                this.ThrowODataException(Strings.ODataBatchWriter_FlushOrFlushAsyncCalledInStreamRequestedState);
-            }
-        }
-
-        /// <summary>
-        /// Verifies that a call is allowed to the writer.
-        /// </summary>
-        /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
-        private void VerifyCallAllowed(bool synchronousCall)
-        {
-            if (synchronousCall)
-            {
-                if (!this.rawOutputContext.Synchronous)
-                {
-                    throw new ODataException(Strings.ODataBatchWriter_SyncCallOnAsyncWriter);
-                }
-            }
-            else
-            {
-#if PORTABLELIB
-                if (this.rawOutputContext.Synchronous)
-                {
-                    throw new ODataException(Strings.ODataBatchWriter_AsyncCallOnSyncWriter);
-                }
-#else
-                Debug.Assert(false, "Async calls are not allowed in this build.");
-#endif
-            }
-        }
-
-        /// <summary>
-        /// Catch any exception thrown by the action passed in; in the exception case move the writer into
-        /// state ExceptionThrown and then rethrow the exception.
-        /// </summary>
-        /// <param name="action">The action to execute.</param>
-        private void InterceptException(Action action)
-        {
-            try
-            {
-                action();
-            }
-            catch
-            {
-                if (!IsErrorState(this.state))
-                {
-                    this.SetState(BatchWriterState.Error);
-                }
-
-                throw;
-            }
-        }
-
-        /// <summary>
-        /// Sets a new writer state; verifies that the transition from the current state into new state is valid.
-        /// </summary>
-        /// <param name="newState">The writer state to transition into.</param>
-        private void SetState(BatchWriterState newState)
-        {
-            this.InterceptException(() => this.ValidateTransition(newState));
-
-            switch (newState)
-            {
-                case BatchWriterState.BatchStarted:
-                    Debug.Assert(!this.batchStartBoundaryWritten, "The batch boundary must not be written before calling WriteStartBatch.");
-                    break;
-                case BatchWriterState.ChangeSetStarted:
-                    Debug.Assert(this.changeSetBoundary == null, "this.changeSetBoundary == null");
-                    this.changeSetBoundary = ODataBatchWriterUtils.CreateChangeSetBoundary(this.rawOutputContext.WritingResponse);
-                    break;
-                case BatchWriterState.ChangeSetCompleted:
-                    Debug.Assert(this.changeSetBoundary != null, "this.changeSetBoundary != null");
-                    this.changeSetBoundary = null;
-                    break;
-            }
-
-            this.state = newState;
-        }
-
-        /// <summary>
-        /// Verify that the transition from the current state into new state is valid .
+        /// Verifies that the transition from the current state into new state is valid .
         /// </summary>
         /// <param name="newState">The new writer state to transition into.</param>
         [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "Validating the transition in the state machine should stay in a single method.")]
-        private void ValidateTransition(BatchWriterState newState)
+        private void CommonTransitionValidation(BatchWriterState newState)
         {
             if (!IsErrorState(this.state) && IsErrorState(newState))
             {
                 // we can always transition into an error state if we are not already in an error state
                 return;
-            }
-
-            // make sure that we are not starting a changeset when one is already active
-            if (newState == BatchWriterState.ChangeSetStarted)
-            {
-                if (this.changeSetBoundary != null)
-                {
-                    throw new ODataException(Strings.ODataBatchWriter_CannotStartChangeSetWithActiveChangeSet);
-                }
-            }
-
-            // make sure that we are not completing a changeset without an active changeset
-            if (newState == BatchWriterState.ChangeSetCompleted)
-            {
-                if (this.changeSetBoundary == null)
-                {
-                    throw new ODataException(Strings.ODataBatchWriter_CannotCompleteChangeSetWithoutActiveChangeSet);
-                }
-            }
-
-            // make sure that we are not completing a batch while a changeset is still active
-            if (newState == BatchWriterState.BatchCompleted)
-            {
-                if (this.changeSetBoundary != null)
-                {
-                    throw new ODataException(Strings.ODataBatchWriter_CannotCompleteBatchWithActiveChangeSet);
-                }
             }
 
             switch (this.state)
@@ -899,14 +688,14 @@ namespace Microsoft.OData
 
                     break;
                 case BatchWriterState.BatchStarted:
-                    if (newState != BatchWriterState.ChangeSetStarted && newState != BatchWriterState.OperationCreated && newState != BatchWriterState.BatchCompleted)
+                    if (newState != BatchWriterState.ChangesetStarted && newState != BatchWriterState.OperationCreated && newState != BatchWriterState.BatchCompleted)
                     {
                         throw new ODataException(Strings.ODataBatchWriter_InvalidTransitionFromBatchStarted);
                     }
 
                     break;
-                case BatchWriterState.ChangeSetStarted:
-                    if (newState != BatchWriterState.OperationCreated && newState != BatchWriterState.ChangeSetCompleted)
+                case BatchWriterState.ChangesetStarted:
+                    if (newState != BatchWriterState.OperationCreated && newState != BatchWriterState.ChangesetCompleted)
                     {
                         throw new ODataException(Strings.ODataBatchWriter_InvalidTransitionFromChangeSetStarted);
                     }
@@ -915,8 +704,8 @@ namespace Microsoft.OData
                 case BatchWriterState.OperationCreated:
                     if (newState != BatchWriterState.OperationCreated &&
                         newState != BatchWriterState.OperationStreamRequested &&
-                        newState != BatchWriterState.ChangeSetStarted &&
-                        newState != BatchWriterState.ChangeSetCompleted &&
+                        newState != BatchWriterState.ChangesetStarted &&
+                        newState != BatchWriterState.ChangesetCompleted &&
                         newState != BatchWriterState.BatchCompleted)
                     {
                         throw new ODataException(Strings.ODataBatchWriter_InvalidTransitionFromOperationCreated);
@@ -934,17 +723,17 @@ namespace Microsoft.OData
                     break;
                 case BatchWriterState.OperationStreamDisposed:
                     if (newState != BatchWriterState.OperationCreated &&
-                        newState != BatchWriterState.ChangeSetStarted &&
-                        newState != BatchWriterState.ChangeSetCompleted &&
+                        newState != BatchWriterState.ChangesetStarted &&
+                        newState != BatchWriterState.ChangesetCompleted &&
                         newState != BatchWriterState.BatchCompleted)
                     {
                         throw new ODataException(Strings.ODataBatchWriter_InvalidTransitionFromOperationContentStreamDisposed);
                     }
 
                     break;
-                case BatchWriterState.ChangeSetCompleted:
+                case BatchWriterState.ChangesetCompleted:
                     if (newState != BatchWriterState.BatchCompleted &&
-                        newState != BatchWriterState.ChangeSetStarted &&
+                        newState != BatchWriterState.ChangesetStarted &&
                         newState != BatchWriterState.OperationCreated)
                     {
                         throw new ODataException(Strings.ODataBatchWriter_InvalidTransitionFromChangeSetCompleted);
@@ -965,124 +754,6 @@ namespace Microsoft.OData
                 default:
                     throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataBatchWriter_ValidateTransition_UnreachableCodePath));
             }
-        }
-
-        /// <summary>
-        /// Validates that the batch writer is ready to process a new write request.
-        /// </summary>
-        private void ValidateWriterReady()
-        {
-            this.rawOutputContext.VerifyNotDisposed();
-
-            // If the operation stream was requested but not yet disposed, the writer can't be used to do anything.
-            if (this.state == BatchWriterState.OperationStreamRequested)
-            {
-                throw new ODataException(Strings.ODataBatchWriter_InvalidTransitionFromOperationContentStreamRequested);
-            }
-        }
-
-        /// <summary>
-        /// Write any pending headers for the current operation message (if any).
-        /// </summary>
-        /// <param name="reportMessageCompleted">
-        /// A flag to control whether after writing the pending data we report writing the message to be completed or not.
-        /// </param>
-        private void WritePendingMessageData(bool reportMessageCompleted)
-        {
-            if (this.CurrentOperationMessage != null)
-            {
-                Debug.Assert(this.rawOutputContext.TextWriter != null, "Must have a batch writer if pending data exists.");
-
-                if (this.CurrentOperationResponseMessage != null)
-                {
-                    Debug.Assert(this.rawOutputContext.WritingResponse, "If the response message is available we must be writing response.");
-                    int statusCode = this.CurrentOperationResponseMessage.StatusCode;
-                    string statusMessage = HttpUtils.GetStatusMessage(statusCode);
-                    this.rawOutputContext.TextWriter.WriteLine("{0} {1} {2}", ODataConstants.HttpVersionInBatching, statusCode, statusMessage);
-                }
-
-                IEnumerable<KeyValuePair<string, string>> headers = this.CurrentOperationMessage.Headers;
-                if (headers != null)
-                {
-                    foreach (KeyValuePair<string, string> headerPair in headers)
-                    {
-                        string headerName = headerPair.Key;
-                        string headerValue = headerPair.Value;
-                        this.rawOutputContext.TextWriter.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0}: {1}", headerName, headerValue));
-                    }
-                }
-
-                // write CRLF after the headers (or request/response line if there are no headers)
-                this.rawOutputContext.TextWriter.WriteLine();
-
-                if (reportMessageCompleted)
-                {
-                    this.CurrentOperationMessage.PartHeaderProcessingCompleted();
-                    this.CurrentOperationRequestMessage = null;
-                    this.CurrentOperationResponseMessage = null;
-                }
-            }
-        }
-
-        /// <summary>
-        /// Writes the start boundary for an operation. This is either the batch or the changeset boundary.
-        /// </summary>
-        private void WriteStartBoundaryForOperation()
-        {
-            if (this.changeSetBoundary == null)
-            {
-                ODataBatchWriterUtils.WriteStartBoundary(this.rawOutputContext.TextWriter, this.batchBoundary, !this.batchStartBoundaryWritten);
-                this.batchStartBoundaryWritten = true;
-            }
-            else
-            {
-                ODataBatchWriterUtils.WriteStartBoundary(this.rawOutputContext.TextWriter, this.changeSetBoundary, !this.changesetStartBoundaryWritten);
-                this.changesetStartBoundaryWritten = true;
-            }
-        }
-
-        /// <summary>
-        /// Sets the 'Error' state and then throws an ODataException with the specified error message.
-        /// </summary>
-        /// <param name="errorMessage">The error message for the exception.</param>
-        private void ThrowODataException(string errorMessage)
-        {
-            this.SetState(BatchWriterState.Error);
-            throw new ODataException(errorMessage);
-        }
-
-        /// <summary>
-        /// Increases the size of the current batch message; throws if the allowed limit is exceeded.
-        /// </summary>
-        private void IncreaseBatchSize()
-        {
-            this.currentBatchSize++;
-
-            if (this.currentBatchSize > this.rawOutputContext.MessageWriterSettings.MessageQuotas.MaxPartsPerBatch)
-            {
-                throw new ODataException(Strings.ODataBatchWriter_MaxBatchSizeExceeded(this.rawOutputContext.MessageWriterSettings.MessageQuotas.MaxPartsPerBatch));
-            }
-        }
-
-        /// <summary>
-        /// Increases the size of the current change set; throws if the allowed limit is exceeded.
-        /// </summary>
-        private void IncreaseChangeSetSize()
-        {
-            this.currentChangeSetSize++;
-
-            if (this.currentChangeSetSize > this.rawOutputContext.MessageWriterSettings.MessageQuotas.MaxOperationsPerChangeset)
-            {
-                throw new ODataException(Strings.ODataBatchWriter_MaxChangeSetSizeExceeded(this.rawOutputContext.MessageWriterSettings.MessageQuotas.MaxOperationsPerChangeset));
-            }
-        }
-
-        /// <summary>
-        /// Resets the size of the current change set to 0.
-        /// </summary>
-        private void ResetChangeSetSize()
-        {
-            this.currentChangeSetSize = 0;
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataRawInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawInputContext.cs
@@ -16,6 +16,8 @@ namespace Microsoft.OData
     using System.Threading.Tasks;
 #endif
     using Microsoft.OData.Edm;
+    using Microsoft.OData.MultipartMixed;
+
     #endregion Namespaces
 
     /// <summary>
@@ -193,7 +195,7 @@ namespace Microsoft.OData
         /// <returns>The newly created <see cref="ODataCollectionReader"/>.</returns>
         private ODataBatchReader CreateBatchReaderImplementation(string batchBoundary, bool synchronous)
         {
-            return new ODataBatchReader(this, batchBoundary, this.encoding, synchronous);
+            return new ODataMultipartMixedBatchReader(this, batchBoundary, this.encoding, synchronous);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataRawOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawOutputContext.cs
@@ -15,6 +15,8 @@ namespace Microsoft.OData
 #if PORTABLELIB
     using System.Threading.Tasks;
 #endif
+    using Microsoft.OData.MultipartMixed;
+
     using Microsoft.OData.Metadata;
     using Microsoft.OData.Edm;
 
@@ -424,7 +426,7 @@ namespace Microsoft.OData
         {
             // Batch writer needs the default encoding to not use the preamble.
             this.encoding = this.encoding ?? MediaTypeUtils.EncodingUtf8NoPreamble;
-            ODataBatchWriter batchWriter = new ODataBatchWriter(this, batchBoundary);
+            ODataBatchWriter batchWriter = new ODataMultipartMixedBatchWriter(this, batchBoundary);
             this.outputInStreamErrorListener = batchWriter;
             return batchWriter;
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataBatchReaderStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataBatchReaderStreamTests.cs
@@ -10,7 +10,7 @@ using System.Text;
 using FluentAssertions;
 using Xunit;
 using ErrorStrings = Microsoft.OData.Strings;
-
+using Microsoft.OData.MultipartMixed;
 namespace Microsoft.OData.Tests
 {
     public class ODataBatchReaderStreamTests
@@ -61,7 +61,7 @@ Second line";
             CreateBatchReaderStream(input).ReadFirstNonEmptyLine().Should().Be("First non-empty line");
         }
 
-        private static ODataBatchReaderStream CreateBatchReaderStream(string inputString)
+        private static ODataMultipartMixedBatchReaderStream CreateBatchReaderStream(string inputString)
         {
             var messageInfo = new ODataMessageInfo
             {
@@ -75,7 +75,7 @@ Second line";
                 ODataFormat.Batch, 
                 messageInfo,
                 new ODataMessageReaderSettings());
-            var batchStream = new ODataBatchReaderStream(inputContext, "batch_862fb28e-dc50-4af1-aad5-9608647761d1", Encoding.UTF8);
+            var batchStream = new ODataMultipartMixedBatchReaderStream(inputContext, "batch_862fb28e-dc50-4af1-aad5-9608647761d1", Encoding.UTF8);
             return batchStream;
         }
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*Ported multi part mime refactoring from 6.X.*

### Description

*Refactored code to support multiple batch formats. This supports only support multi part mime*

### Checklist (Uncheck if it is not completed)

- [  ] Test cases added
- [  ] Build and test with one-click build and test script passed

### Additional work necessary
4 Test failures needs to be fixed. Details are as follows
1 - Public Api test. This can be fixed by updating baseline file. But not sure if this is correct
2-  of them are ODataMessageTests.cs refereing to ODatabatch Writter and Reader. With new model it is abstract class. There are test changes for this. But I haven't ported this yet. Need to make sure this is not breaking change before porting test code
1 - renaming ChangeSetStarted to ChangesetStarted broke the test. 





