### PR TITLE
Fix SelectExpandNode for navigation properties on derived/complex types

### DIFF
--- a/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
+++ b/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
@@ -117,23 +117,23 @@ namespace Microsoft.OData
                 this.ParsePathSegment(segments, 0);
             }
 
-            DetermineSelectionType(this);
+            DetermineSelectionType();
         }
 
-        private static void DetermineSelectionType(SelectedPropertiesNode node)
+        private void DetermineSelectionType()
         {
-            if (node.children != null)
+            if (this.children != null)
             {
-                foreach (SelectedPropertiesNode childNode in node.children.Values)
+                foreach (SelectedPropertiesNode childNode in this.children.Values)
                 {
-                    DetermineSelectionType(childNode);
+                    childNode.DetermineSelectionType();
                 }
             }
 
-            if ((node.selectedProperties == null || node.selectedProperties.Count == 0)
-                && (node.children == null || node.children.Values.All(n => n.selectionType == SelectionType.EntireSubtree)))
+            if ((this.selectedProperties == null || this.selectedProperties.Count == 0)
+                && (this.children == null || this.children.Values.All(n => n.selectionType == SelectionType.EntireSubtree)))
             {
-                node.selectionType = SelectionType.EntireSubtree;
+                this.selectionType = SelectionType.EntireSubtree;
             }
         }
 
@@ -799,7 +799,6 @@ namespace Microsoft.OData
             {
                 return false;
             }
-
 
             return GetPossibleMatchesForSelectedOperation(operation, mustBeNamespaceQualified).Any(possibleMatch => this.selectedProperties.Contains(possibleMatch));
         }

--- a/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
+++ b/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
@@ -101,7 +101,7 @@ namespace Microsoft.OData
             {
                 string[] segments = null;
                 int idxLP = t.IndexOf('(');
-                if ( -1 == idxLP )
+                if (-1 == idxLP)
                 {
                     segments = t.Split(PathSeparator);
                 }
@@ -117,10 +117,23 @@ namespace Microsoft.OData
                 this.ParsePathSegment(segments, 0);
             }
 
-            if ( (this.selectedProperties == null || this.selectedProperties.Count == 0)
-                && this.children.Values.All( n => n.selectionType == SelectionType.EntireSubtree))
+            DetermineSelectionType(this);
+        }
+
+        private static void DetermineSelectionType(SelectedPropertiesNode node)
+        {
+            if (node.children != null)
             {
-                this.selectionType = SelectionType.EntireSubtree;
+                foreach (SelectedPropertiesNode childNode in node.children.Values)
+                {
+                    DetermineSelectionType(childNode);
+                }
+            }
+
+            if ((node.selectedProperties == null || node.selectedProperties.Count == 0)
+                && (node.children == null || node.children.Values.All(n => n.selectionType == SelectionType.EntireSubtree)))
+            {
+                node.selectionType = SelectionType.EntireSubtree;
             }
         }
 
@@ -364,7 +377,7 @@ namespace Microsoft.OData
             }
 
             // $select=Orders will include the entire subtree when there are no same expanded entity.
-            if (this.selectedProperties.Contains(navigationPropertyName) &&
+            if (this.selectedProperties != null && this.selectedProperties.Contains(navigationPropertyName) &&
                 (this.children == null || !this.children.Any(n => n.Key.Equals(navigationPropertyName) && n.Value.isExpandedNavigationProperty)))
             {
                 return new SelectedPropertiesNode(SelectionType.EntireSubtree);
@@ -411,7 +424,7 @@ namespace Microsoft.OData
             }
 
             if (this.selectionType == SelectionType.EntireSubtree || this.hasWildcard
-                || (this.selectedProperties.Count() == 0 && this.children.Values.All( n => n.isExpandedNavigationProperty)))
+                || ((this.selectedProperties == null || this.selectedProperties.Count() == 0) && this.children.Values.All( n => n.isExpandedNavigationProperty)))
             {
                 return structuredType.NavigationProperties();
             }
