### PR TITLE
Update changeset id to use whole boundary value.

### DIFF
--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -98,7 +98,7 @@ namespace Microsoft.OData.MultipartMixed
                 requestUri,
                 headers,
                 this.currentContentId,
-                ODataMultipartMixedBatchWriterUtils.GetChangeSetIdFromBoundary(this.batchStream.ChangeSetBoundary),
+                this.batchStream.ChangeSetBoundary,
                 this.dependsOnIdsTracker.GetDependsOnIds(), /*dependsOnIdsValidationRequired*/false);
 
             if (this.currentContentId != null)

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -245,7 +245,7 @@ namespace Microsoft.OData.MultipartMixed
             ODataBatchOperationRequestMessage operationRequestMessage = BuildOperationRequestMessage(
                 this.RawOutputContext.OutputStream,
                 method, uri, contentId,
-                ODataMultipartMixedBatchWriterUtils.GetChangeSetIdFromBoundary(this.changeSetBoundary),
+                this.changeSetBoundary,
                 dependsOnIds);
 
             this.SetState(BatchWriterState.OperationCreated);
@@ -329,7 +329,7 @@ namespace Microsoft.OData.MultipartMixed
             // so use the URL resolver from the batch message instead.
             this.CurrentOperationResponseMessage = BuildOperationResponseMessage(
                 this.RawOutputContext.OutputStream, contentId,
-                ODataMultipartMixedBatchWriterUtils.GetChangeSetIdFromBoundary(this.changeSetBoundary));
+                this.changeSetBoundary);
 
             this.SetState(BatchWriterState.OperationCreated);
 

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriterUtils.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriterUtils.cs
@@ -44,27 +44,6 @@ namespace Microsoft.OData.MultipartMixed
         }
 
         /// <summary>
-        /// Extract the changeset id from the change set boundary string.
-        /// This is the reversal method of <code>CreateChangeSetBoundary(bool, string)</code>.
-        /// </summary>
-        /// <param name="changesetBoundary">Change set boundary string previous constructed by <code>CreateChangeSetBoundary</code>.
-        /// Can be null.</param>
-        /// <returns>The change set id or null.</returns>
-        internal static string GetChangeSetIdFromBoundary(string changesetBoundary)
-        {
-            if (changesetBoundary == null)
-            {
-                return null;
-            }
-
-            // The changeset boundary can be for either request or response, which are both constructed from templates.
-            // Change set id is the remainder after first char of '_'.
-            int idx = changesetBoundary.IndexOf('_');
-            ExceptionUtils.CheckIntegerNotNegative(idx, "idxOfSeparator");
-            return changesetBoundary.Substring(idx + 1);
-        }
-
-        /// <summary>
         /// Creates the multipart/mixed content type with the specified boundary (if any).
         /// </summary>
         /// <param name="boundary">The boundary to be used for this operation or null if no boundary should be included.</param>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1040.*

### Description

*Update changeset id to use whole boundary value, so that WebAPI test using latest ODL-7.4 can pass.*

### Checklist (Uncheck if it is not completed)

- [] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
