### PR TITLE
Odata v4 7.x - Fix #530 LINQ query generation with Date functions produces weird urls

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/TypeSystem.cs
+++ b/src/Microsoft.OData.Client/ALinq/TypeSystem.cs
@@ -53,7 +53,7 @@ namespace Microsoft.OData.Client
         static TypeSystem()
         {
 #if !PORTABLELIB
-            const int ExpectedCount = 35;
+            const int ExpectedCount = 43;
 #endif
             // string functions
             expressionMethodMap = new Dictionary<MethodInfo, string>(EqualityComparer<MethodInfo>.Default);
@@ -80,13 +80,23 @@ namespace Microsoft.OData.Client
             expressionMethodMap.Add(typeof(TimeOfDay).GetProperty("Minutes", typeof(int)).GetGetMethod(), @"minute");
             expressionMethodMap.Add(typeof(TimeOfDay).GetProperty("Seconds", typeof(int)).GetGetMethod(), @"second");
 
-            // datetimeoffset methods (date? time?)
+            // datetimeoffset methods
+            expressionMethodMap.Add(typeof(DateTimeOffset).GetProperty("Date", typeof(DateTime)).GetGetMethod(), @"date");
             expressionMethodMap.Add(typeof(DateTimeOffset).GetProperty("Day", typeof(int)).GetGetMethod(), @"day");
             expressionMethodMap.Add(typeof(DateTimeOffset).GetProperty("Hour", typeof(int)).GetGetMethod(), @"hour");
             expressionMethodMap.Add(typeof(DateTimeOffset).GetProperty("Month", typeof(int)).GetGetMethod(), @"month");
             expressionMethodMap.Add(typeof(DateTimeOffset).GetProperty("Minute", typeof(int)).GetGetMethod(), @"minute");
             expressionMethodMap.Add(typeof(DateTimeOffset).GetProperty("Second", typeof(int)).GetGetMethod(), @"second");
             expressionMethodMap.Add(typeof(DateTimeOffset).GetProperty("Year", typeof(int)).GetGetMethod(), @"year");
+
+            // datetime methods
+            expressionMethodMap.Add(typeof(DateTime).GetProperty("Date", typeof(DateTime)).GetGetMethod(), @"date");
+            expressionMethodMap.Add(typeof(DateTime).GetProperty("Day", typeof(int)).GetGetMethod(), @"day");
+            expressionMethodMap.Add(typeof(DateTime).GetProperty("Hour", typeof(int)).GetGetMethod(), @"hour");
+            expressionMethodMap.Add(typeof(DateTime).GetProperty("Month", typeof(int)).GetGetMethod(), @"month");
+            expressionMethodMap.Add(typeof(DateTime).GetProperty("Minute", typeof(int)).GetGetMethod(), @"minute");
+            expressionMethodMap.Add(typeof(DateTime).GetProperty("Second", typeof(int)).GetGetMethod(), @"second");
+            expressionMethodMap.Add(typeof(DateTime).GetProperty("Year", typeof(int)).GetGetMethod(), @"year");
 
             // timespan methods
             expressionMethodMap.Add(typeof(TimeSpan).GetProperty("Hours", typeof(int)).GetGetMethod(), @"hour");
@@ -145,6 +155,9 @@ namespace Microsoft.OData.Client
                 typeof(DateTimeOffset).GetProperty("Day", typeof(int)),
                 typeof(DateTimeOffset).GetProperty("Day", typeof(int)).GetGetMethod());
             propertiesAsMethodsMap.Add(
+                typeof(DateTimeOffset).GetProperty("Date", typeof(DateTime)),
+                typeof(DateTimeOffset).GetProperty("Date", typeof(DateTime)).GetGetMethod());
+            propertiesAsMethodsMap.Add(
                 typeof(DateTimeOffset).GetProperty("Hour", typeof(int)),
                 typeof(DateTimeOffset).GetProperty("Hour", typeof(int)).GetGetMethod());
             propertiesAsMethodsMap.Add(
@@ -159,6 +172,29 @@ namespace Microsoft.OData.Client
             propertiesAsMethodsMap.Add(
                 typeof(DateTimeOffset).GetProperty("Year", typeof(int)),
                 typeof(DateTimeOffset).GetProperty("Year", typeof(int)).GetGetMethod());
+
+            propertiesAsMethodsMap.Add(
+                typeof(DateTime).GetProperty("Day", typeof(int)),
+                typeof(DateTime).GetProperty("Day", typeof(int)).GetGetMethod());
+            propertiesAsMethodsMap.Add(
+                typeof(DateTime).GetProperty("Date", typeof(DateTime)),
+                typeof(DateTime).GetProperty("Date", typeof(DateTime)).GetGetMethod());
+            propertiesAsMethodsMap.Add(
+                typeof(DateTime).GetProperty("Hour", typeof(int)),
+                typeof(DateTime).GetProperty("Hour", typeof(int)).GetGetMethod());
+            propertiesAsMethodsMap.Add(
+                typeof(DateTime).GetProperty("Minute", typeof(int)),
+                typeof(DateTime).GetProperty("Minute", typeof(int)).GetGetMethod());
+            propertiesAsMethodsMap.Add(
+                typeof(DateTime).GetProperty("Second", typeof(int)),
+                typeof(DateTime).GetProperty("Second", typeof(int)).GetGetMethod());
+            propertiesAsMethodsMap.Add(
+                typeof(DateTime).GetProperty("Month", typeof(int)),
+                typeof(DateTime).GetProperty("Month", typeof(int)).GetGetMethod());
+            propertiesAsMethodsMap.Add(
+                typeof(DateTime).GetProperty("Year", typeof(int)),
+                typeof(DateTime).GetProperty("Year", typeof(int)).GetGetMethod());
+
             propertiesAsMethodsMap.Add(
                 typeof(TimeSpan).GetProperty("Hours", typeof(int)),
                 typeof(TimeSpan).GetProperty("Hours", typeof(int)).GetGetMethod());
@@ -189,7 +225,7 @@ namespace Microsoft.OData.Client
                 typeof(Date).GetProperty("Day", typeof(int)),
                 typeof(Date).GetProperty("Day", typeof(int)).GetGetMethod());
 
