### PR TITLE
Context url for expand

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -809,7 +809,7 @@ namespace Microsoft.OData.JsonLight
                 ? null
                 : this.jsonLightResourceDeserializer.ContextUriParseResult.SelectQueryOption;
 
-            SelectedPropertiesNode selectedProperties = SelectedPropertiesNode.Create(selectQueryOption);
+            SelectedPropertiesNode selectedProperties = SelectedPropertiesNode.Create(selectQueryOption, this.CurrentResourceType);
 
             if (this.ReadingResourceSet)
             {

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -809,7 +809,7 @@ namespace Microsoft.OData.JsonLight
                 ? null
                 : this.jsonLightResourceDeserializer.ContextUriParseResult.SelectQueryOption;
 
-            SelectedPropertiesNode selectedProperties = SelectedPropertiesNode.Create(selectQueryOption, this.CurrentResourceType);
+            SelectedPropertiesNode selectedProperties = SelectedPropertiesNode.Create(selectQueryOption, this.CurrentResourceType, this.jsonLightInputContext.Model);
 
             if (this.ReadingResourceSet)
             {
@@ -1493,7 +1493,7 @@ namespace Microsoft.OData.JsonLight
                     break;
                 case JsonNodeType.StartArray:
                     // we are at the start of a nested resource set
-                    this.ReadResourceSetStart(new ODataResourceSet(), SelectedPropertiesNode.EntireSubtree);
+                    this.ReadResourceSetStart(new ODataResourceSet(), new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree));
                     break;
                 case JsonNodeType.EndArray:
                     // we are at the end of a resource set
@@ -1925,7 +1925,7 @@ namespace Microsoft.OData.JsonLight
                 if (nestedResourceInfo.NestedResourceInfo.IsCollection == true)
                 {
                     // because this is a request, there is no $select query option.
-                    SelectedPropertiesNode selectedProperties = SelectedPropertiesNode.EntireSubtree;
+                    SelectedPropertiesNode selectedProperties = new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree);
                     ODataDeltaResourceSet deltaResourceSet = nestedResourceInfo.NestedResourceSet as ODataDeltaResourceSet;
                     if (deltaResourceSet != null)
                     {

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -403,8 +403,7 @@ namespace Microsoft.OData
         /// <returns>The generated expand string.</returns>
         private static string ProcessSubExpand(string expandNode, string subExpand, ODataVersion version)
         {
-            return string.IsNullOrEmpty(subExpand) && version <= ODataVersion.V4 ? null :
-                expandNode + ODataConstants.ContextUriProjectionStart + subExpand + ODataConstants.ContextUriProjectionEnd;
+            return expandNode + ODataConstants.ContextUriProjectionStart + subExpand + ODataConstants.ContextUriProjectionEnd;
         }
 
         /// <summary>Create combined result string using selected items list and expand items list.</summary>

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -403,6 +403,8 @@ namespace Microsoft.OData
         /// <returns>The generated expand string.</returns>
         private static string ProcessSubExpand(string expandNode, string subExpand, ODataVersion version)
         {
+
+            // TODO: cleanup the version parameter.
             return expandNode + ODataConstants.ContextUriProjectionStart + subExpand + ODataConstants.ContextUriProjectionEnd;
         }
 
@@ -416,15 +418,6 @@ namespace Microsoft.OData
 
             if (selectList.Any())
             {
-                // https://github.com/OData/odata.net/issues/1104
-                // If the user explicitly selects and expands a nav prop, we should include both forms in contextUrl
-                // We can't, though, because SelectExpandClauseFinisher.AddExplicitNavPropLinksWhereNecessary adds all of
-                // the expanded items to the select before it gets here, so we can't tell what is explicitly selected by the user.
-                foreach (var item in expandList)
-                {
-                    string expandNode = item.Substring(0, item.IndexOf(ODataConstants.ContextUriProjectionStart));
-                    selectList.Remove(expandNode);
-                }
 
                 currentExpandClause += String.Join(ODataConstants.ContextUriProjectionPropertySeparator, selectList.ToArray());
             }

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -287,7 +287,7 @@ namespace Microsoft.OData
                 }
                 else
                 {
-                    return CreateSelectExpandContextUriSegment(odataUri.SelectAndExpand, version);
+                    return CreateSelectExpandContextUriSegment(odataUri.SelectAndExpand);
                 }
             }
 
@@ -379,14 +379,13 @@ namespace Microsoft.OData
         /// Build the expand clause for a given level in the selectExpandClause
         /// </summary>
         /// <param name="selectExpandClause">the current level select expand clause</param>
-        /// <param name="version">OData Version of the response</param>
         /// <returns>the select and expand segment for context url in this level.</returns>
-        private static string CreateSelectExpandContextUriSegment(SelectExpandClause selectExpandClause, ODataVersion version)
+        private static string CreateSelectExpandContextUriSegment(SelectExpandClause selectExpandClause)
         {
             if (selectExpandClause != null)
             {
                 string contextUri;
-                selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, version, out contextUri);
+                selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, out contextUri);
                 if (!string.IsNullOrEmpty(contextUri))
                 {
                     return ODataConstants.ContextUriProjectionStart + contextUri + ODataConstants.ContextUriProjectionEnd;
@@ -399,12 +398,10 @@ namespace Microsoft.OData
         /// <summary>Process sub expand node, contact with subexpand result</summary>
         /// <param name="expandNode">The current expanded node.</param>
         /// <param name="subExpand">Generated sub expand node.</param>
-        /// <param name="version">OData Version of the generated response.</param>
         /// <returns>The generated expand string.</returns>
-        private static string ProcessSubExpand(string expandNode, string subExpand, ODataVersion version)
+        private static string ProcessSubExpand(string expandNode, string subExpand)
         {
 
-            // TODO: cleanup the version parameter.
             return expandNode + ODataConstants.ContextUriProjectionStart + subExpand + ODataConstants.ContextUriProjectionEnd;
         }
 

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -283,7 +283,7 @@ namespace Microsoft.OData
             get
             {
                 return this.SelectExpandClause != null
-                    ? SelectedPropertiesNode.Create(this.SelectExpandClause, this.Version ?? ODataVersion.V4)
+                    ? SelectedPropertiesNode.Create(this.SelectExpandClause)
                     : new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree);
             }
         }

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -284,7 +284,7 @@ namespace Microsoft.OData
             {
                 return this.SelectExpandClause != null
                     ? SelectedPropertiesNode.Create(this.SelectExpandClause, this.Version ?? ODataVersion.V4)
-                    : SelectedPropertiesNode.EntireSubtree;
+                    : new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree);
             }
         }
 

--- a/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
+++ b/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
@@ -688,6 +688,11 @@ namespace Microsoft.OData
             List<string> rawSelect = selectList.ToList();
             rawSelect.RemoveAll(expandList.Select(m => m.nodeName).Contains);
 
