### PR TITLE
Support $index  query option in OData v4.01

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -619,6 +619,7 @@ namespace Microsoft.OData {
         internal const string SyntacticTree_InvalidSkipQueryOptionValue = "SyntacticTree_InvalidSkipQueryOptionValue";
         internal const string SyntacticTree_InvalidTopQueryOptionValue = "SyntacticTree_InvalidTopQueryOptionValue";
         internal const string SyntacticTree_InvalidCountQueryOptionValue = "SyntacticTree_InvalidCountQueryOptionValue";
+        internal const string SyntacticTree_InvalidIndexQueryOptionValue = "SyntacticTree_InvalidIndexQueryOptionValue";
         internal const string QueryOptionUtils_QueryParameterMustBeSpecifiedOnce = "QueryOptionUtils_QueryParameterMustBeSpecifiedOnce";
         internal const string UriBuilder_NotSupportedClrLiteral = "UriBuilder_NotSupportedClrLiteral";
         internal const string UriBuilder_NotSupportedQueryToken = "UriBuilder_NotSupportedQueryToken";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -668,6 +668,7 @@ SyntacticTree_MaxDepthInvalid=The maximum depth setting must be a number greater
 SyntacticTree_InvalidSkipQueryOptionValue=Invalid value '{0}' for $skip query option found. The $skip query option requires a non-negative integer value.
 SyntacticTree_InvalidTopQueryOptionValue=Invalid value '{0}' for $top query option found. The $top query option requires a non-negative integer value.
 SyntacticTree_InvalidCountQueryOptionValue=Invalid value '{0}' for $count query option found. Valid values are '{1}'.
+SyntacticTree_InvalidIndexQueryOptionValue=Invalid value '{0}' for $index query option found. The $index query option requires an integer value.
 
 QueryOptionUtils_QueryParameterMustBeSpecifiedOnce=Query option '{0}' was specified more than once, but it must be specified at most once.
 

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -4236,6 +4236,13 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "Invalid value '{0}' for $index query option found. The $index query option requires an integer value."
+        /// </summary>
+        internal static string SyntacticTree_InvalidIndexQueryOptionValue(object p0) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.SyntacticTree_InvalidIndexQueryOptionValue, p0);
+        }
+
+        /// <summary>
         /// A string like "Query option '{0}' was specified more than once, but it must be specified at most once."
         /// </summary>
         internal static string QueryOptionUtils_QueryParameterMustBeSpecifiedOnce(object p0) {

--- a/src/Microsoft.OData.Core/Uri/ODataUri.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUri.cs
@@ -66,6 +66,7 @@ namespace Microsoft.OData
             ApplyClause apply,
             long? skip,
             long? top,
+            long? index,
             bool? queryCount,
             ComputeClause compute = null)
         {
@@ -79,6 +80,7 @@ namespace Microsoft.OData
             this.Apply = apply;
             this.Skip = skip;
             this.Top = top;
+            this.Index = index;
             this.QueryCount = queryCount;
             this.Compute = compute;
         }
@@ -184,6 +186,11 @@ namespace Microsoft.OData
         public long? Top { get; set; }
 
         /// <summary>
+        /// Gets or sets any $index option for this uri.
+        /// </summary>
+        public long? Index { get; set; }
+
+        /// <summary>
         /// Get or sets any query $count option for this uri.
         /// </summary>
         public bool? QueryCount { get; set; }
@@ -229,6 +236,7 @@ namespace Microsoft.OData
                 Search = Search,
                 Skip = Skip,
                 Top = Top,
+                Index = Index,
                 QueryCount = QueryCount,
                 SkipToken = SkipToken,
                 DeltaToken = DeltaToken,

--- a/src/Microsoft.OData.Core/Uri/ODataUriExtensions.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriExtensions.cs
@@ -78,6 +78,13 @@ namespace Microsoft.OData
                 queryOptions = string.Concat(queryOptions, "$skip", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(odataUri.Skip.ToString()));
             }
 
