### PR TITLE
Fix issue #1181, refactor for the json string escaping in JsonValueUt…

### DIFF
--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -814,6 +814,9 @@
     <Compile Include="$(ODataCrossTargettingSourcePath)\ODataStreamReferenceValue.cs">
       <Link>Microsoft\OData\Core\ODataStreamReferenceValue.cs</Link>
     </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\ODataStringEscapeOption.cs">
+      <Link>Microsoft\OData\Core\ODataStringEscapeOption.cs</Link>
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\ODataTypeAnnotation.cs">
       <Link>Microsoft\OData\Core\ODataTypeAnnotation.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -379,6 +379,9 @@
     <Compile Include="$(ODataCrossTargettingSourcePath)\Json\ODataJsonWriterUtils.cs">
       <Link>Microsoft\OData\Core\Json\ODataJsonWriterUtils.cs</Link>
     </Compile>
+    <Compile Include="$(ODataCrossTargettingSourcePath)\Json\ODataStringEscapeOption.cs">
+      <Link>Microsoft\OData\Core\Json\ODataStringEscapeOption.cs</Link>
+    </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\Json\TextWriterWrapper.cs">
       <Link>Microsoft\OData\Core\Json\TextWriterWrapper.cs</Link>
     </Compile>
@@ -813,9 +816,6 @@
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\ODataStreamReferenceValue.cs">
       <Link>Microsoft\OData\Core\ODataStreamReferenceValue.cs</Link>
-    </Compile>
-    <Compile Include="$(ODataCrossTargettingSourcePath)\ODataStringEscapeOption.cs">
-      <Link>Microsoft\OData\Core\ODataStringEscapeOption.cs</Link>
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\ODataTypeAnnotation.cs">
       <Link>Microsoft\OData\Core\ODataTypeAnnotation.cs</Link>

--- a/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
+++ b/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
@@ -437,6 +437,9 @@
     <Compile Include="..\Json\ODataJsonWriterUtils.cs">
       <Link>Json\ODataJsonWriterUtils.cs</Link>
     </Compile>
+    <Compile Include="..\Json\ODataStringEscapeOption.cs">
+      <Link>Json\ODataStringEscapeOption.cs</Link>
+    </Compile>
     <Compile Include="..\Json\TextWriterWrapper.cs">
       <Link>Json\TextWriterWrapper.cs</Link>
     </Compile>
@@ -886,9 +889,6 @@
     </Compile>
     <Compile Include="..\ODataStreamReferenceValue.cs">
       <Link>ODataStreamReferenceValue.cs</Link>
-    </Compile>
-    <Compile Include="..\ODataStringEscapeOption.cs">
-      <Link>ODataStringEscapeOption.cs</Link>
     </Compile>
     <Compile Include="..\ODataTypeAnnotation.cs">
       <Link>ODataTypeAnnotation.cs</Link>

--- a/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
+++ b/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
@@ -887,6 +887,9 @@
     <Compile Include="..\ODataStreamReferenceValue.cs">
       <Link>ODataStreamReferenceValue.cs</Link>
     </Compile>
+    <Compile Include="..\ODataStringEscapeOption.cs">
+      <Link>ODataStringEscapeOption.cs</Link>
+    </Compile>
     <Compile Include="..\ODataTypeAnnotation.cs">
       <Link>ODataTypeAnnotation.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.OData.Core/ContainerBuilderExtensions.cs
@@ -121,7 +121,7 @@ namespace Microsoft.OData
             Debug.Assert(builder != null, "builder != null");
 
             builder.AddService<IJsonReaderFactory, DefaultJsonReaderFactory>(ServiceLifetime.Singleton);
-            builder.AddService<IJsonWriterFactory, DefaultJsonWriterFactory>(ServiceLifetime.Singleton);
+            builder.AddService<IJsonWriterFactory>(ServiceLifetime.Singleton, sp => new DefaultJsonWriterFactory());
             builder.AddService(ServiceLifetime.Singleton, sp => ODataMediaTypeResolver.GetMediaTypeResolver(null));
             builder.AddService<ODataMessageInfo>(ServiceLifetime.Scoped);
             builder.AddServicePrototype(new ODataMessageReaderSettings());