+            if (selectList.Count == 0)
+            {
+                return SelectedPropertiesNode.EntireSubtree;
+            }
+
             SelectedPropertiesNode node = new SelectedPropertiesNode(SelectionType.PartialSubtree)
             {
                 selectedProperties = CreateSelectedPropertiesHashSet(),

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
@@ -45,6 +45,7 @@ namespace Microsoft.OData.UriParser
         /// <returns>A new SelectExpandClause decorated with the information from the selectToken</returns>
         public SelectExpandClause Bind(SelectToken tokenIn)
         {
+
             if (tokenIn == null || !tokenIn.Properties.Any())
             {
                 // if there are no properties selected for this level, then by default we select

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandClauseFinisher.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandClauseFinisher.cs
@@ -30,10 +30,6 @@ namespace Microsoft.OData.UriParser
             IEnumerable<ODataSelectPath> selectedPaths = selectItems.OfType<PathSelectItem>().Select(item => item.SelectedPath);
             foreach (ExpandedNavigationSelectItem navigationSelect in selectItems.Where(I => I.GetType() == typeof(ExpandedNavigationSelectItem)))
             {
-                if (anyPathSelectItems && !selectedPaths.Any(x => x.Equals(navigationSelect.PathToNavigationProperty.ToSelectPath())))
-                {
-                    clause.AddToSelectedItems(new PathSelectItem(navigationSelect.PathToNavigationProperty.ToSelectPath()));
-                }
 
                 AddExplicitNavPropLinksWhereNecessary(navigationSelect.SelectAndExpand);
             }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -106,12 +106,10 @@ namespace Microsoft.OData.UriParser
             {
                 string currentExpandClause = String.Join("/", expandSelectItem.PathToNavigationProperty.WalkWith(PathSegmentToStringTranslator.Instance).ToArray());
                 T subResult = default(T);
-                if (expandSelectItem.SelectAndExpand.SelectedItems.Any())
-                {
-                    Traverse(expandSelectItem.SelectAndExpand, processSubResult, combineSelectAndExpand, version, out subResult);
-                }
+                Traverse(expandSelectItem.SelectAndExpand, processSubResult, combineSelectAndExpand, version, out subResult);
 
                 var expandItem = processSubResult(currentExpandClause, subResult, version);
+
                 if (expandItem != null)
                 {
                     expandList.Add(expandItem);

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientWithoutTypeResolverTests/JsonWithoutTypeResolverTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientWithoutTypeResolverTests/JsonWithoutTypeResolverTests.cs
@@ -48,6 +48,13 @@ namespace Microsoft.Test.OData.Tests.Client.ClientWithoutTypeResolverTests
         }
 
         [TestMethod]
+        public void ExpandEntryQueryWithNestedSelect()
+        {
+            var contextWrapper = this.CreateContext();
+            var queryResults = contextWrapper.Execute<Customer>(new Uri(this.ServiceUri.OriginalString + "/Customer(-9)?$expand=Info($select=Information)")).ToArray();
+        }
+
+        [TestMethod]
         public void DerivedTypeExpandWithProjectionFeedQuery()
         {
             var contextWrapper = this.CreateContext();

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
@@ -697,16 +697,17 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
         {
             Dictionary<string, int[]> testCases = new Dictionary<string, int[]>()
             {
-                { "Accounts(101)?$select=AccountInfo/FirstName, AccountInfo/LastName", new int[] {1, 0, 0} },
-                { "Accounts(101)?$select=AccountID&$expand=MyPaymentInstruments($select=PaymentInstrumentID;$expand=TheStoredPI)", new int[]{7,4,4} },
-                { "Accounts(101)?$expand=MyPaymentInstruments($select=PaymentInstrumentID,FriendlyName)", new int[]{4, 15, 4} },
+                { "Accounts(101)?$select=AccountInfo/FirstName, AccountInfo/LastName", new int[] {1, 0} },
+                { "Accounts(101)?$select=AccountID&$expand=MyPaymentInstruments($select=PaymentInstrumentID;$expand=TheStoredPI)", new int[]{7,4} },
+                { "Accounts(101)?$expand=MyPaymentInstruments($select=PaymentInstrumentID,FriendlyName)", new int[]{4, 4} },
 
-                { "Accounts(101)?$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 4, 4} },
+                { "Accounts(101)?$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 4} },
 
-                { "Accounts(101)?$expand=MyGiftCard", new int[] {2, 4, 4} },
-                { "Accounts(101)?$expand=MyPaymentInstruments", new int[] {4, 15, 15} },
-                { "Accounts(101)?$select=AccountID&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1, 1}  },
-                { "Accounts(101)?$select=AccountID,MyGiftCard&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1, 1}  },
+                { "Accounts(101)?$expand=MyGiftCard", new int[] {2, 4} },
+                { "Accounts(101)?$expand=MyPaymentInstruments", new int[] {4, 15} },
+                { "Accounts(101)?$select=AccountID&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1} },
+                { "Accounts(101)?$select=AccountID,MyGiftCard&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1}  },
+                {"Accounts(101)?$select=AccountID&$expand=MyPaymentInstruments($select=PaymentInstrumentID;$expand=TheStoredPI($select=StoredPIID))", new int[] {7, 4}},
             };
 
             ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
@@ -790,10 +791,7 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
                             Assert.AreEqual(ODataReaderState.Completed, reader.State);
                             Assert.AreEqual(testCase.Value[0], entries.Count);
 
-                            int expectedLinksCount = mimeType.Contains(MimeTypes.ODataParameterFullMetadata)
-                                ? testCase.Value[1]
-                                : testCase.Value[2];
-                            Assert.AreEqual(expectedLinksCount, navigationLinks.Count);
+                            Assert.AreEqual(testCase.Value[1], navigationLinks.Count);
                         }
                     }
                 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
@@ -697,7 +697,12 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
         {
             Dictionary<string, int[]> testCases = new Dictionary<string, int[]>()
             {
+                { "Accounts(101)?$select=AccountInfo/FirstName, AccountInfo/LastName", new int[] {1, 0} },
+                { "Accounts(101)?$select=AccountID&$expand=MyPaymentInstruments($select=PaymentInstrumentID;$expand=TheStoredPI)", new int[]{7,4} },
+
+                //This case should work for minimal metadata:
                 { "Accounts(101)?$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 4} },
+
                 { "Accounts(101)?$expand=MyGiftCard", new int[] {2, 4} },
                 { "Accounts(101)?$expand=MyPaymentInstruments", new int[] {4, 15} },
                 { "Accounts(101)?$select=AccountID&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1}  }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
@@ -697,15 +697,16 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
         {
             Dictionary<string, int[]> testCases = new Dictionary<string, int[]>()
             {
-                { "Accounts(101)?$select=AccountInfo/FirstName, AccountInfo/LastName", new int[] {1, 0} },
-                { "Accounts(101)?$select=AccountID&$expand=MyPaymentInstruments($select=PaymentInstrumentID;$expand=TheStoredPI)", new int[]{7,4} },
+                { "Accounts(101)?$select=AccountInfo/FirstName, AccountInfo/LastName", new int[] {1, 0, 0} },
+                { "Accounts(101)?$select=AccountID&$expand=MyPaymentInstruments($select=PaymentInstrumentID;$expand=TheStoredPI)", new int[]{7,4,4} },
+                { "Accounts(101)?$expand=MyPaymentInstruments($select=PaymentInstrumentID,FriendlyName)", new int[]{4, 15, 4} },
 
-                //This case should work for minimal metadata:
-                { "Accounts(101)?$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 4} },
+                { "Accounts(101)?$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 4, 4} },
 
-                { "Accounts(101)?$expand=MyGiftCard", new int[] {2, 4} },
-                { "Accounts(101)?$expand=MyPaymentInstruments", new int[] {4, 15} },
-                { "Accounts(101)?$select=AccountID&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1}  }
+                { "Accounts(101)?$expand=MyGiftCard", new int[] {2, 4, 4} },
+                { "Accounts(101)?$expand=MyPaymentInstruments", new int[] {4, 15, 15} },
+                { "Accounts(101)?$select=AccountID&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1, 1}  },
+                { "Accounts(101)?$select=AccountID,MyGiftCard&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1, 1}  },
             };
 
             ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
@@ -788,7 +789,11 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
 
                             Assert.AreEqual(ODataReaderState.Completed, reader.State);
                             Assert.AreEqual(testCase.Value[0], entries.Count);
-                            Assert.AreEqual(testCase.Value[1], navigationLinks.Count);
+
+                            int expectedLinksCount = mimeType.Contains(MimeTypes.ODataParameterFullMetadata)
+                                ? testCase.Value[1]
+                                : testCase.Value[2];
+                            Assert.AreEqual(expectedLinksCount, navigationLinks.Count);
                         }
                     }
                 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
@@ -697,6 +697,7 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
         {
             Dictionary<string, int[]> testCases = new Dictionary<string, int[]>()
             {
+                { "Accounts(101)?$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 4} },
                 { "Accounts(101)?$expand=MyGiftCard", new int[] {2, 4} },
                 { "Accounts(101)?$expand=MyPaymentInstruments", new int[] {4, 15} },
                 { "Accounts(101)?$select=AccountID&$expand=MyGiftCard($select=GiftCardID)", new int[] {2, 1}  }
@@ -1197,9 +1198,9 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
         [TestMethod]
         public void CreateContainedEntityFromODataClientUsingAddRelatedObject()
         {
-           
+
                     TestClientContext.Format.UseJson(Model);
-             
+
                 // create an an account entity and a contained PI entity
                 Account newAccount = new Account()
                 {

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/UriBuilderTests/UriBuilderTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/UriBuilderTests/UriBuilderTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Test.OData.Tests.Client.UriBuilderTests
             IEnumerable<PathSelectItem> pathSelectItem = selectItems.Where(I => I.GetType() == typeof(PathSelectItem)).OfType<PathSelectItem>();
             Assert.AreEqual(expandedNavigationSelectItem.Count(), 1);
             Assert.AreEqual(expandedReferenceSelectItem.Count(), 1);
-            Assert.AreEqual(pathSelectItem.Count(), 3);
+            Assert.AreEqual(pathSelectItem.Count(), 2);
             NavigationPropertySegment navigationProperty = (NavigationPropertySegment)expandedNavigationSelectItem.First().PathToNavigationProperty.FirstSegment;
             Assert.AreEqual(navigationProperty.NavigationProperty.Name, "MyDog");
             navigationProperty = (NavigationPropertySegment)expandedReferenceSelectItem.First().PathToNavigationProperty.FirstSegment;
@@ -93,10 +93,10 @@ namespace Microsoft.Test.OData.Tests.Client.UriBuilderTests
             Assert.AreEqual(searchTermNode.Text, "FA");
 
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
-            Assert.AreEqual(new Uri("http://www.example.com/People?$filter=MyDog%2FColor%20eq%20%27Brown%27&$select=ID%2CMyDog%2CMyCat&$expand=MyDog%2CMyCat%2F%24ref&$orderby=ID&$top=1&$skip=2&$count=true&$search=FA"), actualUri);
+            Assert.AreEqual(new Uri("http://www.example.com/People?$filter=MyDog%2FColor%20eq%20%27Brown%27&$select=ID%2CMyCat&$expand=MyDog%2CMyCat%2F%24ref&$orderby=ID&$top=1&$skip=2&$count=true&$search=FA"), actualUri);
 
             actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Slash);
-            Assert.AreEqual(new Uri("http://www.example.com/People?$filter=MyDog%2FColor%20eq%20%27Brown%27&$select=ID%2CMyDog%2CMyCat&$expand=MyDog%2CMyCat%2F%24ref&$orderby=ID&$top=1&$skip=2&$count=true&$search=FA"), actualUri);
+            Assert.AreEqual(new Uri("http://www.example.com/People?$filter=MyDog%2FColor%20eq%20%27Brown%27&$select=ID%2CMyCat&$expand=MyDog%2CMyCat%2F%24ref&$orderby=ID&$top=1&$skip=2&$count=true&$search=FA"), actualUri);
         }
 
         [TestMethod]
@@ -138,7 +138,7 @@ namespace Microsoft.Test.OData.Tests.Client.UriBuilderTests
             IEnumerable<PathSelectItem> pathSelectItem = selectItems.Where(I => I.GetType() == typeof(PathSelectItem)).OfType<PathSelectItem>();
             Assert.AreEqual(expandedNavigationSelectItem.Count(), 1);
             Assert.AreEqual(expandedReferenceSelectItem.Count(), 1);
-            Assert.AreEqual(pathSelectItem.Count(), 3);
+            Assert.AreEqual(pathSelectItem.Count(), 2);
             NavigationPropertySegment navigationProperty = (NavigationPropertySegment)expandedNavigationSelectItem.First().PathToNavigationProperty.FirstSegment;
             Assert.AreEqual(navigationProperty.NavigationProperty.Name, "MyDog");
             navigationProperty = (NavigationPropertySegment)expandedReferenceSelectItem.First().PathToNavigationProperty.FirstSegment;
@@ -161,7 +161,7 @@ namespace Microsoft.Test.OData.Tests.Client.UriBuilderTests
             SearchTermNode searchTermNode = (SearchTermNode)odataUri.Search.Expression;
             Assert.AreEqual(searchTermNode.Text, "FA");
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
-            Assert.AreEqual(new Uri("http://www.example.com/People(1)?$filter=MyDog%2FColor%20eq%20%27Brown%27&$select=ID%2CMyDog%2CMyCat&$expand=MyDog%2CMyCat%2F%24ref&$orderby=ID&$top=1&$skip=2&$count=true&$search=FA"), actualUri);
+            Assert.AreEqual(new Uri("http://www.example.com/People(1)?$filter=MyDog%2FColor%20eq%20%27Brown%27&$select=ID%2CMyCat&$expand=MyDog%2CMyCat%2F%24ref&$orderby=ID&$top=1&$skip=2&$count=true&$search=FA"), actualUri);
         }
 
         [TestMethod]
@@ -203,7 +203,7 @@ namespace Microsoft.Test.OData.Tests.Client.UriBuilderTests
             IEnumerable<PathSelectItem> pathSelectItem = selectItems.Where(I => I.GetType() == typeof(PathSelectItem)).OfType<PathSelectItem>();
             Assert.AreEqual(expandedNavigationSelectItem.Count(), 1);
             Assert.AreEqual(expandedReferenceSelectItem.Count(), 1);
-            Assert.AreEqual(pathSelectItem.Count(), 3);
+            Assert.AreEqual(pathSelectItem.Count(), 2);
             NavigationPropertySegment navigationProperty = (NavigationPropertySegment)expandedNavigationSelectItem.First().PathToNavigationProperty.FirstSegment;
             Assert.AreEqual(navigationProperty.NavigationProperty.Name, "MyDog");
             navigationProperty = (NavigationPropertySegment)expandedReferenceSelectItem.First().PathToNavigationProperty.FirstSegment;
@@ -219,7 +219,7 @@ namespace Microsoft.Test.OData.Tests.Client.UriBuilderTests
             Assert.AreEqual(odataUri.QueryCount, false);
 
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Slash);
-            Assert.AreEqual(new Uri("http://www.example.com/People/1?$filter=MyDog%2FColor%20eq%20%27Brown%27&$select=ID%2CMyDog%2CMyCat&$expand=MyDog%2CMyCat%2F%24ref&$top=1&$skip=2&$count=false"), actualUri);
+            Assert.AreEqual(new Uri("http://www.example.com/People/1?$filter=MyDog%2FColor%20eq%20%27Brown%27&$select=ID%2CMyCat&$expand=MyDog%2CMyCat%2F%24ref&$top=1&$skip=2&$count=false"), actualUri);
         }
 
         [TestMethod]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataEntryMetadataContextTest.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataEntryMetadataContextTest.cs
@@ -71,21 +71,21 @@ namespace Microsoft.OData.Tests.Evaluation
         {
             this.entry = new ODataResource {TypeName = ActualEntityType.FullName()};
             this.typeContext = new TestFeedAndEntryTypeContext();
-            this.entryMetadataContextWithoutModel = ODataResourceMetadataContext.Create(this.entry, this.typeContext, new ODataResourceSerializationInfo(), /*actualEntityType*/null, new TestMetadataContext(), SelectedPropertiesNode.EntireSubtree);
-            this.entryMetadataContextWithModel = ODataResourceMetadataContext.Create(this.entry, this.typeContext, /*serializationInfo*/null, ActualEntityType, new TestMetadataContext(), SelectedPropertiesNode.EntireSubtree);
+            this.entryMetadataContextWithoutModel = ODataResourceMetadataContext.Create(this.entry, this.typeContext, new ODataResourceSerializationInfo(), /*actualEntityType*/null, new TestMetadataContext(), new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree));
+            this.entryMetadataContextWithModel = ODataResourceMetadataContext.Create(this.entry, this.typeContext, /*serializationInfo*/null, ActualEntityType, new TestMetadataContext(), new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree));
         }
 
         [Fact]
         public void CreateShouldReturnMetadataContextWithoutModel()
         {
-            var entryMetadataContext = ODataResourceMetadataContext.Create(this.entry, this.typeContext, new ODataResourceSerializationInfo(), ActualEntityType, new TestMetadataContext(), SelectedPropertiesNode.EntireSubtree);
+            var entryMetadataContext = ODataResourceMetadataContext.Create(this.entry, this.typeContext, new ODataResourceSerializationInfo(), ActualEntityType, new TestMetadataContext(), new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree));
             entryMetadataContext.GetType().FullName.EndsWith("WithoutModel").Should().BeTrue();
         }
 
         [Fact]
         public void CreateShouldReturnMetadataContextWithModel()
         {
-            var entryMetadataContext = ODataResourceMetadataContext.Create(this.entry, this.typeContext, /*serializationInfo*/null, ActualEntityType, new TestMetadataContext(), SelectedPropertiesNode.EntireSubtree);
+            var entryMetadataContext = ODataResourceMetadataContext.Create(this.entry, this.typeContext, /*serializationInfo*/null, ActualEntityType, new TestMetadataContext(), new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree));
             entryMetadataContext.GetType().FullName.EndsWith("WithModel").Should().BeTrue();
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMetadataContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMetadataContextTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OData.Tests.Evaluation
                 null /*requestUri*/);
             IEdmEntitySet set = this.edmModel.EntityContainer.FindEntitySet("Products");
             ODataResource entry = TestUtils.CreateODataEntry(set, new EdmStructuredValue(new EdmEntityTypeReference(set.EntityType(), true), new IEdmPropertyValue[0]), set.EntityType());
-            Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = new SelectedPropertiesNode("*"), NavigationSource = set }, false);
+            Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = new SelectedPropertiesNode("*", null), NavigationSource = set }, false);
             action.ShouldNotThrow();
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMetadataContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMetadataContextTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.OData.Tests.Evaluation
                 null /*requestUri*/);
             IEdmEntitySet set = this.edmModel.EntityContainer.FindEntitySet("Products");
             ODataResource entry = TestUtils.CreateODataEntry(set, new EdmStructuredValue(new EdmEntityTypeReference(set.EntityType(), true), new IEdmPropertyValue[0]), set.EntityType());
-            Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = SelectedPropertiesNode.EntireSubtree, NavigationSource = set }, false);
+            Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree), NavigationSource = set }, false);
             action.ShouldThrow<ODataException>().WithMessage(Strings.ODataJsonLightResourceMetadataContext_MetadataAnnotationMustBeInPayload("odata.context"));
         }
 
@@ -51,7 +51,7 @@ namespace Microsoft.OData.Tests.Evaluation
                 null /*requestUri*/);
             IEdmEntitySet set = this.edmModel.EntityContainer.FindEntitySet("Products");
             ODataResource entry = TestUtils.CreateODataEntry(set, new EdmStructuredValue(new EdmEntityTypeReference(set.EntityType(), true), new IEdmPropertyValue[0]), set.EntityType());
-            Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = new SelectedPropertiesNode("*", null), NavigationSource = set }, false);
+            Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = new SelectedPropertiesNode("*", null, null), NavigationSource = set }, false);
             action.ShouldNotThrow();
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMissingOperationGeneratorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMissingOperationGeneratorTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OData.Tests.Evaluation
         [Fact]
         public void NoOperationsShouldBeGeneratedIfModelHasNone()
         {
-            AddMissingOperations(this.entry, this.entityType, SelectedPropertiesNode.EntireSubtree, this.model, type => new IEdmOperation[0], null, e => false);
+            AddMissingOperations(this.entry, this.entityType, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree), this.model, type => new IEdmOperation[0], null, e => false);
             entry.Actions.Should().BeEmpty();
             entry.Functions.Should().BeEmpty();
         }
