### PR TITLE
 Add annotation term for OData.Community.UrlEscape.V1.UrlEscapeFunction.

### DIFF
--- a/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
+++ b/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
@@ -340,6 +340,9 @@
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Vocabularies\AlternateKeysVocabularyConstants.cs">
       <Link>Microsoft\OData\Edm\Vocabularies\AlternateKeysVocabularyConstants.cs</Link>
     </Compile>
+    <Compile Include="$(EdmLibCrossTargettingSourcePath)\Vocabularies\CommunityVocabularyConstants.cs">
+      <Link>Microsoft\OData\Edm\Vocabularies\CommunityVocabularyConstants.cs</Link>
+    </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Vocabularies\CoreVocabularyConstants.cs">
       <Link>Microsoft\OData\Edm\Vocabularies\CoreVocabularyConstants.cs</Link>
     </Compile>
@@ -351,6 +354,9 @@
     </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Vocabularies\AlternateKeysVocabularyModel.cs">
       <Link>Microsoft\OData\Edm\Vocabularies\AlternateKeysVocabularyModel.cs</Link>
+    </Compile>
+    <Compile Include="$(EdmLibCrossTargettingSourcePath)\Vocabularies\CommunityVocabularyModel.cs">
+      <Link>Microsoft\OData\Edm\Vocabularies\CommunityVocabularyModel.cs</Link>
     </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Vocabularies\AuthorizationVocabularyModel.cs">
       <Link>Microsoft\OData\Edm\Vocabularies\AuthorizationVocabularyModel.cs</Link>
@@ -1499,6 +1505,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(EdmLibCrossTargettingSourcePath)\Vocabularies\AlternateKeysVocabularies.xml">
       <LogicalName>AlternateKeysVocabularies.xml</LogicalName>
+    </EmbeddedResource>    
+    <EmbeddedResource Include="$(EdmLibCrossTargettingSourcePath)\Vocabularies\CommunityVocabularies.xml">
+      <LogicalName>CommunityVocabularies.xml</LogicalName>
     </EmbeddedResource>
     <EmbeddedResource Include="$(EdmLibCrossTargettingSourcePath)\Vocabularies\AuthorizationVocabularies.xml">
       <LogicalName>AuthorizationVocabularies.xml</LogicalName>

--- a/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
+++ b/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
@@ -1191,6 +1191,12 @@
     </Compile>
     <Compile Include="..\Vocabularies\AlternateKeysVocabularyModel.cs">
       <Link>Vocabularies\AlternateKeysVocabularyModel.cs</Link>
+    </Compile>    
+    <Compile Include="..\Vocabularies\CommunityVocabularyConstants.cs">
+      <Link>Vocabularies\CommunityVocabularyConstants.cs</Link>
+    </Compile>
+    <Compile Include="..\Vocabularies\CommunityVocabularyModel.cs">
+      <Link>Vocabularies\CommunityVocabularyModel.cs</Link>
     </Compile>
     <Compile Include="..\Vocabularies\AuthorizationVocabularyModel.cs">
       <Link>Vocabularies\AuthorizationVocabularyModel.cs</Link>
@@ -1527,6 +1533,9 @@
   <ItemGroup>
     <EmbeddedResource Include="..\Vocabularies\AlternateKeysVocabularies.xml">
       <Link>Vocabularies\AlternateKeysVocabularies.xml</Link>
+    </EmbeddedResource>  
+    <EmbeddedResource Include="..\Vocabularies\CommunityVocabularies.xml">
+      <Link>Vocabularies\CommunityVocabularies.xml</Link>
     </EmbeddedResource>
     <EmbeddedResource Include="..\Vocabularies\AuthorizationVocabularies.xml">
       <Link>Vocabularies\AuthorizationVocabularies.xml</Link>

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.NetStandard.VS2017.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.NetStandard.VS2017.csproj
@@ -32,7 +32,8 @@
     <None Remove="Microsoft.OData.Edm.tt" />
     <None Remove="Microsoft.OData.Edm.txt" />
     <None Remove="Parameterized.Microsoft.OData.Edm.tt" />