--- a/src/Microsoft.OData.Core/Json/DefaultJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/DefaultJsonWriterFactory.cs
@@ -4,15 +4,44 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
 using System.IO;
 
 namespace Microsoft.OData.Json
 {
-    internal sealed class DefaultJsonWriterFactory : IJsonWriterFactory
+    /// <summary>
+    /// Default JSON writer factory
+    /// </summary>
+    public sealed class DefaultJsonWriterFactory : IJsonWriterFactory
     {
+        private ODataStringEscapeOption _stringEscapeOption;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultJsonWriterFactory" />.
+        /// </summary>
+        public DefaultJsonWriterFactory()
+            : this(ODataStringEscapeOption.EscapeNonAscii)
+        { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DefaultJsonWriterFactory" />.
+        /// </summary>
+        /// <param name="stringEscapeOption">The string escape option.</param>
+        public DefaultJsonWriterFactory(ODataStringEscapeOption stringEscapeOption)
+        {
+            _stringEscapeOption = stringEscapeOption;
+        }
+
+        /// <summary>
+        /// Creates a new JSON writer of <see cref="IJsonWriter"/>.
+        /// </summary>
+        /// <param name="textWriter">Writer to which text needs to be written.</param>
+        /// <param name="isIeee754Compatible">True if it is IEEE754Compatible.</param>
+        /// <returns>The JSON writer created.</returns>
+        [CLSCompliant(false)]
         public IJsonWriter CreateJsonWriter(TextWriter textWriter, bool isIeee754Compatible)
         {
-            return new JsonWriter(textWriter, isIeee754Compatible);
+            return new JsonWriter(textWriter, isIeee754Compatible, _stringEscapeOption);
         }
     }
 }

--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -391,7 +391,7 @@ namespace Microsoft.OData.Json
                     char c = inputString[currentIndex];
                     string escapedString = null;
 
-                    if (stringEscapeOption == ODataStringEscapeOption.EscapeNonAscii || c < 0x7F)
+                    if (stringEscapeOption == ODataStringEscapeOption.EscapeNonAscii || c <= 0x7F)
                     {
                         escapedString = JsonValueUtils.SpecialCharToEscapedStringMap[c];
                     }

--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -38,7 +38,6 @@ namespace Microsoft.OData.Json
         /// </summary>
         internal static readonly NumberFormatInfo ODataNumberFormatInfo = JsonValueUtils.InitializeODataNumberFormatInfo();
 
-
         /// <summary>
         /// Const tick value for calculating tick values.
         /// </summary>
@@ -296,8 +295,9 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">String value to be written.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data</param>
-        internal static void WriteValue(TextWriter writer, string value, ref char[] buffer)
+        internal static void WriteValue(TextWriter writer, string value, ODataStringEscapeOption stringEscapeOption, ref char[] buffer)
         {
             Debug.Assert(writer != null, "writer != null");
 
@@ -307,7 +307,7 @@ namespace Microsoft.OData.Json
             }
             else
             {
-                JsonValueUtils.WriteEscapedJsonString(writer, value, ref buffer);
+                JsonValueUtils.WriteEscapedJsonString(writer, value, stringEscapeOption, ref buffer);
             }
         }
 
