### PR TITLE
fix build uri with filter by enum

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/MetadataBindingUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/MetadataBindingUtils.cs
@@ -64,7 +64,8 @@ namespace Microsoft.OData.UriParser
                     IEdmEnumType enumType = targetTypeReference.Definition as IEdmEnumType;
                     if (enumType.Members.Any(m => string.Compare(m.Name, memberName, StringComparison.Ordinal) == 0))
                     {
-                        return new ConstantNode(new ODataEnumValue(constantNode.Value.ToString(), targetTypeReference.Definition.ToString()), constantNode.Value.ToString(), targetTypeReference);
+                        string literalText = ODataUriUtils.ConvertToUriLiteral(constantNode.Value, default(ODataVersion));
+                        return new ConstantNode(new ODataEnumValue(constantNode.Value.ToString(), targetTypeReference.Definition.ToString()), literalText, targetTypeReference);
                     }
                     else
                     {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/FilterAndOrderByBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/FilterAndOrderByBuilderTests.cs
@@ -13,6 +13,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
     {
         #region test $filter
         [Fact]
+        public void BuildFilterEnum()
+        {
+            Uri queryUri = new Uri("http://gobbledygook/Pet2Set?$filter=Shape eq 'Rectangle'");
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(queryUri, actualUri);
+        }
+
+        [Fact]
         public void BuildFilterLongValuesWithOptionalSuffix()
         {
             // filter is a binaryOperatorNode and its right is a int value

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -355,6 +355,7 @@ namespace Microsoft.OData.Tests.UriParser
             FullyQualifiedNamespacePet2.AddKeys(FullyQualifiedNamespacePet2.AddStructuralProperty("ID", EdmPrimitiveTypeKind.Single, false));
             FullyQualifiedNamespacePet2.AddStructuralProperty("Color", EdmPrimitiveTypeKind.String);
             FullyQualifiedNamespacePet2.AddStructuralProperty("PetColorPattern", colorTypeReference);
+            FullyQualifiedNamespacePet2.AddStructuralProperty("Shape", new EdmEnumTypeReference(NonFlagShapeType, false));
             model.AddElement(FullyQualifiedNamespacePet2);
 
             FullyQualifiedNamespacePet3.AddKeys(FullyQualifiedNamespacePet3.AddStructuralProperty("ID", EdmPrimitiveTypeKind.Double, false));
@@ -1144,6 +1145,7 @@ namespace Microsoft.OData.Tests.UriParser
         <Property Name=""ID"" Type=""Edm.Single"" Nullable=""false"" />
         <Property Name=""Color"" Type=""Edm.String"" />
         <Property Name=""PetColorPattern"" Type=""Fully.Qualified.Namespace.ColorPattern"" Nullable=""false"" />
+        <Property Name=""Shape"" Type=""Fully.Qualified.Namespace.NonFlagShape"" Nullable=""false"" />
       </EntityType>
       <EntityType Name=""Pet3"">
         <Key>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

ConstantNode ODataEnumValue not valid property LitralText without quotes.
Therefore ODataUriExtensions.BuildUri produce not valid odata query.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*