### PR TITLE
Add the IEdmOperationReturnType interface and enable annotation on return type of operation

### DIFF
--- a/src/Microsoft.OData.Core/Metadata/EdmTypeWriterResolver.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmTypeWriterResolver.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OData.Metadata
         /// <returns>The <see cref="IEdmType"/> representing the return type fo the <paramref name="operationImport"/>.</returns>
         internal override IEdmTypeReference GetReturnType(IEdmOperationImport operationImport)
         {
-            return operationImport == null ? null : operationImport.Operation.ReturnType;
+            return operationImport == null ? null : operationImport.Operation.GetReturnTypeReference();
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -399,7 +399,7 @@ namespace Microsoft.OData.UriParser
 
             IEnumerable<QueryNode> boundArguments = parsedParameters.Select(p => this.bindMethod(p));
             boundArguments = boundArguments.ToList(); // force enumerable to run : will immediately evaluate all this.bindMethod(p).
-            IEdmTypeReference returnType = function.ReturnType;
+            IEdmTypeReference returnType = function.GetReturnTypeReference();
             IEdmEntitySetBase returnSet = null;
             SingleResourceNode singleEntityNode = parent as SingleResourceNode;
             if (singleEntityNode != null)

--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -179,7 +179,7 @@ namespace Microsoft.OData.UriParser
                     // Look for an overload that returns an entity collection by the specified name. If so parthensis is just key parameters.
                     if (FunctionOverloadResolver.ResolveOperationImportFromList(identifier, EmptyList, configuration.Model, out possibleMatchingOperationImport, configuration.Resolver))
                     {
-                        IEdmCollectionTypeReference collectionReturnType = possibleMatchingOperationImport.Operation.ReturnType as IEdmCollectionTypeReference;
+                        IEdmCollectionTypeReference collectionReturnType = possibleMatchingOperationImport.Operation.GetReturnTypeReference() as IEdmCollectionTypeReference;
                         if (collectionReturnType != null && collectionReturnType.ElementType().IsEntity())
                         {
                             matchingFunctionImport = possibleMatchingOperationImport;
@@ -246,7 +246,7 @@ namespace Microsoft.OData.UriParser
                     // Look for an overload that returns an entity collection by the specified name. If so parthensis is just key parameters.
                     if (FunctionOverloadResolver.ResolveOperationFromList(identifier, new List<string>(), bindingType, configuration.Model, out possibleMatchingOperation, configuration.Resolver))
                     {
-                        IEdmCollectionTypeReference collectionReturnType = possibleMatchingOperation.ReturnType as IEdmCollectionTypeReference;
+                        IEdmCollectionTypeReference collectionReturnType = possibleMatchingOperation.GetReturnTypeReference() as IEdmCollectionTypeReference;
                         if (collectionReturnType != null && collectionReturnType.ElementType().IsEntity())
                         {
                             matchingOperation = possibleMatchingOperation;
@@ -956,7 +956,7 @@ namespace Microsoft.OData.UriParser
                 return false;
             }
 
-            IEdmTypeReference returnType = singleImport.Operation.ReturnType;
+            IEdmTypeReference returnType = singleImport.Operation.GetReturnTypeReference();
             IEdmEntitySetBase targetset = null;
 
             if (returnType != null)
@@ -1028,7 +1028,7 @@ namespace Microsoft.OData.UriParser
                 throw new ODataException(ODataErrorStrings.FunctionCallBinder_CallingFunctionOnOpenProperty(identifier));
             }
 
-            IEdmTypeReference returnType = singleOperation.ReturnType;
+            IEdmTypeReference returnType = singleOperation.GetReturnTypeReference();
             IEdmEntitySetBase targetset = null;
 
             if (returnType != null)

--- a/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
+++ b/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
@@ -530,6 +530,9 @@
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\CsdlSemanticsOperationParameter.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\CsdlSemanticsOperationParameter.cs</Link>
     </Compile>
+    <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\CsdlSemanticsOperationReturnType.cs">
+      <Link>Microsoft\OData\Edm\Csdl\Semantics\CsdlSemanticsOperationReturnType.cs</Link>
+    </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\CsdlSemanticsOptionalParameter.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\CsdlSemanticsOptionalParameter.cs</Link>
     </Compile>
@@ -550,6 +553,9 @@
     </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\BadElements\UnresolvedParameter.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\BadElements\UnresolvedParameter.cs</Link>
+    </Compile>
+    <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\BadElements\UnresolvedReturnType.cs">
+      <Link>Microsoft\OData\Edm\Csdl\Semantics\BadElements\UnresolvedReturnType.cs</Link>
     </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs</Link>
@@ -938,6 +944,9 @@
     <Compile Include="..\Schema\EdmOperationParameter.cs">
       <Link>Microsoft\OData\Edm\Schema\EdmOperationParameter.cs</Link>
     </Compile>
+    <Compile Include="..\Schema\EdmOperationReturnType.cs">
+      <Link>Microsoft\OData\Edm\Schema\EdmOperationReturnType.cs</Link>
+    </Compile>
     <Compile Include="..\Schema\EdmOptionalParameter.cs">
       <Link>Microsoft\OData\Edm\Schema\EdmOptionalParameter.cs</Link>
     </Compile>
@@ -1141,6 +1150,9 @@
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmOperationParameter.cs">
       <Link>Microsoft\OData\Edm\Schema\Interfaces\IEdmOperationParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\Schema\Interfaces\IEdmOperationReturnType.cs">
+      <Link>Microsoft\OData\Edm\Schema\Interfaces\IEdmOperationReturnType.cs</Link>
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmOptionalParameter.cs">
       <Link>Microsoft\OData\Edm\Schema\Interfaces\IEdmOptionalParameter.cs</Link>

--- a/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
+++ b/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
@@ -338,6 +338,9 @@
     <Compile Include="..\Csdl\Semantics\BadElements\UnresolvedParameter.cs">
       <Link>Csdl\Semantics\BadElements\UnresolvedParameter.cs</Link>
     </Compile>
+    <Compile Include="..\Csdl\Semantics\BadElements\UnresolvedReturnType.cs">
+      <Link>Csdl\Semantics\BadElements\UnresolvedReturnType.cs</Link>
+    </Compile>
     <Compile Include="..\Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs">
       <Link>Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs</Link>
     </Compile>
@@ -490,6 +493,9 @@
     </Compile>
     <Compile Include="..\Csdl\Semantics\CsdlSemanticsOperationParameter.cs">
       <Link>Csdl\Semantics\CsdlSemanticsOperationParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\Csdl\Semantics\CsdlSemanticsOperationReturnType.cs">
+      <Link>Csdl\Semantics\CsdlSemanticsOperationReturnType.cs</Link>
     </Compile>
     <Compile Include="..\Csdl\Semantics\CsdlSemanticsOptionalParameter.cs">
       <Link>Csdl\Semantics\CsdlSemanticsOptionalParameter.cs</Link>
@@ -852,6 +858,9 @@
     <Compile Include="..\Schema\EdmOperationParameter.cs">
       <Link>Schema\EdmOperationParameter.cs</Link>
     </Compile>
+    <Compile Include="..\Schema\EdmOperationReturnType.cs">
+      <Link>Schema\EdmOperationReturnType.cs</Link>
+    </Compile>
     <Compile Include="..\Schema\EdmOptionalParameter.cs">
       <Link>Schema\EdmOptionalParameter.cs</Link>
     </Compile>
@@ -1056,6 +1065,9 @@
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmOperationParameter.cs">
       <Link>Schema\Interfaces\IEdmOperationParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\Schema\Interfaces\IEdmOperationReturnType.cs">
+      <Link>Schema\Interfaces\IEdmOperationReturnType.cs</Link>
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmOptionalParameter.cs">
       <Link>Schema\Interfaces\IEdmOptionalParameter.cs</Link>

--- a/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
@@ -232,6 +232,8 @@ namespace Microsoft.OData.Edm.Csdl
         internal const string Element_IncludeAnnotations = "IncludeAnnotations";
         internal const string Element_DataServices = "DataServices";
 
+        internal const string ReturnTypeExternTarget = "$ReturnType";
+
         #endregion
 
         internal static Dictionary<Version, string[]> SupportedVersions = new Dictionary<Version, string[]>()

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAction.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAction.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         public CsdlAction(
             string name,
             IEnumerable<CsdlOperationParameter> parameters,
-            CsdlTypeReference returnType,
+            CsdlOperationReturnType returnType,
             bool isBound,
             string entitySetPath,
             CsdlLocation location)

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlFunction.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlFunction.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         public CsdlFunction(
             string name,
             IEnumerable<CsdlOperationParameter> parameters,
-            CsdlTypeReference returnType,
+            CsdlOperationReturnType returnType,
             bool isBound,
             string entitySetPath,
             bool isComposable,

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlFunctionBase.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlFunctionBase.cs
@@ -14,9 +14,9 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
     internal abstract class CsdlFunctionBase : CsdlNamedElement
     {
         private readonly List<CsdlOperationParameter> parameters;
-        private readonly CsdlTypeReference returnType;
+        private readonly CsdlOperationReturnType returnType;
 
-        protected CsdlFunctionBase(string name, IEnumerable<CsdlOperationParameter> parameters, CsdlTypeReference returnType, CsdlLocation location)
+        protected CsdlFunctionBase(string name, IEnumerable<CsdlOperationParameter> parameters, CsdlOperationReturnType returnType, CsdlLocation location)
             : base(name, location)
         {
             this.parameters = new List<CsdlOperationParameter>(parameters);
@@ -28,7 +28,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
             get { return this.parameters; }
         }
 
-        public CsdlTypeReference ReturnType
+        public CsdlOperationReturnType ReturnType
         {
             get { return this.returnType; }
         }

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperation.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
     internal class CsdlOperation : CsdlFunctionBase
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="CsdlAction"/> class.
+        /// Initializes a new instance of the <see cref="CsdlOperation"/> class.
         /// </summary>
         /// <param name="name">The name.</param>
         /// <param name="parameters">The parameters.</param>
@@ -25,7 +25,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         public CsdlOperation(
             string name,
             IEnumerable<CsdlOperationParameter> parameters,
-            CsdlTypeReference returnType,
+            CsdlOperationReturnType returnType,
             bool isBound,
             string entitySetPath,
             CsdlLocation location)

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperationImport.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperationImport.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
             string schemaOperationQualifiedTypeName,
             string entitySet,
             IEnumerable<CsdlOperationParameter> parameters,
-            CsdlTypeReference returnType,
+            CsdlOperationReturnType returnType,
             CsdlLocation location)
             : base(name, parameters, returnType, location)
         {

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperationReturnType.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperationReturnType.cs
@@ -4,26 +4,19 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using Microsoft.OData.Edm.Vocabularies;
-
 namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
 {
     /// <summary>
-    /// Represents a CSDL function return type.
+    /// Represents a CSDL operation return type.
     /// </summary>
-    internal class CsdlOperationReturnType : CsdlElement, IEdmVocabularyAnnotatable
+    internal class CsdlOperationReturnType : CsdlElement
     {
-        private readonly CsdlTypeReference returnType;
-
         public CsdlOperationReturnType(CsdlTypeReference returnType, CsdlLocation location)
             : base(location)
         {
-            this.returnType = returnType;
+            this.ReturnType = returnType;
         }
 
-        public CsdlTypeReference ReturnType
-        {
-            get { return this.returnType; }
-        }
+        public CsdlTypeReference ReturnType { get; }
     }
 }

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
@@ -1069,11 +1069,10 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             IEnumerable<CsdlOperationParameter> parameters = childValues.ValuesOfType<CsdlOperationParameter>();
 
             CsdlOperationReturnType returnTypeElement = childValues.ValuesOfType<CsdlOperationReturnType>().FirstOrDefault();
-            CsdlTypeReference returnType = returnTypeElement == null ? null : returnTypeElement.ReturnType;
 
             this.ReportOperationReadErrorsIfExist(entitySetPath, isBound, name);
 
-            return new CsdlAction(name, parameters, returnType, isBound, entitySetPath, element.Location);
+            return new CsdlAction(name, parameters, returnTypeElement, isBound, entitySetPath, element.Location);
         }
 
         internal CsdlFunction OnFunctionElement(XmlElementInfo element, XmlElementValueCollection childValues)
@@ -1086,11 +1085,10 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             IEnumerable<CsdlOperationParameter> parameters = childValues.ValuesOfType<CsdlOperationParameter>();
 
             CsdlOperationReturnType returnTypeElement = childValues.ValuesOfType<CsdlOperationReturnType>().FirstOrDefault();
-            CsdlTypeReference returnType = returnTypeElement == null ? null : returnTypeElement.ReturnType;
 
             this.ReportOperationReadErrorsIfExist(entitySetPath, isBound, name);
 
-            return new CsdlFunction(name, parameters, returnType, isBound, entitySetPath, isComposable, element.Location);
+            return new CsdlFunction(name, parameters, returnTypeElement, isBound, entitySetPath, isComposable, element.Location);
         }
 
         private void ReportOperationReadErrorsIfExist(string entitySetPath, bool isBound, string name)

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedOperation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedOperation.cs
@@ -18,14 +18,13 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         private readonly string namespaceName;
         private readonly string name;
         private readonly string fullName;
-        private readonly IEdmTypeReference returnType;
 
         public UnresolvedOperation(string qualifiedName, string errorMessage, EdmLocation location)
             : base(new EdmError[] { new EdmError(location, EdmErrorCode.BadUnresolvedOperation, errorMessage) })
         {
             qualifiedName = qualifiedName ?? string.Empty;
             EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
-            this.returnType = new BadTypeReference(new BadType(this.Errors), true);
+            this.ReturnType = new EdmOperationReturnType(this, new BadTypeReference(new BadType(this.Errors), true));
         }
 
         public string Namespace
@@ -46,10 +45,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             get { return this.fullName; }
         }
 
-        public IEdmTypeReference ReturnType
-        {
-            get { return this.returnType; }
-        }
+        public IEdmTypeReference ReturnType { get; }
 
         public IEnumerable<IEdmOperationParameter> Parameters
         {

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedReturnType.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedReturnType.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             this.DeclaringOperation = declaringOperation;
         }
 
-        public IEdmTypeReference ReturnType
+        public IEdmTypeReference Type
         {
             get { return this.type.GetValue(this, ComputeTypeFunc, null); }
         }
@@ -30,12 +30,12 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
         public bool IsNullable
         {
-            get { return ReturnType.IsNullable; }
+            get { return Type.IsNullable; }
         }
 
         public IEdmType Definition
         {
-            get { return ReturnType.Definition; }
+            get { return Type.Definition; }
         }
 
         private IEdmTypeReference ComputeType()

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedReturnType.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedReturnType.cs
@@ -1,0 +1,46 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="UnresolvedReturnType.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using Microsoft.OData.Edm.Validation;
+
+namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
+{
+    internal class UnresolvedReturnType : BadElement, IEdmOperationReturnType, IUnresolvedElement
+    {
+        // Type cache.
+        private readonly Cache<UnresolvedReturnType, IEdmTypeReference> type = new Cache<UnresolvedReturnType, IEdmTypeReference>();
+        private static readonly Func<UnresolvedReturnType, IEdmTypeReference> ComputeTypeFunc = (me) => me.ComputeType();
+
+        public UnresolvedReturnType(IEdmOperation declaringOperation, EdmLocation location)
+            : base(new EdmError[] { new EdmError(location, EdmErrorCode.BadUnresolvedReturnType, Edm.Strings.Bad_UnresolvedReturnType("")) })
+        {
+            this.DeclaringOperation = declaringOperation;
+        }
+
+        public IEdmTypeReference ReturnType
+        {
+            get { return this.type.GetValue(this, ComputeTypeFunc, null); }
+        }
+
+        public IEdmOperation DeclaringOperation { get; private set; }
+
+        public bool IsNullable
+        {
+            get { return ReturnType.IsNullable; }
+        }
+
+        public IEdmType Definition
+        {
+            get { return ReturnType.Definition; }
+        }
+
+        private IEdmTypeReference ComputeType()
+        {
+            return new BadTypeReference(new BadType(Errors), true);
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperation.cs
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
         private IEdmTypeReference ComputeReturnType()
         {
-            return CsdlSemanticsModel.WrapTypeReference(this.Context, this.operation.ReturnType);
+            return this.operation.ReturnType == null ? null : new CsdlSemanticsOperationReturnType(this, this.operation.ReturnType);
         }
 
         private IEnumerable<IEdmOperationParameter> ComputeParameters()

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperationReturnType.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperationReturnType.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             get { return this.returnType; }
         }
 
-        public IEdmTypeReference ReturnType
+        public IEdmTypeReference Type
         {
             get { return this.typeCache.GetValue(this, ComputeTypeFunc, null); }
         }
@@ -51,12 +51,12 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
         public bool IsNullable
         {
-            get { return ReturnType.IsNullable; }
+            get { return Type.IsNullable; }
         }
 
         public IEdmType Definition
         {
-            get { return ReturnType.Definition; }
+            get { return Type.Definition; }
         }
 
         protected override IEnumerable<IEdmVocabularyAnnotation> ComputeInlineVocabularyAnnotations()

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperationReturnType.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperationReturnType.cs
@@ -1,0 +1,72 @@
+//---------------------------------------------------------------------
+// <copyright file="CsdlSemanticsOperationReturnType.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OData.Edm.Csdl.Parsing.Ast;
+using Microsoft.OData.Edm.Vocabularies;
+
+namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
+{
+    /// <summary>
+    /// Provides semantics for a CsdlOperationReturnType.
+    /// </summary>
+    internal class CsdlSemanticsOperationReturnType : CsdlSemanticsElement, IEdmOperationReturnType
+    {
+        private readonly CsdlSemanticsOperation declaringOperation;
+        private readonly CsdlOperationReturnType returnType;
+
+        private readonly Cache<CsdlSemanticsOperationReturnType, IEdmTypeReference> typeCache = new Cache<CsdlSemanticsOperationReturnType, IEdmTypeReference>();
+        private static readonly Func<CsdlSemanticsOperationReturnType, IEdmTypeReference> ComputeTypeFunc = (me) => me.ComputeType();
+
+        public CsdlSemanticsOperationReturnType(CsdlSemanticsOperation declaringOperation, CsdlOperationReturnType returnType)
+            : base(returnType)
+        {
+            this.returnType = returnType;
+            this.declaringOperation = declaringOperation;
+        }
+
+        public override CsdlSemanticsModel Model
+        {
+            get { return this.declaringOperation.Model; }
+        }
+
+        public override CsdlElement Element
+        {
+            get { return this.returnType; }
+        }
+
+        public IEdmTypeReference ReturnType
+        {
+            get { return this.typeCache.GetValue(this, ComputeTypeFunc, null); }
+        }
+
+        public IEdmOperation DeclaringOperation
+        {
+            get { return this.declaringOperation; }
+        }
+
+        public bool IsNullable
+        {
+            get { return ReturnType.IsNullable; }
+        }
+
+        public IEdmType Definition
+        {
+            get { return ReturnType.Definition; }
+        }
+
+        protected override IEnumerable<IEdmVocabularyAnnotation> ComputeInlineVocabularyAnnotations()
+        {
+            return this.Model.WrapInlineVocabularyAnnotations(this, this.declaringOperation.Context);
+        }
+
+        private IEdmTypeReference ComputeType()
+        {
+            return CsdlSemanticsModel.WrapTypeReference(this.declaringOperation.Context, this.returnType.ReturnType);
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -843,7 +843,7 @@ namespace Microsoft.OData.Edm
         {
             if (operation.ReturnType != null)
             {
-                this.VisitTypeReference(operation.ReturnType);
+                this.VisitOperationReturnType(operation.ReturnType as IEdmOperationReturnType);
             }
 
             // Do not visit vocabularyAnnotatable because functions and operation imports are always going to be either a schema element or a container element and will be visited through those paths.
@@ -855,6 +855,12 @@ namespace Microsoft.OData.Edm
             this.ProcessVocabularyAnnotatable(parameter);
             this.ProcessNamedElement(parameter);
             this.VisitTypeReference(parameter.Type);
+        }
+
+        public virtual void VisitOperationReturnType(IEdmOperationReturnType returnType)
+        {
+            this.ProcessVocabularyAnnotatable(returnType);
+            this.VisitTypeReference(returnType.ReturnType);
         }
 
         #endregion

--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -843,7 +843,15 @@ namespace Microsoft.OData.Edm
         {
             if (operation.ReturnType != null)
             {
-                this.VisitOperationReturnType(operation.ReturnType as IEdmOperationReturnType);
+                IEdmOperationReturnType returnType = operation.ReturnType as IEdmOperationReturnType;
+                if (returnType != null)
+                {
+                    this.VisitOperationReturnType(returnType);
+                }
+                else
+                {
+                    this.VisitTypeReference(operation.ReturnType);
+                }
             }
 
             // Do not visit vocabularyAnnotatable because functions and operation imports are always going to be either a schema element or a container element and will be visited through those paths.
@@ -860,7 +868,7 @@ namespace Microsoft.OData.Edm
         public virtual void VisitOperationReturnType(IEdmOperationReturnType returnType)
         {
             this.ProcessVocabularyAnnotatable(returnType);
-            this.VisitTypeReference(returnType.ReturnType);
+            this.VisitTypeReference(returnType.Type);
         }
 
         #endregion

--- a/src/Microsoft.OData.Edm/EdmUtil.cs
+++ b/src/Microsoft.OData.Edm/EdmUtil.cs
@@ -336,6 +336,8 @@ namespace Microsoft.OData.Edm
                     }
                     else
                     {
+                        IEdmOperationReturnType returnType;
+                        IEdmEnumMember enumMember;
                         IEdmOperationParameter parameter = element as IEdmOperationParameter;
                         if (parameter != null)
                         {
@@ -345,16 +347,20 @@ namespace Microsoft.OData.Edm
                                 return parameterOwnerName + "/" + parameter.Name;
                             }
                         }
-                        else
+                        else if ((enumMember = element as IEdmEnumMember) != null)
                         {
-                            IEdmEnumMember enumMember = element as IEdmEnumMember;
-                            if (enumMember != null)
+                            string enumMemberOwnerName = FullyQualifiedName(enumMember.DeclaringType);
+                            if (enumMemberOwnerName != null)
                             {
-                                string enumMemberOwnerName = FullyQualifiedName(enumMember.DeclaringType);
-                                if (enumMemberOwnerName != null)
-                                {
-                                    return enumMemberOwnerName + "/" + enumMember.Name;
-                                }
+                                return enumMemberOwnerName + "/" + enumMember.Name;
+                            }
+                        }
+                        else if ((returnType = element as IEdmOperationReturnType) != null)
+                        {
+                            string operationName = FullyQualifiedName(returnType.DeclaringOperation);
+                            if (operationName != null)
+                            {
+                                return operationName + "/" + CsdlConstants.ReturnTypeExternTarget;
                             }
                         }
                     }

--- a/src/Microsoft.OData.Edm/ExtensionMethods/EdmTypeSemantics.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/EdmTypeSemantics.cs
@@ -688,6 +688,13 @@ namespace Microsoft.OData.Edm
         public static IEdmPrimitiveTypeReference AsPrimitive(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsPrimitive();
+            }
+
             IEdmPrimitiveTypeReference primitiveReference = type as IEdmPrimitiveTypeReference;
             if (primitiveReference != null)
             {
@@ -814,6 +821,13 @@ namespace Microsoft.OData.Edm
         public static IEdmCollectionTypeReference AsCollection(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsCollection();
+            }
+
             IEdmCollectionTypeReference reference = type as IEdmCollectionTypeReference;
             if (reference != null)
             {
@@ -843,6 +857,13 @@ namespace Microsoft.OData.Edm
         public static IEdmStructuredTypeReference AsStructured(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsStructured();
+            }
+
             IEdmStructuredTypeReference reference = type as IEdmStructuredTypeReference;
             if (reference != null)
             {
@@ -875,6 +896,13 @@ namespace Microsoft.OData.Edm
         public static IEdmEnumTypeReference AsEnum(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsEnum();
+            }
+
             IEdmEnumTypeReference reference = type as IEdmEnumTypeReference;
             if (reference != null)
             {
@@ -902,6 +930,13 @@ namespace Microsoft.OData.Edm
         public static IEdmTypeDefinitionReference AsTypeDefinition(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsTypeDefinition();
+            }
+
             IEdmTypeDefinitionReference reference = type as IEdmTypeDefinitionReference;
             if (reference != null)
             {
@@ -928,6 +963,13 @@ namespace Microsoft.OData.Edm
         public static IEdmEntityTypeReference AsEntity(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsEntity();
+            }
+
             IEdmEntityTypeReference reference = type as IEdmEntityTypeReference;
             if (reference != null)
             {
@@ -958,6 +1000,13 @@ namespace Microsoft.OData.Edm
         public static IEdmEntityReferenceTypeReference AsEntityReference(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsEntityReference();
+            }
+
             IEdmEntityReferenceTypeReference reference = type as IEdmEntityReferenceTypeReference;
             if (reference != null)
             {
@@ -987,6 +1036,13 @@ namespace Microsoft.OData.Edm
         public static IEdmComplexTypeReference AsComplex(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsComplex();
+            }
+
             IEdmComplexTypeReference reference = type as IEdmComplexTypeReference;
             if (reference != null)
             {
@@ -1019,6 +1075,13 @@ namespace Microsoft.OData.Edm
         public static IEdmPathTypeReference AsPath(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsPath();
+            }
+
             IEdmPathTypeReference reference = type as IEdmPathTypeReference;
             if (reference != null)
             {
@@ -1049,6 +1112,13 @@ namespace Microsoft.OData.Edm
         public static IEdmSpatialTypeReference AsSpatial(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsSpatial();
+            }
+
             IEdmSpatialTypeReference spatial = type as IEdmSpatialTypeReference;
             if (spatial != null)
             {
@@ -1073,6 +1143,13 @@ namespace Microsoft.OData.Edm
         public static IEdmTemporalTypeReference AsTemporal(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsTemporal();
+            }
+
             IEdmTemporalTypeReference temporal = type as IEdmTemporalTypeReference;
             if (temporal != null)
             {
@@ -1097,6 +1174,13 @@ namespace Microsoft.OData.Edm
         public static IEdmDecimalTypeReference AsDecimal(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsDecimal();
+            }
+
             IEdmDecimalTypeReference decimalType = type as IEdmDecimalTypeReference;
             if (decimalType != null)
             {
@@ -1121,6 +1205,13 @@ namespace Microsoft.OData.Edm
         public static IEdmStringTypeReference AsString(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsString();
+            }
+
             IEdmStringTypeReference stringType = type as IEdmStringTypeReference;
             if (stringType != null)
             {
@@ -1145,6 +1236,13 @@ namespace Microsoft.OData.Edm
         public static IEdmBinaryTypeReference AsBinary(this IEdmTypeReference type)
         {
             EdmUtil.CheckArgumentNull(type, "type");
+
+            IEdmOperationReturnType returnType = type as IEdmOperationReturnType;
+            if (returnType != null)
+            {
+                return returnType.Type.AsBinary();
+            }
+
             IEdmBinaryTypeReference binaryType = type as IEdmBinaryTypeReference;
             if (binaryType != null)
             {

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -2296,6 +2296,16 @@ namespace Microsoft.OData.Edm
         #region IEdmOperation
 
         /// <summary>
+        /// Gets the <see cref="IEdmOperationReturnType"/> from the given <see cref="IEdmOperation"/>.
+        /// </summary>
+        /// <param name="operation">The operation.</param>
+        /// <returns>null or the <see cref="IEdmOperationReturnType"/> object. </returns>
+        public static IEdmOperationReturnType GetOperationReturnType(this IEdmOperation operation)
+        {
+            return operation.ReturnType as IEdmOperationReturnType;
+        }
+
+        /// <summary>
         /// Determines whether the specified operation is action.
         /// </summary>
         /// <param name="operation">The operation.</param>

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -2306,6 +2306,27 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Gets the <see cref="IEdmTypeReference"/> from the given <see cref="IEdmOperation"/>.
+        /// </summary>
+        /// <param name="operation">The operation.</param>
+        /// <returns>null or the <see cref="IEdmTypeReference"/> object. </returns>
+        public static IEdmTypeReference GetReturnTypeReference(this IEdmOperation operation)
+        {
+            if (operation == null || operation.ReturnType == null)
+            {
+                return null;
+            }
+
+            IEdmOperationReturnType operationReturnType = operation.ReturnType as IEdmOperationReturnType;
+            if (operationReturnType != null)
+            {
+                return operationReturnType.Type;
+            }
+
+            return operationReturnType;
+        }
+
+        /// <summary>
         /// Determines whether the specified operation is action.
         /// </summary>
         /// <param name="operation">The operation.</param>

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
@@ -71,7 +71,6 @@ namespace Microsoft.OData.Edm {
     internal sealed class EntityRes {
         internal const string EdmPrimitive_UnexpectedKind = "EdmPrimitive_UnexpectedKind";
         internal const string EdmPath_UnexpectedKind = "EdmPath_UnexpectedKind";
-        internal const string Annotations_DocumentationPun = "Annotations_DocumentationPun";
         internal const string Annotations_TypeMismatch = "Annotations_TypeMismatch";
         internal const string Constructable_VocabularyAnnotationMustHaveTarget = "Constructable_VocabularyAnnotationMustHaveTarget";
         internal const string Constructable_EntityTypeOrCollectionOfEntityTypeExpected = "Constructable_EntityTypeOrCollectionOfEntityTypeExpected";
@@ -330,6 +329,7 @@ namespace Microsoft.OData.Edm {
         internal const string Bad_UnresolvedEnumMember = "Bad_UnresolvedEnumMember";
         internal const string Bad_UnresolvedProperty = "Bad_UnresolvedProperty";
         internal const string Bad_UnresolvedParameter = "Bad_UnresolvedParameter";
+        internal const string Bad_UnresolvedReturnType = "Bad_UnresolvedReturnType";
         internal const string Bad_UnresolvedLabeledElement = "Bad_UnresolvedLabeledElement";
         internal const string Bad_CyclicEntity = "Bad_CyclicEntity";
         internal const string Bad_CyclicComplex = "Bad_CyclicComplex";

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -371,6 +371,7 @@
     <Compile Include="Csdl\Semantics\CsdlSemanticsEntityTypeDefinition.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsOperation.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsOperationParameter.cs" />
+    <Compile Include="Csdl\Semantics\CsdlSemanticsOperationReturnType.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsOptionalParameter.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsModel.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsNavigationProperty.cs" />
@@ -380,6 +381,7 @@
     <Compile Include="Csdl\Semantics\BadElements\UnresolvedLabeledElement.cs" />
     <Compile Include="Csdl\Semantics\BadElements\UnresolvedEnumMember.cs" />
     <Compile Include="Csdl\Semantics\BadElements\UnresolvedParameter.cs" />
+    <Compile Include="Csdl\Semantics\BadElements\UnresolvedReturnType.cs" />
     <Compile Include="Schema\EdmEnumTypeReference.cs" />
     <Compile Include="Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs" />
     <Compile Include="Schema\EdmCollectionType.cs" />
@@ -422,6 +424,7 @@
     <Compile Include="Schema\Interfaces\IEdmEntityTypeReference.cs" />
     <Compile Include="Schema\Interfaces\IEdmOperationImport.cs" />
     <Compile Include="Schema\Interfaces\IEdmOperationParameter.cs" />
+    <Compile Include="Schema\Interfaces\IEdmOperationReturnType.cs" />
     <Compile Include="Schema\Interfaces\IEdmOptionalParameter.cs" />
     <Compile Include="Schema\Interfaces\IEdmModel.cs" />
     <Compile Include="Schema\Interfaces\IEdmNamedElement.cs" />
@@ -447,6 +450,7 @@
     <Compile Include="Schema\EdmOperation.cs" />
     <Compile Include="Schema\EdmOperationImport.cs" />
     <Compile Include="Schema\EdmOperationParameter.cs" />
+    <Compile Include="Schema\EdmOperationReturnType.cs" />
     <Compile Include="Schema\EdmOptionalParameter.cs" />
     <Compile Include="Schema\EdmModel.cs" />
     <Compile Include="Schema\EdmModelBase.cs" />

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -284,6 +284,7 @@ Bad_UnresolvedEnumType=The enum type '{0}' could not be found.
 Bad_UnresolvedEnumMember=The enum member '{0}' could not be found.
 Bad_UnresolvedProperty=The property '{0}' could not be found.
 Bad_UnresolvedParameter=The parameter '{0}' could not be found.
+Bad_UnresolvedReturnType=The return type '{0}' could not be found.
 Bad_UnresolvedLabeledElement=The labeled element '{0}' could not be found.
 Bad_CyclicEntity=The entity '{0}' is invalid because its base type is cyclic.
 Bad_CyclicComplex=The complex type '{0}' is invalid because its base type is cyclic.

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -403,7 +403,7 @@ namespace Microsoft.OData.Edm {
         }
 
         /// <summary>
-        /// A string like "A property cannot be of type '{0}'. The property type must be a complex, a primitive, an enum or an untyped type, or a collection of complex, primitive, or enum types."
+        /// A string like "A property cannot be of type '{0}'. The property type must be a complex, a primitive, an enum, a type definition or an untyped type, or a collection of complex, primitive, enum types, or type definition."
         /// </summary>
         internal static string EdmModel_Validator_Semantic_InvalidPropertyType(object p0) {
             return Microsoft.OData.Edm.EntityRes.GetString(Microsoft.OData.Edm.EntityRes.EdmModel_Validator_Semantic_InvalidPropertyType, p0);
@@ -1949,6 +1949,13 @@ namespace Microsoft.OData.Edm {
         /// </summary>
         internal static string Bad_UnresolvedParameter(object p0) {
             return Microsoft.OData.Edm.EntityRes.GetString(Microsoft.OData.Edm.EntityRes.Bad_UnresolvedParameter, p0);
+        }
+
+        /// <summary>
+        /// A string like "The return type '{0}' could not be found."
+        /// </summary>
+        internal static string Bad_UnresolvedReturnType(object p0) {
+            return Microsoft.OData.Edm.EntityRes.GetString(Microsoft.OData.Edm.EntityRes.Bad_UnresolvedReturnType, p0);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/EdmOperation.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmOperation.cs
@@ -86,7 +86,7 @@ namespace Microsoft.OData.Edm
         /// Gets the return type of this function.
         /// Be noted, it should be different with the input object in the constructor.
         /// If you want to get the origin input object, cast to "IEdmOperationReturnType" and
-        /// call the "ReturnType" property on that interface.
+        /// call the "Type" property on that interface.
         /// </summary>
         public IEdmTypeReference ReturnType { get; private set; }
 

--- a/src/Microsoft.OData.Edm/Schema/EdmOperation.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmOperation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData.Edm
         private readonly List<IEdmOperationParameter> parameters = new List<IEdmOperationParameter>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmAction"/> class.
+        /// Initializes a new instance of the <see cref="EdmOperation"/> class.
         /// </summary>
         /// <param name="namespaceName">Name of the namespace.</param>
         /// <param name="name">The name.</param>
@@ -29,7 +29,7 @@ namespace Microsoft.OData.Edm
         {
             EdmUtil.CheckArgumentNull(namespaceName, "namespaceName");
 
-            this.ReturnType = returnType;
+            this.ReturnType = returnType == null ? null : new EdmOperationReturnType(this, returnType);
             this.Namespace = namespaceName;
             this.IsBound = isBound;
             this.EntitySetPath = entitySetPathExpression;
@@ -37,7 +37,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmAction"/> class.
+        /// Initializes a new instance of the <see cref="EdmOperation"/> class.
         /// </summary>
         /// <param name="namespaceName">Name of the namespace.</param>
         /// <param name="name">The name.</param>
@@ -84,6 +84,9 @@ namespace Microsoft.OData.Edm
 
         /// <summary>
         /// Gets the return type of this function.
+        /// Be noted, it should be different with the input object in the constructor.
+        /// If you want to get the origin input object, cast to "IEdmOperationReturnType" and
+        /// call the "ReturnType" property on that interface.
         /// </summary>
         public IEdmTypeReference ReturnType { get; private set; }
 

--- a/src/Microsoft.OData.Edm/Schema/EdmOperationParameter.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmOperationParameter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmOperationParameter"/> class.
         /// </summary>
-        /// <param name="declaringOperation">Declaring function of the parameter.</param>
+        /// <param name="declaringOperation">Declaring operation of the parameter.</param>
         /// <param name="name">Name of the parameter.</param>
         /// <param name="type">Type of the parameter.</param>
         public EdmOperationParameter(IEdmOperation declaringOperation, string name, IEdmTypeReference type)

--- a/src/Microsoft.OData.Edm/Schema/EdmOperationReturnType.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmOperationReturnType.cs
@@ -1,0 +1,39 @@
+//---------------------------------------------------------------------
+// <copyright file="EdmOperationReturnType.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Represents an EDM operation return type.
+    /// </summary>
+    public class EdmOperationReturnType : EdmTypeReference, IEdmOperationReturnType
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmOperationReturnType"/> class.
+        /// </summary>
+        /// <param name="declaringOperation">Declaring operation of the return type.</param>
+        /// <param name="returnType">The return type of the operation.</param>
+        public EdmOperationReturnType(IEdmOperation declaringOperation, IEdmTypeReference returnType)
+            : base(returnType.Definition, returnType.IsNullable)
+        {
+            EdmUtil.CheckArgumentNull(declaringOperation, "declaringOperation");
+            EdmUtil.CheckArgumentNull(returnType, "returnType");
+
+            this.DeclaringOperation = declaringOperation;
+            this.ReturnType = returnType;
+        }
+
+        /// <summary>
+        /// Gets the operation that declared this return type.
+        /// </summary>
+        public IEdmOperation DeclaringOperation { get; }
+
+        /// <summary>
+        /// Gets the type reference of this return type.
+        /// </summary>
+        public IEdmTypeReference ReturnType { get; }
+    }
+}

--- a/src/Microsoft.OData.Edm/Schema/EdmOperationReturnType.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmOperationReturnType.cs
@@ -15,15 +15,15 @@ namespace Microsoft.OData.Edm
         /// Initializes a new instance of the <see cref="EdmOperationReturnType"/> class.
         /// </summary>
         /// <param name="declaringOperation">Declaring operation of the return type.</param>
-        /// <param name="returnType">The return type of the operation.</param>
-        public EdmOperationReturnType(IEdmOperation declaringOperation, IEdmTypeReference returnType)
-            : base(returnType.Definition, returnType.IsNullable)
+        /// <param name="type">The return type of the operation.</param>
+        public EdmOperationReturnType(IEdmOperation declaringOperation, IEdmTypeReference type)
+            : base(type.Definition, type.IsNullable)
         {
             EdmUtil.CheckArgumentNull(declaringOperation, "declaringOperation");
-            EdmUtil.CheckArgumentNull(returnType, "returnType");
+            EdmUtil.CheckArgumentNull(type, "type");
 
             this.DeclaringOperation = declaringOperation;
-            this.ReturnType = returnType;
+            this.Type = type;
         }
 
         /// <summary>
@@ -34,6 +34,6 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Gets the type reference of this return type.
         /// </summary>
-        public IEdmTypeReference ReturnType { get; }
+        public IEdmTypeReference Type { get; }
     }
 }

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperationReturnType.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperationReturnType.cs
@@ -23,6 +23,6 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Gets the type reference of this return type.
         /// </summary>
-        IEdmTypeReference ReturnType { get; }
+        IEdmTypeReference Type { get; }
     }
 }

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperationReturnType.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperationReturnType.cs
@@ -1,0 +1,28 @@
+//---------------------------------------------------------------------
+// <copyright file="IEdmOperationReturnType.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm.Vocabularies;
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Represents the return type of an EDM operation.
+    /// It's derived from "IEdmTypeReference" for avoiding breaking change.
+    /// In the next breaking change release, it should be changed to derived from "IEdmElement"
+    /// </summary>
+    public interface IEdmOperationReturnType : IEdmTypeReference, IEdmVocabularyAnnotatable
+    {
+        /// <summary>
+        /// Gets the operation that declared this return type.
+        /// </summary>
+        IEdmOperation DeclaringOperation { get; }
+
+        /// <summary>
+        /// Gets the type reference of this return type.
+        /// </summary>
+        IEdmTypeReference ReturnType { get; }
+    }
+}

--- a/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
+++ b/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
@@ -1356,6 +1356,11 @@ namespace Microsoft.OData.Edm.Validation
         /// <summary>
         /// The type of navigation property cannot have path type property.
         /// </summary>
-        TypeOfNavigationPropertyCannotHavePathProperty = 387
+        TypeOfNavigationPropertyCannotHavePathProperty = 387,
+
+        /// <summary>
+        /// Could not find a return type on the annotated operation
+        /// </summary>
+        BadUnresolvedReturnType = 388,
     }
 }

--- a/src/Microsoft.OData.Edm/Validation/ExpressionTypeChecker.cs
+++ b/src/Microsoft.OData.Edm/Validation/ExpressionTypeChecker.cs
@@ -90,7 +90,7 @@ namespace Microsoft.OData.Edm.Validation
                         IEdmOperation operation = applyExpression.AppliedFunction as IEdmOperation;
                         if (operation != null)
                         {
-                            return TestTypeReferenceMatch(operation.ReturnType, type, expression.Location(), matchExactly, out discoveredErrors);
+                            return TestTypeReferenceMatch(operation.GetReturnTypeReference(), type, expression.Location(), matchExactly, out discoveredErrors);
                         }
                     }
 

--- a/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
@@ -1633,7 +1633,7 @@ namespace Microsoft.OData.Edm.Validation
                 {
                     if (operationImport.EntitySet != null && operationImport.Operation.ReturnType != null)
                     {
-                        IEdmTypeReference elementType = operationImport.Operation.ReturnType.IsCollection() ? operationImport.Operation.ReturnType.AsCollection().ElementType() : operationImport.Operation.ReturnType;
+                        IEdmTypeReference elementType = operationImport.Operation.ReturnType.IsCollection() ? operationImport.Operation.GetReturnTypeReference().AsCollection().ElementType() : operationImport.Operation.GetReturnTypeReference();
                         if (elementType.IsEntity())
                         {
                             IEdmEntityType returnedEntityType = elementType.AsEntity().EntityDefinition();
@@ -1738,7 +1738,7 @@ namespace Microsoft.OData.Edm.Validation
                 {
                     if (operation.ReturnType != null)
                     {
-                        IEdmTypeReference elementType = operation.ReturnType.IsCollection() ? operation.ReturnType.AsCollection().ElementType() : operation.ReturnType;
+                        IEdmTypeReference elementType = operation.ReturnType.IsCollection() ? operation.GetReturnTypeReference().AsCollection().ElementType() : operation.GetReturnTypeReference();
                         var isUnresolvedElement = elementType.Definition is IUnresolvedElement;
                         if (!isUnresolvedElement && context.IsBad(elementType.Definition))
                         {
@@ -1907,7 +1907,7 @@ namespace Microsoft.OData.Edm.Validation
             {
                 if (operation.ReturnType != null && operation.ReturnType.IsCollection())
                 {
-                    IEdmTypeReference elementType = operation.ReturnType.AsCollection().ElementType();
+                    IEdmTypeReference elementType = operation.GetReturnTypeReference().AsCollection().ElementType();
                     if (elementType.Definition == EdmCoreModelComplexType.Instance ||
                         elementType.Definition == EdmCoreModel.Instance.GetPrimitiveType())
                     {
@@ -2175,12 +2175,12 @@ namespace Microsoft.OData.Edm.Validation
                             var bindingParameter = function.Parameters.First();
                             if (!bindingTypeReturnTypeLookup.ContainsKey(bindingParameter.Type))
                             {
-                                bindingTypeReturnTypeLookup.Add(bindingParameter.Type, function.ReturnType);
+                                bindingTypeReturnTypeLookup.Add(bindingParameter.Type, function.GetReturnTypeReference());
                             }
                             else
                             {
                                 IEdmTypeReference expectedReturnType = bindingTypeReturnTypeLookup[bindingParameter.Type];
-                                if (!function.ReturnType.IsEquivalentTo(expectedReturnType))
+                                if (!function.GetReturnTypeReference().IsEquivalentTo(expectedReturnType))
                                 {
                                     context.AddError(
                                         function.Location(),
@@ -2203,11 +2203,11 @@ namespace Microsoft.OData.Edm.Validation
                 {
                     if (!functionNameToReturnTypeLookup.ContainsKey(function.Name))
                     {
-                        functionNameToReturnTypeLookup.Add(function.Name, function.ReturnType);
+                        functionNameToReturnTypeLookup.Add(function.Name, function.GetReturnTypeReference());
                     }
                     else
                     {
-                        if (!function.ReturnType.IsEquivalentTo(functionNameToReturnTypeLookup[function.Name]))
+                        if (!function.GetReturnTypeReference().IsEquivalentTo(functionNameToReturnTypeLookup[function.Name]))
                         {
                             context.AddError(
                                        function.Location(),

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -448,6 +448,59 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Assert.Equal(optionalParamWithDefault.DefaultValueString, "Smith");
         }
 
+        [Theory]
+        [InlineData(EdmVocabularyAnnotationSerializationLocation.Inline)]
+        [InlineData(EdmVocabularyAnnotationSerializationLocation.OutOfLine)]
+        public void ParsingReturnTypeAnnotationShouldSucceed(EdmVocabularyAnnotationSerializationLocation location)
+        {
+                const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <Function Name=""TestFunction"">
+        <ReturnType Type=""Edm.PrimitiveType"" Nullable=""false"" >
+          {0}
+        </ReturnType>
+      </Function>
+      <Annotations Target=""NS.TestFunction()/$ReturnType"">
+         {1}
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+
+            string annotationString =
+                "<Annotation Term =\"Org.OData.Validation.V1.DerivedTypeConstraint\">" +
+                  "<Collection>" +
+                     "<String>Edm.Int32</String>" +
+                     "<String>Edm.Boolean</String>" +
+                   "</Collection>" +
+                 "</Annotation>";
+            string inline = location == EdmVocabularyAnnotationSerializationLocation.Inline ? annotationString : "";
+            string outLine = location == EdmVocabularyAnnotationSerializationLocation.Inline ? "" : annotationString;
+            string csdl = String.Format(template, inline, outLine);
+
+            var model = CsdlReader.Parse(XElement.Parse(csdl).CreateReader());
+            var function = model.FindDeclaredOperations("NS.TestFunction").FirstOrDefault();
+            Assert.NotNull(function);
+            Assert.NotNull(function.ReturnType);
+            IEdmOperationReturnType returnType = function.GetOperationReturnType();
+            Assert.NotNull(returnType);
+            Assert.Same(returnType.DeclaringOperation, function);
+            Assert.Equal("Edm.PrimitiveType", returnType.FullName());
+
+            var termType = model.FindTerm("Org.OData.Validation.V1.DerivedTypeConstraint");
+            Assert.NotNull(termType);
+
+            IEdmVocabularyAnnotation annotation = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(returnType, termType).FirstOrDefault();
+            Assert.NotNull(annotation);
+
+            Assert.True(annotation.GetSerializationLocation(model) == location);
+            IEdmCollectionExpression collectConstant = annotation.Value as IEdmCollectionExpression;
+            Assert.NotNull(collectConstant);
+
+            Assert.Equal(new[] { "Edm.Int32", "Edm.Boolean" }, collectConstant.Elements.Select(e => ((IEdmStringConstantExpression)e).Value));
+        }
+
         [Fact]
         public void ParsingValidXmlWithOneReferencesShouldSucceed()
         {

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsOperationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsOperationTests.cs
@@ -39,7 +39,8 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Semantics
         [Fact]
         public void NonBoundCsdlSemanticsOperationPropertiesShouldBeCorrect()
         {
-            var function = new CsdlFunction("Checkout", Enumerable.Empty<CsdlOperationParameter>(), new CsdlNamedTypeReference("Edm.String", false, testLocation), false /*isBound*/, null /*entitySetPath*/, true /*isComposable*/, testLocation);
+            CsdlOperationReturnType returnType = new CsdlOperationReturnType(new CsdlNamedTypeReference("Edm.String", false, testLocation), testLocation);
+            var function = new CsdlFunction("Checkout", Enumerable.Empty<CsdlOperationParameter>(), returnType, false /*isBound*/, null /*entitySetPath*/, true /*isComposable*/, testLocation);
             var semanticFunction = new CsdlSemanticsFunction(this.semanticSchema, function);
             semanticFunction.IsBound.Should().BeFalse();
             semanticFunction.Location().Should().Be(testLocation);
@@ -56,8 +57,8 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Semantics
         {
             var action = new CsdlAction(
                 "Checkout",
-                new CsdlOperationParameter[] { new CsdlOperationParameter("entity", new CsdlNamedTypeReference("FQ.NS.EntityType", false, testLocation), testLocation) }, 
-                new CsdlNamedTypeReference("Edm.String", false, testLocation), 
+                new CsdlOperationParameter[] { new CsdlOperationParameter("entity", new CsdlNamedTypeReference("FQ.NS.EntityType", false, testLocation), testLocation) },
+                new CsdlOperationReturnType(new CsdlNamedTypeReference("Edm.String", false, testLocation), testLocation),
                 true /*isBound*/,
                 "entity/FakePath",
                 testLocation);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/CsdlBuilder.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/CsdlBuilder.cs
@@ -88,9 +88,9 @@ namespace Microsoft.OData.Edm.Tests
         internal static CsdlFunction Function(
             string name, 
             CsdlOperationParameter[] parameters = default(CsdlOperationParameter[]), 
-            CsdlTypeReference typeReference = null, 
-            bool isBound = false, 
-            string entitySetPath = null, 
+            CsdlOperationReturnType typeReference = null,
+            bool isBound = false,
+            string entitySetPath = null,
             bool isComposable = false,
             CsdlLocation location = null)
         {
@@ -112,7 +112,7 @@ namespace Microsoft.OData.Edm.Tests
         internal static CsdlAction Action(
             string name,
             CsdlOperationParameter[] parameters = default(CsdlOperationParameter[]),
-            CsdlTypeReference typeReference = null,
+            CsdlOperationReturnType typeReference = null,
             bool isBound = false,
             string entitySetPath = null,
             CsdlLocation location = null)

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -237,6 +237,18 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         #endregion
 
         [Fact]
+        public void GetOperationReturnTypeShouldReturnCorrect()
+        {
+            IEdmTypeReference typeReference = EdmCoreModel.Instance.GetString(true);
+            var function = new EdmFunction("d.s", "checkout", typeReference);
+            IEdmOperationReturnType returnType = function.GetOperationReturnType();
+            Assert.NotNull(returnType);
+            Assert.Same(returnType, function.ReturnType);
+            Assert.Same(returnType.ReturnType, typeReference);
+            Assert.Same(returnType.DeclaringOperation, function);
+        }
+
+        [Fact]
         public void EdmFunctionShouldBeFunction()
         {
             var function = new EdmFunction("d.s", "checkout", EdmCoreModel.Instance.GetString(true));
@@ -394,7 +406,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
             var action = new CsdlAction(
                 "Checkout",
                 new CsdlOperationParameter[] { new CsdlOperationParameter("entity", new CsdlNamedTypeReference("FQ.NS.EntityType", false, testLocation), testLocation) },
-                new CsdlNamedTypeReference("Edm.String", false, testLocation),
+                new CsdlOperationReturnType(new CsdlNamedTypeReference("Edm.String", false, testLocation), testLocation),
                 true /*isBound*/,
                 "entity",
                 testLocation);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -244,7 +244,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
             IEdmOperationReturnType returnType = function.GetOperationReturnType();
             Assert.NotNull(returnType);
             Assert.Same(returnType, function.ReturnType);
-            Assert.Same(returnType.ReturnType, typeReference);
+            Assert.Same(returnType.Type, typeReference);
             Assert.Same(returnType.DeclaringOperation, function);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisActionsFunctionsRelationshipChangesAcceptanceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ScenarioTests/OasisActionsFunctionsRelationshipChangesAcceptanceTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
         <ReturnType Type=""Test.Person"" />
       </Function>
       <Function Name=""Get2"" IsComposable=""true"">
-        <ReturnType Type=""Edm.String"" />
+        <ReturnType Type=""Edm.String"" Unicode=""false"" />
       </Function>
       <Function Name=""Get3"">
         <Parameter Name=""Foo"" Type=""Collection(Edm.String)"" />
@@ -62,7 +62,7 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
         <ReturnType Type=""Test.Person"" />
       </Action>
       <Action Name=""Other"">
-        <ReturnType Type=""Edm.String"" />
+        <ReturnType Type=""Edm.String"" Unicode=""false"" />
       </Action>
       <Action Name=""RemoveBadCar"" IsBound=""true"" EntitySetPath=""People/Cars"">
         <Parameter Name=""People"" Type=""Collection(Test.Person)"" />
@@ -326,7 +326,7 @@ namespace Microsoft.OData.Edm.Tests.ScenarioTests
         public void ReturnTypePathReturnsCorrectly()
         {
             this.TestModel.RemoveBadCarAction.ReturnType.Should().NotBeNull();
-            var personType = this.TestModel.RemoveBadCarAction.ReturnType.AsCollection().ElementType().Definition;
+            var personType = this.TestModel.RemoveBadCarAction.GetReturnTypeReference().AsCollection().ElementType().Definition;
             personType.Should().Be(this.TestModel.CarType);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmActionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmActionTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             var edmAction = new EdmAction(defaultNamespaceName, checkout, this.boolType);
             edmAction.Namespace.Should().Be(defaultNamespaceName);
             edmAction.Name.Should().Be(checkout);
-            edmAction.ReturnType.Should().Be(this.boolType);
+            edmAction.GetReturnTypeReference().Should().Be(this.boolType);
             edmAction.EntitySetPath.Should().BeNull();
             edmAction.IsBound.Should().BeFalse();
             edmAction.SchemaElementKind.Should().Be(EdmSchemaElementKind.Action);
@@ -53,7 +53,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             edmAction.AddParameter(new EdmOperationParameter(edmAction, "Param1", new EdmEntityTypeReference(personType, false)));
             edmAction.Namespace.Should().Be(defaultNamespaceName);
             edmAction.Name.Should().Be(checkout);
-            edmAction.ReturnType.Should().Be(this.boolType);
+            edmAction.GetReturnTypeReference().Should().Be(this.boolType);
             edmAction.EntitySetPath.Should().Be(entitySetPath);
             edmAction.IsBound.Should().BeTrue();
             edmAction.SchemaElementKind.Should().Be(EdmSchemaElementKind.Action);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmFunctionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmFunctionTests.cs
@@ -38,7 +38,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             var edmFunction = new EdmFunction(defaultNamespaceName, checkout, this.boolType);
             edmFunction.Namespace.Should().Be(defaultNamespaceName);
             edmFunction.Name.Should().Be(checkout);
-            edmFunction.ReturnType.Should().Be(this.boolType);
+            edmFunction.GetReturnTypeReference().Should().Be(this.boolType);
             edmFunction.IsComposable.Should().BeFalse();
         }
 
@@ -48,7 +48,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             var edmFunction = new EdmFunction(defaultNamespaceName, checkout, this.boolType);
             edmFunction.Namespace.Should().Be(defaultNamespaceName);
             edmFunction.Name.Should().Be(checkout);
-            edmFunction.ReturnType.Should().Be(this.boolType);
+            edmFunction.GetReturnTypeReference().Should().Be(this.boolType);
             edmFunction.EntitySetPath.Should().BeNull();
             edmFunction.IsBound.Should().BeFalse();
             edmFunction.SchemaElementKind.Should().Be(EdmSchemaElementKind.Function);
@@ -63,7 +63,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             edmFunction.AddParameter(new EdmOperationParameter(edmFunction, "Param1", new EdmEntityTypeReference(personType, false)));
             edmFunction.Namespace.Should().Be(defaultNamespaceName);
             edmFunction.Name.Should().Be(checkout);
-            edmFunction.ReturnType.Should().Be(this.boolType);
+            edmFunction.GetReturnTypeReference().Should().Be(this.boolType);
             edmFunction.EntitySetPath.Should().Be(entitySetPath);
             edmFunction.IsBound.Should().BeTrue();
             edmFunction.SchemaElementKind.Should().Be(EdmSchemaElementKind.Function);

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -966,7 +966,7 @@ public interface Microsoft.OData.Edm.IEdmOperationParameter : IEdmElement, IEdmN
 
 public interface Microsoft.OData.Edm.IEdmOperationReturnType : IEdmElement, IEdmTypeReference, IEdmVocabularyAnnotatable {
 	Microsoft.OData.Edm.IEdmOperation DeclaringOperation  { public abstract get; }
-	Microsoft.OData.Edm.IEdmTypeReference ReturnType  { public abstract get; }
+	Microsoft.OData.Edm.IEdmTypeReference Type  { public abstract get; }
 }
 
 public interface Microsoft.OData.Edm.IEdmOptionalParameter : IEdmElement, IEdmNamedElement, IEdmOperationParameter, IEdmVocabularyAnnotatable {
@@ -1975,6 +1975,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
 	[
 	ExtensionAttribute(),
 	]
+	public static Microsoft.OData.Edm.IEdmTypeReference GetReturnTypeReference (Microsoft.OData.Edm.IEdmOperation operation)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static Microsoft.OData.Edm.Vocabularies.IEdmValue GetTermValue (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmStructuredValue context, Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.EdmExpressionEvaluator expressionEvaluator)
 
 	[
@@ -2658,10 +2663,10 @@ public class Microsoft.OData.Edm.EdmOperationParameter : Microsoft.OData.Edm.Edm
 }
 
 public class Microsoft.OData.Edm.EdmOperationReturnType : Microsoft.OData.Edm.EdmTypeReference, IEdmElement, IEdmOperationReturnType, IEdmTypeReference, IEdmVocabularyAnnotatable {
-	public EdmOperationReturnType (Microsoft.OData.Edm.IEdmOperation declaringOperation, Microsoft.OData.Edm.IEdmTypeReference returnType)
+	public EdmOperationReturnType (Microsoft.OData.Edm.IEdmOperation declaringOperation, Microsoft.OData.Edm.IEdmTypeReference type)
 
 	Microsoft.OData.Edm.IEdmOperation DeclaringOperation  { public virtual get; }
-	Microsoft.OData.Edm.IEdmTypeReference ReturnType  { public virtual get; }
+	Microsoft.OData.Edm.IEdmTypeReference Type  { public virtual get; }
 }
 
 public class Microsoft.OData.Edm.EdmOptionalParameter : Microsoft.OData.Edm.EdmOperationParameter, IEdmElement, IEdmNamedElement, IEdmOperationParameter, IEdmOptionalParameter, IEdmVocabularyAnnotatable {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -964,6 +964,11 @@ public interface Microsoft.OData.Edm.IEdmOperationParameter : IEdmElement, IEdmN
 	Microsoft.OData.Edm.IEdmTypeReference Type  { public abstract get; }
 }
 
+public interface Microsoft.OData.Edm.IEdmOperationReturnType : IEdmElement, IEdmTypeReference, IEdmVocabularyAnnotatable {
+	Microsoft.OData.Edm.IEdmOperation DeclaringOperation  { public abstract get; }
+	Microsoft.OData.Edm.IEdmTypeReference ReturnType  { public abstract get; }
+}
+
 public interface Microsoft.OData.Edm.IEdmOptionalParameter : IEdmElement, IEdmNamedElement, IEdmOperationParameter, IEdmVocabularyAnnotatable {
 	string DefaultValueString  { public abstract get; }
 }
@@ -1955,6 +1960,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
 	[
 	ExtensionAttribute(),
 	]
+	public static Microsoft.OData.Edm.IEdmOperationReturnType GetOperationReturnType (Microsoft.OData.Edm.IEdmOperation operation)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static Microsoft.OData.Edm.IEdmPathExpression GetPartnerPath (Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty)
 
 	[
@@ -2647,6 +2657,13 @@ public class Microsoft.OData.Edm.EdmOperationParameter : Microsoft.OData.Edm.Edm
 	Microsoft.OData.Edm.IEdmTypeReference Type  { public virtual get; }
 }
 
+public class Microsoft.OData.Edm.EdmOperationReturnType : Microsoft.OData.Edm.EdmTypeReference, IEdmElement, IEdmOperationReturnType, IEdmTypeReference, IEdmVocabularyAnnotatable {
+	public EdmOperationReturnType (Microsoft.OData.Edm.IEdmOperation declaringOperation, Microsoft.OData.Edm.IEdmTypeReference returnType)
+
+	Microsoft.OData.Edm.IEdmOperation DeclaringOperation  { public virtual get; }
+	Microsoft.OData.Edm.IEdmTypeReference ReturnType  { public virtual get; }
+}
+
 public class Microsoft.OData.Edm.EdmOptionalParameter : Microsoft.OData.Edm.EdmOperationParameter, IEdmElement, IEdmNamedElement, IEdmOperationParameter, IEdmOptionalParameter, IEdmVocabularyAnnotatable {
 	public EdmOptionalParameter (Microsoft.OData.Edm.IEdmOperation declaringOperation, string name, Microsoft.OData.Edm.IEdmTypeReference type)
 	public EdmOptionalParameter (Microsoft.OData.Edm.IEdmOperation declaringOperation, string name, Microsoft.OData.Edm.IEdmTypeReference type, string defaultValue)
@@ -2982,6 +2999,7 @@ public enum Microsoft.OData.Edm.Validation.EdmErrorCode : int {
 	BadUnresolvedParameter = 304
 	BadUnresolvedPrimitiveType = 226
 	BadUnresolvedProperty = 234
+	BadUnresolvedReturnType = 388
 	BadUnresolvedTarget = 361
 	BadUnresolvedTerm = 352
 	BadUnresolvedType = 225


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #52.*

### Description

* Introduce the `IEdmOperationReturnType` interface
* Modify the `IEdmOperation` to use `IEdmOperationReturnType` interface.
* Enable in-line and out of line annotation on return type.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
