### PR TITLE
Fix for not throwing and exception for an invalid enum value

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/MetadataBindingUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/MetadataBindingUtils.cs
@@ -6,7 +6,9 @@
 
 namespace Microsoft.OData.UriParser
 {
+    using System;
     using System.Diagnostics;
+    using System.Linq;
     using Microsoft.OData.Edm;
     using Microsoft.OData;
     using Microsoft.OData.Metadata;
@@ -58,7 +60,16 @@ namespace Microsoft.OData.UriParser
                 ConstantNode constantNode = source as ConstantNode;
                 if (constantNode != null && constantNode.Value != null && source.TypeReference.IsString() && targetTypeReference.IsEnum())
                 {
-                    return new ConstantNode(new ODataEnumValue(constantNode.Value.ToString(), targetTypeReference.Definition.ToString()), constantNode.Value.ToString(), targetTypeReference);
+                    string memberName = constantNode.Value.ToString();
+                    IEdmEnumType enumType = targetTypeReference.Definition as IEdmEnumType;
+                    if (enumType.Members.Any(m => string.Compare(m.Name, memberName, StringComparison.Ordinal) == 0))
+                    {
+                        return new ConstantNode(new ODataEnumValue(constantNode.Value.ToString(), targetTypeReference.Definition.ToString()), constantNode.Value.ToString(), targetTypeReference);
+                    }
+                    else
+                    {
+                        throw new ODataException(ODataErrorStrings.Binder_IsNotValidEnumConstant(memberName));
+                    }
                 }
 
                 if (!TypePromotionUtils.CanConvertTo(source, source.TypeReference, targetTypeReference))


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

### Description

When we added support for casting strings to enum values in URLs, we didn't validate that the string was a valid member of the enum type.  This means that using a prefixed enum value would throw an exception if the value was not a member of the enum, but using the string form would not.

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*

### Additional work necessary


