### PR TITLE
Enable Uri parser to parse escape function

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -806,6 +806,8 @@ namespace Microsoft.OData {
         internal const string RequestUriProcessor_BatchedActionOnEntityCreatedInSameChangeset = "RequestUriProcessor_BatchedActionOnEntityCreatedInSameChangeset";
         internal const string RequestUriProcessor_Forbidden = "RequestUriProcessor_Forbidden";
         internal const string RequestUriProcessor_OperationSegmentBoundToANonEntityType = "RequestUriProcessor_OperationSegmentBoundToANonEntityType";
+        internal const string RequestUriProcessor_NoBoundEscapeFunctionSupported = "RequestUriProcessor_NoBoundEscapeFunctionSupported";
+        internal const string RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter = "RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter";
         internal const string General_InternalError = "General_InternalError";
         internal const string ExceptionUtils_CheckIntegerNotNegative = "ExceptionUtils_CheckIntegerNotNegative";
         internal const string ExceptionUtils_CheckIntegerPositive = "ExceptionUtils_CheckIntegerPositive";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -887,6 +887,8 @@ RequestUriProcessor_ResourceNotFound=Resource not found for the segment '{0}'.
 RequestUriProcessor_BatchedActionOnEntityCreatedInSameChangeset=Batched service action '{0}' cannot be invoked because it was bound to an entity created in the same changeset.
 RequestUriProcessor_Forbidden=Forbidden
 RequestUriProcessor_OperationSegmentBoundToANonEntityType=Found an operation bound to a non-entity type.
+RequestUriProcessor_NoBoundEscapeFunctionSupported=The request URI is not valid. The bound function binding to '{0}' supports the escape function annotation.
+RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter=The UrlEscape function '{0}' must have and only have one 'Edm.String' parameter.
 
 ; Note: The below list of error messages are common to both the OData and the OData.Query project.
 General_InternalError=An internal error '{0}' occurred.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -5657,6 +5657,20 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The request URI is not valid. The bound function binding to '{0}' supports the escape function annotation."
+        /// </summary>
+        internal static string RequestUriProcessor_NoBoundEscapeFunctionSupported(object p0) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_NoBoundEscapeFunctionSupported, p0);
+        }
+
+        /// <summary>
+        /// A string like "The UrlEscape function '{0}' must have and only have one 'Edm.String' parameter."
+        /// </summary>
+        internal static string RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter(object p0) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter, p0);
+        }
+
+        /// <summary>
         /// A string like "An internal error '{0}' occurred."
         /// </summary>
         internal static string General_InternalError(object p0) {

--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -1012,6 +1012,11 @@ namespace Microsoft.OData.UriParser
                 bindingType = (previousSegment is EachSegment) ? previousSegment.TargetEdmType : previousSegment.EdmType;
             }
 
+            if (identifier != null && identifier.Length >= 1 && identifier[0] == ':' && bindingType != null)
+            {
+                identifier = ResolveEscapeFunction(identifier, bindingType, configuration.Model, out parenthesisExpression);
+            }
+
             ICollection<OperationSegmentParameter> resolvedParameters;
             IEdmOperation singleOperation;
             if (!TryBindingParametersAndMatchingOperation(identifier, parenthesisExpression, bindingType, this.configuration, out resolvedParameters, out singleOperation))
@@ -1592,6 +1597,46 @@ namespace Microsoft.OData.UriParser
             }
 
             throw new ODataException(Strings.PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint(fullTypeName, kind, name));
