### PR TITLE
Enable reading validation for derived type constraint annotation

### DIFF
--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -1551,6 +1551,9 @@
     <Compile Include="..\Buffers\BufferUtils.cs">
       <Link>Microsoft\OData\Core\Buffers\BufferUtils.cs</Link>
     </Compile>
+    <Compile Include="..\DerivedTypeValidator.cs">
+      <Link>Microsoft\OData\Core\DerivedTypeValidator.cs</Link>
+    </Compile>
     <Compile Include="..\DuplicatePropertyNameChecker.cs">
       <Link>Microsoft\OData\Core\DuplicatePropertyNameChecker.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
+++ b/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
@@ -89,6 +89,9 @@
     <Compile Include="..\ContainerBuilderExtensions.cs">
       <Link>ContainerBuilderExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\DerivedTypeValidator.cs">
+      <Link>DerivedTypeValidator.cs</Link>
+    </Compile>
     <Compile Include="..\DuplicatePropertyNameChecker.cs">
       <Link>DuplicatePropertyNameChecker.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/DerivedTypeValidator.cs
+++ b/src/Microsoft.OData.Core/DerivedTypeValidator.cs
@@ -1,0 +1,76 @@
+//---------------------------------------------------------------------
+// <copyright file="DerivedTypeValidator.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.OData.Edm;
+
+    /// <summary>
+    ///  Helper class to verify the resource type meets the drived type contraints.
+    /// </summary>
+    internal sealed class DerivedTypeValidator
+    {
+        private IEnumerable<string> derivedTypeConstraints;
+        private IEdmType expectedType;
+        private string resourceKind;
+        private string resourceName;
+
+        /// <summary>
+        /// Constructor.
+        /// </summary>
+        /// <param name="expectedType">The exptected type.</param>
+        /// <param name="derivedTypeConstraints">The derived type contraints.</param>
+        /// <param name="resourceKind">The resource type, be used at error message.</param>
+        /// <param name="resourceName">The resource name, be used at error message.</param>
+        public DerivedTypeValidator(IEdmType expectedType, IEnumerable<string> derivedTypeConstraints, string resourceKind, string resourceName)
+        {
+            this.derivedTypeConstraints = derivedTypeConstraints;
+            this.expectedType = expectedType;
+            this.resourceKind = resourceKind;
+            this.resourceName = resourceName;
+        }
+
+        /// <summary>
+        /// Validates the type of a resource.
+        /// </summary>
+        /// <param name="resourceType">The type of the resource.</param>
+        internal void ValidateResourceType(IEdmType resourceType)
+        {
+            if (resourceType == null)
+            {
+                return;
+            }
+
+            ValidateResourceType(resourceType.FullTypeName());
+        }
+
+        /// <summary>
+        /// Validates the full type name of a resource.
+        /// </summary>
+        /// <param name="resourceTypeName">The full type name of the resource.</param>
+        internal void ValidateResourceType(string resourceTypeName)
+        {
+            if (resourceTypeName == null)
+            {
+                return;
+            }
+
+            if (this.expectedType != null && this.expectedType.FullTypeName() == resourceTypeName)
+            {
+                return;
+            }
+
+            if (derivedTypeConstraints == null || derivedTypeConstraints.Any(c => c == resourceTypeName))
+            {
+                return;
+            }
+
+            throw new ODataException(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint(resourceTypeName, resourceKind, resourceName));
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/DerivedTypeValidator.cs
+++ b/src/Microsoft.OData.Core/DerivedTypeValidator.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="expectedType">The exptected type.</param>
+        /// <param name="expectedType">The expected type.</param>
         /// <param name="derivedTypeConstraints">The derived type contraints.</param>
         /// <param name="resourceKind">The resource type, be used at error message.</param>
         /// <param name="resourceName">The resource name, be used at error message.</param>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -871,6 +871,15 @@ namespace Microsoft.OData.JsonLight
                 propertyTypeName = (string)propertyAnnotation.Value;
             }
 
+            if (propertyTypeName != null)
+            {
+                var validator = propertyAndAnnotationCollector.GetDerivedTypeValidator(propertyName);
+                if (validator != null)
+                {
+                    validator.ValidateResourceType(propertyTypeName);
+                }
+            }
+
             return propertyTypeName;
         }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -1900,7 +1900,7 @@ namespace Microsoft.OData.JsonLight
             this.ApplyResourceTypeNameFromPayload(currentResource.TypeName);
 
             // Validate type with derived type validator if available
-            if (this.CurrentDerivedTypeValidator != null && !(this.ReadingDelta && this.CurrentResourceDepth == 0))
+            if (this.CurrentDerivedTypeValidator != null)
             {
                 this.CurrentDerivedTypeValidator.ValidateResourceType(this.CurrentResourceType);
             }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -171,6 +171,16 @@ namespace Microsoft.OData.JsonLight
 
             ResolveScopeInfoFromContextUrl();
 
+            Scope currentScope = this.CurrentScope;
+            if (this.jsonLightInputContext.Model.IsUserModel())
+            {
+                var derivedTypeConstraints = this.jsonLightInputContext.Model.GetDerivedTypeConstraints(currentScope.NavigationSource);
+                if (derivedTypeConstraints != null)
+                {
+                    currentScope.DerivedTypeValidator = new DerivedTypeValidator(currentScope.ResourceType, derivedTypeConstraints, "navigation source", currentScope.NavigationSource.Name);
+                }
+            }
+
             return this.ReadAtStartImplementationSynchronously(propertyAndAnnotationCollector);
         }
 
