### PR TITLE
401 format fixes

### DIFF
--- a/src/Microsoft.OData.Core/HttpUtils.cs
+++ b/src/Microsoft.OData.Core/HttpUtils.cs
@@ -90,7 +90,32 @@ namespace Microsoft.OData
         /// <returns>returns true if the parameter names are the same.</returns>
         internal static bool CompareMediaTypeParameterNames(string parameterName1, string parameterName2)
         {
-            return string.Equals(parameterName1, parameterName2, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(parameterName1, parameterName2, StringComparison.OrdinalIgnoreCase)
+                || (IsMetadataParameter(parameterName1) && IsMetadataParameter(parameterName2))
+                || (IsStreamingParameter(parameterName1) && IsStreamingParameter(parameterName2));
+        }
+
+        /// <summary>
+        /// Determines whether or not a parameter is the odata metadata parameter.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter.</param>
+        /// <returns>returns true if the parameter name is the odata metadata parameter.</returns>
+        internal static bool IsMetadataParameter(string parameterName)
+        {
+            return (String.Compare(parameterName, MimeConstants.MimeMetadataParameterName, StringComparison.OrdinalIgnoreCase) == 0
+                || String.Compare(parameterName, MimeConstants.MimeShortMetadataParameterName, StringComparison.OrdinalIgnoreCase) == 0);
+        }
+
+
+        /// <summary>
+        /// Determines whether or not a parameter is the odata streaming parameter.
+        /// </summary>
+        /// <param name="parameterName">The name of the parameter.</param>
+        /// <returns>returns true if the parameter name is the odata streaming parameter.</returns>
+        internal static bool IsStreamingParameter(string parameterName)
+        {
+            return (String.Compare(parameterName, MimeConstants.MimeStreamingParameterName, StringComparison.OrdinalIgnoreCase) == 0
+                || String.Compare(parameterName, MimeConstants.MimeShortStreamingParameterName, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
         /// <summary>Gets the best encoding available for the specified charset request.</summary>

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -60,7 +60,7 @@ namespace Microsoft.OData
             this.typeNameOracle = typeNameOracle;
             this.jsonWriter = this.valueSerializer.JsonWriter;
             this.odataAnnotationWriter = new JsonLightODataAnnotationWriter(this.jsonWriter,
-                valueSerializer.JsonLightOutputContext.ODataSimplifiedOptions.EnableWritingODataAnnotationWithoutPrefix);
+                valueSerializer.JsonLightOutputContext.ODataSimplifiedOptions.EnableWritingODataAnnotationWithoutPrefix, this.valueSerializer.MessageWriterSettings.Version);
             this.writerValidator = this.valueSerializer.MessageWriterSettings.Validator;
         }
 

--- a/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
@@ -39,8 +39,7 @@ namespace Microsoft.OData.JsonLight
             {
                 foreach (KeyValuePair<string, string> parameter in mediaType.Parameters)
                 {
-                    if (!HttpUtils.CompareMediaTypeParameterNames(parameter.Key, MimeConstants.MimeMetadataParameterName)
-                        && !HttpUtils.CompareMediaTypeParameterNames(parameter.Key, MimeConstants.MimeShortMetadataParameterName))
+                    if (!HttpUtils.IsMetadataParameter(parameter.Key))
                     {
                         // Only look at the "odata.metadata" parameter.
                         continue;

--- a/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
@@ -39,9 +39,10 @@ namespace Microsoft.OData.JsonLight
             {
                 foreach (KeyValuePair<string, string> parameter in mediaType.Parameters)
                 {
-                    if (!HttpUtils.CompareMediaTypeParameterNames(parameter.Key, MimeConstants.MimeMetadataParameterName))
+                    if (!HttpUtils.CompareMediaTypeParameterNames(parameter.Key, MimeConstants.MimeMetadataParameterName)
+                        && !HttpUtils.CompareMediaTypeParameterNames(parameter.Key, MimeConstants.MimeShortMetadataParameterName))
                     {
-                        // Only look at the "odata" parameter.
+                        // Only look at the "odata.metadata" parameter.
                         continue;
                     }
 
@@ -66,7 +67,7 @@ namespace Microsoft.OData.JsonLight
                 }
             }
 
-            // No "odata" media type parameter implies minimal metadata.
+            // No "odata.metadata" media type parameter implies minimal metadata.
             return new JsonMinimalMetadataLevel();
         }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OData.JsonLight
                 new JsonLightInstanceAnnotationWriter(new ODataJsonLightValueSerializer(jsonLightOutputContext), jsonLightOutputContext.TypeNameOracle));
             this.odataAnnotationWriter = new SimpleLazy<JsonLightODataAnnotationWriter>(() =>
                 new JsonLightODataAnnotationWriter(jsonLightOutputContext.JsonWriter,
-                    this.JsonLightOutputContext.ODataSimplifiedOptions.EnableWritingODataAnnotationWithoutPrefix));
+                    this.JsonLightOutputContext.ODataSimplifiedOptions.EnableWritingODataAnnotationWithoutPrefix, this.MessageWriterSettings.Version));
 
             if (initContextUriBuilder)
             {

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OData.JsonLight
             this.writingParameter = writingParameter;
             this.jsonWriter = this.jsonLightOutputContext.JsonWriter;
             this.odataAnnotationWriter = new JsonLightODataAnnotationWriter(this.jsonWriter,
-                this.jsonLightOutputContext.ODataSimplifiedOptions.EnableWritingODataAnnotationWithoutPrefix);
+                this.jsonLightOutputContext.ODataSimplifiedOptions.EnableWritingODataAnnotationWithoutPrefix, this.jsonLightOutputContext.MessageWriterSettings.Version);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/MimeConstants.cs
+++ b/src/Microsoft.OData.Core/MimeConstants.cs
@@ -59,6 +59,9 @@ namespace Microsoft.OData
         /// <summary>Parameter value for type 'feed'.</summary>
         internal const string MimeTypeParameterValueFeed = "feed";
 
+        /// <summary>JSON Light 4.01 short parameter name for 'metadata' parameter.</summary>
+        internal const string MimeShortMetadataParameterName = "metadata";
+
         /// <summary>JSON Light parameter name for 'odata.metadata' parameter.</summary>
         internal const string MimeMetadataParameterName = "odata.metadata";
 
@@ -73,6 +76,9 @@ namespace Microsoft.OData
 
         /// <summary>JSON Light parameter value 'none'.</summary>
         internal const string MimeMetadataParameterValueNone = "none";
+
+        /// <summary>JSON Light 4.01 short parameter name for 'streaming' parameter.</summary>
+        internal const string MimeShortStreamingParameterName = "streaming";
 
         /// <summary>JSON Light Parameter name for 'odata.streaming' parameter.</summary>
         internal const string MimeStreamingParameterName = "odata.streaming";

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -28,18 +28,36 @@ namespace Microsoft.OData
         private ValidationKinds validations;
 
         /// <summary>Initializes a new instance of the <see cref="T:Microsoft.OData.ODataMessageReaderSettings" /> class
-        /// with default values.</summary>
-        public ODataMessageReaderSettings()
+        /// with default values for OData 4.0.</summary>
+        public ODataMessageReaderSettings() : this(ODataConstants.ODataDefaultProtocolVersion)
+        {
+        }
+
+        /// <summary>Initializes a new instance of the <see cref="T:Microsoft.OData.ODataMessageReaderSettings" /> class
+        /// with default values for the specified OData version.</summary>
+        /// <param name="odataVersion">OData Version for which to create default settings.</param>
+        public ODataMessageReaderSettings(ODataVersion odataVersion)
         {
             this.ClientCustomTypeResolver = null;
             this.PrimitiveTypeResolver = null;
             this.EnablePrimitiveTypeConversion = true;
             this.EnableMessageStreamDisposal = true;
             this.EnableCharactersCheck = false;
-            this.ReadUntypedAsString = true;
-            this.MaxProtocolVersion = ODataConstants.ODataDefaultProtocolVersion;
-            Validations = ValidationKinds.All;
+            this.Version = odataVersion;
+
             Validator = new ReaderValidator(this);
+            if (odataVersion < ODataVersion.V401)
+            {
+                Validations = ValidationKinds.All;
+                this.ReadUntypedAsString = true;
+                this.MaxProtocolVersion = ODataConstants.ODataDefaultProtocolVersion;
+            }
+            else
+            {
+                Validations = ValidationKinds.All & ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+                this.ReadUntypedAsString = false;
+                this.MaxProtocolVersion = odataVersion;
+            }
         }
 
         /// <summary>Gets or sets the OData protocol version to be used for reading payloads. </summary>

--- a/src/Microsoft.OData.Core/ODataObjectModelExtensions.cs
+++ b/src/Microsoft.OData.Core/ODataObjectModelExtensions.cs
@@ -35,6 +35,17 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Provide additional serialization information to the <see cref="ODataWriter"/> for <paramref name="resource"/>.
+        /// </summary>
+        /// <param name="resource">The instance to set the serialization info.</param>
+        /// <param name="serializationInfo">The serialization info to set.</param>
+        public static void SetSerializationInfo(this ODataResource resource, ODataResourceSerializationInfo serializationInfo)
+        {
+            ExceptionUtils.CheckArgumentNotNull(resource, "resource");
+            resource.SerializationInfo = serializationInfo;
+        }
+
+        /// <summary>
         /// Provide additional serialization information to the <see cref="ODataWriter"/> for <paramref name="nestedResourceInfo"/>.
         /// </summary>
         /// <param name="nestedResourceInfo">The instance to set the serialization info.</param>

--- a/src/Microsoft.OData.Core/ODataSimplifiedOptions.cs
+++ b/src/Microsoft.OData.Core/ODataSimplifiedOptions.cs
@@ -28,16 +28,15 @@ namespace Microsoft.OData
         {
             this.EnableParsingKeyAsSegmentUrl = true;
             this.EnableWritingKeyAsSegment = false;
+            this.EnableReadingKeyAsSegment = false;
 
             if (version == null || version < ODataVersion.V401)
             {
-                this.EnableReadingKeyAsSegment = false;
                 this.EnableReadingODataAnnotationWithoutPrefix = false;
                 this.EnableWritingODataAnnotationWithoutPrefix = false;
             }
             else
             {
-                this.EnableReadingKeyAsSegment = true;
                 this.EnableReadingODataAnnotationWithoutPrefix = true;
                 this.EnableWritingODataAnnotationWithoutPrefix = true;
             }
@@ -57,7 +56,8 @@ namespace Microsoft.OData
         public bool EnableReadingKeyAsSegment { get; set; }
 
         /// <summary>
-        /// True if can read reserved annotation name without prefix 'odata.', otherwise false. The default value is false.
+        /// True if can read reserved annotation name without prefix 'odata.', otherwise false.
+        /// The default value is false for OData 4.0 and true for OData 4.01.
         /// The option is applied during deserialization.
         /// </summary>
         public bool EnableReadingODataAnnotationWithoutPrefix { get; set; }
@@ -71,7 +71,8 @@ namespace Microsoft.OData
         public bool EnableWritingKeyAsSegment { get; set; }
 
         /// <summary>
-        /// True if write reserved annotation name without prefix 'odata.', otherwise false. The default value is false.
+        /// True if write reserved annotation name without prefix 'odata.', otherwise false.
+        /// The default value is false for OData 4.0, true for OData 4.01.
         /// The option is applied during serialization.
         /// </summary>
         public bool EnableWritingODataAnnotationWithoutPrefix { get; set; }

--- a/src/Microsoft.OData.Core/ODataUtils.cs
+++ b/src/Microsoft.OData.Core/ODataUtils.cs
@@ -283,14 +283,12 @@ namespace Microsoft.OData
                 {
                     extendedParameters.Add(parameter);
 
-                    if (string.Compare(parameter.Key, MimeConstants.MimeMetadataParameterName, StringComparison.OrdinalIgnoreCase) == 0
-                        || string.Compare(parameter.Key, MimeConstants.MimeShortMetadataParameterName, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (HttpUtils.IsMetadataParameter(parameter.Key))
                     {
                         hasMetadata = true;
                     }
 
-                    if (string.Compare(parameter.Key, MimeConstants.MimeStreamingParameterName, StringComparison.OrdinalIgnoreCase) == 0
-                        || string.Compare(parameter.Key, MimeConstants.MimeShortStreamingParameterName, StringComparison.OrdinalIgnoreCase) == 0)
+                    if (HttpUtils.IsStreamingParameter(parameter.Key))
                     {
                         hasStreaming = true;
                     }

--- a/src/Microsoft.OData.Core/ODataUtils.cs
+++ b/src/Microsoft.OData.Core/ODataUtils.cs
@@ -220,14 +220,36 @@ namespace Microsoft.OData
         ///
         /// When header name is ODataConstants.ContentTypeHeader:
         ///     If header value is application/json, append the following default values:
-        ///         odata.metadata=minimal
-        ///         odata.streaming=true
+        ///         (odata.)metadata=minimal
+        ///         (odata.)streaming=true
         ///         IEEE754Compatible=false
         /// </summary>
         /// <param name="headerName">The name of the header to append default values.</param>
         /// <param name="headerValue">The original header value string.</param>
         /// <returns>The header value string with appended default values.</returns>
         public static string AppendDefaultHeaderValue(string headerName, string headerValue)
+        {
+            return AppendDefaultHeaderValue(headerName, headerValue, ODataVersion.V4);
+        }
+
+        /// <summary>
+        /// Append default values required by OData to specified HTTP header.
+        ///
+        /// When header name is ODataConstants.ContentTypeHeader, if header value is application/json
+        ///     append the following default values for 4.0:
+        ///         odata.metadata=minimal
+        ///         odata.streaming=true
+        ///         IEEE754Compatible=false
+        ///     append the following default values for 4.01:
+        ///         metadata=minimal
+        ///         streaming=true
+        ///         IEEE754Compatible=false
+        /// </summary>
+        /// <param name="headerName">The name of the header to append default values.</param>
+        /// <param name="headerValue">The original header value string.</param>
+        /// <param name="version">The ODataVersion for which to create the default header value</param>
+        /// <returns>The header value string with appended default values.</returns>
+        public static string AppendDefaultHeaderValue(string headerName, string headerValue, ODataVersion version)
         {
             if (string.CompareOrdinal(headerName, ODataConstants.ContentTypeHeader) != 0)
             {
@@ -261,17 +283,19 @@ namespace Microsoft.OData
                 {
                     extendedParameters.Add(parameter);
 
-                    if (string.CompareOrdinal(parameter.Key, MimeConstants.MimeMetadataParameterName) == 0)
+                    if (string.Compare(parameter.Key, MimeConstants.MimeMetadataParameterName, StringComparison.OrdinalIgnoreCase) == 0
+                        || string.Compare(parameter.Key, MimeConstants.MimeShortMetadataParameterName, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         hasMetadata = true;
                     }
 
-                    if (string.CompareOrdinal(parameter.Key, MimeConstants.MimeStreamingParameterName) == 0)
+                    if (string.Compare(parameter.Key, MimeConstants.MimeStreamingParameterName, StringComparison.OrdinalIgnoreCase) == 0
+                        || string.Compare(parameter.Key, MimeConstants.MimeShortStreamingParameterName, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         hasStreaming = true;
                     }
 
-                    if (string.CompareOrdinal(parameter.Key, MimeConstants.MimeIeee754CompatibleParameterName) == 0)
+                    if (string.Compare(parameter.Key, MimeConstants.MimeIeee754CompatibleParameterName, StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         hasIeee754Compatible = true;
                     }
@@ -281,14 +305,14 @@ namespace Microsoft.OData
             if (!hasMetadata)
             {
                 extendedParameters.Add(new KeyValuePair<string, string>(
-                    MimeConstants.MimeMetadataParameterName,
+                    version < ODataVersion.V401 ? MimeConstants.MimeMetadataParameterName : MimeConstants.MimeShortMetadataParameterName,
                     MimeConstants.MimeMetadataParameterValueMinimal));
             }
 
             if (!hasStreaming)
             {
                 extendedParameters.Add(new KeyValuePair<string, string>(
-                    MimeConstants.MimeStreamingParameterName,
+                    version < ODataVersion.V401 ? MimeConstants.MimeStreamingParameterName : MimeConstants.MimeShortStreamingParameterName,
                     MimeConstants.MimeParameterValueTrue));
             }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/MediaTypeUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/MediaTypeUtilsTests.cs
@@ -10,6 +10,7 @@ using FluentAssertions;
 using FluentAssertions.Primitives;
 using Xunit;
 using ErrorStrings = Microsoft.OData.Strings;
+using System.Linq;
 
 namespace Microsoft.OData.Tests
 {
@@ -18,19 +19,49 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void StreamingAcceptShouldResolveToStreamingResponse()
         {
-            TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;odata.metadata=minimal;odata.streaming=true", ODataVersion.V4).Should().BeJsonLight().And.BeStreaming();
+            var mediaTypeWithFormat = TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;odata.metadata=minimal;odata.streaming=true", ODataVersion.V4);
+            mediaTypeWithFormat.Should().BeJsonLight().And.BeStreaming().And.SpecifyDefaultMetadata();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "odata.metadata").Should().BeTrue();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "odata.streaming").Should().BeTrue();
+        }
+
+        [Fact]
+        public void StreamingAcceptShouldResolveToStreamingResponse_Without_Prefix()
+        {
+            var mediaTypeWithFormat = TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;metadata=minimal;streaming=true", ODataVersion.V4);
+            mediaTypeWithFormat.Should().BeJsonLight().And.BeStreaming();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "metadata").Should().BeTrue();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "streaming").Should().BeTrue();
         }
 
         [Fact]
         public void NonStreamingAcceptShouldResolveToNonStreamingResponse()
         {
-            TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;odata.metadata=minimal;odata.streaming=false", ODataVersion.V4).Should().BeJsonLight().And.NotBeStreaming();
+            var mediaTypeWithFormat = TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;odata.metadata=minimal;odata.streaming=false", ODataVersion.V4);
+            mediaTypeWithFormat.Should().BeJsonLight().And.NotBeStreaming();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "odata.metadata").Should().BeTrue();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "odata.streaming").Should().BeTrue();
+        }
+
+        [Fact]
+        public void NonStreamingAcceptShouldResolveToNonStreamingResponse_Without_Prefix()
+        {
+            var mediaTypeWithFormat = TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;metadata=minimal;streaming=false", ODataVersion.V4);
+            mediaTypeWithFormat.Should().BeJsonLight().And.NotBeStreaming();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "metadata").Should().BeTrue();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "streaming").Should().BeTrue();
         }
 
         [Fact]
         public void UnspecifiedAcceptShouldResolveToStreamingResponse()
         {
             TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;odata.metadata=minimal", ODataVersion.V4).Should().BeJsonLight().And.BeStreaming();
+        }
+
+        [Fact]
+        public void UnspecifiedAcceptShouldResolveToStreamingResponse_Without_Prefix()
+        {
+            TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;metadata=minimal", ODataVersion.V4).Should().BeJsonLight().And.BeStreaming();
         }
 
         [Fact]
@@ -112,9 +143,21 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
+        public void StreamingContentTypeShouldParseCorrectly_Without_Prefix()
+        {
+            TestMediaTypeWithFormat.ParseContentType("application/json;metadata=minimal;streaming=true", ODataVersion.V4).Should().BeJsonLight().And.BeStreaming();
+        }
+
+        [Fact]
         public void NonStreamingContentTypeShouldParseCorrectly()
         {
             TestMediaTypeWithFormat.ParseContentType("application/json;odata.metadata=minimal;odata.streaming=false", ODataVersion.V4).Should().BeJsonLight().And.NotBeStreaming();
+        }
+
+        [Fact]
+        public void NonStreamingContentTypeShouldParseCorrectly_Without_Prefix()
+        {
+            TestMediaTypeWithFormat.ParseContentType("application/json;metadata=minimal;streaming=false", ODataVersion.V4).Should().BeJsonLight().And.NotBeStreaming();
         }
 
         [Fact]
@@ -160,9 +203,21 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
+        public void MetadataAllContentTypeShouldSucceed_Without_Prefix()
+        {
+            TestMediaTypeWithFormat.ParseContentType("application/json;metadata=full", ODataVersion.V4).Should().BeJsonLight().And.SpecifyAllMetadata();
+        }
+
+        [Fact]
         public void MetadataNoneContentTypeShouldSucceed()
         {
             TestMediaTypeWithFormat.ParseContentType("application/json;odata.metadata=none", ODataVersion.V4).Should().BeJsonLight().And.SpecifyNoMetadata();
+        }
+
+        [Fact]
+        public void MetadataNoneContentTypeShouldSucceed_Without_Prefix()
+        {
+            TestMediaTypeWithFormat.ParseContentType("application/json;metadata=none", ODataVersion.V4).Should().BeJsonLight().And.SpecifyNoMetadata();
         }
 
         [Fact]
@@ -172,15 +227,43 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
+        public void DefaultMetadataContentTypeShouldSucceed_Without_Prefix()
+        {
+            TestMediaTypeWithFormat.ParseContentType("application/json;metadata=minimal", ODataVersion.V4).Should().BeJsonLight().And.SpecifyDefaultMetadata();
+        }
+
+        [Fact]
         public void MetadataAllAcceptShouldSucceed()
         {
-            TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;odata.metadata=full", ODataVersion.V4).Should().BeJsonLight().And.SpecifyAllMetadata();
+            var mediaTypeWithFormat = TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;odata.metadata=full", ODataVersion.V4);
+            mediaTypeWithFormat.Should().BeJsonLight().And.SpecifyAllMetadata();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "odata.metadata").Should().BeTrue();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "metadata").Should().BeFalse();
+        }
+
+        [Fact]
+        public void MetadataAllAcceptShouldSucceed_Without_Prefix()
+        {
+            var mediaTypeWithFormat = TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json;metadata=full", ODataVersion.V4);
+            mediaTypeWithFormat.Should().BeJsonLight().And.SpecifyAllMetadata();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "metadata").Should().BeTrue();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "odata.metadata").Should().BeFalse();
         }
 
         [Fact]
         public void UnspecifiedAcceptShouldResolveToDefault()
         {
-            TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json", ODataVersion.V4).Should().BeJsonLight().And.SpecifyDefaultMetadata();
+            var mediaTypeWithFormat = TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json", ODataVersion.V4);
+            mediaTypeWithFormat.Should().BeJsonLight().And.SpecifyDefaultMetadata();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "odata.metadata").Should().BeTrue();
+        }
+
+        [Fact]
+        public void UnspecifiedAcceptShouldResolveToDefault_401()
+        {
+            var mediaTypeWithFormat = TestMediaTypeWithFormat.GetResponseTypeFromAccept("application/json", ODataVersion.V401);
+            mediaTypeWithFormat.Should().BeJsonLight().And.SpecifyDefaultMetadata();
+            TestMediaTypeWithFormat.MediaTypeContains(mediaTypeWithFormat.MediaType, "metadata").Should().BeTrue();
         }
 
         [Fact]
