### PR TITLE
fix memory leak #1145

### DIFF
--- a/src/Microsoft.OData.Client/ODataAnnotatableExtensions.cs
+++ b/src/Microsoft.OData.Client/ODataAnnotatableExtensions.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Diagnostics;
 
 namespace Microsoft.OData.Client
@@ -30,12 +30,12 @@ namespace Microsoft.OData.Client
 
         private static class InternalDictionary<T> where T : class
         {
-            private static readonly ConcurrentDictionary<ODataAnnotatable, T> Dictionary =
-                new ConcurrentDictionary<ODataAnnotatable, T>();
+            private static readonly ConditionalWeakTable<ODataAnnotatable, T> Dictionary =
+                new ConditionalWeakTable<ODataAnnotatable, T>();
 
             public static void SetAnnotation(ODataAnnotatable annotatable, T annotation)
             {
-                Dictionary[annotatable] = annotation;
+                Dictionary.Add(annotatable,annotation); 
             }
 
             public static T GetAnnotation(ODataAnnotatable annotatable)


### PR DESCRIPTION
### Issues

*This pull request fixes issue #1145.*

<!-- markdownlint-disable MD002 MD041 -->



### Description


the memory leak occurs because the Annotatable object can never be GC'd once an annotation is attached.

There is a change in semantics here, if SetAnnotation is called twice, the second will exception, rather than updating.
This was previously a condition which would cause an error anyway, as it would orphan the previously set annotation inside CreateLink()

At the moment the only codepath to SetAnnotation is 
Microsoft.OData.Client.Materialization.MaterializerNavigationLink.CreateLink(...) 
create link is only called by FeedAndEntryMaterializerAdapter, which has an existence guard, so this should never trigger the double-insert.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

There is a possible change in behaviour as replaceing  Dictionary[annotatable] = annotation; with Dictionary.Add(annotatable,annotation);  means that setting the same annotation twice is now an error. I do not believe we currently do that anywhere.