@@ -1889,6 +1899,12 @@ namespace Microsoft.OData.JsonLight
             // Resolve the type name
             this.ApplyResourceTypeNameFromPayload(currentResource.TypeName);
 
+            // Validate type with derived type validator if available
+            if (this.CurrentDerivedTypeValidator != null && !(this.ReadingDelta && this.CurrentResourceDepth == 0))
+            {
+                this.CurrentDerivedTypeValidator.ValidateResourceType(this.CurrentResourceType);
+            }
+
             // Validate type with resource set validator if available and not reading top-level delta resource set
             if (this.CurrentResourceSetValidator != null && !(this.ReadingDelta && this.CurrentResourceDepth == 0))
             {
@@ -2147,8 +2163,16 @@ namespace Microsoft.OData.JsonLight
 
             odataUri.Path = odataPath;
 
-            this.EnterScope(new JsonLightNestedResourceInfoScope(readerNestedResourceInfo, navigationSource,
-                targetResourceType, odataUri));
+            JsonLightNestedResourceInfoScope newScope = new JsonLightNestedResourceInfoScope(readerNestedResourceInfo, navigationSource,
+                targetResourceType, odataUri);
+
+            var derivedTypeConstraints = this.jsonLightInputContext.Model.GetDerivedTypeConstraints(nestedProperty);
+            if (derivedTypeConstraints != null)
+            {
+                newScope.DerivedTypeValidator = new DerivedTypeValidator(nestedProperty.Type.ToStructuredType(), derivedTypeConstraints, "nested resource", nestedProperty.Name);
+            }
+
+            this.EnterScope(newScope);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
@@ -1237,6 +1237,12 @@ namespace Microsoft.OData.JsonLight
                         throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_StreamPropertyWithValue(propertyName));
                     }
 
+                    var derivedTypeConstrants = this.JsonLightInputContext.Model.GetDerivedTypeConstraints(edmProperty);
+                    if (derivedTypeConstrants != null)
+                    {
+                        resourceState.PropertyAndAnnotationCollector.SetDerivedTypeValidator(propertyName, new DerivedTypeValidator(propertyTypeReference.Definition, derivedTypeConstrants, "property", propertyName));
+                    }
+
                     // NOTE: we currently do not check whether the property should be skipped
                     //       here because this can only happen for navigation properties and open properties.
                     this.ReadEntryDataProperty(resourceState, edmProperty, ValidateDataPropertyTypeNameAnnotation(resourceState.PropertyAndAnnotationCollector, propertyName));

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -306,6 +306,7 @@ namespace Microsoft.OData {
         internal const string ReaderValidationUtils_NonMatchingPropertyNames = "ReaderValidationUtils_NonMatchingPropertyNames";
         internal const string ReaderValidationUtils_TypeInContextUriDoesNotMatchExpectedType = "ReaderValidationUtils_TypeInContextUriDoesNotMatchExpectedType";
         internal const string ReaderValidationUtils_ContextUriDoesNotReferTypeAssignableToExpectedType = "ReaderValidationUtils_ContextUriDoesNotReferTypeAssignableToExpectedType";
+        internal const string ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint = "ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint";
         internal const string ODataMessageReader_ReaderAlreadyUsed = "ODataMessageReader_ReaderAlreadyUsed";
         internal const string ODataMessageReader_ErrorPayloadInRequest = "ODataMessageReader_ErrorPayloadInRequest";
         internal const string ODataMessageReader_ServiceDocumentInRequest = "ODataMessageReader_ServiceDocumentInRequest";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -79,6 +79,7 @@
     <Compile Include="PropertyCache.cs" />
     <Compile Include="PropertyMetadataTypeInfo.cs" />
     <Compile Include="PropertySerializationInfo.cs" />
+    <Compile Include="DerivedTypeValidator.cs" />
     <Compile Include="DuplicatePropertyNameChecker.cs" />
     <Compile Include="PropertyValueTypeInfo.cs" />
     <Compile Include="BindingPathHelper.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -283,6 +283,7 @@ ReaderValidationUtils_ContextUriValidationNonMatchingDeclaringTypes=The context 
 ReaderValidationUtils_NonMatchingPropertyNames=The property or operation import name '{0}' was read from the payload; however, the name of the expected property or operation import is '{1}'.
 ReaderValidationUtils_TypeInContextUriDoesNotMatchExpectedType=The context URI '{0}' references the type '{1}'; however the expected type is '{2}'.
 ReaderValidationUtils_ContextUriDoesNotReferTypeAssignableToExpectedType=The context URI '{0}' refers to the item type '{1}' which is not assignable to the expected item type '{2}'.
+ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint=The value type '{0}' is not allowed due to an Org.OData.Validation.V1.DerivedTypeConstraint annotation on {1} '{2}'.
 
 ODataMessageReader_ReaderAlreadyUsed=The ODataMessageReader has already been used to read a message payload. An ODataMessageReader can only be used once to read a payload for a given message.
 ODataMessageReader_ErrorPayloadInRequest=A top-level error cannot be read from request payloads. Top-level errors are only supported in responses.

--- a/src/Microsoft.OData.Core/ODataReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataReaderCore.cs
@@ -345,7 +345,7 @@ namespace Microsoft.OData
         {
             get
             {
-                Debug.Assert(this.State == ODataReaderState.ResourceStart, "CurrentDerivedTypeValidator should only be called while reading a resource.");
+                Debug.Assert(this.State == ODataReaderState.ResourceStart || this.State == ODataReaderState.DeletedResourceStart, "CurrentDerivedTypeValidator should only be called while reading a resource.");
                 return this.ParentScope == null ? null : this.ParentScope.DerivedTypeValidator;
             }
         }
@@ -525,7 +525,7 @@ namespace Microsoft.OData
                 scope.ResourceTypeValidator = new ResourceSetWithoutExpectedTypeValidator(scope.ResourceType);
             }
 
