### PR TITLE
Escaped special meaning characters remain escaped 

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightContextUriParser.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightContextUriParser.cs
@@ -126,7 +126,7 @@ namespace Microsoft.OData.Core.JsonLight
             this.parseResult.MetadataDocumentUri = uriBuilderWithoutFragment.Uri;
 
             // Get the fragment of the context URI
-            this.parseResult.Fragment = contextUriFromPayload.GetComponents(UriComponents.Fragment, UriFormat.Unescaped);
+            this.parseResult.Fragment = contextUriFromPayload.GetComponents(UriComponents.Fragment, UriFormat.SafeUnescaped);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightContextUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightContextUriParserTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.OData.Core.JsonLight;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Library;
 using Xunit;
 using ErrorStrings = Microsoft.OData.Core.Strings;
@@ -68,5 +69,26 @@ namespace Microsoft.OData.Core.Tests.JsonLight
             Action parseContextUri = () => ODataJsonLightContextUriParser.Parse(new EdmModel(), relativeUrl, ODataPayloadKind.Unsupported, ODataReaderBehavior.DefaultBehavior, true);
             parseContextUri.ShouldThrow<ODataException>().WithMessage(ErrorStrings.ODataJsonLightContextUriParser_TopLevelContextUrlShouldBeAbsolute(relativeUrl));
         }
+
+        [Fact]
+        public void ParseContextUrlWithEscapedSpecailMeaningCharactersShouldSucceed()
+        {
+            string urlWithUnescapedSpecialMeaningCharacters = "https://www.example.com/api/$metadata#People('i%3A0%23.f%7Cmembership%7Cexample%40example.org')/Dogs";
+            Action parseContextUri = () => ODataJsonLightContextUriParser.Parse(GetModel(), urlWithUnescapedSpecialMeaningCharacters, ODataPayloadKind.Unsupported, null, true);
+            parseContextUri.ShouldNotThrow();
+        }
+
+        private EdmModel GetModel() 
+        { 
+            EdmModel model = new EdmModel(); 
+            EdmEntityType edmEntityType = new EdmEntityType("NS", "Person"); 
+            edmEntityType.AddKeys(edmEntityType.AddStructuralProperty("ID", EdmPrimitiveTypeKind.String)); 
+            edmEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "Dogs", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = edmEntityType }); 
+            model.AddElement(edmEntityType); 
+            EdmEntityContainer container = new EdmEntityContainer("NS", "EntityContainer"); 
+            model.AddElement(container); 
+            container.AddEntitySet("People", edmEntityType); 
+            return model; 
+        } 
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues


*This pull request fixes issue #965 * for 6.x branch
*This pull request ported from #969

### Description

Parsing the tokens of a context url in ODataJsonLightContextUriParser.TokenizeContextUri now use UriFormat.SafeUnescaped instead of UriFormat.Unescaped

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

None
