### PR TITLE
Enable updating top-level properties to null.

### DIFF
--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AllowCrossTargeting>true</AllowCrossTargeting>
@@ -308,26 +308,26 @@
       <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightWriterUtils.cs</Link>
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ReorderingJsonReader.cs">
-      <Link>Microsoft\OData\Core\JsonLight\ReorderingJsonReader.cs</Link>  
-    </Compile>        
+      <Link>Microsoft\OData\Core\JsonLight\ReorderingJsonReader.cs</Link>
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ODataJsonLightBatchBodyContentReaderStream.cs">
       <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightBatchBodyContentReaderStream.cs</Link>
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ODataJsonLightBatchReader.cs">
       <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightBatchReader.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ODataJsonLightBatchWriter.cs">
       <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightBatchWriter.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ODataJsonLightBatchPayloadItemPropertiesCache.cs">
       <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightBatchPayloadItemPropertiesCache.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ODataJsonLightBatchReaderStream.cs">
       <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightBatchReaderStream.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\JsonLight\ODataJsonLightBatchAtomicGroupCache.cs">
       <Link>Microsoft\OData\Core\JsonLight\ODataJsonLightBatchAtomicGroupCache.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\Json\BufferingJsonReader.cs">
       <Link>Microsoft\OData\Core\Json\BufferingJsonReader.cs</Link>
     </Compile>
@@ -453,13 +453,13 @@
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\MultipartMixed\ODataMultipartMixedBatchInputContext.cs">
       <Link>Microsoft\OData\Core\MultipartMixed\ODataMultipartMixedBatchInputContext.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\MultipartMixed\ODataMultipartMixedBatchOutputContext.cs">
       <Link>Microsoft\OData\Core\MultipartMixed\ODataMultipartMixedBatchOutputContext.cs</Link>
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\MultipartMixed\ODataMultipartMixedBatchReader.cs">
       <Link>Microsoft\OData\Core\MultipartMixed\ODataMultipartMixedBatchReader.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\MultipartMixed\ODataMultipartMixedBatchReaderStream.cs">
       <Link>Microsoft\OData\Core\MultipartMixed\ODataMultipartMixedBatchReaderStream.cs</Link>
     </Compile>
@@ -471,7 +471,7 @@
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\MultipartMixed\DependsOnIdsTracker.cs">
       <Link>Microsoft\OData\Core\MultipartMixed\DependsOnIdsTracker.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\NonDisposingStream.cs">
       <Link>Microsoft\OData\Core\NonDisposingStream.cs</Link>
     </Compile>
@@ -1356,7 +1356,7 @@
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\SyntacticAst\QueryTokenKind.cs">
       <Link>Microsoft\OData\Core\UriParser\SyntacticAst\QueryTokenKind.cs</Link>
-    </Compile>	
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\SyntacticAst\RangeVariableToken.cs">
       <Link>Microsoft\OData\Core\UriParser\SyntacticAst\RangeVariableToken.cs</Link>
     </Compile>
@@ -1553,6 +1553,9 @@
     </Compile>
     <Compile Include="..\ODataEdmPropertyAnnotation.cs">
       <Link>Microsoft\OData\Core\ODataEdmPropertyAnnotation.cs</Link>
+    </Compile>
+    <Compile Include="..\ODataLibraryCompatibility.cs">
+      <Link>Microsoft\OData\Core\ODataLibraryCompatibility.cs</Link>
     </Compile>
     <Compile Include="..\ODataNestedResourceInfoSerializationInfo.cs">
       <Link>Microsoft\OData\Core\ODataNestedResourceInfoSerializationInfo.cs</Link>

--- a/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
+++ b/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.Core</AssemblyName>
@@ -292,7 +292,7 @@
     </Compile>
     <Compile Include="..\JsonLight\ODataJsonLightBatchAtomicGroupCache.cs">
       <Link>JsonLight\ODataJsonLightBatchAtomicGroupCache.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="..\JsonLight\ODataJsonLightBatchPayloadItemPropertiesCache.cs">
       <Link>JsonLight\ODataJsonLightBatchPayloadItemPropertiesCache.cs</Link>
     </Compile>
