### PR TITLE
Add AllowedTerms/MinItems/MaxItems to Validation vocabulary

### DIFF
--- a/src/Microsoft.OData.Edm/Vocabularies/ValidationVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/ValidationVocabularies.xml
@@ -92,4 +92,18 @@ even though they are defined in an `Orders` entity set.</String>
     <Annotation Term="Core.Description" String="Values are restricted to types that are both identical to or derived from the declared type and a type listed in this collection." />
     <Annotation Term="Core.LongDescription" String="This allows restricting values to certain sub-trees of an inheritance hierarchy. Types listed in this collection that are not derived from the declared type of the annotated model element are ignored." />
   </Term>
+
+  <Term Name="AllowedTerms" Type="Collection(Core.QualifiedTermName)" AppliesTo="Term Property">
+    <Annotation Term="Core.Description" String="Annotate a term of type Edm.AnnotationPath, or a property of type Edm.AnnotationPath that is used within a structured term, to restrict the terms that can be targeted by the path." />
+    <Annotation Term="Core.LongDescription" String="The annotation path expression is intended to end in a path segment with one of the listed terms. For forward compatibility, clients should be prepared for the annotation to reference terms besides those listed." />
+    <Annotation Term="Core.RequiresType" String="Edm.AnnotationPath" />
+  </Term>
+
+  <Term Name="MaxItems" Type="Edm.Int64" Nullable="false" AppliesTo="Collection">
+    <Annotation Term="Core.Description" String="The annotated collection must have at most the specified number of items." />
+  </Term>
+
+  <Term Name="MinItems" Type="Edm.Int64" Nullable="false" AppliesTo="Collection">
+    <Annotation Term="Core.Description" String="The annotated collection must have at least the specified number of items." />
+  </Term>
 </Schema>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request updates the validation vocabulary based on oasis tc odata vocabulary:

https://issues.oasis-open.org/browse/ODATA-1222 

### Description

* OASIS has added two new terms to the OData Validation vocabulary to specify the minimum or maximum number of items in a collection.

We should add those to the Validation Vocabulary exposed by ODL:

```xml
      <Term Name="MaxItems" Type="Edm.Int64" Nullable="false" AppliesTo="Collection">

        <Annotation Term="Core.Description" String="The annotated collection must have at most the specified number of items." />

      </Term>



      <Term Name="MinItems" Type="Edm.Int64" Nullable="false" AppliesTo="Collection">

        <Annotation Term="Core.Description" String="The annotated collection must have at least the specified number of items." />

      </Term>
```

This PR is also add the Term for "AllowedTerms"

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
