### PR TITLE
IN operator fixes for escaped single-quote and Guid literals

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -654,6 +654,7 @@ namespace Microsoft.OData {
         internal const string MetadataBinder_BinaryOperatorOperandNotSingleValue = "MetadataBinder_BinaryOperatorOperandNotSingleValue";
         internal const string MetadataBinder_UnaryOperatorOperandNotSingleValue = "MetadataBinder_UnaryOperatorOperandNotSingleValue";
         internal const string MetadataBinder_LeftOperandNotSingleValue = "MetadataBinder_LeftOperandNotSingleValue";
+        internal const string StringItemShouldBeQuoted = "StringItemShouldBeQuoted";
         internal const string MetadataBinder_RightOperandNotCollectionValue = "MetadataBinder_RightOperandNotCollectionValue";
         internal const string MetadataBinder_PropertyAccessSourceNotSingleValue = "MetadataBinder_PropertyAccessSourceNotSingleValue";
         internal const string MetadataBinder_IncompatibleOperandsError = "MetadataBinder_IncompatibleOperandsError";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -733,7 +733,7 @@ MetadataBinder_CastOrIsOfCollectionsNotSupported=The Cast and IsOf functions do 
 MetadataBinder_CollectionOpenPropertiesNotSupportedInThisRelease=Collection open properties are not supported in this release.
 MetadataBinder_IllegalSegmentType=Can only bind segments that are Navigation, Structural, Complex, or Collections. We found a segment '{0}' that isn't any of those. Please revise the query.
 MetadataBinder_QueryOptionNotApplicable=The '{0}' option cannot be applied to the query path. '{0}' can only be applied to a collection of entities.
-
+StringItemShouldBeQuoted=String item should be single/double quoted: '{0}'.
 ApplyBinder_AggregateExpressionIncompatibleTypeForMethod=$apply/aggregate expression '{0}' operation does not support value type '{1}'.
 ApplyBinder_UnsupportedAggregateMethod=$apply/aggregate does not support method '{0}'.
 ApplyBinder_UnsupportedAggregateKind=$apply/aggregate expression token kind '{0}' not supported.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -4497,6 +4497,13 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "String item should be single/double quoted: '{0}'."
+        /// </summary>
+        internal static string StringItemShouldBeQuoted(object p0) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.StringItemShouldBeQuoted, p0);
+        }
+
+        /// <summary>
         /// A string like "The right operand for the IN operation is not a collection value. IN operations require the left operand to be a single value and the right operand to be a collection value."
         /// </summary>
         internal static string MetadataBinder_RightOperandNotCollectionValue {

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -170,10 +170,16 @@ namespace Microsoft.OData.UriParser
         /// <returns>The double-quoted string with single quotes properly escaped.</returns>
         private static string NormalizeStringItem(string str)
         {
+            // Validate the string item is quoted properly.
+            if ( !(    str[0] == '\'' && str[str.Length-1] == '\''
+                    || str[0] == '"'  && str[str.Length-1] == '"')
+                )
+            {
+                throw new ODataException(ODataErrorStrings.StringItemShouldBeQuoted(str));
+            }
+
             // Skip conversion if the items are already in double-quote format (for backward compatibility).
             // Note that per ABNF, query option strings should use single quotes.
-            Debug.Assert(str[0] == '\'' || str[0] == '"', "string needs to be single/double quoted.");
-
             string convertedString = str;
             if (str[0] == '\'')
             {

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -9,6 +9,7 @@ namespace Microsoft.OData.UriParser
     using System;
     using System.Diagnostics;
     using System.Globalization;
+    using System.Linq;
     using System.Text;
     using Microsoft.OData.Edm;
     using ODataErrorStrings = Microsoft.OData.Strings;
@@ -22,6 +23,14 @@ namespace Microsoft.OData.UriParser
         /// Method to use for binding the parent node, if needed.
         /// </summary>
         private readonly Func<QueryToken, QueryNode> bindMethod;
+
+        /// <summary>
+        /// Delegate for a function that normalizes a string item representing a certain type.
+        /// Each type should define a different implementation of the delegate.
+        /// </summary>
+        /// <param name="item">The item to be normalized.</param>
+        /// <returns>Normalized string of the item.</returns>
+        private delegate string NormalizeFunction(string item);
 
         /// <summary>
         /// Constructs a InBinder with the given method to be used binding the parent token if needed.
@@ -95,37 +104,22 @@ namespace Microsoft.OData.UriParser
                     bracketLiteralText = replacedText.ToString();
 
                     Debug.Assert(expectedType.IsCollection());
-                    if (expectedType.Definition.AsElementType().FullTypeName().Equals("Edm.String"))
+                    string expectedTypeFullName = expectedType.Definition.AsElementType().FullTypeName();
+                    if (expectedTypeFullName.Equals("Edm.String"))
                     {
                         // For collection of strings, need to convert single-quoted string to double-quoted string,
                         // and also, per ABNF, two consecutive single quotes  to one single quote.
                         // Sample: ['a''bc','''def','xyz'''] ==> ["a'bc","'def","xyz'"], which is legitimate Json format.
-                        string[] items = bracketLiteralText.Substring(1, bracketLiteralText.Length - 2).Split(',');
-
-                        // Skip conversion if the items are already in double-quote format (for backward compatibility).
-                        // Note that per ABNF, query option strings should use single quotes.
-                        if (items.Length > 0 && items[0][0] == '\'')
-                        {
-                            StringBuilder builder = new StringBuilder();
-                            for (int i = 0; i < items.Length; i++)
-                            {
-                                string convertedItem = UriParserHelper.RemoveQuotes(items[i]);
-                                if (i != items.Length - 1)
-                                {
-                                    builder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\",", convertedItem);
-                                }
-                                else
-                                {
-                                    // No trailing comma separator for last item of the collection.
-                                    builder.AppendFormat(CultureInfo.InvariantCulture, "\"{0}\"", convertedItem);
-                                }
-                            }
-
-                            bracketLiteralText =
-                                String.Format(CultureInfo.InvariantCulture, "[{0}]", builder.ToString());
-                        }
+                        bracketLiteralText = NormalizeCollectionItems(bracketLiteralText, NormalizeStringItem);
                     }
-
+                    else if (expectedTypeFullName.Equals("Edm.Guid"))
+                    {
+                        // For collection of Guids, need to convert the Guid literals to single-quoted form, so that it is compatible
+                        // with the Json reader used for deserialization.
+                        // Sample: (D01663CF-EB21-4A0E-88E0-361C10ACE7FD, 492CF54A-84C9-490C-A7A4-B5010FAD8104)
+                        //    ==>  ('D01663CF-EB21-4A0E-88E0-361C10ACE7FD', '492CF54A-84C9-490C-A7A4-B5010FAD8104')
+                        bracketLiteralText = NormalizeCollectionItems(bracketLiteralText, NormalizeGuidItem);
+                    }
                 }
 
                 object collection = ODataUriConversionUtils.ConvertFromCollectionValue(bracketLiteralText, model, expectedType);
@@ -143,6 +137,70 @@ namespace Microsoft.OData.UriParser
             }
 
             return operand;