+            if (odataUri.Index != null)
+            {
+                queryOptions = WriteQueryPrefixOrSeparator(writeQueryPrefix, queryOptions);
+                writeQueryPrefix = false;
+                queryOptions = string.Concat(queryOptions, "$index", ExpressionConstants.SymbolEqual, Uri.EscapeDataString(odataUri.Index.ToString()));
+            }
+
             if (odataUri.QueryCount != null)
             {
                 queryOptions = WriteQueryPrefixOrSeparator(writeQueryPrefix, queryOptions);

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -281,6 +281,16 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
+        /// Parses a $index query option
+        /// </summary>
+        /// <returns>A value representing that index option, null if $index query does not exist.</returns>
+        public long? ParseIndex()
+        {
+            string indexQuery;
+            return this.TryGetQueryOption(UriQueryConstants.IndexQueryOption, out indexQuery) ? ParseIndex(indexQuery) : null;
+        }
+
+        /// <summary>
         /// Parses a $count query option
         /// </summary>
         /// <returns>A count representing that count option, null if $count query does not exist.</returns>
@@ -521,6 +531,30 @@ namespace Microsoft.OData.UriParser
             }
 
             return skipValue;
+        }
+
+        /// <summary>
+        /// Parses a $index query option
+        /// </summary>
+        /// <param name="indexQuery">The value of $index from the query</param>
+        /// <returns>A value representing that index option, null if $index query does not exist.</returns>
+        /// <exception cref="ODataException">Throws if the input value is not a valid $index value.</exception>
+        private static long? ParseIndex(string indexQuery)
+        {
+            if (indexQuery == null)
+            {
+                return null;
+            }
+
+            // A negative ordinal number indexes from the end of the collection,
+            // with -1 representing an insert as the last item in the collection.
+            long indexValue;
+            if (!long.TryParse(indexQuery, out indexValue))
+            {
+                throw new ODataException(Strings.SyntacticTree_InvalidIndexQueryOptionValue(indexQuery));
+            }
+
+            return indexValue;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParser.cs
@@ -372,6 +372,16 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
+        /// Parses a $index query option
+        /// </summary>
+        /// <returns>A value representing that index option, null if $index query does not exist.</returns>
+        public long? ParseIndex()
+        {
+            this.Initialize();
+            return this.queryOptionParser.ParseIndex();
+        }
+
+        /// <summary>
         /// Parses a $count query option
         /// </summary>
         /// <returns>An count representing that count option, null if $count query does not exist.</returns>
@@ -450,6 +460,7 @@ namespace Microsoft.OData.UriParser
             ComputeClause compute = this.ParseCompute();
             long? top = this.ParseTop();
             long? skip = this.ParseSkip();
+            long? index = this.ParseIndex();
             bool? count = this.ParseCount();
             string skipToken = this.ParseSkipToken();
             string deltaToken = this.ParseDeltaToken();
@@ -457,7 +468,7 @@ namespace Microsoft.OData.UriParser
             // TODO:  check it shouldn't be empty
             List<QueryNode> boundQueryOptions = new List<QueryNode>();
 
-            ODataUri odataUri = new ODataUri(this.ParameterAliasValueAccessor, path, boundQueryOptions, selectExpand, filter, orderBy, search, apply, skip, top, count, compute);
+            ODataUri odataUri = new ODataUri(this.ParameterAliasValueAccessor, path, boundQueryOptions, selectExpand, filter, orderBy, search, apply, skip, top, index, count, compute);
             odataUri.ServiceRoot = this.serviceRoot;
             odataUri.SkipToken = skipToken;
             odataUri.DeltaToken = deltaToken;
@@ -585,6 +596,7 @@ namespace Microsoft.OData.UriParser
                 case UriQueryConstants.DeltaTokenQueryOption:
                 case UriQueryConstants.IdQueryOption:
                 case UriQueryConstants.TopQueryOption:
+                case UriQueryConstants.IndexQueryOption:
                 case UriQueryConstants.CountQueryOption:
                 case UriQueryConstants.FormatQueryOption:
                 case UriQueryConstants.SearchQueryOption:

--- a/src/Microsoft.OData.Core/UriParser/UriQueryConstants.cs
+++ b/src/Microsoft.OData.Core/UriParser/UriQueryConstants.cs
@@ -71,6 +71,9 @@ namespace Microsoft.OData.UriParser
         /// <summary>A count query option name.</summary>
         internal const string CountQueryOption = "$count";
 
+        /// <summary>An index query option name.</summary>
+        internal const string IndexQueryOption = "$index";
+
         /// <summary>A format query option name.</summary>
         internal const string FormatQueryOption = "$format";
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/TopAndSkipBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/TopAndSkipBuilderTests.cs
@@ -53,6 +53,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         [InlineData(42)]
         [InlineData(0)]
         [InlineData(-1)]
+        [InlineData(-998)]
         public void BuildUrlWithIndexValueWorks(int value)
         {
             string expect = "http://gobbledygook/People(1)/RelatedIDs?$index=" + value;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/TopAndSkipBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/TopAndSkipBuilderTests.cs
@@ -49,6 +49,19 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
         #endregion $skip option
 
+        [Theory]
+        [InlineData(42)]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public void BuildUrlWithIndexValueWorks(int value)
+        {
+            string expect = "http://gobbledygook/People(1)/RelatedIDs?$index=" + value;
+            string uriString = "People(1)/RelatedIDs?$index=" + value;
+            Uri queryUri = new Uri(uriString, UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(new Uri(expect), actualUri);
+        }
+
         #region new ODataUri
         [Fact]
         public void BuildUrlWithNewODataUri()
@@ -91,6 +104,5 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.Equal(new Uri("http://gobbledygook/People?$deltatoken=MyToken"), res);
         }
         #endregion
-
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FullUriFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FullUriFunctionalTests.cs
@@ -146,6 +146,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void ParseIndex()
+        {
+            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://www.odata.com/OData"), new Uri("http://www.odata.com/OData/People(1)/RelatedIDs?$index=1"));
+            ODataUri parsedUri = parser.ParseUri();
+            parsedUri.Index.Should().Be(1);
+        }
+
+        [Fact]
         public void ParseCount()
         {
             ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://www.odata.com/OData"), new Uri("http://www.odata.com/OData/People?$count=false"));
@@ -153,7 +161,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             parsedUri.QueryCount.Should().BeFalse();
         }
 
-        [Fact]
+       [Fact]
         public void ParseWithAllQueryOptionsWithoutAlias()
         {
             ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://www.odata.com/OData/"), new Uri("http://www.odata.com/OData/Dogs?$select=Color, MyPeople&$expand=MyPeople&$filter=startswith(Color, 'Blue')&$orderby=Color asc"));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/TopAndSkipFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/TopAndSkipFunctionalTests.cs
@@ -85,5 +85,18 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             return new ODataQueryOptionParser(EdmCoreModel.Instance, null, null, new Dictionary<string, string>() { { "$skip", p } }).ParseSkip();
         }
+
+        [Theory]
+        [InlineData("5", 5)]
+        [InlineData("   5   ", 5)]
+        [InlineData("   000   ", 0)]
+        [InlineData("-1", -1)]
+        [InlineData("-1001", -1001)]
+        public void IndexValueWorks(string value, long expect)
+        {
+            var parser = new ODataQueryOptionParser(EdmCoreModel.Instance, null, null, new Dictionary<string, string>() { { "$index", value } });
+            var index = parser.ParseIndex();
+            index.Should().Be(expect);
+        }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/TopAndSkipFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/TopAndSkipFunctionalTests.cs
@@ -98,5 +98,18 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var index = parser.ParseIndex();
             index.Should().Be(expect);
         }
+
+        [Theory]
+        [InlineData("null")]
+        [InlineData("9223372036854775808")]
+        [InlineData("I'm long value")]
+        [InlineData("2 + 3")]
+        [InlineData("(1)")]
+        public void InvaidIndexValueThrows(string value)
+        {
+            var parser = new ODataQueryOptionParser(EdmCoreModel.Instance, null, null, new Dictionary<string, string>() { { "$index", value } });
+            Action action = () => parser.ParseIndex();
+            action.ShouldThrow<ODataException>("'{0}' should be invalid input", value).WithMessage(Strings.SyntacticTree_InvalidIndexQueryOptionValue(value));
+        }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/CaseInsensitiveBuiltinIdentifierTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/CaseInsensitiveBuiltinIdentifierTests.cs
@@ -150,6 +150,17 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
         }
 
         [Fact]