@@ -420,8 +433,7 @@ namespace Microsoft.OData
             // NOTE: the assumption is that the number of selected properties usually is a lot smaller
             //       than the number of all properties on the type and that FindProperty for each selected
             //       property is faster than iterating through all the properties on the type.
-            Debug.Assert(this.selectedProperties != null, "selectedProperties != null");
-            IEnumerable<string> navigationPropertyNames = this.selectedProperties;
+            IEnumerable<string> navigationPropertyNames = this.selectedProperties ?? CreateSelectedPropertiesHashSet();
             if (this.children != null)
             {
                 navigationPropertyNames = this.children.Keys.Concat(navigationPropertyNames);
@@ -465,13 +477,14 @@ namespace Microsoft.OData
                 return entityType.StructuralProperties().Where(sp => sp.Type.IsStream()).ToDictionary(sp => sp.Name, StringComparer.Ordinal);
             }
 
-            Debug.Assert(this.selectedProperties != null, "selectedProperties != null");
-
-            IDictionary<string, IEdmStructuralProperty> selectedStreamProperties = this.selectedProperties
-                .Select(entityType.FindProperty)
-                .OfType<IEdmStructuralProperty>()
-                .Where(p => p.Type.IsStream())
-                .ToDictionary(p => p.Name, StringComparer.Ordinal);
+            IDictionary<string, IEdmStructuralProperty> selectedStreamProperties = 
+                this.selectedProperties == null ?
+                    new Dictionary<string, IEdmStructuralProperty>() :
+                    this.selectedProperties
+                        .Select(entityType.FindProperty)
+                        .OfType<IEdmStructuralProperty>()
+                        .Where(p => p.Type.IsStream())
+                        .ToDictionary(p => p.Name, StringComparer.Ordinal);
 
             // gather up the selected stream from any child nodes that have type segments matching the current type and add them to the dictionary.
             foreach (SelectedPropertiesNode typeSegmentChild in this.GetMatchingTypeSegments(entityType))
@@ -585,37 +598,17 @@ namespace Microsoft.OData
 
         private bool IsValidExpandToken(string item)
         {
-            // Check #1: Expand token must contain '(' and end with ')', must be related to navigation property.
+            // Expand token must contain '(' and end with ')', must not contain a dot, and must be related to navigation property.
             int idxLP = item.IndexOf('(');
             if (idxLP == -1
                 || !item.EndsWith(")", StringComparison.Ordinal)
-                || (this.structuredType != null && !IsNavigationPropertyToken(item.Substring(0, idxLP))))
+                || !IsNavigationPropertyToken(item.Substring(0, idxLP)))
             {
                 // selected item is not properly parenthesized, or is an operation token.
                 return false;
             }
 
-            // Check #2: parentheses must be balanced.
-            int count = 0;
-            foreach (char c in item)
-            {
-                if (c == '(')
-                {
-                    ++count;
-                }
-                else if (c == ')')
-                {
-                    --count;
-                }
-
-                if (count < 0)
-                {
-                    // Malformed parentheses detected ==> not expand token.
-                    return false;
-                }
-            }
-
-            return count == 0;
+            return true;
         }
 
         /// <summary>
@@ -628,23 +621,29 @@ namespace Microsoft.OData
             const char nameSpaceSeparator = '.';
 
             /* Decision tree:
-             #1. if it matches a defined navigation property => treat it as a navigation property
-             #2. otherwise, if the name contains a dot => it's not a navigation property
+             #1. if the name contains a dot => it's not a navigation property
+             #2. otherwise, if it matches a defined navigation property => treat it as a navigation property
              #3. otherwise, if it matches an unqualified bound operation name => it's not a navigation property
              #4. otherwise, it's a navigation property
              */
 
             // For better readability, set the value in if-else branches corresponding to decision tree above.
             bool found;
