### PR TITLE
expand transformation in $apply

### DIFF
--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -1496,6 +1496,9 @@
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\Aggregation\ComputeTransformationNode.cs">
       <Link>Microsoft\OData\Core\UriParser\Aggregation\ComputeTransformationNode.cs</Link>
+    </Compile>    
+    <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\Aggregation\ExpandTransformationNode.cs">
+      <Link>Microsoft\OData\Core\UriParser\Aggregation\ExpandTransformationNode.cs</Link>
     </Compile>
     <Compile Include="$(ODataCrossTargettingSourcePath)\UriParser\Aggregation\GroupByTransformationNode.cs">
       <Link>Microsoft\OData\Core\UriParser\Aggregation\GroupByTransformationNode.cs</Link>

--- a/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
+++ b/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
@@ -1016,6 +1016,9 @@
     <Compile Include="..\UriParser\Aggregation\ComputeTransformationNode.cs">
       <Link>UriParser\Aggregation\ComputeTransformationNode.cs</Link>
     </Compile>
+    <Compile Include="..\UriParser\Aggregation\ExpandTransformationNode.cs">
+      <Link>UriParser\Aggregation\ExpandTransformationNode.cs</Link>
+    </Compile>    
     <Compile Include="..\UriParser\Aggregation\FilterTransformationNode.cs">
       <Link>UriParser\Aggregation\FilterTransformationNode.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -635,6 +635,7 @@ namespace Microsoft.OData {
         internal const string UriQueryExpressionParser_UnrecognizedWithMethod = "UriQueryExpressionParser_UnrecognizedWithMethod";
         internal const string UriQueryExpressionParser_PropertyPathExpected = "UriQueryExpressionParser_PropertyPathExpected";
         internal const string UriQueryExpressionParser_KeywordOrIdentifierExpected = "UriQueryExpressionParser_KeywordOrIdentifierExpected";
+        internal const string UriQueryExpressionParser_InnerMostExpandRequireFilter = "UriQueryExpressionParser_InnerMostExpandRequireFilter";
         internal const string UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri = "UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri";
         internal const string UriQueryPathParser_SyntaxError = "UriQueryPathParser_SyntaxError";
         internal const string UriQueryPathParser_TooManySegments = "UriQueryPathParser_TooManySegments";
@@ -773,8 +774,8 @@ namespace Microsoft.OData {
         internal const string RequestUriProcessor_InvalidValueForKeySegment = "RequestUriProcessor_InvalidValueForKeySegment";
         internal const string RequestUriProcessor_CannotApplyFilterOnSingleEntities = "RequestUriProcessor_CannotApplyFilterOnSingleEntities";
         internal const string RequestUriProcessor_CannotApplyEachOnSingleEntities = "RequestUriProcessor_CannotApplyEachOnSingleEntities";
-        internal const string RequestUriProcessor_NoNavigationSourceFound = "RequestUriProcessor_NoNavigationSourceFound";
         internal const string RequestUriProcessor_FilterPathSegmentSyntaxError = "RequestUriProcessor_FilterPathSegmentSyntaxError";
+        internal const string RequestUriProcessor_NoNavigationSourceFound = "RequestUriProcessor_NoNavigationSourceFound";
         internal const string RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment = "RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment";
         internal const string RequestUriProcessor_EmptySegmentInRequestUrl = "RequestUriProcessor_EmptySegmentInRequestUrl";
         internal const string RequestUriProcessor_SyntaxError = "RequestUriProcessor_SyntaxError";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -82,6 +82,7 @@
     <Compile Include="DuplicatePropertyNameChecker.cs" />
     <Compile Include="PropertyValueTypeInfo.cs" />
     <Compile Include="BindingPathHelper.cs" />
+    <Compile Include="UriParser\Aggregation\ExpandTransformationNode.cs" />
     <Compile Include="UriParser\Binders\ComputeBinder.cs" />
     <Compile Include="UriParser\Binders\InBinder.cs" />
     <Compile Include="UriParser\Aggregation\AggregateTokenBase.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -687,6 +687,7 @@ UriQueryExpressionParser_WithExpected='with' expected at position {0} in '{1}'.
 UriQueryExpressionParser_UnrecognizedWithMethod=Unrecognized with '{0}' at '{1}' in '{2}'.
 UriQueryExpressionParser_PropertyPathExpected=Expression expected at position {0} in '{1}'.
 UriQueryExpressionParser_KeywordOrIdentifierExpected='{0}' expected at position {1} in '{2}'.
+UriQueryExpressionParser_InnerMostExpandRequireFilter=inner most expand require filter() at position {0} in '{1}'.
 
 UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri=The URI '{0}' is not valid because it is not based on '{1}'.
 UriQueryPathParser_SyntaxError=Bad Request: there was an error in the query syntax.

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -687,7 +687,7 @@ UriQueryExpressionParser_WithExpected='with' expected at position {0} in '{1}'.
 UriQueryExpressionParser_UnrecognizedWithMethod=Unrecognized with '{0}' at '{1}' in '{2}'.
 UriQueryExpressionParser_PropertyPathExpected=Expression expected at position {0} in '{1}'.
 UriQueryExpressionParser_KeywordOrIdentifierExpected='{0}' expected at position {1} in '{2}'.
-UriQueryExpressionParser_InnerMostExpandRequireFilter=inner most expand require filter() at position {0} in '{1}'.
+UriQueryExpressionParser_InnerMostExpandRequireFilter=The inner most expand transformation requires a filter transformation at position {0} in '{1}'.
 
 UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri=The URI '{0}' is not valid because it is not based on '{1}'.
 UriQueryPathParser_SyntaxError=Bad Request: there was an error in the query syntax.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -4350,6 +4350,13 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "inner most expand require filter() at position {0} in '{1}'."
+        /// </summary>
+        internal static string UriQueryExpressionParser_InnerMostExpandRequireFilter(object p0, object p1) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriQueryExpressionParser_InnerMostExpandRequireFilter, p0, p1);
+        }
+
+        /// <summary>
         /// A string like "The URI '{0}' is not valid because it is not based on '{1}'."
         /// </summary>
         internal static string UriQueryPathParser_RequestUriDoesNotHaveTheCorrectBaseUri(object p0, object p1) {
@@ -5390,45 +5397,38 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "$filter path segment cannot be applied on single entities or singletons. Entity type: '{0}'."
         /// </summary>
-        internal static string RequestUriProcessor_CannotApplyFilterOnSingleEntities(object p0)
-        {
+        internal static string RequestUriProcessor_CannotApplyFilterOnSingleEntities(object p0) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_CannotApplyFilterOnSingleEntities, p0);
         }
 
         /// <summary>
         /// A string like "$each set-based operation cannot be applied on single entities or singletons. Entity type: '{0}'."
         /// </summary>