@@ -234,10 +317,18 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void StreamingParameterShouldBeCaseInsensitive()
         {
-            TestMediaTypeWithFormat.GetResponseTypeFromAccept("appLICatIOn/jSOn;OdAtA.sTrEaMinG=TrUe", ODataVersion.V4).Should().BeJsonLight().And.BeStreaming();
-            TestMediaTypeWithFormat.GetResponseTypeFromAccept("APpLiCAtIOn/jSoN;oDaTa.stReAMinG=fAlSe", ODataVersion.V4).Should().BeJsonLight().And.NotBeStreaming();
             TestMediaTypeWithFormat.ParseContentType("appLICatIOn/jSOn;OdAtA.sTrEaMinG=TrUe", ODataVersion.V4).Should().BeJsonLight().And.BeStreaming();
             TestMediaTypeWithFormat.ParseContentType("APpLiCAtIOn/jSoN;oDaTa.stReAMinG=fAlSe", ODataVersion.V4).Should().BeJsonLight().And.NotBeStreaming();
+            TestMediaTypeWithFormat.ParseContentType("appLICatIOn/jSOn;sTrEaMinG=TrUe", ODataVersion.V4).Should().BeJsonLight().And.BeStreaming();
+            TestMediaTypeWithFormat.ParseContentType("APpLiCAtIOn/jSoN;stReAMinG=fAlSe", ODataVersion.V4).Should().BeJsonLight().And.NotBeStreaming();
+
+            var mediaTypeWithFormat = TestMediaTypeWithFormat.GetResponseTypeFromAccept("appLICatIOn/jSOn;OdAtA.sTrEaMinG=TrUe", ODataVersion.V4);
+            mediaTypeWithFormat.Should().BeJsonLight().And.BeStreaming();
+            
+            TestMediaTypeWithFormat.GetResponseTypeFromAccept("APpLiCAtIOn/jSoN;oDaTa.stReAMinG=fAlSe", ODataVersion.V4).Should().BeJsonLight().And.NotBeStreaming();
+
+            TestMediaTypeWithFormat.GetResponseTypeFromAccept("appLICatIOn/jSOn;sTrEaMinG=TrUe", ODataVersion.V4).Should().BeJsonLight().And.BeStreaming();
+            TestMediaTypeWithFormat.GetResponseTypeFromAccept("APpLiCAtIOn/jSoN;stReAMinG=fAlSe", ODataVersion.V4).Should().BeJsonLight().And.NotBeStreaming();
         }
 
         [Fact]
