### PR TITLE
Uri parsing on type cast on property allowed in validation vocabulary

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -748,6 +748,7 @@ namespace Microsoft.OData {
         internal const string PathParser_CannotUseValueOnCollection = "PathParser_CannotUseValueOnCollection";
         internal const string PathParser_TypeMustBeRelatedToSet = "PathParser_TypeMustBeRelatedToSet";
         internal const string PathParser_TypeCastOnlyAllowedAfterStructuralCollection = "PathParser_TypeCastOnlyAllowedAfterStructuralCollection";
+        internal const string PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint = "PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint";
         internal const string ODataResourceSet_MustNotContainBothNextPageLinkAndDeltaLink = "ODataResourceSet_MustNotContainBothNextPageLinkAndDeltaLink";
         internal const string ODataExpandPath_OnlyLastSegmentMustBeNavigationProperty = "ODataExpandPath_OnlyLastSegmentMustBeNavigationProperty";
         internal const string ODataExpandPath_InvalidExpandPathSegment = "ODataExpandPath_InvalidExpandPathSegment";
@@ -773,8 +774,8 @@ namespace Microsoft.OData {
         internal const string RequestUriProcessor_InvalidValueForKeySegment = "RequestUriProcessor_InvalidValueForKeySegment";
         internal const string RequestUriProcessor_CannotApplyFilterOnSingleEntities = "RequestUriProcessor_CannotApplyFilterOnSingleEntities";
         internal const string RequestUriProcessor_CannotApplyEachOnSingleEntities = "RequestUriProcessor_CannotApplyEachOnSingleEntities";
-        internal const string RequestUriProcessor_NoNavigationSourceFound = "RequestUriProcessor_NoNavigationSourceFound";
         internal const string RequestUriProcessor_FilterPathSegmentSyntaxError = "RequestUriProcessor_FilterPathSegmentSyntaxError";
+        internal const string RequestUriProcessor_NoNavigationSourceFound = "RequestUriProcessor_NoNavigationSourceFound";
         internal const string RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment = "RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment";
         internal const string RequestUriProcessor_EmptySegmentInRequestUrl = "RequestUriProcessor_EmptySegmentInRequestUrl";
         internal const string RequestUriProcessor_SyntaxError = "RequestUriProcessor_SyntaxError";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -819,7 +819,7 @@ PathParser_EntityReferenceNotSupported=The request URI is not valid. $ref cannot
 PathParser_CannotUseValueOnCollection=$value cannot be applied to a collection.
 PathParser_TypeMustBeRelatedToSet=The type '{0}' does not inherit from and is not a base type of '{1}'. The type of '{2}' must be related to the Type of the EntitySet.
 PathParser_TypeCastOnlyAllowedAfterStructuralCollection=Type cast segment '{0}' after a collection which is not of entity or complex type is not allowed.
-PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint=Type cast segment '{0}' on {1} '{2}' is not allowed from the Org.OData.Validation.V1.DerivedTypeConstraint annotation.
+PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint=Type cast segment '{0}' on {1} '{2}' is not allowed due to an Org.OData.Validation.V1.DerivedTypeConstraint annotation.
 
 ODataResourceSet_MustNotContainBothNextPageLinkAndDeltaLink=A resource set may contain a next page link, a delta link or neither, but must not contain both.
 

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -819,6 +819,7 @@ PathParser_EntityReferenceNotSupported=The request URI is not valid. $ref cannot
 PathParser_CannotUseValueOnCollection=$value cannot be applied to a collection.
 PathParser_TypeMustBeRelatedToSet=The type '{0}' does not inherit from and is not a base type of '{1}'. The type of '{2}' must be related to the Type of the EntitySet.
 PathParser_TypeCastOnlyAllowedAfterStructuralCollection=Type cast segment '{0}' after a collection which is not of entity or complex type is not allowed.
+PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint=Type cast segment '{0}' on {1} '{2}' is not allowed from the Org.OData.Validation.V1.DerivedTypeConstraint annotation.
 
 ODataResourceSet_MustNotContainBothNextPageLinkAndDeltaLink=A resource set may contain a next page link, a delta link or neither, but must not contain both.
 
@@ -881,7 +882,6 @@ RequestUriProcessor_ResourceNotFound=Resource not found for the segment '{0}'.
 RequestUriProcessor_BatchedActionOnEntityCreatedInSameChangeset=Batched service action '{0}' cannot be invoked because it was bound to an entity created in the same changeset.
 RequestUriProcessor_Forbidden=Forbidden
 RequestUriProcessor_OperationSegmentBoundToANonEntityType=Found an operation bound to a non-entity type.
-
 
 ; Note: The below list of error messages are common to both the OData and the OData.Query project.
 General_InternalError=An internal error '{0}' occurred.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -5213,7 +5213,7 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "Type cast segment '{0}' on '{1}' '{2}' is not allowed from the Org.OData.Validation.V1.DerivedTypeConstraint annotation."
+        /// A string like "Type cast segment '{0}' on {1} '{2}' is not allowed due to an Org.OData.Validation.V1.DerivedTypeConstraint annotation."
         /// </summary>
         internal static string PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint(object p0, object p1, object p2) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint, p0, p1, p2);

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -5213,6 +5213,13 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "Type cast segment '{0}' on '{1}' '{2}' is not allowed from the Org.OData.Validation.V1.DerivedTypeConstraint annotation."
+        /// </summary>
+        internal static string PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint(object p0, object p1, object p2) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint, p0, p1, p2);
+        }
+
+        /// <summary>
         /// A string like "A resource set may contain a next page link, a delta link or neither, but must not contain both."
         /// </summary>
         internal static string ODataResourceSet_MustNotContainBothNextPageLinkAndDeltaLink {
@@ -5390,45 +5397,38 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "$filter path segment cannot be applied on single entities or singletons. Entity type: '{0}'."
         /// </summary>
-        internal static string RequestUriProcessor_CannotApplyFilterOnSingleEntities(object p0)
-        {
+        internal static string RequestUriProcessor_CannotApplyFilterOnSingleEntities(object p0) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_CannotApplyFilterOnSingleEntities, p0);
         }
 
         /// <summary>
         /// A string like "$each set-based operation cannot be applied on single entities or singletons. Entity type: '{0}'."
         /// </summary>