@@ -301,13 +301,13 @@
     </Compile>
     <Compile Include="..\JsonLight\ODataJsonLightBatchWriter.cs">
       <Link>JsonLight\ODataJsonLightBatchWriter.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="..\JsonLight\ODataJsonLightBatchReaderStream.cs">
       <Link>JsonLight\ODataJsonLightBatchReaderStream.cs</Link>
     </Compile>
     <Compile Include="..\JsonLight\ODataJsonLightBatchBodyContentReaderStream.cs">
       <Link>JsonLight\ODataJsonLightBatchBodyContentReaderStream.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="..\JsonLight\ODataJsonLightParameterDeserializer.cs">
       <Link>JsonLight\ODataJsonLightParameterDeserializer.cs</Link>
     </Compile>
@@ -499,7 +499,7 @@
     </Compile>
     <Compile Include="..\MultipartMixed\ODataMultipartMixedBatchReader.cs">
       <Link>MultipartMixed\ODataMultipartMixedBatchReader.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="..\MultipartMixed\ODataMultipartMixedBatchReaderStream.cs">
       <Link>MultipartMixed\ODataMultipartMixedBatchReaderStream.cs</Link>
     </Compile>
@@ -508,7 +508,7 @@
     </Compile>
     <Compile Include="..\MultipartMixed\ODataMultipartMixedBatchWriterUtils.cs">
       <Link>MultipartMixed\ODataMultipartMixedBatchWriterUtils.cs</Link>
-    </Compile>    
+    </Compile>
     <Compile Include="..\MultipartMixed\DependsOnIdsTracker.cs">
       <Link>MultipartMixed\DependsOnIdsTracker.cs</Link>
     </Compile>
@@ -706,6 +706,9 @@
     </Compile>
     <Compile Include="..\ODataJsonDateTimeFormat.cs">
       <Link>ODataJsonDateTimeFormat.cs</Link>
+    </Compile>
+    <Compile Include="..\ODataLibraryCompatibility.cs">
+      <Link>ODataLibraryCompatibility.cs</Link>
     </Compile>
     <Compile Include="..\ODataMediaType.cs">
       <Link>ODataMediaType.cs</Link>
@@ -982,7 +985,7 @@
     </Compile>
     <Compile Include="..\TypeUtils.cs">
       <Link>TypeUtils.cs</Link>
-    </Compile>  
+    </Compile>
     <Compile Include="..\UnknownEntitySet.cs">
       <Link>UnknownEntitySet.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/IWriterValidator.cs
+++ b/src/Microsoft.OData.Core/IWriterValidator.cs
@@ -96,9 +96,10 @@ namespace Microsoft.OData
         /// <param name="expectedPropertyTypeReference">The expected property type or null if we
         /// don't have any.</param>
         /// <param name="propertyName">The name of the property.</param>
+        /// <param name="isTopLevel">true if the property is top-level.</param>
         /// <param name="model">The model used to get the OData version.</param>
         void ValidateNullPropertyValue(IEdmTypeReference expectedPropertyTypeReference,
-                                       string propertyName, IEdmModel model);
+                                       string propertyName, bool isTopLevel, IEdmModel model);
 
         /// <summary>
         /// Validates a null collection item against the expected type.

--- a/src/Microsoft.OData.Core/JsonLight/JsonLightConstants.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightConstants.cs
@@ -20,6 +20,13 @@ namespace Microsoft.OData.JsonLight
         /// <summary>The separator of property annotations.</summary>
         internal const char ODataPropertyAnnotationSeparatorChar = '@';
 
+        /// <summary>
+        /// The 'null' property name for the Json Light value property.
+        /// This is an OData 3.0 protocol element used for compatibility
+        /// with 6.x library version.
+        /// </summary>
+        internal const string ODataNullPropertyName = "null";
+
         /// <summary>The value 'true' for the OData null annotation.</summary>
         internal const string ODataNullAnnotationTrueValue = "true";
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataAnnotationNames.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataAnnotationNames.cs
@@ -42,7 +42,8 @@ namespace Microsoft.OData.JsonLight
                     ODataNavigationLinkUrl,
                     ODataDeltaLink,
                     ODataRemoved,
-                    ODataDelta
+                    ODataDelta,
+                    ODataNull,
                 },
                 StringComparer.Ordinal);
 
@@ -99,6 +100,12 @@ namespace Microsoft.OData.JsonLight
 
         /// <summary>The 'odata.delta' annotation name.</summary>
         internal const string ODataDelta = "odata.delta";
