### PR TITLE
FxCopFixes: use ToLowerInvariant

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchWriter.cs
@@ -586,6 +586,7 @@ namespace Microsoft.OData.JsonLight
         /// <summary>
         /// Writing pending data for the current request message.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Justification = "need to use lower characters for header key")]
         private void WritePendingRequestMessageData()
         {
             Debug.Assert(this.CurrentOperationRequestMessage != null, "this.CurrentOperationRequestMessage != null");
@@ -598,7 +599,7 @@ namespace Microsoft.OData.JsonLight
             {
                 foreach (KeyValuePair<string, string> headerPair in headers)
                 {
-                    this.jsonWriter.WriteName(headerPair.Key.ToLower());
+                    this.jsonWriter.WriteName(headerPair.Key.ToLowerInvariant());
                     this.jsonWriter.WriteValue(headerPair.Value);
                 }
             }
@@ -609,6 +610,7 @@ namespace Microsoft.OData.JsonLight
         /// <summary>
         /// Writing pending data for the current response message.
         /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Justification = "need to use lower characters for header key")]
         private void WritePendingResponseMessageData()
         {
             Debug.Assert(this.JsonLightOutputContext.WritingResponse, "If the response message is available we must be writing response.");
@@ -637,7 +639,7 @@ namespace Microsoft.OData.JsonLight
             {
                 foreach (KeyValuePair<string, string> headerPair in headers)
                 {
-                    this.jsonWriter.WriteName(headerPair.Key.ToLower());
+                    this.jsonWriter.WriteName(headerPair.Key.ToLowerInvariant());
                     this.jsonWriter.WriteValue(headerPair.Value);
                 }
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes FxCop error related to using ToLowerInvariant().*

### Description

*Replacing ToLower() with ToLowerInvariant() in ODataJsonLightBatchWriter.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