@@ -60,7 +60,7 @@ namespace Microsoft.OData.Tests.Evaluation
         {
             this.entry.AddAction(this.odataAction);
             this.entry.AddFunction(this.odataFunction);
-            AddMissingOperations(this.entry, this.entityType, SelectedPropertiesNode.EntireSubtree, this.model, type => this.allOperations, null, e => false);
+            AddMissingOperations(this.entry, this.entityType, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree), this.model, type => this.allOperations, null, e => false);
             this.entry.Actions.ToList().Count.Should().Be(1);
 #if !NETCOREAPP1_0
             this.entry.Actions.Single().ShouldHave().AllProperties().EqualTo(this.odataAction);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/KeyAsSegmentTemplateIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/KeyAsSegmentTemplateIntegrationTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
 
             var thing = new ODataResource { Properties = new[] { new ODataProperty { Name = "Id", Value = 1 } } };
             thing.TypeAnnotation = new ODataTypeAnnotation(entityType.FullTypeName());
-            thing.MetadataBuilder = metadataContext.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = thing, SelectedProperties = new SelectedPropertiesNode("*"), NavigationSource = entitySet}, useKeyAsSegment);
+            thing.MetadataBuilder = metadataContext.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = thing, SelectedProperties = new SelectedPropertiesNode("*", null), NavigationSource = entitySet}, useKeyAsSegment);
             return thing;
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/KeyAsSegmentTemplateIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/KeyAsSegmentTemplateIntegrationTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
 
             var thing = new ODataResource { Properties = new[] { new ODataProperty { Name = "Id", Value = 1 } } };
             thing.TypeAnnotation = new ODataTypeAnnotation(entityType.FullTypeName());
-            thing.MetadataBuilder = metadataContext.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = thing, SelectedProperties = new SelectedPropertiesNode("*", null), NavigationSource = entitySet}, useKeyAsSegment);
+            thing.MetadataBuilder = metadataContext.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = thing, SelectedProperties = new SelectedPropertiesNode("*", null, null), NavigationSource = entitySet}, useKeyAsSegment);
             return thing;
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonFullMetadataLevelTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonFullMetadataLevelTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OData.Tests.JsonLight
                 new TestFeedAndEntryTypeContext(),
                 new ODataResourceSerializationInfo(),
                 /*actualEntityType*/null,
-                SelectedPropertiesNode.EntireSubtree,
+                new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree),
                 /*isResponse*/ true,
                 /*keyAsSegment*/ false,
                 /*requestUri*/ null);
@@ -70,7 +70,7 @@ namespace Microsoft.OData.Tests.JsonLight
                 new TestFeedAndEntryTypeContext(),
                 new ODataResourceSerializationInfo(),
                 /*actualEntityType*/null,
-                SelectedPropertiesNode.EntireSubtree,
+                new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree),
                 /*isResponse*/ true,
                 /*keyAsSegment*/ false,
                 /*requestUri*/ null).Should().BeAssignableTo<ODataConventionalResourceMetadataBuilder>();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonMinimalMetadataLevelTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonMinimalMetadataLevelTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.OData.Tests.JsonLight
                 /*typeContext*/ null,
                 /*serializationInfo*/ null,
                 /*actualEntityType*/ null,
-                SelectedPropertiesNode.EntireSubtree,
+                new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree),
                 /*isResponse*/ true,
                 /*keyAsSegment*/ false,
                 /*requestUri*/ null).Should().BeNull();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonNoMetadataLevelTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonNoMetadataLevelTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.OData.Tests.JsonLight
                 /*typeContext*/ null,
                 /*serializationInfo*/ null,
                 /*actualEntityType*/ null,
-                SelectedPropertiesNode.EntireSubtree,
+                new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree),
                 /*isResponse*/ true,
                 /*keyAsSegment*/ false,
                 /*requestUri*/ null).Should().Be(ODataResourceMetadataBuilder.Null);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
@@ -382,7 +382,7 @@ namespace Microsoft.OData.Tests
 
             string expected = version == ODataVersion.V4 ?
                 //OData V4.01
-                "{\"@odata.context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2)\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2())\"," +
                     "\"value\":[" +
                     "{" +
                         "\"UserName\":\"abc\"," +
@@ -414,7 +414,7 @@ namespace Microsoft.OData.Tests
                         "}" +
                     "}]}";
 
-                    Assert.Equal(actual, expected);
+            Assert.Equal(actual, expected);
 
             var entryList = ReadPayload(expected, Model, EntitySet, EntityType, true, version: version).OfType<ODataResource>().ToList();
             entryList[0].Id.Should().Be(new Uri("http://host/City(222)"));
@@ -431,7 +431,7 @@ namespace Microsoft.OData.Tests
         }
 
         private const string v4MinimalMetadataPayload =
-                                               "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav)/$entity\"," +
+                                               "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav())/$entity\"," +
                                                        "\"ID\":\"abc\"," +
                                                         "\"Complex\":{" +
                                                         "\"Prop1\":123," +
@@ -444,7 +444,7 @@ namespace Microsoft.OData.Tests
                                                     "}" +
                                                 "}";
         private const string v4FullMetadataPayload =
-                                         "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav)/$entity\"," +
+                                         "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav())/$entity\"," +
                                              "\"@odata.id\":\"Entities('abc')\"," +
                                              "\"@odata.editLink\":\"Entities('abc')\"," +
                                              "\"ID\":\"abc\"," +
@@ -671,7 +671,7 @@ namespace Microsoft.OData.Tests
 
             string expectedPayload = version == ODataVersion.V4 ?
                 // OData version 4.0
-                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(ZipCode,Region))\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(ZipCode,Region()))\"," +
                 "\"@odata.type\":\"#DefaultNs.WorkAddress\"," +
                 "\"Road\":\"Ziyue\"," +
                 "\"City2\":{" +
@@ -737,7 +737,7 @@ namespace Microsoft.OData.Tests
 
             string expectedPayload = version == ODataVersion.V4 ?
                 // OData V4 Version
-                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(Region()))\"," +
                 "\"@odata.type\":\"#DefaultNs.WorkAddress\"," +
                 "\"Road\":\"Ziyue\"," +
                 "\"City2\":{" +
@@ -815,7 +815,7 @@ namespace Microsoft.OData.Tests
 
             string expectedPayload = version == ODataVersion.V4 ?
                 // OData version 4.0
-                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address(WorkAddress/DefaultNs.WorkAddress/City2(ZipCode,Region))\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address(WorkAddress/DefaultNs.WorkAddress/City2(ZipCode,Region()))\"," +
                 "\"Road\":\"Zixing\"," +
                 "\"WorkAddress\":{" +
                     "\"@odata.type\":\"#DefaultNs.WorkAddress\"," +

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -211,13 +211,13 @@ namespace Microsoft.OData.Tests
 
         [Theory]
         // expand without select, $expand=A
