### PR TITLE
Add the enum member into the expression check and don't return the Ex…

### DIFF
--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
@@ -188,6 +188,7 @@ namespace Microsoft.OData.Edm {
         internal const string EdmModel_Validator_Semantic_IncorrectNumberOfArguments = "EdmModel_Validator_Semantic_IncorrectNumberOfArguments";
         internal const string EdmModel_Validator_Semantic_DuplicateEntityContainerName = "EdmModel_Validator_Semantic_DuplicateEntityContainerName";
         internal const string EdmModel_Validator_Semantic_ExpressionPrimitiveKindNotValidForAssertedType = "EdmModel_Validator_Semantic_ExpressionPrimitiveKindNotValidForAssertedType";
+        internal const string EdmModel_Validator_Semantic_ExpressionEnumKindNotValidForAssertedType = "EdmModel_Validator_Semantic_ExpressionEnumKindNotValidForAssertedType";
         internal const string EdmModel_Validator_Semantic_IntegerConstantValueOutOfRange = "EdmModel_Validator_Semantic_IntegerConstantValueOutOfRange";
         internal const string EdmModel_Validator_Semantic_StringConstantLengthOutOfRange = "EdmModel_Validator_Semantic_StringConstantLengthOutOfRange";
         internal const string EdmModel_Validator_Semantic_BinaryConstantLengthOutOfRange = "EdmModel_Validator_Semantic_BinaryConstantLengthOutOfRange";

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -126,6 +126,7 @@ EdmModel_Validator_Semantic_DuplicateAnnotation=The annotated element '{0}' has 
 EdmModel_Validator_Semantic_IncorrectNumberOfArguments=The function application provides '{0}' arguments, but the function '{1}' expects '{2}' arguments.
 EdmModel_Validator_Semantic_DuplicateEntityContainerName=Each entity container name in a function must be unique. The name '{0}' is already defined.
 EdmModel_Validator_Semantic_ExpressionPrimitiveKindNotValidForAssertedType=The primitive expression is not compatible with the asserted type.
+EdmModel_Validator_Semantic_ExpressionEnumKindNotValidForAssertedType=The enum expression is not compatible with the asserted type.
 EdmModel_Validator_Semantic_IntegerConstantValueOutOfRange=The value of the integer constant is out of range for the asserted type.
 EdmModel_Validator_Semantic_StringConstantLengthOutOfRange=The value of the string constant is '{0}' characters long, but the max length of its type is '{1}'.
 EdmModel_Validator_Semantic_BinaryConstantLengthOutOfRange=The value of the binary constant is '{0}' characters long, but the max length of its type is '{1}'.

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -911,6 +911,15 @@ namespace Microsoft.OData.Edm {
         }
 
         /// <summary>
+        /// A string like "The enum expression is not compatible with the asserted type."
+        /// </summary>
+        internal static string EdmModel_Validator_Semantic_ExpressionEnumKindNotValidForAssertedType {
+            get {
+                return Microsoft.OData.Edm.EntityRes.GetString(Microsoft.OData.Edm.EntityRes.EdmModel_Validator_Semantic_ExpressionEnumKindNotValidForAssertedType);
+            }
+        }
+
+        /// <summary>
         /// A string like "The value of the integer constant is out of range for the asserted type."
         /// </summary>
         internal static string EdmModel_Validator_Semantic_IntegerConstantValueOutOfRange {

--- a/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
+++ b/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
@@ -1303,6 +1303,11 @@ namespace Microsoft.OData.Edm.Validation
         /// <summary>
         /// A required parameter followed an optional parameter.
         /// </summary>
-        RequiredParametersMustPrecedeOptional = 379
+        RequiredParametersMustPrecedeOptional = 379,
+
+        /// <summary>
+        /// The enum type is not valid for the requested type.
+        /// </summary>
+        ExpressionEnumKindNotValidForAssertedType = 380,
     }
 }

--- a/src/Microsoft.OData.Edm/Validation/ExpressionTypeChecker.cs
+++ b/src/Microsoft.OData.Edm/Validation/ExpressionTypeChecker.cs
@@ -488,7 +488,7 @@ namespace Microsoft.OData.Edm.Validation
             return true;
         }
 
