### PR TITLE
fix the CustomUriLiteralPrefixedTests to handle interference to stati…

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesTests.cs
@@ -327,10 +327,30 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         [Fact]
         public void CustomUriLiteralPrefix_CannotParseTypeWithWrongLiteralPrefix()
         {
+            // Ensure the prefix under test is registered. Handle the exception gracefully if
+            // the prefix is already registered.
+            IEdmTypeReference booleanTypeReference = EdmCoreModel.Instance.GetBoolean(false);
+
             try
             {
-                IEdmTypeReference booleanTypeReference = EdmCoreModel.Instance.GetBoolean(false);
-                CustomUriLiteralPrefixes.AddCustomLiteralPrefix(CustomUriLiteralParserUnitTests.BOOLEAN_LITERAL_PREFIX, booleanTypeReference);
+                CustomUriLiteralPrefixes.AddCustomLiteralPrefix(
+                    CustomUriLiteralParserUnitTests.BOOLEAN_LITERAL_PREFIX, booleanTypeReference);
+            }
+            catch (ODataException e)
+            {
+                if (!String.Equals(e.Message, Strings.CustomUriTypePrefixLiterals_AddCustomUriTypePrefixLiteralAlreadyExists(
+                    CustomUriLiteralParserUnitTests.BOOLEAN_LITERAL_PREFIX)))
+                {
+                    // unexpected exception, re-throw.
+                    throw;
+                }
+
+                // Swallow the exception since it is due to trying to register a prefix that is already added.
+            }
+
+            try
+            {
+
 
                 var fullUri = new Uri("http://www.odata.com/OData/People" + string.Format("?$filter=Name eq {0}'{1}'", CustomUriLiteralParserUnitTests.BOOLEAN_LITERAL_PREFIX, CustomUriLiteralParserUnitTests.CUSTOM_PARSER_STRING_VALID_VALUE));
                 ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://www.odata.com/OData/"), fullUri);


### PR DESCRIPTION
…c prefix registration from other test runs

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes stability issue for test CustomUriLiteralPrefixedTests.*

### Description

*The setup stage of CustomUriLiteralPrefixedTests could be subjected to interference from other tests (in the same test execution) via the static registrations of CustomUriLiteralPrefixes, and resulted in false-positive failure. The fix here is the handled the exception gracefully if the exception was caused by such interference.*
*see failure details in https://identitydivision.visualstudio.com/DefaultCollection/OData/_build/index?buildId=29037&_a=summary*

### Checklist (Uncheck if it is not completed)

- [  ] Test cases added
- [ x ] Build and test with one-click build and test script passed

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
