### PR TITLE
Fix threadsafety in DataServiceClient EntityTracker's internal dictionary

### DIFF
--- a/src/Microsoft.OData.Client/DictionaryExtensions.cs
+++ b/src/Microsoft.OData.Client/DictionaryExtensions.cs
@@ -8,11 +8,12 @@ namespace Microsoft.OData.Client
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
+    using System.Collections.Concurrent;
+	using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
-    /// Useful extension methods for IDictionary
+    /// Useful extension methods for IDictionary and ConcurrentDictionary
     /// </summary>
     internal static class DictionaryExtensions
     {
@@ -54,6 +55,22 @@ namespace Microsoft.OData.Client
             }
         }
 
+		/// <summary>
+		/// Convenience funcion that wraps ConcurrentDictionary.TryAdd() to allow same signature as IDictionary
+		/// </summary>
+		public static bool Add<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key, TValue value)
+		{
+			return self.TryAdd(key, value);
+		}
+
+		/// <summary>
+		/// Convenience function for ConcurrentDictionary to allow same signature as IDictionary
+		/// </summary>
+		public static bool Remove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key)
+		{
+			return ((IDictionary<TKey, TValue>)self).Remove(key);
+		}
+
 #if PORTABLELIB
         /// <summary>
         /// Try to add a key/value pair to the dictionary and returns true if the key was added, false if it was already present.
@@ -86,5 +103,5 @@ namespace Microsoft.OData.Client
             return false;
         }
 #endif
-    }
+	}
 }

--- a/src/Microsoft.OData.Client/DictionaryExtensions.cs
+++ b/src/Microsoft.OData.Client/DictionaryExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OData.Client
     using System.Collections.Concurrent;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
-
+    
     /// <summary>
     /// Useful extension methods for IDictionary and ConcurrentDictionary
     /// </summary>
@@ -58,9 +58,10 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Convenience funcion that wraps ConcurrentDictionary.TryAdd() to allow same signature as IDictionary
         /// </summary>
-        public static bool Add<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key, TValue value)
+        public static void Add<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key, TValue value)
         {
-            return self.TryAdd(key, value);
+            if(!self.TryAdd(key, value))
+                throw new ArgumentException("Argument_AddingDuplicate");
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/DictionaryExtensions.cs
+++ b/src/Microsoft.OData.Client/DictionaryExtensions.cs
@@ -55,21 +55,21 @@ namespace Microsoft.OData.Client
             }
         }
 
-		/// <summary>
-		/// Convenience funcion that wraps ConcurrentDictionary.TryAdd() to allow same signature as IDictionary
-		/// </summary>
-		public static bool Add<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key, TValue value)
-		{
-			return self.TryAdd(key, value);
-		}
+        /// <summary>
+        /// Convenience funcion that wraps ConcurrentDictionary.TryAdd() to allow same signature as IDictionary
+        /// </summary>
+        public static bool Add<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key, TValue value)
+        {
+            return self.TryAdd(key, value);
+        }
 
-		/// <summary>
-		/// Convenience function for ConcurrentDictionary to allow same signature as IDictionary
-		/// </summary>
-		public static bool Remove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key)
+        /// <summary>
+        /// Convenience function for ConcurrentDictionary to allow same signature as IDictionary
+        /// </summary>
+        public static bool Remove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key)
 		{
-			return ((IDictionary<TKey, TValue>)self).Remove(key);
-		}
+            return ((IDictionary<TKey, TValue>)self).Remove(key);
+        }
 
 #if PORTABLELIB
         /// <summary>

--- a/src/Microsoft.OData.Client/DictionaryExtensions.cs
+++ b/src/Microsoft.OData.Client/DictionaryExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OData.Client
     using System.Collections.Concurrent;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
-    
+
     /// <summary>
     /// Useful extension methods for IDictionary and ConcurrentDictionary
     /// </summary>
@@ -55,24 +55,7 @@ namespace Microsoft.OData.Client
             }
         }
 
-        /// <summary>
-        /// Convenience funcion that wraps ConcurrentDictionary.TryAdd() to allow same signature as IDictionary
-        /// </summary>
-        public static void Add<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key, TValue value)
-        {
-            if(!self.TryAdd(key, value))
-                throw new ArgumentException("Argument_AddingDuplicate");
-        }
-
-        /// <summary>
-        /// Convenience function for ConcurrentDictionary to allow same signature as IDictionary
-        /// </summary>
-        public static bool Remove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key)
-		{
-            return ((IDictionary<TKey, TValue>)self).Remove(key);
-        }
-
-#if PORTABLELIB
+#if PORTABLELIB && WINDOWSPHONE
         /// <summary>
         /// Try to add a key/value pair to the dictionary and returns true if the key was added, false if it was already present.
         /// The difference with Add is that it will not throw <see cref="ArgumentException"/> if the key is already present.