-        internal static string RequestUriProcessor_CannotApplyEachOnSingleEntities(object p0)
-        {
+        internal static string RequestUriProcessor_CannotApplyEachOnSingleEntities(object p0) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_CannotApplyEachOnSingleEntities, p0);
         }
 
         /// <summary>
-        /// A string like "There are no navigation sources found to apply '{0}'."
+        /// A string like "The $filter path segment must be in the form $filter(expression), where the expression resolves to a boolean."
         /// </summary>
-        internal static string RequestUriProcessor_NoNavigationSourceFound(object p0)
-        {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_NoNavigationSourceFound, p0);
-        }
-
-        /// <summary>
-        /// The $filter path segment must be in the form $filter(expression), where the expression resolves to a boolean.
-        /// </summary>
-        internal static string RequestUriProcessor_FilterPathSegmentSyntaxError
-        {
-            get
-            {
+        internal static string RequestUriProcessor_FilterPathSegmentSyntaxError {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_FilterPathSegmentSyntaxError);
             }
         }
 
         /// <summary>
+        /// A string like "There are no navigation sources found to apply '{0}'."
+        /// </summary>
+        internal static string RequestUriProcessor_NoNavigationSourceFound(object p0) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_NoNavigationSourceFound, p0);
+        }
+
+        /// <summary>
         /// A string like "Only a single operation can follow $each."
         /// </summary>
-        internal static string RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment
-        {
-            get
-            {
+        internal static string RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_OnlySingleOperationCanFollowEachPathSegment);
             }
         }
@@ -5455,8 +5455,7 @@ namespace Microsoft.OData {
         /// A string like "The request URI is not valid, the segment $count cannot be applied to the root of the service."
         /// </summary>
         internal static string RequestUriProcessor_CountOnRoot {
-            get
-            {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_CountOnRoot);
             }
         }
@@ -5465,8 +5464,7 @@ namespace Microsoft.OData {
         /// A string like "The request URI is not valid, the segment $filter cannot be applied to the root of the service."
         /// </summary>
         internal static string RequestUriProcessor_FilterOnRoot {
-            get
-            {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_FilterOnRoot);
             }
         }
@@ -5474,10 +5472,8 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "The request URI is not valid, the segment $each cannot be applied to the root of the service."
         /// </summary>
-        internal static string RequestUriProcessor_EachOnRoot
-        {
-            get
-            {
+        internal static string RequestUriProcessor_EachOnRoot {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_EachOnRoot);
             }
         }
@@ -5485,10 +5481,8 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "The request URI is not valid, the segment $ref cannot be applied to the root of the service."
         /// </summary>
-        internal static string RequestUriProcessor_RefOnRoot
-        {
-            get
-            {
+        internal static string RequestUriProcessor_RefOnRoot {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_RefOnRoot);
             }
         }

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -4350,7 +4350,7 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "inner most expand require filter() at position {0} in '{1}'."
+        /// A string like "The inner most expand transformation requires a filter transformation at position {0} in '{1}'."
         /// </summary>
         internal static string UriQueryExpressionParser_InnerMostExpandRequireFilter(object p0, object p1) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriQueryExpressionParser_InnerMostExpandRequireFilter, p0, p1);

