### PR TITLE
Fix the issue when calculate the context uri with complex type proper…

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPathExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPathExtensions.cs
@@ -215,7 +215,8 @@ namespace Microsoft.OData.UriParser
                         }
                         else
                         {
-                            return null;
+                            // See github issue: https://github.com/OData/odata.net/issues/1022
+                            pathString.Append(segment.TranslateWith(pathTranslator));
                         }
                     }
                 }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPathExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPathExtensions.cs
@@ -177,52 +177,72 @@ namespace Microsoft.OData.UriParser
             StringBuilder pathString = new StringBuilder();
             PathSegmentToContextUrlPathTranslator pathTranslator = PathSegmentToContextUrlPathTranslator.DefaultInstance;
             ODataPathSegment priorSegment = null;
+            bool findOperationWithoutPath = false;
             foreach (ODataPathSegment segment in path)
             {
                 OperationSegment operationSegment = segment as OperationSegment;
-                if (operationSegment != null)
+                OperationImportSegment operationImportSegment = segment as OperationImportSegment;
+                if (operationImportSegment != null)
                 {
-                    bool isBoundPath = false;
+                    IEdmOperationImport operationImport = operationImportSegment.OperationImports.FirstOrDefault();
+                    Debug.Assert(operationImport != null);
 
-                    if (priorSegment != null)
+                    EdmPathExpression pathExpression = operationImport.EntitySet as EdmPathExpression;
+                    if (pathExpression != null)
                     {
-                        foreach (IEdmOperation operation in operationSegment.Operations)
+                        Debug.Assert(priorSegment == null); // operation import is always the first segment?
+                        pathString.Append(pathExpression.Path);
+                    }
+                    else
+                    {
+                        pathString = operationImport.Operation.ReturnType != null ?
+                                new StringBuilder(operationImport.Operation.ReturnType.FullName()) :
+                                new StringBuilder("Edm.Untyped");
+
+                        findOperationWithoutPath = true;
+                    }
+                }
+                else if (operationSegment != null)
+                {
+                    IEdmOperation operation = operationSegment.Operations.FirstOrDefault();
+                    Debug.Assert(operation != null);
+
+                    if (operation.IsBound &&
+                        priorSegment != null &&
+                        operation.Parameters.First().Type.Definition == priorSegment.EdmType)
+                    {
+                        if (operation.EntitySetPath != null)
                         {
-                            if (operation.IsBound && operation.Parameters.First().Type.Definition == priorSegment.EdmType)
+                            foreach (string pathSegment in operation.EntitySetPath.PathSegments.Skip(1))
                             {
-                                if (operation.EntitySetPath != null)
-                                {
-                                    foreach (string pathSegment in operation.EntitySetPath.PathSegments.Skip(1))
-                                    {
-                                        pathString.Append('/');
-                                        pathString.Append(pathSegment);
-                                    }
-
-                                    isBoundPath = true;
-                                }
-
-                                break;
+                                pathString.Append('/');
+                                pathString.Append(pathSegment);
                             }
                         }
-                    }
-
-                    if (!isBoundPath)
-                    {
-                        if (operationSegment.EntitySet != null)
+                        else if (operationSegment.EntitySet != null) // Is it correct to check EntitySet?
                         {
-                            pathString = new StringBuilder();
-                            pathString.Append(operationSegment.EntitySet.Name);
+                            pathString = new StringBuilder(operationSegment.EntitySet.Name);
                         }
                         else
                         {
-                            // See github issue: https://github.com/OData/odata.net/issues/1022
-                            pathString.Append(segment.TranslateWith(pathTranslator));
+                            pathString = operation.ReturnType != null ?
+                                new StringBuilder(operation.ReturnType.FullName()) :
+                                new StringBuilder("Edm.Untyped");
+
+                            findOperationWithoutPath = true;
                         }
                     }
                 }
                 else
                 {
-                    pathString.Append(segment.TranslateWith(pathTranslator));
+                    if (findOperationWithoutPath)
+                    {
+                        pathString = new StringBuilder(segment.EdmType.FullTypeName());
+                    }
+                    else
+                    {
+                        pathString.Append(segment.TranslateWith(pathTranslator));
+                    }
                 }
 
                 priorSegment = segment;

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPathExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPathExtensions.cs
@@ -177,7 +177,7 @@ namespace Microsoft.OData.UriParser
             StringBuilder pathString = new StringBuilder();
             PathSegmentToContextUrlPathTranslator pathTranslator = PathSegmentToContextUrlPathTranslator.DefaultInstance;
             ODataPathSegment priorSegment = null;
-            bool findOperationWithoutPath = false;
+            bool foundOperationWithoutPath = false;
             foreach (ODataPathSegment segment in path)
             {
                 OperationSegment operationSegment = segment as OperationSegment;
@@ -199,7 +199,7 @@ namespace Microsoft.OData.UriParser
                                 new StringBuilder(operationImport.Operation.ReturnType.FullName()) :
                                 new StringBuilder("Edm.Untyped");
 
-                        findOperationWithoutPath = true;
+                        foundOperationWithoutPath = true;
                     }
                 }
                 else if (operationSegment != null)
