### PR TITLE
Set the selectionType to EntireSubtree when the selected list contain…

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -809,7 +809,7 @@ namespace Microsoft.OData.JsonLight
                 ? null
                 : this.jsonLightResourceDeserializer.ContextUriParseResult.SelectQueryOption;
 
-            SelectedPropertiesNode selectedProperties = SelectedPropertiesNode.Create(selectQueryOption);
+            SelectedPropertiesNode selectedProperties = SelectedPropertiesNode.Create(selectQueryOption, this.CurrentResourceType);
 
             if (this.ReadingResourceSet)
             {

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
@@ -697,6 +697,7 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
         {
             Dictionary<string, int[]> testCases = new Dictionary<string, int[]>()
             {
+                { "Accounts(101)?$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 4} },
                 { "Accounts(101)?$expand=MyGiftCard", new int[] {2, 4} },
                 { "Accounts(101)?$expand=MyPaymentInstruments", new int[] {4, 15} },
                 { "Accounts(101)?$select=AccountID&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1}  }
@@ -1197,9 +1198,9 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
         [TestMethod]
         public void CreateContainedEntityFromODataClientUsingAddRelatedObject()
         {
-           
+
                     TestClientContext.Format.UseJson(Model);
-             
+
                 // create an an account entity and a contained PI entity
                 Account newAccount = new Account()
                 {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMetadataContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMetadataContextTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OData.Tests.Evaluation
                 null /*requestUri*/);
             IEdmEntitySet set = this.edmModel.EntityContainer.FindEntitySet("Products");
             ODataResource entry = TestUtils.CreateODataEntry(set, new EdmStructuredValue(new EdmEntityTypeReference(set.EntityType(), true), new IEdmPropertyValue[0]), set.EntityType());
-            Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = new SelectedPropertiesNode("*"), NavigationSource = set }, false);
+            Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = new SelectedPropertiesNode("*", null), NavigationSource = set }, false);
             action.ShouldNotThrow();
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/KeyAsSegmentTemplateIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/KeyAsSegmentTemplateIntegrationTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
 
             var thing = new ODataResource { Properties = new[] { new ODataProperty { Name = "Id", Value = 1 } } };
             thing.TypeAnnotation = new ODataTypeAnnotation(entityType.FullTypeName());
-            thing.MetadataBuilder = metadataContext.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = thing, SelectedProperties = new SelectedPropertiesNode("*"), NavigationSource = entitySet}, useKeyAsSegment);
+            thing.MetadataBuilder = metadataContext.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = thing, SelectedProperties = new SelectedPropertiesNode("*", null), NavigationSource = entitySet}, useKeyAsSegment);
             return thing;
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
@@ -419,7 +419,44 @@ namespace Microsoft.OData.Tests.Evaluation
         [Fact]
         public void UnQualifiedNameWithParametersShouldNotIncludeActionOnOpenType()
         {
-            SelectedPropertiesNode.Create("Action(Edm.Int32)").Should().NotHaveAction(this.openType, this.action);
+            SelectedPropertiesNode.Create("Action(Edm.Int32)", this.openType).Should().NotHaveAction(this.openType, this.action);
+        }
+
+        [Fact]
+        public void ExpandTokenWithoutTypeInfoShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("Districts()").Should().HaveEntireSubtree();
+        }
+
+        [Fact]
+        public void ExpandTokenForNavigationPropertyShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("MetropolisNavigation(Thumbnail)", this.metropolisType).Should().HaveEntireSubtree();
+        }
+
+       [Fact]
+        public void SelectedPropertyAndExpandTokenShouldHavePartialSubtree()
+        {
+            SelectedPropertiesNode.Create("MetropolisStream,MetropolisNavigation(Thumbnail)", this.metropolisType).Should().HaveEntireSubtree(false);
+            SelectedPropertiesNode.Create("MetropolisStream,MetropolisNavigation(Thumbnail)").Should().HaveEntireSubtree(false);
+        }
+
+        [Fact]
+        public void ExpandTokenForCollectionOfNavigationPropertyShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("Districts()", this.cityType).Should().HaveEntireSubtree();
+        }
+
+        [Fact]
+        public void InvalidExpandTokenShouldHavePartialSubtree()
+        {
+            SelectedPropertiesNode.Create("FabrikamNavProp()", this.cityType).Should().HaveEntireSubtree(false);
+        }
+
+        [Fact]
+        public void InvalidExpandTokenWithoutTypeShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("FabrikamNavProp()").Should().HaveEntireSubtree();
         }
 
         [Fact]
@@ -623,6 +660,20 @@ namespace Microsoft.OData.Tests.Evaluation
         internal AndConstraint<SelectedPropertiesNodeAssertions> NotHaveAction(EdmEntityType entityType, IEdmOperation action)
         {
             this.Subject.As<SelectedPropertiesNode>().IsOperationSelected(entityType, action, entityType.IsOpen).Should().BeFalse();
+            return new AndConstraint<SelectedPropertiesNodeAssertions>(this);
+        }
+
+        internal AndConstraint<SelectedPropertiesNodeAssertions> HaveEntireSubtree(bool isTrue = true)
+        {
+            if (isTrue)
+            {
+                this.Subject.As<SelectedPropertiesNode>().IsEntireSubtree().Should().BeTrue();
+            }
+            else
+            {
+                this.Subject.As<SelectedPropertiesNode>().IsEntireSubtree().Should().BeFalse();
+            }
+
             return new AndConstraint<SelectedPropertiesNodeAssertions>(this);
         }
     }


### PR DESCRIPTION
…s only expand tokens.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1259.*

### Description

*During response deserialization, mark the selected properties node as EntireSubtree when the selected list contains only expand tokens, even if the list is not empty.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
