### PR TITLE
ExpressionLexer fix for parameter alias token in dotted expression

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -679,11 +679,22 @@ namespace Microsoft.OData.UriParser
                             break;
                         }
 
+                        int start = this.textPos;
                         this.ParseIdentifier();
+
+                        // Extract the identifier from expression.
+                        string leftToken = ExpressionText.Substring(start, this.textPos - start);
+
+
                         t = this.parsingFunctionParameters
-                            && !(this.ExpressionText[0] == UriQueryConstants.AnnotationPrefix
-                                && this.ExpressionText.Contains("."))
+                            && !(leftToken[0] == UriQueryConstants.AnnotationPrefix
+                                && leftToken.Contains("."))
                             ? ExpressionTokenKind.ParameterAlias : ExpressionTokenKind.Identifier;
+
+                        //                        t = this.parsingFunctionParameters
+                        //                            && !(this.ExpressionText[0] == UriQueryConstants.AnnotationPrefix
+                        //                                && this.ExpressionText.Contains("."))
+                        //                            ? ExpressionTokenKind.ParameterAlias : ExpressionTokenKind.Identifier;
                         break;
                     }
 

--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -686,15 +686,9 @@ namespace Microsoft.OData.UriParser
                         string leftToken = ExpressionText.Substring(start, this.textPos - start);
 
 
-                        t = this.parsingFunctionParameters
-                            && !(leftToken[0] == UriQueryConstants.AnnotationPrefix
-                                && leftToken.Contains("."))
-                            ? ExpressionTokenKind.ParameterAlias : ExpressionTokenKind.Identifier;
-
-                        //                        t = this.parsingFunctionParameters
-                        //                            && !(this.ExpressionText[0] == UriQueryConstants.AnnotationPrefix
-                        //                                && this.ExpressionText.Contains("."))
-                        //                            ? ExpressionTokenKind.ParameterAlias : ExpressionTokenKind.Identifier;
+                        t = this.parsingFunctionParameters && !leftToken.Contains(".")
+                            ? ExpressionTokenKind.ParameterAlias
+                            : ExpressionTokenKind.Identifier;
                         break;
                     }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -707,10 +707,18 @@ namespace Microsoft.OData.Tests.UriParser
         [Fact]
         public void ExpressionLexerShouldParseValidAliasWithDotInExpressionCorrectly()
         {
-            ValidateTokenSequence("@foo eq 1.23", true /*parsingFunctionParameters*/,
-                ParameterAliasToken("@foo"),
-                IdentifierToken("eq"),
-                SingleLiteralToken("1.23"));
+            foreach (string expr in new string[]
+                {
+                    "@foo eq 1.23",
+                    "  @foo  eq  1.23  " // with arbitrary paddings.
+                }
+            )
+            {
+                ValidateTokenSequence(expr, true /*parsingFunctionParameters*/,
+                    ParameterAliasToken("@foo"),
+                    IdentifierToken("eq"),
+                    SingleLiteralToken("1.23"));
+            }
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -586,7 +586,7 @@ namespace Microsoft.OData.Tests.UriParser
                CommaToken,
                OpenParenToken,
                CloseParenToken,
-               EqualsToken, 
+               EqualsToken,
                //SemiColonToken,
                MinusToken,
                SlashToken,
@@ -607,9 +607,9 @@ namespace Microsoft.OData.Tests.UriParser
         ///  The following are allowed by EDM:
         ///     For staring char: [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Nl}].
         ///     For other chars   [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]
-        ///     
+        ///
         /// Note: Letters: \p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm} should already be covered.
-        /// 
+        ///
         /// </summary>
         [Fact]
         public void EdmValidNamesNotAllowedInUri_1()
@@ -702,6 +702,15 @@ namespace Microsoft.OData.Tests.UriParser
         public void ExpressionLexerShouldParseValidAliasCorrectly()
         {
             ValidateTokenSequence("@foo", true /*parsingFunctionParameters*/, ParameterAliasToken("@foo"));
+        }
+
+        [Fact]
+        public void ExpressionLexerShouldParseValidAliasWithDotInExpressionCorrectly()
+        {
+            ValidateTokenSequence("@foo eq 1.23", true /*parsingFunctionParameters*/,
+                ParameterAliasToken("@foo"),
+                IdentifierToken("eq"),
+                SingleLiteralToken("1.23"));
         }
 
         [Fact]
@@ -981,6 +990,11 @@ namespace Microsoft.OData.Tests.UriParser
         private static ExpressionToken ParameterAliasToken(string text)
         {
             return new ExpressionToken() { Kind = ExpressionTokenKind.ParameterAlias, Text = text };
+        }
+
+        private static ExpressionToken SingleLiteralToken(string singleString )
+        {
+            return new ExpressionToken() { Kind = ExpressionTokenKind.SingleLiteral, Text = singleString };
         }
 
         private static ExpressionToken SpatialLiteralToken(string literal, bool geography = true)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes ODL 7.4.1 issue of parameter alias parsing in dotted expression.*

### Description

*ExpressionLexer gets confused when trying to parse ParameterAlias token from expression containing ".", which is intended for annotation, in parts outside of the identifier token *

Example stack trace (from WebAPI test):
Microsoft.OData.ODataException : Could not find a property named '@p' on type 'System.Web.OData.Query.Expressions.DataTypes'.
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.EndPathBinder.GeneratePropertyAccessQueryForOpenType(EndPathToken endPathToken, SingleValueNode parentNode)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.EndPathBinder.BindEndPath(EndPathToken endPathToken)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.MetadataBinder.BindEndPath(EndPathToken endPathToken)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.MetadataBinder.Bind(QueryToken token)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.BinaryOperatorBinder.GetOperandFromToken(BinaryOperatorKind operatorKind, QueryToken queryToken)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.BinaryOperatorBinder.BindBinaryOperator(BinaryOperatorToken binaryOperatorToken)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.MetadataBinder.BindBinaryOperator(BinaryOperatorToken binaryOperatorToken)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.MetadataBinder.Bind(QueryToken token)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.FilterBinder.BindFilter(QueryToken filter)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.ODataQueryOptionParser.ParseFilterImplementation(String filter, ODataUriParserConfiguration configuration, ODataPathInfo odataPathInfo)
c:\github\WebApi-master\myWebApi\tools\WebStack.xunit.targets(12,9): error :    at Microsoft.OData.UriParser.ODataQueryOptionParser.ParseFilter()

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
