### PR TITLE
Add KeyAsSegmentSupported annotation term to Capabiliites vocabulary

### DIFF
--- a/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularies.xml
@@ -242,17 +242,18 @@ Overview:
         <Annotation Term="Core.Description" String="Supports key values according to OData URL conventions" />
       </Term>
 
+      <Term Name="KeyAsSegmentSupported" Type="Core.Tag" DefaultValue="true" AppliesTo="EntityContainer">
+        <Annotation Term="Core.Description" String="Supports key as segment" />
+      </Term>
       <Term Name="TopSupported" Type="Core.Tag" DefaultValue="true" AppliesTo="EntitySet">
         <Annotation Term="Core.Description" String="Supports $top" />
       </Term>
       <Term Name="SkipSupported" Type="Core.Tag" DefaultValue="true" AppliesTo="EntitySet">
         <Annotation Term="Core.Description" String="Supports $skip" />
       </Term>
-
       <Term Name="BatchSupported" Type="Core.Tag" DefaultValue="true" AppliesTo="EntityContainer">
         <Annotation Term="Core.Description" String="Supports $batch requests" />
       </Term>
-
       <Term Name="FilterFunctions" Type="Collection(Edm.String)" AppliesTo="EntityContainer EntitySet">
         <Annotation Term="Core.Description" String="List of functions supported in $filter" />
       </Term>

--- a/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularyModel.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -40,7 +39,7 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
 
             // Resource name has leading namespace and folder in .NetStandard dll.
             string[] allResources = assembly.GetManifestResourceNames();
-            string capabilitiesVocabularies = allResources.Where(x => x.Contains("CapabilitiesVocabularies.xml")).FirstOrDefault();
+            string capabilitiesVocabularies = allResources.FirstOrDefault(x => x.Contains("CapabilitiesVocabularies.xml"));
             Debug.Assert(capabilitiesVocabularies != null, "CapabilitiesVocabularies.xml: not found.");
 
             using (Stream stream = assembly.GetManifestResourceStream(capabilitiesVocabularies))
@@ -51,6 +50,9 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
             }
 
             ChangeTrackingTerm = Instance.FindDeclaredTerm(CapabilitiesVocabularyConstants.ChangeTracking);
+
+            // It needn't to list all other terms like CoreVocabularyModel.cs, because Capabilities model class is
+            // an internal class. Customers can call FindTerm(qualifiedName) method to get the corresponding term.
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.cs
@@ -212,6 +212,9 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""IndexableByKey"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet"">
     <Annotation Term=""Core.Description"" String=""Supports key values according to OData URL conventions"" />
   </Term>
+  <Term Name=""KeyAsSegmentSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityContainer"">
+    <Annotation Term=""Core.Description"" String=""Supports key as segment"" />
+  </Term>
   <Term Name=""TopSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet"">
     <Annotation Term=""Core.Description"" String=""Supports $top"" />
   </Term>
@@ -518,6 +521,34 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
 
             var type = supportedFormats.Type;
             Assert.Equal("Collection(Edm.String)", type.FullName());
+        }
+
+        [Theory]
+        [InlineData("AsynchronousRequestsSupported", "EntityContainer")]
+        [InlineData("BatchContinueOnErrorSupported", "EntityContainer")]
+        [InlineData("CrossJoinSupported", "EntityContainer")]
+        [InlineData("TopSupported", "EntitySet")]
+        [InlineData("SkipSupported", "EntitySet")]
+        [InlineData("IndexableByKey", "EntitySet")]
+        [InlineData("BatchSupported", "EntityContainer")]
+        [InlineData("KeyAsSegmentSupported", "EntityContainer")]
+        public void TestCapabilitiesVocabularySupportedTerm(string name, string appliesTo)
+        {
+            string qualifiedName = "Org.OData.Capabilities.V1." + name;
+            var supported = this.capVocModel.FindDeclaredTerm(qualifiedName);
+            Assert.NotNull(supported);
+            Assert.Equal("Org.OData.Capabilities.V1", supported.Namespace);
+            Assert.Equal(name, supported.Name);
+
+            Assert.Equal(appliesTo, supported.AppliesTo);
+            var type = supported.Type;
+            Assert.Equal("Org.OData.Core.V1.Tag", type.FullName());
+
+            Assert.Equal(EdmTypeKind.TypeDefinition, type.TypeKind());
+            IEdmTypeDefinitionReference typeDefinitionReference = type.AsTypeDefinition();
+            Assert.NotNull(typeDefinitionReference);
+
+            Assert.Equal(EdmPrimitiveTypeKind.Boolean, typeDefinitionReference.TypeDefinition().UnderlyingType.PrimitiveKind);
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

See issue at: https://issues.oasis-open.org/browse/ODATA-1134

### Description

In OData 4.01 we introduced semantics around supporting the popular key-as-segment URL syntax, but we have no generic way for clients to know whether or not the service supports this sytnax. 

This PR is to add a new boolean term to the capabilities vocabulary, `KeyAsSegmentSupported`

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
