### PR TITLE
Allow null values in constant collections

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/CollectionConstantNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/CollectionConstantNode.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OData.UriParser
 
             foreach (object item in objectCollection)
             {
-                this.collection.Add(new ConstantNode(item, item.ToString(), this.itemType));
+                this.collection.Add(new ConstantNode(item, item != null ? item.ToString() : "null", this.itemType));
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/CollectionConstantNodeTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/CollectionConstantNodeTests.cs
@@ -59,6 +59,26 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         }
 
         [Fact]
+        public void NullableCollectionTypeSetsConstantNodeCorrectly()
+        {
+            const string text = "('abc','def', null)";
+            var expectedType = new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true)));
+            object collection = ODataUriConversionUtils.ConvertFromCollectionValue("['abc','def', null]", HardCodedTestModel.TestModel, expectedType);
+            LiteralToken literalToken = new LiteralToken(collection, text, expectedType);
+
+            CollectionConstantNode collectionConstantNode = new CollectionConstantNode(
+                (literalToken.Value as ODataCollectionValue)?.Items, text, expectedType);
+
+            var expectedList = new ConstantNode[] {
+                new ConstantNode("abc", "abc", EdmCoreModel.Instance.GetString(true)),
+                new ConstantNode("def", "def", EdmCoreModel.Instance.GetString(true)),
+                new ConstantNode(null, "null", EdmCoreModel.Instance.GetString(true)),
+            };
+
+            collectionConstantNode.Collection.ShouldBeEquivalentTo(expectedList);
+        }
+
+        [Fact]
         public void TextIsSetCorrectly()
         {
             const string text = "(1,2,3)";


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1373 .*

### Description

CollectionConstantNode did not account for null values in the collection even if the item type is nullable. 
 
### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
I would like to test the nightly build against a sample WebAPI service to ensure that the filter works correctly all the way through for constant collections with null values in it. 
