### PR TITLE
fix write document metadata properties for apply ComputeTransformatio…

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
@@ -106,7 +106,7 @@ namespace Microsoft.OData.UriParser.Aggregation
 
             if (computeExpressions != null)
             {
-                string computeProperties = string.Join(",", computeExpressions.Select(e => e.Alias));
+                string computeProperties = string.Join(",", computeExpressions.Select(e => e.Alias).ToArray());
                 if (!string.IsNullOrEmpty(computeProperties))
                     result = string.IsNullOrEmpty(result)
                         ? computeProperties

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
@@ -108,9 +108,11 @@ namespace Microsoft.OData.UriParser.Aggregation
             {
                 string computeProperties = string.Join(",", computeExpressions.Select(e => e.Alias).ToArray());
                 if (!string.IsNullOrEmpty(computeProperties))
+                {
                     result = string.IsNullOrEmpty(result)
                         ? computeProperties
                         : string.Format(CultureInfo.InvariantCulture, "{0},{1}", result, computeProperties);
+                }
             }
 
             return string.IsNullOrEmpty(result)

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
@@ -67,7 +67,8 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         internal string GetContextUri()
         {
-            return CreatePropertiesUriSegment(lastGroupByPropertyNodes, lastAggregateExpressions);
+            IEnumerable<ComputeExpression> computeExpressions = transformations.OfType<ComputeTransformationNode>().SelectMany(n => n.Expressions);
+            return CreatePropertiesUriSegment(lastGroupByPropertyNodes, lastAggregateExpressions, computeExpressions);
         }
 
         internal List<string> GetLastAggregatedPropertyNames()
@@ -82,13 +83,14 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         private string CreatePropertiesUriSegment(
             IEnumerable<GroupByPropertyNode> groupByPropertyNodes,
-            IEnumerable<AggregateExpression> aggregateExpressions)
+            IEnumerable<AggregateExpression> aggregateExpressions,
+            IEnumerable<ComputeExpression> computeExpressions)
         {
             string result = string.Empty;
             if (groupByPropertyNodes != null)
             {
                 var groupByPropertyArray =
-                    groupByPropertyNodes.Select(prop => prop.Name + CreatePropertiesUriSegment(prop.ChildTransformations, null))
+                    groupByPropertyNodes.Select(prop => prop.Name + CreatePropertiesUriSegment(prop.ChildTransformations, null, null))
                         .ToArray();
                 result = string.Join(",", groupByPropertyArray);
                 result = aggregateExpressions == null
@@ -100,6 +102,15 @@ namespace Microsoft.OData.UriParser.Aggregation
                 result = aggregateExpressions == null
                     ? string.Empty
                     : CreateAggregatePropertiesUriSegment(aggregateExpressions);
+            }
+
+            if (computeExpressions != null)
+            {
+                string computeProperties = string.Join(",", computeExpressions.Select(e => e.Alias));
+                if (!string.IsNullOrEmpty(computeProperties))
+                    result = string.IsNullOrEmpty(result)
+                        ? computeProperties
+                        : string.Format(CultureInfo.InvariantCulture, "{0},{1}", result, computeProperties);
             }
 
             return string.IsNullOrEmpty(result)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

When write response for query "OrderItems?$apply=compute(Count mul Price as Total,Id add OrderId as SumId)" compute properties not append metadata "@odata.context": "http://dummy/$metadata#OrderItems".

Response must be:
"@odata.context": "http://dummy/$metadata#OrderItems(Total,SumId)"