-    <None Remove="Vocabularies\AlternateKeysVocabularies.xml" />
+    <None Remove="Vocabularies\AlternateKeysVocabularies.xml" />    
+    <None Remove="Vocabularies\CommunityVocabularies.xml" />
     <None Remove="Vocabularies\AuthorizationVocabularies.xml" />
     <None Remove="Vocabularies\CapabilitiesVocabularies.xml" />
     <None Remove="Vocabularies\CoreVocabularies.xml" />
@@ -105,6 +106,10 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Vocabularies\AlternateKeysVocabularies.xml">
       <LogicalName>AlternateKeysVocabularies.xml</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>    
+    <EmbeddedResource Include="Vocabularies\CommunityVocabularies.xml">
+      <LogicalName>CommunityVocabularies.xml</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Vocabularies\AuthorizationVocabularies.xml">

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -263,6 +263,8 @@
     <Compile Include="Vocabularies\CapabilitiesVocabularyModel.cs" />
     <Compile Include="Vocabularies\AlternateKeysVocabularyConstants.cs" />
     <Compile Include="Vocabularies\AlternateKeysVocabularyModel.cs" />
+    <Compile Include="Vocabularies\CommunityVocabularyConstants.cs" />
+    <Compile Include="Vocabularies\CommunityVocabularyModel.cs" />
     <Compile Include="Vocabularies\CoreVocabularyConstants.cs" />
     <Compile Include="Vocabularies\CoreVocabularyModel.cs" />
     <Compile Include="Vocabularies\EdmExpressionEvaluator.cs" />
@@ -545,6 +547,10 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Vocabularies\AlternateKeysVocabularies.xml">
       <LogicalName>AlternateKeysVocabularies.xml</LogicalName>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Vocabularies\CommunityVocabularies.xml">
+      <LogicalName>CommunityVocabularies.xml</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Vocabularies\ValidationVocabularies.xml">

--- a/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularies.xml
@@ -6,7 +6,7 @@
   <edmx:DataServices>
     <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Org.OData.Community.V1" Alias="Community">
       <Term AppliesTo="Function" Type="Core.Tag" Name="UrlEscapeFunction">
-        <Annotation Term="Core.Description" String="Annotates a function for converting a colon-escaped segment in Url path"/>
+        <Annotation Term="Core.Description" String="Annotates a function to be substituted for a colon-escaped segment in a Url path"/>
       </Term>
     </Schema>
   </edmx:DataServices>

--- a/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularies.xml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="http://docs.oasis-open.org/odata/odata/v4.0/os/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1" />
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Org.OData.Community.V1" Alias="Community">
+      <Term AppliesTo="Function" Type="Core.Tag" Name="UrlEscapeFunction">
+        <Annotation Term="Core.Description" String="Annotates a function for converting a colon-escaped segment in Url path"/>
+      </Term>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularyConstants.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularyConstants.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OData.Edm.Vocabularies.Community.V1
     /// <summary>
     /// Constant values for Community Vocabularies
     /// </summary>
