### PR TITLE
Fix issue #1390, ODataUriParser can't pass function call with all omi…

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/FunctionOverloadResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/FunctionOverloadResolver.cs
@@ -180,7 +180,8 @@ namespace Microsoft.OData.UriParser
             else if (bindingType != null)
             {
                 // Filter out functions with more than one parameter. Actions should not be filtered as the parameters are in the payload not the uri
-                candidateMatchingOperations = candidateMatchingOperations.Where(o => (o.IsFunction() && o.Parameters.Count() == 1) || o.IsAction()).ToList();
+                candidateMatchingOperations = candidateMatchingOperations.Where(o =>
+                (o.IsFunction() && (o.Parameters.Count() == 1 || o.Parameters.Skip(1).All(p => p is IEdmOptionalParameter))) || o.IsAction()).ToList();
             }
             else
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/FunctionOverloadResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/FunctionOverloadResolverTests.cs
@@ -310,17 +310,17 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
 
             IEdmOperation function;
 
-            // Resolve overload function without parameter. Be noted, it picks the 
+            // Resolve overload function without parameter. Be noted, it picks the one with no optional parameters.
             var parameters = new string[] { };
             FunctionOverloadResolver.ResolveOperationFromList("NS.Function", parameters, int32TypeReference.Definition, model, out function, DefaultUriResolver).Should().BeTrue();
             function.Should().BeSameAs(functionWithoutParameter);
 
-            // Resolve overload function with one required and three optional parameters (one omitted).
+            // Resolve overload function with one bound and two optional parameters (one omitted).
             parameters = new string[] { "Parameter1" };
             FunctionOverloadResolver.ResolveOperationFromList("NS.Function", parameters, int32TypeReference.Definition, model, out function, DefaultUriResolver).Should().BeTrue();
             function.Should().BeSameAs(functionWithAllOptionalParameters);
 
-            // Resolve overload function with one required and three optional parameters (one omitted).
+            // Resolve overload function with one bound and two optional parameters (both specified).
             parameters = new string[] { "Parameter1", "Parameter2" };
             FunctionOverloadResolver.ResolveOperationFromList("NS.Function", parameters, int32TypeReference.Definition, model, out function, DefaultUriResolver).Should().BeTrue();
             function.Should().BeSameAs(functionWithAllOptionalParameters);


### PR DESCRIPTION
…tted optional parameters

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1390.*

### Description

If a function call is with all omitted optional parameter, OData Uri parser can't parse it.
See the detail in the issue.

For example:
`NS.GetMinSalary` is a bound function with two optional parameters, one is "minSalary", the other is "maxSalary".

OData Uri parser can parse:
```C#
~/Customers/NS.GetMinSalary(minSalary=1,maxSalary=2)
~/Customers/NS.GetMinSalary(minSalary=1)
```
But, fails to the following:

```C#
~/Customers/NS.GetMinSalary()
```
This PR is fix that.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
