### PR TITLE
Adding OData Client Net45 binary

### DIFF
--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Nightly.Release.nuspec
@@ -24,6 +24,12 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     </frameworkAssemblies>
   </metadata>
   <files>
+    <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.dll" target="lib\net45" />
+    <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.xml" target="lib\net45" />
+    <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.pdb" target="lib\net45" />
+    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.dll" target="lib\portable-net45+win8+wpa81" />
+    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.pdb" target="lib\portable-net45+win8+wpa81" />
+    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.xml" target="lib\portable-net45+win8+wpa81" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.dll" target="lib\netstandard1.1" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.pdb" target="lib\netstandard1.1" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.xml" target="lib\netstandard1.1" />

--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Nightly.Release.nuspec
@@ -27,9 +27,6 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.dll" target="lib\net45" />
     <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.xml" target="lib\net45" />
     <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.pdb" target="lib\net45" />
-    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.dll" target="lib\portable-net45+win8+wpa81" />
-    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.pdb" target="lib\portable-net45+win8+wpa81" />
-    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.xml" target="lib\portable-net45+win8+wpa81" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.dll" target="lib\netstandard1.1" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.pdb" target="lib\netstandard1.1" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.xml" target="lib\netstandard1.1" />

--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
@@ -28,9 +28,6 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.dll" target="lib\net45" />
     <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.xml" target="lib\net45" />
     <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.pdb" target="lib\net45" />
-    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.dll" target="lib\portable-net45+win8+wpa81" />
-    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.pdb" target="lib\portable-net45+win8+wpa81" />
-    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.xml" target="lib\portable-net45+win8+wpa81" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.dll" target="lib\netstandard1.1" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.pdb" target="lib\netstandard1.1" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.xml" target="lib\netstandard1.1" />

--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
@@ -25,6 +25,12 @@ OData .NET library is open source at http://github.com/OData/odata.net</descript
     </frameworkAssemblies>
   </metadata>
   <files>
+    <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.dll" target="lib\net45" />
+    <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.xml" target="lib\net45" />
+    <file src="$ProductRoot$\Desktop\Microsoft.OData.Client.pdb" target="lib\net45" />
+    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.dll" target="lib\portable-net45+win8+wpa81" />
+    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.pdb" target="lib\portable-net45+win8+wpa81" />
+    <file src="$ProductRoot$\.NETPortable\v4.5\Microsoft.OData.Client.xml" target="lib\portable-net45+win8+wpa81" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.dll" target="lib\netstandard1.1" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.pdb" target="lib\netstandard1.1" />
     <file src="$ProductRoot$\.NETPortable\v5.0\Microsoft.OData.Client.xml" target="lib\netstandard1.1" />


### PR DESCRIPTION
Adding back the OData Client binary for Net45 framework per feedback from community. For reference, the PR that removed the binaries was #981.

### Issues
#731, #1011

### Description
A few users depended on particular code patterns found only in the non-portable versions of OData Client (i.e. Net45 framework), so this PR is to add back that Client version based on the feedback.

### Checklist (Uncheck if it is not completed)
- [x] *Test cases added* (N/A)
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
None
