### PR TITLE
Add StringComparison in String.Equal() method call

### DIFF
--- a/src/Microsoft.OData.Client/BatchSaveResult.cs
+++ b/src/Microsoft.OData.Client/BatchSaveResult.cs
@@ -471,7 +471,7 @@ namespace Microsoft.OData.Client
                     Encoding encoding;
                     Exception inner = contentTypeException;
                     ContentTypeUtil.ReadContentType(this.batchResponseMessage.GetHeader(XmlConstants.HttpContentType), out mime, out encoding);
-                    if (String.Equals(XmlConstants.MimeTextPlain, mime))
+                    if (String.Equals(XmlConstants.MimeTextPlain, mime, StringComparison.Ordinal))
                     {
                         inner = GetResponseText(
                             this.batchResponseMessage.GetStream,

--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -656,7 +656,7 @@ namespace Microsoft.OData.Json
             // We can call ParseName since we know the first character is 'n' and thus it won't be quoted.
             string token = this.ParseName();
 
-            if (!string.Equals(token, JsonConstants.JsonNullLiteral))
+            if (!string.Equals(token, JsonConstants.JsonNullLiteral, StringComparison.Ordinal))
             {
                 throw JsonReaderExtensions.CreateException(Strings.JsonReader_UnexpectedToken(token));
             }
@@ -678,12 +678,12 @@ namespace Microsoft.OData.Json
             // We can call ParseName since we know the first character is 't' or 'f' and thus it won't be quoted.
             string token = this.ParseName();
 
-            if (string.Equals(token, JsonConstants.JsonFalseLiteral))
+            if (string.Equals(token, JsonConstants.JsonFalseLiteral, StringComparison.Ordinal))
             {
                 return false;
             }
 
-            if (string.Equals(token, JsonConstants.JsonTrueLiteral))
+            if (string.Equals(token, JsonConstants.JsonTrueLiteral, StringComparison.Ordinal))
             {
                 return true;
             }

--- a/src/Microsoft.OData.Core/Uri/NodeToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/NodeToStringBuilder.cs
@@ -630,7 +630,10 @@ namespace Microsoft.OData
         private static bool IsValidSearchWord(string text)
         {
             Match match = SearchLexer.InvalidWordPattern.Match(text);
-            if (match.Success || String.Equals(text, "AND") || String.Equals(text, "OR") || String.Equals(text, "NOT"))
+            if (match.Success ||
+                String.Equals(text, "AND", StringComparison.Ordinal) ||
+                String.Equals(text, "OR", StringComparison.Ordinal) ||
+                String.Equals(text, "NOT", StringComparison.Ordinal))
             {
                 return false;
             }

--- a/src/Microsoft.OData.Core/UriParser/Binders/EnumBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EnumBinder.cs
@@ -4,10 +4,11 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
+
 namespace Microsoft.OData.UriParser
 {
     using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using Microsoft.OData.Edm;
 
@@ -56,7 +57,7 @@ namespace Microsoft.OData.UriParser
             Debug.Assert((typeReference == null) || (modelWhenNoTypeReference == null), "((typeReference == null) || (modelWhenNoTypeReference == null)");
 
             // validate typeReference but allow type name not found in model for delayed throwing.
-            if ((typeReference != null) && !string.Equals(namespaceAndType, typeReference.FullName()))
+            if ((typeReference != null) && !string.Equals(namespaceAndType, typeReference.FullName(), StringComparison.Ordinal))
             {
                 return false;
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             complex1.InstanceAnnotations.Count().Should().Be(1);
 
             complex1.TypeName.Should().Be("Server.NS.Address");
-            ODataProperty undeclaredComplex1Prop = complex1.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"));
+            ODataProperty undeclaredComplex1Prop = complex1.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal));
             (undeclaredComplex1Prop.Value as ODataUntypedValue).RawValue.Should().Be("\"hello this is a string.\"");
             undeclaredComplex1Prop.TypeAnnotation.TypeName.Should().Be("Server.NS.UnknownType1");
             undeclaredComplex1Prop.InstanceAnnotations.Count().Should().Be(3);
@@ -186,7 +186,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             complex1.InstanceAnnotations.Count().Should().Be(1);
 
             complex1.TypeName.Should().Be("Server.NS.Address");
-            ODataProperty undeclaredComplex1Prop = complex1.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"));
+            ODataProperty undeclaredComplex1Prop = complex1.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal));
             (undeclaredComplex1Prop.Value as ODataUntypedValue).RawValue.Should().Be("\"hello this is a string.\"");
             undeclaredComplex1Prop.TypeAnnotation.TypeName.Should().Be("Server.NS.UnknownType1");
             undeclaredComplex1Prop.InstanceAnnotations.Count().Should().Be(3);
@@ -276,7 +276,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             entry.Properties.Count().Should().Be(2);
             complex1.Properties.Count().Should().Be(2);
             ODataProperty val = complex1.Properties
-                .First(s => string.Equals("UndeclaredBool", s.Name));
+                .First(s => string.Equals("UndeclaredBool", s.Name, StringComparison.Ordinal));
             val.ODataValue.FromODataValue().Should().Be(false);
 
             val.InstanceAnnotations.Count().Should().Be(2);
@@ -320,7 +320,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             entry.Properties.Count().Should().Be(2);
             complex1.Properties.Count().Should().Be(2);
             ODataProperty val = complex1.Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name));