@@ -102,6 +85,23 @@ namespace Microsoft.OData.Client
             }
 
             return false;
+        }
+#else
+        /// <summary>
+        /// Convenience function that wraps ConcurrentDictionary.TryAdd() to allow same signature as IDictionary
+        /// </summary>
+        public static void Add<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key, TValue value)
+        {
+            if (!self.TryAdd(key, value))
+                throw new ArgumentException("Argument_AddingDuplicate");
+        }
+
+        /// <summary>
+        /// Convenience function for ConcurrentDictionary to allow same signature as IDictionary
+        /// </summary>
+        public static bool Remove<TKey, TValue>(this ConcurrentDictionary<TKey, TValue> self, TKey key)
+        {
+            return ((IDictionary<TKey, TValue>)self).Remove(key);
         }
 #endif
     }

--- a/src/Microsoft.OData.Client/DictionaryExtensions.cs
+++ b/src/Microsoft.OData.Client/DictionaryExtensions.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OData.Client
     using System;
     using System.Collections.Generic;
     using System.Collections.Concurrent;
-	using System.Diagnostics;
+    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -103,5 +103,5 @@ namespace Microsoft.OData.Client
             return false;
         }
 #endif
-	}
+    }
 }

--- a/src/Microsoft.OData.Client/EntityTracker.cs
+++ b/src/Microsoft.OData.Client/EntityTracker.cs
@@ -52,9 +52,9 @@ namespace Microsoft.OData.Client
 
         /// <summary>change order</summary>
         private uint nextChange;
-#endregion
+     #endregion
 
-#region ctor
+     #region ctor
 
         /// <summary>
         /// Creates a new instance of EntityTracker class which tracks all instances of entities and links tracked by the context.
@@ -65,9 +65,9 @@ namespace Microsoft.OData.Client
             this.model = maxProtocolVersion;
         }
 
-#endregion
+     #endregion
 
-#region Properties
+     #region Properties
 
         /// <summary>
         /// Returns a collection of all the links (ie. associations) currently being tracked by the context.
@@ -93,9 +93,9 @@ namespace Microsoft.OData.Client
                 return this.entityDescriptors.Values;
             }
         }
-#endregion
+     #endregion
 
-#region Entity Methods
+     #region Entity Methods
 
         /// <summary>Gets the entity descriptor corresponding to a particular entity</summary>
         /// <param name="entity">Entity for which to find the entity descriptor</param>
@@ -199,9 +199,9 @@ namespace Microsoft.OData.Client
             }
         }
 
-#endregion Entity Methods
+     #endregion Entity Methods
 
-#region Link Methods
+     #region Link Methods
         /// <summary>
         /// Gets the link descriptor corresponding to a particular link b/w source and target objects
         /// </summary>
@@ -382,7 +382,7 @@ namespace Microsoft.OData.Client
             }
         }
 
-#endregion // Link Methods
+     #endregion // Link Methods
 
         /// <summary>response materialization has an identity to attach to the inserted object</summary>
         /// <param name="entityDescriptorFromMaterializer">entity descriptor containing all the information about the entity from the response.</param>

--- a/src/Microsoft.OData.Client/EntityTracker.cs
+++ b/src/Microsoft.OData.Client/EntityTracker.cs
@@ -52,9 +52,9 @@ namespace Microsoft.OData.Client
 
         /// <summary>change order</summary>
         private uint nextChange;
-     #endregion
+        #endregion
 
-     #region ctor
+        #region ctor
 
         /// <summary>
         /// Creates a new instance of EntityTracker class which tracks all instances of entities and links tracked by the context.
@@ -65,9 +65,9 @@ namespace Microsoft.OData.Client
             this.model = maxProtocolVersion;
         }
 
-     #endregion
+        #endregion
 
-     #region Properties
+        #region Properties
 
         /// <summary>
         /// Returns a collection of all the links (ie. associations) currently being tracked by the context.
@@ -93,9 +93,9 @@ namespace Microsoft.OData.Client
                 return this.entityDescriptors.Values;
             }
         }