+
+        /// <summary>
+        /// The OData Null annotation name. This is an OData 3.0 protocol element
+        /// used for compatibility with 6.x library version.
+        /// </summary>
+        internal const string ODataNull = "odata.null";
 
         /// <summary>
         /// Returns true if the <paramref name="annotationName"/> starts with "odata.", false otherwise.

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -65,12 +65,6 @@ namespace Microsoft.OData.JsonLight
             Debug.Assert(property != null, "property != null");
             Debug.Assert(!(property.Value is ODataStreamReferenceValue), "!(property.Value is ODataStreamReferenceValue)");
 
-            if (property.ODataValue == null || property.ODataValue.IsNullValue)
-            {
-                // TODO: Enable updating top-level properties to null #645
-                throw new ODataException("A null top-level property is not allowed to be serialized.");
-            }
-
             this.WriteTopLevelPayload(
                 () =>
                 {
@@ -366,12 +360,27 @@ namespace Microsoft.OData.JsonLight
             ODataProperty property)
         {
             this.WriterValidator.ValidateNullPropertyValue(
-                this.currentPropertyInfo.MetadataType.TypeReference, property.Name, this.Model);
+                this.currentPropertyInfo.MetadataType.TypeReference, property.Name,
+                this.currentPropertyInfo.IsTopLevel, this.Model);
 
             if (this.currentPropertyInfo.IsTopLevel)
             {
-                // TODO: Enable updating top-level properties to null #645
-                throw new ODataException("A null top-level property is not allowed to be serialized.");
+                if (this.JsonLightOutputContext.MessageWriterSettings.LibraryCompatibility <
+                    ODataLibraryCompatibility.Version7)
+                {
+                    // The 6.x library used an OData 3.0 protocol element in this case: @odata.null=true
+                    this.ODataAnnotationWriter.WriteInstanceAnnotationName(ODataAnnotationNames.ODataNull);
+                    this.JsonWriter.WriteValue(true);
+                }
+                else
+                {
+                    // From the spec:
+                    // 11.2.3 Requesting Individual Properties
+                    // ...
+                    // If the property is single-valued and has the null value, the service responds with 204 No Content.
+                    // ...
+                    throw new ODataException(Strings.ODataMessageWriter_CannotWriteTopLevelNull);
+                }
             }
             else
             {

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -128,6 +128,7 @@ namespace Microsoft.OData {
         internal const string ODataMessageWriter_MetadataDocumentInRequest = "ODataMessageWriter_MetadataDocumentInRequest";
         internal const string ODataMessageWriter_DeltaInRequest = "ODataMessageWriter_DeltaInRequest";
         internal const string ODataMessageWriter_AsyncInRequest = "ODataMessageWriter_AsyncInRequest";
+        internal const string ODataMessageWriter_CannotWriteTopLevelNull = "ODataMessageWriter_CannotWriteTopLevelNull";
         internal const string ODataMessageWriter_CannotWriteNullInRawFormat = "ODataMessageWriter_CannotWriteNullInRawFormat";
         internal const string ODataMessageWriter_CannotSetHeadersWithInvalidPayloadKind = "ODataMessageWriter_CannotSetHeadersWithInvalidPayloadKind";
         internal const string ODataMessageWriter_IncompatiblePayloadKinds = "ODataMessageWriter_IncompatiblePayloadKinds";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -53,6 +53,7 @@
     <Compile Include="JsonLight\ODataJsonLightBatchReader.cs" />
     <Compile Include="JsonLight\ODataJsonLightBatchReaderStream.cs" />
     <Compile Include="JsonLight\ODataJsonLightBatchWriter.cs" />
+    <Compile Include="ODataLibraryCompatibility.cs" />
     <Compile Include="MultipartMixed\DependsOnIdsTracker.cs" />
     <Compile Include="MultipartMixed\ODataMultipartMixedBatchFormat.cs" />
     <Compile Include="MultipartMixed\ODataMultipartMixedBatchInputContext.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -79,6 +79,7 @@ ODataMessageWriter_ServiceDocumentInRequest=A service document cannot be written
 ODataMessageWriter_MetadataDocumentInRequest=A metadata document cannot be written to request payloads. Metadata documents are only supported in responses.
 ODataMessageWriter_DeltaInRequest=Cannot write delta in request payload.
 ODataMessageWriter_AsyncInRequest=Cannot write async in request payload.
+ODataMessageWriter_CannotWriteTopLevelNull=Cannot write the value 'null' in top level property; return 204 instead.
 ODataMessageWriter_CannotWriteNullInRawFormat=Cannot write the value 'null' in raw format.
 ODataMessageWriter_CannotSetHeadersWithInvalidPayloadKind=Cannot set message headers for the invalid payload kind '{0}'.
 ODataMessageWriter_IncompatiblePayloadKinds=The payload kind '{0}' used in the last call to ODataUtils.SetHeadersForPayload is incompatible with the payload being written, which is of kind '{1}'.

--- a/src/Microsoft.OData.Core/ODataConstants.cs
+++ b/src/Microsoft.OData.Core/ODataConstants.cs
@@ -176,6 +176,9 @@ namespace Microsoft.OData
         /// <summary>The "," used to split properties of Select and Expand fragment a context URI.</summary>
         internal const string ContextUriProjectionPropertySeparator = ",";
 
+        /// <summary>The token that indicates the payload is a property with null value.</summary>
+        internal const string ContextUriFragmentNull = "Edm.Null";
+
         /// <summary>The token that indicates the payload is a property with an untyped value.</summary>
         internal const string ContextUriFragmentUntyped = "Edm.Untyped";
 

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -313,6 +313,12 @@ namespace Microsoft.OData
                 return null;
             }
 
+            // special identifier for null values.
+            if (value.IsNullValue)
+            {
+                return ODataConstants.ContextUriFragmentNull;
+            }
+
             if (value.TypeAnnotation != null && !string.IsNullOrEmpty(value.TypeAnnotation.TypeName))
             {
                 return value.TypeAnnotation.TypeName;

--- a/src/Microsoft.OData.Core/ODataLibraryCompatibility.cs
+++ b/src/Microsoft.OData.Core/ODataLibraryCompatibility.cs
@@ -1,0 +1,32 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataLibraryCompatibility.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.OData
+{
+    /// <summary>
+    /// Library compatibility levels.
+    /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1008:EnumsShouldHaveZeroValue")]
+    public enum ODataLibraryCompatibility
+    {
+        /// <summary>
+        /// Version 6.x
+        /// </summary>
+        Version6 = 060000,
+
+        /// <summary>
+        /// Version 7.x
+        /// </summary>
+        Version7 = 070000,
+
+        /// <summary>
+        /// The latest version of the library.
+        /// </summary>
+        Latest = int.MaxValue
+    }
+}

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -44,6 +44,7 @@ namespace Microsoft.OData
             this.EnableMessageStreamDisposal = true;
             this.EnableCharactersCheck = false;
             this.Version = odataVersion;
+            this.LibraryCompatibility = ODataLibraryCompatibility.Latest;
 
             Validator = new ReaderValidator(this);
             if (odataVersion < ODataVersion.V401)
@@ -59,6 +60,11 @@ namespace Microsoft.OData
                 this.MaxProtocolVersion = odataVersion;
             }
         }
+
+        /// <summary>
+        /// Gets or sets library compatibility version. Default value is <see cref="T:ODataLibraryCompatibilityLevel.Latest"/>,
+        /// </summary>
+        public ODataLibraryCompatibility LibraryCompatibility { get; set; }
 
         /// <summary>Gets or sets the OData protocol version to be used for reading payloads. </summary>
         /// <returns>The OData protocol version to be used for reading payloads.</returns>
@@ -257,6 +263,7 @@ namespace Microsoft.OData
             this.ThrowOnDuplicatePropertyNames = other.ThrowOnDuplicatePropertyNames;
             this.ThrowIfTypeConflictsWithMetadata = other.ThrowIfTypeConflictsWithMetadata;
             this.ThrowOnUndeclaredPropertyForNonOpenType = other.ThrowOnUndeclaredPropertyForNonOpenType;
+            this.LibraryCompatibility = other.LibraryCompatibility;
             this.Version = other.Version;
         }
     }

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -73,7 +73,13 @@ namespace Microsoft.OData
             this.EnableCharactersCheck = false;
             this.Validations = ValidationKinds.All;
             this.Validator = new WriterValidator(this);