-            if (this.structuredType.NavigationProperties().Any(_ => _.Name.Equals(token, StringComparison.Ordinal)))
+            if (token.IndexOf(nameSpaceSeparator) != -1)
             {
                 // #1
+                found = false;
+            }
+            else if (this.structuredType == null || this.structuredType.NavigationProperties().Any(_ => _.Name.Equals(token, StringComparison.Ordinal)))
+            {
+                // #2
+                // Note that action and function names in a contextUrl *SHOULD* always be qualified, 
+                // So if we can't validate against the structured type, should assume it's a nav prop
                 found = true;
             }
-            else if (token.IndexOf(nameSpaceSeparator) != -1 ||
-                     this.edmModel.FindBoundOperations(this.structuredType).Any(op => op.Name.Equals(token, StringComparison.Ordinal)))
+            else if (this.edmModel != null && this.edmModel.FindBoundOperations(this.structuredType).Any(op => op.Name.Equals(token, StringComparison.Ordinal)))
             {
-                // #2, #3
+                //#3
                 found = false;
             }
             else
@@ -694,18 +693,13 @@ namespace Microsoft.OData
             // NOTE: Each path is the name of a property or a series of property names
             //       separated by slash ('/'). The special star ('*') character is only supported at the end of a path.
             string currentSegment = segments[index].Trim();
-            if (this.selectedProperties == null)
-            {
-                this.selectedProperties = CreateSelectedPropertiesHashSet();
-            }
-
             bool isStar = string.CompareOrdinal(StarSegment, currentSegment) == 0;
             int idxLP = currentSegment.IndexOf('(');
 
             if (idxLP != -1 && IsValidExpandToken(currentSegment))
             {
                 string token = currentSegment.Substring(0, idxLP);
-                SelectedPropertiesNode childNode = this.EnsureChildAnnotation(token, /* isExpandedNavigationProperty */ true);
+                SelectedPropertiesNode childNode = this.EnsureChildNode(token, /* isExpandedNavigationProperty */ true);
                 childNode.edmModel = this.edmModel;
 
                 if (idxLP < currentSegment.Length - 2)
@@ -741,11 +735,16 @@ namespace Microsoft.OData
                         throw new ODataException(ODataErrorStrings.SelectedPropertiesNode_StarSegmentNotLastSegment);
                     }
 
-                    SelectedPropertiesNode childNode = this.EnsureChildAnnotation(currentSegment, false);
+                    SelectedPropertiesNode childNode = this.EnsureChildNode(currentSegment, false);
                     childNode.ParsePathSegment(segments, index + 1);
                 }
                 else
                 {
+                    if (this.selectedProperties == null)
+                    {
+                        this.selectedProperties = CreateSelectedPropertiesHashSet();
+                    }
+
                     this.selectedProperties.Add(currentSegment);
                 }
             }
@@ -754,13 +753,13 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Ensures that a child annotation for the specified segment name already exists; if not creates one.
+        /// Ensures that a child node for the specified segment name already exists; if not creates one.
         /// </summary>
-        /// <param name="segmentName">The segment name to get the child annotation for.</param>
+        /// <param name="segmentName">The segment name to get the child node for.</param>
         /// <param name="isExpandedNavigationProperty">Boolean flag indicating whether this is an expanded navigation property.</param>
 