-        internal static string RequestUriProcessor_CannotApplyEachOnSingleEntities(object p0)
-        {
+        internal static string RequestUriProcessor_CannotApplyEachOnSingleEntities(object p0) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_CannotApplyEachOnSingleEntities, p0);
         }
 
         /// <summary>
-        /// A string like "There are no navigation sources found to apply '{0}'."
+        /// A string like "The $filter path segment must be in the form $filter(expression), where the expression resolves to a boolean."
         /// </summary>
-        internal static string RequestUriProcessor_NoNavigationSourceFound(object p0)
-        {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_NoNavigationSourceFound, p0);
-        }
-
-        /// <summary>
-        /// The $filter path segment must be in the form $filter(expression), where the expression resolves to a boolean.
-        /// </summary>
-        internal static string RequestUriProcessor_FilterPathSegmentSyntaxError
-        {
-            get
-            {
+        internal static string RequestUriProcessor_FilterPathSegmentSyntaxError {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_FilterPathSegmentSyntaxError);
             }
         }
 
         /// <summary>
+        /// A string like "There are no navigation sources found to apply '{0}'."
+        /// </summary>
+        internal static string RequestUriProcessor_NoNavigationSourceFound(object p0) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_NoNavigationSourceFound, p0);
+        }
+
+        /// <summary>
         /// A string like "Only a single operation can follow $each."
         /// </summary>
-        internal static string RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment
-        {
-            get
-            {
+        internal static string RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment);
             }
         }
@@ -5455,8 +5455,7 @@ namespace Microsoft.OData {
         /// A string like "The request URI is not valid, the segment $count cannot be applied to the root of the service."
         /// </summary>
         internal static string RequestUriProcessor_CountOnRoot {
-            get
-            {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_CountOnRoot);
             }
         }
@@ -5465,8 +5464,7 @@ namespace Microsoft.OData {
         /// A string like "The request URI is not valid, the segment $filter cannot be applied to the root of the service."
         /// </summary>
         internal static string RequestUriProcessor_FilterOnRoot {
-            get
-            {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_FilterOnRoot);
             }
         }
@@ -5474,10 +5472,8 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "The request URI is not valid, the segment $each cannot be applied to the root of the service."
         /// </summary>
-        internal static string RequestUriProcessor_EachOnRoot
-        {
-            get
-            {
+        internal static string RequestUriProcessor_EachOnRoot {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_EachOnRoot);
             }
         }
@@ -5485,10 +5481,8 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "The request URI is not valid, the segment $ref cannot be applied to the root of the service."
         /// </summary>
-        internal static string RequestUriProcessor_RefOnRoot
-        {
-            get
-            {
+        internal static string RequestUriProcessor_RefOnRoot {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_RefOnRoot);
             }
         }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -1532,13 +1532,24 @@ namespace Microsoft.OData.UriParser
 
                 return;
             }