+            this.LibraryCompatibility = ODataLibraryCompatibility.Latest;
         }
+
+        /// <summary>
+        /// Gets or sets library compatibility version. Default value is <see cref="T:ODataLibraryCompatibilityLevel.Latest"/>,
+        /// </summary>
+        public ODataLibraryCompatibility LibraryCompatibility { get; set; }
 
         /// <summary>
         /// Gets or sets validations to perform. Default value is <see cref="T:Microsoft.OData.Validations.FullValidation"/>,
@@ -398,6 +404,7 @@ namespace Microsoft.OData
             this.shouldIncludeAnnotation = other.shouldIncludeAnnotation;
             this.useFormat = other.useFormat;
             this.Version = other.Version;
+            this.LibraryCompatibility = other.LibraryCompatibility;
 
             this.validations = other.validations;
             this.ThrowIfTypeConflictsWithMetadata = other.ThrowIfTypeConflictsWithMetadata;

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -501,6 +501,15 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "Cannot write the value 'null' in top level property; return 204 instead."
+        /// </summary>
+        internal static string ODataMessageWriter_CannotWriteTopLevelNull {
+            get {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataMessageWriter_CannotWriteTopLevelNull);
+            }
+        }
+
+        /// <summary>
         /// A string like "Cannot write the value 'null' in raw format."
         /// </summary>
         internal static string ODataMessageWriter_CannotWriteNullInRawFormat {

--- a/src/Microsoft.OData.Core/WriterValidator.cs
+++ b/src/Microsoft.OData.Core/WriterValidator.cs
@@ -197,13 +197,24 @@ namespace Microsoft.OData
         /// <param name="expectedPropertyTypeReference">The expected property type or null if we
         /// don't have any.</param>
         /// <param name="propertyName">The name of the property.</param>
+        /// <param name="isTopLevel">true if the property is top-level.</param>
         /// <param name="model">The model used to get the OData version.</param>
         public void ValidateNullPropertyValue(IEdmTypeReference expectedPropertyTypeReference,
-                                              string propertyName, IEdmModel model)
+                                              string propertyName, bool isTopLevel, IEdmModel model)
         {
             if (settings.ThrowIfTypeConflictsWithMetadata)
             {
                 WriterValidationUtils.ValidateNullPropertyValue(expectedPropertyTypeReference, propertyName, model);
+            }
+
+            if (isTopLevel && this.settings.LibraryCompatibility >= ODataLibraryCompatibility.Version7)
+            {
+                // From the spec:
+                // 11.2.3 Requesting Individual Properties
+                // ...
+                // If the property is single-valued and has the null value, the service responds with 204 No Content.
+                // ...
+                throw new ODataException(Strings.ODataMessageWriter_CannotWriteTopLevelNull);
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeserializerTests.cs
@@ -781,6 +781,43 @@ namespace Microsoft.OData.Tests.JsonLight
             action.ShouldThrow<ODataException>().WithMessage("Value '123456789' was either too large or too small for a 'NS.UInt16'.");
         }
 
+        #region Top level property
+
+        [Fact]
+        public void TopLevelPropertyShouldReadProperty()
+        {
+            var model = this.CreateEdmModelWithEntity();
+            var primitiveTypeRef = ((IEdmEntityType)model.SchemaElements.First()).Properties().First().Type;
+            this.messageReaderSettings = new ODataMessageReaderSettings();
+            ODataJsonLightPropertyAndValueDeserializer deserializer = new ODataJsonLightPropertyAndValueDeserializer(this.CreateJsonLightInputContext("{\"@odata.context\":\"http://odata.org/test/$metadata#Customers(1)/Name\",\"value\":\"Joe\"}", model));
+            ODataProperty property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
+            TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue("Joe"), property.ODataValue);
+        }
+
+        [Fact]
+        public void TopLevelPropertyShouldReadNullProperty()
+        {
+            var model = this.CreateEdmModelWithEntity();
+            var primitiveTypeRef = ((IEdmEntityType)model.SchemaElements.First()).Properties().First().Type;
+            this.messageReaderSettings = new ODataMessageReaderSettings();
+            ODataJsonLightPropertyAndValueDeserializer deserializer = new ODataJsonLightPropertyAndValueDeserializer(this.CreateJsonLightInputContext("{\"@odata.context\":\"http://odata.org/test/$metadata#Customers(1)/Name\",\"value\":null}", model));
+            ODataProperty property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
+            TestUtils.AssertODataValueAreEqual(new ODataNullValue(), property.ODataValue);
+        }
+
+        [Fact]
+        public void TopLevelPropertyShouldRead6xNullProperty()
+        {
+            var model = this.CreateEdmModelWithEntity();
+            var primitiveTypeRef = ((IEdmEntityType)model.SchemaElements.First()).Properties().First().Type;
+            this.messageReaderSettings = new ODataMessageReaderSettings();
+            ODataJsonLightPropertyAndValueDeserializer deserializer = new ODataJsonLightPropertyAndValueDeserializer(this.CreateJsonLightInputContext("{\"@odata.context\":\"http://odata.org/test/$metadata#Customers(1)/Name\",\"@odata.null\":true}", model));
+            ODataProperty property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
+            TestUtils.AssertODataValueAreEqual(new ODataNullValue(), property.ODataValue);
+        }
+
+        #endregion
+
         #region Top level property instance annotation
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.OData.Tests
             Assert.True(1000 == settings.MessageQuotas.MaxOperationsPerChangeset, "MaxOperationsPerChangeset should be int.MaxValue.");
             Assert.True(100 == settings.MessageQuotas.MaxNestingDepth, "The MaxNestingDepth should be set to 100 by default.");
             Assert.True(1024 * 1024 == settings.MessageQuotas.MaxReceivedMessageSize, "The MaxMessageSize should be set to 1024 * 1024 by default.");