@@ -229,15 +229,16 @@ namespace Microsoft.OData.UriParser
                                 new StringBuilder(operation.ReturnType.FullName()) :
                                 new StringBuilder("Edm.Untyped");
 
-                            findOperationWithoutPath = true;
+                            foundOperationWithoutPath = true;
                         }
                     }
                 }
                 else
                 {
-                    if (findOperationWithoutPath)
+                    if (foundOperationWithoutPath)
                     {
                         pathString = new StringBuilder(segment.EdmType.FullTypeName());
+                        foundOperationWithoutPath = false;
                     }
                     else
                     {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ContextUrlPathStringTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ContextUrlPathStringTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Uri queryUri = new Uri("GetSomeAddress/City", UriKind.Relative);
             string res = this.GetContextUrlPathString(queryUri);
             Assert.Equal("City", res);
-        }
+        }       
 
         [Fact]
         public void ContextUrlPathWithEntityServiceOperationIsComposable()
@@ -51,6 +51,16 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Uri queryUri = new Uri("GetCoolestPerson/Fully.Qualified.Namespace.Employee", UriKind.Relative);
             string res = this.GetContextUrlPathString(queryUri);
             Assert.Equal("Fully.Qualified.Namespace.Employee", res);
+        }
+
+        [Theory]
+        [InlineData("People(1)/Fully.Qualified.Namespace.GetSomeAddressFromPerson()/Street")]
+        [InlineData("People(1)/Fully.Qualified.Namespace.GetSomeAddressFromPerson/Street")]
+        public void ContextUrlPathWithComplexPropertyAccessAfterOperationIsComposable(string uri)
+        {
+            Uri queryUri = new Uri(uri, UriKind.Relative);
+            string res = this.GetContextUrlPathString(queryUri);
+            Assert.Equal("People(1)/Fully.Qualified.Namespace.GetSomeAddressFromPerson/Street", res);
         }
 
         #region private methods
@@ -62,6 +72,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             ODataPath odataPath = odataUri.Path;
            return odataPath.ToContextUrlPathString();
         }
-        #endregion  
+        #endregion
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ContextUrlPathStringTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ContextUrlPathStringTests.cs
@@ -87,15 +87,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.Equal("NS.Address", res);
         }
 
-        [Fact(Skip = "Need to verify with Mike")]
-        public void ContextUrlPathWithOperationWithEntitySetPathAndComplexReturnType()
-        {
-            IEdmModel model = GetEdmModel();
-            Uri queryUri = new Uri("Customers(1)/NS.GetSomeAddressFromCustomer2", UriKind.Relative);
-            string res = this.GetContextUrlPathString(model, queryUri);
-            Assert.Equal("Customers(1)/HomeAddress", res);
-        }
-
         [Fact]
         public void ContextUrlPathWithPropertyAccessAfterOperationWithoutEntitySetPathAndComplexReturnType()
         {
@@ -105,13 +96,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.Equal("Edm.String", res);
         }
 
-        [Fact(Skip = "Need to verify with Mike")]
-        public void ContextUrlPathWithPropertyAccessOperationWithEntitySetPathAndComplexReturnType()
+        [Fact]
+        public void ContextUrlPathWithPropertyAccessOperationWithEntitySetPathAndComplexReturnTypeThrows()
         {
             IEdmModel model = GetEdmModel();
             Uri queryUri = new Uri("Customers(1)/NS.GetSomeAddressFromCustomer4/City", UriKind.Relative);
-            string res = this.GetContextUrlPathString(model, queryUri);
-            Assert.Equal("Customers(1)/Orders/City", res);
+            Action test = () => GetContextUrlPathString(model, queryUri);
+            ODataException ode = Assert.Throws<ODataException>(test);
+            Assert.Equal("The return type from the operation is not possible with the given entity set.", ode.Message);
         }
 
         [Fact]
