### PR TITLE
Fix case insensitive search for custom URI functions.

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/CustomUriFunctions.cs
+++ b/src/Microsoft.OData.Core/UriParser/CustomUriFunctions.cs
@@ -161,35 +161,13 @@ namespace Microsoft.OData.UriParser
                 IList<KeyValuePair<string, FunctionSignatureWithReturnType>> bufferedKeyValuePairs
                     = new List<KeyValuePair<string, FunctionSignatureWithReturnType>>();
 
-                // Do case-sensitive search first.
-                if (CustomFunctions.ContainsKey(functionCallToken))
+                foreach (KeyValuePair<string, FunctionSignatureWithReturnType[]> func in CustomFunctions)
                 {
-                    FunctionSignatureWithReturnType[] signatureGroup = null;
-                    CustomFunctions.TryGetValue(functionCallToken, out signatureGroup);
-
-                    Debug.Assert(signatureGroup != null, "signatureGroup != null");
-
-                    foreach (FunctionSignatureWithReturnType sig in signatureGroup)
+                    if (func.Key.Equals(functionCallToken, enableCaseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
                     {
-                        // case-sensitive match: canonical name is just the function token name.
-                        bufferedKeyValuePairs.Add(new KeyValuePair<string, FunctionSignatureWithReturnType>(functionCallToken, sig));
-                    }
-                }
-
-                // Continue to search for match, if case-insensitive is enabled.
-                if (enableCaseInsensitive)
-                {
-                    foreach (KeyValuePair<string, FunctionSignatureWithReturnType[]> func in CustomFunctions)
-                    {
-                        if (func.Key.Equals(functionCallToken, StringComparison.OrdinalIgnoreCase)
-                            /* Skip the exact match above to avoid double-counting. */
-                            && !func.Key.Equals(functionCallToken, StringComparison.Ordinal))
+                        foreach (FunctionSignatureWithReturnType sig in func.Value)
                         {
-                            foreach (FunctionSignatureWithReturnType sig in func.Value)
-                            {
-                                // case-insensitive match: canonical name is the one from the CustomFunctions dictionary.
-                                bufferedKeyValuePairs.Add(new KeyValuePair<string, FunctionSignatureWithReturnType>(func.Key, sig));
-                            }
+                            bufferedKeyValuePairs.Add(new KeyValuePair<string, FunctionSignatureWithReturnType>(func.Key, sig));
                         }
                     }
                 }

--- a/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
@@ -449,30 +449,25 @@ namespace Microsoft.OData.UriParser
                     }
                 }
 
-                KeyValuePair<string, FunctionSignatureWithReturnType> result;
-                if (equallyArgumentsMatchingNameFunctions.Count == 0)
-                {
-                    // Best match count = 0.
-                    result = NotFoundKeyValuePair;
-                }
-                else if (equallyArgumentsMatchingNameFunctions.Count == 1)
+                KeyValuePair<string, FunctionSignatureWithReturnType> result = NotFoundKeyValuePair;
+                if (equallyArgumentsMatchingNameFunctions.Count == 1)
                 {
                     // Best match count = 1.
                     result = equallyArgumentsMatchingNameFunctions[0];
                 }
                 else
                 {
-                    // For multiple best matches based on argument types
-                    if (equallyArgumentsMatchingNameFunctions.Count(
-                            f => f.Key.Equals(functionCallToken, StringComparison.Ordinal)) == 1)
+                    // For multiple best matches based on argument types, should return as ambiguous result
+                    // if no exact match is found.
+                    foreach (KeyValuePair<string, FunctionSignatureWithReturnType> candidate in equallyArgumentsMatchingNameFunctions)
                     {
-                        // There is only one case-sensitive function name match among the equally argument-types matching functions.
-                        result = equallyArgumentsMatchingNameFunctions.First(_ => _.Key.Equals(functionCallToken, StringComparison.Ordinal));
-                    }
-                    else
-                    {
-                        // Ambiguous cases of zero or multiple case-sensitive function name matches.
-                        result = NotFoundKeyValuePair;
+                        if (candidate.Key.Equals(functionCallToken, StringComparison.Ordinal))
+                        {
+                            // Registered function name keys are guaranteed to be case-sensitively unique
+                            // If one is found, it should be what we are looking for.
+                            result = candidate;
+                            break;
+                        }
                     }
                 }
 

--- a/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
@@ -388,7 +388,7 @@ namespace Microsoft.OData.UriParser
             Debug.Assert(nameFunctions != null, "nameFunctions != null");
             Debug.Assert(argumentTypes != null, "argumentTypes != null");
             Debug.Assert(functionCallToken != null, "functionCallToken != null");
-            IList<KeyValuePair<string,FunctionSignatureWithReturnType>> applicableNameFunctions
+            IList<KeyValuePair<string, FunctionSignatureWithReturnType>> applicableNameFunctions
                 = new List<KeyValuePair<string, FunctionSignatureWithReturnType>>(nameFunctions.Count);
 
             // Build a list of applicable functions (and cache their promoted arguments).