+
+            // operation: ~/Users(1)/NS.Operation(...)/NS.Cast
+            // TODO: we should support to verify the casting for the operation return type.
+            // however, ODL doesn't support to annotation on the return type, see https://github.com/OData/odata.net/issues/52
+            // Once ODL supports to annotation on the return type, we should support to verify it.
+            /*
+            OperationSegment operationSegment = previous as OperationSegment;
+            if (operationSegment != null)
+            {
+            }
+            */
         }
 
         private void CheckOperationTypeCastSegmentRestriction(IEdmOperation operation)
         {
             Debug.Assert(operation != null);
 
-            if (this.parsedSegments == null || !this.parsedSegments.Any())
+            if (this.parsedSegments == null)
             {
                 return;
             }
@@ -1574,7 +1585,7 @@ namespace Microsoft.OData.UriParser
 
         private static void VerifyDerivedTypeConstraints(IEdmModel model, IEdmVocabularyAnnotatable target, string fullTypeName, string kind, string name)
         {
-            IList<string> derivedTypes = model.GetDerivedTypeConstraints(target);
+            IEnumerable<string> derivedTypes = model.GetDerivedTypeConstraints(target);
             if (derivedTypes == null || derivedTypes.Any(d => d == fullTypeName))
             {
                 return;

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -758,6 +758,30 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Gets the collection of qualified type name for term Org.OData.Validation.V1.DerivedTypeConstraint from a target annotatable.
+        /// </summary>
+        /// <param name="model">The model referenced to.</param>
+        /// <param name="target">The target annotatable to find annotation.</param>
+        /// <returns>Null or a collection string of qualifed type name.</returns>
+        public static IList<string> GetDerivedTypeConstraints(this IEdmModel model, IEdmVocabularyAnnotatable target)
+        {
+            EdmUtil.CheckArgumentNull(model, "model");
+            EdmUtil.CheckArgumentNull(target, "target");
+
+            IEdmVocabularyAnnotation annotation = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(target, ValidationVocabularyModel.DerivedTypeConstraintTerm).FirstOrDefault();
+            if (annotation != null)
+            {
+                IEdmCollectionExpression collectionExpression = annotation.Value as IEdmCollectionExpression;
+                if (collectionExpression != null && collectionExpression.Elements != null)
+                {
+                    return collectionExpression.Elements.OfType<IEdmStringConstantExpression>().Select(e => e.Value).ToList();
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Gets all schema elements from the model, and models referenced by it.
         /// </summary>
         /// <param name="model">Model to search for elements</param>

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -763,7 +763,7 @@ namespace Microsoft.OData.Edm
         /// <param name="model">The model referenced to.</param>
         /// <param name="target">The target annotatable to find annotation.</param>
         /// <returns>Null or a collection string of qualifed type name.</returns>
-        public static IList<string> GetDerivedTypeConstraints(this IEdmModel model, IEdmVocabularyAnnotatable target)
+        public static IEnumerable<string> GetDerivedTypeConstraints(this IEdmModel model, IEdmVocabularyAnnotatable target)
         {
             EdmUtil.CheckArgumentNull(model, "model");
             EdmUtil.CheckArgumentNull(target, "target");
@@ -774,7 +774,7 @@ namespace Microsoft.OData.Edm
                 IEdmCollectionExpression collectionExpression = annotation.Value as IEdmCollectionExpression;
                 if (collectionExpression != null && collectionExpression.Elements != null)
                 {
-                    return collectionExpression.Elements.OfType<IEdmStringConstantExpression>().Select(e => e.Value).ToList();
+                    return collectionExpression.Elements.OfType<IEdmStringConstantExpression>().Select(e => e.Value);
                 }
             }
 

--- a/src/Microsoft.OData.Edm/Vocabularies/ValidationVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/ValidationVocabularyModel.cs
@@ -22,10 +22,21 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
     public static class ValidationVocabularyModel
     {
         /// <summary>
+        /// The namespace of the validation vocabulary model.
+        /// </summary>
+        public static readonly string Namespace = "Org.OData.Validation.V1";
+
+        /// <summary>
         /// The EDM model with validation vocabularies.
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "EdmModel is immutable")]
         public static readonly IEdmModel Instance;
+
+        /// <summary>
+        /// The DerivedTypeConstraint term.
+        /// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "EdmTerm is immutable")]
+        public static readonly IEdmTerm DerivedTypeConstraintTerm;
 
         /// <summary>
         /// Parse Validation Vocabulary Model from ValidationVocabularies.xml
@@ -45,6 +56,8 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
                 Debug.Assert(stream != null, "ValidationVocabularies.xml: stream!=null");
                 SchemaReader.TryParse(new[] { XmlReader.Create(stream) }, out Instance, out errors);
             }
+
+            DerivedTypeConstraintTerm = Instance.FindDeclaredTerm(Namespace + ".DerivedTypeConstraint");
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/Microsoft.OData.Core.Tests.csproj
@@ -346,6 +346,7 @@
     <Compile Include="..\UriParser\Parsers\LIteralParserTests.cs" />
     <Compile Include="..\UriParser\Parsers\NodeFactoryTests.cs" />
     <Compile Include="..\UriParser\Parsers\ODataPathParserTests.cs" />
+    <Compile Include="..\UriParser\Parsers\ODataPathParserTypeCastTests.cs" />
     <Compile Include="..\UriParser\Parsers\PathReverserTests.cs" />
     <Compile Include="..\UriParser\Parsers\SearchParserTests.cs" />
     <Compile Include="..\UriParser\Parsers\SegmentKeyHandlerTests.cs" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTypeCastTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTypeCastTests.cs
@@ -1,0 +1,655 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataPathParserTypeCastTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using FluentAssertions;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.UriParser;
+using Xunit;
+using ErrorStrings = Microsoft.OData.Strings;
+
+namespace Microsoft.OData.Tests.UriParser.Parsers
+{
+    public class ODataPathParserTypeCastTests
+    {
+        #region Singleton Type cast
+        [Theory]
+        [InlineData("Customer")]
+        [InlineData("VipCustomer")]
+        [InlineData("NormalCustomer")]
+        public void ParseTypeCastOnSingletonWithoutDerivedTypeConstraintAnnotationWorks(string typeCastName)
+        {
+            IEdmModel edmModel = GetSingletonEdmModel(""); // without Derived type constraint
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmEntityType targetType = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == typeCastName);
+
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            // ~/Me/NS.Customer
+            var path = pathParser.ParsePath(new[] { "Me", "NS." + typeCastName });
+            path[1].ShouldBeTypeSegment(customer, targetType);
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void ParseTypeCastOnSingletonWithDerivedTypeConstraintAnnotationWorks(bool isInLine)
+        {
+            string annotation =
+                @"<Annotation Term=""Org.OData.Validation.V1.DerivedTypeConstraint"" >" +
+                    "<Collection>" +
+                      "<String>NS.VipCustomer</String>" +
+                    "</Collection>" +
+                "</Annotation>";
+
+            IEdmModel edmModel = GetSingletonEdmModel(annotation, isInLine);
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmEntityType vipCustomer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "VipCustomer");
+
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            // verify the positive type cast on itself:  ~/Me/NS.Customer
+            var path = pathParser.ParsePath(new[] { "Me", "NS.Customer" });
+            path[1].ShouldBeTypeSegment(customer, customer);
+
+            // verify the positive type cast:  ~/Me/NS.VipCustomer
+            path = pathParser.ParsePath(new[] { "Me", "NS.VipCustomer" });
+            path[1].ShouldBeTypeSegment(customer, vipCustomer);
+
+            // verify the negative type cast: ~/Me/NS.NormalCustomer
+            Action parsePath = () => pathParser.ParsePath(new[] { "Me", "NS.NormalCustomer" });
+            parsePath.ShouldThrow<ODataException>().WithMessage(ErrorStrings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint("NS.NormalCustomer", "singleton", "Me"));
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void ParseTypeCastOnSingletonWithDerivedTypeConstraintButEmptyCollectionAnnotationWorks(bool isInLine)
+        {
+            string annotation =
+                @"<Annotation Term=""Org.OData.Validation.V1.DerivedTypeConstraint"" >" +
+                    "<Collection />" +
+                "</Annotation>";
+
+            IEdmModel edmModel = GetSingletonEdmModel(annotation, isInLine);
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmEntityType vipCustomer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "VipCustomer");
+
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            // verify the positive type cast on itself:  ~/Me/NS.Customer
+            var path = pathParser.ParsePath(new[] { "Me", "NS.Customer" });
+            path[1].ShouldBeTypeSegment(customer, customer);
+
+            // verify the negative type cast: ~/Me/NS.VipCustomer
+            Action parsePath = () => pathParser.ParsePath(new[] { "Me", "NS.VipCustomer" });
+            parsePath.ShouldThrow<ODataException>().WithMessage(ErrorStrings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint("NS.VipCustomer", "singleton", "Me"));
+
+            // verify the negative type cast: ~/Me/NS.NormalCustomer
+            pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+            parsePath = () => pathParser.ParsePath(new[] { "Me", "NS.NormalCustomer" });
+            parsePath.ShouldThrow<ODataException>().WithMessage(ErrorStrings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint("NS.NormalCustomer", "singleton", "Me"));
+        }
+
+        private static IEdmModel GetSingletonEdmModel(string annotation, bool inline = true)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Customer"" />
+      <EntityType Name=""VipCustomer"" BaseType=""NS.Customer"" />
+      <EntityType Name=""NormalCustomer"" BaseType=""NS.Customer"" />
+      <EntityContainer Name =""Default"">
+         <Singleton Name=""Me"" Type=""NS.Customer"" >
+           {0}
+         </Singleton>
+      </EntityContainer>
+      <Annotations Target=""NS.Default/Me"">
+        {1}
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string inlineAnnotation = inline ? annotation : "";
+            string outLineAnnotation = inline ? "" : annotation;
+            string modelText = string.Format(template, inlineAnnotation, outLineAnnotation);
+
+            return GetEdmModel(modelText);
+        }
+        #endregion Singleton Type cast
+
+        #region EntitySet or entity Type cast
+        [Theory]
+        [InlineData("Customer")]
+        [InlineData("VipCustomer")]
+        [InlineData("NormalCustomer")]
+        public void ParseTypeCastOnEntitySetWithoutDerivedTypeConstraintAnnotationWorks(string typeCastName)
+        {
+            IEdmModel edmModel = GetEntitySetEdmModel(""); /*without Derived type constraint*/
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmEntityType targetType = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == typeCastName);
+            IEdmType collectionCustomerType = new EdmCollectionType(new EdmEntityTypeReference(customer, true));
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            // ~/Customers/NS.Customer
+            var path = pathParser.ParsePath(new[] { "Customers", "NS." + typeCastName });
+            path[1].ShouldBeTypeSegment(collectionCustomerType, targetType);
+
+            // ~/Customers(1)/NS.Customer
+            path = pathParser.ParsePath(new[] { "Customers(1)", "NS." + typeCastName });
+            path[2].ShouldBeTypeSegment(customer, targetType);
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void ParseTypeCastOnEntitySetWithDerivedTypeConstraintAnnotationWorks(bool isInLine)
+        {
+            string annotation =
+                @"<Annotation Term=""Org.OData.Validation.V1.DerivedTypeConstraint"" >" +
+                    "<Collection>" +
+                    "<String>NS.VipCustomer</String>" +
+                    "</Collection>" +
+                "</Annotation>";
+
+            IEdmModel edmModel = GetEntitySetEdmModel(annotation, isInLine);
+
+            IEdmEntityType vipCustomer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "VipCustomer");
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmType collectionCustomerType = new EdmCollectionType(new EdmEntityTypeReference(customer, true));
+
+            int index = 1;
+            foreach (string segment in new[] { "Customers", "Customers(1)" })
+            {
+                IEdmType actualType = index == 1 ? collectionCustomerType : customer;
+
+                ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+                // verify the positive type cast on itself:  ~/Customers/NS.Customer
+                var path = pathParser.ParsePath(new[] { segment, "NS.Customer" });
+                path[index].ShouldBeTypeSegment(actualType, customer);
+
+                // verify the positive type cast:  ~/Customers/NS.VipCustomer
+                path = pathParser.ParsePath(new[] { segment, "NS.VipCustomer" });
+                path[index].ShouldBeTypeSegment(actualType, vipCustomer);
+
+                // verify the negative type cast: ~/Customers/NS.NormalCustomer
+                Action parsePath = () => pathParser.ParsePath(new[] { segment, "NS.NormalCustomer" });
+                parsePath.ShouldThrow<ODataException>().WithMessage(ErrorStrings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint("NS.NormalCustomer", "entity set", "Customers"));
+
+                index++;
+            }
+        }
+
+        private static IEdmModel GetEntitySetEdmModel(string annotation, bool inline = true)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Customer"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+      </EntityType>
+      <EntityType Name=""VipCustomer"" BaseType=""NS.Customer"" />
+      <EntityType Name=""NormalCustomer"" BaseType=""NS.Customer"" />
+      <EntityContainer Name =""Default"">
+         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" >
+           {0}
+         </EntitySet>
+      </EntityContainer>
+      <Annotations Target=""NS.Default/Customers"">
+        {1}
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string inlineAnnotation = inline ? annotation : "";
+            string outLineAnnotation = inline ? "" : annotation;
+            string modelText = string.Format(template, inlineAnnotation, outLineAnnotation);
+
+            return GetEdmModel(modelText);
+        }
+        #endregion EntitySet or entity Type cast
+
+        #region Property type cast
+        [Theory]
+        [InlineData("Address", "NS.Address")] // cast to itself
+        [InlineData("Address", "NS.CnAddress")]
+        [InlineData("Address", "NS.UsAddress")]
+        [InlineData("Locations", "NS.Address")] // cast to itself
+        [InlineData("Locations", "NS.CnAddress")]
+        [InlineData("Locations", "NS.UsAddress")]
+        public void ParseTypeCastOnPropertyWithoutDerivedTypeConstraintAnnotationWorks(string propertyName, string typeCast)
+        {
+            IEdmModel edmModel = GetPropertyEdmModel("");
+
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmProperty property = customer.DeclaredProperties.First(c => c.Name == propertyName);
+            IEdmType expectType = edmModel.FindDeclaredType(typeCast);
+            Assert.NotNull(expectType);
+
+            // ~/Customers(1)/{propertyName}/{typeCast}
+            var path = pathParser.ParsePath(new[] { "Customers(1)", propertyName, typeCast });
+            path[3].ShouldBeTypeSegment(property.Type.Definition, expectType);
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void ParseTypeCastOnPropertyWithDerivedTypeConstraintAnnotationWorks(bool isInLine)
+        {
+            string annotation =
+                @"<Annotation Term=""Org.OData.Validation.V1.DerivedTypeConstraint"" >" +
+                    "<Collection>" +
+                      "<String>NS.UsAddress</String>" +
+                    "</Collection>" +
+                "</Annotation>";
+
+            IEdmModel edmModel = GetPropertyEdmModel(annotation, isInLine);
+
+            IEdmComplexType address = edmModel.SchemaElements.OfType<IEdmComplexType>().First(c => c.Name == "Address");
+            IEdmComplexType usAddress = edmModel.SchemaElements.OfType<IEdmComplexType>().First(c => c.Name == "UsAddress");
+            IEdmType collectionAddressType = new EdmCollectionType(new EdmComplexTypeReference(address, true));
+
+            int index = 1;
+            foreach (string segment in new[] { "Address", "Locations" })
+            {
+                IEdmType actualType = index == 1 ? address : collectionAddressType;
+
+                // verify the positive type cast on itself
+                ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+                var path = pathParser.ParsePath(new[] { "Customers(1)", segment, "NS.Address" });
+                path[3].ShouldBeTypeSegment(actualType, address);
+
+                // verify the positive type cast
+                path = pathParser.ParsePath(new[] { "Customers(1)", segment, "NS.UsAddress" });
+                path[3].ShouldBeTypeSegment(actualType, usAddress);
+
+                // verify the negative type cast
+                Action parsePath = () => pathParser.ParsePath(new[] { "Customers(1)", segment, "NS.CnAddress" });
+                parsePath.ShouldThrow<ODataException>().WithMessage(ErrorStrings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint("NS.CnAddress", "property", segment));
+                index++;
+            }
+        }
+
+        private static IEdmModel GetPropertyEdmModel(string annotation, bool inline = true)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Customer"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Address"" Type=""NS.Address"" >
+           {0}
+        </Property>
+        <Property Name=""Locations"" Type=""Collection(NS.Address)"" >
+           {0}
+        </Property>
+      </EntityType>
+      <ComplexType Name=""Address"" />
+      <ComplexType Name=""UsAddress"" BaseType=""NS.Address"" />
+      <ComplexType Name=""CnAddress"" BaseType=""NS.Address"" />
+      <EntityContainer Name =""Default"">
+         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
+      </EntityContainer>
+      <Annotations Target=""NS.Customer/Address"">
+        {1}
+      </Annotations>
+      <Annotations Target=""NS.Customer/Locations"">
+        {1}
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string inlineAnnotation = inline ? annotation : "";
+            string outLineAnnotation = inline ? "" : annotation;
+            string modelText = string.Format(template, inlineAnnotation, outLineAnnotation);
+
+            return GetEdmModel(modelText);
+        }
+        #endregion Property type cast
+
+        #region Navigation Property type cast
+        [Theory]
+        [InlineData("DirectReport", null, "NS.Customer")] // cast to itself
+        [InlineData("DirectReport", null, "NS.VipCustomer")]
+        [InlineData("DirectReport", null, "NS.NormalCustomer")]
+        [InlineData("SubCustomers", null, "NS.Customer")] // cast to itself
+        [InlineData("SubCustomers", null, "NS.VipCustomer")]
+        [InlineData("SubCustomers", null, "NS.NormalCustomer")]
+        [InlineData("SubCustomers", "(1)", "NS.Customer")] // cast to itself
+        [InlineData("SubCustomers", "(1)", "NS.VipCustomer")]
+        [InlineData("SubCustomers", "(1)", "NS.NormalCustomer")]
+        public void ParseTypeCastOnNavigationPropertyWithoutDerivedTypeConstraintAnnotationWorks(string propertyName, string key, string typeCast)
+        {
+            IEdmModel edmModel = GetNavigationPropertyEdmModel("");
+
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmNavigationProperty property = customer.NavigationProperties().First(c => c.Name == propertyName);
+            IEdmType collectionCustomerType = new EdmCollectionType(new EdmEntityTypeReference(customer, true));
+
+            IEdmType expectType = edmModel.FindDeclaredType(typeCast);
+            Assert.NotNull(expectType);
+
+            int index = key != null ? 4 : 3;
+            IEdmType actualType = propertyName == "SubCustomers" && key == null ? collectionCustomerType : customer;
+
+            // ~/Customers(1)/{propertyName}/{typeCast}
+            var path = pathParser.ParsePath(new[] { "Customers(1)", propertyName + key, typeCast });
+            path[index].ShouldBeTypeSegment(actualType, expectType);
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void ParseTypeCastOnNavigationPropertyWithDerivedTypeConstraintAnnotationWorks(bool isInLine)
+        {
+            string annotation =
+                @"<Annotation Term=""Org.OData.Validation.V1.DerivedTypeConstraint"" >" +
+                    "<Collection>" +
+                      "<String>NS.VipCustomer</String>" +
+                    "</Collection>" +
+                "</Annotation>";
+
+            IEdmModel edmModel = GetNavigationPropertyEdmModel(annotation, isInLine);
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmEntityType vipCustomer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "VipCustomer");
+            IEdmType collectionCustomerType = new EdmCollectionType(new EdmEntityTypeReference(customer, true));
+
+            int index = 1;
+            foreach (string segment in new[] { "DirectReport", "SubCustomers" })
+            {
+                IEdmType actualType = index == 1 ? customer : collectionCustomerType;
+
+                // verify the positive type cast on itself
+                ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+                var path = pathParser.ParsePath(new[] { "Customers(1)", segment, "NS.Customer" });
+                path[3].ShouldBeTypeSegment(actualType, customer);
+
+                // verify the positive type cast
+                path = pathParser.ParsePath(new[] { "Customers(1)", segment, "NS.VipCustomer" });
+                path[3].ShouldBeTypeSegment(actualType, vipCustomer);
+
+                // verify the negative type cast
+                Action parsePath = () => pathParser.ParsePath(new[] { "Customers(1)", segment, "NS.NormalCustomer" });
+                parsePath.ShouldThrow<ODataException>().WithMessage(ErrorStrings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint("NS.NormalCustomer", "navigation property", segment));
+                index++;
+            }
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void ParseTypeCastOnNavigationPropertyWithKeySegmentWithDerivedTypeConstraintAnnotationWorks(bool isInLine)
+        {
+            string annotation =
+                @"<Annotation Term=""Org.OData.Validation.V1.DerivedTypeConstraint"" >" +
+                    "<Collection>" +
+                      "<String>NS.VipCustomer</String>" +
+                    "</Collection>" +
+                "</Annotation>";
+
+            IEdmModel edmModel = GetNavigationPropertyEdmModel(annotation, isInLine);
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmEntityType vipCustomer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "VipCustomer");
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            // verify the positive type cast on itself
+            var path = pathParser.ParsePath(new[] { "Customers(1)", "SubCustomers(1)", "NS.Customer" });
+            path[4].ShouldBeTypeSegment(customer, customer);
+
+            // verify the positive type cast
+            path = pathParser.ParsePath(new[] { "Customers(1)", "SubCustomers(1)", "NS.VipCustomer" });
+            path[4].ShouldBeTypeSegment(customer, vipCustomer);
+
+            // verify the negative type cast
+            Action parsePath = () => pathParser.ParsePath(new[] { "Customers(1)", "SubCustomers(1)", "NS.NormalCustomer" });
+            parsePath.ShouldThrow<ODataException>().WithMessage(ErrorStrings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint("NS.NormalCustomer", "navigation property", "SubCustomers"));
+        }
+
+        private static IEdmModel GetNavigationPropertyEdmModel(string annotation, bool inline = true)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Customer"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <NavigationProperty Name=""DirectReport"" Type=""NS.Customer"" >
+           {0}
+        </NavigationProperty>
+        <NavigationProperty Name=""SubCustomers"" Type=""Collection(NS.Customer)"" >
+           {0}
+        </NavigationProperty>
+      </EntityType>
+      <EntityType Name=""VipCustomer"" BaseType=""NS.Customer"" />
+      <EntityType Name=""NormalCustomer"" BaseType=""NS.Customer"" />
+      <EntityContainer Name =""Default"">
+         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
+      </EntityContainer>
+      <Annotations Target=""NS.Customer/DirectReport"">
+        {1}
+      </Annotations>
+      <Annotations Target=""NS.Customer/SubCustomers"">
+        {1}
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string inlineAnnotation = inline ? annotation : "";
+            string outLineAnnotation = inline ? "" : annotation;
+            string modelText = string.Format(template, inlineAnnotation, outLineAnnotation);
+
+            return GetEdmModel(modelText);
+        }
+        #endregion Navigation Property type cast
+
+        #region Type definition type cast
+        [Theory(Skip = "Should pass if fix issue: see: https://github.com/OData/odata.net/issues/1326")]
+        [InlineData("Edm.PrimitiveType")] // cast to itself
+        [InlineData("Edm.Int32")]
+        [InlineData("Edm.Boolean")]
+        [InlineData("Edm.Double")]
+        public void ParseTypeCastOnTypeDefinitionPropertyWithoutDerivedTypeConstraintAnnotationWorks(string typeCast)
+        {
+            IEdmModel edmModel = GetTypeDefinitionEdmModel(""); // without Derived type constraint
+
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmProperty property = customer.DeclaredProperties.First(c => c.Name == "Data");
+            Assert.Equal(EdmTypeKind.TypeDefinition, property.Type.TypeKind());
+
+            IEdmType expectType = edmModel.FindType(typeCast);
+            Assert.NotNull(expectType);
+
+            // ~/Customers(1)/Data/{typeCast}
+            var path = pathParser.ParsePath(new[] { "Customers(1)", "Data", typeCast });
+            path[3].ShouldBeTypeSegment(property.Type.Definition, expectType);
+        }
+
+        [Theory(Skip = "Should pass if fix issue: see: https://github.com/OData/odata.net/issues/1326")]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void ParseTypeCastOnTypeDefinitionPropertyWithDerivedTypeConstraintAnnotationWorks(bool isInLine)
+        {
+            string annotation =
+                @"<Annotation Term=""Org.OData.Validation.V1.DerivedTypeConstraint"" >" +
+                    "<Collection>" +
+                      "<String>Edm.Int32</String>" +
+                      "<String>Edm.Boolean</String>" +
+                    "</Collection>" +
+                "</Annotation>";
+
+            IEdmModel edmModel = GetTypeDefinitionEdmModel(annotation, isInLine);
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmProperty property = customer.DeclaredProperties.First(c => c.Name == "Data");
+            Assert.Equal(EdmTypeKind.TypeDefinition, property.Type.TypeKind());
+
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            // verify the positive type cast on itself
+            var path = pathParser.ParsePath(new[] { "Customers(1)", "Data", "Edm.Int32" });
+            path[3].ShouldBeTypeSegment(property.Type.Definition, edmModel.FindType("Edm.Int32"));
+
+            // verify the positive type cast
+            path = pathParser.ParsePath(new[] { "Customers(1)", "Data", "Edm.Boolean" });
+            path[3].ShouldBeTypeSegment(property.Type.Definition, edmModel.FindType("Edm.Boolean"));
+
+            // verify the negative type cast
+            Action parsePath = () => pathParser.ParsePath(new[] { "Customers(1)", "Data", "Edm.Double" });
+            parsePath.ShouldThrow<ODataException>().WithMessage(ErrorStrings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint("Edm.Double", "type definition", "Data"));
+        }
+
+        private static IEdmModel GetTypeDefinitionEdmModel(string annotation, bool inline = true)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <TypeDefinition Name=""DataType"" UnderlyingType=""Edm.PrimitiveType"" >
+         {0}
+      </TypeDefinition>
+      <EntityType Name=""Customer"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Data"" Type=""NS.DataType"" />
+      </EntityType>
+      <EntityContainer Name =""Default"">
+         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
+      </EntityContainer>
+      <Annotations Target=""NS.DataType"">
+        {1}
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string inlineAnnotation = inline ? annotation : "";
+            string outLineAnnotation = inline ? "" : annotation;
+            string modelText = string.Format(template, inlineAnnotation, outLineAnnotation);
+
+            return GetEdmModel(modelText);
+        }
+        #endregion Type definition type cast
+
+        #region Operation type cast
+        [Theory]
+        [InlineData("Customer")]
+        [InlineData("VipCustomer")]
+        [InlineData("NormalCustomer")]
+        public void ParseTypeCastOnOperationWithoutDerivedTypeConstraintAnnotationWorks(string typeCastName)
+        {
+            IEdmModel edmModel = GetOperationEdmModel(""); // without derived type constraint
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmEntityType targetType = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == typeCastName);
+            IEdmType collectionCustomerType = new EdmCollectionType(new EdmEntityTypeReference(customer, true));
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            // verify the positive type cast on itself: ~/Customers/NS.Customer/NS.Image()
+            var path = pathParser.ParsePath(new[] { "Customers", "NS." + typeCastName, "NS.Image()" });
+            path[1].ShouldBeTypeSegment(collectionCustomerType, targetType);
+        }
+
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        public void ParseBoundOperationWithDerivedTypeConstraintAnnotationWorks(bool inLineAnnotation)
+        {
+            string annotation =
+                @"<Annotation Term=""Org.OData.Validation.V1.DerivedTypeConstraint"" >" +
+                     "<Collection>" +
+                       "<String>NS.VipCustomer</String>" +
+                     "</Collection>" +
+                   "</Annotation>";
+
+            IEdmModel edmModel = GetOperationEdmModel(annotation);
+
+            IEdmEntityType customer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "Customer");
+            IEdmEntityType vipCustomer = edmModel.SchemaElements.OfType<IEdmEntityType>().First(c => c.Name == "VipCustomer");
+            IEdmType collectionCustomerType = new EdmCollectionType(new EdmEntityTypeReference(customer, true));
+
+            ODataPathParser pathParser = new ODataPathParser(new ODataUriParserConfiguration(edmModel));
+
+            // verify the positive type cast on itself: ~/Customers/NS.Customer/NS.Image()
+            var path = pathParser.ParsePath(new[] { "Customers", "NS.Customer", "NS.Image()" });
+            path[1].ShouldBeTypeSegment(collectionCustomerType, customer);
+
+            // verify the positive type cast: ~/Customers(1)/NS.VipCustomer/NS.Image()
+            path = pathParser.ParsePath(new[] { "Customers", "NS.VipCustomer", "NS.Image()" });
+            path[1].ShouldBeTypeSegment(collectionCustomerType, vipCustomer);
+
+            // verify the negative type cast: ~/Customers(1)/NS.NormalCustomer/NS.Image()
+            Action parsePath = () => pathParser.ParsePath(new[] { "Customers", "NS.NormalCustomer", "NS.Image()" });
+            parsePath.ShouldThrow<ODataException>().WithMessage(ErrorStrings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint("NS.NormalCustomer", "operation", "Image"));
+        }
+
+        private static IEdmModel GetOperationEdmModel(string annotation, bool inline = true)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Customer"" />
+      <EntityType Name=""VipCustomer"" BaseType=""NS.Customer"" />
+      <EntityType Name=""NormalCustomer"" BaseType=""NS.Customer"" />
+      <Function Name=""Image"" IsBound=""true"">
+        <Parameter Name=""entity"" Type=""Collection(NS.Customer)"" >
+          {0}
+        </Parameter>
+        <ReturnType Type=""Edm.String"" />
+      </Function>
+      <EntityContainer Name =""Default"">
+         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
+      </EntityContainer>
+      <Annotations Target=""NS.Image(NS.Customer)"">
+        {1}
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string inlineAnnotation = inline ? annotation : "";
+            string outLineAnnotation = inline ? "" : annotation;
+            string modelText = string.Format(template, inlineAnnotation, outLineAnnotation);
+
+            return GetEdmModel(modelText);
+        }
+        #endregion Operation type cast
+
+        private static IEdmModel GetEdmModel(string csdl)
+        {
+            IEdmModel model;
+            IEnumerable<EdmError> errors;
+
+            bool result = CsdlReader.TryParse(XElement.Parse(csdl).CreateReader(), out model, out errors);
+            Assert.True(result);
+            return model;
+        }
+    }
+}

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -1935,6 +1935,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
 	[
 	ExtensionAttribute(),
 	]