--- a/src/Microsoft.OData.Core/Uri/ApplyClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/ApplyClauseToStringBuilder.cs
@@ -157,8 +157,15 @@ namespace Microsoft.OData
         private void Translate(ExpandTransformationNode transformation)
         {
             ExpandedNavigationSelectItem expandedNavigation = transformation.ExpandClause.SelectedItems.Single() as ExpandedNavigationSelectItem;
+            AppendExpandExpression(expandedNavigation);
+        }
+
+        private void AppendExpandExpression(ExpandedNavigationSelectItem expandedNavigation)
+        {
             AppendExpression(expandedNavigation.PathToNavigationProperty);
-            if (expandedNavigation.FilterOption != null || expandedNavigation.SelectAndExpand != null)
+
+            // Append filter
+            if (expandedNavigation.FilterOption != null)
             {
                 AppendComma(true);
                 if (expandedNavigation.FilterOption != null)
@@ -167,6 +174,20 @@ namespace Microsoft.OData
                     query.Append(ExpressionConstants.KeywordFilter);
                     query.Append(ExpressionConstants.SymbolOpenParen);
                     AppendExpression(expandedNavigation.FilterOption.Expression);
+                    query.Append(ExpressionConstants.SymbolClosedParen);
+                }
+            }
+
+            // Append nested expands
+            if (expandedNavigation.SelectAndExpand != null)
+            {
+                foreach(var navigation in expandedNavigation.SelectAndExpand.SelectedItems.OfType<ExpandedNavigationSelectItem>())
+                {
+                    AppendComma(true);
+                    query.Append(ExpressionConstants.SymbolEscapedSpace);
+                    query.Append(ExpressionConstants.KeywordExpand);
+                    query.Append(ExpressionConstants.SymbolOpenParen);
+                    AppendExpandExpression(navigation);
                     query.Append(ExpressionConstants.SymbolClosedParen);
                 }
             }

--- a/src/Microsoft.OData.Core/Uri/ApplyClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/ApplyClauseToStringBuilder.cs
@@ -168,20 +168,17 @@ namespace Microsoft.OData
             if (expandedNavigation.FilterOption != null)
             {
                 AppendComma(true);
-                if (expandedNavigation.FilterOption != null)
-                {
-                    query.Append(ExpressionConstants.SymbolEscapedSpace);
-                    query.Append(ExpressionConstants.KeywordFilter);
-                    query.Append(ExpressionConstants.SymbolOpenParen);
-                    AppendExpression(expandedNavigation.FilterOption.Expression);
-                    query.Append(ExpressionConstants.SymbolClosedParen);
-                }
+                query.Append(ExpressionConstants.SymbolEscapedSpace);
+                query.Append(ExpressionConstants.KeywordFilter);
+                query.Append(ExpressionConstants.SymbolOpenParen);
+                AppendExpression(expandedNavigation.FilterOption.Expression);
+                query.Append(ExpressionConstants.SymbolClosedParen);
             }
 
             // Append nested expands
             if (expandedNavigation.SelectAndExpand != null)
             {
-                foreach(var navigation in expandedNavigation.SelectAndExpand.SelectedItems.OfType<ExpandedNavigationSelectItem>())
+                foreach (var navigation in expandedNavigation.SelectAndExpand.SelectedItems.OfType<ExpandedNavigationSelectItem>())
                 {
                     AppendComma(true);
                     query.Append(ExpressionConstants.SymbolEscapedSpace);

--- a/src/Microsoft.OData.Core/Uri/ApplyClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/ApplyClauseToStringBuilder.cs
@@ -57,6 +57,12 @@ namespace Microsoft.OData
             query.Append(text);
         }
 
+        private void AppendExpression(ODataExpandPath path)
+        {
+            string text = path.ToContextUrlPathString();
+            query.Append(text);
+        }
+
         private bool AppendSlash(bool appendSlash)
         {
             if (appendSlash)
@@ -148,6 +154,24 @@ namespace Microsoft.OData
             }
         }
 
+        private void Translate(ExpandTransformationNode transformation)
+        {
+            ExpandedNavigationSelectItem expandedNavigation = transformation.ExpandClause.SelectedItems.Single() as ExpandedNavigationSelectItem;
+            AppendExpression(expandedNavigation.PathToNavigationProperty);
+            if (expandedNavigation.FilterOption != null || expandedNavigation.SelectAndExpand != null)
+            {
+                AppendComma(true);
+                if (expandedNavigation.FilterOption != null)
+                {
+                    query.Append(ExpressionConstants.SymbolEscapedSpace);
+                    query.Append(ExpressionConstants.KeywordFilter);
+                    query.Append(ExpressionConstants.SymbolOpenParen);
+                    AppendExpression(expandedNavigation.FilterOption.Expression);
+                    query.Append(ExpressionConstants.SymbolClosedParen);
+                }
+            }
+        }
+
         private void Translate(FilterTransformationNode transformation)
         {
             AppendExpression(transformation.FilterClause.Expression);
@@ -209,6 +233,9 @@ namespace Microsoft.OData
                 case TransformationNodeKind.Compute:
                     query.Append(ExpressionConstants.KeywordCompute);
                     break;
+                case TransformationNodeKind.Expand:
+                    query.Append(ExpressionConstants.KeywordExpand);
+                    break;
                 default:
                     throw new NotSupportedException("unknown TransformationNodeKind value " + transformation.Kind.ToString());
             }