-     #endregion
+        #endregion
 
-     #region Entity Methods
+        #region Entity Methods
 
         /// <summary>Gets the entity descriptor corresponding to a particular entity</summary>
         /// <param name="entity">Entity for which to find the entity descriptor</param>
@@ -199,9 +199,9 @@ namespace Microsoft.OData.Client
             }
         }
 
-     #endregion Entity Methods
+        #endregion Entity Methods
 
-     #region Link Methods
+        #region Link Methods
         /// <summary>
         /// Gets the link descriptor corresponding to a particular link b/w source and target objects
         /// </summary>
@@ -382,7 +382,7 @@ namespace Microsoft.OData.Client
             }
         }
 
-     #endregion // Link Methods
+        #endregion // Link Methods
 
         /// <summary>response materialization has an identity to attach to the inserted object</summary>
         /// <param name="entityDescriptorFromMaterializer">entity descriptor containing all the information about the entity from the response.</param>
@@ -558,8 +558,8 @@ namespace Microsoft.OData.Client
             #else
                 System.Threading.Interlocked.CompareExchange(ref this.bindings, new ConcurrentDictionary<LinkDescriptor, LinkDescriptor>(LinkDescriptor.EquivalenceComparer), null);
             #endif
-			}
-		}
+            }
+        }
 
         /// <summary>
         /// Ensure an identity is unique and does not point to another resource

--- a/src/Microsoft.OData.Client/EntityTracker.cs
+++ b/src/Microsoft.OData.Client/EntityTracker.cs
@@ -28,8 +28,8 @@ namespace Microsoft.OData.Client
 		#region Resource state management
 
 #if PORTABLELIB && WINDOWSPHONE
-		/// <summary>Set of tracked resources</summary>
-		private Dictionary<object, EntityDescriptor> entityDescriptors = new Dictionary<object, EntityDescriptor>(EqualityComparer<object>.Default);
+        /// <summary>Set of tracked resources</summary>
+        private Dictionary<object, EntityDescriptor> entityDescriptors = new Dictionary<object, EntityDescriptor>(EqualityComparer<object>.Default);
 #else
 		/// <summary>Set of tracked resources</summary>
 		private ConcurrentDictionary<object, EntityDescriptor> entityDescriptors = new ConcurrentDictionary<object, EntityDescriptor>(EqualityComparer<object>.Default);
@@ -43,7 +43,7 @@ namespace Microsoft.OData.Client
 #endif
 
 #if PORTABLELIB && WINDOWSPHONE
-		/// <summary>Set of tracked bindings</summary>
+        /// <summary>Set of tracked bindings</summary>
         private Dictionary<LinkDescriptor, LinkDescriptor> bindings;
 #else
 		/// <summary>Set of tracked bindings</summary>