+	public static System.Collections.Generic.IList`1[[System.String]] GetDerivedTypeConstraints (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static string GetDescriptionAnnotation (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target)
 
 	[
@@ -4024,7 +4029,9 @@ public sealed class Microsoft.OData.Edm.Vocabularies.V1.CoreVocabularyModel {
 }
 
 public sealed class Microsoft.OData.Edm.Vocabularies.V1.ValidationVocabularyModel {
+	public static readonly Microsoft.OData.Edm.Vocabularies.IEdmTerm DerivedTypeConstraintTerm = Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsTerm
 	public static readonly Microsoft.OData.Edm.IEdmModel Instance = Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsModel
+	public static readonly string Namespace = "Org.OData.Validation.V1"
 }
 
 public sealed class Microsoft.OData.Edm.Vocabularies.Community.V1.AlternateKeysVocabularyConstants {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -1935,7 +1935,7 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
 	[
 	ExtensionAttribute(),
 	]
-	public static System.Collections.Generic.IList`1[[System.String]] GetDerivedTypeConstraints (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target)
+	public static System.Collections.Generic.IEnumerable`1[[System.String]] GetDerivedTypeConstraints (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target)
 
 	[
 	ExtensionAttribute(),


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request is part of Union type supporting.*

### Description

* To parse the type cast on a property (structural or navigation property), the allowed type case segment should within the Validation vocabulary [DerivedTypeConstraint](https://github.com/OData/odata.net/blob/master/src/Microsoft.OData.Edm/Vocabularies/ValidationVocabularies.xml#L91-L94) annotation if it applied on such property, otherwise the Uri parse should throw exception.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
