### PR TITLE
Cache EDMX per metadata uri

### DIFF
--- a/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
@@ -102,7 +102,7 @@ namespace Microsoft.OData
             this.AssertSynchronous();
 
             IEnumerable<EdmError> errors;
-            if (!CsdlWriter.TryWriteCsdl(this.Model, this.xmlWriter, CsdlTarget.OData, out errors))
+            if (!CsdlWriter.TryWriteCsdl(this.Model, this.xmlWriter, CsdlTarget.OData, MessageWriterSettings.MetadataDocumentUri, out errors))
             {
                 Debug.Assert(errors != null, "errors != null");
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -745,7 +745,7 @@ namespace Microsoft.OData.Tests.UriParser
                 IEnumerable<EdmError> errors;
                 using (var writer = document.CreateWriter())
                 {
-                    CsdlWriter.TryWriteCsdl(model, writer, CsdlTarget.OData, out errors).Should().BeTrue();
+                    CsdlWriter.TryWriteCsdl(model, writer, CsdlTarget.OData, new Uri("http://www.test.com"), out errors).Should().BeTrue();
                 }
 
                 string doc = document.ToString();

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -14,6 +14,7 @@ using Microsoft.OData.Edm.Validation;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OData.Edm.Vocabularies.V1;
 using Xunit;
+using System;
 
 namespace Microsoft.OData.Edm.Tests.Csdl
 {
@@ -519,7 +520,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                 using (XmlWriter xw = XmlWriter.Create(sw, settings))
                 {
                     IEnumerable<EdmError> errors;
-                    CsdlWriter.TryWriteCsdl(model, xw, target, out errors);
+                    CsdlWriter.TryWriteCsdl(model, xw, target, new Uri("http://www.test.com"), out errors);
                     xw.Flush();
                 }
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisActionsFunctionsRelationshipChangesAcceptanceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisActionsFunctionsRelationshipChangesAcceptanceTests.cs
@@ -407,7 +407,7 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
             using (var writer = XmlWriter.Create(builder))
             {
                 IEnumerable<EdmError> errors;
-                CsdlWriter.TryWriteCsdl(this.TestModel.RepresentativeModel, writer, CsdlTarget.OData, out errors).Should().BeTrue();
+                CsdlWriter.TryWriteCsdl(this.TestModel.RepresentativeModel, writer, CsdlTarget.OData, new Uri("http://www.test.com"), out errors).Should().BeTrue();
                 errors.Should().BeEmpty();
                 writer.Flush();
             }
@@ -420,3 +420,4 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
         }
     }
 }
+ 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisRelationshipChangesAcceptanceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisRelationshipChangesAcceptanceTests.cs
@@ -13,6 +13,7 @@ using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Validation;
 using Xunit;
 using ErrorStrings = Microsoft.OData.Edm.Strings;