@@ -387,6 +478,11 @@ namespace Microsoft.OData.Tests
             return GetResponseType(version, s => s.SetContentType(format));
         }
 
+        internal static bool MediaTypeContains(ODataMediaType mediaType, string parameterName)
+        {
+            return mediaType.Parameters != null && mediaType.Parameters.Any(p => String.Compare(p.Key, parameterName, StringComparison.OrdinalIgnoreCase) == 0);
+        }
+
         private static TestMediaTypeWithFormat GetResponseType(ODataVersion version, Action<ODataMessageWriterSettings> configureSettings)
         {
             var settings = new ODataMessageWriterSettings { Version = version };
@@ -425,7 +521,7 @@ namespace Microsoft.OData.Tests
 
         public AndConstraint<MediaTypeAssertions> BeUnspecifiedJson()
         {
-            return this.HaveFullTypeName("application/json").And.NotHaveParameter("odata.metadata");
+            return this.HaveFullTypeName("application/json").And.NotHaveParameter("odata.metadata").And.NotHaveParameter("metadata");
         }
 
         public AndConstraint<MediaTypeAssertions> BeStreaming()
@@ -454,22 +550,28 @@ namespace Microsoft.OData.Tests
 
         public AndConstraint<MediaTypeAssertions> SpecifyNoMetadata()
         {
-            return this.HaveParameterValue("odata.metadata", "none");
+            return this.HaveParameterValue(new string[] { "odata.metadata", "metadata" }, "none");
         }
 
         public AndConstraint<MediaTypeAssertions> SpecifyDefaultMetadata()
         {
-            return this.HaveParameterValue("odata.metadata", "minimal");
+            return this.HaveParameterValue(new string[] { "odata.metadata", "metadata" }, "minimal");
         }
 
         public AndConstraint<MediaTypeAssertions> SpecifyAllMetadata()
         {
-            return this.HaveParameterValue("odata.metadata", "full");
+            return this.HaveParameterValue(new string[] { "odata.metadata", "metadata" }, "full");
         }
 
         public AndConstraint<MediaTypeAssertions> HaveParameterValue(string parameterName, string parameterValue)
         {
             this.MediaType.MediaTypeHasParameterWithValue(parameterName, parameterValue).Should().BeTrue();
+            return new AndConstraint<MediaTypeAssertions>(this);
+        }
+
+        public AndConstraint<MediaTypeAssertions> HaveParameterValue(string[] parameterNames, string parameterValue)
+        {
+            parameterNames.Any(p => this.MediaType.MediaTypeHasParameterWithValue(p, parameterValue)).Should().BeTrue();
             return new AndConstraint<MediaTypeAssertions>(this);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
@@ -30,9 +30,35 @@ namespace Microsoft.OData.Tests
             Assert.True(settings.EnableMessageStreamDisposal, "EnableMessageStreamDisposal should be false by default.");
             Assert.False(settings.EnableCharactersCheck, "The CheckCharacters should be off by default.");
             Assert.True((settings.Validations & ValidationKinds.ThrowIfTypeConflictsWithMetadata) != 0, "The ThrowIfTypeConflictsWithMetadata should be true by default");                        
-            Assert.Null(settings.ShouldIncludeAnnotation);            
+            Assert.Null(settings.ShouldIncludeAnnotation);
+            Assert.True(settings.ReadUntypedAsString, "ReadUntypedAsString should be true by default for OData 4.0.");
             Assert.True((settings.Validations & ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType) != 0, "ThrowOnUndeclaredPropertyForNonOpenType should be true by default.");
-            Assert.True(ODataVersion.V4 == settings.MaxProtocolVersion, "MaxProtocolVersion should be V3.");
+            Assert.True(ODataVersion.V4 == settings.Version, "Version should be 4.0.");
+            Assert.True(ODataVersion.V4 == settings.MaxProtocolVersion, "MaxProtocolVersion should be V4.");
+            Assert.True(100 == settings.MessageQuotas.MaxPartsPerBatch, "MaxPartsPerBatch should be int.MaxValue.");
+            Assert.True(1000 == settings.MessageQuotas.MaxOperationsPerChangeset, "MaxOperationsPerChangeset should be int.MaxValue.");
+            Assert.True(100 == settings.MessageQuotas.MaxNestingDepth, "The MaxNestingDepth should be set to 100 by default.");
+            Assert.True(1024 * 1024 == settings.MessageQuotas.MaxReceivedMessageSize, "The MaxMessageSize should be set to 1024 * 1024 by default.");
+        }
+
+        [Fact]
+        public void DefaultValuesTest401()
+        {
+            ODataMessageReaderSettings settings = new ODataMessageReaderSettings(ODataVersion.V401);
+
+            Assert.True((settings.Validations & ValidationKinds.ThrowOnDuplicatePropertyNames) != 0, "The ThrowOnDuplicatePropertyNames should be true by default");
+            Assert.Null(settings.BaseUri);
+            Assert.Null(settings.ClientCustomTypeResolver);
+            Assert.Null(settings.PrimitiveTypeResolver);
+            Assert.True(settings.EnablePrimitiveTypeConversion, "EnablePrimitiveTypeConversion should be true by default.");
+            Assert.True(settings.EnableMessageStreamDisposal, "EnableMessageStreamDisposal should be false by default.");
+            Assert.False(settings.EnableCharactersCheck, "The CheckCharacters should be off by default.");
+            Assert.False(settings.ReadUntypedAsString, "ReadUntypedAsString should be false by default for OData 4.01.");
+            Assert.True((settings.Validations & ValidationKinds.ThrowIfTypeConflictsWithMetadata) != 0, "The ThrowIfTypeConflictsWithMetadata should be true by default");
+            Assert.Null(settings.ShouldIncludeAnnotation);
+            Assert.True((settings.Validations & ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType) == 0, "ThrowOnUndeclaredPropertyForNonOpenType should be false by default for OData 4.01.");
+            Assert.True(ODataVersion.V401 == settings.Version, "Version should be 4.01.");
+            Assert.True(ODataVersion.V401 == settings.MaxProtocolVersion, "MaxProtocolVersion should be 4.01.");
             Assert.True(100 == settings.MessageQuotas.MaxPartsPerBatch, "MaxPartsPerBatch should be int.MaxValue.");
             Assert.True(1000 == settings.MessageQuotas.MaxOperationsPerChangeset, "MaxOperationsPerChangeset should be int.MaxValue.");
             Assert.True(100 == settings.MessageQuotas.MaxNestingDepth, "The MaxNestingDepth should be set to 100 by default.");
@@ -181,7 +207,7 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
-        public void ShouldSkipAnnotationsByDefaultForV3()
+        public void ShouldSkipAnnotationsByDefaultForV4()
         {
             ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings();
             readerSettings.MaxProtocolVersion = ODataVersion.V4;
@@ -189,7 +215,7 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
-        public void ShouldHonorAnnotationFilterForV3()
+        public void ShouldHonorAnnotationFilterForV4()
         {
             ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings();
             readerSettings.MaxProtocolVersion = ODataVersion.V4;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/PrimitiveValuesRoundtripJsonLightTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/PrimitiveValuesRoundtripJsonLightTests.cs
@@ -552,9 +552,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
         private void VerifyUIntValuesRoundtripWithTypeInformation(IEnumerable clrValues, string edmTypeDefinitionName)
         {
             var typeReference = new EdmTypeDefinitionReference((IEdmTypeDefinition)this.model.FindType(edmTypeDefinitionName), true);
-            foreach (object clrValue in clrValues)
+            foreach (ODataVersion version in new ODataVersion[] { ODataVersion.V4, ODataVersion.V401 })
             {
-                this.VerifyPrimitiveValueRoundtrips(clrValue, typeReference, ODataVersion.V4, string.Format("JSON Light roundtrip value {0} of type {1}.", clrValue, edmTypeDefinitionName), isIeee754Compatible: true);
+                foreach (object clrValue in clrValues)
+                {
+                    this.VerifyPrimitiveValueRoundtrips(clrValue, typeReference, version, string.Format("JSON Light roundtrip value {0} of type {1}.", clrValue, edmTypeDefinitionName), isIeee754Compatible: true);
+                }
             }
         }
 
@@ -563,7 +566,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
             var typeReference = new EdmPrimitiveTypeReference((IEdmPrimitiveType)this.model.FindType(edmTypeName), true);
             foreach (object clrValue in clrValues)
             {
-                this.VerifyPrimitiveValueRoundtrips(clrValue, typeReference, ODataVersion.V4, string.Format("JSON Light roundtrip value {0} of type {1}.", clrValue, edmTypeName), isIeee754Compatible: true);
+                foreach (ODataVersion version in new ODataVersion[] { ODataVersion.V4, ODataVersion.V401 })
+                {
+                    this.VerifyPrimitiveValueRoundtrips(clrValue, typeReference, version, string.Format("JSON Light roundtrip value {0} of type {1}.", clrValue, edmTypeName), isIeee754Compatible: true);
+                }
             }
         }
 
@@ -578,7 +584,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
             {
                 object clrValue = clrValues.GetValue(iterator);
                 object expectedValue = expectedValues.GetValue(iterator);
-                this.VerifyPrimitiveValueRoundtrips(clrValue, typeReference, ODataVersion.V4, string.Format("JSON Light roundtrip value {0} of type {1} of expected value {2}.", clrValue, edmTypeName, expectedValue), isIeee754Compatible: true, expectedValue: expectedValue);
+                foreach (ODataVersion version in new ODataVersion[] { ODataVersion.V4, ODataVersion.V401 })
+                {
+                    this.VerifyPrimitiveValueRoundtrips(clrValue, typeReference, version, string.Format("JSON Light roundtrip value {0} of type {1} of expected value {2}.", clrValue, edmTypeName, expectedValue), isIeee754Compatible: true, expectedValue: expectedValue);
+                }
             }
         }
 
@@ -586,7 +595,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
         {
             foreach (object clrValue in clrValues)
             {
-                this.VerifyPrimitiveValueRoundtrips(clrValue, null, ODataVersion.V4, string.Format("JSON Light roundtrip value {0} with no expected type.", clrValue), isIeee754Compatible: true);
+                foreach (ODataVersion version in new ODataVersion[] { ODataVersion.V4, ODataVersion.V401 })
+                {
+                    this.VerifyPrimitiveValueRoundtrips(clrValue, null, version, string.Format("JSON Light roundtrip value {0} with no expected type.", clrValue), isIeee754Compatible: true);
+                }
             }
         }
 
@@ -594,7 +606,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
         {
             foreach (object clrValue in clrValues)
             {
-                this.VerifyPrimitiveValueDoesNotRoundtrip(clrValue, null, ODataVersion.V4, string.Format("JSON Light roundtrip value {0} with no expected type.", clrValue), isIeee754Compatible: true);
+                foreach (ODataVersion version in new ODataVersion[] { ODataVersion.V4, ODataVersion.V401 })
+                {
+                    this.VerifyPrimitiveValueDoesNotRoundtrip(clrValue, null, version, string.Format("JSON Light roundtrip value {0} with no expected type.", clrValue), isIeee754Compatible: true);
+                }
             }
         }
 
@@ -602,7 +617,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
         {
             foreach (object clrValue in clrValues)
             {
-                this.VerifyPrimitiveValueDoesNotRoundtrip(clrValue, null, ODataVersion.V4, string.Format("JSON Light roundtrip value {0} with no expected type.", clrValue), isIeee754Compatible: false);
+                foreach (ODataVersion version in new ODataVersion[] { ODataVersion.V4, ODataVersion.V401 })
+                {
+                    this.VerifyPrimitiveValueDoesNotRoundtrip(clrValue, null, version, string.Format("JSON Light roundtrip value {0} with no expected type.", clrValue), isIeee754Compatible: false);
+                }
             }
         }
 
@@ -611,7 +629,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
             var typeReference = new EdmPrimitiveTypeReference((IEdmPrimitiveType)this.model.FindType(edmTypeName), true);
             foreach (object clrValue in clrValues)
             {
-                this.VerifyPrimitiveValueRoundtrips(clrValue, typeReference, ODataVersion.V4, string.Format("JSON Light roundtrip value {0} with no expected type.", clrValue), isIeee754Compatible: false);
+                foreach (ODataVersion version in new ODataVersion[] { ODataVersion.V4, ODataVersion.V401 })
+                {
+                    this.VerifyPrimitiveValueRoundtrips(clrValue, typeReference, version, string.Format("JSON Light roundtrip value {0} with no expected type.", clrValue), isIeee754Compatible: false);
+                }
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightPropertyTypeSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightPropertyTypeSerializerTests.cs
@@ -51,10 +51,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
         }
 
         [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeBinary_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = new byte[] { 1, 2, 4 } }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"Binary");
+        }
+
+        [Fact]
         public void ShouldNotWriteODataTypeForPrimitiveTypeBoolean()
         {
             string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = true });
             result.Should().NotContain("@odata.type");