+            Assert.True(ODataLibraryCompatibility.Latest == settings.LibraryCompatibility, "The LibraryCompatibility should be set to ODataLibraryCompatibility.Latest by default.");
         }
 
         [Fact]
@@ -63,6 +64,7 @@ namespace Microsoft.OData.Tests
             Assert.True(1000 == settings.MessageQuotas.MaxOperationsPerChangeset, "MaxOperationsPerChangeset should be int.MaxValue.");
             Assert.True(100 == settings.MessageQuotas.MaxNestingDepth, "The MaxNestingDepth should be set to 100 by default.");
             Assert.True(1024 * 1024 == settings.MessageQuotas.MaxReceivedMessageSize, "The MaxMessageSize should be set to 1024 * 1024 by default.");
+            Assert.True(ODataLibraryCompatibility.Latest == settings.LibraryCompatibility, "The LibraryCompatibility should be set to ODataLibraryCompatibility.Latest by default.");
         }
 
         [Fact]
@@ -137,9 +139,11 @@ namespace Microsoft.OData.Tests
             this.CompareMessageReaderSettings(settings, copyOfSettings);
 
             // Compare original and settings created from copy constructor after setting rest of the values 
-            settings.EnableMessageStreamDisposal = false;            
+            settings.EnableMessageStreamDisposal = false;
             settings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
