### PR TITLE
Escaped special meaning characters remain escaped when parsing the co…

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightContextUriParser.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightContextUriParser.cs
@@ -125,7 +125,7 @@ namespace Microsoft.OData.JsonLight
             this.parseResult.MetadataDocumentUri = uriBuilderWithoutFragment.Uri;
 
             // Get the fragment of the context URI
-            this.parseResult.Fragment = contextUriFromPayload.GetComponents(UriComponents.Fragment, UriFormat.Unescaped);
+            this.parseResult.Fragment = contextUriFromPayload.GetComponents(UriComponents.Fragment, UriFormat.SafeUnescaped);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightContextUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightContextUriParserTests.cs
@@ -16,6 +16,20 @@ namespace Microsoft.OData.Tests.JsonLight
 {
     public class ODataJsonLightContextUriParserTests
     {
+        private EdmModel GetModel()
+        {
+            EdmModel model = new EdmModel();
+            EdmEntityType edmEntityType = new EdmEntityType("NS", "Person");
+            edmEntityType.AddKeys(edmEntityType.AddStructuralProperty("ID", EdmPrimitiveTypeKind.String));
+            edmEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "Dogs", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = edmEntityType });
+            model.AddElement(edmEntityType);
+            EdmEntityContainer container = new EdmEntityContainer("NS", "EntityContainer");
+            model.AddElement(container);
+            container.AddEntitySet("People", edmEntityType);
+
+            return model;
+        }
+
         // TODO: Support relative context uri and resolving other relative uris
         [Fact]
         public void ParseRelativeContextUrlShouldThrowException()
@@ -23,6 +37,14 @@ namespace Microsoft.OData.Tests.JsonLight
             string relativeUrl = "$metadata#R";
             Action parseContextUri = () => ODataJsonLightContextUriParser.Parse(new EdmModel(), relativeUrl, ODataPayloadKind.Unsupported, null, true);
             parseContextUri.ShouldThrow<ODataException>().WithMessage(ErrorStrings.ODataJsonLightContextUriParser_TopLevelContextUrlShouldBeAbsolute(relativeUrl));
+        }
+
+        [Fact]
+        public void ParseContextUrlWithEscapedSpecailMeaningCharactersShouldSucceed()
+        {
+            string urlWithUnescapedSpecialMeaningCharacters = "https://www.example.com/api/$metadata#People('i%3A0%23.f%7Cmembership%7Cexample%40example.org')/Dogs";
+            Action parseContextUri = () => ODataJsonLightContextUriParser.Parse(GetModel(), urlWithUnescapedSpecialMeaningCharacters, ODataPayloadKind.Unsupported, null, true);
+            parseContextUri.ShouldNotThrow();
         }
     }
 }


### PR DESCRIPTION
…ntext uri +UT

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #965 *

### Description

Parsing the tokens of a context url in ODataJsonLightContextUriParser.TokenizeContextUri now use UriFormat.SafeUnescaped instead of UriFormat.Unescaped

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary
None
