### PR TITLE
Fix issue #1216, parameter reader should not throw exception if missing optional parameter

### DIFF
--- a/src/Microsoft.OData.Core/ODataParameterReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterReaderCore.cs
@@ -280,9 +280,14 @@ this.State == ODataParameterReaderState.Collection,
                     // Note that the binding parameter will be specified on the Uri rather than the payload, skip the binding parameter.
                     foreach (IEdmOperationParameter parameter in this.Operation.Parameters.Skip(this.Operation.IsBound ? 1 : 0))
                     {
-                        if (!this.parametersRead.Contains(parameter.Name) && !this.inputContext.EdmTypeResolver.GetParameterType(parameter).IsNullable)
+                        bool isOptionalPameter = parameter is IEdmOptionalParameter;
+                        if (!isOptionalPameter)
                         {
-                            missingParameters.Add(parameter.Name);
+                            // only check the non-optional parameter
+                            if (!this.parametersRead.Contains(parameter.Name) && !this.inputContext.EdmTypeResolver.GetParameterType(parameter).IsNullable)
+                            {
+                                missingParameters.Add(parameter.Name);
+                            }
                         }
                     }
 

--- a/src/Microsoft.OData.Core/ODataParameterReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterReaderCore.cs
@@ -280,10 +280,9 @@ this.State == ODataParameterReaderState.Collection,
                     // Note that the binding parameter will be specified on the Uri rather than the payload, skip the binding parameter.
                     foreach (IEdmOperationParameter parameter in this.Operation.Parameters.Skip(this.Operation.IsBound ? 1 : 0))
                     {
-                        bool isOptionalPameter = parameter is IEdmOptionalParameter;
-                        if (!isOptionalPameter)
+                        // only check the non-optional parameter
+                        if (!(parameter is IEdmOptionalParameter))
                         {
-                            // only check the non-optional parameter
                             if (!this.parametersRead.Contains(parameter.Name) && !this.inputContext.EdmTypeResolver.GetParameterType(parameter).IsNullable)
                             {
                                 missingParameters.Add(parameter.Name);

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOptionalParameter.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOptionalParameter.cs
@@ -4,8 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using Microsoft.OData.Edm.Vocabularies;
-
 namespace Microsoft.OData.Edm
 {
     /// <summary>


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

* OData parameter reader should not throw exception if missing the optional parameter.

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
