### PR TITLE
add vscode support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/test/FunctionalTests/Microsoft.OData.Core.Tests/bin/Debug/netcoreapp1.0/Microsoft.OData.Core.Tests.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/test/FunctionalTests/Microsoft.OData.Core.Tests",
+            // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ,]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.NetCore.csproj"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This have no Issue.

### Description

This add the build assets to hit F5 in vscode too.
This comes from the PR #1348 and has been discussed with @mikepizzo .

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