-        [InlineData(ODataVersion.V4, "TestModel.CapitolCity/Districts", "")]
+        [InlineData(ODataVersion.V4, "TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts()")]
         [InlineData(ODataVersion.V401, "TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts()")]
         // expands without select, $expand=A,B
-        [InlineData(ODataVersion.V4, "TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", "")]
+        [InlineData(ODataVersion.V4, "TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts",   "TestModel.CapitolCity/CapitolDistrict(),TestModel.CapitolCity/Districts()")]
         [InlineData(ODataVersion.V401, "TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", "TestModel.CapitolCity/CapitolDistrict(),TestModel.CapitolCity/Districts()")]
         // expand with nested select, $expand=A($select=B)
-        [InlineData(ODataVersion.V4, "TestModel.CapitolCity/Districts($select=Name)", "TestModel.CapitolCity/Districts(Name)")]
+        [InlineData(ODataVersion.V4, "TestModel.CapitolCity/Districts($select=Name)",   "TestModel.CapitolCity/Districts(Name)")]
         [InlineData(ODataVersion.V401, "TestModel.CapitolCity/Districts($select=Name)", "TestModel.CapitolCity/Districts(Name)")]
 
         public void FeedContextUriWithSingleExpandString(ODataVersion version, string expandClause, string expectedClause)
@@ -227,23 +227,24 @@ namespace Microsoft.OData.Tests
 
         [Theory]
         // $select=A&$expand=B
-        [InlineData(ODataVersion.V4, "Name", "Districts", "Name,Districts")]
+        [InlineData(ODataVersion.V4,   "Name", "Districts", "Name,Districts()")]
         [InlineData(ODataVersion.V401, "Name", "Districts", "Name,Districts()")]
         // $select=A&$expand=A
-        [InlineData(ODataVersion.V4, "Districts", "Districts", "Districts")]
+        [InlineData(ODataVersion.V4,   "Districts", "Districts", "Districts()")]
         [InlineData(ODataVersion.V401, "Districts", "Districts", "Districts()")]
         // $select=A,B,C&$expand=A
-        [InlineData(ODataVersion.V4, "Name,Districts,Size", "Districts", "Name,Districts,Size")]
+        [InlineData(ODataVersion.V4,   "Name,Districts,Size", "Districts", "Name,Size,Districts()")]
         [InlineData(ODataVersion.V401, "Name,Districts,Size", "Districts", "Name,Size,Districts()")]
-        // $select=A&$expand=A,B
-        [InlineData(ODataVersion.V4, "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,TestModel.CapitolCity/CapitolDistrict")]
+        // $select=A&$expand=A,B ---Nav prop "Districts" is currently filtered out in ODataContextUrlInfo.CombineSelectAndExpandResult
+        [InlineData(ODataVersion.V4,   "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts(),TestModel.CapitolCity/CapitolDistrict()")]
         [InlineData(ODataVersion.V401, "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts(),TestModel.CapitolCity/CapitolDistrict()")]
         // $select=A,B&$expand=B($select=C)
         [InlineData(ODataVersion.V4, "Name,Districts", "Districts($select=Name)", "Name,Districts(Name)")]
         [InlineData(ODataVersion.V401, "Name,Districts", "Districts($select=Name)", "Name,Districts(Name)")]
         public void FeedContextUriWithSelectAndExpandString(ODataVersion version, string selectClause, string expandClause, string expectedClause)
         {
-            this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
+            string uriString = this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString;
+            uriString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
 
         [Fact]
@@ -266,17 +267,19 @@ namespace Microsoft.OData.Tests
         }
 
         [Theory]
-        [InlineData(ODataVersion.V4, "")]
-        [InlineData(ODataVersion.V401, "Districts(City(Districts()))")]
-        public void EntryContextUriWithExpandNestedExpandString(ODataVersion version, string expectedExpandWithoutNesting)
+        [InlineData(ODataVersion.V4)]
+        [InlineData(ODataVersion.V401)]
+        public void EntryContextUriWithExpandNestedExpandString(ODataVersion version)
         {
             // Without inner $select, $expand=A($expand=B($expand=C))
             string expandClause = "Districts($expand=City($expand=Districts))";
-            this.CreateEntryContextUri(null, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedExpandWithoutNesting));
+            string expectedClause = "Districts(City(Districts()))";
+            string urlString = this.CreateEntryContextUri(null, expandClause, version).OriginalString;
+            urlString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedClause));
 
             // With inner $select, $expand=A($expand=B($select=C))
             expandClause = "Districts($expand=City($select=Districts))";
-            string expectedClause = "Districts(City(Districts))";
+            expectedClause = "Districts(City(Districts))";
             this.CreateEntryContextUri(null, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedClause));
 
             // With inner $expand, $expand=A($expand=C($select=D)))
@@ -291,12 +294,13 @@ namespace Microsoft.OData.Tests
         }
 
         [Theory]
-        [InlineData(ODataVersion.V4, "Size,Name,Districts(Zip,City(Name,Districts))")]
-        [InlineData(ODataVersion.V401, "Size,Name,Districts(Zip,City(Name,Districts()))")]
-        public void FeedContextUriWithMixedSelectAndExpandString(ODataVersion version, string expectedClause)
+        [InlineData(ODataVersion.V4)]
+        [InlineData(ODataVersion.V401)]
+        public void FeedContextUriWithMixedSelectAndExpandString(ODataVersion version)
         {
             const string selectClause = "Size,Name";
             const string expandClause = "Districts($select=Zip,City;$expand=City($expand=Districts;$select=Name))";
+            const string expectedClause = "Size,Name,Districts(Zip,City(Name,Districts()))";
             this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
         #endregion context uri with $select and $expand

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -211,40 +211,36 @@ namespace Microsoft.OData.Tests
 
         [Theory]
         // expand without select, $expand=A
-        [InlineData(ODataVersion.V4, "TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts()")]
-        [InlineData(ODataVersion.V401, "TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts()")]
+        [InlineData("TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts()")]
         // expands without select, $expand=A,B
-        [InlineData(ODataVersion.V4, "TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts",   "TestModel.CapitolCity/CapitolDistrict(),TestModel.CapitolCity/Districts()")]
-        [InlineData(ODataVersion.V401, "TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", "TestModel.CapitolCity/CapitolDistrict(),TestModel.CapitolCity/Districts()")]
+        [InlineData("TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", "TestModel.CapitolCity/CapitolDistrict(),TestModel.CapitolCity/Districts()")]
         // expand with nested select, $expand=A($select=B)
-        [InlineData(ODataVersion.V4, "TestModel.CapitolCity/Districts($select=Name)",   "TestModel.CapitolCity/Districts(Name)")]
-        [InlineData(ODataVersion.V401, "TestModel.CapitolCity/Districts($select=Name)", "TestModel.CapitolCity/Districts(Name)")]
+        [InlineData("TestModel.CapitolCity/Districts($select=Name)", "TestModel.CapitolCity/Districts(Name)")]
 
-        public void FeedContextUriWithSingleExpandString(ODataVersion version, string expandClause, string expectedClause)
+        public void FeedContextUriWithSingleExpandString(string expandClause, string expectedClause)
         {
+            foreach (ODataVersion version in Versions)
             this.CreateFeedContextUri("", expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
 
         [Theory]
         // $select=A&$expand=B
-        [InlineData(ODataVersion.V4,   "Name", "Districts", "Name,Districts()")]
-        [InlineData(ODataVersion.V401, "Name", "Districts", "Name,Districts()")]
+        [InlineData( "Name", "Districts", "Name,Districts()")]
         // $select=A&$expand=A
-        [InlineData(ODataVersion.V4,   "Districts", "Districts", "Districts,Districts()")]
-        [InlineData(ODataVersion.V401, "Districts", "Districts", "Districts,Districts()")]
+        [InlineData( "Districts", "Districts", "Districts,Districts()")]
         // $select=A,B,C&$expand=A
-        [InlineData(ODataVersion.V4,   "Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()")]
-        [InlineData(ODataVersion.V401, "Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()")]
+        [InlineData( "Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()")]
         // $select=A&$expand=A,B
-        [InlineData(ODataVersion.V4,   "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()")]
-        [InlineData(ODataVersion.V401, "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()")]
+        [InlineData( "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()")]
         // $select=A,B&$expand=B($select=C)
-        [InlineData(ODataVersion.V4, "Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)")]
-        [InlineData(ODataVersion.V401, "Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)")]
-        public void FeedContextUriWithSelectAndExpandString(ODataVersion version, string selectClause, string expandClause, string expectedClause)
+        [InlineData( "Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)")]
+        public void FeedContextUriWithSelectAndExpandString(string selectClause, string expandClause, string expectedClause)
         {
-            string uriString = this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString;
-            uriString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
+            foreach (ODataVersion version in Versions)
+            {
+                string uriString = this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString;
+                uriString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
+            }
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -230,17 +230,17 @@ namespace Microsoft.OData.Tests
         [InlineData(ODataVersion.V4,   "Name", "Districts", "Name,Districts()")]
         [InlineData(ODataVersion.V401, "Name", "Districts", "Name,Districts()")]
         // $select=A&$expand=A
-        [InlineData(ODataVersion.V4,   "Districts", "Districts", "Districts()")]
-        [InlineData(ODataVersion.V401, "Districts", "Districts", "Districts()")]
+        [InlineData(ODataVersion.V4,   "Districts", "Districts", "Districts,Districts()")]
+        [InlineData(ODataVersion.V401, "Districts", "Districts", "Districts,Districts()")]
         // $select=A,B,C&$expand=A
-        [InlineData(ODataVersion.V4,   "Name,Districts,Size", "Districts", "Name,Size,Districts()")]
-        [InlineData(ODataVersion.V401, "Name,Districts,Size", "Districts", "Name,Size,Districts()")]
-        // $select=A&$expand=A,B ---Nav prop "Districts" is currently filtered out in ODataContextUrlInfo.CombineSelectAndExpandResult
-        [InlineData(ODataVersion.V4,   "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts(),TestModel.CapitolCity/CapitolDistrict()")]
-        [InlineData(ODataVersion.V401, "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts(),TestModel.CapitolCity/CapitolDistrict()")]
+        [InlineData(ODataVersion.V4,   "Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()")]
+        [InlineData(ODataVersion.V401, "Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()")]
+        // $select=A&$expand=A,B
+        [InlineData(ODataVersion.V4,   "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()")]
+        [InlineData(ODataVersion.V401, "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()")]
         // $select=A,B&$expand=B($select=C)
-        [InlineData(ODataVersion.V4, "Name,Districts", "Districts($select=Name)", "Name,Districts(Name)")]
-        [InlineData(ODataVersion.V401, "Name,Districts", "Districts($select=Name)", "Name,Districts(Name)")]
+        [InlineData(ODataVersion.V4, "Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)")]
+        [InlineData(ODataVersion.V401, "Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)")]
         public void FeedContextUriWithSelectAndExpandString(ODataVersion version, string selectClause, string expandClause, string expectedClause)
         {
             string uriString = this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString;
@@ -261,7 +261,7 @@ namespace Microsoft.OData.Tests
                 // With $select in same level, $select=A&$expand=A($select=B,C)
                 selectClause = "Districts";
                 expandClause = "Districts($select=Name,Zip)";
-                expectedClause = "Districts(Name,Zip)";
+                expectedClause = "Districts,Districts(Name,Zip)";
                 this.CreateEntryContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedClause));
             }
         }
@@ -300,7 +300,7 @@ namespace Microsoft.OData.Tests
         {
             const string selectClause = "Size,Name";
             const string expandClause = "Districts($select=Zip,City;$expand=City($expand=Districts;$select=Name))";
-            const string expectedClause = "Size,Name,Districts(Zip,City(Name,Districts()))";
+            const string expectedClause = "Size,Name,Districts(Zip,City,City(Name,Districts()))";
             this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
         #endregion context uri with $select and $expand

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNavigationLinkTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNavigationLinkTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.OData.Tests
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.BaseType", ExpectedTypeName = "ns.BaseType" };
             var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
             var metadataContext = new TestMetadataContext();
-            var entryMetadataContext = ODataResourceMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, SelectedPropertiesNode.EntireSubtree);
+            var entryMetadataContext = ODataResourceMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree));
             var metadataBuilder = new ODataConventionalEntityMetadataBuilder(entryMetadataContext, metadataContext,
                 new ODataConventionalUriBuilder(ServiceUri, ODataUrlKeyDelimiter.Parentheses));
             this.navigationLinkWithFullBuilder = new ODataNestedResourceInfo { Name = "NavProp" };

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataOperationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataOperationTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OData.Tests
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.BaseType", ExpectedTypeName = "ns.BaseType" };
             var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
             var metadataContext = new TestMetadataContext();