-        /// <returns>The existing or newly created child annotation for the <paramref name="segmentName"/>.</returns>
-        private SelectedPropertiesNode EnsureChildAnnotation(string segmentName, bool isExpandedNavigationProperty)
+        /// <returns>The existing or newly created child node for the <paramref name="segmentName"/>.</returns>
+        private SelectedPropertiesNode EnsureChildNode(string segmentName, bool isExpandedNavigationProperty)
         {
             Debug.Assert(segmentName != null, "segmentName != null");
 
@@ -791,15 +790,16 @@ namespace Microsoft.OData
         {
             Debug.Assert(operation != null, "operation != null");
 
-            if (this.selectionType == SelectionType.Empty)
-            {
-                return false;
-            }
-
             if (this.selectionType == SelectionType.EntireSubtree)
             {
                 return true;
             }
+
+            if (this.selectionType == SelectionType.Empty || this.selectedProperties == null )
+            {
+                return false;
+            }
+
 
             return GetPossibleMatchesForSelectedOperation(operation, mustBeNamespaceQualified).Any(possibleMatch => this.selectedProperties.Contains(possibleMatch));
         }
@@ -829,22 +829,22 @@ namespace Microsoft.OData
         }
 
         /// <summary>Create SelectedPropertiesNode using selected name list and expand node list.</summary>
-        /// <param name="selectList">A list of selected item names.</param>
-        /// <param name="expandList">A list of sub expanded nodes.</param>
+        /// <param name="selectList">An enumerable of selected item names.</param>
+        /// <param name="expandList">An enumerable of sub expanded nodes.</param>
         /// <returns>The generated SelectedPropertiesNode.</returns>
-        private static SelectedPropertiesNode CombineSelectAndExpandResult(IList<string> selectList, IList<SelectedPropertiesNode> expandList)
+        private static SelectedPropertiesNode CombineSelectAndExpandResult(IEnumerable<string> selectList, IEnumerable<SelectedPropertiesNode> expandList)
         {
             List<string> rawSelect = selectList.ToList();
             rawSelect.RemoveAll(expandList.Select(m => m.nodeName).Contains);
 
-            if (selectList.Count == 0 && expandList.All( n => n.IsEntireSubtree()))
+            if (rawSelect.Count == 0 && expandList.All( n => n.IsEntireSubtree()))
             {
                 return new SelectedPropertiesNode(SelectionType.EntireSubtree);
             }
 
             SelectedPropertiesNode node = new SelectedPropertiesNode(SelectionType.PartialSubtree)
             {
-                selectedProperties = CreateSelectedPropertiesHashSet(),
+                selectedProperties = rawSelect.Count > 0 ? CreateSelectedPropertiesHashSet() : null,
                 children = new Dictionary<string, SelectedPropertiesNode>(StringComparer.Ordinal)
             };
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
@@ -67,18 +67,16 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void DeepExpand()
         {
             const string expandClauseText = "Navigation1($expand=Navigation2($expand=Navigation1))";
-            const string expectedExpandClauseText = "Navigation1($expand=Navigation2($expand=Navigation1))";
             const string expectedSelectClause = "";
-            this.ParseAndExtract(expandClauseText, null, expectedExpandClauseText, expectedSelectClause);
+            this.ParseAndExtract(expandClauseText, null, expandClauseText, expectedSelectClause);
         }
 
         [Fact]
         public void MultiLevelExpand()
         {
             const string expandClauseText = "Navigation1,Navigation2($expand=Navigation1)";
-            const string expectedExpandClause = "Navigation1,Navigation2($expand=Navigation1)";
             const string expectedSelectClause = "";
-            this.ParseAndExtract(expandClauseText, expectedExpandClauseFromOM: expectedExpandClause, expectedSelectClauseFromOM: expectedSelectClause);
+            this.ParseAndExtract(expandClauseText, expectedExpandClauseFromOM: expandClauseText, expectedSelectClauseFromOM: expectedSelectClause);
         }
 
         [Fact]
@@ -112,8 +110,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             const string expandClauseText = "Navigation1($expand=FQ.NS.Derived/Navigation2)";
             const string expectedSelectClause = "";
-            const string expectedExpandClause = "Navigation1($expand=FQ.NS.Derived/Navigation2)";
-            this.ParseAndExtract(expandClauseText, null, expectedExpandClause, expectedSelectClause);
+            this.ParseAndExtract(expandClauseText, null, expandClauseText, expectedSelectClause);
         }
 
         [Fact]