+        }
+
+        [Fact]
+        public void ShouldNotWriteODataTypeForPrimitiveTypeBoolean_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = true }, ODataVersion.V401);
+            result.Should().NotContain("@type");
         }
 
         [Fact]
@@ -65,10 +79,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
         }
 
         [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeByte_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Byte.Parse("12") }, ODataVersion.V401);
+            result.Should().Contain("type\":\"Byte");
+        }
+
+        [Fact]
         public void ShouldWriteODataTypeForPrimitiveTypeDate()
         {
             string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = new Date(2014, 8, 8) });
             result.Should().Contain("@odata.type\":\"#Date");
+        }
+
+        [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeDate_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = new Date(2014, 8, 8) }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"Date");
         }
 
         [Fact]
@@ -79,10 +107,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
         }
 
         [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeDateTimeOffset_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = new DateTimeOffset(2013, 11, 28, 12, 12, 12, TimeSpan.Zero) }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"DateTimeOffset");
+        }
+
+        [Fact]
         public void ShouldWriteODataTypeForPrimitiveTypeDecimal()
         {
             string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Decimal.Parse("111.100") });
             result.Should().Contain("@odata.type\":\"#Decimal");
+        }
+
+        [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeDecimal_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Decimal.Parse("111.100") }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"Decimal");
         }
 
         [Fact]