+                .First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal));
             val.ODataValue.FromODataValue().Should().Be("No.10000000999,Zixing Rd Minhang");
 
             val.InstanceAnnotations.Count().Should().Be(2);
@@ -365,7 +365,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             entry.Properties.Count().Should().Be(2);
             complex1.Properties.Count().Should().Be(2);
             ODataProperty val = complex1.Properties
-                .First(s => string.Equals("UndeclaredStreetNo", s.Name));
+                .First(s => string.Equals("UndeclaredStreetNo", s.Name, StringComparison.Ordinal));
             val.ODataValue.FromODataValue().Should().Be(12d);
 
             val.InstanceAnnotations.Count().Should().Be(2);
@@ -411,7 +411,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             complex1.TypeName.Should().Be("Server.NS.Address");
             complex1.Properties.Count().Should().Be(2);
             complex1.Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>()
+                .First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.As<ODataUntypedValue>()
                 .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
             complex1.InstanceAnnotations.Count().Should().Be(0);
 
@@ -454,7 +454,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            ODataProperty val = entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1"));
+            ODataProperty val = entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal));
             val.ODataValue.As<ODataCollectionValue>().Items.Cast<string>().Count().Should().Be(3);
 
             val.InstanceAnnotations.Count().Should().Be(2);
@@ -543,10 +543,10 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(2);
-            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name)).Value.As<ODataUntypedValue>().RawValue.Should().Be("12.3"); // numeric
+            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name, StringComparison.Ordinal)).Value.As<ODataUntypedValue>().RawValue.Should().Be("12.3"); // numeric
             complex1.Properties.Count().Should().Be(2);
             complex1.Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>() // string
+                .First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.As<ODataUntypedValue>() // string
                 .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
         }
 
@@ -629,7 +629,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal)).Value.As<ODataUntypedValue>().RawValue
               .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
             complex1.Properties.Count().Should().Be(2);
         }
@@ -661,7 +661,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            Assert.Equal("null", entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredType1")).ODataValue.As<ODataUntypedValue>().RawValue);
+            Assert.Equal("null", entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredType1", StringComparison.Ordinal)).ODataValue.As<ODataUntypedValue>().RawValue);
         }
 
         [Fact]
@@ -738,7 +738,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).ODataValue.As<ODataCollectionValue>().Items
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal)).ODataValue.As<ODataCollectionValue>().Items
                 .Cast<string>().Count().Should().Be(3);
             complex1.Properties.Count().Should().Be(2);
         }
@@ -770,7 +770,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            ODataProperty val = entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"));
+            ODataProperty val = entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal));
             val.Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
             val.InstanceAnnotations.Count().Should().Be(2);
             val.InstanceAnnotations.First().Value.As<ODataPrimitiveValue>().Value.Should().Be("unknown odata.xxx value1");
@@ -839,7 +839,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value.As<ODataUntypedValue>()
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal)).Value.As<ODataUntypedValue>()
                 .RawValue.Should().Be(@"{}");
         }
 
@@ -866,7 +866,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal)).Value.As<ODataUntypedValue>().RawValue
                 .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
             complex1.Properties.Count().Should().Be(2);
         }
@@ -894,9 +894,9 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>()
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal)).Value.As<ODataUntypedValue>()
                 .RawValue.Should().Be(@"[]");