-            if (scope.State == ODataReaderState.ResourceSetStart)
+            if (scope.State == ODataReaderState.ResourceSetStart || scope.State == ODataReaderState.DeltaResourceSetStart)
             {
                 scope.DerivedTypeValidator = this.CurrentScope.DerivedTypeValidator;
             }

--- a/src/Microsoft.OData.Core/ODataReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataReaderCore.cs
@@ -339,6 +339,18 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Validator to validate the derived type constraint.
+        /// </summary>
+        protected DerivedTypeValidator CurrentDerivedTypeValidator
+        {
+            get
+            {
+                Debug.Assert(this.State == ODataReaderState.ResourceStart, "CurrentDerivedTypeValidator should only be called while reading a resource.");
+                return this.ParentScope == null ? null : this.ParentScope.DerivedTypeValidator;
+            }
+        }
+
+        /// <summary>
         /// Reads the next <see cref="ODataItem"/> from the message payload.
         /// </summary>
         /// <returns>true if more items were read; otherwise false.</returns>
@@ -511,6 +523,11 @@ namespace Microsoft.OData
                 && this.inputContext.Model.IsUserModel())
             {
                 scope.ResourceTypeValidator = new ResourceSetWithoutExpectedTypeValidator(scope.ResourceType);
+            }
+
+            if (scope.State == ODataReaderState.ResourceSetStart)
+            {
+                scope.DerivedTypeValidator = this.CurrentScope.DerivedTypeValidator;
             }
 
             // TODO: implement some basic validation that the transitions are ok
@@ -939,6 +956,11 @@ namespace Microsoft.OData
                     this.resourceTypeValidator = value;
                 }
             }
+
+            /// <summary>
+            /// Gets or sets the derived type constraint validator.
+            /// </summary>
+            internal DerivedTypeValidator DerivedTypeValidator { get; set; }
         }
     }
 }

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -1881,6 +1881,13 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The value type '{0}' is not allowed due to an Org.OData.Validation.V1.DerivedTypeConstraint annotation on {1} '{2}'."
+        /// </summary>
+        internal static string ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint(object p0, object p1, object p2) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint, p0, p1, p2);
+        }
+
+        /// <summary>
         /// A string like "The ODataMessageReader has already been used to read a message payload. An ODataMessageReader can only be used once to read a payload for a given message."
         /// </summary>
         internal static string ODataMessageReader_ReaderAlreadyUsed {

--- a/src/Microsoft.OData.Core/PropertyAndAnnotationCollector.cs
+++ b/src/Microsoft.OData.Core/PropertyAndAnnotationCollector.cs
@@ -379,6 +379,44 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Set the derived type validator for a property.
+        /// </summary>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <param name="validator">Derived type validator.</param>
+        internal void SetDerivedTypeValidator(string propertyName, DerivedTypeValidator validator)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(propertyName));
+
+            if (validator == null)
+            {
+                return;
+            }
+
+            PropertyData data;
+            if (!propertyData.TryGetValue(propertyName, out data))
+            {
+                propertyData[propertyName] = data = new PropertyData(PropertyState.AnnotationSeen);
+            }
+
+            data.DerivedTypeValidator = validator;
+        }
+
+        /// <summary>
+        /// Gets the derived type validator for a property.
+        /// </summary>
+        /// <param name="propertyName">Name of the property.</param>
+        /// <returns>Null or the derived type validator.</returns>
+        internal DerivedTypeValidator GetDerivedTypeValidator(string propertyName)
+        {
+            Debug.Assert(propertyName != null);
+
+            PropertyData data;
+            return propertyData.TryGetValue(propertyName, out data)
+                   ? data.DerivedTypeValidator
+                   : null;
+        }
+
+        /// <summary>
         /// Returns OData annotations for a property.
         /// </summary>
         /// <param name="propertyName">Name of the property.</param>
@@ -528,6 +566,11 @@ namespace Microsoft.OData
             /// Denotes whether the property has been marked as processed.
             /// </summary>
             internal bool Processed { get; set; }
