### PR TITLE
Include dots in parseIdentifier for annotation parsing

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -680,7 +680,9 @@ namespace Microsoft.OData.UriParser
                         }
 
                         int start = this.textPos;
-                        this.ParseIdentifier();
+
+                        // Include dots for the case of annotation.
+                        this.ParseIdentifier(true /*includingDots*/);
 
                         // Extract the identifier from expression.
                         string leftToken = ExpressionText.Substring(start, this.textPos - start);
@@ -1201,14 +1203,15 @@ namespace Microsoft.OData.UriParser
 
 
         /// <summary>Parses an identifier by advancing the current character.</summary>
-        private void ParseIdentifier()
+        /// <param name="includingDots">Optional flag for whether to include dots as part of the identifier.</param>
+        private void ParseIdentifier(bool includingDots = false)
         {
             Debug.Assert(this.IsValidStartingCharForIdentifier || this.ch == UriQueryConstants.AnnotationPrefix, "Expected valid starting char for identifier");
             do
             {
                 this.NextChar();
             }
-            while (this.IsValidNonStartingCharForIdentifier);
+            while (this.IsValidNonStartingCharForIdentifier || (includingDots && this.ch == '.'));
         }
 
         /// <summary>Sets the text position.</summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -722,6 +722,14 @@ namespace Microsoft.OData.Tests.UriParser
         }
 
         [Fact]
+        public void ExpressionLexerShouldParseValidAnnotationCorrectly()
+        {
+            string exprAnnotation = "@NS.myAnnotation1";
+            ValidateTokenSequence(exprAnnotation, true /*parsingFunctionParameters*/,
+                IdentifierToken("@NS.myAnnotation1"));
+        }
+
+        [Fact]
         public void ExpressionLexerShouldGrabEntireIdentifierForAliasUntilANonIdentifierCharacter()
         {
             ValidateTokenSequence(


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes an issue for annotation parsing in ODL 7.4.2.*

### Description

*Annotation such as "@NS.myAnnotation" are not parsed correctly as Identifier token because lexer stops at the dot char during the traversing. This can be fixed by allowing to include dot chars for paring string token starting with "@", which could be either an parameter alias (w/o dots) or an annotation.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
