### PR TITLE
Avoid use of string builder in GetProperty to reduce string allocations.

### DIFF
--- a/src/Microsoft.OData.Core/PropertyCacheHandler.cs
+++ b/src/Microsoft.OData.Core/PropertyCacheHandler.cs
@@ -10,6 +10,8 @@ using Microsoft.OData.Edm;
 
 namespace Microsoft.OData
 {
+    using System.Globalization;
+
     /// <summary>
     /// Manage PropertyCache for ODataResourceSet in serialization.
     /// One ODataResourceSet has one PropertyCache.
@@ -35,8 +37,8 @@ namespace Microsoft.OData
         {
             int depth = this.currentResourceScopeLevel - this.resourceSetScopeLevel;
             string uniqueName = owningType != null 
-                ? string.Concat(owningType.FullTypeName(), PropertyCacheHandler.PropertyTypeDelimiter, name, depth.ToString()) 
-                : string.Concat(name, depth.ToString());
+                ? string.Concat(owningType.FullTypeName(), PropertyCacheHandler.PropertyTypeDelimiter, name, depth.ToString(CultureInfo.InvariantCulture)) 
+                : string.Concat(name, depth.ToString(CultureInfo.InvariantCulture));
 
             return this.currentPropertyCache.GetProperty(name, uniqueName, owningType);
         }

--- a/src/Microsoft.OData.Core/PropertyCacheHandler.cs
+++ b/src/Microsoft.OData.Core/PropertyCacheHandler.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
+
 using Microsoft.OData.Edm;
 
 namespace Microsoft.OData
@@ -36,10 +37,12 @@ namespace Microsoft.OData
         public PropertySerializationInfo GetProperty(string name, IEdmStructuredType owningType)
         {
             int depth = this.currentResourceScopeLevel - this.resourceSetScopeLevel;
-            string depthStr = depth == 1 ? string.Empty : depth.ToString(CultureInfo.InvariantCulture); 
 
-            string uniqueName = owningType != null 
-                ? string.Concat(owningType.FullTypeName(), PropertyCacheHandler.PropertyTypeDelimiter, depthStr, name) 
+            Debug.Assert(depth >= 1, $"{nameof(depth)} should always be greater than 1");
+            string depthStr = depth == 1 ? string.Empty : depth.ToString(CultureInfo.InvariantCulture);
+
+            string uniqueName = owningType != null
+                ? string.Concat(owningType.FullTypeName(), PropertyCacheHandler.PropertyTypeDelimiter, depthStr, name)
                 : string.Concat(depthStr, name);
 
             return this.currentPropertyCache.GetProperty(name, uniqueName, owningType);

--- a/src/Microsoft.OData.Core/PropertyCacheHandler.cs
+++ b/src/Microsoft.OData.Core/PropertyCacheHandler.cs
@@ -36,9 +36,11 @@ namespace Microsoft.OData
         public PropertySerializationInfo GetProperty(string name, IEdmStructuredType owningType)
         {
             int depth = this.currentResourceScopeLevel - this.resourceSetScopeLevel;
+            string depthStr = depth == 1 ? string.Empty : depth.ToString(CultureInfo.InvariantCulture); 
+
             string uniqueName = owningType != null 
-                ? string.Concat(owningType.FullTypeName(), PropertyCacheHandler.PropertyTypeDelimiter, name, depth.ToString(CultureInfo.InvariantCulture)) 
-                : string.Concat(name, depth.ToString(CultureInfo.InvariantCulture));
+                ? string.Concat(owningType.FullTypeName(), PropertyCacheHandler.PropertyTypeDelimiter, depthStr, name) 
+                : string.Concat(depthStr, name);
 
             return this.currentPropertyCache.GetProperty(name, uniqueName, owningType);
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1172 .

### Description

Instead of using string builder moving everything to string concat.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