@@ -554,7 +554,7 @@ namespace Microsoft.OData.Client
             if (null == this.bindings)
             {
 #if PORTABLELIB && WINDOWSPHONE
-				System.Threading.Interlocked.CompareExchange(ref this.bindings, new Dictionary<LinkDescriptor, LinkDescriptor>(LinkDescriptor.EquivalenceComparer), null);
+                System.Threading.Interlocked.CompareExchange(ref this.bindings, new Dictionary<LinkDescriptor, LinkDescriptor>(LinkDescriptor.EquivalenceComparer), null);
 #else
 				System.Threading.Interlocked.CompareExchange(ref this.bindings, new ConcurrentDictionary<LinkDescriptor, LinkDescriptor>(LinkDescriptor.EquivalenceComparer), null);
 #endif

--- a/src/Microsoft.OData.Client/EntityTracker.cs
+++ b/src/Microsoft.OData.Client/EntityTracker.cs
@@ -9,8 +9,8 @@ namespace Microsoft.OData.Client
     #region Namespaces
     using System;
     using System.Collections.Generic;
-	using System.Collections.Concurrent;
-	using System.Diagnostics;
+    using System.Collections.Concurrent;
+    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Runtime.Serialization;
@@ -25,33 +25,33 @@ namespace Microsoft.OData.Client
         /// <summary>Storage for the client model.</summary>
         private readonly ClientEdmModel model;
 
-		#region Resource state management
+        #region Resource state management
 
-#if PORTABLELIB && WINDOWSPHONE
+    #if PORTABLELIB && WINDOWSPHONE
         /// <summary>Set of tracked resources</summary>
         private Dictionary<object, EntityDescriptor> entityDescriptors = new Dictionary<object, EntityDescriptor>(EqualityComparer<object>.Default);
-#else
-		/// <summary>Set of tracked resources</summary>
-		private ConcurrentDictionary<object, EntityDescriptor> entityDescriptors = new ConcurrentDictionary<object, EntityDescriptor>(EqualityComparer<object>.Default);
-#endif
-#if PORTABLELIB && WINDOWSPHONE
-		/// <summary>Set of tracked resources by Identity</summary>
-		private Dictionary<Uri, EntityDescriptor> identityToDescriptor;
-#else
-		/// <summary>Set of tracked resources by Identity</summary>
-		private ConcurrentDictionary<Uri, EntityDescriptor> identityToDescriptor;
-#endif
+    #else
+        /// <summary>Set of tracked resources</summary>
+        private ConcurrentDictionary<object, EntityDescriptor> entityDescriptors = new ConcurrentDictionary<object, EntityDescriptor>(EqualityComparer<object>.Default);
+    #endif
+    #if PORTABLELIB && WINDOWSPHONE
+        /// <summary>Set of tracked resources by Identity</summary>
+        private Dictionary<Uri, EntityDescriptor> identityToDescriptor;
+    #else
+        /// <summary>Set of tracked resources by Identity</summary>
+        private ConcurrentDictionary<Uri, EntityDescriptor> identityToDescriptor;
+    #endif
 
-#if PORTABLELIB && WINDOWSPHONE
+    #if PORTABLELIB && WINDOWSPHONE
         /// <summary>Set of tracked bindings</summary>
         private Dictionary<LinkDescriptor, LinkDescriptor> bindings;
-#else
-		/// <summary>Set of tracked bindings</summary>
-		private ConcurrentDictionary<LinkDescriptor, LinkDescriptor> bindings;
-#endif
+    #else
+        /// <summary>Set of tracked bindings</summary>
+        private ConcurrentDictionary<LinkDescriptor, LinkDescriptor> bindings;
+    #endif
 
-		/// <summary>change order</summary>
-		private uint nextChange;
+        /// <summary>change order</summary>
+        private uint nextChange;
 #endregion
 
 #region ctor
@@ -540,11 +540,11 @@ namespace Microsoft.OData.Client
         {
             if (null == this.identityToDescriptor)
             {
-#if PORTABLELIB && WINDOWSPHONE
+            #if PORTABLELIB && WINDOWSPHONE
                 System.Threading.Interlocked.CompareExchange(ref this.identityToDescriptor, new Dictionary<Uri, EntityDescriptor>(EqualityComparer<Uri>.Default), null);
-#else
-				System.Threading.Interlocked.CompareExchange(ref this.identityToDescriptor, new ConcurrentDictionary<Uri, EntityDescriptor>(EqualityComparer<Uri>.Default), null);
-#endif
+            #else
+                System.Threading.Interlocked.CompareExchange(ref this.identityToDescriptor, new ConcurrentDictionary<Uri, EntityDescriptor>(EqualityComparer<Uri>.Default), null);
+            #endif
 			}
 		}
 
@@ -553,11 +553,11 @@ namespace Microsoft.OData.Client
         {
             if (null == this.bindings)
             {
-#if PORTABLELIB && WINDOWSPHONE
+            #if PORTABLELIB && WINDOWSPHONE
                 System.Threading.Interlocked.CompareExchange(ref this.bindings, new Dictionary<LinkDescriptor, LinkDescriptor>(LinkDescriptor.EquivalenceComparer), null);
-#else
-				System.Threading.Interlocked.CompareExchange(ref this.bindings, new ConcurrentDictionary<LinkDescriptor, LinkDescriptor>(LinkDescriptor.EquivalenceComparer), null);
-#endif
+            #else
+                System.Threading.Interlocked.CompareExchange(ref this.bindings, new ConcurrentDictionary<LinkDescriptor, LinkDescriptor>(LinkDescriptor.EquivalenceComparer), null);
+            #endif
 			}
 		}
 


### PR DESCRIPTION
Issues
This pull request fixes issue #1043 and is a resubmit of PR #1054 with CR comments addressed.

Description
Replaces EntityTracker's internal Dictionary<> objects with thread-safe ConcurrentDictionary<> ones.

Checklist (Uncheck if it is not completed)
 Test cases added
 Build and test with one-click build and test script passed