+        }
+
+        private static string ResolveEscapeFunction(string identifier, IEdmType bindingType, IEdmModel model, out string parenthesisExpression)
+        {
+            Debug.Assert(identifier != null && identifier.Length >= 1 && identifier[0] == ':');
+            Debug.Assert(bindingType != null);
+
+            IEnumerable<IEdmOperation> operations = model.FindBoundOperations(bindingType);
+            IEdmFunction function = operations.OfType<IEdmFunction>().FirstOrDefault(f => IsUrlEscapeFunction(model, f));
+            if (function == null)
+            {
+                throw ExceptionUtil.CreateBadRequestError(ODataErrorStrings.RequestUriProcessor_NoBoundEscapeFunctionSupported(bindingType.FullTypeName()));
+            }
+
+            if (function.Parameters == null || function.Parameters.Count() != 2 || !function.Parameters.ElementAt(1).Type.IsString())
+            {
+                throw ExceptionUtil.CreateBadRequestError(ODataErrorStrings.RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter(function.FullName()));
+            }
+
+            parenthesisExpression = function.Parameters.ElementAt(1).Name + "='" + identifier.Substring(1) + "'";
+            return function.FullName();
+        }
+
+        internal static bool IsUrlEscapeFunction(IEdmModel model, IEdmFunction function)
+        {
+            Debug.Assert(model != null);
+            Debug.Assert(function != null);
+
+            IEdmVocabularyAnnotation annotation = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(function,
+                Edm.Vocabularies.Community.V1.CommunityVocabularyModel.UrlEscapeFunctionTerm).FirstOrDefault();
+            if (annotation != null)
+            {
+                IEdmBooleanConstantExpression tagConstant = annotation.Value as IEdmBooleanConstantExpression;
+                if (tagConstant != null)
+                {
+                    return tagConstant.Value;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriPathParser.cs
@@ -91,7 +91,39 @@ namespace Microsoft.OData.UriParser
                             throw new ODataException(Strings.UriQueryPathParser_TooManySegments);
                         }
 
-                        segments.Add(Uri.UnescapeDataString(segment));
+                        if (segment.Length != 0 && segment[segment.Length - 1] == ':' && i != uriSegments.Length - 1)
+                        {
+                            segment = segment.Substring(0, segment.Length - 1);
+                            segments.Add(Uri.UnescapeDataString(segment));
+
+                            int j = i + 1;
+                            for(; j < uriSegments.Length; j++)
+                            {
+                                string subSegment = uriSegments[j];
+                                if (subSegment.Length != 0 && subSegment[subSegment.Length - 1] == ':')
+                                {
+                                    break;
+                                }
+                            }
+
+                            if (j == uriSegments.Length)
+                            {
+                                string escapedSegment = ":" + String.Join("/", uriSegments, i + 1, uriSegments.Length - i - 1);
+                                segments.Add(Uri.UnescapeDataString(escapedSegment));
+                                break;
+                            }
+                            else
+                            {
+                                uriSegments[j] = uriSegments[j].Substring(0, uriSegments[j].Length - 1); // remove the last ':'
+                                string escapedSegment = ":" + String.Join("/", uriSegments, i + 1, j - i);
+                                segments.Add(Uri.UnescapeDataString(escapedSegment));
+                                i = j;
+                            }
+                        }
+                        else
+                        {
+                            segments.Add(Uri.UnescapeDataString(segment));
+                        }
                     }
                 }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -10,10 +10,12 @@ using System.Globalization;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OData.Edm.Vocabularies.Community.V1;
 using Microsoft.OData.UriParser;
 using Xunit;
 using ODataErrorStrings = Microsoft.OData.Strings;
