### PR TITLE
Fixing lexer bug that breaks functions named 'in'

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -348,7 +348,18 @@ namespace Microsoft.OData.UriParser
             {
             }
 
-            bool matched = this.CurrentToken.Kind == ExpressionTokenKind.Identifier && this.PeekNextToken().Kind == ExpressionTokenKind.OpenParen;
+            bool matched = false;
+            if (this.CurrentToken.Kind == ExpressionTokenKind.Identifier)
+            {
+                ExpressionTokenKind nextKind = this.PeekNextToken().Kind;
+
+                // Special case for 'in' operator: It is legal to have a custom function with the same name as an operator.
+                // If the current identifier is 'in', PeekNextToken() will return ParenthesesExpression instead of OpenParen.
+                // Nevertheless, we should still treat it as a function.
+                matched =
+                    nextKind == ExpressionTokenKind.OpenParen ||
+                    (nextKind == ExpressionTokenKind.ParenthesesExpression && this.CurrentToken.Text == ExpressionConstants.KeywordIn);
+            }
 
             if (matched)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -64,6 +64,16 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
 
         [Fact]
+        public void QualifiedFunctionNamedAfterOperatorShouldParseSuccessfully()
+        {
+            this.testSubject.ParseFilter("fq.ns.in()").ShouldBeFunctionCallToken("fq.ns.in");
+            this.testSubject.ParseFilter("fq.ns.eq()").ShouldBeFunctionCallToken("fq.ns.eq");
+            this.testSubject.ParseFilter("fq.ns.ne()").ShouldBeFunctionCallToken("fq.ns.ne");
+            this.testSubject.ParseFilter("fq.ns.any()").ShouldBeFunctionCallToken("fq.ns.any");
+            this.testSubject.ParseFilter("fq.ns.all()").ShouldBeFunctionCallToken("fq.ns.all");
+        }
+
+        [Fact]
         public void QualifiedFunctionNameWithParameterShouldParseSuccessfully()
         {
             this.testSubject.ParseFilter("fq.ns.container.function(arg=1)")


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1232 .*

### Description

Judging by the behavior of all previous versions of OData, it should be legal to have a custom function with the same name as an operator. However, the introduction of the 'in' operator broke this for functions named 'in'. This change ensures that functions named 'in' are treated the same as any other function by the ExpressionLexer.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [] *Build and test with one-click build and test script passed*

### Additional work necessary

None
