### PR TITLE
Issue #855: enable out of line optional parameter works

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
@@ -151,6 +151,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             get { return this.schemata.Select(s => s.Namespace); }
         }
 
+        public IDictionary<string, List<CsdlSemanticsAnnotations>> OutOfLineAnnotations
+        {
+            get
+            {
+                return outOfLineAnnotations;
+            }
+        }
+
         public override IEnumerable<IEdmVocabularyAnnotation> VocabularyAnnotations
         {
             get

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperation.cs
@@ -7,8 +7,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.OData.Edm.Csdl.Parsing.Ast;
 using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OData.Edm.Vocabularies.V1;
 
 namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 {
@@ -132,7 +134,125 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                 }
             }
 
-            return parameters;
+            // Handle the out-of-line optinal parameter annotation for parameters.
+            // First, use the above built parameters to create the full target name, for example: NS.TestFunction(Edm.String, Edm.String, Edm.String)
+            // Then, go through each prameters by visiting the out-of-line optional parameter annotation.
+            // If we find at least one of out-of-line optional parameter annotation, we replace it as an optional parameter.
+            // Otherwise, re-use the built parameter.
+            // Be noted: if a parameter has inline and out-of-line optional parameter, the out-of-line will win.
+            string fullName = Namespace + "." + Name;
+            string fullParametersName = ParameterizedTargetName(parameters);
+
+            List<IEdmOperationParameter> newParameters = new List<IEdmOperationParameter>(parameters.Count);
+            foreach (var parameter in parameters)
+            {
+                // for example: NS.TestFunction(Edm.String, Edm.String, Edm.String)/OptionalParameter
+                string fullTargetName = fullName + fullParametersName + "/" + parameter.Name;
+
+                // for example: NS.TestFunction/OptionalParameter
+                string targetName = fullName + "/" + parameter.Name;
+
+                string defaultValue;
+
+                if (TryGetOptionalParameterOutOfLineAnnotation(fullTargetName, targetName, out defaultValue))
+                {
+                    CsdlSemanticsOperationParameter csdlSemanticsParameter = (CsdlSemanticsOperationParameter)parameter;
+                    newParameters.Add(new CsdlSemanticsOptionalParameter(this, (CsdlOperationParameter)csdlSemanticsParameter.Element, defaultValue));
+                }
+                else
+                {
+                    newParameters.Add(parameter);
+                }
+            }
+
+            return newParameters;
+        }
+
+        private bool TryGetOptionalParameterOutOfLineAnnotation(string fullTargetName, string targetName, out string defaultValue)
+        {
+            defaultValue = null;
+            bool isOptional = false;
+
+            List<CsdlSemanticsAnnotations> annotations;
+
+            // OData 4.0 applies annotations to all overloads of a function or action.
+            // We still need to support annotating the non-overloaded version.
+            // So, we should probably first check the fullTargetName and, if that doesn't match, check just the function or action name.
+            bool found = Model.OutOfLineAnnotations.TryGetValue(fullTargetName, out annotations) ? true :
+                Model.OutOfLineAnnotations.TryGetValue(targetName, out annotations);
+
+            if (found)
+            {
+                foreach (var annotation in annotations)
+                {
+                    var optionalParameterAnnotation = annotation.Annotations.Annotations.FirstOrDefault(a =>
+                        a.Term == CoreVocabularyModel.OptionalParameterTerm.ShortQualifiedName() ||
+                        a.Term == CoreVocabularyModel.OptionalParameterTerm.FullName());
+
+                    if (optionalParameterAnnotation != null)
+                    {
+                        isOptional = true;
+
+                        CsdlRecordExpression optionalValueExpression = optionalParameterAnnotation.Expression as CsdlRecordExpression;
+                        if (optionalValueExpression != null)
+                        {
+                            foreach (CsdlPropertyValue property in optionalValueExpression.PropertyValues)
+                            {
+                                if (property.Property == CsdlConstants.Attribute_DefaultValue)
+                                {
+                                    CsdlConstantExpression propertyValue = property.Expression as CsdlConstantExpression;
+                                    if (propertyValue != null)
+                                    {
+                                        defaultValue = propertyValue.Value;
+                                    }
+                                }
+                            }
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            return isOptional;
+        }
+
+        internal static string ParameterizedTargetName(IList<IEdmOperationParameter> parameters)
+        {
+            int index = 0;
+            int parameterCount = parameters.Count();
+
+            StringBuilder sb = new StringBuilder("(");
+            foreach (IEdmOperationParameter parameter in parameters)
+            {
+                string typeName = "";
+                if (parameter.Type == null)
+                {
+                    typeName = CsdlConstants.TypeName_Untyped;
+                }
+                else if (parameter.Type.IsCollection())
+                {
+                    typeName = CsdlConstants.Value_Collection + "(" + parameter.Type.AsCollection().ElementType().FullName() + ")";
+                }
+                else if (parameter.Type.IsEntityReference())
+                {
+                    typeName = CsdlConstants.Value_Ref + "(" + parameter.Type.AsEntityReference().EntityType().FullName() + ")";
+                }
+                else
+                {
+                    typeName = parameter.Type.FullName();
+                }
+
+                sb.Append(typeName);
+                index++;
+                if (index < parameterCount)
+                {
+                    sb.Append(", ");
+                }
+            }
+
+            sb.Append(")");
+            return sb.ToString();
         }
 
         private sealed class OperationPathExpression : EdmPathExpression, IEdmLocatable

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -462,7 +462,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
         #region Optional Parameters
 
         [Fact]
-        public void ShouldWriteOptionalParameters()
+        public void ShouldWriteInLineOptionalParameters()
         {
             string expected =
             "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
@@ -501,6 +501,112 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             function.AddParameter(optionalParamWithDefault);
             model.AddElement(function);
             model.AddEntityContainer("test", "Default").AddFunctionImport("TestFunction", function);
+            string csdlStr = GetCsdl(model, CsdlTarget.OData);
+            Assert.Equal(expected, csdlStr);
+        }
+
+        [Fact]
+        public void ShouldWriteOutofLineOptionalParameters()
+        {
+            string expected =
+            "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+            "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+              "<edmx:DataServices>" +
+                "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                  "<Function Name=\"TestFunction\">" +
+                    "<Parameter Name=\"requiredParam\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                    "<Parameter Name=\"optionalParam\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                    "<Parameter Name=\"optionalParamWithDefault\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                    "<ReturnType Type=\"Edm.String\" Nullable=\"false\" />" +
+                  "</Function>" +
+                  "<Annotations Target=\"NS.TestFunction(Edm.String, Edm.String, Edm.String)/optionalParam\">" +
+                   "<Annotation Term=\"Org.OData.Core.V1.OptionalParameter\">" +
+                     "<Record />" +
+                  "</Annotation>" +
+                 "</Annotations>" +
+                 "<Annotations Target=\"NS.TestFunction(Edm.String, Edm.String, Edm.String)/optionalParamWithDefault\">" +
+                   "<Annotation Term=\"Org.OData.Core.V1.OptionalParameter\">" +
+                     "<Record Type=\"Org.OData.Core.V1.OptionalParameterType\">" +
+                       "<PropertyValue Property=\"DefaultValue\" String=\"Smith\" />" +
+                     "</Record>" +
+                  "</Annotation>" +
+                 "</Annotations>" +
+                "</Schema>" +
+              "</edmx:DataServices>" +
+            "</edmx:Edmx>";
+
+            var stringTypeReference = new EdmStringTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.String), false);
+            var model = new EdmModel();
+            var function = new EdmFunction("NS", "TestFunction", stringTypeReference);
+            var requiredParam = new EdmOperationParameter(function, "requiredParam", stringTypeReference);
+            var optionalParam = new EdmOptionalParameter(function, "optionalParam", stringTypeReference, null);
+            var optionalParamWithDefault = new EdmOptionalParameter(function, "optionalParamWithDefault", stringTypeReference, "Smith");
+            function.AddParameter(requiredParam);
+            function.AddParameter(optionalParam);
+            function.AddParameter(optionalParamWithDefault);
+            model.AddElement(function);
+
+            // parameter without default value
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(optionalParam, CoreVocabularyModel.OptionalParameterTerm, new EdmRecordExpression());
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            model.SetVocabularyAnnotation(annotation);
+
+            // parameter with default value
+            IEdmComplexType optionalParameterType = CoreVocabularyModel.Instance.FindDeclaredType("Org.OData.Core.V1.OptionalParameterType") as IEdmComplexType;
+            Assert.NotNull(optionalParameterType);
+
+            IEdmRecordExpression optionalParameterRecord = new EdmRecordExpression(
+                    new EdmComplexTypeReference(optionalParameterType, false),
+                    new EdmPropertyConstructor("DefaultValue", new EdmStringConstant("Smith")));
+            annotation = new EdmVocabularyAnnotation(optionalParamWithDefault, CoreVocabularyModel.OptionalParameterTerm, optionalParameterRecord);
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            model.SetVocabularyAnnotation(annotation);
+
+            string csdlStr = GetCsdl(model, CsdlTarget.OData);
+            Assert.Equal(expected, csdlStr);
+        }
+
+        [Fact]
+        public void ShouldWriteOutOfLineOptionalParametersOverwriteInLineOptionalParameter()
+        {
+            string expected =
+            "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+            "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+              "<edmx:DataServices>" +
+                "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                  "<Function Name=\"TestFunction\">" +
+                    "<Parameter Name=\"optionalParamWithDefault\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                    "<ReturnType Type=\"Edm.String\" Nullable=\"false\" />" +
+                  "</Function>" +
+                  "<Annotations Target=\"NS.TestFunction(Edm.String)/optionalParamWithDefault\">" +
+                   "<Annotation Term=\"Org.OData.Core.V1.OptionalParameter\">" +
+                     "<Record Type=\"Org.OData.Core.V1.OptionalParameterType\">" +
+                       "<PropertyValue Property=\"DefaultValue\" String=\"OutofLineValue\" />" +
+                     "</Record>" +
+                  "</Annotation>" +
+                 "</Annotations>" +
+                "</Schema>" +
+              "</edmx:DataServices>" +
+            "</edmx:Edmx>";
+
+            var stringTypeReference = new EdmStringTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.String), false);
+            var model = new EdmModel();
+            var function = new EdmFunction("NS", "TestFunction", stringTypeReference);
+            var optionalParamWithDefault = new EdmOptionalParameter(function, "optionalParamWithDefault", stringTypeReference, "InlineDefaultValue");
+            function.AddParameter(optionalParamWithDefault);
+            model.AddElement(function);
+
+            // parameter with default value
+            IEdmComplexType optionalParameterType = CoreVocabularyModel.Instance.FindDeclaredType("Org.OData.Core.V1.OptionalParameterType") as IEdmComplexType;
+            Assert.NotNull(optionalParameterType);
+
+            IEdmRecordExpression optionalParameterRecord = new EdmRecordExpression(
+                    new EdmComplexTypeReference(optionalParameterType, false),
+                    new EdmPropertyConstructor("DefaultValue", new EdmStringConstant("OutofLineValue")));
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(optionalParamWithDefault, CoreVocabularyModel.OptionalParameterTerm, optionalParameterRecord);
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            model.SetVocabularyAnnotation(annotation);
+
             string csdlStr = GetCsdl(model, CsdlTarget.OData);
             Assert.Equal(expected, csdlStr);
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Issue #855: enable out of line optional parameter works

### Description

If we create a non-optional (general) parameter, and apply the “OptionalParameter” term on it, we also can get the similar result:

# 1
```C#
var requiredParam = new EdmOperationParameter(function, "requiredParam", stringTypeReference);

IEdmRecordExpression optionalParameterRecord = new EdmRecordExpression(.., new EdmPropertyConstructor("DefaultValue", new EdmStringConstant("Smith")));

EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(requiredParam, CoreVocabularyModel.OptionalParameterTerm, optionalParameterRecord);
annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
model.SetVocabularyAnnotation(annotation);
```
The above will get the result same as the following codes:

# 2.
```C#
var requiredParam = new EdmOptionalParameter(function, "requiredParam", stringTypeReference, "Smith");
```
So, #1 and #2 can get the same result, and #1 is more generic process in the ODL (#2 will do some process to add the annotation at backend), I don’t think we should introduce the **IEdmOptionalParameter**.

However, this PR is following up the design with **IEdmOptionalParameter** and to make the out of line optional parameter work.


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