@@ -100,10 +142,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
         }
 
         [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeInfiniteDouble_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Double.NegativeInfinity }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"Double");
+        }
+
+        [Fact]
         public void ShouldNotWriteODataTypeForPrimitiveTypeNormalDouble()
         {
             string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Double.Parse("111.11") });
             result.Should().NotContain("@odata.type");
+        }
+
+        [Fact]
+        public void ShouldNotWriteODataTypeForPrimitiveTypeNormalDouble_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Double.Parse("111.11") }, ODataVersion.V401);
+            result.Should().NotContain("@type");
         }
 
         [Fact]
@@ -114,10 +170,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
         }
 
         [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeGuid_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Guid.Empty }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"Guid");
+        }
+
+        [Fact]
         public void ShouldWriteODataTypeForPrimitiveTypeInt16()
         {
             string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Int16.Parse("16") });
             result.Should().Contain("@odata.type\":\"#Int16");
+        }
+
+        [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeInt16_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Int16.Parse("16") }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"Int16");
         }
 
         [Fact]
@@ -128,10 +198,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
         }
 
         [Fact]
+        public void ShouldNotWriteODataTypeForPrimitiveTypeInt32_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Int32.Parse("32") }, ODataVersion.V401);
+            result.Should().NotContain("@type");
+        }
+
+        [Fact]
         public void ShouldWriteODataTypeForPrimitiveTypeInt64()
         {
             string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Int64.Parse("64") });
             result.Should().Contain("@odata.type\":\"#Int64");