@@ -161,17 +158,15 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void SelectNavigationPropertiesThatAreAlsoExpanded()
         {
             const string expandClauseText = "Navigation1($expand=Navigation1($select=Navigation2))";
-            const string expectedExpandClauseText = "Navigation1($expand=Navigation1($select=Navigation2))";
             const string expectedSelectClauseText = "";
-            this.ParseAndExtract(expandClauseText: expandClauseText, expectedExpandClauseFromOM: expectedExpandClauseText, expectedSelectClauseFromOM: expectedSelectClauseText);
+            this.ParseAndExtract(expandClauseText: expandClauseText, expectedExpandClauseFromOM: expandClauseText, expectedSelectClauseFromOM: expectedSelectClauseText);
         }
 
         [Fact]
         public void SelectPrimitiveAndNavigationPropertyThatIsAlsoExpanded()
         {
             const string selectClauseText = "Id,Navigation1";
-            const string expectedSelectText = "Id,Navigation1";
-            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: "Navigation1", expectedSelectClauseFromOM: expectedSelectText);
+            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: "Navigation1", expectedSelectClauseFromOM: selectClauseText);
         }
 
         [Fact]
@@ -194,24 +189,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             const string expandClauseText = "Navigation1($select=*)";
             const string expectedSelectText = "";
-            const string expectedExpandText = "Navigation1($select=*)";
-            this.ParseAndExtract(expandClauseText: expandClauseText, expectedExpandClauseFromOM: expectedExpandText, expectedSelectClauseFromOM: expectedSelectText);
+            this.ParseAndExtract(expandClauseText: expandClauseText, expectedExpandClauseFromOM: expandClauseText, expectedSelectClauseFromOM: expectedSelectText);
         }
 
         [Fact]
         public void SelectAndExpandWithTypeSegments()
         {
-            const string selectClauseText = "FQ.NS.Derived/Navigation1";
-            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: selectClauseText);
+            const string navClauseText = "FQ.NS.Derived/Navigation1";
+            this.ParseAndExtract(selectClauseText: navClauseText, expandClauseText: navClauseText, expectedSelectClauseFromOM: navClauseText,  expectedExpandClauseFromOM: navClauseText);
+            this.ParseAndExtract(selectClauseText: navClauseText, expandClauseText: "", expectedSelectClauseFromOM: navClauseText);
+            this.ParseAndExtract(selectClauseText: "", expandClauseText: navClauseText, expectedExpandClauseFromOM: navClauseText);
         }
 
         [Fact]
         public void SelectAndExpandWithTypeSegments2()
         {
             const string expandClauseText = "FQ.NS.Derived/Navigation1($select=FQ.NS.Derived/Derived,FQ.NS.Derived/Navigation2)";
-            const string expectedExpandText = "FQ.NS.Derived/Navigation1($select=FQ.NS.Derived/Derived,FQ.NS.Derived/Navigation2)";
             const string expectedSelectText = "";
-            this.ParseAndExtract(expandClauseText, expectedExpandClauseFromOM: expectedExpandText, expectedSelectClauseFromOM: expectedSelectText);
+            this.ParseAndExtract(expandClauseText, expectedExpandClauseFromOM: expandClauseText, expectedSelectClauseFromOM: expectedSelectText);
         }
 
         [Fact]
@@ -242,9 +237,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void SelectPropertiesDefinedOnDerivedTypesWithoutRepeatingTypeSegments()
         {
             const string expandClauseText = "FQ.NS.Derived/DerivedNavigation($expand=DerivedNavigation($select=Derived))";
-            const string expectedExpandClause = "FQ.NS.Derived/DerivedNavigation($expand=DerivedNavigation($select=Derived))";
             const string expectedSelect = "";
-            this.ParseAndExtract(expandClauseText: expandClauseText, expectedExpandClauseFromOM: expectedExpandClause, expectedSelectClauseFromOM: expectedSelect);
+            this.ParseAndExtract(expandClauseText: expandClauseText, expectedExpandClauseFromOM: expandClauseText, expectedSelectClauseFromOM: expectedSelect);
         }
 
         [Fact]
