### PR TITLE
Modify the codegen auto code string to pass policheck

### DIFF
--- a/src/CodeGen/ODataT4CodeGenerator.cs
+++ b/src/CodeGen/ODataT4CodeGenerator.cs
@@ -6944,8 +6944,8 @@ this.Write(" to its derived type ");
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeFullName));
 
 this.Write("\r\n        \'\'\' </summary>\r\n        \'\'\' <param name=\"source\">source entity</param>\r" +
-        "\n        <Global.System.Runtime.CompilerServices.Extension()>\r\n        Public Fu" +
-        "nction CastTo");
+        "\n        <Global.System.Runtime.CompilerServices.Extension()>\r\n        Public " +
+        "Function CastTo");
 
 this.Write(this.ToStringHelper.ToStringWithCulture(derivedTypeName));
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Pass the policheck for auto code gen string

### Description

* The auto code gen string separate "function" to "Fu" and "nction" in different link.
* "FU" can't pass the policheck.
* This PR is to adjust it.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
