### PR TITLE
OptionalDollarSign: Small test update and expose API for DI option setter/getter

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ODataUriParserConfiguration.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParserConfiguration.cs
@@ -122,11 +122,15 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
-        /// Whether no dollar query options is enabled.
+        /// Gets or Sets an option whether no dollar query options is enabled.
         /// If it is enabled, the '$' prefix of system query options becomes optional.
         /// For example, "select" and "$select" are equivalent in this case.
         /// </summary>
-        internal bool EnableNoDollarQueryOptions { get; set; }
+        internal bool EnableNoDollarQueryOptions
+        {
+            get { return this.Resolver.EnableNoDollarQueryOptions; }
+            set { this.Resolver.EnableNoDollarQueryOptions = value; }
+        }
 
         /// <summary>
         /// Whether Uri template parsing is enabled. See <see cref="UriTemplateExpression"/> class for detail.

--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -36,6 +36,14 @@ namespace Microsoft.OData.UriParser
         public virtual bool EnableCaseInsensitive { get; set; }
 
         /// <summary>
+        /// Gets and sets the optional-$-sign-prefix for OData system query option.
+        /// </summary>
+        /// <remarks>
+        /// All extensions should look at this property and keep case sensitive behavior consistent.
+        /// </remarks>
+        public virtual bool EnableNoDollarQueryOptions { get; set; }
+
+        /// <summary>
         /// Gets and sets promotion rules for type facets.
         /// </summary>
         public TypeFacetsPromotionRules TypeFacetsPromotionRules

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SemanticTreeFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SemanticTreeFunctionalTests.cs
@@ -336,8 +336,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void CountQueryWithDuplicateCount()
         {
-            Action test = () => HardCodedTestModel.ParseUri("Dogs?$count=true&$count=true", this.edmModel);
-            test.ShouldThrow<ODataException>().WithMessage(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce("$count"));
+            string input = "Dogs?$count=true&$count=true";
+            var serviceBaseUri = new Uri("http://server/service/");
+            var queryUri = new Uri(serviceBaseUri, input);
+            ODataUriParser parser = new ODataUriParser(this.edmModel, serviceBaseUri, queryUri);
+            Action test = () => parser.ParseUri();
+
+            bool originalValue = parser.EnableNoDollarQueryOptions;
+            try
+            {
+                //Ensure $-sign is required.
+                parser.EnableNoDollarQueryOptions = false;
+                test.ShouldThrow<ODataException>()
+                    .WithMessage(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce("$count"));
+            }
+            finally
+            {
+                parser.EnableNoDollarQueryOptions = originalValue;
+            }
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -76,13 +76,33 @@ namespace Microsoft.OData.Tests.UriParser
         [Fact]
         public void DupilicateNonODataQueryOptionShouldWork()
         {
-            Action action = () => new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(FullUri, "?$filter=UserName eq 'foo'&$filter=UserName eq 'bar'")).ParsePath();
-            var uriParser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(FullUri, "?$filter=UserName eq 'Tom'&nonODataQuery=foo&$select=Emails&nonODataQuery=bar"));
-            var nonODataqueryOptions = uriParser.CustomQueryOptions;
+            ODataUriParser uriParserProcessingDupODataSystemQuery = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot,
+                new Uri(FullUri, "?$filter=UserName eq 'foo'&$filter=UserName eq 'bar'"));
 
-            action.ShouldThrow<ODataException>().WithMessage(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce("$filter"));
-            Assert.Equal(nonODataqueryOptions.Count, 2);
-            Assert.True(nonODataqueryOptions[0].Key.Equals("nonODataQuery") && nonODataqueryOptions[1].Key.Equals("nonODataQuery"));
+            bool originalValue = uriParserProcessingDupODataSystemQuery.EnableNoDollarQueryOptions;
+            try
+            {
+                // Set the parser option in the static singleton to be $-sign required.
+                uriParserProcessingDupODataSystemQuery.EnableNoDollarQueryOptions = false;
+
+                Action action = () => uriParserProcessingDupODataSystemQuery.ParsePath();
+
+                var uriParserProcessingDupCustomQuery =
+                    new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot,
+                        new Uri(FullUri, "?$filter=UserName eq 'Tom'&nonODataQuery=foo&$select=Emails&nonODataQuery=bar"));
+                var nonODataqueryOptions = uriParserProcessingDupCustomQuery.CustomQueryOptions;
+
+                action.ShouldThrow<ODataException>()
+                    .WithMessage(Strings.QueryOptionUtils_QueryParameterMustBeSpecifiedOnce("$filter"));
+                Assert.Equal(nonODataqueryOptions.Count, 2);
+                Assert.True(nonODataqueryOptions[0].Key.Equals("nonODataQuery") &&
+                            nonODataqueryOptions[1].Key.Equals("nonODataQuery"));
+            }
+            finally
+            {
+                // Restore original value
+                uriParserProcessingDupODataSystemQuery.EnableNoDollarQueryOptions = originalValue;
+            }
         }
 
         #region Setter/getter and validation tests