-            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
         }
 
@@ -931,7 +931,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
             complex1.Properties.Count().Should().Be(2);
         }
@@ -968,11 +968,11 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
-            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp1", StringComparison.Ordinal))
                 .InstanceAnnotations.Single(s => s.Name == "NS1.abc").Value.As<ODataPrimitiveValue>()
                 .Value.Should().Be(1908);
 
@@ -1011,11 +1011,11 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp2"))
+            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp2", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
-            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp2"))
+            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp2", StringComparison.Ordinal))
                 .InstanceAnnotations.Single(s => s.Name == "NS1.abc").Value.As<ODataPrimitiveValue>()
                 .Value.Should().Be(1908);
 
@@ -1063,13 +1063,13 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
-            complex1.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp3"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp3", StringComparison.Ordinal))
                .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
-            complex1.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp3"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp3", StringComparison.Ordinal))
                 .InstanceAnnotations.Single(s => s.Name == "NS1.abc").Value.As<ODataPrimitiveValue>()
                 .Value.Should().Be(1908);
 
@@ -1111,14 +1111,14 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1", StringComparison.Ordinal))
                 .InstanceAnnotations.Single(s => s.Name == "NS1.helloworld").Value.As<ODataPrimitiveValue>()
                 .Value.Should().Be(true);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1")).TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1", StringComparison.Ordinal)).TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
             string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
@@ -1165,14 +1165,14 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             );
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2"))
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2"))
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2", StringComparison.Ordinal))
                 .InstanceAnnotations.Single(s => s.Name == "NS1.helloworld").Value.As<ODataPrimitiveValue>()
                 .Value.Should().Be(true);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2"))
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2", StringComparison.Ordinal))
                 .TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
@@ -1219,14 +1219,14 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
-            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3", StringComparison.Ordinal))
                 .InstanceAnnotations.Single(s => s.Name == "NS1.helloworld").Value.As<ODataPrimitiveValue>()
                 .Value.Should().Be(true);
-            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3", StringComparison.Ordinal))
                 .TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
             complex2.Should().BeNull();
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
 
             entry.Properties.Count().Should().Be(2);
             complex1.Properties.Count().Should().Be(2);
-            complex1.Properties.First(s => string.Equals("UndeclaredBool", s.Name)).Value.Should().Be(false);
+            complex1.Properties.First(s => string.Equals("UndeclaredBool", s.Name, StringComparison.Ordinal)).Value.Should().Be(false);
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
             string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
@@ -219,7 +219,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             entry.Properties.Count().Should().Be(2);
             complex1.Properties.Count().Should().Be(2);
             complex1.Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
+                .First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
             string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
@@ -260,7 +260,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             entry.Properties.Count().Should().Be(2);
             complex1.Properties.Count().Should().Be(2);
             complex1.Properties
-                .First(s => string.Equals("UndeclaredStreetNo", s.Name)).Value.Should().Be(12d);
+                .First(s => string.Equals("UndeclaredStreetNo", s.Name, StringComparison.Ordinal)).Value.Should().Be(12d);
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
             string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
@@ -302,7 +302,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             complex1.TypeName.Should().Be("Server.NS.Address");
             complex1.Properties.Count().Should().Be(2);
             complex1.Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>()
+                .First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.As<ODataUntypedValue>()
                 .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
@@ -342,7 +342,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).ODataValue.As<ODataCollectionValue>().Items
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal)).ODataValue.As<ODataCollectionValue>().Items
                 .Cast<string>().Count().Should().Be(3);
             complex1.Properties.Count().Should().Be(2);
 
@@ -411,10 +411,10 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(2);
-            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name)).Value.As<ODataUntypedValue>().RawValue.Should().Be("12.3"); // numeric
+            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name, StringComparison.Ordinal)).Value.As<ODataUntypedValue>().RawValue.Should().Be("12.3"); // numeric
             complex1.Properties.Count().Should().Be(2);
             complex1.Properties
-                .First(s => string.Equals("UndeclaredStreet", s.Name)).Value.As<ODataUntypedValue>() // string
+                .First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.As<ODataUntypedValue>() // string
                 .RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
         }
 
@@ -486,7 +486,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal)).Value.As<ODataUntypedValue>().RawValue
               .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
             complex1.Properties.Count().Should().Be(2);
         }