-            settings.MaxProtocolVersion = ODataVersion.V4;
+            settings.Version = ODataVersion.V401;
+            settings.MaxProtocolVersion = ODataVersion.V401;
+            settings.LibraryCompatibility = ODataLibraryCompatibility.Version6;
             settings.MessageQuotas.MaxPartsPerBatch = 100;
             settings.MessageQuotas.MaxOperationsPerChangeset = 200;
             settings.MessageQuotas.MaxNestingDepth = 20;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -119,6 +119,12 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
+        public void LibraryCompatibilityShouldBeLatestByDefault()
+        {
+            this.settings.LibraryCompatibility.Should().Be(ODataLibraryCompatibility.Latest);
+        }
+
+        [Fact]
         public void VersionShouldBeNullByDefault()
         {
             this.settings.Version.Should().BeNull();
@@ -233,6 +239,13 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
+        public void CopyConstructorShouldCopyLibraryCompatibility()
+        {
+            this.settings.LibraryCompatibility = ODataLibraryCompatibility.Version6;
+            this.settings.Clone().LibraryCompatibility.Should().Be(ODataLibraryCompatibility.Version6);
+        }
+
+        [Fact]
         public void CopyConstructorShouldCopyAnnotationFilter()
         {
             Func<string, bool> filter = name => true;
@@ -315,6 +328,7 @@ namespace Microsoft.OData.Tests
             const int maxOperationsPerChangeset = 43;
             const int maxNestingDepth = 44;
             const ODataVersion version = ODataVersion.V4;
+            const ODataLibraryCompatibility library = ODataLibraryCompatibility.Version6;
 
             this.settings = new ODataMessageWriterSettings()
             {
@@ -329,6 +343,7 @@ namespace Microsoft.OData.Tests
                     MaxNestingDepth = maxNestingDepth,
                 },
                 Version = version,
+                LibraryCompatibility = library,
             };
 
             this.settings.ThrowOnDuplicatePropertyNames.Should().BeFalse();
@@ -339,6 +354,7 @@ namespace Microsoft.OData.Tests
             this.settings.MessageQuotas.MaxOperationsPerChangeset.Should().Be(maxOperationsPerChangeset);
             this.settings.MessageQuotas.MaxNestingDepth.Should().Be(maxNestingDepth);
             this.settings.Version.Should().Be(version);
+            this.settings.LibraryCompatibility.Should().Be(library);
         }
 
         [Fact]