+        public void CaseInsensitiveIndexShouldWork()
+        {
+            this.TestCaseInsensitiveBuiltIn(
+                "People(0)/RelatedIDs?$index=4",
+                "People(0)/RelatedIDs?$iNDex=4",
+                uriParser => uriParser.ParseIndex(),
+                val => val.Should().Be(4),
+                /*errorMessage*/ null);
+        }
+
+        [Fact]
         public void CaseInsensitiveIdShouldWork()
         {
             this.TestCaseInsensitiveBuiltIn(

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataQueryOptionParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataQueryOptionParserTests.cs
@@ -41,6 +41,7 @@ namespace Microsoft.OData.Tests.UriParser
             uriParser.ParseOrderBy().Should().BeNull();
             uriParser.ParseTop().Should().Be(null);
             uriParser.ParseSkip().Should().Be(null);
+            uriParser.ParseIndex().Should().Be(null);
             uriParser.ParseCount().Should().Be(null);
             uriParser.ParseSearch().Should().BeNull();
             uriParser.ParseCompute().Should().BeNull();
@@ -57,6 +58,7 @@ namespace Microsoft.OData.Tests.UriParser
                 {"$orderby" , ""},
                 {"$top"     , ""},
                 {"$skip"    , ""},
+                {"$index"   , ""},
                 {"$count"   , ""},
                 {"$search"  , ""},
                 {"$compute" , ""},
@@ -73,6 +75,8 @@ namespace Microsoft.OData.Tests.UriParser
             action.ShouldThrow<ODataException>().WithMessage(Strings.SyntacticTree_InvalidTopQueryOptionValue(""));
             action = () => uriParser.ParseSkip();
             action.ShouldThrow<ODataException>().WithMessage(Strings.SyntacticTree_InvalidSkipQueryOptionValue(""));
+            action = () => uriParser.ParseIndex();
+            action.ShouldThrow<ODataException>().WithMessage(Strings.SyntacticTree_InvalidIndexQueryOptionValue(""));
             action = () => uriParser.ParseCount();
             action.ShouldThrow<ODataException>().WithMessage(Strings.ODataUriParser_InvalidCount(""));
             action = () => uriParser.ParseSearch();
@@ -90,6 +94,7 @@ namespace Microsoft.OData.Tests.UriParser
                 {"$orderby" , null},
                 {"$top"     , null},
                 {"$skip"    , null},
+                {"index"    , null},
                 {"$count"   , null},
                 {"$search"  , null},
                 {"$compute" , null},
@@ -101,6 +106,7 @@ namespace Microsoft.OData.Tests.UriParser
             uriParser.ParseOrderBy().Should().BeNull();
             uriParser.ParseTop().Should().Be(null);
             uriParser.ParseSkip().Should().Be(null);
+            uriParser.ParseIndex().Should().Be(null);
             uriParser.ParseCount().Should().Be(null);
             uriParser.ParseSearch().Should().BeNull();
             uriParser.ParseCompute().Should().BeNull();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -47,9 +47,9 @@ namespace Microsoft.OData.Tests.UriParser
         }
 
         [Theory]
-        [InlineData("?filter=&select=&expand=&orderby=&top=&skip=&count=&search=&unknown=&$unknownvalue&skiptoken=&deltatoken=&$compute=", true)]
-        [InlineData("?$filter=&$select=&$expand=&$orderby=&$top=&$skip=&$count=&$search=&$unknown=&$unknownvalue&$skiptoken=&$deltatoken=&$compute=", true)]
-        [InlineData("?$filter=&$select=&$expand=&$orderby=&$top=&$skip=&$count=&$search=&$unknown=&$unknownvalue&$skiptoken=&$deltatoken=&$compute=", false)]
+        [InlineData("?filter=&select=&expand=&orderby=&top=&skip=&index=&count=&search=&unknown=&$unknownvalue&skiptoken=&deltatoken=&$compute=", true)]
+        [InlineData("?$filter=&$select=&$expand=&$orderby=&$top=&$skip=&$index=&$count=&$search=&$unknown=&$unknownvalue&$skiptoken=&$deltatoken=&$compute=", true)]
+        [InlineData("?$filter=&$select=&$expand=&$orderby=&$top=&$skip=&$index=&$count=&$search=&$unknown=&$unknownvalue&$skiptoken=&$deltatoken=&$compute=", false)]
         public void EmptyValueQueryOptionShouldWork(string relativeUriString, bool enableNoDollarQueryOptions)
         {
             var uriParser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(FullUri, relativeUriString));
@@ -66,6 +66,8 @@ namespace Microsoft.OData.Tests.UriParser
             action.ShouldThrow<ODataException>().WithMessage(Strings.SyntacticTree_InvalidTopQueryOptionValue(""));
             action = () => uriParser.ParseSkip();
             action.ShouldThrow<ODataException>().WithMessage(Strings.SyntacticTree_InvalidSkipQueryOptionValue(""));
+            action = () => uriParser.ParseIndex();
+            action.ShouldThrow<ODataException>().WithMessage(Strings.SyntacticTree_InvalidIndexQueryOptionValue(""));
             action = () => uriParser.ParseCount();
             action.ShouldThrow<ODataException>().WithMessage(Strings.ODataUriParser_InvalidCount(""));
             action = () => uriParser.ParseSearch();
@@ -466,6 +468,17 @@ namespace Microsoft.OData.Tests.UriParser
             parser.ParseSearch().Should().NotBeNull();
             parser.ParseSkipToken().Should().Be("abc");
             parser.ParseDeltaToken().Should().Be("def");
+        }
+
+        [Theory]
+        [InlineData("People(1)/RelatedIDs?index=42", true)]
+        [InlineData("People(1)/RelatedIDs?$index=42", true)]
+        [InlineData("People(1)/RelatedIDs?$index=42", false)]
+        public void ParseIndexQueryOptionShouldWork(string relativeUriString, bool enableNoDollarQueryOptions)
+        {
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri(relativeUriString, UriKind.Relative));
+            parser.EnableNoDollarQueryOptions = enableNoDollarQueryOptions;
+            parser.ParseIndex().Should().Be(42);
         }
 
         [Theory]

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5324,6 +5324,7 @@ public sealed class Microsoft.OData.ODataUri {
 	System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.QueryNode]] CustomQueryOptions  { public get; public set; }
 	string DeltaToken  { public get; public set; }
 	Microsoft.OData.UriParser.FilterClause Filter  { public get; public set; }