+        }
+
+        private static string NormalizeCollectionItems(string bracketLiteralText, NormalizeFunction normalizeFunc)
+        {
+            string[] items = bracketLiteralText.Substring(1, bracketLiteralText.Length - 2).Split(',')
+                .Select(s => s.Trim()).ToArray();
+
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < items.Length; i++)
+            {
+                string convertedItem = normalizeFunc(items[i]);
+                if (i != items.Length - 1)
+                {
+                    builder.AppendFormat(CultureInfo.InvariantCulture, "{0},", convertedItem);
+                }
+                else
+                {
+                    // No trailing comma separator for last str of the collection.
+                    builder.Append(convertedItem);
+                }
+            }
+
+            return String.Format(CultureInfo.InvariantCulture, "[{0}]", builder.ToString());
+        }
+
+        /// <summary>
+        /// Function to normalize quoted string, ensuring single quotes are escaped properly.
+        /// If the string is double-quoted, no op since single quote doesn't need to be escaped.
+        /// </summary>
+        /// <param name="str">The quoted string item to be normalized.</param>
+        /// <returns>The double-quoted string with single quotes properly escaped.</returns>
+        private static string NormalizeStringItem(string str)
+        {
+            // Skip conversion if the items are already in double-quote format (for backward compatibility).
+            // Note that per ABNF, query option strings should use single quotes.
+            Debug.Assert(str[0] == '\'' || str[0] == '"', "string needs to be single/double quoted.");
+
+            string convertedString = str;
+            if (str[0] == '\'')
+            {
+                convertedString = String.Format(CultureInfo.InvariantCulture, "\"{0}\"", UriParserHelper.RemoveQuotes(str));
+            }
+
+            return convertedString;
+        }
+
+        /// <summary>
+        /// Function to normalize string representing GUID so that it is compatible with Json reader for de-serialization.
+        /// No op if the input string is ready in quoted form.
+        /// </summary>
+        /// <param name="guid">The GUID.</param>
+        /// <returns>A Guid string in quoted form.</returns>
+        private static string NormalizeGuidItem(string guid)
+        {
+            // Skip conversion if the items are already in quoted format (for backward compatibility).
+            // Otherwise, make it single-quoted.
+            if (guid[0] == '\'' || guid[0] == '"')
+            {
+                return guid;
+            }
+            else
+            {
+                return String.Format(CultureInfo.InvariantCulture, "'{0}'", guid);
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -4,12 +4,11 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System.Globalization;
-
 namespace Microsoft.OData.UriParser
 {
     using System;
     using System.Diagnostics;
+    using System.Globalization;
     using System.Text;
     using Microsoft.OData.Edm;
     using ODataErrorStrings = Microsoft.OData.Strings;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -1784,6 +1784,16 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             filter.Expression.As<InNode>().Right.As<CollectionConstantNode>().LiteralText.Should().Be(collection);
         }
 
+        [Theory]
+        [InlineData("('abc'd, 'xy,z')", "'abc'd")]
+        [InlineData("('xy,z', 'abc'd)", "'xy")]
+        public void FilterWithInOperationWithMalformCollection(string collection, string errorItem)
+        {
+            string filterClause = $"SSN in {collection}";
+            Action parse = () => ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+            parse.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.StringItemShouldBeQuoted(errorItem));
+        }
+
         [Fact]
         public void FilterWithInOperationWithParensStringCollection_EscapedSingleQuote()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -161,6 +161,7 @@ namespace Microsoft.OData.Tests.UriParser
             FullyQualifiedNamespacePerson.AddStructuralProperty("RelatedSSNs", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true))));
             FullyQualifiedNamespacePerson.AddStructuralProperty("StockQuantity", FullyQualifiedNamespaceUInt32Reference);
             FullyQualifiedNamespacePerson.AddStructuralProperty("LifeTime", FullyQualifiedNamespaceUInt64Reference);
+            FullyQualifiedNamespacePerson.AddStructuralProperty("MyGuid", EdmPrimitiveTypeKind.Guid);
             FullyQualifiedNamespacePerson.AddKeys(FullyQualifiedNamespacePerson_ID);
             var FullyQualifiedNamespacePerson_MyDog = FullyQualifiedNamespacePerson.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "MyDog", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = FullyQualifiedNamespaceDog });
             var FullyQualifiedNamespacePerson_MyRelatedDogs = FullyQualifiedNamespacePerson.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "MyFriendsDogs", TargetMultiplicity = EdmMultiplicity.Many, Target = FullyQualifiedNamespaceDog });
@@ -383,7 +384,7 @@ namespace Microsoft.OData.Tests.UriParser
 
             var fullyQualifiedStructuredAnnotationTerm = new EdmTerm("Fully.Qualified.Namespace", "ComplexTerm", new EdmComplexTypeReference(FullyQualifiedNamespaceAddress, false));
             model.AddElement(fullyQualifiedStructuredAnnotationTerm);
-            
+
             #endregion
 
             #region Operations
@@ -993,6 +994,7 @@ namespace Microsoft.OData.Tests.UriParser
         <Property Name=""RelatedSSNs"" Type=""Collection(Edm.String)"" Nullable=""true"" />
         <Property Name=""StockQuantity"" Type=""Fully.Qualified.Namespace.UInt32"" />
         <Property Name=""LifeTime"" Type=""Fully.Qualified.Namespace.UInt64"" />
+        <Property Name=""MyGuid"" Type=""Edm.Guid"" />
         <NavigationProperty Name=""MyDog"" Type=""Fully.Qualified.Namespace.Dog"" />
         <NavigationProperty Name=""MyFriendsDogs"" Type=""Collection(Fully.Qualified.Namespace.Dog)"" />
         <NavigationProperty Name=""MyPaintings"" Type=""Collection(Fully.Qualified.Namespace.Painting)"" />
@@ -1222,7 +1224,7 @@ namespace Microsoft.OData.Tests.UriParser
 <edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
     <Schema Namespace=""Fully.Qualified.Namespace"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Alias=""SubAlias3"">
-            
+
       <Function Name=""GetPetCountNullable"" IsComposable=""true"">
         <Parameter Name=""colorPattern"" Type=""Fully.Qualified.Namespace.ColorPattern"" Nullable=""true"" />
         <ReturnType Type=""Fully.Qualified.Namespace.Pet5"" />
@@ -1393,7 +1395,7 @@ namespace Microsoft.OData.Tests.UriParser
 <edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>
     <Schema Namespace=""Fully.Qualified.Namespace"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Alias=""SubAlias4"">
-      
+
       <Action Name=""Restore"" IsBound=""true"">
         <Parameter Name=""painting"" Type=""Fully.Qualified.Namespace.Painting"" />
         <ReturnType Type=""Edm.Boolean"" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes the following issues related to IN operator:
- https://github.com/OData/odata.net/issues/1313: Invalid Json due to single quotes.
- https://github.com/OData/WebApi/issues/1596: Invalid Json due to Guid literals.

### Description

*Fix the escaped single quote for collection of strings for IN operator*
*Fix for collection of Guid literals for IN operator*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