@@ -401,15 +421,28 @@ namespace Microsoft.OData.Tests.UriParser
         public void ParseNoDollarQueryOptionsShouldReturnNullIfNoDollarQueryOptionsIsNotEnabled()
         {
             var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("People?filter=MyDog/Color eq 'Brown'&select=ID&expand=MyDog&orderby=ID&top=1&skip=2&count=true&search=FA&$unknown=&$unknownvalue&skiptoken=abc&deltatoken=def", UriKind.Relative));
-            parser.ParseFilter().Should().BeNull();
-            parser.ParseSelectAndExpand().Should().BeNull();
-            parser.ParseOrderBy().Should().BeNull();
-            parser.ParseTop().Should().Be(null);
-            parser.ParseSkip().Should().Be(null);
-            parser.ParseCount().Should().Be(null);
-            parser.ParseSearch().Should().BeNull();
-            parser.ParseSkipToken().Should().BeNull();
-            parser.ParseDeltaToken().Should().BeNull();
+
+            bool originalValue = parser.EnableNoDollarQueryOptions;
+            try
+            {
+                // Ensure $-sign is required.
+                parser.EnableNoDollarQueryOptions = false;
+
+                parser.ParseFilter().Should().BeNull();
+                parser.ParseSelectAndExpand().Should().BeNull();
+                parser.ParseOrderBy().Should().BeNull();
+                parser.ParseTop().Should().Be(null);
+                parser.ParseSkip().Should().Be(null);
+                parser.ParseCount().Should().Be(null);
+                parser.ParseSearch().Should().BeNull();
+                parser.ParseSkipToken().Should().BeNull();
+                parser.ParseDeltaToken().Should().BeNull();
+            }
+            finally
+            {
+                // Restore original value
+                parser.EnableNoDollarQueryOptions = originalValue;
+            }
         }
 
         [Theory]
@@ -422,7 +455,7 @@ namespace Microsoft.OData.Tests.UriParser
         [InlineData("People?$select=ID&select=Name", true, false, "$select", false)]
         [InlineData("People?$select=ID&SELECT=Name", true, false, "$select", false)]
 
-        // 3. Case insensitive, No dollar not enabled, be treated as custom query options.
+        // 3. Case sensitive, No dollar not enabled, be treated as custom query options.
         // Duplication is allowed.
         [InlineData("People?select=ID&select=Name", false, false, "select", false)]
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5779,6 +5779,7 @@ public class Microsoft.OData.UriParser.ODataUriResolver {
 	public ODataUriResolver ()
 
 	bool EnableCaseInsensitive  { public virtual get; public virtual set; }
+	bool EnableNoDollarQueryOptions  { public virtual get; public virtual set; }
 	Microsoft.OData.UriParser.TypeFacetsPromotionRules TypeFacetsPromotionRules  { public get; public set; }
 
 	public virtual void PromoteBinaryOperandTypes (Microsoft.OData.UriParser.BinaryOperatorKind binaryOperatorKind, Microsoft.OData.UriParser.SingleValueNode& leftNode, Microsoft.OData.UriParser.SingleValueNode& rightNode, out Microsoft.OData.Edm.IEdmTypeReference& typeReference)


### PR DESCRIPTION
Enable public API for DI in
* ODataUriResolver
* ODataUriParserConfiguration

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request provides support for using optionalDollarSign from WebAPI.*

### Description

*small test update and expose API for option EnableOptionalDollarSign.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added in WebAPI*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