@@ -564,11 +564,11 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             }, /*readUntypedAsValue*/ true);
 
             entry.Properties.Count().Should().Be(2);
-            ODataProperty decimalProperty = entry.Properties.First(s => string.Equals("UndeclaredDecimal", s.Name));
+            ODataProperty decimalProperty = entry.Properties.First(s => string.Equals("UndeclaredDecimal", s.Name, StringComparison.Ordinal));
             decimalProperty.Value.Should().Be(12.3M);
             decimalProperty.TypeAnnotation.TypeName.Should().Be("Server.NS.UndeclaredDecimalType");
             complex1.Properties.Count().Should().Be(2);
-            ODataProperty addressProperty = complex1.Properties.First(s => string.Equals("UndeclaredStreet", s.Name));
+            ODataProperty addressProperty = complex1.Properties.First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal));
             addressProperty.Value.Should().Be("No.10000000999,Zixing Rd Minhang");
             addressProperty.TypeAnnotation.TypeName.Should().Be("Server.NS.UndeclaredStreetType");
         }
@@ -596,9 +596,9 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             }, /*readUntypedAsValue*/ true);
 
             entry.Properties.Count().Should().Be(2);
-            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name)).Value.Should().Be(12.3M);
+            entry.Properties.First(s => string.Equals("UndeclaredFloatId", s.Name, StringComparison.Ordinal)).Value.Should().Be(12.3M);
             complex1.Properties.Count().Should().Be(2);
-            complex1.Properties.First(s => string.Equals("UndeclaredStreet", s.Name)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
+            complex1.Properties.First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
         }
 
         [Fact]
@@ -627,7 +627,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             entry.Properties.Count().Should().Be(1);
             undeclaredAddress1.TypeName.Should().Be("Server.NS.AddressInValid");
             undeclaredAddress1.Properties.Count().Should().Be(2);
-            undeclaredAddress1.Properties.First(s => string.Equals("UndeclaredStreet", s.Name)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
+            undeclaredAddress1.Properties.First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
         }
 
         [Fact]
@@ -661,11 +661,11 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             entry.Properties.Count().Should().Be(1);
             undeclaredAddress1.TypeName.Should().Be("Server.NS.AddressInValid");
             undeclaredAddress1.Properties.Count().Should().Be(2);
-            undeclaredAddress1.Properties.First(s => string.Equals("UndeclaredStreet", s.Name)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
-            undeclaredAddress1.Properties.First(s => string.Equals("Street", s.Name)).Value.Should().Be("No.999,Zixing Rd Minhang");
+            undeclaredAddress1.Properties.First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
+            undeclaredAddress1.Properties.First(s => string.Equals("Street", s.Name, StringComparison.Ordinal)).Value.Should().Be("No.999,Zixing Rd Minhang");
             innerComplex1.Properties.Count().Should().Be(2);
-            innerComplex1.Properties.First(s => string.Equals("innerProp1", s.Name)).Value.Should().Be(null);
-            innerComplex1.Properties.First(s => string.Equals("innerProp2", s.Name)).Value.Should().Be("abc");
+            innerComplex1.Properties.First(s => string.Equals("innerProp1", s.Name, StringComparison.Ordinal)).Value.Should().Be(null);
+            innerComplex1.Properties.First(s => string.Equals("innerProp2", s.Name, StringComparison.Ordinal)).Value.Should().Be("abc");
         }
 
         [Fact]
@@ -716,8 +716,8 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             addressNestedInfo.Name.Should().Be("Address");
             address.TypeName.Should().Be("Server.NS.Address");
             address.Properties.Count().Should().Be(2);
-            address.Properties.First(s => string.Equals("Street", s.Name)).Value.Should().Be("No.999,Zixing Rd Minhang");
-            address.Properties.First(s => string.Equals("UndeclaredStreet", s.Name)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
+            address.Properties.First(s => string.Equals("Street", s.Name, StringComparison.Ordinal)).Value.Should().Be("No.999,Zixing Rd Minhang");
+            address.Properties.First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
         }
 
         [Fact]
@@ -769,10 +769,10 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             entry.Properties.Count().Should().Be(2);
             undeclaredCollection1.TypeAnnotation.TypeName.Should().Be("Collection(Server.NS.UnknownCollectionType)");
             untypedCollection.Count().Should().Be(3);
