### PR TITLE
Adding test coverage for selecting complex collection properties

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
@@ -187,6 +187,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
 
         [Fact]
+        public void CanSelectSubPropertyOfComplexCollection()
+        {
+            Uri queryUri = new Uri("People?$select=PreviousAddresses/City", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("PreviousAddresses/City"), actualUri.OriginalString);
+        }
+
+        [Fact]
         public void SelectManyDeclaredPropertiesSucceeds()
         {
             Uri queryUri = new Uri("People?$select= Shoe, Birthdate,GeographyPoint,    TimeEmployed, \tPreviousAddresses", UriKind.Relative);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -385,6 +385,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void CanSelectSubPropertyOfComplexCollection()
+        {
+            const string select = "PreviousAddresses/City";
+            var result = RunParseSelectExpandAndAssertPaths(
+                select,
+                null,
+                select,
+                null,
+                HardCodedTestModel.GetPersonType(),
+                HardCodedTestModel.GetPeopleSet());
+
+            result.SelectedItems.Single().ShouldBePathSelectionItem(new ODataSelectPath(
+                    new PropertySegment(HardCodedTestModel.GetPersonPreviousAddressesProp()),
+                    new PropertySegment(HardCodedTestModel.GetAddressCityProperty())));
+            result.AllSelected.Should().BeFalse();
+        }
+
+        [Fact]
         public void SelectManyDeclaredPropertiesSucceeds()
         {
             const string select = " Shoe, Birthdate,GeographyPoint,    TimeEmployed, \tPreviousAddresses";


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request adds test coverage to confirm that this issue has been fixed: https://github.com/OData/odata.net/issues/513

### Description

This change adds new test coverage for the scenario of selecting a property of a complex collection. For example: `$select=PreviousAddresses/City` where `PreviousAddress` is of type `Collection(Address)` and `Address` is a complex type.

Originally I thought this scenario was still broken, but it looks like it was fixed by an unrelated change almost two years ago. I think it would be prudent to add test coverage for this case to prevent future regressions.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*