-using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OData.Tests.UriParser
 {
@@ -1034,6 +1036,96 @@ namespace Microsoft.OData.Tests.UriParser
 
             Uri resultUri = uri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(fullUriString, Uri.UnescapeDataString(resultUri.OriginalString));
+        }
+
+        [Fact]
+        public void ParseEscapeFunctionUrlReturnsTheSameODataPath()
+        {
+            // Arrange
+            IEdmModel model = GetEdmModelWithEscapeFunction(escape: true);
+
+            // Act
+            string fullUriString = ServiceRoot + "/root/NS.Function(path='photos%2F2018%2FFebruray')";
+            ODataUriParser parser = new ODataUriParser(model, ServiceRoot, new Uri(fullUriString));
+            var functionPath = parser.ParsePath();
+
+            fullUriString = ServiceRoot + "/root:/photos/2018/Februray";
+            parser = new ODataUriParser(model, ServiceRoot, new Uri(fullUriString));
+            var escapePath = parser.ParsePath();
+
+            // Assert
+            Assert.True(functionPath.Equals(escapePath));
+
+            Assert.Equal(2, escapePath.Count());
+            OperationSegment segment = Assert.IsType<OperationSegment>(escapePath.Last());
+            Assert.Equal("NS.Function", segment.Operations.First().FullName());
+        }
+
+        [Fact]
+        public void ParseEscapeFunctionUrlThrowsWithoutEscapeFunction()
+        {
+            // Arrange
+            IEdmModel model = GetEdmModelWithEscapeFunction(escape: false);
+
+            // Act
+            var fullUriString = ServiceRoot + "/root:/photos/2018/Februray";
+            var parser = new ODataUriParser(model, ServiceRoot, new Uri(fullUriString));
+            Action test = () => parser.ParsePath();
+
+            // Assert
+            var odataException = Assert.Throws<ODataException>(test);
+            Assert.Equal(ODataErrorStrings.RequestUriProcessor_NoBoundEscapeFunctionSupported("NS.OneDrive"), odataException.Message);
+        }
+
+        [Fact]
+        public void ParseEscapeFunctionUrlThrowsInvalidEscapeFunction()
+        {
+            // Arrange
+            IEdmModel model = GetEdmModelWithEscapeFunction(escape: true, multipleParameter: true);
+
+            // Act
+            var fullUriString = ServiceRoot + "/root:/photos/2018/Februray";
+            var parser = new ODataUriParser(model, ServiceRoot, new Uri(fullUriString));
+            Action test = () => parser.ParsePath();
+
+            // Assert
+            var odataException = Assert.Throws<ODataException>(test);
+            Assert.Equal(ODataErrorStrings.RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter("NS.Function"), odataException.Message);
+        }
+
+        internal static IEdmModel GetEdmModelWithEscapeFunction(bool escape, bool multipleParameter = false)
+        {
+            EdmModel model = new EdmModel();
+            EdmEntityType entityType = new EdmEntityType("NS", "OneDrive");
+            entityType.AddKeys(entityType.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+
+            EdmFunction function = new EdmFunction("NS", "Function", EdmCoreModel.Instance.GetInt32(true), true, null, false);
+            function.AddParameter("entity", new EdmEntityTypeReference(entityType, true));
+            function.AddParameter("path", EdmCoreModel.Instance.GetString(true));
+
+            if (multipleParameter)
+            {
+                function.AddParameter("path2", EdmCoreModel.Instance.GetString(true));
+            }
+
+            model.AddElement(entityType);
+            model.AddElement(function);
+
+            EdmEntityContainer container = new EdmEntityContainer("Default", "Container");
+            container.AddSingleton("root", entityType);
+            model.AddElement(container);
+
+            if (escape)
+            {
+                IEdmBooleanConstantExpression booleanConstant = new EdmBooleanConstant(true);
+                IEdmTerm term = CommunityVocabularyModel.UrlEscapeFunctionTerm;
+
+                EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(function, term, booleanConstant);
+                annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+                model.SetVocabularyAnnotation(annotation);
+            }
+
+            return model;
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPathParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPathParserTests.cs
@@ -199,6 +199,28 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
 #endif
         }
 
+        [Theory]
+        [InlineData("root:/", new[] { "root", ":" })]
+        [InlineData("root:/:/permissions", new[] { "root", ":", "permissions" })]
+        [InlineData("root:/photos/2018/February", new[] { "root", ":photos/2018/February" } )]
+        [InlineData("root:/photos%2f2018%2fFebruary", new[] { "root", ":photos/2018/February" } )]
+        [InlineData("root:/photos/2018/February:/permissions", new[] { "root", ":photos/2018/February", "permissions" } )]
+        [InlineData("root:/photos:2018:/permissions:/abc", new[] { "root", ":photos:2018", "permissions", ":abc" } )]
+        [InlineData("EntitySet('key'):/xyz:/perm", new[] { "EntitySet('key')", ":xyz", "perm" } )]
+        [InlineData(":/xyz:/perm", new[] { "", ":xyz", "perm" })]
+        public void ParsePathShouldAllowEscapeFunctionPattern(string pattern, string[] expected)
+        {
+            // Arrange
+            var fullUrl = new Uri(this.baseUri.AbsoluteUri + pattern);
+
+            // Act
+            var actual = this.pathParser.ParsePathIntoSegments(fullUrl, this.baseUri);
+
+            // Assert
+            Assert.Equal(expected.Length, actual.Count);
+            Assert.Equal(expected, actual);
+        }
+
         [Fact]
         public void ParsePathRequiresBaseUriToMatch()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Currently, OneDrive supports path segments following any driveItem, and maps it to a bound function.  i.e.;

     ` root:/photos/2018/February:/permissions`

would be translated to:

       `root/oneDrive.getByPath(path='photos/2018/February')/permissions`

while:

        `root:/photos/2018/February`

would be translated to:

  ` root/oneDrive.getByTerminalPath(path='photos/2018/February')`

This PR enables the above translation. 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
