### PR TITLE
Remove the NavigationPropertyEntityMustNotIndirectlyContainItself rule

### DIFF
--- a/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
@@ -103,7 +103,6 @@ namespace Microsoft.OData.Edm.Validation
                 ValidationRules.AnnotationInaccessibleTerm,
                 ValidationRules.ElementDirectValueAnnotationFullNameMustBeUnique,
                 ValidationRules.VocabularyAnnotationInaccessibleTarget,
-                ValidationRules.NavigationPropertyEntityMustNotIndirectlyContainItself,
                 ValidationRules.EntitySetRecursiveNavigationPropertyMappingsMustPointBackToSourceEntitySet,
                 ValidationRules.NavigationPropertyMappingMustPointToValidTargetForProperty,
                 ValidationRules.DirectValueAnnotationHasXmlSerializableName,

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRuleSetTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRuleSetTests.cs
@@ -22,7 +22,8 @@ namespace Microsoft.OData.Edm.Tests.Validation
         public void NewValidationRulesShouldBeInTheRuleSetExceptBaselinedExceptionRules()
         {
             var validationRules = new Dictionary<object, string>();
-            var items = typeof(ValidationRules).GetFields().Select(f=> new KeyValuePair<object, string>(f.GetValue(null), f.Name));
+            var items = typeof(ValidationRules).GetFields().Where(f => f.Name != "NavigationPropertyEntityMustNotIndirectlyContainItself")
+                .Select(f=> new KeyValuePair<object, string>(f.GetValue(null), f.Name));
             foreach (var item in items)
             {
                 validationRules.Add(item.Key, item.Value);

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/NavigationValidationTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/NavigationValidationTests.cs
@@ -291,33 +291,6 @@ namespace EdmLibTests.FunctionalTests
         }
 
         [TestMethod]
-        public void ValidateIndirectRecursiveContainment()
-        {
-            var expectedErrors = new EdmLibTestErrors()
-            {
-                { 8, 10, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself },
-                { 19, 10, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself },
-            };
-
-            var model = NavigationTestModelBuilder.NonDirectRecursiveContainment();
-
-            this.VerifySemanticValidation(model, EdmVersion.V40, expectedErrors);
-        }
-
-        [TestMethod]
-        public void ValidateNavigationWithBothContainmentEnds()
-        {
-
-            var model = NavigationTestModelBuilder.NavigationWithBothContainmentEnds();
-            var expectedErrors = new EdmLibTestErrors()
-            {
-                { null, null, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself },
-                { null, null, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself }
-            };
-            this.VerifySemanticValidation(model, EdmVersion.V40, expectedErrors);
-        }
-
-        [TestMethod]
         public void ValidateNavigationWithOneMultiplicityContainmentEnd()
         {
             var model = NavigationTestModelBuilder.NavigationWithOneMultiplicityContainmentEnd();
@@ -436,32 +409,6 @@ namespace EdmLibTests.FunctionalTests
         {
             var model = NavigationTestModelBuilder.ContainmentNavigationWithDifferentEnds();
             var expectedErrors = new EdmLibTestErrors();
-            this.VerifySemanticValidation(model, EdmVersion.V40, expectedErrors);
-        }
-
-        [TestMethod]
-        public void ValidateRecursiveThreeContainmentNavigations()
-        {
-            var expectedErrors = new EdmLibTestErrors()
-            {
-                { null, null, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself },
-                { null, null, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself },
-                { null, null, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself }
-            };
-            var model = NavigationTestModelBuilder.RecursiveThreeContainmentNavigations();
-            this.VerifySemanticValidation(model, EdmVersion.V40, expectedErrors);
-        }
-
-        [TestMethod]
-        public void ValidateRecursiveThreeContainmentNavigationsWithEntitySet()
-        {
-            var expectedErrors = new EdmLibTestErrors()
-            {
-                { null, null, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself },
-                { null, null, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself },
-                { null, null, EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself }
-            };
-            var model = NavigationTestModelBuilder.RecursiveThreeContainmentNavigationsWithEntitySet();
             this.VerifySemanticValidation(model, EdmVersion.V40, expectedErrors);
         }
 

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/SemanticValidationTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/SemanticValidationTests.cs
@@ -1637,17 +1637,6 @@ namespace EdmLibTests.FunctionalTests
         }
 
         [TestMethod]
-        public void TestBidirectionalContainment()
-        {
-            var expectedErrors = new EdmLibTestErrors()
-            {
-                {"(Microsoft.OData.Edm.EdmNavigationProperty)", EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself},
-                {"(Microsoft.OData.Edm.EdmNavigationProperty)", EdmErrorCode.NavigationPropertyEntityMustNotIndirectlyContainItself},
-            };
-            this.VerifySemanticValidation(ValidationTestModelBuilder.BidirectionalContainmentModel(), expectedErrors);
-        }
-
-        [TestMethod]
         public void TestNavigationPropertyContainTargetBeforeV3()
         {
             this.VerifySemanticValidation(ValidationTestModelBuilder.ModelWithNavigationPropertyWithContainsTarget(), EdmVersion.V40, null);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Issue from the Graph beta validation. It shows: 

Problem 3: NavigationPropertyEntityMustNotIndirectlyContainItself:The navigation property 'events' is invalid because it indirectly contains itself. 

### Description

When we validate the Graph beta CSDL, it gives us the following error messages:

```C#
The navigation property 'drive' is invalid because it indirectly contains itself.
The navigation property 'driveItem' is invalid because it indirectly contains itself.
The navigation property 'site' is invalid because it indirectly contains itself.
The navigation property 'worksheet' is invalid because it indirectly contains itself.
The navigation property 'worksheet' is invalid because it indirectly contains itself.
The navigation property 'charts' is invalid because it indirectly contains itself.
```
As discussed with Mike, it's better to remove the in-correct validation rule.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
