### PR TITLE
fix parse fully qualified enum with resolver

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/DottedIdentifierBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/DottedIdentifierBinder.cs
@@ -69,7 +69,7 @@ namespace Microsoft.OData.UriParser
                 {
                     // check if it is enum or not
                     QueryNode enumNode;
-                    if (EnumBinder.TryBindDottedIdentifierAsEnum(dottedIdentifierToken, parentAsSingleResource, state, out enumNode))
+                    if (EnumBinder.TryBindDottedIdentifierAsEnum(dottedIdentifierToken, parentAsSingleResource, state, this.Resolver, out enumNode))
                     {
                         return enumNode;
                     }

--- a/src/Microsoft.OData.Core/UriParser/Binders/EnumBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EnumBinder.cs
@@ -23,11 +23,12 @@ namespace Microsoft.OData.UriParser
         /// <param name="dottedIdentifierToken">a dotted identifier token</param>
         /// <param name="parent">the parent node</param>
         /// <param name="state">the current state of the binding algorithm</param>
+        /// <param name="resolver">ODataUriResolver</param>
         /// <param name="boundEnum">the output bound enum node</param>
         /// <returns>true if we bound an enum node, false otherwise.</returns>
-        internal static bool TryBindDottedIdentifierAsEnum(DottedIdentifierToken dottedIdentifierToken, SingleValueNode parent, BindingState state, out QueryNode boundEnum)
+        internal static bool TryBindDottedIdentifierAsEnum(DottedIdentifierToken dottedIdentifierToken, SingleValueNode parent, BindingState state, ODataUriResolver resolver, out QueryNode boundEnum)
         {
-            return TryBindIdentifier(dottedIdentifierToken.Identifier, null, state.Model, out boundEnum);
+            return TryBindIdentifier(dottedIdentifierToken.Identifier, null, state.Model, resolver, out boundEnum);
         }
 
         /// <summary>
@@ -39,6 +40,19 @@ namespace Microsoft.OData.UriParser
         /// <param name="boundEnum">an enum node .</param>
         /// <returns>true if we bound an enum for this token.</returns>
         internal static bool TryBindIdentifier(string identifier, IEdmEnumTypeReference typeReference, IEdmModel modelWhenNoTypeReference, out QueryNode boundEnum)
+        {
+            return TryBindIdentifier(identifier, typeReference, modelWhenNoTypeReference, null, out boundEnum);
+        }
+        /// <summary>
+        /// Try to bind an identifier to a EnumNode
+        /// </summary>
+        /// <param name="identifier">the identifier to bind</param>
+        /// <param name="typeReference">the enum typeReference</param>
+        /// <param name="modelWhenNoTypeReference">the current model when no enum typeReference.</param>
+        /// <param name="resolver">ODataUriResolver .</param>
+        /// <param name="boundEnum">an enum node .</param>
+        /// <returns>true if we bound an enum for this token.</returns>
+        internal static bool TryBindIdentifier(string identifier, IEdmEnumTypeReference typeReference, IEdmModel modelWhenNoTypeReference, ODataUriResolver resolver, out QueryNode boundEnum)
         {
             boundEnum = null;
             string text = identifier;
@@ -67,7 +81,7 @@ namespace Microsoft.OData.UriParser
                 ?
                (IEdmEnumType)typeReference.Definition
                 :
-                UriEdmHelpers.FindEnumTypeFromModel(modelWhenNoTypeReference, namespaceAndType);
+                UriEdmHelpers.FindEnumTypeFromModel(modelWhenNoTypeReference, namespaceAndType, resolver);
             if (enumType == null)
             {
                 return false;

--- a/src/Microsoft.OData.Core/UriParser/UriEdmHelpers.cs
+++ b/src/Microsoft.OData.Core/UriParser/UriEdmHelpers.cs
@@ -41,6 +41,18 @@ namespace Microsoft.OData.UriParser
             IEdmEnumType enumType = FindTypeFromModel(model, qualifiedName, ODataUriResolver.GetUriResolver(null)) as IEdmEnumType;
             return enumType;
         }
+        /// <summary>
+        /// Wraps call to FindTypeFromModel for an Enum type.
+        /// </summary>
+        /// <param name="model">the model to search</param>
+        /// <param name="qualifiedName">the name to find within the model</param>
+        /// <param name="resolver">ODataUriResolver</param>
+        /// <returns>a type reference to the enum type, or null if no such type exists.</returns>
+        internal static IEdmEnumType FindEnumTypeFromModel(IEdmModel model, string qualifiedName, ODataUriResolver resolver)
+        {
+            IEdmEnumType enumType = FindTypeFromModel(model, qualifiedName, resolver ?? ODataUriResolver.GetUriResolver(null)) as IEdmEnumType;
+            return enumType;
+        }
 
         /// <summary>
         /// Check whether the parent and child are properly related types


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues
Thrown exception ODataException : 'The string 'Fully.Qualified.Namespace.ColorPattern'Red'' is not a valid enumeration type constant.' when use custom ODataUriResolver.

### Description

Pass resolver parameter in method parse enum type.

### Checklist (Uncheck if it is not completed)

- [x ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
