### PR TITLE
fix build uri from groupby navigation property with many child structural proeprties

### DIFF
--- a/src/Microsoft.OData.Core/Uri/ApplyClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/ApplyClauseToStringBuilder.cs
@@ -153,10 +153,10 @@ namespace Microsoft.OData
                     AppendExpression(node.Expression);
                 }
 
-                bool appendSlash = false;
+                bool appendCommaChild = false;
                 foreach (GroupByPropertyNode childNode in node.ChildTransformations)
                 {
-                    appendSlash = AppendSlash(appendSlash);
+                    appendCommaChild = AppendComma(appendCommaChild);
                     AppendExpression(childNode.Expression);
                 }
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/Microsoft.OData.Core.Tests.csproj
@@ -242,6 +242,7 @@
     <Compile Include="..\ScenarioTests\Roundtrip\JsonLight\JsonBigBatchRoundTripTests.cs" />
     <Compile Include="..\ScenarioTests\Roundtrip\JsonLight\MultipartMixedBatchDependsOnIdsTests.cs" />
     <Compile Include="..\ScenarioTests\Roundtrip\JsonLight\Utils.cs" />
+    <Compile Include="..\ScenarioTests\UriBuilder\ApplyBuilderTest.cs" />
     <Compile Include="..\ScenarioTests\UriBuilder\ContextUrlPathStringTests.cs" />
     <Compile Include="..\ScenarioTests\UriBuilder\CountBuilderTests.cs" />
     <Compile Include="..\ScenarioTests\UriBuilder\FilterAndOrderByBuilderTests.cs" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ApplyBuilderTest.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ApplyBuilderTest.cs
@@ -18,6 +18,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.UriBuilder
         [InlineData("http://gobbledygook/People?$apply=groupby((FirstName),aggregate($count as cnt))")]
         [InlineData("http://gobbledygook/People?$apply=groupby((FirstName),aggregate(LifeTime with Custom.Aggregate as custLifeTime))")]
         [InlineData("http://gobbledygook/People?$apply=compute((cast(LifeTime,'Edm.Double') add MyDog/LionWhoAteMe/AngerLevel) mul 2 as lifeAngerLevel,StockQuantity div FavoriteNumber as StockNumber)")]
+        [InlineData("http://gobbledygook/People?$apply=groupby((MyDog/Color,MyDog/Breed))")]
         public void BuildUrlWithApply(string query)
         {
             var parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(query));


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description
```cs
[InlineData("http://gobbledygook/People?$apply=groupby((MyDog/Color,MyDog/Breed))")]
public void BuildUrlWithApply(string query)
{
    var parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(query));
    ODataUri odataUri = parser.ParseUri();

    Uri result = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
    Assert.Equal(query, Uri.UnescapeDataString(result.OriginalString));
}
```
Expected result http://gobbledygook/People?$apply=groupby((MyDog/Color,MyDog/Breed))
Actual result  http://gobbledygook/People?$apply=groupby((MyDog/Color/MyDog/Breed))

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*