-            var entryMetadataContext = ODataResourceMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, SelectedPropertiesNode.EntireSubtree);
+            var entryMetadataContext = ODataResourceMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree));
             var fullMetadataBuilder = new ODataConventionalEntityMetadataBuilder(entryMetadataContext, metadataContext,
                 new ODataConventionalUriBuilder(ServiceUri, ODataUrlKeyDelimiter.Parentheses));
             this.operationWithFullBuilder = new TestODataOperation { Metadata = ContextUri };

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.OData.Tests
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.BaseType", ExpectedTypeName = "ns.BaseType" };
             var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
             var metadataContext = new TestMetadataContext();
-            var entryMetadataContext = ODataResourceMetadataContext.Create(this.odataEntryWithFullBuilder, typeContext, serializationInfo, null, metadataContext, SelectedPropertiesNode.EntireSubtree);
+            var entryMetadataContext = ODataResourceMetadataContext.Create(this.odataEntryWithFullBuilder, typeContext, serializationInfo, null, metadataContext, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree));
             this.odataEntryWithFullBuilder.MetadataBuilder =
                 new ODataConventionalEntityMetadataBuilder(entryMetadataContext, metadataContext,
                     new ODataConventionalUriBuilder(new Uri("http://service/", UriKind.Absolute),

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataStreamReferenceValueTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataStreamReferenceValueTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OData.Tests
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.BaseType", ExpectedTypeName = "ns.BaseType" };
             var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
             var metadataContext = new TestMetadataContext();
-            var entryMetadataContext = ODataResourceMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, SelectedPropertiesNode.EntireSubtree);
+            var entryMetadataContext = ODataResourceMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree));
             var fullMetadataBuilder = new ODataConventionalEntityMetadataBuilder(entryMetadataContext, metadataContext,
                 new ODataConventionalUriBuilder(ServiceUri, ODataUrlKeyDelimiter.Parentheses));
             this.streamWithFullBuilder = new ODataStreamReferenceValue();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataUtilsInternalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataUtilsInternalTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.Tests
         public void SelectedPropertiesShouldReturnEntireSubtreeWhenMetadataDocumentUriIsNull()
         {
             ODataMessageWriterSettings settings = new ODataMessageWriterSettings();
-            settings.SelectedProperties.Should().BeSameAs(SelectedPropertiesNode.EntireSubtree);
+            settings.SelectedProperties.IsEntireSubtree().Should().BeTrue();
         }
 
         [Fact]
@@ -24,7 +24,7 @@ namespace Microsoft.OData.Tests
         {
             ODataMessageWriterSettings settings = new ODataMessageWriterSettings();
             settings.SetServiceDocumentUri(new Uri("http://service/$metadata"));
-            settings.SelectedProperties.Should().BeSameAs(SelectedPropertiesNode.EntireSubtree);
+            settings.SelectedProperties.IsEntireSubtree().Should().BeTrue();
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
@@ -737,7 +737,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
         // Sample Request: http://host/service/Employees?$expand=Company
         // Context Url in Response: http://host/service/$metadata#Employees(Company())
         [Theory]
-        [InlineData(ODataVersion.V4, "\"{0}$metadata#Employees\"")]
+        [InlineData(ODataVersion.V4, "\"{0}$metadata#Employees(AssociatedCompany())\"")]
         [InlineData(ODataVersion.V401, "\"{0}$metadata#Employees(AssociatedCompany())\"")]
         public void CollectionOfExpandedEntities(ODataVersion version, string contextString)
         {
@@ -780,7 +780,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
         {
             foreach (ODataFormat mimeType in mimeTypes)
             {
-                // In 7.4.1 and before, this scenario resulted in the same 
+                // In 7.4.1 and before, this scenario resulted in the same
                 // context Uri as 10.2: http://host/service/$metadata#Employees
                 var writerSettings = new ODataMessageWriterSettings
                 {
@@ -803,7 +803,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                     feed.Id = new Uri("urn:test");
                     writer.WriteStart(feed);
                     writer.WriteEnd();
-                }, string.Format("\"{0}$metadata#Employees\"", TestBaseUri), out payload, out contentType);
+                }, string.Format("\"{0}$metadata#Employees(AssociatedCompany())\"", TestBaseUri), out payload, out contentType);
 
                 this.ReadPayload(payload, contentType, model, omReader =>
                 {
@@ -906,7 +906,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                     writer.WriteStart(entry);
                     writer.WriteEnd();
                 },
-                string.Format("\"{0}$metadata#Employees(AssociatedCompany)/$entity\"", TestBaseUri),
+                string.Format("\"{0}$metadata#Employees(AssociatedCompany())/$entity\"", TestBaseUri),
                 out payload, out contentType);
 
                 this.ReadPayload(payload, contentType, model, omReader =>
@@ -921,7 +921,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
         // V4 Protocol Spec Chapter 10.10: Projected Expanded Entities (not contain select)
         // Sample Request: http://host/service/Employees(0)?$expand=AssociatedCompany
         [Theory]
-        [InlineData(ODataVersion.V4, "\"{0}$metadata#Employees(AssociatedCompany)/$entity\"")]
+        [InlineData(ODataVersion.V4, "\"{0}$metadata#Employees(AssociatedCompany())/$entity\"")]
         [InlineData(ODataVersion.V401, "\"{0}$metadata#Employees(AssociatedCompany())/$entity\"")]
         public void ExpandedMultiSegmentEntity(ODataVersion version, string contextString)
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
@@ -906,7 +906,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                     writer.WriteStart(entry);
                     writer.WriteEnd();
                 },
-                string.Format("\"{0}$metadata#Employees(AssociatedCompany())/$entity\"", TestBaseUri),
+                string.Format("\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany())/$entity\"", TestBaseUri),
                 out payload, out contentType);
 
                 this.ReadPayload(payload, contentType, model, omReader =>
@@ -921,8 +921,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
         // V4 Protocol Spec Chapter 10.10: Projected Expanded Entities (not contain select)
         // Sample Request: http://host/service/Employees(0)?$expand=AssociatedCompany
         [Theory]
-        [InlineData(ODataVersion.V4, "\"{0}$metadata#Employees(AssociatedCompany())/$entity\"")]
-        [InlineData(ODataVersion.V401, "\"{0}$metadata#Employees(AssociatedCompany())/$entity\"")]
+        [InlineData(ODataVersion.V4, "\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany())/$entity\"")]
+        [InlineData(ODataVersion.V401, "\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany())/$entity\"")]
         public void ExpandedMultiSegmentEntity(ODataVersion version, string contextString)
         {
             ODataResource entry = new ODataResource()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
@@ -926,10 +926,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
         // V4 Protocol Spec Chapter 10.10: Projected Expanded Entities (not contain select)
         // Sample Request: http://host/service/Employees(0)?$expand=AssociatedCompany
         [Theory]
-        [InlineData(ODataVersion.V4, "\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany())/$entity\"")]
-        [InlineData(ODataVersion.V401, "\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany())/$entity\"")]
-        public void ExpandedMultiSegmentEntity(ODataVersion version, string contextString)
+        [InlineData(ODataVersion.V4)]
+        [InlineData(ODataVersion.V401)]
+        public void ExpandedMultiSegmentEntity(ODataVersion version)
         {
+            string contextString = "\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany())/$entity\"";
             ODataResource entry = new ODataResource()
             {
                 TypeName = TestNameSpace + ".Employee",

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
@@ -367,7 +367,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         {
             Uri queryUri = new Uri("People?$select=MyAddress&$expand=MyDog, MyFavoritePainting", UriKind.Relative);
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
-            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("MyAddress,MyDog,MyFavoritePainting") + "&$expand=" + Uri.EscapeDataString("MyDog,MyFavoritePainting"), actualUri.OriginalString);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("MyAddress") + "&$expand=" + Uri.EscapeDataString("MyDog,MyFavoritePainting"), actualUri.OriginalString);
         }
 
         [Fact]
@@ -375,7 +375,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         {
             Uri queryUri = new Uri("People?$select=MyAddress, MyDog&$expand=MyDog, MyFavoritePainting", UriKind.Relative);
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
-            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("MyAddress,MyDog,MyFavoritePainting") + "&$expand=" + Uri.EscapeDataString("MyDog,MyFavoritePainting"), actualUri.OriginalString);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("MyAddress,MyDog") + "&$expand=" + Uri.EscapeDataString("MyDog,MyFavoritePainting"), actualUri.OriginalString);
         }
 
         [Fact]
@@ -407,7 +407,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         {
             Uri queryUri = new Uri("People?$select=Fully.Qualified.Namespace.Employee/MyDog&$expand=MyDog", UriKind.Relative);
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
-            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("Fully.Qualified.Namespace.Employee/MyDog,MyDog") + "&$expand=MyDog", actualUri.OriginalString);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("Fully.Qualified.Namespace.Employee/MyDog") + "&$expand=MyDog", actualUri.OriginalString);
         }
 
         [Fact]
@@ -415,7 +415,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         {
             Uri queryUri = new Uri("People?$select=MyDog&$expand=Fully.Qualified.Namespace.Employee/MyDog", UriKind.Relative);
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
-            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("MyDog,Fully.Qualified.Namespace.Employee/MyDog") + "&$expand=" + Uri.EscapeDataString("Fully.Qualified.Namespace.Employee/MyDog"), actualUri.OriginalString);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("MyDog") + "&$expand=" + Uri.EscapeDataString("Fully.Qualified.Namespace.Employee/MyDog"), actualUri.OriginalString);
         }
 
         [Fact]
@@ -455,7 +455,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         {
             Uri queryUri = new Uri("People?$select=Name,Birthdate,MyAddress,Fully.Qualified.Namespace.*,MyLions&$expand=MyDog", UriKind.Relative);
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
-            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("Name,Birthdate,MyAddress,Fully.Qualified.Namespace.*,MyLions,MyDog") + "&$expand=" + Uri.EscapeDataString("MyDog"), actualUri.OriginalString);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("Name,Birthdate,MyAddress,Fully.Qualified.Namespace.*,MyLions") + "&$expand=" + Uri.EscapeDataString("MyDog"), actualUri.OriginalString);
         }
 
         [Fact]