@@ -337,8 +337,10 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="inputString">Input string value.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data</param>
-        internal static void WriteEscapedJsonString(TextWriter writer, string inputString, ref char[] buffer)
+        internal static void WriteEscapedJsonString(TextWriter writer, string inputString,
+            ODataStringEscapeOption stringEscapeOption, ref char[] buffer)
         {
             Debug.Assert(writer != null, "writer != null");
             Debug.Assert(inputString != null, "The string value must not be null.");
@@ -346,7 +348,7 @@ namespace Microsoft.OData.Json
             writer.Write(JsonConstants.QuoteCharacter);
 
             int firstIndex;
-            if (!JsonValueUtils.CheckIfStringHasSpecialChars(inputString, out firstIndex))
+            if (!JsonValueUtils.CheckIfStringHasSpecialChars(inputString, stringEscapeOption, out firstIndex))
             {
                 writer.Write(inputString);
             }
@@ -387,7 +389,12 @@ namespace Microsoft.OData.Json
                 for (; currentIndex < inputStringLength; currentIndex++)
                 {
                     char c = inputString[currentIndex];
-                    string escapedString = JsonValueUtils.SpecialCharToEscapedStringMap[c];
+                    string escapedString = null;
+
+                    if (stringEscapeOption == ODataStringEscapeOption.EscapeNonAscii || c < 0x7F)
+                    {
+                        escapedString = JsonValueUtils.SpecialCharToEscapedStringMap[c];
+                    }
 
                     // Append the unhandled characters (that do not require special treament)
                     // to the buffer.
@@ -491,13 +498,14 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
-        /// Checks if the string contains special char and returns the first index 
+        /// Checks if the string contains special char and returns the first index
         /// of special char if present.
         /// </summary>
         /// <param name="inputString">string that might contain special characters.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="firstIndex">first index of the special char</param>
         /// <returns>A value indicating whether the string contains special character</returns>
-        private static bool CheckIfStringHasSpecialChars(string inputString, out int firstIndex)
+        private static bool CheckIfStringHasSpecialChars(string inputString, ODataStringEscapeOption stringEscapeOption, out int firstIndex)
         {
             Debug.Assert(inputString != null, "The string value must not be null.");
 
@@ -506,6 +514,11 @@ namespace Microsoft.OData.Json
             for (int currentIndex = 0; currentIndex < inputStringLength; currentIndex++)
             {
                 char c = inputString[currentIndex];
+
+                if (stringEscapeOption == ODataStringEscapeOption.EscapeOnlyControls && c >= 0x7F)
+                {
+                    continue;
+                }
 
                 // Append the un-handled characters (that do not require special treatment)
                 // to the string builder when special characters are detected.

--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -39,6 +39,11 @@ namespace Microsoft.OData.Json
         private readonly bool isIeee754Compatible;
 
         /// <summary>
+        /// Gets or sets a value indicating how to escape the string when writing JSON string.
+        /// </summary>
+        private readonly ODataStringEscapeOption stringEscapeOption;
+
+        /// <summary>
         /// The buffer to help with streaming responses.
         /// </summary>
         private char[] buffer;
@@ -47,12 +52,24 @@ namespace Microsoft.OData.Json
         /// Creates a new instance of Json writer.
         /// </summary>
         /// <param name="writer">Writer to which text needs to be written.</param>
-        /// <param name="isIeee754Compatible">if it is IEEE754Compatible</param>
+        /// <param name="isIeee754Compatible">if it is IEEE754Compatible.</param>
         internal JsonWriter(TextWriter writer, bool isIeee754Compatible)
+            : this(writer, isIeee754Compatible, ODataStringEscapeOption.EscapeNonAscii)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of Json writer.
+        /// </summary>
+        /// <param name="writer">Writer to which text needs to be written.</param>
+        /// <param name="isIeee754Compatible">if it is IEEE754Compatible.</param>
+        /// <param name="stringEscapeOption">Specifies how to escape string.</param>
+        internal JsonWriter(TextWriter writer, bool isIeee754Compatible, ODataStringEscapeOption stringEscapeOption)
         {
             this.writer = new NonIndentedTextWriter(writer);
             this.scopes = new Stack<Scope>();
             this.isIeee754Compatible = isIeee754Compatible;
+            this.stringEscapeOption = stringEscapeOption;
         }
 
         /// <summary>
@@ -167,7 +184,7 @@ namespace Microsoft.OData.Json
 
             currentScope.ObjectCount++;
 
-            JsonValueUtils.WriteEscapedJsonString(this.writer, name, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, name, this.stringEscapeOption, ref this.buffer);
             this.writer.Write(JsonConstants.NameValueSeparator);
         }
 
@@ -231,7 +248,8 @@ namespace Microsoft.OData.Json
             // if it is IEEE754Compatible, write numbers with quotes; otherwise, write numbers directly.
             if (isIeee754Compatible)
             {
-                JsonValueUtils.WriteValue(this.writer, value.ToString(CultureInfo.InvariantCulture), ref this.buffer);
+                JsonValueUtils.WriteValue(this.writer, value.ToString(CultureInfo.InvariantCulture),
+                    this.stringEscapeOption, ref this.buffer);
             }
             else
             {
@@ -270,7 +288,8 @@ namespace Microsoft.OData.Json
             // if it is not IEEE754Compatible, write numbers directly without quotes;
             if (isIeee754Compatible)
             {
-                JsonValueUtils.WriteValue(this.writer, value.ToString(CultureInfo.InvariantCulture), ref this.buffer);
+                JsonValueUtils.WriteValue(this.writer, value.ToString(CultureInfo.InvariantCulture),
+                    this.stringEscapeOption, ref this.buffer);
             }
             else
             {
@@ -345,7 +364,7 @@ namespace Microsoft.OData.Json
         public void WriteValue(string value)
         {
             this.WriteValueSeparator();
-            JsonValueUtils.WriteValue(this.writer, value, ref this.buffer);
+            JsonValueUtils.WriteValue(this.writer, value, this.stringEscapeOption, ref this.buffer);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/ODataStringEscapeOption.cs
+++ b/src/Microsoft.OData.Core/Json/ODataStringEscapeOption.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-namespace Microsoft.OData
+namespace Microsoft.OData.Json
 {
     /// <summary>
     /// Enum type to specify how to escape string value when writing JSON text.

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -63,7 +63,6 @@
     <Compile Include="MultipartMixed\ODataMultipartMixedBatchReader.cs" />
     <Compile Include="MultipartMixed\ODataMultipartMixedBatchReaderStream.cs" />
     <Compile Include="MultipartMixed\ODataMultipartMixedBatchWriter.cs" />
-    <Compile Include="ODataStringEscapeOption.cs" />
     <Compile Include="UnknownEntitySet.cs" />
     <Compile Include="IContainerProvider.cs" />
     <Compile Include="IDuplicatePropertyNameChecker.cs" />
@@ -223,6 +222,7 @@
     <Compile Include="Json\NonIndentedTextWriter.cs" />
     <Compile Include="Json\ODataJsonReaderCoreUtils.cs" />
     <Compile Include="Json\ODataJsonWriterUtils.cs" />
+    <Compile Include="Json\ODataStringEscapeOption.cs" />
     <Compile Include="Json\TextWriterWrapper.cs" />
     <Compile Include="ODataErrorDetail.cs" />
     <Compile Include="ODataUntypedValue.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -63,6 +63,7 @@
     <Compile Include="MultipartMixed\ODataMultipartMixedBatchReader.cs" />
     <Compile Include="MultipartMixed\ODataMultipartMixedBatchReaderStream.cs" />
     <Compile Include="MultipartMixed\ODataMultipartMixedBatchWriter.cs" />
+    <Compile Include="ODataStringEscapeOption.cs" />
     <Compile Include="UnknownEntitySet.cs" />
     <Compile Include="IContainerProvider.cs" />
     <Compile Include="IDuplicatePropertyNameChecker.cs" />

--- a/src/Microsoft.OData.Core/ODataStringEscapeOption.cs
+++ b/src/Microsoft.OData.Core/ODataStringEscapeOption.cs
@@ -1,0 +1,25 @@
+//---------------------------------------------------------------------
+// <copyright file="ODataStringEscapeOption.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData
+{
+    /// <summary>
+    /// Enum type to specify how to escape string value when writing JSON text.
+    /// </summary>
+    public enum ODataStringEscapeOption
+    {
+        /// <summary>
+        /// All non-ASCII and control characters (e.g. newline) are escaped.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1704", Justification = "Ascii is meaningful")]
+        EscapeNonAscii,
+
+        /// <summary>
+        /// Only control characters (e.g. newline) are escaped.
+        /// </summary>
+        EscapeOnlyControls
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/NonIndentedTextWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/NonIndentedTextWriterTests.cs
@@ -32,19 +32,23 @@ namespace Microsoft.OData.Tests.Json
             {string.Format("{0}", (char)0x80), string.Format(CultureInfo.InvariantCulture, "\\u{0:x4}", 0x80)},
         };
 
-        [Fact]
-        public void WriteEmptyStringShouldWork()
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        public void WriteEmptyStringShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, string.Empty, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, string.Empty, stringEscapeOption, ref this.buffer);
             this.StreamToString().Should().Be("\"\"");
         }
 
-        [Fact]
-        public void WriteNonSpecialCharactersShouldWork()
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        public void WriteNonSpecialCharactersShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "abcdefg123", ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "abcdefg123", stringEscapeOption, ref this.buffer);
             this.StreamToString().Should().Be("\"abcdefg123\"");
         }
 
@@ -54,9 +58,26 @@ namespace Microsoft.OData.Tests.Json
             foreach (string specialChar in this.escapedCharMap.Keys)
             {
                 this.TestInit();
-                JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("{0}", specialChar), ref this.buffer);
+                JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("{0}", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
                 this.StreamToString().Should().Be(string.Format("\"{0}\"", this.escapedCharMap[specialChar]));
             }
+        }
+
+        [Fact]
+        public void WriteHighSpecialCharactersShouldWorkForEscapeNonAsciiOption()
+        {
+            this.TestInit();
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
+            this.StreamToString().Should().Be("\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\"");
+        }
+
+        [Fact]
+        public void WriteHighSpecialCharactersShouldWorkForEscapeOnlyControlsOption()
+        {
+            this.TestInit();
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeOnlyControls, ref this.buffer);
+            this.StreamToString().Should().Be("\"cA_Россия\"");
         }
 
         [Fact]

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -4035,6 +4035,11 @@ public enum Microsoft.OData.ODataReaderState : int {
 	Start = 0
 }
 
+public enum Microsoft.OData.ODataStringEscapeOption : int {
+	EscapeNonAscii = 0
+	EscapeOnlyControls = 1
+}
+
 public enum Microsoft.OData.ODataVersion : int {
 	V4 = 0
 	V401 = 1
@@ -5392,6 +5397,16 @@ CLSCompliantAttribute(),
 ]
 public interface Microsoft.OData.Json.IJsonWriterFactory {
 	Microsoft.OData.Json.IJsonWriter CreateJsonWriter (System.IO.TextWriter textWriter, bool isIeee754Compatible)
+}
+
+public sealed class Microsoft.OData.Json.DefaultJsonWriterFactory : IJsonWriterFactory {
+	public DefaultJsonWriterFactory ()
+	public DefaultJsonWriterFactory (Microsoft.OData.ODataStringEscapeOption stringEscapeOption)
+
+	[
+	CLSCompliantAttribute(),
+	]
+	public virtual Microsoft.OData.Json.IJsonWriter CreateJsonWriter (System.IO.TextWriter textWriter, bool isIeee754Compatible)
 }
 
 public enum Microsoft.OData.UriParser.BinaryOperatorKind : int {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -4035,11 +4035,6 @@ public enum Microsoft.OData.ODataReaderState : int {
 	Start = 0
 }
 
-public enum Microsoft.OData.ODataStringEscapeOption : int {
-	EscapeNonAscii = 0
-	EscapeOnlyControls = 1
-}
-
 public enum Microsoft.OData.ODataVersion : int {
 	V4 = 0
 	V401 = 1
@@ -5348,6 +5343,11 @@ public enum Microsoft.OData.Json.JsonNodeType : int {
 	StartObject = 1
 }
 
+public enum Microsoft.OData.Json.ODataStringEscapeOption : int {
+	EscapeNonAscii = 0
+	EscapeOnlyControls = 1
+}
+
 public interface Microsoft.OData.Json.IJsonReader {
 	bool IsIeee754Compatible  { public abstract get; }
 	Microsoft.OData.Json.JsonNodeType NodeType  { public abstract get; }
@@ -5401,7 +5401,7 @@ public interface Microsoft.OData.Json.IJsonWriterFactory {
 
 public sealed class Microsoft.OData.Json.DefaultJsonWriterFactory : IJsonWriterFactory {
 	public DefaultJsonWriterFactory ()
-	public DefaultJsonWriterFactory (Microsoft.OData.ODataStringEscapeOption stringEscapeOption)
+	public DefaultJsonWriterFactory (Microsoft.OData.Json.ODataStringEscapeOption stringEscapeOption)
 
 	[
 	CLSCompliantAttribute(),

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Json/JsonValueUtilsTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Json/JsonValueUtilsTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Json
     using Microsoft.Test.Taupo.Execution;
     using Microsoft.Test.Taupo.OData.Common;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.OData;
+    using Microsoft.OData.Json;
 
     /// <summary>
     /// Tests for the ODataJsonConvert class

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Json/JsonValueUtilsTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Json/JsonValueUtilsTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Json
     using Microsoft.Test.Taupo.Execution;
     using Microsoft.Test.Taupo.OData.Common;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.OData;
 
     /// <summary>
     /// Tests for the ODataJsonConvert class
@@ -284,7 +285,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Json
             public static void WriteValue(TextWriter writer, TimeSpan value) { ReflectionUtils.InvokeMethod(classType, "WriteValue", writer, value); }
             public static void WriteValue(TextWriter writer, byte value) { ReflectionUtils.InvokeMethod(classType, "WriteValue", writer, value); }
             public static void WriteValue(TextWriter writer, sbyte value) { ReflectionUtils.InvokeMethod(classType, "WriteValue", writer, value); }
-            public static void WriteValue(TextWriter writer, string value) { char[] buffer = null; ReflectionUtils.InvokeMethod(classType, "WriteValue", new Type[] { typeof(TextWriter), typeof(string), typeof(char[]).MakeByRefType() }, writer, value, buffer); }
+            public static void WriteValue(TextWriter writer, string value) { char[] buffer = null; ReflectionUtils.InvokeMethod(classType, "WriteValue", new Type[] { typeof(TextWriter), typeof(string), typeof(ODataStringEscapeOption), typeof(char[]).MakeByRefType() }, writer, value, ODataStringEscapeOption.EscapeNonAscii, buffer); }
         }
 #endif
     }


### PR DESCRIPTION
…ils class

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1181.*

### Description


Add configuration option for the ODataMessageWriterSetting using the new added `ODataStringEscapeOption`, internally, the JsonValueUtils will use the escape setting to write the string value.

By default, we use "EscapeNonAscii" option to make sure without breaking change for the default behavior. 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