-            Debug.Assert(propertiesAsMethodsMap.Count == 16, "propertiesAsMethodsMap.Count == 16");
+            Debug.Assert(propertiesAsMethodsMap.Count == 24, "propertiesAsMethodsMap.Count == 24");
         }
 
         /// <summary>

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/LinqIntegrationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/LinqIntegrationTests.cs
@@ -891,6 +891,28 @@ namespace AstoriaUnitTests.Tests.Client
 
             Assert.AreEqual(rootUrl + "Test?$filter=second(timeOfDayProperty) ne 59", query);
         }
+        [TestMethod]
+        public void WhereClauseWithDateOfDateTimeOffsetShouldReturnUrlWithDateFunction()
+        {
+            query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date == (DateTime.MinValue)).ToString();
+
+            Assert.AreEqual(rootUrl + "Test?$filter=date(dateTimeOffsetProperty) eq 0001-01-01T00:00:00Z", query);
+        }
+        [TestMethod]
+        public void WhereClauseWithDateAndHourOfDateTimeOffsetShouldReturnUrlWithDateAndHourFunctions()
+        {
+            query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date.Hour == 12).ToString();
+
+            Assert.AreEqual(rootUrl + "Test?$filter=hour(date(dateTimeOffsetProperty)) eq 12", query);
+        }
+        [TestMethod]
+        public void WhereClauseWithDateAndYearOfDateTimeOffsetShouldReturnUrlWithDateAndYearFunctions()
+        {
+            query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date.Year == 2014).ToString();
+
+            Assert.AreEqual(rootUrl + "Test?$filter=year(date(dateTimeOffsetProperty)) eq 2014", query);
+        }
+
         #endregion
     }
 }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/LinqIntegrationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/LinqIntegrationTests.cs
@@ -894,9 +894,9 @@ namespace AstoriaUnitTests.Tests.Client
         [TestMethod]
         public void WhereClauseWithDateOfDateTimeOffsetShouldReturnUrlWithDateFunction()
         {
-            query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date == (DateTime.MinValue)).ToString();
+            query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date == (DateTimeOffset.MinValue)).ToString();
 
-            Assert.AreEqual(rootUrl + "Test?$filter=date(dateTimeOffsetProperty) eq 0001-01-01T00:00:00Z", query);
+            Assert.AreEqual(rootUrl + "Test?$filter=cast(date(dateTimeOffsetProperty),'Edm.DateTimeOffset') eq 0001-01-01T00:00:00Z", query);
         }
         [TestMethod]
         public void WhereClauseWithDateAndHourOfDateTimeOffsetShouldReturnUrlWithDateAndHourFunctions()
@@ -906,11 +906,39 @@ namespace AstoriaUnitTests.Tests.Client
             Assert.AreEqual(rootUrl + "Test?$filter=hour(date(dateTimeOffsetProperty)) eq 12", query);
         }
         [TestMethod]
+        public void WhereClauseWithDateAndMinuteOfDateTimeOffsetShouldReturnUrlWithDateAndMinuteFunctions()
+        {
+            query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date.Minute == 30).ToString();
+
+            Assert.AreEqual(rootUrl + "Test?$filter=minute(date(dateTimeOffsetProperty)) eq 30", query);
+        }
+        [TestMethod]
+        public void WhereClauseWithDateAndSecondOfDateTimeOffsetShouldReturnUrlWithDateAndSecondFunctions()
+        {
+            query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date.Second == 30).ToString();
+
+            Assert.AreEqual(rootUrl + "Test?$filter=second(date(dateTimeOffsetProperty)) eq 30", query);
+        }
+        [TestMethod]
         public void WhereClauseWithDateAndYearOfDateTimeOffsetShouldReturnUrlWithDateAndYearFunctions()
         {
             query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date.Year == 2014).ToString();
 
             Assert.AreEqual(rootUrl + "Test?$filter=year(date(dateTimeOffsetProperty)) eq 2014", query);
+        }
+        [TestMethod]
+        public void WhereClauseWithDateAndMonthOfDateTimeOffsetShouldReturnUrlWithDateAndMonthFunctions()
+        {
+            query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date.Month == 9).ToString();
+
+            Assert.AreEqual(rootUrl + "Test?$filter=month(date(dateTimeOffsetProperty)) eq 9", query);
+        }
+        [TestMethod]
+        public void WhereClauseWithDateAndDayOfDateTimeOffsetShouldReturnUrlWithDateAndDayFunctions()
+        {
+            query = context.CreateQuery<EntityWithDateAndTime>("Test").Where(p => p.dateTimeOffsetProperty.Date.Day == 9).ToString();
+
+            Assert.AreEqual(rootUrl + "Test?$filter=day(date(dateTimeOffsetProperty)) eq 9", query);
         }
 
         #endregion


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #530.*

### Description

*The DateTimeOffset.Date method was added to the TypeSystem class.*
*Also corresponding methods were added for the DateTime class to make work expressions like this `dateTimeOffsetProperty.Date.Hour`*

### Checklist

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*