### PR TITLE
Add an optional file path for large metadata files

### DIFF
--- a/src/CodeGen/ODataT4CodeGenerator.cs
+++ b/src/CodeGen/ODataT4CodeGenerator.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.OData.Client.Design.T4
+namespace Microsoft.Test.OData.Tests.Client
 {
     using System;
     using System.IO;

--- a/src/CodeGen/ODataT4CodeGenerator.cs
+++ b/src/CodeGen/ODataT4CodeGenerator.cs
@@ -7,7 +7,7 @@
 //     the code is regenerated.
 // </auto-generated>
 // ------------------------------------------------------------------------------
-namespace Microsoft.Test.OData.Tests.Client
+namespace Microsoft.OData.Client.Design.T4
 {
     using System;
     using System.IO;

--- a/src/CodeGen/ODataT4CodeGenerator.tt
+++ b/src/CodeGen/ODataT4CodeGenerator.tt
@@ -17,6 +17,10 @@ public static class Configuration
 
 	// The target language of the generated client code. The value must be set to "CSharp" or "VB".
 	public const string TargetLanguage = "OutputLanguage";
+	
+	// The path for the temporary file where the metadata xml document can be stored. Use this if your metadata is too big to be stored in a string literal. Ensure that you have write permission for this path.
+	// For example - "C:\\temp\\Test.xml"	
+	public const string TempFilePath = "";
 
 	// This flag indicates whether to enable naming alias. The value must be set to true or false.
 	public const bool EnableNamingAlias = true;

--- a/src/CodeGen/ODataT4CodeGenerator.tt
+++ b/src/CodeGen/ODataT4CodeGenerator.tt
@@ -20,7 +20,7 @@ public static class Configuration
 	
 	// The path for the temporary file where the metadata xml document can be stored. Use this if your metadata is too big to be stored in a string literal. Ensure that you have write permission for this path.
 	// For example - "C:\\temp\\Test.xml"	
-	public const string TempFilePath = "";
+	public const string TempFilePath = string.Empty;
 
 	// This flag indicates whether to enable naming alias. The value must be set to true or false.
 	public const bool EnableNamingAlias = true;

--- a/src/CodeGen/ODataT4CodeGenerator.tt
+++ b/src/CodeGen/ODataT4CodeGenerator.tt
@@ -20,7 +20,7 @@ public static class Configuration
 	
 	// The path for the temporary file where the metadata xml document can be stored. Use this if your metadata is too big to be stored in a string literal. Ensure that you have write permission for this path.
 	// For example - "C:\\temp\\Test.xml"	
-	public const string TempFilePath = string.Empty;
+	public const string TempFilePath = "";
 
 	// This flag indicates whether to enable naming alias. The value must be set to true or false.
 	public const bool EnableNamingAlias = true;

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -3440,9 +3440,10 @@ namespace <#= fullNamespace #>
 
     internal override void WriteGeneratedEdmModel(string escapedEdmxString)
     {
+
 		string path = this.context.TempFilePath; 
         
-		if(String.IsNullOrEmpty(path))
+		if(!String.IsNullOrEmpty(path))
 		{
 			using (StreamWriter writer = new StreamWriter(path, true))
 			{

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -695,7 +695,7 @@ public class CodeGenerationContext
         get;
         set;
     }
-	
+    
     /// <summary>
     /// The path for the temporary file where the metadata xml document can be stored.
     /// </summary>
@@ -3441,17 +3441,17 @@ namespace <#= fullNamespace #>
     internal override void WriteGeneratedEdmModel(string escapedEdmxString)
     {
 
-		string path = this.context.TempFilePath; 
+        string path = this.context.TempFilePath; 
         
-		if(!String.IsNullOrEmpty(path))
-		{
-			using (StreamWriter writer = new StreamWriter(path, true))
-			{
-				writer.WriteLine(escapedEdmxString);
-			}
-		}
+        if(!String.IsNullOrEmpty(path))
+        {
+            using (StreamWriter writer = new StreamWriter(path, true))
+            {
+                writer.WriteLine(escapedEdmxString);
+            }
+        }
 
-		bool useTempFile = !String.IsNullOrEmpty(path) && System.IO.File.Exists(path);
+        bool useTempFile = !String.IsNullOrEmpty(path) && System.IO.File.Exists(path);
 #>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
         private abstract class GeneratedEdmModel
@@ -3479,17 +3479,17 @@ namespace <#= fullNamespace #>
             private static global::Microsoft.OData.Edm.IEdmModel ParsedModel = LoadModelFromString();
 <#+
         if(useTempFile)
-		{
+        {
 #>   
-		   [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
+           [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
            private const string filePath = @"<#= path #>";
 <#+
         }
-		else
-		{
+        else
+        {
 #>
-		   [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-           private const string Edmx = @"<#= escapedEdmxString #>";
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
+            private const string Edmx = @"<#= escapedEdmxString #>";
 <#+
         }
 #>
@@ -3517,18 +3517,18 @@ namespace <#= fullNamespace #>
             private static global::Microsoft.OData.Edm.IEdmModel LoadModelFromString()
             {
 <#+
-			if(useTempFile)
-			{
+            if(useTempFile)
+            {
 #>   
-				global::System.Xml.XmlReader reader = CreateXmlReader();
+                global::System.Xml.XmlReader reader = CreateXmlReader();
 <#+
-			}
-			else
-			{
+            }
+            else
+            {
 #>
-				global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
+                global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
 <#+
-			}
+            }
 #>
                 try
                 {
@@ -3548,18 +3548,18 @@ namespace <#= fullNamespace #>
             private static global::Microsoft.OData.Edm.IEdmModel LoadModelFromString()
             {
 <#+
-			if(useTempFile)
-			{
+            if(useTempFile)
+            {
 #>   
-				global::System.Xml.XmlReader reader = CreateXmlReader();
+                global::System.Xml.XmlReader reader = CreateXmlReader();
 <#+
-			}
-			else
-			{
+            }
+            else
+            {
 #>
-				global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
+                global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
 <#+
-			}
+            }
 #>
                 try
                 {
@@ -3593,16 +3593,16 @@ namespace <#= fullNamespace #>
                 return global::System.Xml.XmlReader.Create(new global::System.IO.StringReader(edmxToParse));
             }
 <#+
-		if(useTempFile)
-		{
+        if(useTempFile)
+        {
 #>   
-				[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-				private static global::System.Xml.XmlReader CreateXmlReader()
-				{
-					return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(filePath));
-				}
+                [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
+                private static global::System.Xml.XmlReader CreateXmlReader()
+                {
+                    return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(filePath));
+                }
 <#+
-		}
+        }
 #>
         }
 <#+

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -328,7 +328,7 @@ private void ApplyParametersFromConfigurationClass()
     this.ValidateAndSetTargetLanguageFromString(Configuration.TargetLanguage);
     this.EnableNamingAlias = Configuration.EnableNamingAlias;
     this.TempFilePath = Configuration.TempFilePath;
-	this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
+    this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
 }
 
 /// <summary>
@@ -3450,8 +3450,7 @@ namespace <#= fullNamespace #>
         
 		if(String.IsNullOrEmpty(path))
 		{
-			using (StreamWriter writer =
-            new StreamWriter(path, true))
+			using (StreamWriter writer = new StreamWriter(path, true))
 			{
 				writer.WriteLine(escapedEdmxString);
 			}

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -70,7 +70,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
         };
     }
 
-    if(this.GetReferencedModelReaderFunc != null)
+    if (this.GetReferencedModelReaderFunc != null)
     {
         context.GetReferencedModelReaderFunc = this.GetReferencedModelReaderFunc;
     }
@@ -3443,7 +3443,7 @@ namespace <#= fullNamespace #>
 
         string path = this.context.TempFilePath; 
         
-        if(!String.IsNullOrEmpty(path))
+        if (!String.IsNullOrEmpty(path))
         {
             using (StreamWriter writer = new StreamWriter(path, true))
             {
@@ -3478,7 +3478,7 @@ namespace <#= fullNamespace #>
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
             private static global::Microsoft.OData.Edm.IEdmModel ParsedModel = LoadModelFromString();
 <#+
-        if(useTempFile)
+        if (useTempFile)
         {
 #>   
            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
@@ -3517,7 +3517,7 @@ namespace <#= fullNamespace #>
             private static global::Microsoft.OData.Edm.IEdmModel LoadModelFromString()
             {
 <#+
-            if(useTempFile)
+            if (useTempFile)
             {
 #>   
                 global::System.Xml.XmlReader reader = CreateXmlReader();
@@ -3548,7 +3548,7 @@ namespace <#= fullNamespace #>
             private static global::Microsoft.OData.Edm.IEdmModel LoadModelFromString()
             {
 <#+
-            if(useTempFile)
+            if (useTempFile)
             {
 #>   
                 global::System.Xml.XmlReader reader = CreateXmlReader();
@@ -3593,7 +3593,7 @@ namespace <#= fullNamespace #>
                 return global::System.Xml.XmlReader.Create(new global::System.IO.StringReader(edmxToParse));
             }
 <#+
-        if(useTempFile)
+        if (useTempFile)
         {
 #>   
                 [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -353,12 +353,6 @@ private void ApplyParametersFromCommandLine()
         this.NamespacePrefix = namespacePrefix;
     }
 
-	string tempFilePath = this.Host.ResolveParameterValue("notempty", "notempty", "TempFilePath");
-    if (!string.IsNullOrEmpty(tempFilePath))
-    {
-        this.TempFilePath = tempFilePath;
-    }
-
     string useDataServiceCollection = this.Host.ResolveParameterValue("notempty", "notempty", "UseDataServiceCollection");
     if (!string.IsNullOrEmpty(useDataServiceCollection))
     {

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -48,6 +48,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             UseDataServiceCollection = this.UseDataServiceCollection,
             TargetLanguage = this.TargetLanguage,
             EnableNamingAlias = this.EnableNamingAlias,
+			TempFilePath = this.TempFilePath,
             IgnoreUnexpectedElementsAndAttributes = this.IgnoreUnexpectedElementsAndAttributes
         };
     }
@@ -64,6 +65,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             UseDataServiceCollection = this.UseDataServiceCollection,
             TargetLanguage = this.TargetLanguage,
             EnableNamingAlias = this.EnableNamingAlias,
+            TempFilePath = this.TempFilePath,
             IgnoreUnexpectedElementsAndAttributes = this.IgnoreUnexpectedElementsAndAttributes
         };
     }
@@ -206,6 +208,15 @@ public bool EnableNamingAlias
 }
 
 /// <summary>
+/// The path for the temporary file where the metadata xml document can be stored.
+/// </summary>
+public string TempFilePath
+{
+    get;
+    set;
+}
+
+/// <summary>
 /// true to ignore unknown elements or attributes in metadata, false otherwise.
 /// </summary>
 public bool IgnoreUnexpectedElementsAndAttributes
@@ -316,7 +327,8 @@ private void ApplyParametersFromConfigurationClass()
     this.UseDataServiceCollection = Configuration.UseDataServiceCollection;
     this.ValidateAndSetTargetLanguageFromString(Configuration.TargetLanguage);
     this.EnableNamingAlias = Configuration.EnableNamingAlias;
-    this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
+    this.TempFilePath = Configuration.TempFilePath;
+	this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
 }
 
 /// <summary>
@@ -339,6 +351,12 @@ private void ApplyParametersFromCommandLine()
     if (!string.IsNullOrEmpty(namespacePrefix))
     {
         this.NamespacePrefix = namespacePrefix;
+    }
+
+	string tempFilePath = this.Host.ResolveParameterValue("notempty", "notempty", "TempFilePath");
+    if (!string.IsNullOrEmpty(tempFilePath))
+    {
+        this.TempFilePath = tempFilePath;
     }
 
     string useDataServiceCollection = this.Host.ResolveParameterValue("notempty", "notempty", "UseDataServiceCollection");
@@ -683,7 +701,15 @@ public class CodeGenerationContext
         get;
         set;
     }
-
+	
+    /// <summary>
+    /// The path for the temporary file where the metadata xml document can be stored.
+    /// </summary>
+    public string TempFilePath
+    {
+        get;
+        set;
+    }
     /// <summary>
     /// true to use Upper camel case for all class and property names, false otherwise.
     /// </summary>
@@ -3420,6 +3446,18 @@ namespace <#= fullNamespace #>
 
     internal override void WriteGeneratedEdmModel(string escapedEdmxString)
     {
+		string path = this.context.TempFilePath; 
+        
+		if(String.IsNullOrEmpty(path))
+		{
+			using (StreamWriter writer =
+            new StreamWriter(path, true))
+			{
+				writer.WriteLine(escapedEdmxString);
+			}
+		}
+
+		bool useTempFile = !String.IsNullOrEmpty(path) && System.IO.File.Exists(path);
 #>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
         private abstract class GeneratedEdmModel
@@ -3445,8 +3483,22 @@ namespace <#= fullNamespace #>
 #>
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
             private static global::Microsoft.OData.Edm.IEdmModel ParsedModel = LoadModelFromString();
-            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
-            private const string Edmx = @"<#= escapedEdmxString #>";
+<#+
+        if(useTempFile)
+		{
+#>   
+		   [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
+           private const string filePath = @"<#= path #>";
+<#+
+        }
+		else
+		{
+#>
+		   [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
+           private const string Edmx = @"<#= escapedEdmxString #>";
+<#+
+        }
+#>
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
             public static global::Microsoft.OData.Edm.IEdmModel GetInstance()
             {
@@ -3470,7 +3522,20 @@ namespace <#= fullNamespace #>
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
             private static global::Microsoft.OData.Edm.IEdmModel LoadModelFromString()
             {
-                global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
+<#+
+			if(useTempFile)
+			{
+#>   
+				global::System.Xml.XmlReader reader = CreateXmlReader();
+<#+
+			}
+			else
+			{
+#>
+				global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
+<#+
+			}
+#>
                 try
                 {
                     return global::Microsoft.OData.Edm.Csdl.CsdlReader.Parse(reader, getReferencedModelFromMap);
@@ -3488,7 +3553,20 @@ namespace <#= fullNamespace #>
             [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
             private static global::Microsoft.OData.Edm.IEdmModel LoadModelFromString()
             {
-                global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
+<#+
+			if(useTempFile)
+			{
+#>   
+				global::System.Xml.XmlReader reader = CreateXmlReader();
+<#+
+			}
+			else
+			{
+#>
+				global::System.Xml.XmlReader reader = CreateXmlReader(Edmx);
+<#+
+			}
+#>
                 try
                 {
                     global::System.Collections.Generic.IEnumerable<global::Microsoft.OData.Edm.Validation.EdmError> errors;
@@ -3520,6 +3598,18 @@ namespace <#= fullNamespace #>
             {
                 return global::System.Xml.XmlReader.Create(new global::System.IO.StringReader(edmxToParse));
             }
+<#+
+		if(useTempFile)
+		{
+#>   
+				[global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "<#=T4Version#>")]
+				private static global::System.Xml.XmlReader CreateXmlReader()
+				{
+					return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(filePath));
+				}
+<#+
+		}
+#>
         }
 <#+
     }

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -48,7 +48,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             UseDataServiceCollection = this.UseDataServiceCollection,
             TargetLanguage = this.TargetLanguage,
             EnableNamingAlias = this.EnableNamingAlias,
-			TempFilePath = this.TempFilePath,
+            TempFilePath = this.TempFilePath,
             IgnoreUnexpectedElementsAndAttributes = this.IgnoreUnexpectedElementsAndAttributes
         };
     }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTestDescriptors.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTestDescriptors.cs
@@ -79,18 +79,22 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
                 "Global.System.CodeDom.Compiler.GeneratedCodeAttribute\\(.*\\)",
                 "Global.System.CodeDom.Compiler.GeneratedCodeAttribute(\"Microsoft.OData.Client.Design.T4\", \"" + T4Version + "\")",
                 RegexOptions.Multiline);
+            //Remove the spaces from the string to avoid indentation change errors
+            string rawExpectedCode = Regex.Replace(normalizedExpectedCode, @"\s+", "");
             actualCode = Regex.Replace(actualCode, "// Generation date:.*", string.Empty);
             actualCode = Regex.Replace(actualCode, "'Generation date:.*", string.Empty);
             actualCode = Regex.Replace(actualCode, "//     Runtime Version:.*", string.Empty);
             actualCode = Regex.Replace(actualCode, "'     Runtime Version:.*", string.Empty);
+            //Remove the spaces from the string to avoid indentation change errors 
+            string rawActualCode = Regex.Replace(actualCode, @"\s+", "");
 
             if (key == null)
             {
-                actualCode.Should().Be(normalizedExpectedCode);
+                rawActualCode.Should().Be(rawExpectedCode);
             }
             else
             {
-                bool equal = actualCode == normalizedExpectedCode;
+                bool equal = rawExpectedCode == rawActualCode;
 
                 if (!equal)
                 {

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTestDescriptors.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTestDescriptors.cs
@@ -98,7 +98,8 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
                     string currentFolder = Directory.GetCurrentDirectory();
                     string path = Path.Combine(currentFolder, filename);
                     File.WriteAllText(path, actualBak);
-                    string basePath = string.Format(currentFolder + @"\..\CodeGen\{0}", filename);
+                    string basePath = string.Format(Path.Combine(currentFolder,"Expected" + filename));
+                    File.WriteAllText(basePath, expected);
                     equal.Should().Be(true, "Baseline not equal.\n " +
                         "To diff run: \n" +
                         "odd \"{0}\" \"{1}\"\n" +

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTestDescriptors.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTestDescriptors.cs
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
                     string currentFolder = Directory.GetCurrentDirectory();
                     string path = Path.Combine(currentFolder, filename);
                     File.WriteAllText(path, actualBak);
-                    string basePath = string.Format(Path.Combine(currentFolder,"Expected" + filename));
+                    string basePath = Path.Combine(currentFolder, "Expected" + filename);
                     File.WriteAllText(basePath, expected);
                     equal.Should().Be(true, "Baseline not equal.\n " +
                         "To diff run: \n" +


### PR DESCRIPTION
Add another field to the configuration class to specify the filepath.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1220.

### Description
This pull request introduces another parameter to the client code generator that specifies a temporary file path where the metadata can be stored for the client proxy classes. Alternatively, if nothing is specified, it gets stored in a string literal. 

### Checklist (Uncheck if it is not completed)
Previous unit tests passed with nothing specified in the parameter. 

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