-    public static class CommunityVocabularyConstants
+    internal static class CommunityVocabularyConstants
     {
         /// <summary>OData.Community.V1.UrlEscapeFunction </summary>
         internal const string UrlEscapeFunction = "Org.OData.Community.V1.UrlEscapeFunction";

--- a/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularyConstants.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularyConstants.cs
@@ -1,0 +1,17 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CommunityVocabularyConstants.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Edm.Vocabularies.Community.V1
+{
+    /// <summary>
+    /// Constant values for Community Vocabularies
+    /// </summary>
+    public static class CommunityVocabularyConstants
+    {
+        /// <summary>OData.Community.V1.UrlEscapeFunction </summary>
+        internal const string UrlEscapeFunction = "Org.OData.Community.V1.UrlEscapeFunction";
+    }
+}

--- a/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularyModel.cs
@@ -1,0 +1,61 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CommunityVocabularyModel.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Xml;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+
+namespace Microsoft.OData.Edm.Vocabularies.Community.V1
+{
+    /// <summary>
+    /// Representing Url Escape Vocabulary Model.
+    /// </summary>
+    public static class CommunityVocabularyModel
+    {
+        /// <summary>
+        /// The EDM model with Community vocabularies.
+        /// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "EdmModel is immutable")]
+        public static readonly IEdmModel Instance = CommunityVocabularyReader.GetEdmModel();
+
+        /// <summary>
+        /// The Url escape function term.
+        /// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "EdmTerm is immutable")]
+        public static readonly IEdmTerm UrlEscapeFunctionTerm = Instance.FindDeclaredTerm(CommunityVocabularyConstants.UrlEscapeFunction);
+    }
+
+    internal static class CommunityVocabularyReader
+    {
+        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "EdmModel is immutable")]
+
+        internal static IEdmModel GetEdmModel()
+        {
+            Assembly assembly = typeof(CommunityVocabularyModel).GetAssembly();
+
+            // Resource name has leading namespace and folder in .NetStandard dll.
+            string[] allResources = assembly.GetManifestResourceNames();
+            string communityVocabularies = allResources.Where(x => x.Contains("CommunityVocabularies.xml")).FirstOrDefault();
+            Debug.Assert(communityVocabularies != null, "CommunityVocabularies.xml: not found.");
+
+            IEdmModel instance;
+            using (Stream stream = assembly.GetManifestResourceStream(communityVocabularies))
+            {
+                IEnumerable<EdmError> errors;
+                Debug.Assert(stream != null, "CommunityVocabularies.xml: stream!=null");
+                CsdlReader.TryParse(XmlReader.Create(stream), out instance, out errors);
+            }
+
+            return instance;
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CommunityVocabularyModel.cs
@@ -17,7 +17,7 @@ using Microsoft.OData.Edm.Validation;
 namespace Microsoft.OData.Edm.Vocabularies.Community.V1
 {
     /// <summary>
-    /// Representing Url Escape Vocabulary Model.
+    /// Representing Community Vocabulary Model.
     /// </summary>
     public static class CommunityVocabularyModel
     {

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Build.NetFramework/Microsoft.OData.Edm.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Build.NetFramework/Microsoft.OData.Edm.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="..\Vocabularies\CoreVocabularyTests.cs" />
     <Compile Include="..\Vocabularies\AuthorizationVocabularyTests.cs" />
     <Compile Include="..\Vocabularies\ValidationVocabularyTests.cs" />
+    <Compile Include="..\Vocabularies\CommunityVocabularyTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\packages.config" />

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CommunityVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CommunityVocabularyTests.cs
@@ -1,0 +1,58 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CommunityVocabularyTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml;
+using System.Text;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OData.Edm.Vocabularies.Community.V1;
+using Xunit;
+
+namespace Microsoft.OData.Edm.Tests.Vocabularies
+{
+    public class CommunityVocabularyTests
+    {
+        private readonly IEdmModel model = CommunityVocabularyModel.Instance;
+
+        [Fact]
+        public void TestCommunitySchemaModel()
+        {
+            const string expectedUrlEscape = @"<?xml version=""1.0"" encoding=""utf-16""?>
+<Schema Namespace=""Org.OData.Community.V1"" Alias=""Community"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+  <Term Name=""UrlEscapeFunction"" Type=""Core.Tag"" AppliesTo=""Function"">
+    <Annotation Term=""Core.Description"" String=""Annotates a function for converting a colon-escaped segment in Url path"" />
+  </Term>
+</Schema>";
+
+            StringWriter sw = new StringWriter();
+            IEnumerable<EdmError> errors;
+            using (var xw = XmlWriter.Create(sw, new XmlWriterSettings { Indent = true, Encoding = Encoding.UTF8 }))
+            {
+                Assert.True(model.TryWriteSchema(xw, out errors));
+            }
+
+
+            Assert.False(errors.Any(), "No Errors");
+
+            string output = sw.ToString();
+            Assert.True(expectedUrlEscape == output, "expected Community schema not matching");
+        }
+
+        [Fact]
+        public void TestUrlEscapeFunctionAnnotationTerm()
+        {
+            var urlEscapeFunctionTerm = model.FindDeclaredTerm(CommunityVocabularyConstants.UrlEscapeFunction);
+            Assert.NotNull(urlEscapeFunctionTerm);
+            Assert.Equal(CommunityVocabularyModel.UrlEscapeFunctionTerm, urlEscapeFunctionTerm);
+            Assert.Equal("Org.OData.Community.V1", urlEscapeFunctionTerm.Namespace);
+            Assert.Equal("UrlEscapeFunction", urlEscapeFunctionTerm.Name);
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CommunityVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CommunityVocabularyTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
         private readonly IEdmModel model = CommunityVocabularyModel.Instance;
 
         [Fact]
-        public void TestCommunitySchemaModel()
+        public void TestCommunityVocabularyModel()
         {
             const string expectedUrlEscape = @"<?xml version=""1.0"" encoding=""utf-16""?>
 <Schema Namespace=""Org.OData.Community.V1"" Alias=""Community"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CommunityVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CommunityVocabularyTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             const string expectedUrlEscape = @"<?xml version=""1.0"" encoding=""utf-16""?>
 <Schema Namespace=""Org.OData.Community.V1"" Alias=""Community"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
   <Term Name=""UrlEscapeFunction"" Type=""Core.Tag"" AppliesTo=""Function"">
-    <Annotation Term=""Core.Description"" String=""Annotates a function for converting a colon-escaped segment in Url path"" />
+    <Annotation Term=""Core.Description"" String=""Annotates a function to be substituted for a colon-escaped segment in a Url path"" />
   </Term>
 </Schema>";
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -3927,9 +3927,6 @@ public sealed class Microsoft.OData.Edm.Vocabularies.Community.V1.AlternateKeysV
 	public static readonly Microsoft.OData.Edm.IEdmModel Instance = Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsModel
 }
 
-public sealed class Microsoft.OData.Edm.Vocabularies.Community.V1.CommunityVocabularyConstants {
-}
-
 public sealed class Microsoft.OData.Edm.Vocabularies.Community.V1.CommunityVocabularyModel {
 	public static readonly Microsoft.OData.Edm.IEdmModel Instance = Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsModel
 	public static readonly Microsoft.OData.Edm.Vocabularies.IEdmTerm UrlEscapeFunctionTerm = Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsTerm

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -3927,6 +3927,14 @@ public sealed class Microsoft.OData.Edm.Vocabularies.Community.V1.AlternateKeysV
 	public static readonly Microsoft.OData.Edm.IEdmModel Instance = Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsModel
 }
 
+public sealed class Microsoft.OData.Edm.Vocabularies.Community.V1.CommunityVocabularyConstants {
+}
+
+public sealed class Microsoft.OData.Edm.Vocabularies.Community.V1.CommunityVocabularyModel {
+	public static readonly Microsoft.OData.Edm.IEdmModel Instance = Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsModel
+	public static readonly Microsoft.OData.Edm.Vocabularies.IEdmTerm UrlEscapeFunctionTerm = Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsTerm
+}
+
 public enum Microsoft.OData.BatchPayloadUriOption : int {
 	AbsoluteUri = 0
 	AbsoluteUriUsingHostHeader = 1


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request is to add OData.Community.UrlEscape.V1.UrlEscapeFunction annotation, so that it is available for use in URI parsing (pending).*

### Description

*Refactor community annotation schema with the additional schema ns "OData.Community.UrlEscape.V1".*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
