### PR TITLE
Updating package ID to match the existing VSIX ID in the marketplace

### DIFF
--- a/src/CodeGen/ODataT4ItemTemplate/source.extension.vsixmanifest
+++ b/src/CodeGen/ODataT4ItemTemplate/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="ODataT4ItemTemplate.7a8976ef-0030-47ec-bd10-e8cdf7a2ccb2" Version="2.5.0" Language="en-US" Publisher="Microsoft" />
+        <Identity Id="ODataT4ItemTemplate.2592cbe8-b1fe-45b6-9a18-7518079af6a8" Version="2.5.0" Language="en-US" Publisher="Microsoft" />
         <DisplayName>OData v4 Client Code Generator</DisplayName>
         <Description xml:space="preserve">An item template that simplifies the process of accessing OData v4 services by generating C# and VB.Net client-side proxy classes.</Description>
         <MoreInfo>https://github.com/odata/odata.net</MoreInfo>


### PR DESCRIPTION
### Issues
The ID in the new VS2017 Client Code Gen package is different from the ID of the current VSIX package on the [VS marketplace](https://marketplace.visualstudio.com/items?itemName=bingl.ODatav4ClientCodeGenerator).

### Description
This PR changes the ID to the existing ID.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added* N/A
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary
N/A
