### PR TITLE
Add the spatial factory and related files into office performance build

### DIFF
--- a/test/PerformanceTests/ComponentTests/Microsoft.OData.Performance.ComponentTests.csproj
+++ b/test/PerformanceTests/ComponentTests/Microsoft.OData.Performance.ComponentTests.csproj
@@ -126,6 +126,14 @@
           <Private>True</Private>
         </Reference>
       </ItemGroup>
+      <ItemGroup>
+        <!-- Should remove these references if we update the official version to > 7.5.1 -->
+        <Compile Include="..\..\..\src\Microsoft.Spatial\GeographyFactory.cs" />
+        <Compile Include="..\..\..\src\Microsoft.Spatial\GeographyFactoryOfT.cs" />
+        <Compile Include="..\..\..\src\Microsoft.Spatial\GeometryFactory.cs" />
+        <Compile Include="..\..\..\src\Microsoft.Spatial\GeometryFactoryOfT.cs" />
+        <Compile Include="..\..\..\src\Microsoft.Spatial\SpatialFactory.cs" />
+      </ItemGroup>
     </When>
   </Choose>
   <ItemGroup>


### PR DESCRIPTION


<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue the build issue for performance.

### Description

With the PR https://github.com/OData/odata.net/pull/1309 merged, it will make the performance build failure as:
* 
![image](https://user-images.githubusercontent.com/9426627/48654030-568ded00-e9be-11e8-857c-3346d784507a.png)

That's because the office performance build reference to the Microsoft.Spatial nuget package which doesn't include new added files.

This PR is to re-add the files into the performance office build.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