@@ -228,6 +220,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             function.AddParameter("binding", new EdmEntityTypeReference(customer, true));
             model.AddElement(function);
 
+            // We leave the "GetSomeAddressFromCustomer2" code here.
+            // However, the operation with the entity set path containing a complex type doesn't make sense.
             IEdmPathExpression complexPath = new EdmPathExpression("binding/HomeAddress");
             function = new EdmFunction("NS", "GetSomeAddressFromCustomer2", new EdmComplexTypeReference(address, true), true, complexPath, true /*isComposable*/);
             function.AddParameter("binding", new EdmEntityTypeReference(customer, true));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ContextUrlPathStringTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ContextUrlPathStringTests.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 using System;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Tests.UriParser;
 using Microsoft.OData.UriParser;
 using Xunit;
@@ -17,7 +18,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         public void ContextUrlPathWithSimpleEntitySet()
         {
             Uri queryUri = new Uri("Dogs", UriKind.Relative);
-            string res = this.GetContextUrlPathString(queryUri);
+            string res = this.GetContextUrlPathString(HardCodedTestModel.TestModel, queryUri);
             Assert.Equal("Dogs", res);
         }
 
@@ -25,7 +26,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         public void ContextUrlPathWithNavigationPropertyLinks()
         {
             Uri queryUri = new Uri("People(1)/MyDog/$ref", UriKind.Relative);
-            string res = this.GetContextUrlPathString(queryUri);
+            string res = this.GetContextUrlPathString(HardCodedTestModel.TestModel, queryUri);
             Assert.Equal("People(1)", res);
         }
 
@@ -33,24 +34,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         public void ContextUrlPathWithSimpleServiceOperation()
         {
             Uri queryUri = new Uri("GetCoolPeople", UriKind.Relative);
-            string res = this.GetContextUrlPathString(queryUri);
-            Assert.Equal("", res);
+            string res = this.GetContextUrlPathString(HardCodedTestModel.TestModel, queryUri);
+            Assert.Equal("People", res);
         }
 
         [Fact]
         public void ContextUrlPathWithComplexServiceOperationIsComposable()
         {
             Uri queryUri = new Uri("GetSomeAddress/City", UriKind.Relative);
-            string res = this.GetContextUrlPathString(queryUri);
-            Assert.Equal("City", res);
-        }       
+            string res = this.GetContextUrlPathString(HardCodedTestModel.TestModel, queryUri);
+            Assert.Equal("Edm.String", res);
+        }
 
         [Fact]
         public void ContextUrlPathWithEntityServiceOperationIsComposable()
         {
             Uri queryUri = new Uri("GetCoolestPerson/Fully.Qualified.Namespace.Employee", UriKind.Relative);
-            string res = this.GetContextUrlPathString(queryUri);
-            Assert.Equal("Fully.Qualified.Namespace.Employee", res);
+            string res = this.GetContextUrlPathString(HardCodedTestModel.TestModel, queryUri);
+            Assert.Equal("People/Fully.Qualified.Namespace.Employee", res);
         }
 
         [Theory]
@@ -59,19 +60,217 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         public void ContextUrlPathWithComplexPropertyAccessAfterOperationIsComposable(string uri)
         {
             Uri queryUri = new Uri(uri, UriKind.Relative);
-            string res = this.GetContextUrlPathString(queryUri);
-            Assert.Equal("People(1)/Fully.Qualified.Namespace.GetSomeAddressFromPerson/Street", res);
+            string res = this.GetContextUrlPathString(HardCodedTestModel.TestModel, queryUri);
+            Assert.Equal("Edm.String", res);
         }
 