-            String.Concat(untypedCollection.Select(c=>((ODataResource)c).Properties.Single(p => string.Equals(p.Name, "email")).Value)).Should().Be("email1@163.comemail2@gmail.comemail3@gmail2.com");
+            String.Concat(untypedCollection.Select(c=>((ODataResource)c).Properties.Single(p => string.Equals(p.Name, "email", StringComparison.Ordinal)).Value)).Should().Be("email1@163.comemail2@gmail.comemail3@gmail2.com");
             address.Properties.Count().Should().Be(2);
-            address.Properties.First(s => string.Equals("Street", s.Name)).Value.Should().Be("No.999,Zixing Rd Minhang");
-            address.Properties.First(s => string.Equals("UndeclaredStreet", s.Name)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
+            address.Properties.First(s => string.Equals("Street", s.Name, StringComparison.Ordinal)).Value.Should().Be("No.999,Zixing Rd Minhang");
+            address.Properties.First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
         }
         #endregion
 
@@ -790,7 +790,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            Assert.Equal("null", entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredType1")).ODataValue.As<ODataUntypedValue>().RawValue);
+            Assert.Equal("null", entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredType1", StringComparison.Ordinal)).ODataValue.As<ODataUntypedValue>().RawValue);
         }
 
         [Fact]
@@ -867,7 +867,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).ODataValue.As<ODataCollectionValue>().Items
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal)).ODataValue.As<ODataCollectionValue>().Items
                 .Cast<string>().Count().Should().Be(3);
             complex1.Properties.Count().Should().Be(2);
         }
@@ -898,7 +898,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
             complex1.Properties.Count().Should().Be(2);
         }
@@ -940,7 +940,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1")).Value.As<ODataUntypedValue>()
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal)).Value.As<ODataUntypedValue>()
                 .RawValue.Should().Be(@"{}");
         }
 
@@ -967,7 +967,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>().RawValue
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal)).Value.As<ODataUntypedValue>().RawValue
                 .Should().Be(@"[""email1@163.com"",""email2@gmail.com"",""email3@gmail2.com""]");
             complex1.Properties.Count().Should().Be(2);
         }
@@ -995,9 +995,9 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1")).Value.As<ODataUntypedValue>()
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredCollection1", StringComparison.Ordinal)).Value.As<ODataUntypedValue>()
                 .RawValue.Should().Be(@"[]");
-            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"""No.10000000999,Zixing Rd Minhang""");
         }
 
@@ -1306,7 +1306,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             undeclaredCollection1Items.Count().Should().Be(0);
             address.TypeName.Should().Be("Server.NS.Address");
             addressNestedInfo.Name.Should().Be("Address");
-            address.Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet")).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
+            address.Properties.Single(s => string.Equals(s.Name, "UndeclaredStreet", StringComparison.Ordinal)).Value.Should().Be("No.10000000999,Zixing Rd Minhang");
         }
 
         #endregion
@@ -1472,9 +1472,9 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
@@ -1515,9 +1515,9 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp2"))
+            entry.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp2", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
@@ -1557,9 +1557,9 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            complex1.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp3"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "MyEdmUntypedProp3", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
@@ -1607,11 +1607,11 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1")).
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1", StringComparison.Ordinal)).
                 Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1")).TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp1", StringComparison.Ordinal)).TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
             complex2.Should().BeNull();
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
@@ -1652,11 +1652,11 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(4);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2")).
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2", StringComparison.Ordinal)).
                 Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