+using System;
 
 namespace Microsoft.OData.Edm.Tests.ScenarioTests
 {
@@ -190,7 +191,7 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
             using (var writer = XmlWriter.Create(builder))
             {
                 IEnumerable<EdmError> errors;
-                CsdlWriter.TryWriteCsdl(this.representativeModel, writer, CsdlTarget.OData, out errors).Should().BeTrue();
+                CsdlWriter.TryWriteCsdl(this.representativeModel, writer, CsdlTarget.OData, new Uri("http://www.test.com"), out errors).Should().BeTrue();
                 errors.Should().BeEmpty();
                 writer.Flush();
             }

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/EdmVersionTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/EdmVersionTests.cs
@@ -205,7 +205,7 @@ namespace EdmLibTests.FunctionalTests
 
             using (XmlWriter xw = XmlWriter.Create(sw, settings))
             {
-                CsdlWriter.TryWriteCsdl(model, xw, CsdlTarget.OData, out errors);
+                CsdlWriter.TryWriteCsdl(model, xw, CsdlTarget.OData, new Uri("http://www.test.com"), out errors);
                 xw.Close();
 
                 parsed = CsdlReader.TryParse(XmlReader.Create(new StringReader(sw.ToString())), out model, out errors);
@@ -255,7 +255,7 @@ namespace EdmLibTests.FunctionalTests
             using (XmlWriter xw = XmlWriter.Create(sw, settings))
             {
                 model.SetEdmxVersion(CsdlConstants.EdmxVersionLatest);
-                CsdlWriter.TryWriteCsdl(model, xw, CsdlTarget.OData, out errors);
+                CsdlWriter.TryWriteCsdl(model, xw, CsdlTarget.OData, new Uri("http://www.test.com"), out errors);
                 xw.Close();
 
                 parsed = CsdlReader.TryParse(XmlReader.Create(new StringReader(sw.ToString())), out model, out errors);
@@ -305,7 +305,7 @@ namespace EdmLibTests.FunctionalTests
             using (XmlWriter xw = XmlWriter.Create(sw, settings))
             {
                 model.SetEdmxVersion(CsdlConstants.EdmxVersionLatest);
-                CsdlWriter.TryWriteCsdl(model, xw, CsdlTarget.OData, out errors);
+                CsdlWriter.TryWriteCsdl(model, xw, CsdlTarget.OData, new Uri("http://www.test.com"), out errors);
                 xw.Close();
 
                 parsed = CsdlReader.TryParse(XmlReader.Create(new StringReader(sw.ToString())), out model, out errors);
@@ -389,7 +389,7 @@ namespace EdmLibTests.FunctionalTests
                 model.SetEdmxVersion(new Version(1, 123));
                 try
                 {
-                    CsdlWriter.TryWriteCsdl(model, xw, CsdlTarget.OData, out errors);
+                    CsdlWriter.TryWriteCsdl(model, xw, CsdlTarget.OData, new Uri("http://www.test.com"), out errors);
                 }
                 catch (Exception e)
                 {

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/EdmxRoundTripTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/EdmxRoundTripTests.cs
@@ -272,7 +272,7 @@ namespace EdmLibTests.FunctionalTests
                 using (XmlWriter xw = XmlWriter.Create(sw, settings))
                 {
                     IEnumerable<EdmError> errors;
-                    CsdlWriter.TryWriteCsdl(model, xw, target, out errors);
+                    CsdlWriter.TryWriteCsdl(model, xw, target, new Uri("http://www.test.com"), out errors);
                     xw.Flush();
                 }
 

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/EdmxSerializingTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/EdmxSerializingTests.cs
@@ -306,7 +306,7 @@ namespace EdmLibTests.FunctionalTests
 
             try
             {
-                CsdlWriter.TryWriteCsdl(null, XmlWriter.Create(new StringWriter()), CsdlTarget.EntityFramework, out errors);
+                CsdlWriter.TryWriteCsdl(null, XmlWriter.Create(new StringWriter()), CsdlTarget.EntityFramework, new Uri("http://www.test.com"), out errors);
             }
             catch (Exception e)
             {
@@ -314,7 +314,7 @@ namespace EdmLibTests.FunctionalTests
             }
             try
             {
-                CsdlWriter.TryWriteCsdl(model, null, CsdlTarget.EntityFramework, out errors);
+                CsdlWriter.TryWriteCsdl(model, null, CsdlTarget.EntityFramework, new Uri("http://www.test.com"), out errors);
             }
             catch (Exception e)
             {
@@ -335,7 +335,7 @@ namespace EdmLibTests.FunctionalTests
             settings.Indent = true;
             settings.Encoding = System.Text.Encoding.UTF8;
             XmlWriter xw = XmlWriter.Create(sw, settings);
-            CsdlWriter.TryWriteCsdl(model, xw, target, out errors);
+            CsdlWriter.TryWriteCsdl(model, xw, target, new Uri("http://www.test.com"), out errors);
             xw.Flush();
             xw.Close();
             string outputText = sw.ToString();
@@ -370,7 +370,7 @@ namespace EdmLibTests.FunctionalTests
             settings.Indent = true;
             settings.Encoding = System.Text.Encoding.UTF8;
             XmlWriter xw = XmlWriter.Create(sw, settings);
-            CsdlWriter.TryWriteCsdl(model, xw, target, out errors);
+            CsdlWriter.TryWriteCsdl(model, xw, target, new Uri("http://www.test.com"), out errors);
             xw.Flush();
             xw.Close();
             string outputText = sw.ToString();

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ParallelTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ParallelTests.cs
@@ -123,7 +123,7 @@ namespace EdmLibTests.FunctionalTests
                 using (var xw = XmlWriter.Create(tw))
                 {
                     IEnumerable<EdmError> errors;
-                    CsdlWriter.TryWriteCsdl(BaseModel, xw, CsdlTarget.OData, out errors);
+                    CsdlWriter.TryWriteCsdl(BaseModel, xw, CsdlTarget.OData, new Uri("http://www.test.com"), out errors);
                 }
             }
             catch (Exception)
@@ -283,7 +283,7 @@ namespace EdmLibTests.FunctionalTests
                 var xw = XmlWriter.Create(ms, new XmlWriterSettings { Indent = true });
 
                 IEnumerable<EdmError> errors;
-                var res = CsdlWriter.TryWriteCsdl(edmModel, xw, CsdlTarget.OData, out errors);
+                var res = CsdlWriter.TryWriteCsdl(edmModel, xw, CsdlTarget.OData, new Uri("http://www.test.com"), out errors);
                 xw.Flush();
                 ms.Flush();
                 ms.Seek(0, SeekOrigin.Begin);

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/VocabularyParsingTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/VocabularyParsingTests.cs
@@ -2828,7 +2828,7 @@ namespace EdmLibTests.FunctionalTests
 
             using (var xw = XmlWriter.Create(stream, new XmlWriterSettings() { Indent = true }))
             {
-                Assert.IsTrue(CsdlWriter.TryWriteCsdl(edmModel, xw, CsdlTarget.OData, out errors));
+                Assert.IsTrue(CsdlWriter.TryWriteCsdl(edmModel, xw, CsdlTarget.OData, new Uri("http://www.test.com"), out errors));
             }
 
             stream.Seek(0, SeekOrigin.Begin);

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/MetadataReaderTestDescriptor.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/MetadataReaderTestDescriptor.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests
                 {
                     IEnumerable<EdmError> errors;
 
-                    if (!CsdlWriter.TryWriteCsdl(this.PayloadEdmModel, xmlWriter, CsdlTarget.OData, out errors))
+                    if (!CsdlWriter.TryWriteCsdl(this.PayloadEdmModel, xmlWriter, CsdlTarget.OData, new Uri("http://www.test.com"), out errors))
                     {
                         var errorBuilder = new StringBuilder();
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

### Description

*Store EDMX in memory, per metadata URI, to avoid traversing the EDM model multiple times*

### Checklist (Uncheck if it is not completed)

- [X ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary
