### PR TITLE
Skip validation of reference uri that is different from base uri.

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -211,7 +211,6 @@ namespace Microsoft.OData {
         internal const string ODataBatchReader_SelfReferenceDependsOnRequestIdNotAllowed = "ODataBatchReader_SelfReferenceDependsOnRequestIdNotAllowed";
         internal const string ODataBatchReader_DependsOnRequestIdIsPartOfAtomicityGroupNotAllowed = "ODataBatchReader_DependsOnRequestIdIsPartOfAtomicityGroupNotAllowed";
         internal const string ODataBatchReader_DependsOnIdNotFound = "ODataBatchReader_DependsOnIdNotFound";
-        internal const string ODataBatchReader_AbsoluteURINotMatchingBaseUri = "ODataBatchReader_AbsoluteURINotMatchingBaseUri";
         internal const string ODataBatchReader_ReferenceIdNotIncludedInDependsOn = "ODataBatchReader_ReferenceIdNotIncludedInDependsOn";
         internal const string ODataBatch_GroupIdOrChangeSetIdCannotBeNull = "ODataBatch_GroupIdOrChangeSetIdCannotBeNull";
         internal const string ODataBatchReader_MessageIdPositionedIncorrectly = "ODataBatchReader_MessageIdPositionedIncorrectly";

--- a/src/Microsoft.OData.Core/ODataBatchUtils.cs
+++ b/src/Microsoft.OData.Core/ODataBatchUtils.cs
@@ -170,7 +170,7 @@ namespace Microsoft.OData
             {
                 if (baseUri == null)
                 {
-                    // The absolution Uri can contain $ character followed by name of system resource
+                    // The absolute Uri can contain $ character followed by name of system resource
                     // such as $all, $metadata, etc, along with an unspecified baseUri. In such cases there are
                     // not reference Uri to validate.
                     return;

--- a/src/Microsoft.OData.Core/ODataBatchUtils.cs
+++ b/src/Microsoft.OData.Core/ODataBatchUtils.cs
@@ -179,8 +179,8 @@ namespace Microsoft.OData
                 string baseUriString = UriUtils.UriToString(baseUri);
                 if (!uri.AbsoluteUri.StartsWith(baseUriString, StringComparison.Ordinal))
                 {
-                    throw new ODataException(Strings.ODataBatchReader_AbsoluteURINotMatchingBaseUri(
-                        uri.AbsoluteUri, baseUriString));
+                    // Skip validation if uri doesn't start with the baseUri.
+                    return;
                 }
 
                 relativePath = uri.AbsoluteUri.Substring(baseUriString.Length);

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -270,7 +270,7 @@ namespace Microsoft.OData {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataWriterCore_CannotWriteTopLevelResourceSetWithResourceWriter);
             }
         }
-        
+
         /// <summary>
         /// A string like "Cannot write a top-level resource with a writer that was created to write a top-level resource set."
         /// </summary>
@@ -1191,14 +1191,6 @@ namespace Microsoft.OData {
         internal static string ODataBatchReader_DependsOnIdNotFound(object p0, object p1)
         {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataBatchReader_DependsOnIdNotFound, p0, p1);
-        }
-
-        /// <summary>
-        /// A string like "Absolute URI {0} is not start with the base URI [{1}] specified by the operation message."
-        /// </summary>
-        internal static string ODataBatchReader_AbsoluteURINotMatchingBaseUri(object p0, object p1)
-        {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataBatchReader_AbsoluteURINotMatchingBaseUri, p0, p1);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/MultipartMixedBatchDependsOnIdsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/MultipartMixedBatchDependsOnIdsTests.cs
@@ -44,7 +44,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2A
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -54,7 +54,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2B
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/SingletonBatchRoundtripJsonLightTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/SingletonBatchRoundtripJsonLightTests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
 
         private const string batchContentTypeMultipartMime = "multipart/mixed; boundary=batch_cb48b61f-511b-48e6-b00a-77c847badfb9";
         private const string batchContentTypeApplicationJson = "application/json; odata.streaming=true";
-        private const string serviceDocumentUri = "http://odata.org/test/";
-        private const string differentServiceUri = "http://vip.odata.org/test/";
+        private const string serviceDocumentUri = "http://odata.org/test";
+        private const string differentServiceUri = "http://vip.odata.org/test";
         private const string dependsOnIdNotFound = "is not matching any of the request Id and atomic group Id seen so far. Forward reference is not allowed.";
         private const string changesetContainingQueryNotAllowed =
             "was detected for a request in a change set. Requests in change sets only support the HTTP methods 'POST', 'PUT', 'DELETE', and 'PATCH'.";
@@ -44,7 +44,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET http://odata.org/test//MySingleton HTTP/1.1
+GET http://odata.org/test/MySingleton HTTP/1.1
 Accept: application/json;odata.metadata=full
 
 
@@ -56,7 +56,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 1
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -66,7 +66,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -76,7 +76,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET http://odata.org/test//MySingleton/WebId HTTP/1.1
+GET http://odata.org/test/MySingleton/WebId HTTP/1.1
 Accept: application/json;odata.metadata=full
 
 
@@ -103,7 +103,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 1
 
-PATCH http://odata.org/test//MySingleton1 HTTP/1.1
+PATCH http://odata.org/test/MySingleton1 HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -113,7 +113,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2
 
-PATCH http://odata.org/test//MySingleton2 HTTP/1.1
+PATCH http://odata.org/test/MySingleton2 HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -127,7 +127,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 3
 
-PATCH http://odata.org/test//MySingleton3 HTTP/1.1
+PATCH http://odata.org/test/MySingleton3 HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -137,7 +137,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-GET http://odata.org/test//MySingleton3/WebId HTTP/1.1
+GET http://odata.org/test/MySingleton3/WebId HTTP/1.1
 Accept: application/json;odata.metadata=full
 
 
@@ -262,7 +262,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2A
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -272,7 +272,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2B
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -296,7 +296,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 3A
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -329,7 +329,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2A
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -339,7 +339,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2B
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -363,7 +363,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 3A
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-Version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -463,7 +463,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2A
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -473,7 +473,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2B
 
-PATCH http://odata.org/test//MySingleton HTTP/1.1
+PATCH http://odata.org/test/MySingleton HTTP/1.1
 OData-version: 4.0
 Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
 
@@ -560,7 +560,7 @@ Content-Type: application/json;odata.metadata=none
     ""requests"": [{
             ""id"": ""a05368c8-479d-4409-a2ee-9b54b133ec38"",
             ""method"": ""GET"",
-            ""url"": ""http://odata.org/test//MySingleton"",
+            ""url"": ""http://odata.org/test/MySingleton"",
             ""headers"": {
                 ""accept"": ""application/json;odata.metadata=full""
             }
@@ -568,7 +568,7 @@ Content-Type: application/json;odata.metadata=none
             ""id"": ""1"",
             ""atomicityGroup"": ""f7de7314-2f3d-4422-b840-ada6d6de0f18"",
             ""method"": ""PATCH"",
-            ""url"": ""http://odata.org/test//MySingleton"",
+            ""url"": ""http://odata.org/test/MySingleton"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -582,7 +582,7 @@ Content-Type: application/json;odata.metadata=none
             ""id"": ""2"",
             ""atomicityGroup"": ""f7de7314-2f3d-4422-b840-ada6d6de0f18"",
             ""method"": ""PATCH"",
-            ""url"": ""http://odata.org/test//MySingleton"",
+            ""url"": ""http://odata.org/test/MySingleton"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -594,7 +594,7 @@ Content-Type: application/json;odata.metadata=none
         }, {
             ""id"": ""adec0e52-7647-4d9d-baac-9316f9dc6927"",
             ""method"": ""GET"",
-            ""url"": ""http://odata.org/test//MySingleton/WebId"",
+            ""url"": ""http://odata.org/test/MySingleton/WebId"",
             ""headers"": {
                 ""accept"": ""application/json;odata.metadata=full""
             }
@@ -614,7 +614,7 @@ Content-Type: application/json;odata.metadata=none
             ""id"": ""1"",
             ""atomicityGroup"": ""2ffeac98-237b-46a7-b97c-6a360d622aaa"",
             ""method"": ""PATCH"",
-            ""url"": ""http://odata.org/test//MySingleton1"",
+            ""url"": ""http://odata.org/test/MySingleton1"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -628,7 +628,7 @@ Content-Type: application/json;odata.metadata=none
             ""id"": ""2"",
             ""atomicityGroup"": ""2ffeac98-237b-46a7-b97c-6a360d622aaa"",
             ""method"": ""PATCH"",
-            ""url"": ""http://odata.org/test//MySingleton2"",
+            ""url"": ""http://odata.org/test/MySingleton2"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -641,7 +641,7 @@ Content-Type: application/json;odata.metadata=none
             ""id"": ""3"",
             ""atomicityGroup"": ""2ffabc98-257b-46a7-b17c-97650d6220aa"",
             ""method"": ""PATCH"",
-            ""url"": ""http://odata.org/test//MySingleton3"",
+            ""url"": ""http://odata.org/test/MySingleton3"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -654,7 +654,7 @@ Content-Type: application/json;odata.metadata=none
         }, {
             ""id"": ""0d24a607-3fb0-4a83-a8fb-ef33f8c7e4ba"",
             ""method"": ""GET"",
-            ""url"": ""http://odata.org/test//MySingleton3/WebId"",
+            ""url"": ""http://odata.org/test/MySingleton3/WebId"",
             ""headers"": {
                 ""accept"": ""application/json;odata.metadata=full""
             }
@@ -756,7 +756,7 @@ Content-Type: application/json;odata.metadata=none
             ""id"": ""1"",
             ""atomicityGroup"": ""11d431dd-cfee-48c8-95fb-da8491644fa6"",
             ""method"": ""PUT"",
-            ""url"": ""http://odata.org/test//MySingleton"",
+            ""url"": ""http://odata.org/test/MySingleton"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -771,7 +771,7 @@ Content-Type: application/json;odata.metadata=none
             ""atomicityGroup"": ""11d431dd-cfee-48c8-95fb-da8491644fa6"",
             ""dependsOn"": [""1""],
             ""method"": ""PATCH"",
-            ""url"": ""http://odata.org/test//$1"",
+            ""url"": ""http://odata.org/test/$1"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -803,7 +803,7 @@ Content-Type: application/json;odata.metadata=none
             ""id"": ""1"",
             ""atomicityGroup"": ""11d431dd-cfee-48c8-95fb-da8491644fa6"",
             ""method"": ""PUT"",
-            ""url"": ""http://odata.org/test//MySingleton"",
+            ""url"": ""http://odata.org/test/MySingleton"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -818,7 +818,7 @@ Content-Type: application/json;odata.metadata=none
             ""atomicityGroup"": ""11d431dd-cfee-48c8-95fb-da8491644fa6"",
             ""dependsOn"": [""1""],
             ""method"": ""PATCH"",
-            ""url"": ""http://odata.org/test//$1"",
+            ""url"": ""http://odata.org/test/$1"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -831,7 +831,7 @@ Content-Type: application/json;odata.metadata=none
             ""id"": ""3"",
             ""dependsOn"": [""1"", ""2""],
             ""method"": ""PATCH"",
-            ""url"": ""http://odata.org/test//$1/alias"",
+            ""url"": ""http://odata.org/test/$1/alias"",
             ""headers"": {
                 ""odata-version"": ""4.0"",
                 ""content-type"": ""application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8""
@@ -1350,7 +1350,7 @@ Content-Type: application/json;odata.metadata=none
 
                 // DELETE singleton, invalid
                 batchWriter.WriteStartChangeset();
-                batchWriter.CreateOperationRequestMessage("DELETE", new Uri(serviceDocumentUri + "MySingleton"), "3");
+                batchWriter.CreateOperationRequestMessage("DELETE", new Uri(serviceDocumentUri + "/MySingleton"), "3");
                 batchWriter.WriteEndChangeset();
 
                 batchWriter.WriteEndBatch();
@@ -1955,7 +1955,7 @@ Content-Type: application/json;odata.metadata=none
 
                 // Write a query operation.
                 ODataBatchOperationRequestMessage queryOperationMessage =
-                    batchWriter.CreateOperationRequestMessage("GET", new Uri(serviceDocumentUri + "MySingleton"), "1"/*not written*/);
+                    batchWriter.CreateOperationRequestMessage("GET", new Uri(serviceDocumentUri + "/MySingleton"), "1"/*not written*/);
 
                 // Header modification on inner payload.
                 queryOperationMessage.SetHeader("Accept", "application/json;odata.metadata=full");
@@ -2042,7 +2042,7 @@ Content-Type: application/json;odata.metadata=none
 
                 // Write a query operation.
                 queryOperationMessage =
-                    batchWriter.CreateOperationRequestMessage("GET", new Uri(serviceDocumentUri + "MySingleton"), "4"/*not written*/);
+                    batchWriter.CreateOperationRequestMessage("GET", new Uri(serviceDocumentUri + "/MySingleton"), "4"/*not written*/);
 
                 // Header modification on inner payload.
                 queryOperationMessage.SetHeader("Accept", "application/json;odata.metadata=full");


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1187.*

### Description

*Skip reference url validation when it is in absolute url form and it is different from the baseUri.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
