### PR TITLE
Fix SegmentKeyHandler to include UnqualifiedODataUriResolver proccessing

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/SegmentArgumentParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SegmentArgumentParser.cs
@@ -188,7 +188,6 @@ namespace Microsoft.OData.UriParser
         public bool TryConvertValues(IEdmEntityType targetEntityType, out IEnumerable<KeyValuePair<string, object>> keyPairs, ODataUriResolver resolver)
         {
             Debug.Assert(!this.IsEmpty, "!this.IsEmpty -- caller should check");
-            Debug.Assert(targetEntityType.Key().Count() == this.ValueCount || resolver.GetType() != typeof(ODataUriResolver), "type.KeyProperties.Count == this.ValueCount -- will change with containment");
 
             if (this.NamedValues != null)
             {
@@ -197,7 +196,6 @@ namespace Microsoft.OData.UriParser
             else
             {
                 Debug.Assert(this.positionalValues != null, "positionalValues != null -- otherwise this is Empty");
-                Debug.Assert(this.PositionalValues.Count == targetEntityType.Key().Count() || resolver.GetType() != typeof(ODataUriResolver), "Count of positional values does not match.");
                 keyPairs = resolver.ResolveKeys(targetEntityType, this.PositionalValues, this.ConvertValueWrapper);
             }
 

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SegmentKeyHandler.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SegmentKeyHandler.cs
@@ -153,7 +153,7 @@ namespace Microsoft.OData.UriParser
 
             Debug.Assert(targetEntityType != null, "targetEntityType != null");
 
-            // Make sure the keys specified in the uri matches with the number of keys in the metadata
+            // Adjust the keys for navigation segment.
             var keyProperties = targetEntityType.Key().ToList();
             if (keyProperties.Count != key.ValueCount)
             {
@@ -161,13 +161,6 @@ namespace Microsoft.OData.UriParser
                 if (currentNavPropSegment != null)
                 {
                     key = KeyFinder.FindAndUseKeysFromRelatedSegment(key, keyProperties, currentNavPropSegment.NavigationProperty, previousKeySegment);
-                }
-
-                // If we still didn't find any keys, throw an error, except for case of
-                // AlternateKeysODataUriResolver which can handle alternate keys and can throw later for unresolvable case.
-                if (keyProperties.Count != key.ValueCount && !(resolver is AlternateKeysODataUriResolver))
-                {
-                    throw ExceptionUtil.CreateBadRequestError(ErrorStrings.BadRequest_KeyCountMismatch(targetEntityType.FullName()));
                 }
             }
 

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SegmentKeyHandler.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SegmentKeyHandler.cs
@@ -163,8 +163,9 @@ namespace Microsoft.OData.UriParser
                     key = KeyFinder.FindAndUseKeysFromRelatedSegment(key, keyProperties, currentNavPropSegment.NavigationProperty, previousKeySegment);
                 }
 
-                // if we still didn't find any keys, then throw an error.
-                if (keyProperties.Count != key.ValueCount && resolver.GetType() == typeof(ODataUriResolver))
+                // If we still didn't find any keys, throw an error, except for case of
+                // AlternateKeysODataUriResolver which can handle alternate keys and can throw later for unresolvable case.
+                if (keyProperties.Count != key.ValueCount && !(resolver is AlternateKeysODataUriResolver))
                 {
                     throw ExceptionUtil.CreateBadRequestError(ErrorStrings.BadRequest_KeyCountMismatch(targetEntityType.FullName()));
                 }

--- a/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
@@ -89,6 +89,14 @@ namespace Microsoft.OData.UriParser
         /// <returns>True if resolve succeeded.</returns>
         private bool TryResolveKeys(IEdmEntityType type, IDictionary<string, string> namedValues, IDictionary<string, IEdmProperty> keyProperties, Func<IEdmTypeReference, string, object> convertFunc, out IEnumerable<KeyValuePair<string, object>> convertedPairs)
         {
+            if (namedValues.Count != keyProperties.Count)
+            {
+                // Count of name value pair does not match the alias count in this set of
+                // alternative keys ==> Unresolvable for this set.
+                convertedPairs = null;
+                return false;
+            }
+
             Dictionary<string, object> pairs = new Dictionary<string, object>(StringComparer.Ordinal);
 
             foreach (KeyValuePair<string, IEdmProperty> kvp in keyProperties)

--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -289,6 +289,15 @@ namespace Microsoft.OData.UriParser
         public virtual IEnumerable<KeyValuePair<string, object>> ResolveKeys(IEdmEntityType type, IList<string> positionalValues, Func<IEdmTypeReference, string, object> convertFunc)
         {
             var keyProperties = type.Key().ToList();
+
+            // Throw an error if key size from url doesn't match that from model.
+            // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
+            // should override this ResolveKeys method.
+            if (keyProperties.Count != positionalValues.Count)
+            {
+                throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyCountMismatch(type.FullName()));
+            }
+
             var keyPairList = new List<KeyValuePair<string, object>>(positionalValues.Count);
 
             for (int i = 0; i < keyProperties.Count; i++)
@@ -318,6 +327,14 @@ namespace Microsoft.OData.UriParser
         {
             var convertedPairs = new Dictionary<string, object>(StringComparer.Ordinal);
             var keyProperties = type.Key().ToList();
+
+            // Throw an error if key size from url doesn't match that from model.
+            // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
+            // should override this ResolveKeys method.
+            if (keyProperties.Count != namedValues.Count)
+            {
+                throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyCountMismatch(type.FullName()));
+            }
 
             foreach (IEdmStructuralProperty property in keyProperties)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -388,7 +388,8 @@ namespace Microsoft.OData.Tests.UriParser
                 Resolver = new AlternateKeysODataUriResolver(HardCodedTestModel.TestModel)
             }.ParsePath();
 
-            action.ShouldThrow<ODataException>().WithMessage("Bad Request - Error in query syntax.");
+            action.ShouldThrow<ODataException>()
+                .WithMessage(ODataErrorStrings.BadRequest_KeyCountMismatch(HardCodedTestModel.GetPersonType().FullTypeName()));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -380,6 +380,18 @@ namespace Microsoft.OData.Tests.UriParser
         }
 
         [Fact]
+        public void CompositeAlternateKeyShouldFailOnlyWithInvalidAlternateKey()
+        {
+            Uri fullUri = new Uri("http://host/People(NameAlias='anyName', FirstNameAlias='anyFirst', extraAltKey='any')");
+            Action action = () => new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), fullUri)
+            {
+                Resolver = new AlternateKeysODataUriResolver(HardCodedTestModel.TestModel)
+            }.ParsePath();
+
+            action.ShouldThrow<ODataException>().WithMessage("Bad Request - Error in query syntax.");
+        }
+
+        [Fact]
         public void AlternateKeyShouldFailWithDefaultUriResolver()
         {
             Uri fullUri = new Uri("http://host/People(SocialSN = \'1\')");


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1153.*

### Description

*Include UnqualifiedODataUriResolve type when checking for mismatched keys count.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
