### PR TITLE
Updating test's error message to align with previous API prolog chagnes.

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/JsonBatchRoundTripTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/JsonBatchRoundTripTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
                 batchWriter.WriteStartBatch();
 
                 ArgumentNullException ane = Assert.Throws<ArgumentNullException>(() => batchWriter.WriteStartChangeset(null));
-                Assert.True(ane.Message.Contains("groupOrChangesetId"));
+                Assert.True(ane.Message.Contains("changesetId"));
             }
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes test error message string in BatchJsonLightAtomicGroupCannotCreateGroupIdWithNullValue.*

### Description

*Updated the error message string to the last API prolog change.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