@@ -261,8 +255,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             const string selectClauseText = "FQ.NS.Derived/Navigation2";
             const string expandClauseText = "FQ.NS.Derived/Navigation1/$ref";
             const string expectedSelectClause = "FQ.NS.Derived/Navigation2,FQ.NS.Derived/Navigation1";
-            const string expectedExpandClause = "FQ.NS.Derived/Navigation1/$ref";
-            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: expectedSelectClause, expectedExpandClauseFromOM: expectedExpandClause);
+            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: expectedSelectClause, expectedExpandClauseFromOM: expandClauseText);
         }
 
         [Fact]
@@ -270,9 +263,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             const string selectClauseText = "FQ.NS.Derived/Navigation1,FQ.NS.Derived/Navigation2";
             const string expandClauseText = "FQ.NS.Derived/Navigation1/$ref";
-            const string expectedSelectClause = "FQ.NS.Derived/Navigation1,FQ.NS.Derived/Navigation2";
-            const string expectedExpandClause = "FQ.NS.Derived/Navigation1/$ref";
-            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: expectedSelectClause, expectedExpandClauseFromOM: expectedExpandClause);
+            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: selectClauseText, expectedExpandClauseFromOM: expandClauseText);
         }
 
         private void ParseAndExtract(string expandClauseText = null, string selectClauseText = null, string expectedExpandClauseFromOM = null, string expectedSelectClauseFromOM = null)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -852,6 +852,38 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void ExpandOnDerivedTypeWorks()
+        {
+            var results = RunParseSelectExpand("FirstName, MyAddress", "Fully.Qualified.Namespace.Employee/OfficeDog", HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            results.SelectedItems.OfType<PathSelectItem>().ElementAt(0).ShouldBePathSelectionItem(new ODataPath(new PropertySegment(HardCodedTestModel.GetPersonFirstNameProp())));
+            results.SelectedItems.OfType<PathSelectItem>().ElementAt(1).ShouldBePathSelectionItem(new ODataPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp())));
+            results.SelectedItems.OfType<ExpandedNavigationSelectItem>().Should().HaveCount(1);
+            var expand = results.SelectedItems.OfType<ExpandedNavigationSelectItem>().Single();
+            expand.SelectAndExpand.AllSelected.Should().BeTrue();
+
+            AssertSelectString("FirstName,MyAddress", results);
+            AssertExpandString("Fully.Qualified.Namespace.Employee/OfficeDog", results);
+        }
+
+        [Fact]
+        public void ExpandOnDerivedWithSelectTypeWorks()
+        {
+            var results = RunParseSelectExpand("FirstName, MyAddress", "Fully.Qualified.Namespace.Employee/OfficeDog($select=Color)", HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            results.SelectedItems.OfType<PathSelectItem>().ElementAt(0).ShouldBePathSelectionItem(new ODataPath(new PropertySegment(HardCodedTestModel.GetPersonFirstNameProp())));
+            results.SelectedItems.OfType<PathSelectItem>().ElementAt(1).ShouldBePathSelectionItem(new ODataPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp())));
+            results.SelectedItems.OfType<ExpandedNavigationSelectItem>().Should().HaveCount(1);
+            var expand = results.SelectedItems.OfType<ExpandedNavigationSelectItem>().Single();
+            expand.SelectAndExpand.AllSelected.Should().BeFalse();
+            expand.SelectAndExpand.SelectedItems.OfType<PathSelectItem>().Single().ShouldBePathSelectionItem(new ODataPath(new PropertySegment(HardCodedTestModel.GetDogColorProp())));
+            results.AllSelected.Should().BeFalse();
+
+            AssertSelectString("FirstName,MyAddress", results);
+            AssertExpandString("Fully.Qualified.Namespace.Employee/OfficeDog($select=Color)", results);
+        }
+
+        [Fact]
         public void MultipleDeepLevelExpansionsAndSelectionsShouldWork()
         {
             const string select = "MyDog, MyFavoritePainting";

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
@@ -66,9 +66,11 @@ namespace Microsoft.OData.Tests.Evaluation
             EdmComplexType airportType = new EdmComplexType("TestModel", "Airport");
             airportType.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(/*isNullable*/false));
             airportType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "City", Target = cityType, TargetMultiplicity = EdmMultiplicity.ZeroOrOne });
