### PR TITLE
use V7 ODL content as the default site for on odata.github.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,8 +65,7 @@ $(document).ready(function(){
       <ul class="nav nav-pills nav-stacked">
         {% assign sortedCategories = site.categories | sort %}
         {% for category in sortedCategories %}
-        {% if category contains "v6" or category contains "v7" or category contains "4. Release Notes" or category contains "5. OData Features" %}
-        {% else %}
+        {% if category contains "1. Core" or category contains "2. EdmLib" or category contains "3. Spatial" or category contains "4. Release Notes" or category contains "5. OData Features" %}
         <li class="panel panel-default">
           <a class="panel-heading">
             <small>{{ category[0] | upcase }}</small>
@@ -75,7 +74,7 @@ $(document).ready(function(){
             <ul class="nav nav-pills nav-stacked">
               {% for posts in category %}
               {% for post in posts reversed %}
-              {% if post.categories contains "v6" %}
+              {% if post.categories contains "v7" %}
               {% if post.title != null%}
               <li class="nav-item">
                 <a href="#{{ post.id | remove_first:'/'}}"><small>{{ post.title }}</small></a>
@@ -96,19 +95,18 @@ $(document).ready(function(){
       <div class="alert alert-success" role="alert">
         For a unified experience, please go to the <a href="https://github.com/odata/odata.net/issues" target="_blank">GitHub Issues</a> to ask question, report bugs, and ask for features.
         <br />
-        This document is for library version 6.
+        This documentation describes the latest OData library version 7.
         <br />
-        For library version 7 document (still under construction), please refer <a href="http://odata.github.io/odata.net/v7" target="_blank">here</a>.
+        For documentation of earlier versions of the OData Library, which are now in maintenance mode, please refer <a href="http://odata.github.io/odata.net/v6" target="_blank">here</a>.
       </div>
       {% assign sortedCategories = site.categories | sort %}
       {% for category in sortedCategories %}
-      {% if category contains "v6" or category contains "v7" or category contains "4. Release Notes" or category contains "5. OData Features" %}
-      {% else %}
+      {% if category contains "1. Core" or category contains "2. EdmLib" or category contains "3. Spatial" or category contains "4. Release Notes" or category contains "5. OData Features" %}
       <h1 class="post-title" id="{{ category[0] | replace:' ','-' | replace:'.','' }}">{{ category[0] | join: "/" | upcase }}</h1>
       <ul class="post-list">
         {% for posts in category %}
         {% for post in posts reversed %}
-        {% if post.categories contains "v6" %}
+        {% if post.categories contains "v7" %}
         {% if post.title != null%}
         <li>
           <h2 class="post-title" id="{{ post.id | remove_first:'/'}}">{{ post.title }}</h2>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request updates the odata.net gh-page doc root index to serve V7 content.*

### Description

*Updates for using V7 categories & content.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
