### PR TITLE
Modify the duplicated annotation validation issue

### DIFF
--- a/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
@@ -2589,7 +2589,7 @@ namespace Microsoft.OData.Edm.Validation
                 (context, annotatable) =>
                 {
                     HashSetInternal<string> annotationSet = new HashSetInternal<string>();
-                    foreach (IEdmVocabularyAnnotation annotation in annotatable.VocabularyAnnotations(context.Model))
+                    foreach (IEdmVocabularyAnnotation annotation in context.Model.FindDeclaredVocabularyAnnotations(annotatable))
                     {
                         if (!annotationSet.Add(annotation.Term.FullName() + ":" + annotation.Qualifier))
                         {

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -13,6 +13,8 @@ using FluentAssertions;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Csdl.CsdlSemantics;
 using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OData.Edm.Vocabularies.V1;
 using Xunit;
 using ErrorStrings = Microsoft.OData.Edm.Strings;
 
@@ -605,6 +607,84 @@ namespace Microsoft.OData.Edm.Tests.Csdl
   </edmx:DataServices>
 </edmx:Edmx>";
             string modelText = string.Format(template, types, properties);
+
+            IEdmModel model;
+            IEnumerable<EdmError> errors;
+
+            bool result = CsdlReader.TryParse(XElement.Parse(modelText).CreateReader(), out model, out errors);
+            Assert.True(result);
+            return model;
+        }
+
+        [Fact]
+        public void ParsingBaseAndDerivedTypeWithSameAnnotationWorksButValidationSuccessful()
+        {
+            string annotations =@"
+            <Annotations Target=""NS.Base"">
+                <Annotation Term=""Org.OData.Core.V1.Description"" String=""Base description"" />
+            </Annotations>
+            <Annotations Target=""NS.Derived"">
+                <Annotation Term=""Org.OData.Core.V1.Description"" String=""Derived description"" />
+            </Annotations>";
+
+            IEdmModel model = GetInheritanceEdmModel(annotations);
+
+            var edmType = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Base");
+            Assert.NotNull(edmType);
+            Assert.Equal("Base description", model.GetDescriptionAnnotation(edmType));
+
+            edmType = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Derived");
+            Assert.NotNull(edmType);
+            Assert.Equal("Derived description", model.GetDescriptionAnnotation(edmType));
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors));
+        }
+
+        [Fact]
+        public void ParsingDerivedTypeWithDuplicatedAnnotationsWorksButValidationFailed()
+        {
+            string annotations = @"
+            <Annotations Target=""NS.Derived"">
+                <Annotation Term=""Org.OData.Core.V1.Description"" String=""Derived description 1"" />
+            </Annotations>
+            <Annotations Target=""NS.Derived"">
+                <Annotation Term=""Org.OData.Core.V1.Description"" String=""Derived description 2"" />
+            </Annotations>";
+
+            IEdmModel model = GetInheritanceEdmModel(annotations);
+
+            var edmType = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Derived");
+            Assert.NotNull(edmType);
+            var descriptions = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(edmType, CoreVocabularyModel.DescriptionTerm);
+            Assert.Equal(new [] { "Derived description 1", "Derived description 2" },
+                descriptions.Select(d => d.Value as IEdmStringConstantExpression).Select(e => e.Value));
+
+            IEnumerable<EdmError> errors;
+            Assert.False(model.Validate(out errors));
+            EdmError error = Assert.Single(errors);
+            Assert.NotNull(error);
+            Assert.Equal(EdmErrorCode.DuplicateAnnotation, error.ErrorCode);
+            Assert.Equal("The annotated element 'NS.Derived' has multiple annotations with the term 'Org.OData.Core.V1.Description' and the qualifier ''.", error.ErrorMessage);
+        }
+
+        private static IEdmModel GetInheritanceEdmModel(string annotation)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Base"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+      </EntityType>
+      <EntityType Name=""Derived"" BaseType=""NS.Base"" />
+      {0}
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string modelText = string.Format(template, annotation);
 
             IEdmModel model;
             IEnumerable<EdmError> errors;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* https://github.com/OData/odata.net/issues/1046

### Description

When we do some validation on Graph beta, we get the following error messages:

**DuplicateAnnotation:The annotated element 'microsoft.graph.managedAppProtection' has multiple annotations with the term 'Org.OData.Core.V1.Description' and the qualifier ''.**

That's because DuplicateAnnotation validation rule verifies the base and derived type's annotation together. Once it finds a duplicated annotation applied, no matter on base or derived, it outputs an error message.



### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