@@ -511,7 +511,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         {
             Uri queryUri = new Uri("People?$expand=MyDog($select=Color;$expand=MyPeople)", UriKind.Relative);
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
-            Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString("MyDog($select=Color,MyPeople;$expand=MyPeople)"), actualUri.OriginalString);
+            Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString("MyDog($select=Color;$expand=MyPeople)"), actualUri.OriginalString);
         }
 
         [Fact]
@@ -649,7 +649,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         {
             Uri queryUri = new Uri("People?$select=Name,MyOpenAddress/Test&$expand=MyDog($filter=Color eq 'Brown';$orderby=Color; $search=Color)", UriKind.Relative);
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
-            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("Name,MyOpenAddress/Test,MyDog") + "&$expand=" + Uri.EscapeDataString("MyDog($filter=Color eq 'Brown';$orderby=Color;$search=Color)"), actualUri.OriginalString);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("Name,MyOpenAddress/Test") + "&$expand=" + Uri.EscapeDataString("MyDog($filter=Color eq 'Brown';$orderby=Color;$search=Color)"), actualUri.OriginalString);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
@@ -228,16 +228,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             const string selectClauseText = "Navigation2";
             const string expandClauseText = "Navigation1";
-            const string expectedSelectClause = "Navigation2";
-            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: expectedSelectClause, expectedExpandClauseFromOM: "Navigation1");
+            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: selectClauseText, expectedExpandClauseFromOM: "Navigation1");
         }
 
         [Fact]
         public void ExpandNavigationThatIsNotSelectedInNonTopLevelAutomaticallySelectsLink()
         {
             const string expandClauseText = "Navigation1($select=Navigation1;$expand=Navigation2)";
-            const string expectedExpandClauseText = "Navigation1($select=Navigation1;$expand=Navigation2)";
-            this.ParseAndExtract(selectClauseText: null, expandClauseText: expandClauseText, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: expectedExpandClauseText);
+            this.ParseAndExtract(selectClauseText: null, expandClauseText: expandClauseText, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: expandClauseText);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             const string selectClauseText = "Navigation2";
             const string expandClauseText = "Navigation1";
-            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: selectClauseText, expectedExpandClauseFromOM: "Navigation1");
+            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: selectClauseText, expectedExpandClauseFromOM: expandClauseText);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
@@ -228,7 +228,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             const string selectClauseText = "Navigation2";
             const string expandClauseText = "Navigation1";
-            const string expectedSelectClause = "Navigation2,Navigation1";
+            const string expectedSelectClause = "Navigation2";
             this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: expectedSelectClause, expectedExpandClauseFromOM: "Navigation1");
         }
 
@@ -236,7 +236,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void ExpandNavigationThatIsNotSelectedInNonTopLevelAutomaticallySelectsLink()
         {
             const string expandClauseText = "Navigation1($select=Navigation1;$expand=Navigation2)";
-            const string expectedExpandClauseText = "Navigation1($select=Navigation1,Navigation2;$expand=Navigation2)";
+            const string expectedExpandClauseText = "Navigation1($select=Navigation1;$expand=Navigation2)";
             this.ParseAndExtract(selectClauseText: null, expandClauseText: expandClauseText, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: expectedExpandClauseText);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -108,7 +108,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             selectItem.ShouldBePathSelectionItem(new ODataPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp())));
         }
 
-        [Fact]  
+        [Fact]
         public void SelectComplexPropertyWithCast()
         {
             var selectItem = ParseSingleSelectForPerson("MyAddress/Fully.Qualified.Namespace.HomeAddress");
@@ -824,13 +824,13 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             var results = RunParseSelectExpand("MyAddress", "MyDog, MyFavoritePainting", HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
 
-            results.SelectedItems.Should().HaveCount(5);
+            results.SelectedItems.Should().HaveCount(3);
             results.SelectedItems.OfType<ExpandedNavigationSelectItem>().Should().HaveCount(2);
             results.SelectedItems.OfType<ExpandedNavigationSelectItem>().ElementAt(0).SelectAndExpand.AllSelected.Should().BeTrue();
             results.SelectedItems.OfType<ExpandedNavigationSelectItem>().ElementAt(1).SelectAndExpand.AllSelected.Should().BeTrue();
             results.AllSelected.Should().BeFalse();
 
-            AssertSelectString("MyAddress,MyDog,MyFavoritePainting", results);
+            AssertSelectString("MyAddress", results);
             AssertExpandString("MyDog,MyFavoritePainting", results);
         }
 
@@ -839,16 +839,15 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             var results = RunParseSelectExpand("MyAddress, MyDog", "MyDog, MyFavoritePainting", HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
 
-            results.SelectedItems.Should().HaveCount(5);
+            results.SelectedItems.Should().HaveCount(4);
             results.SelectedItems.OfType<ExpandedNavigationSelectItem>().Should().HaveCount(2);
             results.SelectedItems.OfType<ExpandedNavigationSelectItem>().ElementAt(0).SelectAndExpand.AllSelected.Should().BeTrue();
             results.SelectedItems.OfType<ExpandedNavigationSelectItem>().ElementAt(1).SelectAndExpand.AllSelected.Should().BeTrue();
             results.SelectedItems.OfType<PathSelectItem>().ElementAt(0).ShouldBePathSelectionItem(new ODataPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp())));
             results.SelectedItems.OfType<PathSelectItem>().ElementAt(1).ShouldBePathSelectionItem(new ODataPath(new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), HardCodedTestModel.GetPeopleSet())));
-            results.SelectedItems.OfType<PathSelectItem>().ElementAt(2).ShouldBePathSelectionItem(new ODataPath(new NavigationPropertySegment(HardCodedTestModel.GetPersonMyFavoritePaintingNavProp(), HardCodedTestModel.GetPeopleSet())));
             results.AllSelected.Should().BeFalse();
 
-            AssertSelectString("MyAddress,MyDog,MyFavoritePainting", results);
+            AssertSelectString("MyAddress,MyDog", results);
             AssertExpandString("MyDog,MyFavoritePainting", results);
         }
 
@@ -932,10 +931,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void SelectAndExpandWithDifferentTypesWorks()
         {
             var result = RunParseSelectExpand("Fully.Qualified.Namespace.Employee/MyDog", "Fully.Qualified.Namespace.Manager/MyDog", HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
-            result.SelectedItems.Count().Should().Be(3);
+            result.SelectedItems.Count().Should().Be(2);
             result.SelectedItems.Single(x => x is ExpandedNavigationSelectItem).ShouldBeExpansionFor(HardCodedTestModel.GetPersonMyDogNavProp());
-            result.SelectedItems.First(x => x is PathSelectItem).ShouldBePathSelectionItem(new ODataPath(new TypeSegment(HardCodedTestModel.GetEmployeeType(), HardCodedTestModel.GetPeopleSet()), new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), HardCodedTestModel.GetPeopleSet())));
-            result.SelectedItems.Last(x => x is PathSelectItem).ShouldBePathSelectionItem(new ODataPath(new TypeSegment(HardCodedTestModel.GetManagerType(), HardCodedTestModel.GetPeopleSet()), new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), HardCodedTestModel.GetPeopleSet())));
+            result.SelectedItems.Single(x => x is PathSelectItem).ShouldBePathSelectionItem(new ODataPath(new TypeSegment(HardCodedTestModel.GetEmployeeType(), HardCodedTestModel.GetPeopleSet()), new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), HardCodedTestModel.GetPeopleSet())));
         }
 
         [Fact]
@@ -1021,7 +1019,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void MixOfSelectionTypesShouldWork()
         {
             const string select = "Name,Birthdate,MyAddress,Fully.Qualified.Namespace.*,MyLions";
-            const string expectedSelect = "Name,Birthdate,MyAddress,Fully.Qualified.Namespace.*,MyLions,MyDog";
+            const string expectedSelect = "Name,Birthdate,MyAddress,Fully.Qualified.Namespace.*,MyLions";
             const string expand = "MyDog";
             var results = RunParseSelectExpandAndAssertPaths(
                 select,
@@ -1030,7 +1028,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                 expand,
                 HardCodedTestModel.GetPersonType(),
                 null);
-            results.SelectedItems.Should().HaveCount(7);
+            results.SelectedItems.Should().HaveCount(6);
             results.AllSelected.Should().BeFalse();
         }
 
@@ -1169,11 +1167,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
-        public void ExplicitNavPropIsAddedIfNeededAtDeeperLevels()
+        public void ExplicitNavPropIsNotAddedIfNeededAtDeeperLevels()
         {
             const string expandClauseText = "MyDog($select=Color;$expand=MyPeople)";
             const string selectClauseText = "";
-            const string expectedExpandClauseText = "MyDog($select=Color,MyPeople;$expand=MyPeople)";
+            const string expectedExpandClauseText = "MyDog($select=Color;$expand=MyPeople)";
             const string expectedSelectClause = "";
             var results = RunParseSelectExpand(selectClauseText, expandClauseText, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
             AssertSelectString(expectedSelectClause, results);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -1019,12 +1019,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void MixOfSelectionTypesShouldWork()
         {
             const string select = "Name,Birthdate,MyAddress,Fully.Qualified.Namespace.*,MyLions";
-            const string expectedSelect = "Name,Birthdate,MyAddress,Fully.Qualified.Namespace.*,MyLions";
             const string expand = "MyDog";
             var results = RunParseSelectExpandAndAssertPaths(
                 select,
                 expand,
-                expectedSelect,
+                select,
                 expand,
                 HardCodedTestModel.GetPersonType(),
                 null);
@@ -1171,11 +1170,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             const string expandClauseText = "MyDog($select=Color;$expand=MyPeople)";
             const string selectClauseText = "";
-            const string expectedExpandClauseText = "MyDog($select=Color;$expand=MyPeople)";
-            const string expectedSelectClause = "";
             var results = RunParseSelectExpand(selectClauseText, expandClauseText, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
-            AssertSelectString(expectedSelectClause, results);
-            AssertExpandString(expectedExpandClauseText, results);
+            AssertSelectString(selectClauseText, results);
+            AssertExpandString(expandClauseText, results);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
@@ -317,7 +317,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ContainedCollectionNavProp))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ContainedCollectionNavProp()))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -357,7 +357,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp(ContainedNavProp))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp(ContainedNavProp()))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -392,7 +392,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ContainedNavProp))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ContainedNavProp()))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -427,7 +427,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp(ContainedNavProp))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp(ContainedNavProp()))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ExpandedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ExpandedCollectionNavProp\":" +
@@ -463,7 +463,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ExpandedNavProp))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ExpandedNavProp()))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -500,7 +500,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp()))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -539,7 +539,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=Namespace.DerivedType/ContainedNavProp;$expand=Namespace.DerivedType/ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, DerivedType, selectClause, expandClause, "EntitySet/Namespace.DerivedType");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp(Namespace.DerivedType/ContainedNavProp))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp(Namespace.DerivedType/ContainedNavProp()))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -574,7 +574,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "Namespace.DerivedType/ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp()))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -659,7 +659,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ExpandedNavProp,ContainedCollectionNavProp($select=ID),ContainedNavProp($select=ID,Name)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ID,Name,ExpandedNavProp,ContainedCollectionNavProp(ID),ContainedNavProp(ID,Name))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ID,Name,ExpandedNavProp(),ContainedCollectionNavProp(ID),ContainedNavProp(ID,Name))/$entity\"," +
                                             "\"ID\":101,\"Name\":\"Alice\"," +
                                             "\"ExpandedNavProp\":{\"ID\":102,\"Name\":\"Bob\"}," +
                                             "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
