### PR TITLE
Align PublicApi.bsl with preceding API prolog changes.

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/JsonBatchRoundTripTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/JsonBatchRoundTripTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
                 batchWriter.WriteStartBatch();
 
                 ArgumentNullException ane = Assert.Throws<ArgumentNullException>(() => batchWriter.WriteStartChangeset(null));
-                Assert.True(ane.Message.Contains("groupOrChangesetId"));
+                Assert.True(ane.Message.Contains("changesetId"));
             }
         }
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -4101,9 +4101,9 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataBatchOperationLis
 	public System.Threading.Tasks.Task WriteStartBatchAsync ()
 	protected abstract void WriteStartBatchImplementation ()
 	public void WriteStartChangeset ()
-	public void WriteStartChangeset (string groupOrChangesetId)
+	public void WriteStartChangeset (string changesetId)
 	public System.Threading.Tasks.Task WriteStartChangesetAsync ()
-	public System.Threading.Tasks.Task WriteStartChangesetAsync (string groupOrChangesetId)
+	public System.Threading.Tasks.Task WriteStartChangesetAsync (string changesetId)
 	protected abstract void WriteStartChangesetImplementation (string groupOrChangesetId)
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue in Public API bsl.*

### Description

*Align the changed parameter name in PublicAPI.bsl since it checks param name as well.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
