### PR TITLE
modify the error text file for TT generator

### DIFF
--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -255,7 +255,7 @@ UnknownEnumVal_SchemaElementKind=Invalid schema element kind: '{0}'
 UnknownEnumVal_TypeKind=Invalid type kind: '{0}'
 UnknownEnumVal_PrimitiveKind=Invalid primitive kind: '{0}'
 UnknownEnumVal_ContainerElementKind=Invalid container element kind: '{0}'
-UnknownEnumVal_EdmxTarget=Invalid edmx target: '{0}'
+UnknownEnumVal_CsdlTarget=Invalid CSDL target: '{0}'
 UnknownEnumVal_PropertyKind=Invalid property kind: '{0}'
 UnknownEnumVal_ExpressionKind=Invalid expression kind: '{0}'
 

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -417,11 +417,9 @@ namespace Microsoft.OData.Edm {
         /// <summary>
         /// A string like "Required Parameter '{0}' must not follow an optional parameter."
         /// </summary>
-        internal static string EdmModel_Validator_Semantic_RequiredParametersMustPrecedeOptional(object p0)
-        {
+        internal static string EdmModel_Validator_Semantic_RequiredParametersMustPrecedeOptional(object p0) {
             return Microsoft.OData.Edm.EntityRes.GetString(Microsoft.OData.Edm.EntityRes.EdmModel_Validator_Semantic_RequiredParametersMustPrecedeOptional, p0);
         }
-        
 
         /// <summary>
         /// A string like "The return type is not valid in operation '{0}'. The operation has an unsupported type."


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

When we change the EdmxTarget to CsdlTarget, we forgot to rename the error message. That will be used to AutoTextGenerator. 

Without change, if we regenerate the error message file, we will have build error because the TT will generate "UnknownEnumVal_EdmxTarget".

### Checklist (Uncheck if it is not completed)

- [] *Test cases added*
- [] *Build and test with one-click build and test script passed*

### Additional work necessary