+	System.Nullable`1[[System.Int64]] Index  { public get; public set; }
 	Microsoft.OData.UriParser.OrderByClause OrderBy  { public get; public set; }
 	System.Collections.Generic.IDictionary`2[[System.String],[Microsoft.OData.UriParser.SingleValueNode]] ParameterAliasNodes  { public get; }
 	Microsoft.OData.UriParser.ODataPath Path  { public get; public set; }
@@ -5865,6 +5866,7 @@ public class Microsoft.OData.UriParser.ODataQueryOptionParser {
 	public System.Nullable`1[[System.Boolean]] ParseCount ()
 	public string ParseDeltaToken ()
 	public Microsoft.OData.UriParser.FilterClause ParseFilter ()
+	public System.Nullable`1[[System.Int64]] ParseIndex ()
 	public Microsoft.OData.UriParser.OrderByClause ParseOrderBy ()
 	public Microsoft.OData.UriParser.SearchClause ParseSearch ()
 	public Microsoft.OData.UriParser.SelectExpandClause ParseSelectAndExpand ()
@@ -6535,6 +6537,7 @@ public sealed class Microsoft.OData.UriParser.ODataUriParser {
 	public string ParseDeltaToken ()
 	public Microsoft.OData.UriParser.EntityIdSegment ParseEntityId ()
 	public Microsoft.OData.UriParser.FilterClause ParseFilter ()
+	public System.Nullable`1[[System.Int64]] ParseIndex ()
 	public Microsoft.OData.UriParser.OrderByClause ParseOrderBy ()
 	public Microsoft.OData.UriParser.ODataPath ParsePath ()
 	public Microsoft.OData.UriParser.SearchClause ParseSearch ()


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1272.*

### Description

* Add supporting for the $index query option.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