+            this.edmModel.AddElement(airportType);
 
             EdmComplexType regionalAirportType = new EdmComplexType("TestModel", "RegionalAirport", airportType);
             airportType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "Region", Target = districtType, TargetMultiplicity = EdmMultiplicity.ZeroOrOne });
+            this.edmModel.AddElement(regionalAirportType);
 
             this.metropolisType = new EdmEntityType("TestModel", "Metropolis", this.cityType);
             this.metropolisType.AddStructuralProperty("MetropolisStream", EdmCoreModel.Instance.GetStream(/*isNullable*/false));
@@ -474,7 +476,7 @@ namespace Microsoft.OData.Tests.Evaluation
         }
 
         [Fact]
-        public void ExpandTokenForNavigationPropertyDerivedOnComplexShouldHaveEntireSubtree()
+        public void ExpandTokenForNavigationPropertyOnDerivedComplexShouldHaveEntireSubtree()
         {
             SelectedPropertiesNode.Create("NearestAirport/TestModel.RegionalAirport/Region()", this.metropolisType, this.edmModel).Should().HaveEntireSubtree();
         }
@@ -486,7 +488,7 @@ namespace Microsoft.OData.Tests.Evaluation
         }
 
         [Fact]
-        public void ExpandTokenForNavigationPropertyDerivedOnComplexWithSelectShouldHavePartialSubtree()
+        public void ExpandTokenForNavigationPropertyOnDerivedComplexWithSelectShouldHavePartialSubtree()
         {
             SelectedPropertiesNode p = SelectedPropertiesNode.Create("NearestAirport/TestModel.RegionalAirport(Name),NearestAirport/TestModel.RegionalAirport/Region()", this.metropolisType, this.edmModel);
             p.IsEntireSubtree().Should().BeFalse();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
@@ -63,8 +63,16 @@ namespace Microsoft.OData.Tests.Evaluation
             this.defaultContainer.AddEntitySet("Cities", cityType);
             this.defaultContainer.AddEntitySet("Districts", districtType);
 
+            EdmComplexType airportType = new EdmComplexType("TestModel", "Airport");
+            airportType.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(/*isNullable*/false));
+            airportType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "City", Target = cityType, TargetMultiplicity = EdmMultiplicity.ZeroOrOne });
+
+            EdmComplexType regionalAirportType = new EdmComplexType("TestModel", "RegionalAirport", airportType);
+            airportType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "Region", Target = districtType, TargetMultiplicity = EdmMultiplicity.ZeroOrOne });
+
             this.metropolisType = new EdmEntityType("TestModel", "Metropolis", this.cityType);
             this.metropolisType.AddStructuralProperty("MetropolisStream", EdmCoreModel.Instance.GetStream(/*isNullable*/false));
+            this.metropolisType.AddStructuralProperty("NearestAirport", new EdmComplexTypeReference(airportType,false));
             this.edmModel.AddElement(metropolisType);
 
             metropolisType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "MetropolisNavigation", Target = districtType, TargetMultiplicity = EdmMultiplicity.ZeroOrOne });
@@ -399,6 +407,18 @@ namespace Microsoft.OData.Tests.Evaluation
         }
 
         [Fact]