--- a/test/FunctionalTests/Tests/DataOData/Common/OData/JsonLight/AnnotatedPayloadElementToJsonLightConverter.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData/JsonLight/AnnotatedPayloadElementToJsonLightConverter.cs
@@ -253,11 +253,6 @@ namespace Microsoft.Test.Taupo.OData.JsonLight
 
                 if (isTopLevel)
                 {
-                    if (payloadElement.Value.IsNull)
-                    {
-                        // TODO: Change the payload of null top-level properties #645
-                    }
-
                     JsonValue complexValue = this.Recurse(payloadElement.Value);
 
                     // NOTE: top-level complex properties don't use a wrapper object.
@@ -644,7 +639,6 @@ namespace Microsoft.Test.Taupo.OData.JsonLight
                 bool needsWrapping = this.CurrentElementIsRoot();
 
                 string propertyName = needsWrapping ? JsonLightConstants.ODataValuePropertyName : payloadElement.Name;
-                // TODO: Change the payload of null top-level properties #645
                 JsonProperty jsonProperty = new JsonProperty(propertyName, null);
                 jsonProperty.Value = this.Recurse(payloadElement.Value, jsonProperty);
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -3966,6 +3966,12 @@ public enum Microsoft.OData.ODataDeltaReaderState : int {
 	Start = 0
 }
 
+public enum Microsoft.OData.ODataLibraryCompatibility : int {
+	Latest = 2147483647
+	Version6 = 60000
+	Version7 = 70000
+}
+
 public enum Microsoft.OData.ODataNullValueBehaviorKind : int {
 	Default = 0
 	DisableValidation = 2
@@ -5083,6 +5089,7 @@ public sealed class Microsoft.OData.ODataMessageReaderSettings {
 	bool EnableCharactersCheck  { public get; public set; }
 	bool EnableMessageStreamDisposal  { public get; public set; }
 	bool EnablePrimitiveTypeConversion  { public get; public set; }
+	Microsoft.OData.ODataLibraryCompatibility LibraryCompatibility  { public get; public set; }
 	Microsoft.OData.ODataVersion MaxProtocolVersion  { public get; public set; }
 	Microsoft.OData.ODataMessageQuotas MessageQuotas  { public get; public set; }
 	System.Func`3[[System.Object],[System.String],[Microsoft.OData.Edm.IEdmTypeReference]] PrimitiveTypeResolver  { public get; public set; }
@@ -5167,6 +5174,7 @@ public sealed class Microsoft.OData.ODataMessageWriterSettings {
 	bool EnableCharactersCheck  { public get; public set; }
 	bool EnableMessageStreamDisposal  { public get; public set; }
 	string JsonPCallback  { public get; public set; }
+	Microsoft.OData.ODataLibraryCompatibility LibraryCompatibility  { public get; public set; }
 	Microsoft.OData.ODataMessageQuotas MessageQuotas  { public get; public set; }
 	Microsoft.OData.ODataUri ODataUri  { public get; public set; }
 	Microsoft.OData.ValidationKinds Validations  { public get; public set; }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/TestCodeTests/AnnotatedPayloadElementToJsonLightConverterTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/TestCodeTests/AnnotatedPayloadElementToJsonLightConverterTests.cs
@@ -239,7 +239,6 @@ namespace Microsoft.Test.Taupo.OData.Common.Tests.TestCodeTests
             var testCases = new JsonLightSerializerTestCase[]
             {
                 // Null property
-                // TODO: Change the payload of null top-level properties #645
                 new JsonLightSerializerTestCase
                 {
                     PayloadElement = PayloadBuilder.PrimitiveProperty("Prop", null).WithContextUri("http://odata.org/metadatauri"),

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/CollectionValueReaderJsonLightTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/CollectionValueReaderJsonLightTests.cs
@@ -34,7 +34,6 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
         public PayloadReaderTestDescriptor.Settings Settings { get; set; }
 
         [TestMethod, TestCategory("Reader.Json"), Variation(Description = "Verifies correct reading of collection values")]
-        // TODO: Change the payload of null top-level properties #645
         public void CollectionValueTest()
         {
             EdmModel model = new EdmModel();

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/NullValueTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/NullValueTests.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
         public PayloadReaderTestDescriptor.Settings Settings { get; set; }
 
         [TestMethod, TestCategory("Reader.Json"), Variation(Description = "Verifies correct reading of null property values")]
-        // TODO: Change the payload of null top-level properties #645
         public void NullValuePropertyTests()
         {
             EdmModel model = new EdmModel();

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/PropertyReaderJsonLightTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/PropertyReaderJsonLightTests.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
         public EntityModelSchemaToEdmModelConverter EntityModelSchemaToEdmModelConverter { get; set; }
 
         [TestMethod, TestCategory("Reader.Json"), Variation(Description = "Verifies correct reading of top-level property payloads")]
-        // TODO: Change the payload of null top-level properties #645
         public void TopLevelPropertyTest()
         {
             var injectedProperties = new[]
@@ -329,7 +328,6 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
         }
 
         [TestMethod, TestCategory("Reader.Json"), Variation(Description = "Verifies correct reading of top-level open properties.")]
-        // TODO: Change the payload of null top-level properties #645
         public void OpenTopLevelPropertiesTest()
         {
             IEdmModel model = TestModels.BuildTestModel();

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/PropertyReaderTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/PropertyReaderTests.cs
@@ -163,7 +163,6 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.Reader
         }
 
         [TestMethod, TestCategory("Reader.Properties"), Variation(Description = "Test reading of non-nullable property payloads with 'null' value and metadata.")]
-        // TODO: Change the payload of null top-level properties #645
         public void NonNullablePropertiesWithNullValuesTest()
         {
             IEnumerable<NonNullablePropertyTest> testCases = new NonNullablePropertyTest[]

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Utils/PayloadGenerator.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Utils/PayloadGenerator.cs
@@ -695,7 +695,6 @@ namespace AstoriaUnitTests.Tests
                     }
                 }
 
-                // TODO: Change the payload of null top-level properties #645
                 if (property.PropertyKind == PayloadBuilderPropertyKind.Primitive || property.Value == null)
                 {
                     // Write primitive property value

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests1/Tests/UpdatePropertyTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests1/Tests/UpdatePropertyTests.cs
@@ -709,7 +709,6 @@ namespace AstoriaUnitTests.Tests
             }
 
             [Ignore]
-            // TODO: Change the payload of null top-level properties #645
             // [TestCategory("Partition2"), TestMethod, Variation]
             public void UpdateMergePrimitivePropertyToNull()
             {

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests2/Tests/NonNullablePropertiesTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests2/Tests/NonNullablePropertiesTests.cs
@@ -149,7 +149,6 @@ namespace AstoriaUnitTests.Tests
                         if (requestMDSV != null) request.RequestMaxVersion = requestMDSV.ToString();                           
                            
                         request.RequestContentType = format;
-                        // TODO: Change the payload of null top-level properties #645
                         request.SetRequestStreamAsText(@"{ ""value"" : null }");
 
                         IDisposable dispose = null;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #645.

### Description

Support for writing top-level properties with null values at
the time @odata.null:true was removed. The 4.0 spec states in
1.2.3 Requesting Individual Properties that if the property is
single-valued and has the null value, the service responds with
204 No Content. The library is correct in throwing an exception
when asked to write a null top-level values.

This change adds support for the scenario in the following ways:

1.) Writing a null top-level value still throws but with a well-defined
    error message.

2.) The scenario can be enabled by turning off the validation in the
    writer settings, i.e. settings.Validations = ~ ValidationKinds.ThrowOnTopLevelNullProperty.
    In this case, the value is written as: "value":null

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