@@ -953,7 +953,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp)/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp())/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":[{\"ID\":102,\"Name\":\"Bob\"}]" +
@@ -1008,7 +1008,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
                 ServiceRoot = new Uri("http://example.org/odata.svc"),
                 SelectAndExpand = parser.ParseSelectAndExpand(),
                 Apply = parser.ParseApply()
-        };
+            };
 
             if (resourcePath != null)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
@@ -317,7 +317,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ContainedCollectionNavProp()))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedCollectionNavProp,ContainedCollectionNavProp()))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -357,7 +357,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp(ContainedNavProp()))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp(ContainedNavProp,ContainedNavProp()))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -392,7 +392,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ContainedNavProp()))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp()))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -427,7 +427,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp(ContainedNavProp()))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp,ExpandedCollectionNavProp(ContainedNavProp,ContainedNavProp()))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ExpandedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ExpandedCollectionNavProp\":" +
@@ -463,7 +463,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ExpandedNavProp()))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ExpandedNavProp,ExpandedNavProp()))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -500,7 +500,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp()))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp()))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -539,7 +539,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=Namespace.DerivedType/ContainedNavProp;$expand=Namespace.DerivedType/ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, DerivedType, selectClause, expandClause, "EntitySet/Namespace.DerivedType");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp(Namespace.DerivedType/ContainedNavProp()))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp,ContainedNavProp(Namespace.DerivedType/ContainedNavProp,Namespace.DerivedType/ContainedNavProp()))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -574,7 +574,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "Namespace.DerivedType/ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp()))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp()))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -953,7 +953,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp())/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp())/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":[{\"ID\":102,\"Name\":\"Bob\"}]" +

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.Tests.Evaluation
 {
     public class SelectedPropertiesNodeTests
     {
-        private static readonly SelectedPropertiesNode EntireSubtreeNode = SelectedPropertiesNode.Create(null);
+        private static readonly SelectedPropertiesNode EntireSubtreeNode = SelectedPropertiesNode.Create((string)null);
         private static readonly SelectedPropertiesNode EmptyNode = SelectedPropertiesNode.Create(string.Empty);
 
         private EdmModel edmModel;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.Tests.Evaluation
 {
     public class SelectedPropertiesNodeTests
     {
-        private static readonly SelectedPropertiesNode EntireSubtreeNode = SelectedPropertiesNode.EntireSubtree;
+        private static readonly SelectedPropertiesNode EntireSubtreeNode = SelectedPropertiesNode.Create(null);
         private static readonly SelectedPropertiesNode EmptyNode = SelectedPropertiesNode.Create(string.Empty);
 
         private EdmModel edmModel;
@@ -92,7 +92,7 @@ namespace Microsoft.OData.Tests.Evaluation
         [Fact]
         public void NoSelectClauseShouldIncludeEntireSubtree()
         {
-            SelectedPropertiesNode.EntireSubtree.Should().BeSameAsEntireSubtree().And.IncludeEntireSubtree(this.cityType);
+            SelectedPropertiesNode.EntireSubtree.Should().HaveEntireSubtree().And.IncludeEntireSubtree(this.cityType);
         }
 
         [Fact]
@@ -128,25 +128,25 @@ namespace Microsoft.OData.Tests.Evaluation
         [Fact]
         public void SelectingANavigationShouldSelectTheEntireTree()
         {
-            SelectedPropertiesNode.Create("Districts").Should().HaveOnlyNavigations(this.cityType, "Districts").And.HaveChild(this.cityType, "Districts", c => c.Should().BeSameAsEntireSubtree());
+            SelectedPropertiesNode.Create("Districts").Should().HaveOnlyNavigations(this.cityType, "Districts").And.HaveChild(this.cityType, "Districts", c => c.Should().HaveEntireSubtree());
         }
 
         [Fact]
         public void SpecifyingTheSameNavigationTwiceShouldNotCauseDuplicates()
         {
-            SelectedPropertiesNode.Create("Districts,Districts").Should().HaveOnlyNavigations(this.cityType, "Districts").And.HaveChild(this.cityType, "Districts", c => c.Should().BeSameAsEntireSubtree());
+            SelectedPropertiesNode.Create("Districts,Districts").Should().HaveOnlyNavigations(this.cityType, "Districts").And.HaveChild(this.cityType, "Districts", c => c.Should().HaveEntireSubtree());
         }
 
         [Fact]
         public void SpecifyingAWildCardShouldNotCauseDuplicates()
         {
-            SelectedPropertiesNode.Create("Districts,*,Photo").Should().HaveStreams(this.cityType, "Photo").And.HaveNavigations(this.cityType, "Districts").And.HaveChild(this.cityType, "Districts", c => c.Should().BeSameAsEntireSubtree());
+            SelectedPropertiesNode.Create("Districts,*,Photo").Should().HaveStreams(this.cityType, "Photo").And.HaveNavigations(this.cityType, "Districts").And.HaveChild(this.cityType, "Districts", c => c.Should().HaveEntireSubtree());
         }
 
         [Fact]
         public void SelectingANavigationShouldSelectTheEntireTreeIfWildcardAlsoPresent()
         {
-            SelectedPropertiesNode.Create("Districts,Districts/*").Should().HaveOnlyNavigations(this.cityType, "Districts").And.HaveChild(this.cityType, "Districts", c => c.Should().BeSameAsEntireSubtree());
+            SelectedPropertiesNode.Create("Districts,Districts/*").Should().HaveOnlyNavigations(this.cityType, "Districts").And.HaveChild(this.cityType, "Districts", c => c.Should().HaveEntireSubtree());
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace Microsoft.OData.Tests.Evaluation
             SelectedPropertiesNode.Create("Districts,Districts/Thumbnail")
                 .Should()
                 .HaveOnlyNavigations(this.cityType, "Districts")
-                .And.HaveChild(this.cityType, "Districts", c => c.Should().BeSameAsEntireSubtree());
+                .And.HaveChild(this.cityType, "Districts", c => c.Should().HaveEntireSubtree());
         }
 
         [Fact]
@@ -167,7 +167,7 @@ namespace Microsoft.OData.Tests.Evaluation
             SelectedPropertiesNode.Create("*,Districts,Districts/*").Should()
                 .HaveStreams(this.cityType, "Photo")
                 .And.HaveNavigations(this.cityType, "Districts")
-                .And.HaveChild(this.cityType, "Districts", c => c.Should().BeSameAsEntireSubtree());
+                .And.HaveChild(this.cityType, "Districts", c => c.Should().HaveEntireSubtree());
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace Microsoft.OData.Tests.Evaluation
                     "Districts",
                     c => c.Should()
                         .HaveStreams(this.districtType, "Thumbnail")
-                        .And.HaveChild(this.districtType, "City", c2 => c2.Should().BeSameAsEntireSubtree()));
+                        .And.HaveChild(this.districtType, "City", c2 => c2.Should().HaveEntireSubtree()));
         }
 
         [Fact]
@@ -312,10 +312,10 @@ namespace Microsoft.OData.Tests.Evaluation
         [Fact]
         public void CombiningEntireSubtreeWithAnythingShouldReturnEntireSubtree()
         {
-            SelectedPropertiesNode.CombineNodes(EntireSubtreeNode, EntireSubtreeNode).Should().BeSameAsEntireSubtree();
+            SelectedPropertiesNode.CombineNodes(EntireSubtreeNode, EntireSubtreeNode).Should().HaveEntireSubtree();
 
-            this.VerifyCombination(EmptyNode, EntireSubtreeNode, n => n.Should().BeSameAsEntireSubtree());
-            this.VerifyCombination(SelectedPropertiesNode.Create("*"), EntireSubtreeNode, n => n.Should().BeSameAsEntireSubtree());
+            this.VerifyCombination(EmptyNode, EntireSubtreeNode, n => n.Should().HaveEntireSubtree());
+            this.VerifyCombination(SelectedPropertiesNode.Create("*"), EntireSubtreeNode, n => n.Should().HaveEntireSubtree());
         }
 
         [Fact]
@@ -399,9 +399,9 @@ namespace Microsoft.OData.Tests.Evaluation
         }
 
         [Fact]
-        public void SpecificActionWithParametersShouldBeSelected()
+        public void UnqualifiedUnboundActionWithParametersShouldNotBeSelected()
         {
-            SelectedPropertiesNode.Create("Action(Edm.Int32)").Should().HaveAction(this.cityType, this.action);
+            SelectedPropertiesNode.Create("Action(Edm.Int32)", this.cityType, this.edmModel).Should().NotHaveAction(this.cityType, this.action);
         }
 
         [Fact]
@@ -419,7 +419,7 @@ namespace Microsoft.OData.Tests.Evaluation
         [Fact]
         public void UnQualifiedNameWithParametersShouldNotIncludeActionOnOpenType()
         {
-            SelectedPropertiesNode.Create("Action(Edm.Int32)", this.openType).Should().NotHaveAction(this.openType, this.action);
+            SelectedPropertiesNode.Create("Action(Edm.Int32)", this.openType, this.edmModel).Should().NotHaveAction(this.openType, this.action);
         }
 
         [Fact]
@@ -429,28 +429,28 @@ namespace Microsoft.OData.Tests.Evaluation
         }
 
         [Fact]
-        public void ExpandTokenForNavigationPropertyShouldHaveEntireSubtree()
+        public void ExpandTokenForNavigationPropertyShouldNotHaveEntireSubtree()
         {
-            SelectedPropertiesNode.Create("MetropolisNavigation(Thumbnail)", this.metropolisType).Should().HaveEntireSubtree();
+            SelectedPropertiesNode.Create("MetropolisNavigation(Thumbnail)", this.metropolisType, this.edmModel).Should().HaveEntireSubtree(false);
         }
 
        [Fact]
         public void SelectedPropertyAndExpandTokenShouldHavePartialSubtree()
         {
-            SelectedPropertiesNode.Create("MetropolisStream,MetropolisNavigation(Thumbnail)", this.metropolisType).Should().HaveEntireSubtree(false);
+            SelectedPropertiesNode.Create("MetropolisStream,MetropolisNavigation(Thumbnail)", this.metropolisType, this.edmModel).Should().HaveEntireSubtree(false);
             SelectedPropertiesNode.Create("MetropolisStream,MetropolisNavigation(Thumbnail)").Should().HaveEntireSubtree(false);
         }
 
         [Fact]
         public void ExpandTokenForCollectionOfNavigationPropertyShouldHaveEntireSubtree()
         {
-            SelectedPropertiesNode.Create("Districts()", this.cityType).Should().HaveEntireSubtree();
+            SelectedPropertiesNode.Create("Districts()", this.cityType, this.edmModel).Should().HaveEntireSubtree();
         }
 
         [Fact]
         public void InvalidExpandTokenShouldHavePartialSubtree()
         {
-            SelectedPropertiesNode.Create("FabrikamNavProp()", this.cityType).Should().HaveEntireSubtree(false);
+            SelectedPropertiesNode.Create("FabrikamNavProp()", this.cityType, this.edmModel).Should().HaveEntireSubtree();
         }
 
         [Fact]
@@ -462,7 +462,7 @@ namespace Microsoft.OData.Tests.Evaluation
         [Fact]
         public void NamespaceAndContainerQualifiedNameWithParametersShouldIncludeAction()
         {
-            SelectedPropertiesNode.Create("TestModel.Action(Edm.Int32)").Should().HaveAction(this.cityType, this.action);
+            SelectedPropertiesNode.Create("TestModel.Action(Edm.Int32)", this.cityType, this.edmModel).Should().HaveAction(this.cityType, this.action);
         }
 
         [Fact]
@@ -534,8 +534,8 @@ namespace Microsoft.OData.Tests.Evaluation
         [Fact]
         public void GetSelectedPropertiesForNavigationPropertyForNonEmptyNodeShouldAlwaysReturnEntireSubtreeWhenEntityTypeIsNull()
         {
-            EntireSubtreeNode.GetSelectedPropertiesForNavigationProperty(structuredType: null, navigationPropertyName: "foo").Should().BeSameAs(EntireSubtreeNode);
-            SelectedPropertiesNode.Create("bar").GetSelectedPropertiesForNavigationProperty(structuredType: null, navigationPropertyName: "foo").Should().BeSameAs(EntireSubtreeNode);
+            EntireSubtreeNode.GetSelectedPropertiesForNavigationProperty(structuredType: null, navigationPropertyName: "foo").Should().HaveEntireSubtree();
+            SelectedPropertiesNode.Create("bar").GetSelectedPropertiesForNavigationProperty(structuredType: null, navigationPropertyName: "foo").Should().HaveEntireSubtree();
         }
 
         [Fact]
@@ -613,12 +613,6 @@ namespace Microsoft.OData.Tests.Evaluation
             return this.HaveNavigations(entityType, streamPropertyNames).And.NotHaveStreams(entityType);
         }
 