+        }
+
+        [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeInt64_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = Int64.Parse("64") }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"Int64");
         }
 
         [Fact]
@@ -142,10 +226,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
         }
 
         [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeSByte_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = SByte.Parse("1") }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"SByte");
+        }
+
+        [Fact]
         public void ShouldWriteODataTypeForPrimitiveTypeTimeOfDay()
         {
             string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = new TimeOfDay(23, 59, 59, 0) });
             result.Should().Contain("@odata.type\":\"#TimeOfDay");
+        }
+
+        [Fact]
+        public void ShouldWriteODataTypeForPrimitiveTypeTimeOfDay_401()
+        {
+            string result = this.SerializeProperty(new ODataProperty() { Name = "TestProperty", Value = new TimeOfDay(23, 59, 59, 0) }, ODataVersion.V401);
+            result.Should().Contain("@type\":\"TimeOfDay");
         }
 
         [Fact]
@@ -336,10 +434,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
         }
 
         #region assist private functions
-        private string SerializeProperty(ODataProperty odataProperty)
+        private string SerializeProperty(ODataProperty odataProperty, ODataVersion version = ODataVersion.V4)
         {
             MemoryStream outputStream = new MemoryStream();
-            ODataJsonLightOutputContext jsonLightOutputContext = this.CreateJsonLightOutputContext(outputStream);
+            ODataJsonLightOutputContext jsonLightOutputContext = this.CreateJsonLightOutputContext(outputStream, version);
             var serializer = new ODataJsonLightPropertySerializer(jsonLightOutputContext);
 
             jsonLightOutputContext.JsonWriter.StartObjectScope();
@@ -374,9 +472,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             return payload;
         }
 
