### PR TITLE
Support parantheses and brackets in a CollectionConstantNode for IN operator

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/LiteralBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/LiteralBinder.cs
@@ -26,29 +26,40 @@ namespace Microsoft.OData.UriParser
             {
                 if (literalToken.ExpectedEdmTypeReference != null)
                 {
-                    OData.Edm.IEdmCollectionTypeReference collectionReference =
-                        literalToken.ExpectedEdmTypeReference as OData.Edm.IEdmCollectionTypeReference;
-                    if (collectionReference != null && literalToken.OriginalText[0] == '(')
-                    {
-                        // CollectionConstantNode currently supports only parenthesis-based literals.
-                        // See https://github.com/OData/odata.net/issues/1164. When we are ready to move bracket-based
-                        // literals to CollectionConstantNode, simply remove the '(' check in the if-statement.
-                        ODataCollectionValue collectionValue = literalToken.Value as ODataCollectionValue;
-                        if (collectionValue != null)
-                        {
-                            return new CollectionConstantNode(collectionValue.Items, literalToken.OriginalText, collectionReference);
-                        }
-
-                        Debug.Assert(collectionValue != null,
-                            "Literal token creates ODataCollectionValue. If this is not the case anymore, update the code path.");
-                    }
-
                     return new ConstantNode(literalToken.Value, literalToken.OriginalText, literalToken.ExpectedEdmTypeReference);
                 }
 
                 return new ConstantNode(literalToken.Value, literalToken.OriginalText);
             }
 
+            return new ConstantNode(literalToken.Value);
+        }
+
+        /// <summary>
+        /// Binds a literal value to a ConstantNode
+        /// </summary>
+        /// <param name="literalToken">Literal token to bind.</param>
+        /// <returns>Bound query node.</returns>
+        internal static QueryNode BindInLiteral(LiteralToken literalToken)
+        {
+            ExceptionUtils.CheckArgumentNotNull(literalToken, "literalToken");
+
+            if (!string.IsNullOrEmpty(literalToken.OriginalText))
+            {
+                if (literalToken.ExpectedEdmTypeReference != null)
+                {
+                    OData.Edm.IEdmCollectionTypeReference collectionReference =
+                        literalToken.ExpectedEdmTypeReference as OData.Edm.IEdmCollectionTypeReference;
+                    if (collectionReference != null)
+                    {
+                        ODataCollectionValue collectionValue = literalToken.Value as ODataCollectionValue;
+                        if (collectionValue != null)
+                        {
+                            return new CollectionConstantNode(collectionValue.Items, literalToken.OriginalText, collectionReference);
+                        }
+                    }
+                }
+            }
             return new ConstantNode(literalToken.Value);
         }
     }

--- a/src/Microsoft.OData.Core/UriParser/Binders/LiteralBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/LiteralBinder.cs
@@ -58,7 +58,9 @@ namespace Microsoft.OData.UriParser
                             return new CollectionConstantNode(collectionValue.Items, literalToken.OriginalText, collectionReference);
                         }
                     }
+                    return new ConstantNode(literalToken.Value, literalToken.OriginalText, literalToken.ExpectedEdmTypeReference);
                 }
+                return new ConstantNode(literalToken.Value, literalToken.OriginalText);
             }
             return new ConstantNode(literalToken.Value);
         }

--- a/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
@@ -357,6 +357,8 @@ namespace Microsoft.OData.UriParser
         {
             Func<QueryToken, QueryNode> InBinderMethod = (queryToken) =>
              {
+                 ExceptionUtils.CheckArgumentNotNull(queryToken, "queryToken");
+
                  if (queryToken.Kind == QueryTokenKind.Literal)
                  {
                      return LiteralBinder.BindInLiteral((LiteralToken)queryToken);

--- a/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.OData.UriParser
 {
+    using System;
     #region Namespaces
 
     using System.Collections.Generic;
@@ -354,7 +355,15 @@ namespace Microsoft.OData.UriParser
         /// <returns>The bound In token.</returns>
         protected virtual QueryNode BindIn(InToken inToken)
         {
-            InBinder inBinder = new InBinder(this.Bind);
+            Func<QueryToken, QueryNode> InBinderMethod = (queryToken) =>
+             {
+                 if (queryToken.Kind == QueryTokenKind.Literal)
+                 {
+                     return LiteralBinder.BindInLiteral((LiteralToken)queryToken);
+                 }
+                 return this.Bind(queryToken);
+             };
+            InBinder inBinder = new InBinder(InBinderMethod);
             return inBinder.BindInOperator(inToken, this.BindingState);
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/FilterAndOrderByBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/FilterAndOrderByBuilderTests.cs
@@ -420,6 +420,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
 
         [Fact]
+        public void BuildFilterWithInOperatorUsingBracketedCollectionConstant()
+        {
+            Uri queryUri = new Uri("People?$filter=ID in [1,2,3]", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(new Uri("http://gobbledygook/People?$filter=ID%20in%20[1%2C2%2C3]"), actualUri);
+        }
+
+        [Fact]
         public void BuildFilterWithInOperatorUsingSingleConstant()
         {
             Uri queryUri = new Uri("People?$filter=1 in RelatedIDs", UriKind.Relative);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -1773,6 +1773,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void FilterWithInOperationWithBracketedCollection()
+        {
+            FilterClause filter = ParseFilter("ID in [1,2,3]", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+            filter.Expression.As<InNode>().Left.As<SingleValuePropertyAccessNode>().Property.Name.Should().Be("ID");
+            filter.Expression.As<InNode>().Right.As<CollectionConstantNode>().LiteralText.Should().Be("[1,2,3]");
+        }
+
+        [Fact]
         public void FilterWithInOperationWithMismatchedClosureCollection()
         {
             Action parse = () => ParseFilter("ID in (1,2,3]", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
@@ -1883,6 +1891,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             OrderByClause orderby = ParseOrderBy("ID in (1,2,3)", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
             orderby.Expression.As<InNode>().Left.As<SingleValuePropertyAccessNode>().Property.Name.Should().Be("ID");
             orderby.Expression.As<InNode>().Right.As<CollectionConstantNode>().LiteralText.Should().Be("(1,2,3)");
+        }
+
+        [Fact]
+        public void OrderByWithInOperationWithBracketedCollection()
+        {
+            OrderByClause orderby = ParseOrderBy("ID in [1,2,3]", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+            orderby.Expression.As<InNode>().Left.As<SingleValuePropertyAccessNode>().Property.Name.Should().Be("ID");
+            orderby.Expression.As<InNode>().Right.As<CollectionConstantNode>().LiteralText.Should().Be("[1,2,3]");
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1385 and #1164 .*

### Description
This pull request modifies the bind method for the InNode to handle collection constants with a special method to support for both parentheses and brackets for a collection constant. 
#### Parsing
Previously, bracketed collection constants were parsed as constant nodes but the In operator is only compatible with collection constant nodes.  Now, we use a different method to bind literals for the InNode that parses bracketed collection as collection nodes as well.
The downside is that previously we allowed custom implementations to bind literals by overriding the bind method but that will not be possible for the In operator.
#### Generation
For the generation, we always returned the literal's text. Therefore, we will support both parentheses and brackets for the generation. 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*