-        internal AndConstraint<SelectedPropertiesNodeAssertions> BeSameAsEntireSubtree()
-        {
-            this.Subject.Should().BeSameAs(EntireSubtreeNode);
-            return new AndConstraint<SelectedPropertiesNodeAssertions>(this);
-        }
-
         internal AndConstraint<SelectedPropertiesNodeAssertions> BeSameAsEmpty()
         {
             this.Subject.Should().BeSameAs(EmptyNode);
@@ -632,7 +626,7 @@ namespace Microsoft.OData.Tests.Evaluation
 
             foreach (var navigation in entityType.NavigationProperties())
             {
-                this.Subject.As<SelectedPropertiesNode>().GetSelectedPropertiesForNavigationProperty(entityType, navigation.Name).Should().BeSameAsEntireSubtree();
+                this.Subject.As<SelectedPropertiesNode>().GetSelectedPropertiesForNavigationProperty(entityType, navigation.Name).Should().HaveEntireSubtree();
             }
 
             return new AndConstraint<SelectedPropertiesNodeAssertions>(this);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
@@ -399,12 +399,6 @@ namespace Microsoft.OData.Tests.Evaluation
         }
 
         [Fact]
-        public void UnqualifiedUnboundActionWithParametersShouldNotBeSelected()
-        {
-            SelectedPropertiesNode.Create("Action(Edm.Int32)", this.cityType, this.edmModel).Should().NotHaveAction(this.cityType, this.action);
-        }
-
-        [Fact]
         public void NamespaceQualifiedActionNameShouldBeSelected()
         {
             SelectedPropertiesNode.Create("TestModel.Action").Should().HaveAction(this.cityType, this.action);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
@@ -419,7 +419,44 @@ namespace Microsoft.OData.Tests.Evaluation
         [Fact]
         public void UnQualifiedNameWithParametersShouldNotIncludeActionOnOpenType()
         {
-            SelectedPropertiesNode.Create("Action(Edm.Int32)").Should().NotHaveAction(this.openType, this.action);
+            SelectedPropertiesNode.Create("Action(Edm.Int32)", this.openType).Should().NotHaveAction(this.openType, this.action);
+        }
+
+        [Fact]
+        public void ExpandTokenWithoutTypeInfoShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("Districts()").Should().HaveEntireSubtree();
+        }
+
+        [Fact]
+        public void ExpandTokenForNavigationPropertyShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("MetropolisNavigation(Thumbnail)", this.metropolisType).Should().HaveEntireSubtree();
+        }
+
+       [Fact]
+        public void SelectedPropertyAndExpandTokenShouldHavePartialSubtree()
+        {
+            SelectedPropertiesNode.Create("MetropolisStream,MetropolisNavigation(Thumbnail)", this.metropolisType).Should().HaveEntireSubtree(false);
+            SelectedPropertiesNode.Create("MetropolisStream,MetropolisNavigation(Thumbnail)").Should().HaveEntireSubtree(false);
+        }
+
+        [Fact]
+        public void ExpandTokenForCollectionOfNavigationPropertyShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("Districts()", this.cityType).Should().HaveEntireSubtree();
+        }
+
+        [Fact]
+        public void InvalidExpandTokenShouldHavePartialSubtree()
+        {
+            SelectedPropertiesNode.Create("FabrikamNavProp()", this.cityType).Should().HaveEntireSubtree(false);
+        }
+
+        [Fact]
+        public void InvalidExpandTokenWithoutTypeShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("FabrikamNavProp()").Should().HaveEntireSubtree();
         }
 
         [Fact]
@@ -623,6 +660,20 @@ namespace Microsoft.OData.Tests.Evaluation
         internal AndConstraint<SelectedPropertiesNodeAssertions> NotHaveAction(EdmEntityType entityType, IEdmOperation action)
         {
             this.Subject.As<SelectedPropertiesNode>().IsOperationSelected(entityType, action, entityType.IsOpen).Should().BeFalse();
+            return new AndConstraint<SelectedPropertiesNodeAssertions>(this);
+        }
+
+        internal AndConstraint<SelectedPropertiesNodeAssertions> HaveEntireSubtree(bool isTrue = true)
+        {
+            if (isTrue)
+            {
+                this.Subject.As<SelectedPropertiesNode>().IsEntireSubtree().Should().BeTrue();
+            }
+            else
+            {
+                this.Subject.As<SelectedPropertiesNode>().IsEntireSubtree().Should().BeFalse();
+            }
+
             return new AndConstraint<SelectedPropertiesNodeAssertions>(this);
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/SelectExpandClauseFinisherTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/SelectExpandClauseFinisherTests.cs
@@ -18,15 +18,16 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void ExpandedNavigationPropertiesAreImplicitlyAddedAsPathSelectionItemsIfSelectIsPopulated()
         {
             IEdmNavigationProperty navigationProperty = ModelBuildingHelpers.BuildValidNavigationProperty();
+            IEdmStructuralProperty structuralProperty = ModelBuildingHelpers.BuildValidPrimitiveProperty();
             SelectExpandClause clause = new SelectExpandClause(new SelectItem[]
             {
-                new PathSelectItem(new ODataSelectPath(new PropertySegment(ModelBuildingHelpers.BuildValidPrimitiveProperty()))),
-                new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(navigationProperty, ModelBuildingHelpers.BuildValidEntitySet())), ModelBuildingHelpers.BuildValidEntitySet(), new SelectExpandClause(new List<SelectItem>(), false)), 
+                new PathSelectItem(new ODataSelectPath(new PropertySegment(structuralProperty))),
+                new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(navigationProperty, ModelBuildingHelpers.BuildValidEntitySet())), ModelBuildingHelpers.BuildValidEntitySet(), new SelectExpandClause(new List<SelectItem>(), false)),
             },
             false /*allSelected*/);
             SelectExpandClauseFinisher.AddExplicitNavPropLinksWhereNecessary(clause);
-            clause.SelectedItems.Should().HaveCount(3)
-                .And.Contain(x => x is PathSelectItem && x.As<PathSelectItem>().SelectedPath.LastSegment is NavigationPropertySegment && x.As<PathSelectItem>().SelectedPath.LastSegment.As<NavigationPropertySegment>().NavigationProperty.Name == navigationProperty.Name);
+            clause.SelectedItems.Should().HaveCount(2)
+                .And.Contain(x => x is PathSelectItem && x.As<PathSelectItem>().SelectedPath.LastSegment is PropertySegment && x.As<PathSelectItem>().SelectedPath.LastSegment.As<PropertySegment>().Property.Name == structuralProperty.Name);
         }
 
         [Fact]
@@ -34,7 +35,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         {
             SelectExpandClause clause = new SelectExpandClause(new SelectItem[]
             {
-                new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(ModelBuildingHelpers.BuildValidNavigationProperty(), ModelBuildingHelpers.BuildValidEntitySet())), ModelBuildingHelpers.BuildValidEntitySet(), new SelectExpandClause(new List<SelectItem>(), false)), 
+                new ExpandedNavigationSelectItem(new ODataExpandPath(new NavigationPropertySegment(ModelBuildingHelpers.BuildValidNavigationProperty(), ModelBuildingHelpers.BuildValidEntitySet())), ModelBuildingHelpers.BuildValidEntitySet(), new SelectExpandClause(new List<SelectItem>(), false)),
             },
             false /*allSelected*/);
             SelectExpandClauseFinisher.AddExplicitNavPropLinksWhereNecessary(clause);

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/SelectExpand/SelectExpandTest.DeepSelectionsAreRedundantIfEntireSubtreeIsSelected.approved.txt
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/SelectExpand/SelectExpandTest.DeepSelectionsAreRedundantIfEntireSubtreeIsSelected.approved.txt
@@ -22,5 +22,4 @@ SelectExpandQueryOption
 										SelectedItems
 											Path]
 								Path[(Property: City)]
-								Path[(NavigationProperty: Orders)]
 					(Wildcard)

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/SelectExpand/SelectExpandTest.NoExpandWhenNavPropNotSelected.approved.txt
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/SelectExpand/SelectExpandTest.NoExpandWhenNavPropNotSelected.approved.txt
@@ -16,4 +16,3 @@ SelectExpandQueryOption
 							AllSelected = True
 							SelectedItems(Empty List)
 		Path[(Property: Quantity)]
-		Path[(NavigationProperty: AssociatedOrder)]

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/SelectExpand/SelectExpandTest.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Scenario.Tests/UriParser/SelectExpand/SelectExpandTest.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Test.Taupo.OData.Scenario.Tests.UriParser
         public void DeepSelectionsAreRedundantIfEntireSubtreeIsSelected()
         {
             // note that the selection of 'AssociatedOrder' in the middle of the $select makes the rest of it redundant.
+            // And parenthesized expand clause is not added to select list.
             this.ApprovalVerifySelectAndExpandParser(
                 orderDetailBase,
                 "",


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue ##1265 ($expand in context url), including the two prerequisite issues #1259 and #1268. It also includes fix for issue #1104.*
*Please note that the PR #1264 associated with issue #1259 has been superseded by this PR, which contains the changes needed. PR #1264 will be cancelled in favor of this PR.*

### Description

*Changes include the followings: 
1). Add parenthesized token for navigation property for $expand clause in context url; 
2). Context url select list parsing implementation update from ABNF V3 to ABNF V4.01 (#1268); 
3). Ensure explicit selected navigation properties are present in context url (#1104); 
4). Ensure navigation links are materialized for case of minimal metadata with expand-sub-select clause (#1259) .*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