-        private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream)
+        private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream, ODataVersion version = ODataVersion.V4)
         {
-            var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
+            var settings = new ODataMessageWriterSettings { Version = version };
             settings.SetServiceDocumentUri(new Uri("http://example.com/"));
 
             var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/WriterUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/WriterUtilsTests.cs
@@ -26,7 +26,20 @@ namespace Microsoft.OData.Tests
                 typeFromValue, 
                 /* isOpenProperty*/ false);
             result.Should().Be("Edm.GeographyPoint");
-            WriterUtils.RemoveEdmPrefixFromTypeName(result).Should().Be("GeographyPoint");
+            WriterUtils.PrefixTypeNameForWriting(result, ODataVersion.V4).Should().Be("#GeographyPoint");
+        }
+
+        [Fact]
+        public void TypeNameShouldBeWrittenIfSpatialValueIsMoreDerivedThanMetadataType_401()
+        {
+            var typeFromMetadata = EdmCoreModel.Instance.GetSpatial(EdmPrimitiveTypeKind.Geography, true);
+            var typeFromValue = EdmCoreModel.Instance.GetSpatial(EdmPrimitiveTypeKind.GeographyPoint, false);
+            var result = this.typeNameOracle.GetValueTypeNameForWriting(new ODataPrimitiveValue(Microsoft.Spatial.GeographyPoint.Create(42, 42)),
+                typeFromMetadata,
+                typeFromValue,
+                /* isOpenProperty*/ false);
+            result.Should().Be("Edm.GeographyPoint");
+            WriterUtils.PrefixTypeNameForWriting(result, ODataVersion.V401).Should().Be("GeographyPoint");
         }
 
         [Fact]
