### PR TITLE
Fix issue #1299, Enable write navigation property binding for containment target

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaWriter.cs
@@ -730,7 +730,15 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.WriteRequiredAttribute(CsdlConstants.Attribute_Path, binding.Path.Path, EdmValueWriter.StringAsXml);
 
             // TODO: handle container names, etc.
-            this.WriteRequiredAttribute(CsdlConstants.Attribute_Target, binding.Target.Name, EdmValueWriter.StringAsXml);
+            IEdmContainedEntitySet containedEntitySet = binding.Target as IEdmContainedEntitySet;
+            if (containedEntitySet != null)
+            {
+                this.WriteRequiredAttribute(CsdlConstants.Attribute_Target, containedEntitySet.Path.Path, EdmValueWriter.StringAsXml);
+            }
+            else
+            {
+                this.WriteRequiredAttribute(CsdlConstants.Attribute_Target, binding.Target.Name, EdmValueWriter.StringAsXml);
+            }
 
             this.xmlWriter.WriteEndElement();
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1299.*

### Description

* The writer of CSDL incorrectly output the target path for the containment on singleton.
* This PR enable to write the correct target path for the navigation property binding.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
