### PR TITLE
Improve Json reader buffer logic

### DIFF
--- a/src/Microsoft.OData.Core/Buffers/BufferUtils.cs
+++ b/src/Microsoft.OData.Core/Buffers/BufferUtils.cs
@@ -6,8 +6,6 @@
 
 namespace Microsoft.OData.Buffers
 {
-    using System;
-
     /// <summary>
     /// Helpers to deal with buffers
     /// </summary>
@@ -31,6 +29,36 @@ namespace Microsoft.OData.Buffers
             }
 
             return buffer;
+        }
+
+        /// <summary>
+        /// Rents a character array from the pool.
+        /// </summary>
+        /// <param name="bufferPool">The character pool.</param>
+        /// <param name="minSize">The min required size of the character array.</param>
+        /// <returns>The character array from the pool.</returns>
+        public static char[] RentFromBuffer(ICharArrayPool bufferPool, int minSize)
+        {
+            if (bufferPool == null)
+            {
+                return new char[minSize];
+            }
+
+            char[] buffer = bufferPool.Rent(minSize);
+            return buffer;
+        }
+
+        /// <summary>
+        /// Returns a character array to the pool.
+        /// </summary>
+        /// <param name="bufferPool">The character pool.</param>
+        /// <param name="buffer">The character array should be returned.</param>
+        public static void ReturnToBuffer(ICharArrayPool bufferPool, char[] buffer)
+        {
+            if (bufferPool != null)
+            {
+                bufferPool.Return(buffer);
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Core/Buffers/ICharArrayPool.cs
+++ b/src/Microsoft.OData.Core/Buffers/ICharArrayPool.cs
@@ -1,0 +1,29 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ICharArrayPool.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Buffers
+{
+    /// <summary>
+    /// Provides an interface for using character arrays.
+    /// </summary>
+    public interface ICharArrayPool
+    {
+        /// <summary>
+        /// Rents a character array from the pool.
+        /// This character array must be returned when it is no longer used.
+        /// </summary>
+        /// <param name="minSize">The min required size of the character array.</param>
+        /// <returns>The character array from the pool.</returns>
+        char[] Rent(int minSize);
+
+        /// <summary>
+        /// Returns a character array to the pool.
+        /// </summary>
+        /// <param name="array">The character array should be returned.</param>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Return")]
+        void Return(char[] array);
+    }
+}

--- a/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
+++ b/src/Microsoft.OData.Core/Build.Net35/Microsoft.OData.Core.NetFX35.csproj
@@ -1554,6 +1554,9 @@
     <Compile Include="..\DerivedTypeValidator.cs">
       <Link>Microsoft\OData\Core\DerivedTypeValidator.cs</Link>
     </Compile>
+    <Compile Include="..\Buffers\ICharArrayPool.cs">
+      <Link>Microsoft\OData\Core\Buffers\ICharArrayPool.cs</Link>
+    </Compile>
     <Compile Include="..\DuplicatePropertyNameChecker.cs">
       <Link>Microsoft\OData\Core\DuplicatePropertyNameChecker.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
+++ b/src/Microsoft.OData.Core/Build.NetStandard/Microsoft.OData.Core.NetStandard.csproj
@@ -83,6 +83,9 @@
     <Compile Include="..\Buffers\BufferUtils.cs">
       <Link>Buffers\BufferUtils.cs</Link>
     </Compile>
+    <Compile Include="..\Buffers\ICharArrayPool.cs">
+      <Link>Buffers\ICharArrayPool.cs</Link>
+    </Compile>
     <Compile Include="..\CollectionWithoutExpectedTypeValidator.cs">
       <Link>CollectionWithoutExpectedTypeValidator.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -14,13 +14,14 @@ namespace Microsoft.OData.Json
     using System.Globalization;
     using System.IO;
     using System.Text;
+    using Microsoft.OData.Buffers;
     #endregion Namespaces
 
     /// <summary>
     /// Reader for the JSON format. http://www.json.org
     /// </summary>
     [DebuggerDisplay("{NodeType}: {Value}")]
-    internal class JsonReader : IJsonReader
+    internal class JsonReader : IJsonReader, IDisposable
     {
         /// <summary>
         /// The initial size of the buffer of characters.
@@ -32,12 +33,6 @@ namespace Microsoft.OData.Json
         /// too many L1 cache misses.
         /// </remarks>
         private const int InitialCharacterBufferSize = ((4 * 1024) / 2) - 8;
-
-        /// <summary>
-        /// Maximum number of characters to move in the buffer. If the current token size is bigger than this, we will allocate a larger buffer.
-        /// </summary>
-        /// <remarks>This threshold is copied from the XmlReader implementation.</remarks>
-        private const int MaxCharacterCountToMove = 128 / 2;
 
         /// <summary>
         /// The text reader to read input characters from.
@@ -122,7 +117,6 @@ namespace Microsoft.OData.Json
             this.nodeType = JsonNodeType.None;
             this.nodeValue = null;
             this.reader = reader;
-            this.characterBuffer = new char[InitialCharacterBufferSize];
             this.storedCharacterCount = 0;
             this.tokenStartIndex = 0;
             this.endOfInputReached = false;
@@ -131,6 +125,11 @@ namespace Microsoft.OData.Json
             this.scopes = new Stack<Scope>();
             this.scopes.Push(new Scope(ScopeType.Root));
         }
+
+        /// <summary>
+        /// Get/sets the character buffer pool.
+        /// </summary>
+        public ICharArrayPool ArrayPool { get; set; }
 
         /// <summary>
         /// Various scope types for Json writer.
@@ -813,6 +812,13 @@ namespace Microsoft.OData.Json
             Debug.Assert(this.nodeValue == null, "The node value should have been reset to null.");
 
             this.nodeType = JsonNodeType.EndOfInput;
+
+            if (this.ArrayPool != null)
+            {
+                BufferUtils.ReturnToBuffer(this.ArrayPool, this.characterBuffer);
+                this.characterBuffer = null;
+            }
+
             return false;
         }
 
@@ -921,7 +927,6 @@ namespace Microsoft.OData.Json
         /// all indeces to the characterBuffer are invalid except for tokenStartIndex.</remarks>
         private bool ReadInput()
         {
-            Debug.Assert(this.storedCharacterCount <= this.characterBuffer.Length, "We can only store as many characters as fit into our buffer.");
             Debug.Assert(this.tokenStartIndex >= 0 && this.tokenStartIndex <= this.storedCharacterCount, "The token start is out of stored characters range.");
 
             if (this.endOfInputReached)
@@ -929,51 +934,48 @@ namespace Microsoft.OData.Json
                 return false;
             }
 
+            // initialze the buffer
+            if (this.characterBuffer == null)
+            {
+                this.characterBuffer = BufferUtils.RentFromBuffer(ArrayPool, InitialCharacterBufferSize);
+            }
+            Debug.Assert(this.storedCharacterCount <= this.characterBuffer.Length, "We can only store as many characters as fit into our buffer.");
+
             // We need to make sure we have more room in the buffer to read characters into
             if (this.storedCharacterCount == this.characterBuffer.Length)
             {
                 // No more room in the buffer, move or grow the buffer.
                 if (this.tokenStartIndex == this.storedCharacterCount)
                 {
-                    // If the buffer is empty (all characters were consumed from it)
-                    // just start over.
+                    // If the buffer is empty (all characters were consumed from it), just start over.
                     this.tokenStartIndex = 0;
                     this.storedCharacterCount = 0;
                 }
-                else if (this.tokenStartIndex > (this.characterBuffer.Length - MaxCharacterCountToMove))
+                else if (this.tokenStartIndex == 0)
                 {
-                    // Some characters were consumed, we can just move them in the buffer
-                    // to get more room without allocating.
-                    Array.Copy(
-                        this.characterBuffer,
-                        this.tokenStartIndex,
-                        this.characterBuffer,
-                        0,
+                    // The entire buffer is full of unconsumed characters
+                    // We need to grow the buffer. Double the size of the buffer.
+                    int newBufferSize = this.characterBuffer.Length * 2;
+                    newBufferSize = newBufferSize < 0 ? int.MaxValue : newBufferSize; // maybe overflow
+
+                    char[] newCharacterBuffer = BufferUtils.RentFromBuffer(ArrayPool, newBufferSize);
+
+                    // Copy the existing characters to the new buffer.
+                    Array.Copy(this.characterBuffer, this.tokenStartIndex, newCharacterBuffer, 0,
                         this.storedCharacterCount - this.tokenStartIndex);
-                    this.storedCharacterCount -= this.tokenStartIndex;
-                    this.tokenStartIndex = 0;
+
+                    // And switch the buffers
+                    BufferUtils.ReturnToBuffer(ArrayPool, this.characterBuffer);
+                    this.characterBuffer = newCharacterBuffer;
                 }
                 else
                 {
-                    // The entire buffer is full of unconsumed characters
-                    // We need to grow the buffer.
-                    // Double the size of the buffer.
-                    int newBufferSize = this.characterBuffer.Length * 2;
-                    char[] newCharacterBuffer = new char[newBufferSize];
-
-                    // Copy the existing characters to the new buffer.
-                    Array.Copy(
-                        this.characterBuffer,
-                        0,  // The tokenStartIndex is 0 - we checked above.
-                        newCharacterBuffer,
-                        0,
-                        this.characterBuffer.Length);  // The storedCharacterCount is the size of the old buffer
-
-                    // And switch the buffers
-                    this.characterBuffer = newCharacterBuffer;
-
-                    // Note that the number of characters stored in the buffer remains unchanged
-                    // as well as the token start index which is 0.
+                    // Some characters were consumed, we can just move them in the buffer
+                    // to get more room without allocating.
+                    Array.Copy(this.characterBuffer, this.tokenStartIndex, this.characterBuffer, 0,
+                        this.storedCharacterCount - this.tokenStartIndex);
+                    this.storedCharacterCount -= this.tokenStartIndex;
+                    this.tokenStartIndex = 0;
                 }
             }
 
@@ -999,6 +1001,18 @@ namespace Microsoft.OData.Json
 
             this.storedCharacterCount += readCount;
             return true;
+        }
+
+        /// <summary>
+        /// Dispose the reader
+        /// </summary>
+        public void Dispose()
+        {
+            if (this.ArrayPool != null && this.characterBuffer != null)
+            {
+                BufferUtils.ReturnToBuffer(this.ArrayPool, this.characterBuffer);
+                this.characterBuffer = null;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -951,7 +951,7 @@ namespace Microsoft.OData.Json
                     this.tokenStartIndex = 0;
                     this.storedCharacterCount = 0;
                 }
-                else if (this.tokenStartIndex == 0)
+                else if (this.tokenStartIndex < this.characterBuffer.Length / 2)
                 {
                     // The entire buffer is full of unconsumed characters
                     // We need to grow the buffer. Double the size of the buffer.

--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -950,7 +950,7 @@ namespace Microsoft.OData.Json
             else if (this.storedCharacterCount == this.characterBuffer.Length)
             {
                 // No more room in the buffer, move or grow the buffer.
-                if (this.tokenStartIndex < this.characterBuffer.Length / 2)
+                if (this.tokenStartIndex < this.characterBuffer.Length / 4) // Tested 1/2, 3/4 and 1/4, it seems 1/4 is better than other two.
                 {
                     // The entire buffer is full of unconsumed characters
                     // We need to grow the buffer. Double the size of the buffer.

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightInputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightInputContext.cs
@@ -647,12 +647,6 @@ namespace Microsoft.OData.JsonLight
             var jsonReader = jsonReaderFactory.CreateJsonReader(textReader, isIeee754Compatible);
             Debug.Assert(jsonReader != null, "jsonWriter != null");
 
-            JsonReader odataJsonReader = jsonReader as JsonReader;
-            if (odataJsonReader != null)
-            {
-                odataJsonReader.ArrayPool = container.GetService<ICharArrayPool>();
-            }
-
             return jsonReader;
         }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightInputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightInputContext.cs
@@ -16,6 +16,7 @@ namespace Microsoft.OData.JsonLight
     using System.Threading.Tasks;
 #endif
     using Microsoft.OData.Metadata;
+    using Microsoft.OData.Buffers;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Json;
     // ReSharper disable RedundantUsingDirective
@@ -76,6 +77,16 @@ namespace Microsoft.OData.JsonLight
             {
                 this.textReader = textReader;
                 var innerReader = CreateJsonReader(this.Container, this.textReader, messageInfo.MediaType.HasIeee754CompatibleSetToTrue());
+                if (messageReaderSettings.ArrayPool != null)
+                {
+                    // make sure customer also can use reading setting if without DI.
+                    JsonReader jsonReader = innerReader as JsonReader;
+                    if (jsonReader != null && jsonReader.ArrayPool == null)
+                    {
+                        jsonReader.ArrayPool = messageReaderSettings.ArrayPool;
+                    }
+                }
+
                 if (messageInfo.MediaType.HasStreamingSetToTrue())
                 {
                     this.jsonReader = new BufferingJsonReader(
@@ -635,6 +646,12 @@ namespace Microsoft.OData.JsonLight
             var jsonReaderFactory = container.GetRequiredService<IJsonReaderFactory>();
             var jsonReader = jsonReaderFactory.CreateJsonReader(textReader, isIeee754Compatible);
             Debug.Assert(jsonReader != null, "jsonWriter != null");
+
+            JsonReader odataJsonReader = jsonReader as JsonReader;
+            if (odataJsonReader != null)
+            {
+                odataJsonReader.ArrayPool = container.GetService<ICharArrayPool>();
+            }
 
             return jsonReader;
         }

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -845,6 +845,7 @@ namespace Microsoft.OData {
         internal const string JsonReader_InvalidNumberFormat = "JsonReader_InvalidNumberFormat";
         internal const string JsonReader_MissingComma = "JsonReader_MissingComma";
         internal const string JsonReader_InvalidPropertyNameOrUnexpectedComma = "JsonReader_InvalidPropertyNameOrUnexpectedComma";
+        internal const string JsonReader_MaxBufferReached = "JsonReader_MaxBufferReached";
         internal const string JsonReaderExtensions_UnexpectedNodeDetected = "JsonReaderExtensions_UnexpectedNodeDetected";
         internal const string JsonReaderExtensions_UnexpectedNodeDetectedWithPropertyName = "JsonReaderExtensions_UnexpectedNodeDetectedWithPropertyName";
         internal const string JsonReaderExtensions_CannotReadPropertyValueAsString = "JsonReaderExtensions_CannotReadPropertyValueAsString";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -45,6 +45,7 @@
     <Compile Include="AnnotationFilterPattern.cs" />
     <Compile Include="AsyncBufferedStream.cs" />
     <Compile Include="Buffers\BufferUtils.cs" />
+    <Compile Include="Buffers\ICharArrayPool.cs" />
     <Compile Include="ContainerBuilderExtensions.cs" />
     <Compile Include="EdmExtensionMethods.cs" />
     <Compile Include="Evaluation\ODataConventionalResourceMetadataBuilder.cs" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -944,6 +944,7 @@ JsonReader_UnexpectedEndOfString=Invalid JSON. Unexpected end of input reached w
 JsonReader_InvalidNumberFormat=Invalid JSON. The value '{0}' is not a valid number.
 JsonReader_MissingComma=Invalid JSON. A comma character ',' was expected in scope '{0}'. Every two elements in an array and properties of an object must be separated by commas.
 JsonReader_InvalidPropertyNameOrUnexpectedComma=Invalid JSON. The property name '{0}' is not valid. The name of a property cannot be empty.
+JsonReader_MaxBufferReached=Cannot increase the JSON reader buffer to hold the input JSON which has very long token.
 
 JsonReaderExtensions_UnexpectedNodeDetected=An unexpected '{1}' node was found when reading from the JSON reader. A '{0}' node was expected.
 JsonReaderExtensions_UnexpectedNodeDetectedWithPropertyName=An unexpected '{1}' node was found for property named '{2}' when reading from the JSON reader. A '{0}' node was expected.

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -7,6 +7,7 @@
 namespace Microsoft.OData
 {
     using System;
+    using Microsoft.OData.Buffers;
     using Microsoft.OData.Edm;
 
     /// <summary>
@@ -69,6 +70,12 @@ namespace Microsoft.OData
         /// <summary>Gets or sets the OData protocol version to be used for reading payloads. </summary>
         /// <returns>The OData protocol version to be used for reading payloads.</returns>
         public ODataVersion? Version { get; set; }
+
+        /// <summary>
+        /// Get/sets the character buffer pool. This pool is used for non-container scenario.
+        /// If the service container has an array pool, that pool will be used.
+        /// </summary>
+        public ICharArrayPool ArrayPool { get; set; }
 
         /// <summary>
         /// Gets or sets validation settings.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -5952,6 +5952,15 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "Cannot increase the JSON reader buffer to hold the input JSON which has very long token."
+        /// </summary>
+        internal static string JsonReader_MaxBufferReached {
+            get {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.JsonReader_MaxBufferReached);
+            }
+        }
+
+        /// <summary>
         /// A string like "An unexpected '{1}' node was found when reading from the JSON reader. A '{0}' node was expected."
         /// </summary>
         internal static string JsonReaderExtensions_UnexpectedNodeDetected(object p0, object p1) {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonReaderTests.cs
@@ -7,6 +7,7 @@
 using System;
 using System.IO;
 using FluentAssertions;
+using Microsoft.OData.Buffers;
 using Microsoft.OData.Json;
 using Xunit;
 
@@ -74,6 +75,19 @@ namespace Microsoft.OData.Tests.Json
             this.CreateJsonLightReader("\"\\/Date(628318530718)\\/\"").ReadPrimitiveValue().Should().BeOfType<String>();
         }
 
+        [Theory]
+        [InlineData("\"abc\u6211xyz\"")]
+        [InlineData("\"abcxyz\u6211\"")]
+        [InlineData("\"\u6211abcxyz\"")]
+        public void EscapeStringShouldBeReadAsString(string value)
+        {
+            // Arrange & Act
+            object actual = this.CreateJsonLightReader(value).ReadPrimitiveValue();
+
+            // Assert
+            Assert.IsType<string>(actual);
+        }
+
         private JsonReader CreateJsonLightReader(string jsonValue)
         {
             JsonReader reader = new JsonReader(new StringReader(String.Format("{{ \"data\" : {0} }}", jsonValue)), isIeee754Compatible: false);
@@ -83,6 +97,46 @@ namespace Microsoft.OData.Tests.Json
             reader.NodeType.Should().Be(JsonNodeType.PrimitiveValue);
 
             return reader;
+        }
+
+        [Fact]
+        public void ShouldUseArrayPoolIfSet()
+        {
+            // Arrange
+            TestArrayPool pool = new TestArrayPool();
+            Assert.Equal(0, pool.RentCount); // guard
+            Assert.Equal(0, pool.ReturnCount); // guard
+            IJsonReader reader = new JsonReader(new StringReader("[]"), isIeee754Compatible: false)
+            {
+                ArrayPool = pool
+            };
+
+            // Act
+            while (reader.Read())
+            { }
+
+            // Assert
+            Assert.Equal(JsonNodeType.EndOfInput, reader.NodeType);
+            Assert.Equal(1, pool.RentCount);
+            Assert.Equal(1, pool.ReturnCount);
+        }
+
+        public class TestArrayPool : ICharArrayPool
+        {
+            public int RentCount { get; set; }
+
+            public int ReturnCount { get; set; }
+
+            public char[] Rent(int minSize)
+            {
+                RentCount++;
+                return new char[minSize];
+            }
+
+            public void Return(char[] array)
+            {
+                ReturnCount++;
+            }
         }
     }
 }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5234,6 +5234,7 @@ public sealed class Microsoft.OData.ODataMessageReaderSettings {
 	public ODataMessageReaderSettings ()
 	public ODataMessageReaderSettings (Microsoft.OData.ODataVersion odataVersion)
 
+	Microsoft.OData.Buffers.ICharArrayPool ArrayPool  { public get; public set; }
 	System.Uri BaseUri  { public get; public set; }
 	System.Func`3[[Microsoft.OData.Edm.IEdmType],[System.String],[Microsoft.OData.Edm.IEdmType]] ClientCustomTypeResolver  { public get; public set; }
 	bool EnableCharactersCheck  { public get; public set; }
@@ -5489,6 +5490,11 @@ public sealed class Microsoft.OData.ODataUri {
 public sealed class Microsoft.OData.ODataUrlKeyDelimiter {
 	Microsoft.OData.ODataUrlKeyDelimiter Parentheses  { public static get; }
 	Microsoft.OData.ODataUrlKeyDelimiter Slash  { public static get; }
+}
+
+public interface Microsoft.OData.Buffers.ICharArrayPool {
+	char[] Rent (int minSize)
+	void Return (char[] array)
 }
 
 public enum Microsoft.OData.Json.JsonNodeType : int {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue https://github.com/OData/odata.net/issues/1024.*

### Description

* Introduce the array pool
* Fix the buffer double problem for large object JSON payload

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