@@ -219,6 +246,7 @@ namespace Microsoft.OData
             AggregateTransformationNode aggTransformation;
             FilterTransformationNode filterTransformation;
             ComputeTransformationNode computeTransformation;
+            ExpandTransformationNode expandTransformation;
             if ((groupByTransformation = transformation as GroupByTransformationNode) != null)
             {
                 Translate(groupByTransformation);
@@ -234,6 +262,10 @@ namespace Microsoft.OData
             else if ((computeTransformation = transformation as ComputeTransformationNode) != null)
             {
                 Translate(computeTransformation);
+            }
+            else if ((expandTransformation = transformation as ExpandTransformationNode) != null)
+            {
+                Translate(expandTransformation);
             }
             else
             {

--- a/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
+++ b/src/Microsoft.OData.Core/Uri/ExpressionConstants.cs
@@ -236,5 +236,8 @@ namespace Microsoft.OData
 
         /// <summary>the compute query option.</summary>
         internal const string QueryOptionCompute = "$compute";
+
+        /// <summary>"expand" keyword for $apply.</summary>
+        internal const string KeywordExpand = "expand";
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -24,7 +24,12 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         private IEnumerable<AggregateExpressionBase> aggregateExpressionsCache;
 
-        public ApplyBinder(MetadataBinder.QueryTokenVisitor bindMethod, BindingState state, ODataUriParserConfiguration configuration = null, ODataPathInfo odataPathInfo = null)
+        public ApplyBinder(MetadataBinder.QueryTokenVisitor bindMethod, BindingState state)
+            :this(bindMethod, state, null, null)
+        {
+        }
+
+        public ApplyBinder(MetadataBinder.QueryTokenVisitor bindMethod, BindingState state, ODataUriParserConfiguration configuration, ODataPathInfo odataPathInfo)
         {
             this.bindMethod = bindMethod;
             this.state = state;

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -19,14 +19,18 @@ namespace Microsoft.OData.UriParser.Aggregation
         private BindingState state;
 
         private FilterBinder filterBinder;
+        private ODataUriParserConfiguration configuration;
+        private ODataPathInfo odataPathInfo;
 
         private IEnumerable<AggregateExpressionBase> aggregateExpressionsCache;
 
-        public ApplyBinder(MetadataBinder.QueryTokenVisitor bindMethod, BindingState state)
+        public ApplyBinder(MetadataBinder.QueryTokenVisitor bindMethod, BindingState state, ODataUriParserConfiguration configuration = null, ODataPathInfo odataPathInfo = null)
         {
             this.bindMethod = bindMethod;
             this.state = state;
             this.filterBinder = new FilterBinder(bindMethod, state);
+            this.configuration = configuration;
+            this.odataPathInfo = odataPathInfo;
         }
 
         public ApplyClause BindApply(IEnumerable<QueryToken> tokens)
@@ -52,6 +56,11 @@ namespace Microsoft.OData.UriParser.Aggregation
                     case QueryTokenKind.Compute:
                         var compute = BindComputeToken((ComputeToken)token);
                         transformations.Add(compute);
+                        break;
+                    case QueryTokenKind.Expand:
+                        SelectExpandClause expandClause = SelectExpandSemanticBinder.Bind(this.odataPathInfo,  (ExpandToken)token, null, this.configuration);
+                        ExpandTransformationNode expandNode = new ExpandTransformationNode(expandClause);
+                        transformations.Add(expandNode);
                         break;
                     default:
                         FilterClause filterClause = this.filterBinder.BindFilter(token);

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ExpandTransformationNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ExpandTransformationNode.cs
@@ -1,0 +1,51 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="FilterTransformationNode.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.UriParser.Aggregation
+{
+    using Microsoft.OData.UriParser;
+
+    /// <summary>
+    /// Node representing a filter transformation.
+    /// </summary>
+    public sealed class ExpandTransformationNode : TransformationNode
+    {
+        private readonly SelectExpandClause expandClause;
+
+        /// <summary>
+        /// Create a ExpandTransformationNode.
+        /// </summary>
+        /// <param name="filterClause">A <see cref="SelectExpandClause"/> representing the metadata bound expand expression.</param>
+        public ExpandTransformationNode(SelectExpandClause expandClause)
+        {
+            ExceptionUtils.CheckArgumentNotNull(expandClause, "expandClause");
+
+            this.expandClause = expandClause;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="SelectExpandClause"/> representing the metadata bound expand expression.
+        /// </summary>
+        public SelectExpandClause ExpandClause
+        {
+            get
+            {
+                return this.expandClause;
+            }
+        }
+
+        /// <summary>
+        /// Gets the kind of the transformation node.
+        /// </summary>
+        public override TransformationNodeKind Kind
+        {
+            get
+            {
+                return TransformationNodeKind.Expand;
+            }
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ExpandTransformationNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ExpandTransformationNode.cs
@@ -1,5 +1,5 @@
 ﻿//---------------------------------------------------------------------
-// <copyright file="FilterTransformationNode.cs" company="Microsoft">
+// <copyright file="ExpandTransformationNode.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
 //---------------------------------------------------------------------
@@ -9,7 +9,7 @@ namespace Microsoft.OData.UriParser.Aggregation
     using Microsoft.OData.UriParser;
 
     /// <summary>
-    /// Node representing a filter transformation.
+    /// Node representing a expand transformation.
     /// </summary>
     public sealed class ExpandTransformationNode : TransformationNode
     {
@@ -18,7 +18,7 @@ namespace Microsoft.OData.UriParser.Aggregation
         /// <summary>
         /// Create a ExpandTransformationNode.
         /// </summary>
-        /// <param name="filterClause">A <see cref="SelectExpandClause"/> representing the metadata bound expand expression.</param>
+        /// <param name="expandClause">A <see cref="SelectExpandClause"/> representing the metadata bound expand expression.</param>
         public ExpandTransformationNode(SelectExpandClause expandClause)
         {
             ExceptionUtils.CheckArgumentNotNull(expandClause, "expandClause");

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/TransformationNodeKind.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/TransformationNodeKind.cs
@@ -30,5 +30,10 @@ namespace Microsoft.OData.UriParser.Aggregation
         /// A Compute expressions
         /// </summary>
         Compute = 3,
+
+        /// <summary>
+        /// A Expand expressions
+        /// </summary>
+        Expand = 4,
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -425,7 +425,7 @@ namespace Microsoft.OData.UriParser
             state.ImplicitRangeVariable = NodeFactory.CreateImplicitRangeVariable(odataPathInfo.TargetEdmType.ToTypeReference(), odataPathInfo.TargetNavigationSource);
             state.RangeVariables.Push(state.ImplicitRangeVariable);
             MetadataBinder binder = new MetadataBinder(state);
-            ApplyBinder applyBinder = new ApplyBinder(binder.Bind, state);
+            ApplyBinder applyBinder = new ApplyBinder(binder.Bind, state, configuration, odataPathInfo);
             ApplyClause boundNode = applyBinder.BindApply(applyTokens);
 
             return boundNode;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -318,8 +318,8 @@ namespace Microsoft.OData.UriParser
             QueryToken filterToken = null;
             ExpandToken nestedExpand = null;
 
-            // Followed (optionaly) by filter and expand
-            // Syntax for expand inside $apply is different (and muc simplier)  from $expand clause => had to use different parsing approach
+            // Followed (optionally) by filter and expand
+            // Syntax for expand inside $apply is different (and much simplier)  from $expand clause => had to use different parsing approach
             while (this.lexer.CurrentToken.Kind == ExpressionTokenKind.Comma)
             {
                 this.lexer.NextToken();

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -331,7 +331,10 @@ namespace Microsoft.OData.UriParser
                             filterToken= this.ParseApplyFilter();
                             break;
                         case ExpressionConstants.KeywordExpand:
-                            nestedExpand = ParseExpand();
+                            ExpandToken tempNestedExpand = ParseExpand();
+                            nestedExpand = nestedExpand == null 
+                                ? tempNestedExpand 
+                                : new ExpandToken(nestedExpand.ExpandTerms.Concat(tempNestedExpand.ExpandTerms));
                             break;
                         default:
                             throw ParseError(ODataErrorStrings.UriQueryExpressionParser_KeywordOrIdentifierExpected(supportedKeywords, this.lexer.CurrentToken.Position, this.lexer.ExpressionText));

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -297,6 +297,64 @@ namespace Microsoft.OData.UriParser
             return new ComputeToken(transformationTokens);
         }
 
+        internal ExpandToken ParseExpand()
+        {
+            Debug.Assert(TokenIdentifierIs(ExpressionConstants.KeywordExpand), "token identifier is expand");
+            lexer.NextToken();
+
+            // '('
+            if (this.lexer.CurrentToken.Kind != ExpressionTokenKind.OpenParen)
+            {
+                throw ParseError(ODataErrorStrings.UriQueryExpressionParser_OpenParenExpected(this.lexer.CurrentToken.Position, this.lexer.ExpressionText));
+            }
+            this.lexer.NextToken();
+
+            List<ExpandTermToken> termTokens = new List<ExpandTermToken>();
+
+            // First token must be Path
+            var termParser = new SelectExpandTermParser(this.lexer, this.maxDepth - 1, false);
+            PathSegmentToken pathToken = termParser.ParseTerm(allowRef: true);
+            
+            QueryToken filterToken = null;
+            ExpandToken nestedExpand = null;
+
+            // Followed (optionaly) by filter and expand
+            // Syntax for expand inside $apply is different (and muc simplier)  from $expand clause => had to use different parsing approach
+            while (this.lexer.CurrentToken.Kind == ExpressionTokenKind.Comma)
+            {
+                this.lexer.NextToken();
+                if (this.lexer.CurrentToken.Kind == ExpressionTokenKind.Identifier)
+                {
+                    switch (this.lexer.CurrentToken.GetIdentifier())
+                    {
+                        case ExpressionConstants.KeywordFilter:
+                            filterToken= this.ParseApplyFilter();
+                            break;
+                        case ExpressionConstants.KeywordExpand:
+                            nestedExpand = ParseExpand();
+                            break;
+                        default:
+                            throw ParseError(ODataErrorStrings.UriQueryExpressionParser_KeywordOrIdentifierExpected(supportedKeywords, this.lexer.CurrentToken.Position, this.lexer.ExpressionText));
+
+                    }
+                }
+            }
+
+            ExpandTermToken expandTermToken = new ExpandTermToken(pathToken, filterToken, null, null, null, null, null, null, null, nestedExpand); 
+            termTokens.Add(expandTermToken);
+
+            // ")"
+            if (this.lexer.CurrentToken.Kind != ExpressionTokenKind.CloseParen)
+            {
+                throw ParseError(ODataErrorStrings.UriQueryExpressionParser_CloseParenOrCommaExpected(this.lexer.CurrentToken.Position, this.lexer.ExpressionText));
+            }
+
+            this.lexer.NextToken();
+
+
+            return new ExpandToken(termTokens);
+        }
+
         internal IEnumerable<QueryToken> ParseApply(string apply)
         {
             Debug.Assert(apply != null, "apply != null");
@@ -326,6 +384,9 @@ namespace Microsoft.OData.UriParser
                         break;
                     case ExpressionConstants.KeywordCompute:
                         transformationTokens.Add(ParseCompute());
+                        break;
+                    case ExpressionConstants.KeywordExpand:
+                        transformationTokens.Add(ParseExpand());
                         break;
                     default:
                         throw ParseError(ODataErrorStrings.UriQueryExpressionParser_KeywordOrIdentifierExpected(supportedKeywords, this.lexer.CurrentToken.Position, this.lexer.ExpressionText));

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -343,6 +343,12 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
+            // Leaf level expands require filter
+            if (filterToken == null && nestedExpand == null)
+            {
+                throw ParseError(ODataErrorStrings.UriQueryExpressionParser_InnerMostExpandRequireFilter(this.lexer.CurrentToken.Position, this.lexer.ExpressionText));
+            }
+
             ExpandTermToken expandTermToken = new ExpandTermToken(pathToken, filterToken, null, null, null, null, null, null, null, nestedExpand); 
             termTokens.Add(expandTermToken);
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ApplyBuilderTest.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ApplyBuilderTest.cs
@@ -20,6 +20,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.UriBuilder
         [InlineData("http://gobbledygook/People?$apply=compute((cast(LifeTime,'Edm.Double') add MyDog/LionWhoAteMe/AngerLevel) mul 2 as lifeAngerLevel,StockQuantity div FavoriteNumber as StockNumber)")]
         [InlineData("http://gobbledygook/People?$apply=groupby((MyDog/Color,MyDog/Breed))")]
         [InlineData("http://gobbledygook/People?$apply=groupby((FirstName),aggregate(MyPaintings($count as cnt)))")]
+        [InlineData("http://gobbledygook/People?$apply=expand(MyPaintings, filter(FrameColor eq 'Red'))/groupby((LifeTime),aggregate(MyPaintings($count as Count)))")]
         public void BuildUrlWithApply(string query)
         {
             var parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(query));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ApplyBuilderTest.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/ApplyBuilderTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.UriBuilder
         [InlineData("http://gobbledygook/People?$apply=groupby((MyDog/Color,MyDog/Breed))")]
         [InlineData("http://gobbledygook/People?$apply=groupby((FirstName),aggregate(MyPaintings($count as cnt)))")]
         [InlineData("http://gobbledygook/People?$apply=expand(MyPaintings, filter(FrameColor eq 'Red'))/groupby((LifeTime),aggregate(MyPaintings($count as Count)))")]
+        [InlineData("http://gobbledygook/People?$apply=expand(MyPaintings, filter(FrameColor eq 'Red'), expand(Owner, filter(FirstName eq 'Me')))/groupby((LifeTime),aggregate(MyPaintings($count as Count)))")]
         public void BuildUrlWithApply(string query)
         {
             var parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, new Uri(query));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -319,7 +319,7 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         {
             IEnumerable<QueryToken> tokens =
                 _parser.ParseApply(
-                    "expand(MyPaintings, filter(FrameColor eq 'Red'), expand(Owner))");
+                    "expand(MyPaintings, filter(FrameColor eq 'Red'), expand(Owner, filter(Name eq 'Me')))");
 
             BindingState state = new BindingState(_configuration);
             MetadataBinder metadataBiner = new MetadataBinder(_bindingState);
@@ -340,6 +340,9 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
             expandItem.SelectAndExpand.Should().NotBeNull();
             expandItem.SelectAndExpand.SelectedItems.Should().HaveCount(1);
             expandItem.FilterOption.Should().NotBeNull();
+
+            ExpandedNavigationSelectItem expandItem1 = expandItem.SelectAndExpand.SelectedItems.First() as ExpandedNavigationSelectItem;
+            expandItem1.FilterOption.Should().NotBeNull();
         }
 
         private static ConstantNode _booleanPrimitiveNode = new ConstantNode(true);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -314,6 +314,34 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
             entitySetAggregate.Should().NotBeNull();
         }
 
+        [Fact]
+        public void BindApplyWithNestedExpandReturnApplyClause()
+        {
+            IEnumerable<QueryToken> tokens =
+                _parser.ParseApply(
+                    "expand(MyPaintings, filter(FrameColor eq 'Red'), expand(Owner))");
+
+            BindingState state = new BindingState(_configuration);
+            MetadataBinder metadataBiner = new MetadataBinder(_bindingState);
+
+            ApplyBinder binder = new ApplyBinder(metadataBiner.Bind, _bindingState, V4configuration, new ODataPathInfo(HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()));
+            ApplyClause actual = binder.BindApply(tokens);
+
+            actual.Should().NotBeNull();
+            actual.Transformations.Should().HaveCount(1);
+
+            ExpandTransformationNode expand = actual.Transformations.First() as ExpandTransformationNode;
+            expand.Should().NotBeNull();
+            expand.ExpandClause.Should().NotBeNull();
+            expand.ExpandClause.SelectedItems.Should().HaveCount(1);
+            ExpandedNavigationSelectItem expandItem = expand.ExpandClause.SelectedItems.First() as ExpandedNavigationSelectItem;
+            expandItem.Should().NotBeNull();
+            expandItem.NavigationSource.Name.ShouldBeEquivalentTo("Paintings");
+            expandItem.SelectAndExpand.Should().NotBeNull();
+            expandItem.SelectAndExpand.SelectedItems.Should().HaveCount(1);
+            expandItem.FilterOption.Should().NotBeNull();
+        }
+
         private static ConstantNode _booleanPrimitiveNode = new ConstantNode(true);
 
         private static SingleValueNode BindMethodReturnsBooleanPrimitive(QueryToken token)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -732,7 +732,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         [Fact]
         public void ParseApplyWithNestedExpand()
         {
-            string apply = "expand(Sales, expand(Customer))";
+            string apply = "expand(Sales, expand(Customers))";
             IEnumerable<QueryToken> actual = this.testSubject.ParseApply(apply);
             actual.Should().NotBeNull();
             actual.Should().HaveCount(1);
@@ -747,7 +747,65 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             expandTerm.ExpandOption.ExpandTerms.Should().HaveCount(1);
             expandTerm = expandTerm.ExpandOption.ExpandTerms.First();
             expandTerm.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
-            expandTerm.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Customer");
+            expandTerm.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Customers");
+        }
+
+        [Fact]
+        public void ParseApplyWithMultipleNestedExpands()
+        {
+            string apply = "expand(Sales, expand(Customers), expand(Cashiers))";
+            IEnumerable<QueryToken> actual = this.testSubject.ParseApply(apply);
+            actual.Should().NotBeNull();
+            actual.Should().HaveCount(1);
+
+            ExpandToken expand = (ExpandToken)actual.First();
+            expand.ExpandTerms.Should().HaveCount(1);
+
+            ExpandTermToken expandTerm = expand.ExpandTerms.First();
+            expandTerm.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Sales");
+            expandTerm.ExpandOption.Should().NotBeNull();
+            expandTerm.ExpandOption.ExpandTerms.Should().HaveCount(2);
+            ExpandTermToken expandTerm1 = expandTerm.ExpandOption.ExpandTerms.First();
+            expandTerm1.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm1.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Customers");
+
+            ExpandTermToken expandTerm2 = expandTerm.ExpandOption.ExpandTerms.Last();
+            expandTerm2.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm2.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Cashiers");
+        }
+
+        [Fact]
+        public void ParseApplyWithMultipleNestedExpandFiltersAndLevels()
+        {
+            string apply = "expand(Sales, expand(Customers, filter(City eq 'Redmond')), expand(Cashiers, expand(Stores, filter(City eq 'Seattle'))))";
+            IEnumerable<QueryToken> actual = this.testSubject.ParseApply(apply);
+            actual.Should().NotBeNull();
+            actual.Should().HaveCount(1);
+
+            ExpandToken expand = (ExpandToken)actual.First();
+            expand.ExpandTerms.Should().HaveCount(1);
+
+            ExpandTermToken expandTerm = expand.ExpandTerms.First();
+            expandTerm.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Sales");
+            expandTerm.ExpandOption.Should().NotBeNull();
+            expandTerm.ExpandOption.ExpandTerms.Should().HaveCount(2);
+            ExpandTermToken expandTerm1 = expandTerm.ExpandOption.ExpandTerms.First();
+            expandTerm1.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm1.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Customers");
+            expandTerm1.FilterOption.Should().NotBeNull();
+
+            ExpandTermToken expandTerm2 = expandTerm.ExpandOption.ExpandTerms.Last();
+            expandTerm2.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm2.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Cashiers");
+            expandTerm2.ExpandOption.Should().NotBeNull();
+
+            expandTerm2.ExpandOption.ExpandTerms.Should().HaveCount(1);
+            ExpandTermToken expandTerm3 = expandTerm2.ExpandOption.ExpandTerms.First();
+            expandTerm3.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Stores");
+            expandTerm3.FilterOption.Should().NotBeNull();
+
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriQueryExpressionParserTests.cs
@@ -676,5 +676,78 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             Action accept2 = () => token.Accept<ComputeExpression>(null);
             accept2.ShouldThrow<NotImplementedException>();
         }
+
+        [Fact]
+        public void ParseApplyWithExpand()
+        {
+            string apply = "expand(Sales)";
+            IEnumerable<QueryToken> actual = this.testSubject.ParseApply(apply);
+            actual.Should().NotBeNull();
+            actual.Should().HaveCount(1);
+
+            ExpandToken expand = (ExpandToken)actual.First();
+            expand.ExpandTerms.Should().HaveCount(1);
+
+            ExpandTermToken expandTerm = expand.ExpandTerms.First();
+            expandTerm.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Sales");
+        }
+
+        [Fact]
+        public void ParseApplyWithExpandFollowedByAggregate()
+        {
+            string apply = "expand(Sales)/aggregate($count as Count)";
+            IEnumerable<QueryToken> actual = this.testSubject.ParseApply(apply);
+            actual.Should().NotBeNull();
+            actual.Should().HaveCount(2);
+
+            ExpandToken expand = (ExpandToken)actual.First();
+            expand.ExpandTerms.Should().HaveCount(1);
+
+            ExpandTermToken expandTerm = expand.ExpandTerms.First();
+            expandTerm.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Sales");
+
+            AggregateToken aggregate = (AggregateToken)actual.Last();
+            aggregate.AggregateExpressions.Should().HaveCount(1);
+        }
+
+        [Fact]
+        public void ParseApplyWithFilteredExpand()
+        {
+            string apply = "expand(Sales, filter(Amount gt 3))";
+            IEnumerable<QueryToken> actual = this.testSubject.ParseApply(apply);
+            actual.Should().NotBeNull();
+            actual.Should().HaveCount(1);
+
+            ExpandToken expand = (ExpandToken)actual.First();
+            expand.ExpandTerms.Should().HaveCount(1);
+
+            ExpandTermToken expandTerm = expand.ExpandTerms.First();
+            expandTerm.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Sales");
+            expandTerm.FilterOption.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void ParseApplyWithNestedExpand()
+        {
+            string apply = "expand(Sales, expand(Customer))";
+            IEnumerable<QueryToken> actual = this.testSubject.ParseApply(apply);
+            actual.Should().NotBeNull();
+            actual.Should().HaveCount(1);
+
+            ExpandToken expand = (ExpandToken)actual.First();
+            expand.ExpandTerms.Should().HaveCount(1);
+
+            ExpandTermToken expandTerm = expand.ExpandTerms.First();
+            expandTerm.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Sales");
+            expandTerm.ExpandOption.Should().NotBeNull();
+            expandTerm.ExpandOption.ExpandTerms.Should().HaveCount(1);
+            expandTerm = expandTerm.ExpandOption.ExpandTerms.First();
+            expandTerm.Kind.ShouldBeEquivalentTo(QueryTokenKind.ExpandTerm);
+            expandTerm.PathToNavigationProp.Identifier.ShouldBeEquivalentTo("Customer");
+        }
     }
 }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -7083,6 +7083,7 @@ public enum Microsoft.OData.UriParser.Aggregation.AggregationMethod : int {
 public enum Microsoft.OData.UriParser.Aggregation.TransformationNodeKind : int {
 	Aggregate = 0
 	Compute = 3
+	Expand = 4
 	Filter = 2
 	GroupBy = 1
 }
@@ -7201,6 +7202,13 @@ public sealed class Microsoft.OData.UriParser.Aggregation.EntitySetAggregateToke
 	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
 	public static Microsoft.OData.UriParser.Aggregation.EntitySetAggregateToken Merge (Microsoft.OData.UriParser.Aggregation.EntitySetAggregateToken token1, Microsoft.OData.UriParser.Aggregation.EntitySetAggregateToken token2)
 	public string Path ()
+}
+
+public sealed class Microsoft.OData.UriParser.Aggregation.ExpandTransformationNode : Microsoft.OData.UriParser.Aggregation.TransformationNode {
+	public ExpandTransformationNode (Microsoft.OData.UriParser.SelectExpandClause expandClause)
+
+	Microsoft.OData.UriParser.SelectExpandClause ExpandClause  { public get; }
+	Microsoft.OData.UriParser.Aggregation.TransformationNodeKind Kind  { public virtual get; }
 }
 
 public sealed class Microsoft.OData.UriParser.Aggregation.FilterTransformationNode : Microsoft.OData.UriParser.Aggregation.TransformationNode {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1344.*

### Description

Added parsing and binding for expand inside $apply.
For example $apply=expand(Sales, filter(Amount gt 10), expand(Customers))

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