-            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2")).TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
+            entry.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp2", StringComparison.Ordinal)).TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
             string result = this.WriteEntryPayload(this.serverOpenEntitySet, this.serverOpenEntityType, writer =>
@@ -1695,12 +1695,12 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             entry.Properties.Count().Should().Be(3);
-            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1"))
+            entry.Properties.Single(s => string.Equals(s.Name, "undeclaredComplex1", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp1"":""aaaaaaaaa"",""UndeclaredProp1"":""bbbbbbb""}");
-            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3"))
+            complex1.Properties.Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3", StringComparison.Ordinal))
                 .Value.As<ODataUntypedValue>().RawValue.Should().Be(@"{""MyProp12"":""bbb222"",""abc"":null}");
             complex1.Properties
-                .Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3")).TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
+                .Single(s => string.Equals(s.Name, "UndeclaredMyEdmUntypedProp3", StringComparison.Ordinal)).TypeAnnotation.TypeName.Should().Be("Edm.Untyped");
 
             entry.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(entry);
             string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -769,19 +769,19 @@ namespace Microsoft.OData.Tests.UriParser
                 IEdmModel parsedModel;
                 if (CsdlReader.TryParse(XmlReader.Create(new StringReader(HardCodedTestModelXml.MainModelXml)), (Uri uri) =>
                 {
-                    if (string.Equals(uri.AbsoluteUri, "http://submodel1/"))
+                    if (string.Equals(uri.AbsoluteUri, "http://submodel1/", StringComparison.Ordinal))
                     {
                         return XmlReader.Create(new StringReader(HardCodedTestModelXml.SubModelXml1));
                     }
-                    else if (string.Equals(uri.AbsoluteUri, "http://submodel2/"))
+                    else if (string.Equals(uri.AbsoluteUri, "http://submodel2/", StringComparison.Ordinal))
                     {
                         return XmlReader.Create(new StringReader(HardCodedTestModelXml.SubModelXml2));
                     }
-                    else if (string.Equals(uri.AbsoluteUri, "http://submodel3/"))
+                    else if (string.Equals(uri.AbsoluteUri, "http://submodel3/", StringComparison.Ordinal))
                     {
                         return XmlReader.Create(new StringReader(HardCodedTestModelXml.SubModelXml3));
                     }
-                    else if (string.Equals(uri.AbsoluteUri, "http://submodel4/"))
+                    else if (string.Equals(uri.AbsoluteUri, "http://submodel4/", StringComparison.Ordinal))
                     {
                         return XmlReader.Create(new StringReader(HardCodedTestModelXml.SubModelXml4));
                     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserInjectionTests.cs
@@ -154,12 +154,12 @@ namespace Microsoft.OData.Tests.UriParser
 
         public ODataUriParserInjectionTests()
         {
-            folderType = oneDriveModel.SchemaElements.OfType<IEdmComplexType>().Single(e => string.Equals(e.Name, "folder"));
-            itemType = oneDriveModel.SchemaElements.OfType<IEdmEntityType>().Single(e => string.Equals(e.Name, "item"));
-            specialItemType = oneDriveModel.SchemaElements.OfType<IEdmEntityType>().Single(e => string.Equals(e.Name, "specialItem"));
+            folderType = oneDriveModel.SchemaElements.OfType<IEdmComplexType>().Single(e => string.Equals(e.Name, "folder", StringComparison.Ordinal));
+            itemType = oneDriveModel.SchemaElements.OfType<IEdmEntityType>().Single(e => string.Equals(e.Name, "item", StringComparison.Ordinal));
+            specialItemType = oneDriveModel.SchemaElements.OfType<IEdmEntityType>().Single(e => string.Equals(e.Name, "specialItem", StringComparison.Ordinal));
             folderProp = itemType.FindProperty("folder") as IEdmStructuralProperty;
             sizeProp = itemType.FindProperty("size") as IEdmStructuralProperty;
-            driveType = oneDriveModel.SchemaElements.OfType<IEdmEntityType>().Single(e => string.Equals(e.Name, "drive"));
+            driveType = oneDriveModel.SchemaElements.OfType<IEdmEntityType>().Single(e => string.Equals(e.Name, "drive", StringComparison.Ordinal));
             itemsNavProp = driveType.DeclaredNavigationProperties().FirstOrDefault(p => p.Name == "items");
             childrenNavProp = itemType.DeclaredNavigationProperties().FirstOrDefault(p => p.Name == "children");
             thumbnailsNavProp = itemType.DeclaredNavigationProperties().FirstOrDefault(p => p.Name == "thumbnails");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesTests.cs
@@ -339,7 +339,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             catch (ODataException e)
             {
                 if (!String.Equals(e.Message, Strings.CustomUriTypePrefixLiterals_AddCustomUriTypePrefixLiteralAlreadyExists(
-                    CustomUriLiteralParserUnitTests.BOOLEAN_LITERAL_PREFIX)))
+                    CustomUriLiteralParserUnitTests.BOOLEAN_LITERAL_PREFIX), StringComparison.Ordinal))
                 {
                     // unexpected exception, re-throw.
                     throw;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* similar issue at: https://github.com/OData/WebApi/issues/1215

### Description

* Add StringComparison in String.Equal() method call.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