+        public void SpecificUnqualifedActionWithParametersShouldNotBeSelected()
+        {
+            SelectedPropertiesNode.Create("Action(Edm.Int32)").Should().NotHaveAction(this.cityType, this.action);
+        }
+
+        [Fact]
+        public void SpecificQualifiedActionWithParametersShouldBeSelected()
+        {
+            SelectedPropertiesNode.Create("TestModel.Action(Edm.Int32)").Should().HaveAction(this.cityType, this.action);
+        }
+
+        [Fact]
         public void NamespaceQualifiedActionNameShouldBeSelected()
         {
             SelectedPropertiesNode.Create("TestModel.Action").Should().HaveAction(this.cityType, this.action);
@@ -442,7 +462,51 @@ namespace Microsoft.OData.Tests.Evaluation
         }
 
         [Fact]
-        public void InvalidExpandTokenShouldHavePartialSubtree()
+        public void ExpandTokenForNavigationPropertyShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("MetropolisNavigation()", this.metropolisType, this.edmModel).Should().HaveEntireSubtree();
+        }
+
+        [Fact]
+        public void ExpandTokenForNavigationPropertyOnDerivedTypeShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("TestModel.Metropolis/MetropolisNavigation()", this.cityType, this.edmModel).Should().HaveEntireSubtree();
+        }
+
+        [Fact]
+        public void ExpandTokenForNavigationPropertyDerivedOnComplexShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("NearestAirport/TestModel.RegionalAirport/Region()", this.metropolisType, this.edmModel).Should().HaveEntireSubtree();
+        }
+
+        [Fact]
+        public void ExpandTokenForNavigationPropertyOnComplexShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("NearestAirport/City()", this.metropolisType, this.edmModel).Should().HaveEntireSubtree();
+        }
+
+        [Fact]
+        public void ExpandTokenForNavigationPropertyDerivedOnComplexWithSelectShouldHavePartialSubtree()
+        {
+            SelectedPropertiesNode p = SelectedPropertiesNode.Create("NearestAirport/TestModel.RegionalAirport(Name),NearestAirport/TestModel.RegionalAirport/Region()", this.metropolisType, this.edmModel);
+            p.IsEntireSubtree().Should().BeFalse();
+        }
+
+        [Fact]
+        public void ExpandTokenForNavigationPropertyOnComplexOnDerivedTypeShouldHaveEntireSubtree()
+        {
+            SelectedPropertiesNode.Create("TestModel.Metropolis/NearestAirport/City()", this.cityType, this.edmModel).Should().HaveEntireSubtree();
+        }
+
+        [Fact]
+        public void ExpandTokenForNavigationPropertyOnDerivedTypeShouldNotBeAddedToProperties()
+        {
+            var p = SelectedPropertiesNode.Create("Name,TestModel.Metropolis/MetropolisNavigation()", this.cityType, this.edmModel);
+            p.IsEntireSubtree().Should().BeFalse();
+        }
+
+        [Fact]
+        public void InvalidExpandTokenShouldHaveEntireSubtree()
         {
             SelectedPropertiesNode.Create("FabrikamNavProp()", this.cityType, this.edmModel).Should().HaveEntireSubtree();
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

PR #1286 fixed a number of issues related to how non-selected expanded navigation properties were represented in the ContextUrl. However, in the new code that attempts to determine if the entire subtree is selected, it looks only at direct children to see if they are navigation properties and not deeper.  

For example, prior to this fix the following URL would return a SelectExpandNode with SelectionType=PartialSubtree.

             Employees?$expand=ns.Manager/DirectReports

After the PR, this is correctly returned as EntireSubtree

### Description

The primary purpose of this PR is to set whether the SelectNode is entiresubtree based on a deep traverse of child paths, rather than only looking at direct children.

Other changes, in addition to new tests, include some test clean-up as well as code optimizations around deferring creation of hashsets until required.

### Checklist (Uncheck if it is not completed)

- [x ] *Test cases added*
- [x ] *Build and test with one-click build and test script passed*