-        private static bool TryCastEnumConstantAsType(IEdmEnumMemberExpression expression, IEdmTypeReference type, bool matachExactly, out IEnumerable<EdmError> discoveredErrors)
+        private static bool TryCastEnumConstantAsType(IEdmEnumMemberExpression expression, IEdmTypeReference type, bool matchExactly, out IEnumerable<EdmError> discoveredErrors)
         {
             if (!type.IsEnum())
             {
@@ -503,7 +503,7 @@ namespace Microsoft.OData.Edm.Validation
 
             foreach (var member in expression.EnumMembers)
             {
-                if (!TestTypeMatch(member.DeclaringType, type.Definition, expression.Location(), matachExactly, out discoveredErrors))
+                if (!TestTypeMatch(member.DeclaringType, type.Definition, expression.Location(), matchExactly, out discoveredErrors))
                 {
                     return false;
                 }

--- a/src/Microsoft.OData.Edm/Validation/ExpressionTypeChecker.cs
+++ b/src/Microsoft.OData.Edm/Validation/ExpressionTypeChecker.cs
@@ -123,6 +123,8 @@ namespace Microsoft.OData.Edm.Validation
                     return TestTypeReferenceMatch(((IEdmCastExpression)expression).Type, type, expression.Location(), matchExactly, out discoveredErrors);
                 case EdmExpressionKind.LabeledExpressionReference:
                     return TryCast(((IEdmLabeledExpressionReferenceExpression)expression).ReferencedLabeledExpression, type, out discoveredErrors);
+                case EdmExpressionKind.EnumMember:
+                    return TryCastEnumConstantAsType((IEdmEnumMemberExpression)expression, type, matchExactly, out discoveredErrors);
                 default:
                     discoveredErrors = new EdmError[] { new EdmError(expression.Location(), EdmErrorCode.ExpressionNotValidForTheAssertedType, Edm.Strings.EdmModel_Validator_Semantic_ExpressionNotValidForTheAssertedType) };
                     return false;
@@ -480,6 +482,31 @@ namespace Microsoft.OData.Edm.Validation
             {
                 discoveredErrors = new EdmError[] { new EdmError(expression.Location(), EdmErrorCode.BinaryConstantLengthOutOfRange, Edm.Strings.EdmModel_Validator_Semantic_BinaryConstantLengthOutOfRange(expression.Value.Length, binaryType.MaxLength.Value)) };
                 return false;
+            }
+
+            discoveredErrors = Enumerable.Empty<EdmError>();
+            return true;
+        }
+
+        private static bool TryCastEnumConstantAsType(IEdmEnumMemberExpression expression, IEdmTypeReference type, bool matachExactly, out IEnumerable<EdmError> discoveredErrors)
+        {
+            if (!type.IsEnum())
+            {
+                discoveredErrors = new EdmError[]
+                {
+                    new EdmError(expression.Location(),
+                    EdmErrorCode.ExpressionEnumKindNotValidForAssertedType,
+                    Edm.Strings.EdmModel_Validator_Semantic_ExpressionEnumKindNotValidForAssertedType)
+                };
+                return false;
+            }
+
+            foreach (var member in expression.EnumMembers)
+            {
+                if (!TestTypeMatch(member.DeclaringType, type.Definition, expression.Location(), matachExactly, out discoveredErrors))
+                {
+                    return false;
+                }
             }
 
             discoveredErrors = Enumerable.Empty<EdmError>();

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisRelationshipChangesAcceptanceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisRelationshipChangesAcceptanceTests.cs
@@ -466,7 +466,7 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
         [Fact]
         public void ValidationShouldFailIfEnumMemberIsSpecifiedButCannotBeFound()
         {
-            IEdmModel model = GetEdmModel(@"<EnumMember>TestNS2.UnknowColor/Blue</EnumMember>");
+            IEdmModel model = GetEdmModel(@"<EnumMember>TestNS2.UnknownColor/Blue</EnumMember>");
             IEnumerable<EdmError> errors;
             model.Validate(out errors).Should().BeFalse();
             errors.Should().HaveCount(1);
@@ -476,12 +476,12 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
         [Fact]
         public void ValidationShouldFailIfEnumMemberIsSpecifiedButCannotBeFoundTheMember()
         {
-            IEdmModel model = GetEdmModel(@"<EnumMember>TestNS2.Color/Yellow</EnumMember>");
+            IEdmModel model = GetEdmModel(@"<EnumMember>TestNS2.Color/UnknownMember</EnumMember>");
             IEnumerable<EdmError> errors;
             model.Validate(out errors).Should().BeFalse();
             errors.Should().HaveCount(2);
             errors.Should().Contain(e => e.ErrorCode == EdmErrorCode.InvalidEnumMemberPath &&
-            e.ErrorMessage == ErrorStrings.CsdlParser_InvalidEnumMemberPath("TestNS2.Color/Yellow"));
+            e.ErrorMessage == ErrorStrings.CsdlParser_InvalidEnumMemberPath("TestNS2.Color/UnknownMember"));
         }
 
         [Fact]

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/VocabularyParsingTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/VocabularyParsingTests.cs
@@ -2824,7 +2824,7 @@ namespace EdmLibTests.FunctionalTests
             edmModel.SetVocabularyAnnotation(annotation);
             var stream = new MemoryStream();
 
-            Assert.IsFalse(edmModel.Validate(out errors));
+            Assert.IsTrue(edmModel.Validate(out errors));
 
             using (var xw = XmlWriter.Create(stream, new XmlWriterSettings() { Indent = true }))
             {
@@ -2840,7 +2840,7 @@ namespace EdmLibTests.FunctionalTests
 
 
             Assert.IsTrue(CsdlReader.TryParse(XmlReader.Create(new StringReader(csdl)), out model, out errors), "parsed");
-            Assert.IsFalse(model.Validate(out validationErrors));
+            Assert.IsTrue(model.Validate(out validationErrors));
 
             TestEnumMember(model);
         }
@@ -2893,7 +2893,7 @@ namespace EdmLibTests.FunctionalTests
                     out model,
                     out errors),
                 "parsed");
-            Assert.IsFalse(model.Validate(out validationErrors));
+            Assert.IsTrue(model.Validate(out validationErrors));
 
             TestEnumMember(model);
         }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -2861,6 +2861,7 @@ public enum Microsoft.OData.Edm.Validation.EdmErrorCode : int {
 	EnumMemberMustHaveValue = 206
 	EnumMemberValueOutOfRange = 292
 	EnumMustHaveIntegerUnderlyingType = 351
+	ExpressionEnumKindNotValidForAssertedType = 380
 	ExpressionNotValidForTheAssertedType = 314
 	ExpressionPrimitiveKindNotValidForAssertedType = 312
 	FunctionImportWithParameterShouldNotBeIncludedInServiceDocument = 373


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This PR is related to https://github.com/OData/odata.net/issues/1028. But it's fixed in master branch. Once we have done it, we can consider to port to maintenance-6x branch.*

### Description

Originally, if the CSDL has annotation with 'EnumMember', it will output an error message:
```C#
ExpressionNotValidForTheAssertedType:The type of the expression is incompatible with the asserted type.
```
However, the `EnumMember` is valid expression type and should not return error message.

This PR is to fix it. 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
