### PR TITLE
Cache full name for edm types

### DIFF
--- a/src/Microsoft.OData.Client/Serialization/PrimitiveType.cs
+++ b/src/Microsoft.OData.Client/Serialization/PrimitiveType.cs
@@ -10,8 +10,9 @@ namespace Microsoft.OData.Client
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
-    using Microsoft.Spatial;
+
     using Microsoft.OData.Edm;
+    using Microsoft.Spatial;
 
     /// <summary>
     /// Represent a Primitive Type on the client
@@ -448,7 +449,7 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Represents a definition of an EDM primitive type.
         /// </summary>
-        private class ClientEdmPrimitiveType : EdmType, IEdmPrimitiveType
+        private class ClientEdmPrimitiveType : EdmType, IEdmPrimitiveType, IEdmFullNamedElement
         {
             /// <summary>
             /// Namespace of the type.
@@ -459,6 +460,11 @@ namespace Microsoft.OData.Client
             /// Name of the type.
             /// </summary>
             private readonly string name;
+
+            /// <summary>
+            /// Full name of the type;
+            /// </summary>
+            private readonly string fullName;
 
             /// <summary>
             /// The kind of primitive.
@@ -476,6 +482,7 @@ namespace Microsoft.OData.Client
                 this.namespaceName = namespaceName;
                 this.name = name;
                 this.primitiveKind = primitiveKind;
+                this.fullName = this.namespaceName + "." + this.name;
             }
 
             /// <summary>
@@ -492,6 +499,14 @@ namespace Microsoft.OData.Client
             public string Namespace
             {
                 get { return this.namespaceName; }
+            }
+
+            /// <summary>
+            /// Full name of the type
+            /// </summary>
+            public string FullName
+            {
+                get { return this.fullName; }
             }
 
             /// <summary>

--- a/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
+++ b/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
@@ -1090,6 +1090,9 @@
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmExpression.cs">
       <Link>Microsoft\OData\Edm\Schema\Interfaces\IEdmExpression.cs</Link>
+    </Compile> 
+    <Compile Include="..\Schema\Interfaces\IEdmFullNamedElement.cs">
+      <Link>Microsoft\OData\Edm\Schema\Interfaces\IEdmFullNamedElement.cs</Link>
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmFunction.cs">
       <Link>Microsoft\OData\Edm\Schema\Interfaces\IEdmFunction.cs</Link>

--- a/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
+++ b/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
@@ -1015,6 +1015,9 @@
     <Compile Include="..\Schema\Interfaces\IEdmExpression.cs">
       <Link>Schema\Interfaces\IEdmExpression.cs</Link>
     </Compile>
+    <Compile Include="..\Schema\Interfaces\IEdmFullNamedElement.cs">
+      <Link>Schema\Interfaces\IEdmFullNamedElement.cs</Link>
+    </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmFunction.cs">
       <Link>Schema\Interfaces\IEdmFunction.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedOperation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedOperation.cs
@@ -13,17 +13,18 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
     /// <summary>
     /// Represents information about an EDM operation that failed to resolve.
     /// </summary>
-    internal class UnresolvedOperation : BadElement, IEdmOperation, IUnresolvedElement
+    internal class UnresolvedOperation : BadElement, IEdmOperation, IUnresolvedElement, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
         private readonly IEdmTypeReference returnType;
 
         public UnresolvedOperation(string qualifiedName, string errorMessage, EdmLocation location)
             : base(new EdmError[] { new EdmError(location, EdmErrorCode.BadUnresolvedOperation, errorMessage) })
         {
             qualifiedName = qualifiedName ?? string.Empty;
-            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name);
+            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
             this.returnType = new BadTypeReference(new BadType(this.Errors), true);
         }
 
@@ -35,6 +36,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public IEdmTypeReference ReturnType

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedType.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedType.cs
@@ -11,16 +11,17 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
     /// <summary>
     /// Represents information about an EDM type definition that failed to resolve.
     /// </summary>
-    internal class UnresolvedType : BadType, IEdmSchemaType, IUnresolvedElement
+    internal class UnresolvedType : BadType, IEdmSchemaType, IUnresolvedElement, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
 
         public UnresolvedType(string qualifiedName, EdmLocation location)
             : base(new EdmError[] { new EdmError(location, EdmErrorCode.BadUnresolvedType, Edm.Strings.Bad_UnresolvedType(qualifiedName)) })
         {
             qualifiedName = qualifiedName ?? string.Empty;
-            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name);
+            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
         }
 
         public EdmSchemaElementKind SchemaElementKind