@@ -79,7 +92,19 @@ namespace Microsoft.OData.Tests
                 typeFromValue,
                 /* isOpenProperty*/ true);
             result.Should().Be("Collection(Edm.String)");
-            WriterUtils.RemoveEdmPrefixFromTypeName(result).Should().Be("Collection(String)");
+            WriterUtils.PrefixTypeNameForWriting(result, ODataVersion.V4).Should().Be("#Collection(String)");
+        }
+
+        [Fact]
+        public void TypeNameShouldBeWrittenForUndeclaredCollectionProperty_401()
+        {
+            var typeFromValue = EdmCoreModel.GetCollection(EdmCoreModel.Instance.GetString(false));
+            var result = this.typeNameOracle.GetValueTypeNameForWriting(new ODataCollectionValue() { TypeName = "Collection(String)" },
+                null,
+                typeFromValue,
+                /* isOpenProperty*/ true);
+            result.Should().Be("Collection(Edm.String)");
+            WriterUtils.PrefixTypeNameForWriting(result, ODataVersion.V401).Should().Be("Collection(String)");
         }
 
         [Fact]

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -4576,6 +4576,7 @@ ExtensionAttribute(),
 ]
 public sealed class Microsoft.OData.ODataUtils {
 	public static string AppendDefaultHeaderValue (string headerName, string headerValue)
+	public static string AppendDefaultHeaderValue (string headerName, string headerValue, Microsoft.OData.ODataVersion version)
 	public static System.Func`2[[System.String],[System.Boolean]] CreateAnnotationFilter (string annotationFilter)
 	[
 	ExtensionAttribute(),
@@ -5012,6 +5013,7 @@ public sealed class Microsoft.OData.ODataMessageReader : IDisposable {
 
 public sealed class Microsoft.OData.ODataMessageReaderSettings {
 	public ODataMessageReaderSettings ()
+	public ODataMessageReaderSettings (Microsoft.OData.ODataVersion odataVersion)
 
 	System.Uri BaseUri  { public get; public set; }
 	System.Func`3[[Microsoft.OData.Edm.IEdmType],[System.String],[Microsoft.OData.Edm.IEdmType]] ClientCustomTypeResolver  { public get; public set; }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -4541,6 +4541,11 @@ public sealed class Microsoft.OData.ODataObjectModelExtensions {
 	[
 	ExtensionAttribute(),
 	]
+	public static void SetSerializationInfo (Microsoft.OData.ODataResource resource, Microsoft.OData.ODataResourceSerializationInfo serializationInfo)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static void SetSerializationInfo (Microsoft.OData.ODataResourceBase resource, Microsoft.OData.ODataResourceSerializationInfo serializationInfo)
 
 	[


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1037.*

### Description

In PR #989 we added support for writing the new 4.01 delta format by specifying ODataVersion.401 in WriterSettings. This PR supports additional requirements when writing, or reading, a 4.01 payload.

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*