--- a/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
@@ -385,7 +385,7 @@ namespace Microsoft.OData.UriParser
             SingleValueNode[] argumentNodes, string functionCallToken)
         {
             IEdmTypeReference[] argumentTypes = argumentNodes.Select(s => s.TypeReference).ToArray();
-            Debug.Assert(nameFunctions != null, "functions != null");
+            Debug.Assert(nameFunctions != null, "nameFunctions != null");
             Debug.Assert(argumentTypes != null, "argumentTypes != null");
             Debug.Assert(functionCallToken != null, "functionCallToken != null");
             IList<KeyValuePair<string,FunctionSignatureWithReturnType>> applicableNameFunctions
@@ -464,7 +464,7 @@ namespace Microsoft.OData.UriParser
                 {
                     // For multiple best matches based on argument types
                     if (equallyArgumentsMatchingNameFunctions.Count(
-                            _ => _.Key.Equals(functionCallToken, StringComparison.Ordinal)) == 1)
+                            f => f.Key.Equals(functionCallToken, StringComparison.Ordinal)) == 1)
                     {
                         // There is only one case-sensitive function name match among the equally argument-types matching functions.
                         result = equallyArgumentsMatchingNameFunctions.First(_ => _.Key.Equals(functionCallToken, StringComparison.Ordinal));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/CustomUriFunctionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/CustomUriFunctionsTests.cs
@@ -538,7 +538,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
-        public void ParseWithExactMatchCustomUriFunction_EnableCaseInsensitive_ShouldWorkForMultipleEquiventArgumentsMatches()
+        public void ParseWithExactMatchCustomUriFunction_EnableCaseInsensitive_ShouldWorkForMultipleEquivalentArgumentsMatches()
         {
             string lowerCaseName = "myfunction";
             string upperCaseName = lowerCaseName.ToUpper();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -813,7 +813,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             // regression test for: [UriParser] day() allowed. What does that mean?
             // make sure that, if we do find a cannonical function, we match its parameters. 
             Action parseWithInvalidParameters = () => ParseFilter("day() eq 20", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
-            FunctionSignatureWithReturnType[] signatures = FunctionCallBinder.GetUriFunctionSignatures("day"); // to match the error message... blah
+            FunctionSignatureWithReturnType[] signatures = FunctionCallBinder.ExtractSignatures(
+                FunctionCallBinder.GetUriFunctionSignatures("day")); // to match the error message... blah
             parseWithInvalidParameters.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.MetadataBinder_NoApplicableFunctionFound(
                     "day",
                     UriFunctionsHelper.BuildFunctionSignatureListDescription("day", signatures)));
@@ -825,7 +826,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             // regression test for: [UriParser] day() allowed. What does that mean?
             // make sure that, if we do find a cannonical function, we match its parameters. 
             Action parseWithInvalidParameters = () => ParseFilter("day(1) eq 20", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
-            FunctionSignatureWithReturnType[] signatures = FunctionCallBinder.GetUriFunctionSignatures("day"); // to match the error message... blah
+            FunctionSignatureWithReturnType[] signatures = FunctionCallBinder.ExtractSignatures(
+                FunctionCallBinder.GetUriFunctionSignatures("day")); // to match the error message... blah
             parseWithInvalidParameters.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.MetadataBinder_NoApplicableFunctionFound(
                     "day",
                     UriFunctionsHelper.BuildFunctionSignatureListDescription("day", signatures)));

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/Filter/FilterTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/Filter/FilterTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Test.Taupo.OData.Scenario.Tests.UriParser.Filter
         public void SpatialDistance()
         {
             this.ApprovalVerifyFilterParser(employeeBase, "geo.distance(Home, Office) lt 0.5");
-            
+
             this.TestAllInOneExtensionFilter(
                employeeBase,
                "GEO.distance(Home, Office) lt 0.5",
@@ -348,6 +348,17 @@ namespace Microsoft.Test.Taupo.OData.Scenario.Tests.UriParser.Filter
         public void ExceptionSholdThrowForFunctionImport()
         {
             Action action = () => this.ApprovalVerifyFilterParser(orderBase, "HasLotsOfOrders() eq 3");
+            action.ShouldThrow<ODataException>().WithMessage("An unknown function with name 'HasLotsOfOrders' was found. This may also be a function import or a key lookup on a navigation property, which is not allowed.");
+        }
+
+        [TestMethod]
+        [MethodImplAttribute(MethodImplOptions.NoOptimization)]
+        public void ExceptionSholdThrowForFunctionImport_EnableCaseInsensitive()
+        {
+            ODataUriParser parser = new ODataUriParser(this.model, this.serviceRoot, new Uri(orderBase, "?$filter=HasLotsOfOrders() eq 3"));
+            parser.Resolver = new ODataUriResolver { EnableCaseInsensitive = true };
+
+            Action action = () => parser.ParseFilter();
             action.ShouldThrow<ODataException>().WithMessage("An unknown function with name 'HasLotsOfOrders' was found. This may also be a function import or a key lookup on a navigation property, which is not allowed.");
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1155.*

### Description

*Update the FunctionCallBinder.GetUriFunctionSignatures() function accommodate enableCaseInsensitive logic. First scan by exact match for custom Uri functions, followed by case-insensitive match if case-insensitive is enabled. Ensure function name is correctly set in the message when exception is thrown. Updated related logic to make case-insensitive search work along with looking for best signature matched for overloaded functions.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