@@ -36,6 +37,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedVocabularyTerm.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedVocabularyTerm.cs
@@ -8,18 +8,19 @@ using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 {
-    internal class UnresolvedVocabularyTerm : EdmElement, IEdmTerm, IUnresolvedElement
+    internal class UnresolvedVocabularyTerm : EdmElement, IEdmTerm, IUnresolvedElement, IEdmFullNamedElement
     {
         private readonly UnresolvedTermTypeReference type = new UnresolvedTermTypeReference();
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
         private readonly string appliesTo = null;
         private readonly string defaultValue = null;
 
         public UnresolvedVocabularyTerm(string qualifiedName)
         {
             qualifiedName = qualifiedName ?? string.Empty;
-            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name);
+            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
         }
 
         public string Namespace
@@ -30,6 +31,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public EdmSchemaElementKind SchemaElementKind

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsComplexTypeDefinition.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsComplexTypeDefinition.cs
@@ -13,8 +13,9 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
     /// <summary>
     /// Provides semantics for CsdlComplexType.
     /// </summary>
-    internal class CsdlSemanticsComplexTypeDefinition : CsdlSemanticsStructuredTypeDefinition, IEdmComplexType
+    internal class CsdlSemanticsComplexTypeDefinition : CsdlSemanticsStructuredTypeDefinition, IEdmComplexType, IEdmFullNamedElement
     {
+        private readonly string fullName;
         private readonly CsdlComplexType complex;
 
         private readonly Cache<CsdlSemanticsComplexTypeDefinition, IEdmComplexType> baseTypeCache = new Cache<CsdlSemanticsComplexTypeDefinition, IEdmComplexType>();
@@ -25,6 +26,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             : base(context, complex)
         {
             this.complex = complex;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(context?.Namespace, this.complex?.Name);
         }
 
         public override IEdmStructuredType BaseType
@@ -50,6 +52,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Name
         {
             get { return this.complex.Name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         protected override CsdlStructuredType MyStructured

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEntityContainer.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEntityContainer.cs
@@ -17,8 +17,9 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
     /// <summary>
     /// Provides semantics for CsdlEntityContainer.
     /// </summary>
-    internal class CsdlSemanticsEntityContainer : CsdlSemanticsElement, IEdmEntityContainer, IEdmCheckable
+    internal class CsdlSemanticsEntityContainer : CsdlSemanticsElement, IEdmEntityContainer, IEdmCheckable, IEdmFullNamedElement
     {
+        private readonly string fullName;
         private readonly CsdlEntityContainer entityContainer;
         private readonly CsdlSemanticsSchema context;
 
@@ -46,6 +47,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         {
             this.context = context;
             this.entityContainer = entityContainer;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.context?.Namespace, this.entityContainer?.Name);
         }
 
         public EdmSchemaElementKind SchemaElementKind
@@ -71,6 +73,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Name
         {
             get { return this.entityContainer.Name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public IEnumerable<EdmError> Errors

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEntityTypeDefinition.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEntityTypeDefinition.cs
@@ -14,9 +14,10 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
     /// <summary>
     /// Provides semantics for CsdlEntityType.
     /// </summary>
-    internal class CsdlSemanticsEntityTypeDefinition : CsdlSemanticsStructuredTypeDefinition, IEdmEntityType
+    internal class CsdlSemanticsEntityTypeDefinition : CsdlSemanticsStructuredTypeDefinition, IEdmEntityType, IEdmFullNamedElement
     {
         private readonly CsdlEntityType entity;
+        private readonly string fullName;
 
         private readonly Cache<CsdlSemanticsEntityTypeDefinition, IEdmEntityType> baseTypeCache = new Cache<CsdlSemanticsEntityTypeDefinition, IEdmEntityType>();
         private static readonly Func<CsdlSemanticsEntityTypeDefinition, IEdmEntityType> ComputeBaseTypeFunc = (me) => me.ComputeBaseType();
@@ -29,6 +30,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             : base(context, entity)
         {
             this.entity = entity;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(context?.Namespace, this.entity?.Name);
         }
 
         public override IEdmStructuredType BaseType
@@ -44,6 +46,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Name
         {
             get { return this.entity.Name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public override bool IsAbstract

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEnumTypeDefinition.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEnumTypeDefinition.cs
@@ -14,8 +14,9 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
     /// <summary>
     /// Provides semantics for CsdlEnumType.
     /// </summary>
-    internal class CsdlSemanticsEnumTypeDefinition : CsdlSemanticsTypeDefinition, IEdmEnumType
+    internal class CsdlSemanticsEnumTypeDefinition : CsdlSemanticsTypeDefinition, IEdmEnumType, IEdmFullNamedElement
     {
+        private readonly string fullName;
         private readonly CsdlEnumType enumeration;
 
         private readonly Cache<CsdlSemanticsEnumTypeDefinition, IEdmPrimitiveType> underlyingTypeCache = new Cache<CsdlSemanticsEnumTypeDefinition, IEdmPrimitiveType>();
@@ -29,6 +30,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         {
             this.Context = context;
             this.enumeration = enumeration;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.Context?.Namespace, this.enumeration?.Name);
         }
 
         IEdmPrimitiveType IEdmEnumType.UnderlyingType
@@ -54,6 +56,11 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Namespace
         {
             get { return this.Context.Namespace; }
+        }
+
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         string IEdmNamedElement.Name

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperation.cs
@@ -15,8 +15,9 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
     /// <summary>
     /// Provides semantics for a CsdlOperation
     /// </summary>
-    internal abstract class CsdlSemanticsOperation : CsdlSemanticsElement, IEdmOperation
+    internal abstract class CsdlSemanticsOperation : CsdlSemanticsElement, IEdmOperation, IEdmFullNamedElement
     {
+        private readonly string fullName;
         private readonly CsdlOperation operation;
         private readonly Cache<CsdlSemanticsOperation, IEdmPathExpression> entitySetPathCache = new Cache<CsdlSemanticsOperation, IEdmPathExpression>();
         private static readonly Func<CsdlSemanticsOperation, IEdmPathExpression> ComputeEntitySetPathFunc = (me) => me.ComputeEntitySetPath();
@@ -32,6 +33,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         {
             this.Context = context;
             this.operation = operation;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.Context?.Namespace, this.operation?.Name);
         }
 
         public abstract EdmSchemaElementKind SchemaElementKind { get; }
@@ -44,6 +46,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Name
         {
             get { return this.operation.Name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public override CsdlElement Element

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsTerm.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsTerm.cs
@@ -15,9 +15,10 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
     /// Provides semantics for a CsdlTerm.
     /// </summary>
     [System.Diagnostics.DebuggerDisplay("CsdlSemanticsTerm({Name})")]
-    internal class CsdlSemanticsTerm : CsdlSemanticsElement, IEdmTerm
+    internal class CsdlSemanticsTerm : CsdlSemanticsElement, IEdmTerm, IEdmFullNamedElement
     {
         protected readonly CsdlSemanticsSchema Context;
+        private readonly string fullName;
         protected CsdlTerm term;
 
         private readonly Cache<CsdlSemanticsTerm, IEdmTypeReference> typeCache = new Cache<CsdlSemanticsTerm, IEdmTypeReference>();
@@ -28,6 +29,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         {
             this.Context = context;
             this.term = valueTerm;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.Context?.Namespace, this.term?.Name);
         }
 
         public string Name
@@ -38,6 +40,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Namespace
         {
             get { return this.Context.Namespace; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public EdmSchemaElementKind SchemaElementKind

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsTypeDefinitionDefinition.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsTypeDefinitionDefinition.cs
@@ -14,10 +14,11 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
     /// <summary>
     /// Provides semantics for CsdlTypeDefinition.
     /// </summary>
-    internal class CsdlSemanticsTypeDefinitionDefinition : CsdlSemanticsTypeDefinition, IEdmTypeDefinition
+    internal class CsdlSemanticsTypeDefinitionDefinition : CsdlSemanticsTypeDefinition, IEdmTypeDefinition, IEdmFullNamedElement
     {
         private readonly CsdlSemanticsSchema context;
         private readonly CsdlTypeDefinition typeDefinition;
+        private readonly string fullName;
 
         private readonly Cache<CsdlSemanticsTypeDefinitionDefinition, IEdmPrimitiveType> underlyingTypeCache = new Cache<CsdlSemanticsTypeDefinitionDefinition, IEdmPrimitiveType>();
         private static readonly Func<CsdlSemanticsTypeDefinitionDefinition, IEdmPrimitiveType> ComputeUnderlyingTypeFunc = (me) => me.ComputeUnderlyingType();
@@ -27,6 +28,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         {
             this.context = context;
             this.typeDefinition = typeDefinition;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.context?.Namespace, this.typeDefinition?.Name);
         }
 
         IEdmPrimitiveType IEdmTypeDefinition.UnderlyingType
@@ -47,6 +49,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         string IEdmNamedElement.Name
         {
             get { return this.typeDefinition.Name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public override EdmTypeKind TypeKind

--- a/src/Microsoft.OData.Edm/EdmUtil.cs
+++ b/src/Microsoft.OData.Edm/EdmUtil.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Csdl.CsdlSemantics;
 using Microsoft.OData.Edm.Vocabularies;
@@ -260,6 +261,14 @@ namespace Microsoft.OData.Edm
             return sb.ToString();
         }
 
+        internal static bool TryGetNamespaceNameFromQualifiedName(string qualifiedName, out string namespaceName, out string name, out string fullName)
+        {
+            bool foundNamespace = EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out namespaceName, out name);
+
+            fullName = EdmUtil.GetFullNameForSchemaElement(namespaceName, name);
+            return foundNamespace;
+        }
+
         internal static bool TryGetNamespaceNameFromQualifiedName(string qualifiedName, out string namespaceName, out string name)
         {
             // Qualified name can be a operation import name which is separated by '/'
@@ -279,7 +288,6 @@ namespace Microsoft.OData.Edm
                 name = qualifiedName.Substring(lastDot + 1);
                 return true;
             }
-
             namespaceName = qualifiedName.Substring(0, lastSlash);
             name = qualifiedName.Substring(lastSlash + 1);
             return true;
@@ -479,6 +487,27 @@ namespace Microsoft.OData.Edm
             }
 
             return val;
+        }
+
+        /// <summary>
+        /// Gets full name for the schema element with the provided namespace and name
+        /// </summary>
+        /// <param name="elementNamespace">Namespace of the element</param>
+        /// <param name="elementName">The element name</param>
+        /// <returns>The full name of the element</returns>
+        internal static string GetFullNameForSchemaElement(string elementNamespace, string elementName)
+        {
+            if (elementName == null)
+            {
+                return string.Empty;
+            }
+
+            if (elementNamespace == null)
+            {
+                return elementName;
+            }
+
+            return elementNamespace + "." + elementName;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -10,6 +10,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Csdl.CsdlSemantics;
 using Microsoft.OData.Edm.Csdl.Parsing.Ast;
@@ -18,7 +19,6 @@ using Microsoft.OData.Edm.Validation;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OData.Edm.Vocabularies.Community.V1;
 using Microsoft.OData.Edm.Vocabularies.V1;
-using ErrorStrings = Microsoft.OData.Edm.Strings;
 
 namespace Microsoft.OData.Edm
 {
@@ -1387,14 +1387,19 @@ namespace Microsoft.OData.Edm
             {
                 return string.Empty;
             }
-            else if (element.Namespace == null)
+
+            if (element.Namespace == null)
             {
                 return element.Name;
             }
-            else
+
+            IEdmFullNamedElement fullNamedElement = element as IEdmFullNamedElement;
+            if (fullNamedElement != null)
             {
-                return element.Namespace + "." + element.Name;
+                return fullNamedElement.FullName;
             }
+
+            return element.Namespace + "." + element.Name;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Schema\EdmUntypedStructuredTypeReference.cs" />
     <Compile Include="Schema\EdmPathTypeReference.cs" />
     <Compile Include="Schema\EdmUntypedTypeReference.cs" />
+    <Compile Include="Schema\Interfaces\IEdmFullNamedElement.cs" />
     <Compile Include="Schema\Interfaces\IEdmPathTypeReference.cs" />
     <Compile Include="Schema\Interfaces\IEdmPathType.cs" />
     <Compile Include="Schema\Interfaces\IEdmUntypedType.cs" />

--- a/src/Microsoft.OData.Edm/Schema/AmbiguousEntityContainerBinding.cs
+++ b/src/Microsoft.OData.Edm/Schema/AmbiguousEntityContainerBinding.cs
@@ -9,9 +9,10 @@ using System.Linq;
 
 namespace Microsoft.OData.Edm
 {
-    internal class AmbiguousEntityContainerBinding : AmbiguousBinding<IEdmEntityContainer>, IEdmEntityContainer
+    internal class AmbiguousEntityContainerBinding : AmbiguousBinding<IEdmEntityContainer>, IEdmEntityContainer, IEdmFullNamedElement
     {
         private readonly string namespaceName;
+        private readonly string fullName;
 
         public AmbiguousEntityContainerBinding(IEdmEntityContainer first, IEdmEntityContainer second)
             : base(first, second)
@@ -19,6 +20,7 @@ namespace Microsoft.OData.Edm
             // Ambiguous entity containers can be produced by either searching for full name or simple name.
             // This results in the reported NamespaceName being ambiguous so the first one is selected arbitrarily.
             this.namespaceName = first.Namespace ?? string.Empty;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.Name);
         }
 
         public EdmSchemaElementKind SchemaElementKind
@@ -29,6 +31,14 @@ namespace Microsoft.OData.Edm
         public string Namespace
         {
             get { return this.namespaceName; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public IEnumerable<IEdmEntityContainerElement> Elements

--- a/src/Microsoft.OData.Edm/Schema/AmbiguousOperationBinding.cs
+++ b/src/Microsoft.OData.Edm/Schema/AmbiguousOperationBinding.cs
@@ -8,14 +8,16 @@ using System.Collections.Generic;
 
 namespace Microsoft.OData.Edm
 {
-    internal class AmbiguousOperationBinding : AmbiguousBinding<IEdmOperation>, IEdmOperation
+    internal class AmbiguousOperationBinding : AmbiguousBinding<IEdmOperation>, IEdmOperation, IEdmFullNamedElement
     {
+        private readonly string fullName;
         private IEdmOperation first;
 
         public AmbiguousOperationBinding(IEdmOperation first, IEdmOperation second)
             : base(first, second)
         {
             this.first = first;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.Namespace, this.Name);
         }
 
         public IEdmTypeReference ReturnType
@@ -27,6 +29,14 @@ namespace Microsoft.OData.Edm
         public string Namespace
         {
             get { return this.first.Namespace; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public IEnumerable<IEdmOperationParameter> Parameters

--- a/src/Microsoft.OData.Edm/Schema/AmbiguousTermBinding.cs
+++ b/src/Microsoft.OData.Edm/Schema/AmbiguousTermBinding.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 using System;
+
 using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OData.Edm
@@ -12,9 +13,10 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents a name binding to more than one item.
     /// </summary>
-    internal class AmbiguousTermBinding : AmbiguousBinding<IEdmTerm>, IEdmTerm
+    internal class AmbiguousTermBinding : AmbiguousBinding<IEdmTerm>, IEdmTerm, IEdmFullNamedElement
     {
         private readonly IEdmTerm first;
+        private readonly string fullName;
 
         // Type cache.
         private readonly Cache<AmbiguousTermBinding, IEdmTypeReference> type = new Cache<AmbiguousTermBinding, IEdmTypeReference>();
@@ -27,6 +29,7 @@ namespace Microsoft.OData.Edm
             : base(first, second)
         {
             this.first = first;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.Namespace, this.Name);
         }
 
         public EdmSchemaElementKind SchemaElementKind
@@ -37,6 +40,14 @@ namespace Microsoft.OData.Edm
         public string Namespace
         {
             get { return this.first.Namespace ?? string.Empty; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public IEdmTypeReference Type

--- a/src/Microsoft.OData.Edm/Schema/AmbiguousTypeBinding.cs
+++ b/src/Microsoft.OData.Edm/Schema/AmbiguousTypeBinding.cs
@@ -11,15 +11,17 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents a name binding to more than one item.
     /// </summary>
-    internal class AmbiguousTypeBinding : AmbiguousBinding<IEdmSchemaType>, IEdmSchemaType
+    internal class AmbiguousTypeBinding : AmbiguousBinding<IEdmSchemaType>, IEdmSchemaType, IEdmFullNamedElement
     {
         private readonly string namespaceName;
+        private readonly string fullName;
 
         public AmbiguousTypeBinding(IEdmSchemaType first, IEdmSchemaType second)
             : base(first, second)
         {
             Debug.Assert(first.Namespace == second.Namespace, "Schema elements should only be ambiguous with other elements in the same namespace");
             this.namespaceName = first.Namespace ?? string.Empty;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.Name);
         }
 
         public EdmSchemaElementKind SchemaElementKind
@@ -30,6 +32,14 @@ namespace Microsoft.OData.Edm
         public string Namespace
         {
             get { return this.namespaceName; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public EdmTypeKind TypeKind

--- a/src/Microsoft.OData.Edm/Schema/BadEntityContainer.cs
+++ b/src/Microsoft.OData.Edm/Schema/BadEntityContainer.cs
@@ -13,16 +13,17 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents a semantically invalid EDM entity container.
     /// </summary>
-    internal class BadEntityContainer : BadElement, IEdmEntityContainer
+    internal class BadEntityContainer : BadElement, IEdmEntityContainer, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
 
         public BadEntityContainer(string qualifiedName, IEnumerable<EdmError> errors)
             : base(errors)
         {
             qualifiedName = qualifiedName ?? string.Empty;
-            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name);
+            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
         }
 
         public IEnumerable<IEdmEntityContainerElement> Elements
@@ -38,6 +39,14 @@ namespace Microsoft.OData.Edm
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/BadEnumType.cs
+++ b/src/Microsoft.OData.Edm/Schema/BadEnumType.cs
@@ -13,16 +13,17 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents a semantically invalid EDM enumeration type.
     /// </summary>
-    internal class BadEnumType : BadType, IEdmEnumType
+    internal class BadEnumType : BadType, IEdmEnumType, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
 
         public BadEnumType(string qualifiedName, IEnumerable<EdmError> errors)
             : base(errors)
         {
             qualifiedName = qualifiedName ?? string.Empty;
-            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name);
+            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
         }
 
         public IEnumerable<IEdmEnumMember> Members
@@ -58,6 +59,14 @@ namespace Microsoft.OData.Edm
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Schema/BadNamedStructuredType.cs
+++ b/src/Microsoft.OData.Edm/Schema/BadNamedStructuredType.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 using System.Collections.Generic;
+
 using Microsoft.OData.Edm.Validation;
 
 namespace Microsoft.OData.Edm
@@ -12,16 +13,17 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents a semantically invalid EDM named structured type definition.
     /// </summary>
-    internal abstract class BadNamedStructuredType : BadStructuredType, IEdmSchemaElement
+    internal abstract class BadNamedStructuredType : BadStructuredType, IEdmSchemaElement, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
 
         protected BadNamedStructuredType(string qualifiedName, IEnumerable<EdmError> errors)
             : base(errors)
         {
             qualifiedName = qualifiedName ?? string.Empty;
-            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name);
+            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
         }
 
         public string Name
@@ -32,6 +34,14 @@ namespace Microsoft.OData.Edm
         public string Namespace
         {
             get { return this.namespaceName; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public EdmSchemaElementKind SchemaElementKind

--- a/src/Microsoft.OData.Edm/Schema/BadPathType.cs
+++ b/src/Microsoft.OData.Edm/Schema/BadPathType.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using Microsoft.OData.Edm.Validation;
 
 namespace Microsoft.OData.Edm
@@ -13,7 +14,7 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents a semantically invalid EDM path type.
     /// </summary>
-    internal class BadPathType : BadType, IEdmPathType
+    internal class BadPathType : BadType, IEdmPathType, IEdmFullNamedElement
     {
         public BadPathType(string qualifiedName, IEnumerable<EdmError> errors)
             : base(errors)
@@ -29,6 +30,14 @@ namespace Microsoft.OData.Edm
         }
 
         public string Namespace
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public string FullName
         {
             get
             {

--- a/src/Microsoft.OData.Edm/Schema/BadPrimitiveType.cs
+++ b/src/Microsoft.OData.Edm/Schema/BadPrimitiveType.cs
@@ -12,18 +12,19 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents a semantically invalid EDM primitive type definition.
     /// </summary>
-    internal class BadPrimitiveType : BadType, IEdmPrimitiveType
+    internal class BadPrimitiveType : BadType, IEdmPrimitiveType, IEdmFullNamedElement
     {
         private readonly EdmPrimitiveTypeKind primitiveKind;
         private readonly string name;
         private readonly string namespaceName;
+        private readonly string fullName;
 
         public BadPrimitiveType(string qualifiedName, EdmPrimitiveTypeKind primitiveKind, IEnumerable<EdmError> errors)
             : base(errors)
         {
             this.primitiveKind = primitiveKind;
             qualifiedName = qualifiedName ?? string.Empty;
-            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name);
+            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
         }
 
         public EdmPrimitiveTypeKind PrimitiveKind
@@ -39,6 +40,14 @@ namespace Microsoft.OData.Edm
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         public override EdmTypeKind TypeKind

--- a/src/Microsoft.OData.Edm/Schema/BadTypeDefinition.cs
+++ b/src/Microsoft.OData.Edm/Schema/BadTypeDefinition.cs
@@ -7,21 +7,23 @@
 namespace Microsoft.OData.Edm
 {
     using System.Collections.Generic;
+
     using Microsoft.OData.Edm.Validation;
 
     /// <summary>
     /// Represents a semantically invalid EDM type definition.
     /// </summary>
-    internal class BadTypeDefinition : BadType, IEdmTypeDefinition
+    internal class BadTypeDefinition : BadType, IEdmTypeDefinition, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
 
         public BadTypeDefinition(string qualifiedName, IEnumerable<EdmError> errors)
             : base(errors)
         {
             qualifiedName = qualifiedName ?? string.Empty;
-            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name);
+            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
         }
 
         public override EdmTypeKind TypeKind
@@ -47,6 +49,14 @@ namespace Microsoft.OData.Edm
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelComplexType.cs
+++ b/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelComplexType.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.OData.Edm.Csdl;
 
 namespace Microsoft.OData.Edm
@@ -13,7 +14,7 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// The built-in Edm.ComplexType abstract type in the core model.
     /// </summary>
-    internal sealed class EdmCoreModelComplexType : EdmType, IEdmComplexType, IEdmCoreModelElement
+    internal sealed class EdmCoreModelComplexType : EdmType, IEdmComplexType, IEdmCoreModelElement, IEdmFullNamedElement
     {
         /// <summary>
         /// The core Edm.ComplexType singleton.
@@ -39,6 +40,11 @@ namespace Microsoft.OData.Edm
         /// Gets the namespace of this type.
         /// </summary>
         public string Namespace => EdmConstants.EdmNamespace;
+
+        /// <summary>
+        /// Gets the full name of this type.
+        /// </summary>
+        public string FullName => CsdlConstants.TypeName_Complex;
 
         /// <summary>
         /// Gets a value indicating whether this type is abstract.

--- a/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelEntityType.cs
+++ b/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelEntityType.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+
 using Microsoft.OData.Edm.Csdl;
 
 namespace Microsoft.OData.Edm
@@ -13,7 +14,7 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// The built-in Edm.EntityType abstract type in the core model.
     /// </summary>
-    internal sealed class EdmCoreModelEntityType : EdmType, IEdmEntityType, IEdmCoreModelElement
+    internal sealed class EdmCoreModelEntityType : EdmType, IEdmEntityType, IEdmCoreModelElement, IEdmFullNamedElement
     {
         /// <summary>
         /// The core Edm.EntityType singleton.
@@ -39,6 +40,11 @@ namespace Microsoft.OData.Edm
         /// Gets the namespace of this type.
         /// </summary>
         public string Namespace => EdmConstants.EdmNamespace;
+
+        /// <summary>
+        /// Gets the full name of this type.
+        /// </summary>
+        public string FullName => CsdlConstants.TypeName_Entity;
 
         /// <summary>
         /// Gets the value indicating whether or not this type is a media entity.

--- a/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelPathType.cs
+++ b/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelPathType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// The built-in Edm.AnnotationPath, Edm.PropertyPath, Edm.NavigationPropertyPath abstract type in the core model.
     /// </summary>
-    internal sealed class EdmCoreModelPathType : EdmType, IEdmPathType, IEdmCoreModelElement
+    internal sealed class EdmCoreModelPathType : EdmType, IEdmPathType, IEdmCoreModelElement, IEdmFullNamedElement
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmCoreModelPathType"/> class.

--- a/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelPrimitiveType.cs
+++ b/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelPrimitiveType.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// The built-in Edm.PrimitiveType and other concrete primitive types in the core model.
     /// </summary>
-    internal sealed class EdmCoreModelPrimitiveType : EdmType, IEdmPrimitiveType, IEdmCoreModelElement
+    internal sealed class EdmCoreModelPrimitiveType : EdmType, IEdmPrimitiveType, IEdmCoreModelElement, IEdmFullNamedElement
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmCoreModelPrimitiveType"/> class.
@@ -19,6 +19,7 @@ namespace Microsoft.OData.Edm
         {
             Name = primitiveKind.ToString();
             PrimitiveKind = primitiveKind;
+            FullName = this.Namespace + "." + this.Name;
         }
 
         /// <summary>
@@ -49,6 +50,6 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Gets the full name of this type.
         /// </summary>
-        public string FullName => Namespace + "." + Name;
+        public string FullName { get; }
     }
 }

--- a/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelUntypeType.cs
+++ b/src/Microsoft.OData.Edm/Schema/CoreModel/EdmCoreModelUntypeType.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// The built-in Edm.Untyped type in the core model.
     /// </summary>
-    internal sealed class EdmCoreModelUntypedType : EdmType, IEdmUntypedType, IEdmCoreModelElement
+    internal sealed class EdmCoreModelUntypedType : EdmType, IEdmUntypedType, IEdmCoreModelElement, IEdmFullNamedElement
     {
         /// <summary>
         /// The core Edm.Untyped singleton.
@@ -37,6 +37,11 @@ namespace Microsoft.OData.Edm
         /// Gets the namespace of this type.
         /// </summary>
         public string Namespace => EdmConstants.EdmNamespace;
+
+        /// <summary>
+        /// Gets the full name of this type.
+        /// </summary>
+        public string FullName => CsdlConstants.TypeName_Untyped;
 
         /// <summary>
         /// Private constructor.

--- a/src/Microsoft.OData.Edm/Schema/EdmComplexType.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmComplexType.cs
@@ -4,17 +4,17 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OData.Edm
 {
     /// <summary>
     /// Represents a definition of an EDM complex type.
     /// </summary>
-    public class EdmComplexType : EdmStructuredType, IEdmComplexType
+    public class EdmComplexType : EdmStructuredType, IEdmComplexType, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmComplexType"/> class.
@@ -65,6 +65,7 @@ namespace Microsoft.OData.Edm
 
             this.namespaceName = namespaceName;
             this.name = name;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.Name);
         }
 
         /// <summary>
@@ -89,6 +90,14 @@ namespace Microsoft.OData.Edm
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/EdmEntityContainer.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmEntityContainer.cs
@@ -7,17 +7,17 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OData.Edm
 {
     /// <summary>
     /// Represents an EDM entity container.
     /// </summary>
-    public class EdmEntityContainer : EdmElement, IEdmEntityContainer
+    public class EdmEntityContainer : EdmElement, IEdmEntityContainer, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
         private readonly List<IEdmEntityContainerElement> containerElements = new List<IEdmEntityContainerElement>();
         private readonly Dictionary<string, IEdmEntitySet> entitySetDictionary = new Dictionary<string, IEdmEntitySet>();
         private readonly Dictionary<string, IEdmSingleton> singletonDictionary = new Dictionary<string, IEdmSingleton>();
@@ -35,6 +35,7 @@ namespace Microsoft.OData.Edm
 
             this.namespaceName = namespaceName;
             this.name = name;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.Name);
         }
 
         /// <summary>
@@ -59,6 +60,14 @@ namespace Microsoft.OData.Edm
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/EdmEntityType.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmEntityType.cs
@@ -7,17 +7,17 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OData.Edm
 {
     /// <summary>
     /// Represents a definition of an EDM entity type.
     /// </summary>
-    public class EdmEntityType : EdmStructuredType, IEdmEntityType
+    public class EdmEntityType : EdmStructuredType, IEdmEntityType, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
         private readonly bool hasStream;
         private List<IEdmStructuralProperty> declaredKey;
 
@@ -73,6 +73,7 @@ namespace Microsoft.OData.Edm
             this.namespaceName = namespaceName;
             this.name = name;
             this.hasStream = hasStream;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.Name);
         }
 
         /// <summary>
@@ -105,6 +106,14 @@ namespace Microsoft.OData.Edm
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/EdmEnumType.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmEnumType.cs
@@ -11,11 +11,12 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents the definition of an Edm enumeration type.
     /// </summary>
-    public class EdmEnumType : EdmType, IEdmEnumType
+    public class EdmEnumType : EdmType, IEdmEnumType, IEdmFullNamedElement
     {
         private readonly IEdmPrimitiveType underlyingType;
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
         private readonly bool isFlags;
         private readonly List<IEdmEnumMember> members = new List<IEdmEnumMember>();
 
@@ -69,6 +70,7 @@ namespace Microsoft.OData.Edm
             this.name = name;
             this.namespaceName = namespaceName;
             this.isFlags = isFlags;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.name);
         }
 
         /// <summary>
@@ -101,6 +103,14 @@ namespace Microsoft.OData.Edm
         public string Name
         {
             get { return this.name; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/EdmOperation.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmOperation.cs
@@ -11,8 +11,9 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents an EDM operation.
     /// </summary>
-    public abstract class EdmOperation : EdmNamedElement, IEdmOperation
+    public abstract class EdmOperation : EdmNamedElement, IEdmOperation, IEdmFullNamedElement
     {
+        private readonly string fullName;
         private readonly List<IEdmOperationParameter> parameters = new List<IEdmOperationParameter>();
 
         /// <summary>
@@ -32,6 +33,7 @@ namespace Microsoft.OData.Edm
             this.Namespace = namespaceName;
             this.IsBound = isBound;
             this.EntitySetPath = entitySetPathExpression;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(namespaceName, this.Name);
         }
 
         /// <summary>
@@ -71,6 +73,14 @@ namespace Microsoft.OData.Edm
         /// Gets the namespace of this function.
         /// </summary>
         public string Namespace { get; private set; }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
+        }
 
         /// <summary>
         /// Gets the return type of this function.

--- a/src/Microsoft.OData.Edm/Schema/EdmTypeDefinition.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmTypeDefinition.cs
@@ -9,11 +9,12 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Represents the definition of an Edm type definition.
     /// </summary>
-    public class EdmTypeDefinition : EdmType, IEdmTypeDefinition
+    public class EdmTypeDefinition : EdmType, IEdmTypeDefinition, IEdmFullNamedElement
     {
         private readonly IEdmPrimitiveType underlyingType;
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmTypeDefinition"/> class with <see cref="EdmPrimitiveTypeKind.Int32"/> underlying type.
@@ -41,6 +42,7 @@ namespace Microsoft.OData.Edm
             this.underlyingType = underlyingType;
             this.name = name;
             this.namespaceName = namespaceName;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.name);
         }
 
         /// <summary>
@@ -65,6 +67,14 @@ namespace Microsoft.OData.Edm
         public string Namespace
         {
             get { return this.namespaceName; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/EdmUntypedStructuredType.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmUntypedStructuredType.cs
@@ -4,8 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
 using Microsoft.OData.Edm.Csdl;
 
 namespace Microsoft.OData.Edm
@@ -13,10 +11,11 @@ namespace Microsoft.OData.Edm
     /// <summary>
     /// Common base class for definitions of EDM structured types.
     /// </summary>
-    public sealed class EdmUntypedStructuredType : EdmStructuredType, IEdmStructuredType, IEdmSchemaElement, IEdmSchemaType
+    public sealed class EdmUntypedStructuredType : EdmStructuredType, IEdmStructuredType, IEdmSchemaElement, IEdmSchemaType, IEdmFullNamedElement
     {
         private readonly string namespaceName;
         private readonly string name;
+        private readonly string fullName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmStructuredType"/> class.
@@ -31,6 +30,7 @@ namespace Microsoft.OData.Edm
 
             this.namespaceName = namespaceName;
             this.name = name;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.name);
         }
 
         /// <summary>
@@ -47,6 +47,14 @@ namespace Microsoft.OData.Edm
         public string Namespace
         {
             get { return this.namespaceName; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmFullNamedElement.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmFullNamedElement.cs
@@ -1,0 +1,19 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="IEdmFullNamedElement.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Common base interface for all named EDM elements.
+    /// </summary>
+    public interface IEdmFullNamedElement : IEdmNamedElement
+    {
+        /// <summary>
+        /// Gets the full name of this element.
+        /// </summary>
+        string FullName { get; }
+    }
+}

--- a/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
+++ b/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
@@ -400,6 +400,14 @@ namespace Microsoft.OData.Edm.Validation
             }
         }
 
+        private sealed class VisitorOfIEdmFullNamedElement : VisitorOfT<IEdmFullNamedElement>
+        {
+            protected override IEnumerable<EdmError> VisitT(IEdmFullNamedElement element, List<object> followup, List<object> references)
+            {
+                return element.Name != null ? null : new EdmError[] { CreatePropertyMustNotBeNullError(element, "Name") };
+            }
+        }
+
         private sealed class VisitorOfIEdmNamedElement : VisitorOfT<IEdmNamedElement>
         {
             protected override IEnumerable<EdmError> VisitT(IEdmNamedElement element, List<object> followup, List<object> references)

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmTerm.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmTerm.cs
@@ -9,9 +9,10 @@ namespace Microsoft.OData.Edm.Vocabularies
     /// <summary>
     /// Represents an EDM term.
     /// </summary>
-    public class EdmTerm : EdmNamedElement, IEdmTerm
+    public class EdmTerm : EdmNamedElement, IEdmTerm, IEdmFullNamedElement
     {
         private readonly string namespaceName;
+        private readonly string fullName;
         private readonly IEdmTypeReference type;
         private readonly string appliesTo;
         private readonly string defaultValue;
@@ -82,6 +83,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             this.type = type;
             this.appliesTo = appliesTo;
             this.defaultValue = defaultValue;
+            this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.Name);
         }
 
         /// <summary>
@@ -90,6 +92,14 @@ namespace Microsoft.OData.Edm.Vocabularies
         public string Namespace
         {
             get { return this.namespaceName; }
+        }
+
+        /// <summary>
+        /// Gets the full name of this schema element.
+        /// </summary>
+        public string FullName
+        {
+            get { return this.fullName; }
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Metadata/EdmLibraryExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Metadata/EdmLibraryExtensionsTests.cs
@@ -745,7 +745,7 @@ namespace Microsoft.OData.Tests.Metadata
             }
         }
 
-        private class EntityContainerThatThrowsOnLookup : EdmEntityContainer, IEdmEntityContainer
+        private class EntityContainerThatThrowsOnLookup : EdmEntityContainer, IEdmEntityContainer, IEdmFullNamedElement
         {
             public EntityContainerThatThrowsOnLookup(string namespaceName, string name) 
                 : base(namespaceName, name)

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
@@ -1351,6 +1351,7 @@ namespace Microsoft.OData.Edm.Tests.Validation
             {
                 this.Name = name;
                 this.Namespace = namespaceName;
+                this.FullName = this.Namespace + "." + this.Name;
                 this.IsComposable = false;
                 this.ReturnType = null;
                 this.Parameters = new Collection<IEdmOperationParameter>();
@@ -1380,6 +1381,8 @@ namespace Microsoft.OData.Edm.Tests.Validation
             public string Namespace { get; set; }
 
             public string Name { get; set; }
+
+            public string FullName { get; set; }
         }
 
         private sealed class CustomEntitySet : EdmNamedElement, IEdmEntitySet

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -764,6 +764,10 @@ public interface Microsoft.OData.Edm.IEdmExpression : IEdmElement {
 	Microsoft.OData.Edm.EdmExpressionKind ExpressionKind  { public abstract get; }
 }
 
+public interface Microsoft.OData.Edm.IEdmFullNamedElement : IEdmElement, IEdmNamedElement {
+	string FullName  { public abstract get; }
+}
+
 public interface Microsoft.OData.Edm.IEdmFunction : IEdmElement, IEdmNamedElement, IEdmOperation, IEdmSchemaElement, IEdmVocabularyAnnotatable {
 	bool IsComposable  { public abstract get; }
 }
@@ -1027,11 +1031,12 @@ public abstract class Microsoft.OData.Edm.EdmNavigationSource : Microsoft.OData.
 	public virtual Microsoft.OData.Edm.IEdmNavigationSource FindNavigationTarget (Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty, Microsoft.OData.Edm.IEdmPathExpression bindingPath)
 }
 
-public abstract class Microsoft.OData.Edm.EdmOperation : Microsoft.OData.Edm.EdmNamedElement, IEdmElement, IEdmNamedElement, IEdmOperation, IEdmSchemaElement, IEdmVocabularyAnnotatable {
+public abstract class Microsoft.OData.Edm.EdmOperation : Microsoft.OData.Edm.EdmNamedElement, IEdmElement, IEdmFullNamedElement, IEdmNamedElement, IEdmOperation, IEdmSchemaElement, IEdmVocabularyAnnotatable {
 	protected EdmOperation (string namespaceName, string name, Microsoft.OData.Edm.IEdmTypeReference returnType)
 	protected EdmOperation (string namespaceName, string name, Microsoft.OData.Edm.IEdmTypeReference returnType, bool isBound, Microsoft.OData.Edm.IEdmPathExpression entitySetPathExpression)
 
 	Microsoft.OData.Edm.IEdmPathExpression EntitySetPath  { public virtual get; }
+	string FullName  { public virtual get; }
 	bool IsBound  { public virtual get; }
 	string Namespace  { public virtual get; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmOperationParameter]] Parameters  { public virtual get; }
@@ -2234,7 +2239,7 @@ public sealed class Microsoft.OData.Edm.ToTraceStringExtensionMethods {
 	public static string ToTraceString (Microsoft.OData.Edm.IEdmTypeReference type)
 }
 
-public class Microsoft.OData.Edm.EdmAction : Microsoft.OData.Edm.EdmOperation, IEdmAction, IEdmElement, IEdmNamedElement, IEdmOperation, IEdmSchemaElement, IEdmVocabularyAnnotatable {
+public class Microsoft.OData.Edm.EdmAction : Microsoft.OData.Edm.EdmOperation, IEdmAction, IEdmElement, IEdmFullNamedElement, IEdmNamedElement, IEdmOperation, IEdmSchemaElement, IEdmVocabularyAnnotatable {
 	public EdmAction (string namespaceName, string name, Microsoft.OData.Edm.IEdmTypeReference returnType)
 	public EdmAction (string namespaceName, string name, Microsoft.OData.Edm.IEdmTypeReference returnType, bool isBound, Microsoft.OData.Edm.IEdmPathExpression entitySetPathExpression)
 
@@ -2270,12 +2275,13 @@ public class Microsoft.OData.Edm.EdmCollectionTypeReference : Microsoft.OData.Ed
 	public EdmCollectionTypeReference (Microsoft.OData.Edm.IEdmCollectionType collectionType)
 }
 
-public class Microsoft.OData.Edm.EdmComplexType : Microsoft.OData.Edm.EdmStructuredType, IEdmComplexType, IEdmElement, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmStructuredType, IEdmType, IEdmVocabularyAnnotatable {
+public class Microsoft.OData.Edm.EdmComplexType : Microsoft.OData.Edm.EdmStructuredType, IEdmComplexType, IEdmElement, IEdmFullNamedElement, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmStructuredType, IEdmType, IEdmVocabularyAnnotatable {
 	public EdmComplexType (string namespaceName, string name)
 	public EdmComplexType (string namespaceName, string name, Microsoft.OData.Edm.IEdmComplexType baseType)
 	public EdmComplexType (string namespaceName, string name, Microsoft.OData.Edm.IEdmComplexType baseType, bool isAbstract)
 	public EdmComplexType (string namespaceName, string name, Microsoft.OData.Edm.IEdmComplexType baseType, bool isAbstract, bool isOpen)
 
+	string FullName  { public virtual get; }
 	string Name  { public virtual get; }
 	string Namespace  { public virtual get; }
 	Microsoft.OData.Edm.EdmSchemaElementKind SchemaElementKind  { public virtual get; }
@@ -2357,10 +2363,11 @@ public class Microsoft.OData.Edm.EdmDecimalTypeReference : Microsoft.OData.Edm.E
 	System.Nullable`1[[System.Int32]] Scale  { public virtual get; }
 }
 
-public class Microsoft.OData.Edm.EdmEntityContainer : Microsoft.OData.Edm.EdmElement, IEdmElement, IEdmEntityContainer, IEdmNamedElement, IEdmSchemaElement, IEdmVocabularyAnnotatable {
+public class Microsoft.OData.Edm.EdmEntityContainer : Microsoft.OData.Edm.EdmElement, IEdmElement, IEdmEntityContainer, IEdmFullNamedElement, IEdmNamedElement, IEdmSchemaElement, IEdmVocabularyAnnotatable {
 	public EdmEntityContainer (string namespaceName, string name)
 
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmEntityContainerElement]] Elements  { public virtual get; }
+	string FullName  { public virtual get; }
 	string Name  { public virtual get; }
 	string Namespace  { public virtual get; }
 	Microsoft.OData.Edm.EdmSchemaElementKind SchemaElementKind  { public virtual get; }
@@ -2405,13 +2412,14 @@ public class Microsoft.OData.Edm.EdmEntitySet : Microsoft.OData.Edm.EdmEntitySet
 	Microsoft.OData.Edm.IEdmType Type  { public virtual get; }
 }
 
-public class Microsoft.OData.Edm.EdmEntityType : Microsoft.OData.Edm.EdmStructuredType, IEdmElement, IEdmEntityType, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmStructuredType, IEdmType, IEdmVocabularyAnnotatable {
+public class Microsoft.OData.Edm.EdmEntityType : Microsoft.OData.Edm.EdmStructuredType, IEdmElement, IEdmEntityType, IEdmFullNamedElement, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmStructuredType, IEdmType, IEdmVocabularyAnnotatable {
 	public EdmEntityType (string namespaceName, string name)
 	public EdmEntityType (string namespaceName, string name, Microsoft.OData.Edm.IEdmEntityType baseType)
 	public EdmEntityType (string namespaceName, string name, Microsoft.OData.Edm.IEdmEntityType baseType, bool isAbstract, bool isOpen)
 	public EdmEntityType (string namespaceName, string name, Microsoft.OData.Edm.IEdmEntityType baseType, bool isAbstract, bool isOpen, bool hasStream)
 
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmStructuralProperty]] DeclaredKey  { public virtual get; }
+	string FullName  { public virtual get; }
 	bool HasStream  { public virtual get; }
 	string Name  { public virtual get; }
 	string Namespace  { public virtual get; }
@@ -2441,12 +2449,13 @@ public class Microsoft.OData.Edm.EdmEnumMemberValue : IEdmElement, IEdmEnumMembe
 	long Value  { public virtual get; }
 }
 
-public class Microsoft.OData.Edm.EdmEnumType : Microsoft.OData.Edm.EdmType, IEdmElement, IEdmEnumType, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmType, IEdmVocabularyAnnotatable {
+public class Microsoft.OData.Edm.EdmEnumType : Microsoft.OData.Edm.EdmType, IEdmElement, IEdmEnumType, IEdmFullNamedElement, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmType, IEdmVocabularyAnnotatable {
 	public EdmEnumType (string namespaceName, string name)
 	public EdmEnumType (string namespaceName, string name, bool isFlags)
 	public EdmEnumType (string namespaceName, string name, Microsoft.OData.Edm.EdmPrimitiveTypeKind underlyingType, bool isFlags)
 	public EdmEnumType (string namespaceName, string name, Microsoft.OData.Edm.IEdmPrimitiveType underlyingType, bool isFlags)
 
+	string FullName  { public virtual get; }
 	bool IsFlags  { public virtual get; }
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmEnumMember]] Members  { public virtual get; }
 	string Name  { public virtual get; }
@@ -2463,7 +2472,7 @@ public class Microsoft.OData.Edm.EdmEnumTypeReference : Microsoft.OData.Edm.EdmT
 	public EdmEnumTypeReference (Microsoft.OData.Edm.IEdmEnumType enumType, bool isNullable)
 }
 
-public class Microsoft.OData.Edm.EdmFunction : Microsoft.OData.Edm.EdmOperation, IEdmElement, IEdmFunction, IEdmNamedElement, IEdmOperation, IEdmSchemaElement, IEdmVocabularyAnnotatable {
+public class Microsoft.OData.Edm.EdmFunction : Microsoft.OData.Edm.EdmOperation, IEdmElement, IEdmFullNamedElement, IEdmFunction, IEdmNamedElement, IEdmOperation, IEdmSchemaElement, IEdmVocabularyAnnotatable {
 	public EdmFunction (string namespaceName, string name, Microsoft.OData.Edm.IEdmTypeReference returnType)
 	public EdmFunction (string namespaceName, string name, Microsoft.OData.Edm.IEdmTypeReference returnType, bool isBound, Microsoft.OData.Edm.IEdmPathExpression entitySetPathExpression, bool isComposable)
 
@@ -2620,10 +2629,11 @@ public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.
 	System.Nullable`1[[System.Int32]] Precision  { public virtual get; }
 }
 
-public class Microsoft.OData.Edm.EdmTypeDefinition : Microsoft.OData.Edm.EdmType, IEdmElement, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmType, IEdmTypeDefinition, IEdmVocabularyAnnotatable {
+public class Microsoft.OData.Edm.EdmTypeDefinition : Microsoft.OData.Edm.EdmType, IEdmElement, IEdmFullNamedElement, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmType, IEdmTypeDefinition, IEdmVocabularyAnnotatable {
 	public EdmTypeDefinition (string namespaceName, string name, Microsoft.OData.Edm.EdmPrimitiveTypeKind underlyingType)
 	public EdmTypeDefinition (string namespaceName, string name, Microsoft.OData.Edm.IEdmPrimitiveType underlyingType)
 
+	string FullName  { public virtual get; }
 	string Name  { public virtual get; }
 	string Namespace  { public virtual get; }
 	Microsoft.OData.Edm.EdmSchemaElementKind SchemaElementKind  { public virtual get; }
@@ -2677,10 +2687,11 @@ public sealed class Microsoft.OData.Edm.EdmNavigationPropertyInfo {
 	public Microsoft.OData.Edm.EdmNavigationPropertyInfo Clone ()
 }
 
-public sealed class Microsoft.OData.Edm.EdmUntypedStructuredType : Microsoft.OData.Edm.EdmStructuredType, IEdmElement, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmStructuredType, IEdmType, IEdmVocabularyAnnotatable {
+public sealed class Microsoft.OData.Edm.EdmUntypedStructuredType : Microsoft.OData.Edm.EdmStructuredType, IEdmElement, IEdmFullNamedElement, IEdmNamedElement, IEdmSchemaElement, IEdmSchemaType, IEdmStructuredType, IEdmType, IEdmVocabularyAnnotatable {
 	public EdmUntypedStructuredType ()
 	public EdmUntypedStructuredType (string namespaceName, string name)
 
+	string FullName  { public virtual get; }
 	string Name  { public virtual get; }
 	string Namespace  { public virtual get; }
 	Microsoft.OData.Edm.EdmSchemaElementKind SchemaElementKind  { public virtual get; }
@@ -3769,7 +3780,7 @@ public class Microsoft.OData.Edm.Vocabularies.EdmStructuredValue : Microsoft.ODa
 	public virtual Microsoft.OData.Edm.Vocabularies.IEdmPropertyValue FindPropertyValue (string propertyName)
 }
 
-public class Microsoft.OData.Edm.Vocabularies.EdmTerm : Microsoft.OData.Edm.EdmNamedElement, IEdmElement, IEdmNamedElement, IEdmSchemaElement, IEdmTerm, IEdmVocabularyAnnotatable {
+public class Microsoft.OData.Edm.Vocabularies.EdmTerm : Microsoft.OData.Edm.EdmNamedElement, IEdmElement, IEdmFullNamedElement, IEdmNamedElement, IEdmSchemaElement, IEdmTerm, IEdmVocabularyAnnotatable {
 	public EdmTerm (string namespaceName, string name, Microsoft.OData.Edm.EdmPrimitiveTypeKind type)
 	public EdmTerm (string namespaceName, string name, Microsoft.OData.Edm.IEdmTypeReference type)
 	public EdmTerm (string namespaceName, string name, Microsoft.OData.Edm.EdmPrimitiveTypeKind type, string appliesTo)
@@ -3778,6 +3789,7 @@ public class Microsoft.OData.Edm.Vocabularies.EdmTerm : Microsoft.OData.Edm.EdmN
 
 	string AppliesTo  { public virtual get; }
 	string DefaultValue  { public virtual get; }
+	string FullName  { public virtual get; }
 	string Namespace  { public virtual get; }
 	Microsoft.OData.Edm.EdmSchemaElementKind SchemaElementKind  { public virtual get; }
 	Microsoft.OData.Edm.IEdmTypeReference Type  { public virtual get; }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1227 .*

### Description

Add a new interface for holding the Full Type Name, later in GetFullName method check if the type is inheriting from the new interface. If yes, use the cached value or fall back.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