+
+            /// <summary>
+            /// The derived type validator for property.
+            /// </summary>
+            internal DerivedTypeValidator DerivedTypeValidator { get; set; }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -792,8 +792,10 @@ namespace Microsoft.OData.Edm
         /// <returns>Null or a collection string of qualifed type name.</returns>
         public static IEnumerable<string> GetDerivedTypeConstraints(this IEdmModel model, IEdmVocabularyAnnotatable target)
         {
-            EdmUtil.CheckArgumentNull(model, "model");
-            EdmUtil.CheckArgumentNull(target, "target");
+            if (model == null || target == null)
+            {
+                return null;
+            }
 
             IEdmVocabularyAnnotation annotation = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(target, ValidationVocabularyModel.DerivedTypeConstraintTerm).FirstOrDefault();
             if (annotation != null)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/Microsoft.OData.Core.Tests.csproj
@@ -204,6 +204,7 @@
     <Compile Include="..\ODataPrimitiveValueTests.cs" />
     <Compile Include="..\ODataPropertySerializationInfoAnnotationTests.cs" />
     <Compile Include="..\ODataPropertyTests.cs" />
+    <Compile Include="..\ODataReaderDerivedTypeConstraintTests.cs" />
     <Compile Include="..\ODataRequestMessageTests.cs" />
     <Compile Include="..\ODataStreamReferenceValueTests.cs" />
     <Compile Include="..\ODataUtilsInternalTests.cs" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataReaderDerivedTypeConstraintTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataReaderDerivedTypeConstraintTests.cs
@@ -1,0 +1,657 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataReaderDerivedTypeConstraintTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OData.Edm.Vocabularies.V1;
+using Xunit;
+
+namespace Microsoft.OData.Tests
+{
+    /// <summary>
+    /// Unit tests for reading ODataItem with Org.OData.Validation.V1.DerivedTypeConstraint.
+    /// </summary>
+    public class ODataReaderDerivedTypeConstraintTests
+    {
+        public static string TestBaseUri = "http://example.com/";
+
+        private EdmModel edmModel;
+        private EdmEntityType edmCustomerType;
+        private EdmEntityType edmVipCustomerType;
+        private EdmEntityType edmNormalCustomerType;
+
+        private EdmComplexType edmAddressType;
+        private EdmComplexType edmUsAddressType;
+        private EdmComplexType edmCnAddressType;
+
+        private EdmSingleton edmMe;
+        private EdmEntitySet edmCustomers;
+
+        public ODataReaderDerivedTypeConstraintTests()
+        {
+            // Create the basic model
+            edmModel = new EdmModel();
+
+            // Entity Type
+            edmCustomerType = new EdmEntityType("NS", "Customer");
+            edmCustomerType.AddKeys(edmCustomerType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+
+            edmVipCustomerType = new EdmEntityType("NS", "VipCustomer", edmCustomerType);
+            edmVipCustomerType.AddStructuralProperty("Vip", EdmPrimitiveTypeKind.String);
+
+            edmNormalCustomerType = new EdmEntityType("NS", "NormalCustomer", edmCustomerType);
+            edmNormalCustomerType.AddStructuralProperty("Email", EdmPrimitiveTypeKind.String);
+
+            edmModel.AddElements(new[] { edmCustomerType, edmVipCustomerType, edmNormalCustomerType });
+
+            // Complex type
+            edmAddressType = new EdmComplexType("NS", "Address");
+            edmAddressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+
+            edmUsAddressType = new EdmComplexType("NS", "UsAddress", edmAddressType);
+            edmUsAddressType.AddStructuralProperty("ZipCode", EdmPrimitiveTypeKind.Int32);
+
+            edmCnAddressType = new EdmComplexType("NS", "CnAddress", edmAddressType);
+            edmCnAddressType.AddStructuralProperty("PostCode", EdmPrimitiveTypeKind.String);
+
+            edmModel.AddElements(new[] { edmAddressType, edmUsAddressType, edmCnAddressType });
+
+            // EntityContainer
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            edmMe = container.AddSingleton("Me", edmCustomerType);
+            edmCustomers = container.AddEntitySet("Customers", edmCustomerType);
+            edmModel.AddElement(container);
+        }
+
+        #region Singleton Derived Type Constraints
+
+        [Fact]
+        public void ReaderResourceWithSameTypeAsSingletonTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            Action<Stack<ODataItem>> verifyItems = (s) =>
+            {
+                Assert.NotNull(s);
+                var item = Assert.Single(s);
+                ODataResource resource = item as ODataResource;
+                Assert.NotNull(resource);
+                Assert.Equal("Id", resource.Properties.Single().Name);
+                Assert.Equal(7, resource.Properties.Single().Value);
+            };
+
+            string payload = @"{""@odata.context"":""http://example.com/$metadata#Me"",""Id"":7}";
+
+            // Singleton doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
+            verifyItems(items);
+
+            // Singleton has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, this.edmMe, "NS.VipCustomer");
+            items = ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingResourceAsAllowedTypeForSingletonWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            Action<Stack<ODataItem>> verifyItems = (s) =>
+            {
+                Assert.NotNull(s);
+                var item = Assert.Single(s);
+                ODataResource resource = item as ODataResource;
+                Assert.NotNull(resource);
+                Assert.Equal("NS.VipCustomer", resource.TypeName);
+                Assert.Equal(8, resource.Properties.Single(c => c.Name == "Id").Value);
+                Assert.Equal("Boss", resource.Properties.Single(c => c.Name == "Vip").Value);
+            };
+
+            string payload = @"{""@odata.context"":""http://example.com/$metadata#Me"",""@odata.type"":""#NS.VipCustomer"",""Id"":8,""Vip"":""Boss""}";
+
+            // Singleton doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
+            verifyItems(items);
+
+            // Singleton has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, this.edmMe, "NS.VipCustomer");
+            items = ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingResourceForSingletonWithoutDerivedTypeConstraintsWorksButWithConstraintFailed()
+        {
+            string payload = @"{""@odata.context"":""http://example.com/$metadata#Me"",""@odata.type"":""#NS.NormalCustomer"",""Id"":9,""Email"":""a@abc.com""}";
+
+            // Singleton doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
+            var item = Assert.Single(items);
+            ODataResource resource = item as ODataResource;
+            Assert.NotNull(resource);
+            Assert.Equal("NS.NormalCustomer", resource.TypeName);
+
+            // Negative test case -- singleton has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, this.edmMe, "NS.VipCustomer");
+
+            Action test = () => ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint("NS.NormalCustomer", "navigation source", "Me"), exception.Message);
+        }
+        #endregion
+
+        #region EntitySet Derived Type Constraints
+        [Fact]
+        public void ReadingResourceWithSameTypeAsEntitySetTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            Action<Stack<ODataItem>> verifyItems = (ms) =>
+            {
+                Assert.NotNull(ms);
+                Assert.Equal(3, ms.Count());
+                Assert.IsType<ODataResourceSet>(ms.Pop()); // toplevel resource set
+                ODataResource resource = Assert.IsType<ODataResource>(ms.Pop()); // second resource
+                Assert.Equal(17, resource.Properties.Single(c => c.Name == "Id").Value);
+                resource = Assert.IsType<ODataResource>(ms.Pop());
+                Assert.Equal(6, resource.Properties.Single(c => c.Name == "Id").Value); // first resource
+            };
+
+            string payload = @"{""@odata.context"":""http://example.com/$metadata#Customers"",""value"":[{""Id"":6},{""Id"":17}]}";
+
+            // EntitySet doesn't have the derived type constraint.
+            var items = ReadEntitySetPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+
+            // EntitySet has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, this.edmCustomers, "NS.VipCustomer");
+            items = ReadEntitySetPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingResourceWithSameAndAllowedTypeAsEntitySetTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            Action<Stack<ODataItem>> verifyItems = (ms) =>
+            {
+                Assert.NotNull(ms);
+                Assert.Equal(3, ms.Count());
+                Assert.IsType<ODataResourceSet>(ms.Pop()); // toplevel resource set
+                ODataResource resource = Assert.IsType<ODataResource>(ms.Pop()); // second resource
+                Assert.Equal(17, resource.Properties.Single(c => c.Name == "Id").Value);
+                Assert.Equal("NS.VipCustomer", resource.TypeName);
+                resource = Assert.IsType<ODataResource>(ms.Pop());
+                Assert.Equal(6, resource.Properties.Single(c => c.Name == "Id").Value); // first resource
+            };
+
+            string payload = @"{""@odata.context"":""http://example.com/$metadata#Customers"",""value"":[{""Id"":6},{""@odata.type"":""#NS.VipCustomer"",""Id"":17}]}";
+
+            // EntitySet doesn't have the derived type constraint.
+            var items = ReadEntitySetPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+
+            // EntitySet has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, this.edmCustomers, "NS.VipCustomer");
+            items = ReadEntitySetPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingResourceForEntitySetWithoutDerivedTypeConstraintsWorksButWithConstraintFailed()
+        {
+            string payload = @"{""@odata.context"":""http://example.com/$metadata#Customers"",""value"":[{""Id"":6},{""@odata.type"":""#NS.VipCustomer"",""Id"":17}]}";
+
+            // EntitySet doesn't have the derived type constraint.
+            var items = ReadEntitySetPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            Assert.NotNull(items);
+            Assert.Equal(3, items.Count()); // entityset + 2 resources
+
+            // Negative test case -- EntitySet has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, this.edmCustomers, "NS.NormalCustomer");
+
+            Action test = () => ReadEntitySetPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint("NS.VipCustomer", "navigation source", "Customers"), exception.Message);
+        }
+        #endregion
+
+        #region Entity Derived Type Constraints
+        [Fact]
+        public void ReadingResourceWithSameTypeAsEntityTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            Action<Stack<ODataItem>> verifyItems = (s) =>
+            {
+                Assert.NotNull(s);
+                var item = Assert.Single(s);
+                ODataResource resource = item as ODataResource;
+                Assert.NotNull(resource);
+                Assert.Equal(7, resource.Properties.Single().Value);
+            };
+
+            string payload = @"{""@odata.context"":""http://example.com/$metadata#Customers/$entity"",""Id"":7}";
+
+            // EntitySet doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+
+            // EntitySet has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, this.edmCustomers, "NS.VipCustomer");
+            items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingResourceWithSameAndAllowedTypeAsEntityTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            Action<Stack<ODataItem>> verifyItems = (s) =>
+            {
+                Assert.NotNull(s);
+                var item = Assert.Single(s);
+                ODataResource resource = item as ODataResource;
+                Assert.NotNull(resource);
+                Assert.Equal("NS.VipCustomer", resource.TypeName);
+                Assert.Equal(8, resource.Properties.Single(c => c.Name == "Id").Value);
+                Assert.Equal("Boss", resource.Properties.Single(c => c.Name == "Vip").Value);
+            };
+
+            string payload = @"{""@odata.context"":""http://example.com/$metadata#Customers/$entity"",""@odata.type"":""#NS.VipCustomer"",""Id"":8,""Vip"":""Boss""}";
+
+            // EntitySet doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+
+            // EntitySet has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, this.edmCustomers, "NS.VipCustomer");
+            items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingResourceForEntityWorksWithoutDerivedTypeConstraintsButFailedWithConstraint()
+        {
+            string payload = @"{""@odata.context"":""http://example.com/$metadata#Customers/$entity"",""@odata.type"":""#NS.NormalCustomer"",""Id"":8,""Email"":""a@abc.com""}";
+
+            // EntitySet doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            Assert.NotNull(items);
+            Assert.Single(items);
+
+            // Negative test case -- EntitySet has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, this.edmCustomers, "NS.VipCustomer");
+
+            Action test = () => ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint("NS.NormalCustomer", "navigation source", "Customers"), exception.Message);
+        }
+        #endregion
+
+        #region Navigation property nested resource info Derived Type Constraints
+        [Fact]
+        public void ReadingSingleNavigationProppertyWithSameTypeAsNavigationPropertyTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            // Add a <NavigationProperty Name="FriendCustomer" Type="NS.Customer" />
+            var navigationProperty = this.edmCustomerType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Target = this.edmCustomerType,
+                TargetMultiplicity = EdmMultiplicity.One,
+                Name = "FriendCustomer"
+            });
+
+            Action<Stack<ODataItem>> verifyItems = (ms) =>
+            {
+                Assert.NotNull(ms);
+                Assert.Equal(4, ms.Count);
+                ODataResource resource = Assert.IsType<ODataResource>(ms.Pop()); // top level resource (id=7)
+                Assert.Equal(7, resource.Properties.Single().Value);
+
+                ODataNestedResourceInfo nestedLink = Assert.IsType<ODataNestedResourceInfo>(ms.Pop()); // FriendCustomer Navigation Link
+                Assert.Equal(new Uri("http://example.com/Customers(7)/FriendCustomer"), nestedLink.Url);
+                Assert.Equal("FriendCustomer", nestedLink.Name);
+
+                resource = Assert.IsType<ODataResource>(ms.Pop()); // nested resource (id=5)
+                Assert.Equal(5, resource.Properties.Single().Value);
+
+                ODataNestedResourceInfo nestedResourceInfo = Assert.IsType<ODataNestedResourceInfo>(ms.Pop()); // FriendCustomer Nested resource info
+                Assert.Throws<ODataException>(() => nestedResourceInfo.Url);
+                Assert.Equal("FriendCustomer", nestedResourceInfo.Name);
+            };
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Customers/$entity\",\"Id\":7,\"FriendCustomer\":{\"Id\":5}}";
+
+            // Navigation property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+
+            // Navigation property has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, navigationProperty, "NS.VipCustomer");
+
+            items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingSingleNavigationProppertyWithAllowedTypeAsNavigationPropertyTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            // Add a <NavigationProperty Name="FriendCustomer" Type="NS.Customer" />
+            var navigationProperty = this.edmCustomerType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Target = this.edmCustomerType,
+                TargetMultiplicity = EdmMultiplicity.One,
+                Name = "FriendCustomer"
+            });
+
+            Action<Stack<ODataItem>> verifyItems = (ms) =>
+            {
+                Assert.NotNull(ms);
+                Assert.Equal(4, ms.Count);
+                ODataResource resource = Assert.IsType<ODataResource>(ms.Pop()); // top level resource (id=7)
+                Assert.Equal(7, resource.Properties.Single().Value);
+
+                ODataNestedResourceInfo nestedLink = Assert.IsType<ODataNestedResourceInfo>(ms.Pop()); // FriendCustomer Navigation Link
+                Assert.Equal(new Uri("http://example.com/Customers(7)/FriendCustomer"), nestedLink.Url);
+                Assert.Equal("FriendCustomer", nestedLink.Name);
+
+                resource = Assert.IsType<ODataResource>(ms.Pop()); // nested resource (id=8)
+                Assert.Equal(8, resource.Properties.Single().Value);
+                Assert.Equal("NS.VipCustomer", resource.TypeName);
+
+                ODataNestedResourceInfo nestedResourceInfo = Assert.IsType<ODataNestedResourceInfo>(ms.Pop()); // FriendCustomer Nested resource info
+                Assert.Throws<ODataException>(() => nestedResourceInfo.Url);
+                Assert.Equal("FriendCustomer", nestedResourceInfo.Name);
+            };
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Customers/$entity\",\"Id\":7,\"FriendCustomer\":{\"@odata.type\":\"#NS.VipCustomer\",\"Id\":8}}";
+
+            // Navigation property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+
+            // Navigation property has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, navigationProperty, "NS.VipCustomer");
+
+            items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingSingleNavigationProppertyWithNotAllowedTypeWorksWithoutDerivedTypeConstraintButFailedWithDerivedTypeConstraint()
+        {
+            // Add a <NavigationProperty Name="FriendCustomer" Type="NS.Customer" />
+            var navigationProperty = this.edmCustomerType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Target = this.edmCustomerType,
+                TargetMultiplicity = EdmMultiplicity.One,
+                Name = "FriendCustomer"
+            });
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Customers/$entity\",\"Id\":7,\"FriendCustomer\":{\"@odata.type\":\"#NS.VipCustomer\",\"Id\":8}}";
+
+            // Navigation property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            Assert.Equal(4, items.Count);
+
+            // Negative test case --Navigation property has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, navigationProperty, "NS.NormalCustomer");
+
+            Action test = () => ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint("NS.VipCustomer", "nested resource", "FriendCustomer"), exception.Message);
+        }
+
+        [Fact]
+        public void ReadingMultipleNavigationProppertyWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            // Add a <NavigationProperty Name="FriendCustomers" Type="Collection(NS.Customer)" />
+            var navigationProperty = this.edmCustomerType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Target = this.edmCustomerType,
+                TargetMultiplicity = EdmMultiplicity.Many,
+                Name = "FriendCustomers"
+            });
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Customers/$entity\",\"Id\":7,\"FriendCustomers\":[{\"@odata.type\":\"#NS.NormalCustomer\",\"Id\":9,\"Email\":\"a@abc.com\"},{\"@odata.type\":\"#NS.VipCustomer\",\"Id\":8,\"Vip\":\"Boss\"}]}";
+
+            // Navigation property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            Assert.Equal(7, items.Count); // 1 top level resource + 3 nested resource info + 1 nested resource set + 2 nested resource
+
+            // Negative test case --Navigation property has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, navigationProperty, "NS.NormalCustomer");
+
+            Action test = () => ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint("NS.VipCustomer", "nested resource", "FriendCustomers"), exception.Message);
+        }
+
+        #endregion
+
+        #region Complex nested resource info Derived Type Constraints
+
+        [Fact]
+        public void ReadingSingleComplexProppertyWithSameTypeAsPropertyTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            // Add a <Property Name="Location" Type="NS.Address" />
+            var locationProperty = this.edmCustomerType.AddStructuralProperty("Location", new EdmComplexTypeReference(this.edmAddressType, false));
+
+            Action<Stack<ODataItem>> verifyItems = (ms) =>
+            {
+                Assert.NotNull(ms);
+                Assert.Equal(3, ms.Count);
+                ODataResource resource = Assert.IsType<ODataResource>(ms.Pop()); // top level resource (id=7)
+                Assert.Equal(7, resource.Properties.Single().Value);
+
+                ODataNestedResourceInfo nestedResourceInfo = Assert.IsType<ODataNestedResourceInfo>(ms.Pop()); // Location Nested resource info
+                Assert.Null(nestedResourceInfo.Url);
+                Assert.Equal("Location", nestedResourceInfo.Name);
+
+                resource = Assert.IsType<ODataResource>(ms.Pop()); // nested complex resource (id=8)
+                Assert.Equal("Way", resource.Properties.Single().Value);
+            };
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Customers/$entity\",\"Id\":7,\"Location\":{\"Street\":\"Way\"}}";
+
+            // Structural property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+
+            // Structural property has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, locationProperty, "NS.VipCustomer");
+
+            items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingSingleComplexProppertyWithAllowedTypeAsPropertyTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            // Add a <Property Name="Location" Type="NS.Address" />
+            var locationProperty = this.edmCustomerType.AddStructuralProperty("Location", new EdmComplexTypeReference(this.edmAddressType, false));
+
+            Action<Stack<ODataItem>> verifyItems = (ms) =>
+            {
+                Assert.NotNull(ms);
+                Assert.Equal(3, ms.Count);
+                ODataResource resource = Assert.IsType<ODataResource>(ms.Pop()); // top level resource (id=7)
+                Assert.Equal(7, resource.Properties.Single().Value);
+
+                ODataNestedResourceInfo nestedResourceInfo = Assert.IsType<ODataNestedResourceInfo>(ms.Pop()); // Location Nested resource info
+                Assert.Null(nestedResourceInfo.Url);
+                Assert.Equal("Location", nestedResourceInfo.Name);
+
+                resource = Assert.IsType<ODataResource>(ms.Pop()); // nested complex resource (id=8)
+                Assert.Equal("NS.UsAddress", resource.TypeName);
+                Assert.Equal("RedWay", resource.Properties.Single(c => c.Name == "Street").Value);
+                Assert.Equal(98052, resource.Properties.Single(c => c.Name == "ZipCode").Value);
+            };
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Me\",\"Id\":7,\"Location\":{\"@odata.type\":\"#NS.UsAddress\",\"Street\":\"RedWay\",\"ZipCode\":98052}}";
+
+            // Structural property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
+            verifyItems(items);
+
+            // Structural property has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, locationProperty, "NS.UsAddress");
+
+            items = ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingingSingleComplexProppertyWithNotAllowedTypeWorksWithoutDerivedTypeConstraintButFailedWithDerivedTypeConstraint()
+        {
+            // Add a <Property Name="Location" Type="NS.Address" />
+            var locationProperty = this.edmCustomerType.AddStructuralProperty("Location", new EdmComplexTypeReference(this.edmAddressType, false));
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Me\",\"Id\":7,\"Location\":{\"@odata.type\":\"#NS.UsAddress\",\"Street\":\"RedWay\",\"ZipCode\":98052}}";
+
+            // Structural property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
+            Assert.Equal(3, items.Count);
+
+            // Negative test case --Structural property has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, locationProperty, "NS.CnAddress");
+
+            Action test = () => ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType); ;
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint("NS.UsAddress", "nested resource", "Location"), exception.Message);
+        }
+
+        [Fact]
+        public void ReadingMultipleComplexProppertyWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            // Add a <Property Name="Locations" Type="Collection(NS.Address)" />
+            var locationsProperty = this.edmCustomerType.AddStructuralProperty("Locations", new EdmCollectionTypeReference(new EdmCollectionType(new EdmComplexTypeReference(this.edmAddressType, false))));
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Customers/$entity\",\"Id\":7,\"Locations\":[{\"@odata.type\":\"#NS.CnAddress\",\"Street\":\"ShaWay\",\"PostCode\":\"201100\"},{\"@odata.type\":\"#NS.UsAddress\",\"Street\":\"RedWay\",\"ZipCode\":98052}]}";
+
+            // Structural property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            Assert.Equal(5, items.Count); // 1 top level resource + 1 nested resource info + 1 nested resource set + 2 nested resources
+
+            // Negative test case --Structural property has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, locationsProperty, "NS.CnAddress");
+
+            Action test = () => ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint("NS.UsAddress", "nested resource", "Locations"), exception.Message);
+        }
+
+        #endregion
+
+        #region Primitive property Derived Type Constraints
+
+        [Fact]
+        public void ReadingEdmPrimitiveProppertyWithAllowedTypeAsPropertyTypeWithOrWithoutDerivedTypeConstraintWorks()
+        {
+            // Add a <Property Name="Data" Type="Edm.PrimitiveType" />
+            var locationProperty = this.edmCustomerType.AddStructuralProperty("Data", EdmCoreModel.Instance.GetPrimitiveType(false));
+
+            Action<Stack<ODataItem>> verifyItems = (ms) =>
+            {
+                Assert.NotNull(ms);
+                Assert.Single(ms);
+                ODataResource resource = Assert.IsType<ODataResource>(ms.Pop()); // top level resource (id=7)
+                Assert.Equal(7, resource.Properties.Single(c => c.Name == "Id").Value);
+                Assert.Equal(false, resource.Properties.Single(c => c.Name == "Data").Value);
+            };
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Customers/$entity\",\"Id\":7,\"Data@odata.type\":\"#Boolean\",\"Data\":false}";
+
+            // EdmPrimitive property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+
+            // EdmPrimitive property has the derived type constraints.
+            SetDerivedTypeAnnotation(this.edmModel, locationProperty, "Edm.Boolean", "Edm.Int32");
+
+            items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            verifyItems(items);
+        }
+
+        [Fact]
+        public void ReadingEdmPrimitiveProppertyWithNotAllowedTypeWorksWithoutDerivedTypeConstraintButFailedWithDerivedTypeConstraint()
+        {
+            // Add a <Property Name="Data" Type="Edm.PrimitiveType" />
+            var locationProperty = this.edmCustomerType.AddStructuralProperty("Data", EdmCoreModel.Instance.GetPrimitiveType(false));
+
+            string payload = "{\"@odata.context\":\"http://example.com/$metadata#Customers/$entity\",\"Id\":7,\"Data@odata.type\":\"#Double\",\"Data\":8.9}";
+
+            // EdmPrimitive property doesn't have the derived type constraint.
+            var items = ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            Assert.Single(items);
+
+            // Negative test case --EdmPrimitive property has the derived type constraint.
+            SetDerivedTypeAnnotation(this.edmModel, locationProperty, "Edm.Boolean", "Edm.Int32");
+
+            Action test = () => ReadEntityPayload(payload, this.edmModel, this.edmCustomers, this.edmCustomerType);
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint("Edm.Double", "property", "Data"), exception.Message);
+        }
+        #endregion
+
+        private static void SetDerivedTypeAnnotation(EdmModel model, IEdmVocabularyAnnotatable target, params string[] derivedTypes)
+        {
+            IEdmTerm term = ValidationVocabularyModel.DerivedTypeConstraintTerm;
+            var collectionExpression = new EdmCollectionExpression(derivedTypes.Select(d => new EdmStringConstant(d)));
+            EdmVocabularyAnnotation valueAnnotationOnProperty = new EdmVocabularyAnnotation(target, term, collectionExpression);
+            valueAnnotationOnProperty.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+            model.AddVocabularyAnnotation(valueAnnotationOnProperty);
+        }
+
+        private Stack<ODataItem> ReadEntityPayload(string payload, IEdmModel edmModel, IEdmNavigationSource source, IEdmEntityType sourceType)
+        {
+            Func<ODataMessageReader, ODataReader> createReader = (msReader) => msReader.CreateODataResourceReader(source, sourceType);
+
+            return ReadPayload(payload, edmModel, createReader);
+        }
+
+        private Stack<ODataItem> ReadEntitySetPayload(string payload, IEdmModel edmModel, IEdmEntitySetBase source, IEdmEntityType sourceType)
+        {
+            Func<ODataMessageReader, ODataReader> createReader = (msReader) => msReader.CreateODataResourceSetReader(source, sourceType);
+
+            return ReadPayload(payload, edmModel, createReader);
+        }
+
+        private Stack<ODataItem> ReadPayload(string payload, IEdmModel edmModel, Func<ODataMessageReader, ODataReader> createReader)
+        {
+            var message = new InMemoryMessage()
+            {
+                Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload))
+            };
+            message.SetHeader("Content-Type", "application/json;odata.metadata=minimal");
+
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings()
+            {
+                BaseUri = new Uri(TestBaseUri + "$metadata"),
+                EnableMessageStreamDisposal = true,
+                Version = ODataVersion.V4,
+            };
+
+            Stack<ODataItem> items = new Stack<ODataItem>();
+            using (var msgReader = new ODataMessageReader((IODataResponseMessage)message, readerSettings, edmModel))
+            {
+                var reader = createReader(msgReader);
+                while (reader.Read())
+                {
+                    switch (reader.State)
+                    {
+                        case ODataReaderState.ResourceSetEnd:
+                        case ODataReaderState.ResourceEnd:
+                        case ODataReaderState.NestedResourceInfoEnd:
+                            items.Push(reader.Item);
+                            break;
+                    }
+                }
+
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+
+            return items;
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes enable the resource reading derived type constraint annotation validation.*

### Description

*Enable the resource reading derived type constraint annotation validation.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
