### PR TITLE
Fixing missing JSON batch doc

### DIFF
--- a/v7/_posts/odata features/2017-12-26-06-00-JsonBatch.md
+++ b/v7/_posts/odata features/2017-12-26-06-00-JsonBatch.md
@@ -1,8 +1,8 @@
 ---
-title: "Json batch format in ODataLib"
 layout: post
-category: "6. OData Features"
+title: "Json batch format in ODataLib"
 description: ""
+category: "5. OData Features"
 ---
 
 # Introduction to JSON Batching 


### PR DESCRIPTION
### Description
JSON batch doc was missing due to the way the index.html parses for posts.