-        #region private methods
-        private string GetContextUrlPathString(Uri queryUri)
+
+        [Theory]
+        [InlineData("Customers(1)/NS.GetSomeOrders")]
+        [InlineData("Customers(1)/NS.GetSomeOrders()")]
+        [InlineData("Customers(1)/NS.GetAnOrder")]
+        [InlineData("Customers(1)/NS.GetAnOrder()")]
+        public void ContextUrlPathWithOperationWithEntitySetPathAndReturnType(string uri)
         {
-            ODataUriParser odataUriParser = new ODataUriParser(HardCodedTestModel.TestModel, queryUri);
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri(uri, UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("Customers(1)/Orders", res);
+        }
+
+        [Fact]
+        public void ContextUrlPathWithOperationWithoutEntitySetPathAndComplexReturnType()
+        {
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri("Customers(1)/NS.GetSomeAddressFromCustomer1", UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("NS.Address", res);
+        }
+
+        [Fact(Skip = "Need to verify with Mike")]
+        public void ContextUrlPathWithOperationWithEntitySetPathAndComplexReturnType()
+        {
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri("Customers(1)/NS.GetSomeAddressFromCustomer2", UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("Customers(1)/HomeAddress", res);
+        }
+
+        [Fact]
+        public void ContextUrlPathWithPropertyAccessAfterOperationWithoutEntitySetPathAndComplexReturnType()
+        {
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri("Customers(1)/NS.GetSomeAddressFromCustomer3/City", UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("Edm.String", res);
+        }
+
+        [Fact(Skip = "Need to verify with Mike")]
+        public void ContextUrlPathWithPropertyAccessOperationWithEntitySetPathAndComplexReturnType()
+        {
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri("Customers(1)/NS.GetSomeAddressFromCustomer4/City", UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("Customers(1)/Orders/City", res);
+        }
+
+        [Fact]
+        public void ContextUrlPathWithOperationWithOutEntitySetPathWithoutReturnType()
+        {
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri("Customers(1)/NS.DoSomeThing", UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("Edm.Untyped", res);
+        }
+
+        [Theory]
+        [InlineData("GetSomeOrders2")]
+        [InlineData("GetSomeOrders2()")]
+        [InlineData("GetAnOrder2")]
+        [InlineData("GetAnOrder2()")]
+        public void ContextUrlPathWithOperationImportWithEntitySetWithReturnType(string uri)
+        {
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri(uri, UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("Orders", res);
+        }
+
+        [Fact]
+        public void ContextUrlPathWithOperationImportWithoutEntitySetWithComplexReturnType()
+        {
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri("GetSomeAddress", UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("NS.Address", res);
+        }
+
+        [Fact]
+        public void ContextUrlPathWithPropertyAccessAfterOperationImportWithoutEntitySetWithComplexReturnType()
+        {
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri("GetSomeAddress/City", UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("Edm.String", res);
+        }
+
+        [Fact]
+        public void ContextUrlPathWithOperationImportWithoutEntitySetWithOutReturnType()
+        {
+            IEdmModel model = GetEdmModel();
+            Uri queryUri = new Uri("DoSomeThing2", UriKind.Relative);
+            string res = this.GetContextUrlPathString(model, queryUri);
+            Assert.Equal("Edm.Untyped", res);
+        }
+
+        internal static IEdmModel GetEdmModel()
+        {
+            var model = new EdmModel();
+
+            // open address
+            var address = new EdmComplexType("NS", "Address", null, false, true);
+            address.AddStructuralProperty("Street", EdmCoreModel.Instance.GetString(true));
+            address.AddStructuralProperty("City", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(address);
+
+            // customer
+            var customer = new EdmEntityType("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            customer.AddStructuralProperty("HomeAddress", new EdmComplexTypeReference(address, true));
+            model.AddElement(customer);
+
+            // order
+            var order = new EdmEntityType("NS", "Order");
+            order.AddKeys(order.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            model.AddElement(order);
+
+            var nav = customer.AddBidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+
+                    Name = "Orders",
+                    Target = order,
+                    TargetMultiplicity = EdmMultiplicity.Many
+                },
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Customer",
+                    TargetMultiplicity = EdmMultiplicity.ZeroOrOne,
+                });
+
+            var container = new EdmEntityContainer("Default", "Container");
+            model.AddElement(container);
+
+            var customers = new EdmEntitySet(container, "Customers", customer);
+            container.AddElement(customers);
+
+            var orders = new EdmEntitySet(container, "Orders", order);
+            container.AddElement(orders);
+            customers.AddNavigationTarget(nav, orders);
+
+            // bound operations
+            var customerReference = new EdmEntityTypeReference(customer, true);
+            var orderReference = new EdmEntityTypeReference(order, true);
+
+            IEdmPathExpression path = new EdmPathExpression("binding/Orders");
+
+            // entityset path & return type
+            var function = new EdmFunction("NS", "GetSomeOrders", new EdmCollectionTypeReference(new EdmCollectionType(orderReference)), true, path, true /*isComposable*/);
+            function.AddParameter("binding", customerReference);
+            model.AddElement(function);
+
+            function = new EdmFunction("NS", "GetAnOrder", orderReference, true, path, true /*isComposable*/);
+            function.AddParameter("binding", customerReference);
+            model.AddElement(function);
+
+            // GetSomeAddressFromCustomer
+            function = new EdmFunction("NS", "GetSomeAddressFromCustomer1", new EdmComplexTypeReference(address, true), true, null, true /*isComposable*/);
+            function.AddParameter("binding", new EdmEntityTypeReference(customer, true));
+            model.AddElement(function);
+
+            IEdmPathExpression complexPath = new EdmPathExpression("binding/HomeAddress");
+            function = new EdmFunction("NS", "GetSomeAddressFromCustomer2", new EdmComplexTypeReference(address, true), true, complexPath, true /*isComposable*/);
+            function.AddParameter("binding", new EdmEntityTypeReference(customer, true));
+            model.AddElement(function);
+
+            function = new EdmFunction("NS", "GetSomeAddressFromCustomer3", new EdmComplexTypeReference(address, true), true, null, true /*isComposable*/);
+            function.AddParameter("binding", new EdmEntityTypeReference(customer, true));
+            model.AddElement(function);
+
+            function = new EdmFunction("NS", "GetSomeAddressFromCustomer4", new EdmComplexTypeReference(address, true), true, path, true /*isComposable*/);
+            function.AddParameter("binding", new EdmEntityTypeReference(customer, true));
+            model.AddElement(function);
+
+            var action = new EdmAction("NS", "DoSomeThing", null, true, null);
+            action.AddParameter("binding", new EdmEntityTypeReference(customer, true));
+            model.AddElement(action);
+
+            // operation import
+            function = new EdmFunction("NS", "GetSomeOrders2", new EdmCollectionTypeReference(new EdmCollectionType(orderReference)));
+            EdmFunctionImport functionImport = new EdmFunctionImport(container, "GetSomeOrders2", function, new EdmPathExpression("Orders"), false);
+            container.AddElement(functionImport);
+
+            function = new EdmFunction("NS", "GetAnOrder2", orderReference);
+            functionImport = new EdmFunctionImport(container, "GetAnOrder2", function, new EdmPathExpression("Orders"), false);
+            container.AddElement(functionImport);
+
+            function = new EdmFunction("NS", "GetSomeAddress", new EdmComplexTypeReference(address, true), false, null, true);
+            functionImport = new EdmFunctionImport(container, "GetSomeAddress", function, null, false);
+            container.AddElement(functionImport);
+
+            action = new EdmAction("NS", "DoSomeThing2", null, false, null);
+            var actionImport = new EdmActionImport(container, "DoSomeThing2", action, null);
+            container.AddElement(actionImport);
+            return model;
+        }
+
+        private string GetContextUrlPathString(IEdmModel model, Uri queryUri)
+        {
+            ODataUriParser odataUriParser = new ODataUriParser(model, queryUri);
             odataUriParser.UrlKeyDelimiter = ODataUrlKeyDelimiter.Parentheses;
             ODataUri odataUri = odataUriParser.ParseUri();
             ODataPath odataPath = odataUri.Path;
-           return odataPath.ToContextUrlPathString();
+            return odataPath.ToContextUrlPathString();
         }
-        #endregion
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ContextUrlPathStringTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ContextUrlPathStringTests.cs
@@ -97,16 +97,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
 
         [Fact]
-        public void ContextUrlPathWithPropertyAccessOperationWithEntitySetPathAndComplexReturnTypeThrows()
-        {
-            IEdmModel model = GetEdmModel();
-            Uri queryUri = new Uri("Customers(1)/NS.GetSomeAddressFromCustomer4/City", UriKind.Relative);
-            Action test = () => GetContextUrlPathString(model, queryUri);
-            ODataException ode = Assert.Throws<ODataException>(test);
-            Assert.Equal("The return type from the operation is not possible with the given entity set.", ode.Message);
-        }
-
-        [Fact]
         public void ContextUrlPathWithOperationWithOutEntitySetPathWithoutReturnType()
         {
             IEdmModel model = GetEdmModel();
@@ -228,10 +218,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             model.AddElement(function);
 
             function = new EdmFunction("NS", "GetSomeAddressFromCustomer3", new EdmComplexTypeReference(address, true), true, null, true /*isComposable*/);
-            function.AddParameter("binding", new EdmEntityTypeReference(customer, true));
-            model.AddElement(function);
-
-            function = new EdmFunction("NS", "GetSomeAddressFromCustomer4", new EdmComplexTypeReference(address, true), true, path, true /*isComposable*/);
             function.AddParameter("binding", new EdmEntityTypeReference(customer, true));
             model.AddElement(function);
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -592,6 +592,10 @@ namespace Microsoft.OData.Tests.UriParser
             var FullyQualifiedNamespaceGetSomeAddressAction = new EdmFunction("Fully.Qualified.Namespace", "GetSomeAddress", FullyQualifiedNamespaceAddressTypeReference, false, null, true /*isComposable*/);
             model.AddElement(FullyQualifiedNamespaceGetSomeAddressAction);
 
+            var FullyQualifiedNamespaceGetSomeAddressFromPersoFunction = new EdmFunction("Fully.Qualified.Namespace", "GetSomeAddressFromPerson", FullyQualifiedNamespaceAddressTypeReference, true, null, true /*isComposable*/);
+            FullyQualifiedNamespaceGetSomeAddressFromPersoFunction.AddParameter("person", FullyQualifiedNamespacePersonTypeReference);
+            model.AddElement(FullyQualifiedNamespaceGetSomeAddressFromPersoFunction);
+
             var FullyQualifiedNamespaceGetSomeNumbersAction = new EdmFunction("Fully.Qualified.Namespace", "GetSomeNumbers", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(true))), false, null, true /*isComposable*/);
             model.AddElement(FullyQualifiedNamespaceGetSomeNumbersAction);
 
@@ -1379,6 +1383,10 @@ namespace Microsoft.OData.Tests.UriParser
         <ReturnType Type=""Edm.Int32"" />
       </Function>
       <Function Name=""GetSomeAddress"" IsComposable=""true"">
+        <ReturnType Type=""Fully.Qualified.Namespace.Address"" />
+      </Function>
+      <Function Name=""GetSomeAddressFromPerson"" IsBound=""true"" IsComposable=""true"">
+        <Parameter Name=""person"" Type=""Fully.Qualified.Namespace.Person"" />
         <ReturnType Type=""Fully.Qualified.Namespace.Address"" />
       </Function>
       <Function Name=""GetSomeNumbers"" IsComposable=""true"">

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -592,9 +592,9 @@ namespace Microsoft.OData.Tests.UriParser
             var FullyQualifiedNamespaceGetSomeAddressAction = new EdmFunction("Fully.Qualified.Namespace", "GetSomeAddress", FullyQualifiedNamespaceAddressTypeReference, false, null, true /*isComposable*/);
             model.AddElement(FullyQualifiedNamespaceGetSomeAddressAction);
 
-            var FullyQualifiedNamespaceGetSomeAddressFromPersoFunction = new EdmFunction("Fully.Qualified.Namespace", "GetSomeAddressFromPerson", FullyQualifiedNamespaceAddressTypeReference, true, null, true /*isComposable*/);
-            FullyQualifiedNamespaceGetSomeAddressFromPersoFunction.AddParameter("person", FullyQualifiedNamespacePersonTypeReference);
-            model.AddElement(FullyQualifiedNamespaceGetSomeAddressFromPersoFunction);
+            var FullyQualifiedNamespaceGetSomeAddressFromPersonFunction = new EdmFunction("Fully.Qualified.Namespace", "GetSomeAddressFromPerson", FullyQualifiedNamespaceAddressTypeReference, true, null, true /*isComposable*/);
+            FullyQualifiedNamespaceGetSomeAddressFromPersonFunction.AddParameter("person", FullyQualifiedNamespacePersonTypeReference);
+            model.AddElement(FullyQualifiedNamespaceGetSomeAddressFromPersonFunction);
 
             var FullyQualifiedNamespaceGetSomeNumbersAction = new EdmFunction("Fully.Qualified.Namespace", "GetSomeNumbers", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(true))), false, null, true /*isComposable*/);
             model.AddElement(FullyQualifiedNamespaceGetSomeNumbersAction);


### PR DESCRIPTION
### Issues

*This pull request fixes issue #1022.*

### Description

The problem is that Old codes return `null` if to access the complex type property returned from the Composable operation call.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
