### PR TITLE
Revert empty parentheses for expanded navigation properties without su…

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
@@ -43,8 +43,9 @@ namespace Microsoft.OData.Evaluation
         /// </summary>
         /// <param name="resourceState">Resource state to use as reference for information needed by the builder.</param>
         /// <param name="useKeyAsSegment">true if keys should go in separate segments in auto-generated URIs, false if they should go in parentheses.</param>
+        /// <param name="isDelta">true if the payload being read is a delta payload.</param>
         /// <returns>An entity metadata builder.</returns>
-        ODataResourceMetadataBuilder GetResourceMetadataBuilderForReader(IODataJsonLightReaderResourceState resourceState, bool useKeyAsSegment);
+        ODataResourceMetadataBuilder GetResourceMetadataBuilderForReader(IODataJsonLightReaderResourceState resourceState, bool useKeyAsSegment, bool isDelta);
 
         /// <summary>
         /// Gets the list of operations that are bindable to a type.
@@ -233,8 +234,9 @@ namespace Microsoft.OData.Evaluation
         /// </summary>
         /// <param name="resourceState">Resource state to use as reference for information needed by the builder.</param>
         /// <param name="useKeyAsSegment">true if keys should go in separate segments in auto-generated URIs, false if they should go in parentheses.</param>
+        /// <param name="isDelta">true if the payload being read is a delta payload</param>
         /// <returns>A resource metadata builder.</returns>
-        public ODataResourceMetadataBuilder GetResourceMetadataBuilderForReader(IODataJsonLightReaderResourceState resourceState, bool useKeyAsSegment)
+        public ODataResourceMetadataBuilder GetResourceMetadataBuilderForReader(IODataJsonLightReaderResourceState resourceState, bool useKeyAsSegment, bool isDelta = false)
         {
             Debug.Assert(resourceState != null, "resource != null");
 
@@ -242,7 +244,7 @@ namespace Microsoft.OData.Evaluation
             if (resourceState.MetadataBuilder == null)
             {
                 ODataResourceBase resource = resourceState.Resource;
-                if (this.isResponse)
+                if (this.isResponse && !isDelta)
                 {
                     ODataTypeAnnotation typeAnnotation = resource.TypeAnnotation;
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeltaWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeltaWriter.cs
@@ -60,9 +60,6 @@ namespace Microsoft.OData.JsonLight
         {
             Debug.Assert(jsonLightOutputContext != null, "jsonLightOutputContext != null");
 
-            // TODO: Replace the assertion with ODataException.
-            Debug.Assert(jsonLightOutputContext.WritingResponse, "jsonLightOutputContext.WritingResponse is true");
-
             this.navigationSource = navigationSource;
             this.entityType = entityType;
             this.jsonLightOutputContext = jsonLightOutputContext;

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -254,7 +254,7 @@ namespace Microsoft.OData.JsonLight
                     contextUriAnnotationValue,
                     payloadKind,
                     this.MessageReaderSettings.ClientCustomTypeResolver,
-                    this.JsonLightInputContext.ReadingResponse,
+                    this.JsonLightInputContext.ReadingResponse || payloadKind == ODataPayloadKind.Delta,
                     this.JsonLightInputContext.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata);
             }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -819,7 +819,7 @@ namespace Microsoft.OData.JsonLight
                 ? null
                 : this.jsonLightResourceDeserializer.ContextUriParseResult.SelectQueryOption;
 
-            SelectedPropertiesNode selectedProperties = SelectedPropertiesNode.Create(selectQueryOption, this.CurrentResourceType, this.jsonLightInputContext.Model);
+            SelectedPropertiesNode selectedProperties = SelectedPropertiesNode.Create(selectQueryOption, this.CurrentResourceType, this.jsonLightInputContext.Model, this.jsonLightInputContext.MessageReaderSettings.Version);
 
             if (this.ReadingResourceSet)
             {

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -1024,7 +1024,8 @@ namespace Microsoft.OData.JsonLight
                 ODataResourceMetadataBuilder builder =
                     this.jsonLightResourceDeserializer.MetadataContext.GetResourceMetadataBuilderForReader(
                         this.CurrentResourceState,
-                        this.jsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment);
+                        this.jsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment,
+                        this.ReadingDelta);
                 if (builder != currentResource.MetadataBuilder)
                 {
                     ODataNestedResourceInfo parentNestInfo = this.ParentNestedInfo;
@@ -1750,27 +1751,24 @@ namespace Microsoft.OData.JsonLight
                         contextUriStr,
                         this.ReadingDelta ? ODataPayloadKind.Delta : ODataPayloadKind.Resource,
                         this.jsonLightResourceDeserializer.MessageReaderSettings.ClientCustomTypeResolver,
-                        this.jsonLightInputContext.ReadingResponse);
+                        this.jsonLightInputContext.ReadingResponse || this.ReadingDelta);
                     if (parseResult != null)
                     {
                         resourceKind = parseResult.DeltaKind;
-                        if (this.jsonLightInputContext.ReadingResponse)
+                        // a top-level (deleted) resource in a delta response can come from any entity set
+                        if (this.ReadingDelta && this.IsTopLevel && (resourceKind == ODataDeltaKind.Resource || resourceKind == ODataDeltaKind.DeletedEntry))
                         {
-                            // a top-level (deleted) resource in a delta response can come from any entity set
-                            if (this.ReadingDelta && this.IsTopLevel && (resourceKind == ODataDeltaKind.Resource || resourceKind == ODataDeltaKind.DeletedEntry))
+                            IEdmStructuredType parsedType = parseResult.EdmType as IEdmStructuredType;
+                            if (parsedType != null)
                             {
-                                IEdmStructuredType parsedType = parseResult.EdmType as IEdmStructuredType;
-                                if (parsedType != null)
-                                {
-                                    resourceType = parsedType;
-                                    source = parseResult.NavigationSource;
-                                }
+                                resourceType = parsedType;
+                                source = parseResult.NavigationSource;
                             }
-                            else
-                            {
-                                ReaderValidationUtils.ValidateResourceSetOrResourceContextUri(parseResult, this.CurrentScope,
-                                    false);
-                            }
+                        }
+                        else
+                        {
+                            ReaderValidationUtils.ValidateResourceSetOrResourceContextUri(parseResult, this.CurrentScope,
+                                false);
                         }
                     }
                 }
@@ -2099,7 +2097,8 @@ namespace Microsoft.OData.JsonLight
                 ODataResourceMetadataBuilder resourceMetadataBuilder =
                     this.jsonLightResourceDeserializer.MetadataContext.GetResourceMetadataBuilderForReader(
                         this.CurrentResourceState,
-                        this.jsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment);
+                        this.jsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment,
+                        this.ReadingDelta);
                 nestedResourceInfo.MetadataBuilder = resourceMetadataBuilder;
             }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
@@ -1155,7 +1155,8 @@ namespace Microsoft.OData.JsonLight
 
             ODataResourceMetadataBuilder builder =
                 this.MetadataContext.GetResourceMetadataBuilderForReader(resourceState,
-                    this.JsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment);
+                    this.JsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment,
+                    /*isDelta*/ false);
             mediaResource.SetMetadataBuilder(builder, /*propertyName*/ null);
             resource.MediaResource = mediaResource;
         }
@@ -1579,7 +1580,8 @@ namespace Microsoft.OData.JsonLight
 
             ODataResourceMetadataBuilder builder =
                 this.MetadataContext.GetResourceMetadataBuilderForReader(resourceState,
-                    this.JsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment);
+                    this.JsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment,
+                    /*isDelta*/ false);
 
             // Note that we set the metadata builder even when streamProperty is null, which is the case when the stream property is undeclared.
             // For undeclared stream properties, we will apply conventional metadata evaluation just as declared stream properties.
@@ -1771,7 +1773,8 @@ namespace Microsoft.OData.JsonLight
         {
             ODataResourceMetadataBuilder builder =
                 this.MetadataContext.GetResourceMetadataBuilderForReader(resourceState,
-                    this.JsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment);
+                    this.JsonLightInputContext.ODataSimplifiedOptions.EnableReadingKeyAsSegment,
+                    /*isDelta*/ false);
             operation.SetMetadataBuilder(builder, this.ContextUriParseResult.MetadataDocumentUri);
         }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
@@ -605,23 +605,18 @@ namespace Microsoft.OData.JsonLight
                     "We should have verified that resource sets can only be written into IsCollection = true links in requests.");
 
                 string propertyName = this.ParentNestedResourceInfo.Name;
-                if (this.jsonLightOutputContext.WritingResponse)
-                {
-                    // Write the inline count if it's available.
-                    this.WriteResourceSetCount(deltaResourceSet.Count, propertyName);
 
-                    // Write the next link if it's available.
-                    this.WriteResourceSetNextLink(deltaResourceSet.NextPageLink, propertyName);
+                // Write the inline count if it's available.
+                this.WriteResourceSetCount(deltaResourceSet.Count, propertyName);
 
-                    //// Write the odata type.
-                    // this.jsonLightResourceSerializer.WriteResourceSetStartMetadataProperties(deltaResourceSet, propertyName, expectedResourceTypeName, isUndeclared);
+                // Write the next link if it's available.
+                this.WriteResourceSetNextLink(deltaResourceSet.NextPageLink, propertyName);
 
-                    //// Write the name for the nested delta payload
-                    this.jsonWriter.WritePropertyAnnotationName(propertyName, JsonLightConstants.ODataDeltaPropertyName);
+                //// Write the name for the nested delta payload
+                this.jsonWriter.WritePropertyAnnotationName(propertyName, JsonLightConstants.ODataDeltaPropertyName);
 
-                    // Start array which will hold the entries in the nested delta resource set.
-                    this.jsonWriter.StartArrayScope();
-                }
+                // Start array which will hold the entries in the nested delta resource set.
+                this.jsonWriter.StartArrayScope();
             }
         }
 

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -99,6 +99,8 @@ namespace Microsoft.OData {
         internal const string ODataWriterCore_WriteEndCalledInInvalidState = "ODataWriterCore_WriteEndCalledInInvalidState";
         internal const string ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties = "ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties";
         internal const string ODataWriterCore_QueryCountInRequest = "ODataWriterCore_QueryCountInRequest";
+        internal const string ODataWriterCore_QueryDeltaLinkInRequest = "ODataWriterCore_QueryDeltaLinkInRequest";
+        internal const string ODataWriterCore_QueryNextLinkInRequest = "ODataWriterCore_QueryNextLinkInRequest";
         internal const string ODataWriterCore_CannotWriteDeltaWithResourceSetWriter = "ODataWriterCore_CannotWriteDeltaWithResourceSetWriter";
         internal const string ODataWriterCore_NestedContentNotAllowedIn40DeletedEntry = "ODataWriterCore_NestedContentNotAllowedIn40DeletedEntry";
         internal const string ODataWriterCore_CannotWriteTopLevelResourceSetWithResourceWriter = "ODataWriterCore_CannotWriteTopLevelResourceSetWithResourceWriter";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -45,6 +45,8 @@ ODataWriterCore_WriteEndCalledInInvalidState=ODataWriter.WriteEnd was called in 
 
 ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties=No Id or key properties were found. A resource in a delta response requires an ID or key properties be specified.
 ODataWriterCore_QueryCountInRequest=The ODataResourceSet.Count must be null for request payloads. Query counts are only supported in responses.
+ODataWriterCore_QueryNextLinkInRequest=The NextPageLink must be null for request payloads. Next page links are only supported in responses.
+ODataWriterCore_QueryDeltaLinkInRequest=The DeltaLink must be null for request payloads. Delta links are only supported in responses.
 ODataWriterCore_CannotWriteDeltaWithResourceSetWriter=Cannot write a delta deleted resource, link, or deleted link using ODataResourceSetWriter. Please use an ODataDeltaResourceSetWriter.
 ODataWriterCore_NestedContentNotAllowedIn40DeletedEntry=Nested content is not allowed in an OData 4.0 deleted entry. For content in deleted entries, please specify OData 4.01 or greater.
 ODataWriterCore_CannotWriteTopLevelResourceSetWithResourceWriter=Cannot write a top-level resource set with a writer that was created to write a top-level resource.

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -287,7 +287,7 @@ namespace Microsoft.OData
                 }
                 else
                 {
-                    return CreateSelectExpandContextUriSegment(odataUri.SelectAndExpand);
+                    return CreateSelectExpandContextUriSegment(odataUri.SelectAndExpand, version);
                 }
             }
 
@@ -385,13 +385,14 @@ namespace Microsoft.OData
         /// Build the expand clause for a given level in the selectExpandClause
         /// </summary>
         /// <param name="selectExpandClause">the current level select expand clause</param>
+        /// <param name="version">OData Version of the response</param>
         /// <returns>the select and expand segment for context url in this level.</returns>
-        private static string CreateSelectExpandContextUriSegment(SelectExpandClause selectExpandClause)
+        private static string CreateSelectExpandContextUriSegment(SelectExpandClause selectExpandClause, ODataVersion version)
         {
             if (selectExpandClause != null)
             {
                 string contextUri;
-                selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, out contextUri);
+                selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, version, out contextUri);
                 if (!string.IsNullOrEmpty(contextUri))
                 {
                     return ODataConstants.ContextUriProjectionStart + contextUri + ODataConstants.ContextUriProjectionEnd;
@@ -404,11 +405,12 @@ namespace Microsoft.OData
         /// <summary>Process sub expand node, contact with subexpand result</summary>
         /// <param name="expandNode">The current expanded node.</param>
         /// <param name="subExpand">Generated sub expand node.</param>
+        /// <param name="version">OData Version of the generated response.</param>
         /// <returns>The generated expand string.</returns>
-        private static string ProcessSubExpand(string expandNode, string subExpand)
+        private static string ProcessSubExpand(string expandNode, string subExpand, ODataVersion version)
         {
-
-            return expandNode + ODataConstants.ContextUriProjectionStart + subExpand + ODataConstants.ContextUriProjectionEnd;
+            return string.IsNullOrEmpty(subExpand) && version <= ODataVersion.V4 ? expandNode :
+                            expandNode + ODataConstants.ContextUriProjectionStart + subExpand + ODataConstants.ContextUriProjectionEnd;
         }
 
         /// <summary>Create combined result string using selected items list and expand items list.</summary>

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -417,13 +417,33 @@ namespace Microsoft.OData
         /// <param name="selectList">A list of selected item names.</param>
         /// <param name="expandList">A list of sub expanded item names.</param>
         /// <returns>The generated expand string.</returns>
-        private static string CombineSelectAndExpandResult(IList<string> selectList, IList<string> expandList)
+        private static string CombineSelectAndExpandResult(IList<string> selectList, IList<string> expandList, ODataVersion version)
         {
             string currentExpandClause = string.Empty;
-
+            IList<string> RemoveFromExpandList = new List<string>();
             if (selectList.Any())
             {
+                if (version <= ODataVersion.V4)
+                {
+                    foreach (var item in expandList)
+                    {
+                        //For backwards compatibility, we want to remove duplicate properties in select and expand list for v4
+                        int idx = item.IndexOf(ODataConstants.ContextUriProjectionStart);
+                        if (idx >= 0)
+                        {
+                            selectList.Remove(item.Substring(0, idx));
+                        }
+                        else if(selectList.Contains(item))
+                        {
+                            RemoveFromExpandList.Add(item);
+                        }
+                    }
 
+                    foreach (string s in RemoveFromExpandList)
+                    {
+                        expandList.Remove(s);
+                    }
+                }
                 currentExpandClause += String.Join(ODataConstants.ContextUriProjectionPropertySeparator, selectList.ToArray());
             }
 

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -283,7 +283,7 @@ namespace Microsoft.OData
             get
             {
                 return this.SelectExpandClause != null
-                    ? SelectedPropertiesNode.Create(this.SelectExpandClause)
+                    ? SelectedPropertiesNode.Create(this.SelectExpandClause, this.Version ?? ODataVersion.V4)
                     : new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree);
             }
         }

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -1215,17 +1215,19 @@ namespace Microsoft.OData
 
             this.InterceptException(() =>
             {
-                // Verify query count
-                if (deltaResourceSet.Count.HasValue)
+                // Check that links are not set for requests
+                if (!this.outputContext.WritingResponse)
                 {
-                    // Check that Count is not set for requests
-                    if (!this.outputContext.WritingResponse)
+                    if (deltaResourceSet.NextPageLink != null)
                     {
-                        this.ThrowODataException(Strings.ODataWriterCore_QueryCountInRequest, deltaResourceSet);
+                        this.ThrowODataException(Strings.ODataWriterCore_QueryNextLinkInRequest, deltaResourceSet);
                     }
 
-                    // Verify version requirements
+                    if (deltaResourceSet.DeltaLink != null)
+                    {
+                        this.ThrowODataException(Strings.ODataWriterCore_QueryDeltaLinkInRequest, deltaResourceSet);
                     }
+                }
 
                 this.StartDeltaResourceSet(deltaResourceSet);
             });
@@ -1747,6 +1749,8 @@ namespace Microsoft.OData
                         {
                             throw new ODataException(Strings.ResourceSetWithoutExpectedTypeValidator_IncompatibleTypes(resourceType.FullTypeName(), resourceScope.NavigationSource.EntityType()));
                         }
+
+                        resourceScope.ResourceTypeFromMetadata = resourceScope.NavigationSource.EntityType();
                     }
                     else
                     {
@@ -2003,7 +2007,7 @@ namespace Microsoft.OData
                 {
                     selectedProperties = currentScope.SelectedProperties.GetSelectedPropertiesForNavigationProperty(currentScope.ResourceType, nestedResourceInfo.Name);
 
-                    if (this.outputContext.WritingResponse)
+                    if (this.outputContext.WritingResponse || this.writingDelta)
                     {
                         ODataPath odataPath = odataUri.Path;
                         IEdmStructuredType currentResourceType = currentScope.ResourceType;

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -249,6 +249,28 @@ namespace Microsoft.OData {
             }
         }
 
+
+        /// A string like "The DeltaLink must be null for request payloads. Delta links are only supported in responses."
+        /// </summary>
+        internal static string ODataWriterCore_QueryDeltaLinkInRequest
+        {
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataWriterCore_QueryDeltaLinkInRequest);
+            }
+        }
+
+        /// <summary>
+        /// A string like "The NextPageLink must be null for request payloads. Next page links are only supported in responses."
+        /// </summary>
+        internal static string ODataWriterCore_QueryNextLinkInRequest
+        {
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataWriterCore_QueryNextLinkInRequest);
+            }
+        }
+
         /// <summary>
         /// A string like "Cannot write a delta deleted resource, link, or deleted link using ODataResourceSetWriter. Please use an ODataDeltaResourceSetWriter."
         /// </summary>

--- a/src/Microsoft.OData.Core/ReaderValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ReaderValidationUtils.cs
@@ -584,10 +584,6 @@ namespace Microsoft.OData
             }
 
             Debug.Assert(contextUriParseResult != null, "contextUriParseResult != null");
-            Debug.Assert(
-                contextUriParseResult.Path != null && contextUriParseResult.Path.IsUndeclared() ||
-                contextUriParseResult.NavigationSource != null || (contextUriParseResult.EdmType != null && contextUriParseResult.EdmType is IEdmStructuredType),
-                "contextUriParseResult.Path != null && contextUriParseResult.Path.IsUndeclared() || contextUriParseResult.NavigationSource != null || (contextUriParseResult.EdmType != null && contextUriParseResult.EdmType is IEdmStructuredType)");
 
             // Set the navigation source name or make sure the navigation source names match.
             if (scope.NavigationSource == null)

--- a/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
+++ b/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
@@ -256,8 +256,9 @@ namespace Microsoft.OData
         /// Creates a node from the given SelectExpandClause.
         /// </summary>
         /// <param name="selectExpandClause">The value of the $select query option.</param>
+        /// <param name="version">OData Version.</param>
         /// <returns>A tree representation of the selected properties specified in the query option.</returns>
-        internal static SelectedPropertiesNode Create(SelectExpandClause selectExpandClause)
+        internal static SelectedPropertiesNode Create(SelectExpandClause selectExpandClause, ODataVersion version)
         {
             if (selectExpandClause.AllSelected
             && selectExpandClause.SelectedItems.OfType<ExpandedNavigationSelectItem>().All(_ => _.SelectAndExpand.AllSelected))
@@ -266,7 +267,7 @@ namespace Microsoft.OData
                 return new SelectedPropertiesNode(SelectionType.EntireSubtree);
             }
 
-            return CreateFromSelectExpandClause(selectExpandClause);
+            return CreateFromSelectExpandClause(selectExpandClause, version);
         }
 
         /// <summary>
@@ -805,19 +806,21 @@ namespace Microsoft.OData
 
         /// <summary>Create SelectedPropertiesNode from SelectExpandClause.</summary>
         /// <param name="selectExpandClause">The SelectExpandClause representing $select and $expand clauses.</param>
+        /// <param name="version">OData Version.</param>
         /// <returns>SelectedPropertiesNode generated using <paramref name="selectExpandClause"/></returns>
-        private static SelectedPropertiesNode CreateFromSelectExpandClause(SelectExpandClause selectExpandClause)
+        private static SelectedPropertiesNode CreateFromSelectExpandClause(SelectExpandClause selectExpandClause, ODataVersion version)
         {
             SelectedPropertiesNode node;
-            selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, out node);
+            selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, version, out node);
             return node;
         }
 
         /// <summary>Process sub expand node, set name for the node.</summary>
         /// <param name="nodeName">Node name for the subexpandnode.</param>
         /// <param name="subExpandNode">Generated sub expand node.</param>
+        /// <param name="version">OData Version.</param>
         /// <returns>The sub expanded node passed in.</returns>
-        private static SelectedPropertiesNode ProcessSubExpand(string nodeName, SelectedPropertiesNode subExpandNode)
+        private static SelectedPropertiesNode ProcessSubExpand(string nodeName, SelectedPropertiesNode subExpandNode, ODataVersion version)
         {
             if (subExpandNode != null)
             {

--- a/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
+++ b/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
@@ -478,7 +478,7 @@ namespace Microsoft.OData
                 return entityType.StructuralProperties().Where(sp => sp.Type.IsStream()).ToDictionary(sp => sp.Name, StringComparer.Ordinal);
             }
 
-            IDictionary<string, IEdmStructuralProperty> selectedStreamProperties = 
+            IDictionary<string, IEdmStructuralProperty> selectedStreamProperties =
                 this.selectedProperties == null ?
                     new Dictionary<string, IEdmStructuralProperty>() :
                     this.selectedProperties
@@ -638,7 +638,7 @@ namespace Microsoft.OData
             else if (this.structuredType == null || this.structuredType.NavigationProperties().Any(_ => _.Name.Equals(token, StringComparison.Ordinal)))
             {
                 // #2
-                // Note that action and function names in a contextUrl *SHOULD* always be qualified, 
+                // Note that action and function names in a contextUrl *SHOULD* always be qualified,
                 // So if we can't validate against the structured type, should assume it's a nav prop
                 found = true;
             }
@@ -834,7 +834,7 @@ namespace Microsoft.OData
         /// <param name="selectList">An enumerable of selected item names.</param>
         /// <param name="expandList">An enumerable of sub expanded nodes.</param>
         /// <returns>The generated SelectedPropertiesNode.</returns>
-        private static SelectedPropertiesNode CombineSelectAndExpandResult(IEnumerable<string> selectList, IEnumerable<SelectedPropertiesNode> expandList)
+        private static SelectedPropertiesNode CombineSelectAndExpandResult(IList<string> selectList, IList<SelectedPropertiesNode> expandList, ODataVersion version)
         {
             List<string> rawSelect = selectList.ToList();
             rawSelect.RemoveAll(expandList.Select(m => m.nodeName).Contains);

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="combineSelectAndExpand">The method to combine select and expand result lists.</param>
         /// <param name="version">OData version to use in traversing the selectExpand clause</param>
         /// <param name="result">The result of the traversing.</param>
-        internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, ODataVersion, T> processSubResult, Func<IList<string>, IList<T>, T> combineSelectAndExpand, ODataVersion version, out T result)
+        internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, ODataVersion, T> processSubResult, Func<IList<string>, IList<T>, ODataVersion, T> combineSelectAndExpand, ODataVersion version, out T result)
         {
             List<string> selectList = selectExpandClause.GetCurrentLevelSelectList();
             List<T> expandList = new List<T>();
@@ -130,7 +130,7 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
-            result = combineSelectAndExpand(selectList, expandList);
+            result = combineSelectAndExpand(selectList, expandList, version);
         }
 
         /// <summary>
@@ -221,7 +221,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="selectList">A list of selected item names.</param>
         /// <param name="expandList">A list of sub expanded item names.</param>
         /// <returns>The generated expand string.</returns>
-        private static string CombineSelectAndExpandResult(IList<string> selectList, IList<string> expandList)
+        private static string CombineSelectAndExpandResult(IList<string> selectList, IList<string> expandList, ODataVersion version)
         {
             string currentExpandClause = "";
             if (selectList.Any())

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -75,7 +75,7 @@ namespace Microsoft.OData.UriParser
             selectClause = new StringBuilder();
             expandClause = new StringBuilder();
             selectClause.Append(BuildTopLevelSelect(selectExpandClause));
-            expandClause.Append(BuildExpandsForNode(selectExpandClause));
+            expandClause.Append(BuildExpandsForNode(selectExpandClause, version));
         }
 
         /// <summary>
@@ -95,8 +95,9 @@ namespace Microsoft.OData.UriParser
         /// <param name="selectExpandClause">The select expand clause for evaluation.</param>
         /// <param name="processSubResult">The method to deal with sub expand result.</param>
         /// <param name="combineSelectAndExpand">The method to combine select and expand result lists.</param>
+        /// <param name="version">OData version to use in traversing the selectExpand clause</param>
         /// <param name="result">The result of the traversing.</param>
-        internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, T> processSubResult, Func<IList<string>, IList<T>, T> combineSelectAndExpand, out T result)
+        internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, ODataVersion, T> processSubResult, Func<IList<string>, IList<T>, T> combineSelectAndExpand, ODataVersion version, out T result)
         {
             List<string> selectList = selectExpandClause.GetCurrentLevelSelectList();
             List<T> expandList = new List<T>();
@@ -107,12 +108,10 @@ namespace Microsoft.OData.UriParser
                 T subResult = default(T);
                 if (expandSelectItem.SelectAndExpand.SelectedItems.Any())
                 {
-                    Traverse(expandSelectItem.SelectAndExpand, processSubResult, combineSelectAndExpand,
-                        out subResult);
+                    Traverse(expandSelectItem.SelectAndExpand, processSubResult, combineSelectAndExpand, version, out subResult);
                 }
 
-                var expandItem = processSubResult(currentExpandClause, subResult);
-
+                var expandItem = processSubResult(currentExpandClause, subResult, version);
                 if (expandItem != null)
                 {
                     expandList.Add(expandItem);
@@ -124,7 +123,7 @@ namespace Microsoft.OData.UriParser
                 string currentExpandClause = String.Join("/", expandSelectItem.PathToNavigationProperty.WalkWith(PathSegmentToStringTranslator.Instance).ToArray());
                 currentExpandClause += "/$ref";
 
-                var expandItem = processSubResult(currentExpandClause, default(T));
+                var expandItem = processSubResult(currentExpandClause, default(T), version);
                 if (expandItem != null)
                 {
                     expandList.Add(expandItem);
@@ -180,15 +179,16 @@ namespace Microsoft.OData.UriParser
         /// Build the expand clause for a given level in the selectExpandClause
         /// </summary>
         /// <param name="selectExpandClause">the current level select expand clause</param>
+        /// <param name="version">OData Version.</param>
         /// <returns>the expand clause for this level.</returns>
-        private static string BuildExpandsForNode(SelectExpandClause selectExpandClause)
+        private static string BuildExpandsForNode(SelectExpandClause selectExpandClause, ODataVersion version)
         {
             List<string> currentLevelExpandClauses = new List<string>();
             foreach (ExpandedNavigationSelectItem expandItem in selectExpandClause.SelectedItems.Where(I => I.GetType() == typeof(ExpandedNavigationSelectItem)))
             {
                 string currentExpandClause = String.Join("/", expandItem.PathToNavigationProperty.WalkWith(PathSegmentToStringTranslator.Instance).ToArray());
                 string expandStr;
-                expandItem.SelectAndExpand.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, out expandStr);
+                expandItem.SelectAndExpand.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, version, out expandStr);
                 if (!string.IsNullOrEmpty(expandStr))
                 {
                     currentExpandClause += "(" + expandStr + ")";
@@ -210,8 +210,9 @@ namespace Microsoft.OData.UriParser
         /// <summary>Process sub expand node, contact with subexpad result</summary>
         /// <param name="expandNode">The current expanded node.</param>
         /// <param name="subExpand">Generated sub expand node.</param>
+        /// <param name="version">OData version.</param>
         /// <returns>The generated expand string.</returns>
-        private static string ProcessSubExpand(string expandNode, string subExpand)
+        private static string ProcessSubExpand(string expandNode, string subExpand, ODataVersion version)
         {
             return string.IsNullOrEmpty(subExpand) ? expandNode : expandNode + "(" + subExpand + ")";
         }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
@@ -710,7 +710,7 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
                 {"Accounts(101)?$select=AccountID&$expand=MyPaymentInstruments($select=PaymentInstrumentID;$expand=TheStoredPI($select=StoredPIID))", new int[] {7, 4}},
             };
 
-            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri, Version = ODataVersion.V401 };
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
 
             foreach (var testCase in testCases)
             {

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
@@ -710,7 +710,7 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
                 {"Accounts(101)?$select=AccountID&$expand=MyPaymentInstruments($select=PaymentInstrumentID;$expand=TheStoredPI($select=StoredPIID))", new int[] {7, 4}},
             };
 
-            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri, Version = ODataVersion.V401 };
 
             foreach (var testCase in testCases)
             {

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceQueryTests.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Test.OData.Tests.Client.ModelReferenceTests
                 { "Trucks('Key1')?$expand=HeadUnit,VehicleGPS", new int[] {3, 4} },
             };
 
-            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri, Version = ODataVersion.V401 };
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
 
             foreach (var testCase in testCases)
             {

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceQueryTests.cs
@@ -374,7 +374,7 @@ namespace Microsoft.Test.OData.Tests.Client.ModelReferenceTests
                 { "Trucks('Key1')?$expand=HeadUnit,VehicleGPS", new int[] {3, 4} },
             };
 
-            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri, Version = ODataVersion.V401 };
 
             foreach (var testCase in testCases)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMissingOperationGeneratorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMissingOperationGeneratorTests.cs
@@ -188,7 +188,7 @@ namespace Microsoft.OData.Tests.Evaluation
             }
         }
 
-        public ODataResourceMetadataBuilder GetResourceMetadataBuilderForReader(IODataJsonLightReaderResourceState entryState, bool useKeyAsSegment)
+        public ODataResourceMetadataBuilder GetResourceMetadataBuilderForReader(IODataJsonLightReaderResourceState entryState, bool useKeyAsSegment, bool isDelta = false)
         {
             if (this.GetEntityMetadataBuilderFunc != null)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaReaderTests.cs
@@ -80,17 +80,21 @@ namespace Microsoft.OData.Tests.JsonLight
 
         #region ODataV4 tests
 
-        [Fact]
-        public void ReadExample30FromV4Spec()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadExample30FromV4Spec(bool isResponse)
         {
-            var tuples = this.ReadItem(payload, Model, customers, customer);
+            var tuples = this.ReadItem(payload, Model, customers, customer, isResponse);
             this.ValidateTuples(tuples);
         }
 
-        [Fact]
-        public async void ReadExample30FromV4SpecAsync()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public async void ReadExample30FromV4SpecAsync(bool isResponse)
         {
-            var tuples = await this.ReadItemAsync(payload, Model, customers, customer);
+            var tuples = await this.ReadItemAsync(payload, Model, customers, customer, isResponse);
             this.ValidateTuples(tuples);
         }
 
@@ -99,7 +103,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ReadExample30FromV4SpecWithNavigationLinks()
         {
-            var tuples = this.ReadItem(payloadWithNavigationLinks, this.Model, customers, customer);
+            var tuples = this.ReadItem(payloadWithNavigationLinks, this.Model, customers, customer, /*isResponse*/ true);
             this.ValidateTuples(tuples);
         }
 
@@ -107,7 +111,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ReadExample30FromV4SpecWithFullODataAnnotationsODataSimplified()
         {
             // cover "@odata.deltaLink"
-            var tuples = this.ReadItem(payloadWithNavigationLinks, this.Model, customers, customer, enableReadingODataAnnotationWithoutPrefix: true);
+            var tuples = this.ReadItem(payloadWithNavigationLinks, this.Model, customers, customer, /*isResponse*/ true, enableReadingODataAnnotationWithoutPrefix: true);
             this.ValidateTuples(tuples);
         }
 
@@ -115,17 +119,19 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ReadExample30FromV4SpecWithSimplifiedODataAnnotationsODataSimplified()
         {
             // cover "@deltaLink"
-            var tuples = this.ReadItem(payloadWithSimplifiedAnnotations, this.Model, customers, customer, enableReadingODataAnnotationWithoutPrefix: true);
+            var tuples = this.ReadItem(payloadWithSimplifiedAnnotations, this.Model, customers, customer, /*isResponse*/ true, enableReadingODataAnnotationWithoutPrefix: true);
             this.ValidateTuples(tuples);
         }
 
         #endregion
 
-        [Fact]
-        public void ReadODataType()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadODataType(bool isResponse)
         {
             var payloadWithODataType = "{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@odata.context\":\"http://host/service/$metadata#Orders/$entity\",\"@odata.type\":\"MyNS.Order\",\"@odata.id\":\"Orders(10643)\",\"Address\":{\"Street\":\"23 Tsawassen Blvd.\",\"City\":{\"CityName\":\"Tsawassen\"},\"Region\":\"BC\",\"PostalCode\":\"T2F 8M4\"}}]}";
-            var tuples = this.ReadItem(payloadWithODataType, Model, customers, customer);
+            var tuples = this.ReadItem(payloadWithODataType, Model, customers, customer, isResponse);
             this.ValidateTuples(tuples);
         }
 
@@ -133,7 +139,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ReadNextLinkAtStart()
         {
             var payload = "{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"@odata.nextLink\":\"http://tempuri.org/\",\"value\":[]}";
-            var tuples = this.ReadItem(payload, this.Model, customers, customer);
+            var tuples = this.ReadItem(payload, this.Model, customers, customer, /*isResponse*/ true);
             this.ValidateTuples(tuples, new Uri("http://tempuri.org/"));
         }
 
@@ -141,7 +147,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ReadNextLinkAtEnd()
         {
             var payload = "{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[],\"@odata.nextLink\":\"http://tempuri.org/\"}";
-            var tuples = this.ReadItem(payload, this.Model, customers, customer);
+            var tuples = this.ReadItem(payload, this.Model, customers, customer, /*isResponse*/ true);
             this.ValidateTuples(tuples, new Uri("http://tempuri.org/"));
         }
 
@@ -149,7 +155,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ReadDeltaLinkAtStart()
         {
             var payload = "{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"@odata.deltaLink\":\"http://tempuri.org/\",\"value\":[]}";
-            var tuples = this.ReadItem(payload, this.Model, customers, customer);
+            var tuples = this.ReadItem(payload, this.Model, customers, customer, /*isResponse*/ true);
             this.ValidateTuples(tuples, null, new Uri("http://tempuri.org/"));
         }
 
@@ -157,7 +163,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ReadDeltaLinkAtEnd()
         {
             var payload = "{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[],\"@odata.deltaLink\":\"http://tempuri.org/\"}";
-            var tuples = this.ReadItem(payload, this.Model, customers, customer);
+            var tuples = this.ReadItem(payload, this.Model, customers, customer, /*isResponse*/ true);
             this.ValidateTuples(tuples, null, new Uri("http://tempuri.org/"));
         }
 
@@ -192,17 +198,21 @@ namespace Microsoft.OData.Tests.JsonLight
                     "]" +
                 "}";
 
-        [Fact]
-        public void ReadExpandedFeed()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadExpandedFeed(bool isResponse)
         {
-            var tuples = this.ReadItem(expandedPayload, this.Model, customers, customer);
+            var tuples = this.ReadItem(expandedPayload, this.Model, customers, customer, isResponse);
             this.ValidateTuples(tuples);
         }
 
-        [Fact]
-        public async void ReadExpandedFeedAsync()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public async void ReadExpandedFeedAsync(bool isResponse)
         {
-            var tuples = await this.ReadItemAsync(expandedPayload, this.Model, customers, customer);
+            var tuples = await this.ReadItemAsync(expandedPayload, this.Model, customers, customer, isResponse);
             this.ValidateTuples(tuples);
         }
 
@@ -248,7 +258,7 @@ namespace Microsoft.OData.Tests.JsonLight
                         "}" +
                     "]" +
                 "}";
-            var tuples = this.ReadItem(payload, this.Model, customers, customer);
+            var tuples = this.ReadItem(payload, this.Model, customers, customer, /*isResponse*/ true);
             this.ValidateTuples(tuples);
         }
 
@@ -289,22 +299,28 @@ namespace Microsoft.OData.Tests.JsonLight
                     "]" +
                 "}";
 
-        [Fact]
-        public void ReadMutlipleExpandedFeeds()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadMutlipleExpandedFeeds(bool isResponse)
         {
-            var tuples = this.ReadItem(multipleExpandedPayload, this.Model, customers, customer);
+            var tuples = this.ReadItem(multipleExpandedPayload, this.Model, customers, customer, isResponse);
             this.ValidateTuples(tuples);
         }
 
-        [Fact]
-        public async void ReadMutlipleExpandedFeedsAsync()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public async void ReadMutlipleExpandedFeedsAsync(bool isResponse)
         {
-            var tuples = await this.ReadItemAsync(multipleExpandedPayload, this.Model, customers, customer);
+            var tuples = await this.ReadItemAsync(multipleExpandedPayload, this.Model, customers, customer, isResponse);
             this.ValidateTuples(tuples);
         }
 
-        [Fact]
-        public void ReadContainmentExpandedFeed()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadContainmentExpandedFeed(bool isResponse)
         {
             var payload =
                 "{" +
@@ -333,12 +349,14 @@ namespace Microsoft.OData.Tests.JsonLight
                         "}" +
                     "]" +
                 "}";
-            var tuples = this.ReadItem(payload, this.Model, customers, customer);
+            var tuples = this.ReadItem(payload, this.Model, customers, customer, isResponse);
             this.ValidateTuples(tuples);
         }
 
-        [Fact]
-        public void ReadExpandedSingleton()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadExpandedSingleton(bool isResponse)
         {
             var payload =
                 "{" +
@@ -365,12 +383,14 @@ namespace Microsoft.OData.Tests.JsonLight
                         "}" +
                     "]" +
                 "}";
-            var tuples = this.ReadItem(payload, this.Model, customers, customer);
+            var tuples = this.ReadItem(payload, this.Model, customers, customer, isResponse);
             this.ValidateTuples(tuples);
         }
 
-        [Fact]
-        public void ReadExpandedFeedException()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadExpandedFeedException(bool isResponse)
         {
             var payload =
                 "{" +
@@ -403,7 +423,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
             Action readAction = () =>
             {
-                var tuples = this.ReadItem(payload, this.Model, customers, customer);
+                var tuples = this.ReadItem(payload, this.Model, customers, customer, isResponse);
                 this.ValidateTuples(tuples);
             };
             readAction.ShouldThrow<ODataException>().Where(e => e.Message.Contains("Id shouldn't be a string"));
@@ -413,8 +433,10 @@ namespace Microsoft.OData.Tests.JsonLight
 
         #region ComplexProperty
 
-        [Fact]
-        public void ReadNestedComplexProperty()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedComplexProperty(bool isResponse)
         {
             var payload =
                 "{" +
@@ -437,12 +459,14 @@ namespace Microsoft.OData.Tests.JsonLight
                         "}" +
                     "]" +
                 "}";
-            var tuples = this.ReadItem(payload, this.Model, orders, order);
+            var tuples = this.ReadItem(payload, this.Model, orders, order, isResponse);
             this.ValidateTuples(tuples);
         }
 
-        [Fact]
-        public void ReadNestedOpenCollectionOfComplexProperty()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedOpenCollectionOfComplexProperty(bool isResponse)
         {
             var payload =
                 "{" +
@@ -479,7 +503,7 @@ namespace Microsoft.OData.Tests.JsonLight
                         "}" +
                     "]" +
                 "}";
-            var tuples = this.ReadItem(payload, this.Model, orders, order);
+            var tuples = this.ReadItem(payload, this.Model, orders, order, isResponse);
             this.ValidateTuples(tuples);
         }
 
@@ -489,11 +513,13 @@ namespace Microsoft.OData.Tests.JsonLight
 
         #region ODataV401 tests
 
-        [Fact]
-        public void Read41DeletedEntryWithId()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void Read41DeletedEntryWithId(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"@id\":\"Customers/1\"}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while (reader.Read())
             {
@@ -509,11 +535,13 @@ namespace Microsoft.OData.Tests.JsonLight
             deletedResource.Id.Should().Be(new Uri("Customers/1", UriKind.Relative));
         }
 
-        [Fact]
-        public void Read41DeletedEntryWithKeyProperties()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void Read41DeletedEntryWithKeyProperties(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while (reader.Read())
             {
@@ -526,16 +554,18 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             Assert.NotNull(deletedResource);
-            deletedResource.Id.Should().Be(new Uri("http://host/service/Customers/1"));
+            deletedResource.Properties.FirstOrDefault(p => p.Name == "Id").Value.Should().Be(1);
             deletedResource.Properties.Count().Should().Be(1);
             deletedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(1);
         }
 
-        [Fact]
-        public void Read41DeletedEntryRemovedAtEnd()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void Read41DeletedEntryRemovedAtEnd(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"Id\":1,\"@removed\":{\"reason\":\"changed\"}}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while (reader.Read())
             {
@@ -548,14 +578,16 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             Assert.NotNull(deletedResource);
-            deletedResource.Id.Should().Be(new Uri("http://host/service/Customers/1"));
-        }
+            deletedResource.Properties.FirstOrDefault(p=>p.Name == "Id").Value.Should().Be(1);
+       }
 
-        [Fact]
-        public void Read41DeletedEntryWithEmptyRemoved()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void Read41DeletedEntryWithEmptyRemoved(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{},\"Id\":1}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while (reader.Read())
             {
@@ -568,14 +600,16 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             Assert.NotNull(deletedResource);
-            deletedResource.Id.Should().Be(new Uri("http://host/service/Customers/1"));
+            deletedResource.Properties.FirstOrDefault(p => p.Name == "Id").Value.Should().Be(1);
         }
 
-        [Fact]
-        public void Read41DeletedEntryWithNullRemoved()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void Read41DeletedEntryWithNullRemoved(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":null,\"Id\":1}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while (reader.Read())
             {
@@ -588,14 +622,16 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             Assert.NotNull(deletedResource);
-            deletedResource.Id.Should().Be(new Uri("http://host/service/Customers/1"));
+            deletedResource.Properties.FirstOrDefault(p => p.Name == "Id").Value.Should().Be(1);
         }
 
-        [Fact]
-        public void Read41DeletedEntryWithExtraContentInRemoved()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void Read41DeletedEntryWithExtraContentInRemoved(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\",\"extraProperty\":\"value\",\"@extra.annotation\":\"annotationValue\"},\"Id\":1}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while (reader.Read())
             {
@@ -608,14 +644,16 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             Assert.NotNull(deletedResource);
-            deletedResource.Id.Should().Be(new Uri("http://host/service/Customers/1"));
+            deletedResource.Properties.FirstOrDefault(p => p.Name == "Id").Value.Should().Be(1);
         }
 
-        [Fact]
-        public void ReadPropertiesIn41DeletedEntry()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadPropertiesIn41DeletedEntry(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"ContactName\":\"Samantha Stones\"}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while(reader.Read())
             {
@@ -628,18 +666,19 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             Assert.NotNull(deletedResource);
-            deletedResource.Id.Should().Be(new Uri("http://host/service/Customers/1"));
             deletedResource.Properties.Count().Should().Be(2);
             deletedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(1);
-            deletedResource.Properties.First(p=>p.Name=="ContactName").Value.Should().Be("Samantha Stones");
+            deletedResource.Properties.First(p => p.Name=="ContactName").Value.Should().Be("Samantha Stones");
             deletedResource.Reason.Should().Be(DeltaDeletedEntryReason.Changed);
         }
 
-        [Fact]
-        public void ReadIgnorePropertiesIn40DeletedEntry()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadIgnorePropertiesIn40DeletedEntry(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@context\":\"http://host/service/$metadata#Orders/$deletedEntity\",\"id\":\"Customers('BOTTM')\",\"reason\":\"deleted\",\"ContactName\":\"Susan Halvenstern\"}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while (reader.Read())
             {
@@ -656,12 +695,14 @@ namespace Microsoft.OData.Tests.JsonLight
             deletedResource.Reason.Should().Be(DeltaDeletedEntryReason.Deleted);
         }
 
-        [Fact]
-        public void ReadNestedResourceIn41DeletedEntry()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedResourceIn41DeletedEntry(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"ProductBeingViewed\":{\"Name\":\"Scissors\",\"Id\":10}}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataResource nestedResource = null;
@@ -685,18 +726,19 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.NotNull(nestedResourceInfo);
             nestedResourceInfo.Name.Should().Be("ProductBeingViewed");
             Assert.NotNull(nestedResource);
-            nestedResource.Id.Should().Be(new Uri("http://host/service/Products/10"));
             nestedResource.Properties.Count().Should().Be(2);
             nestedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(10);
             nestedResource.Properties.First(p => p.Name == "Name").Value.Should().Be("Scissors");
         }
 
-        [Fact]
-        public void ReadNullResourceIn41DeletedEntry()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNullResourceIn41DeletedEntry(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"ProductBeingViewed\":null}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataResource nestedResource = null;
@@ -722,12 +764,14 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.Null(nestedResource);
         }
 
-        [Fact]
-        public void ReadNestedResourceIn41DeltaResource()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedResourceIn41DeltaResource(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"Id\":1,\"ProductBeingViewed\":{\"Name\":\"Scissors\",\"Id\":10},\"ContactName\":\"Samantha Stones\"}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataResource deltaResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataResource nestedResource = null;
@@ -752,25 +796,25 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             Assert.NotNull(deltaResource);
-            deltaResource.Id.Should().Be(new Uri("http://host/service/Customers/1"));
             deltaResource.Properties.Count().Should().Be(2);
             deltaResource.Properties.First(p => p.Name == "Id").Value.Should().Be(1);
             deltaResource.Properties.First(p => p.Name == "ContactName").Value.Should().Be("Samantha Stones");
             Assert.NotNull(nestedResourceInfo);
             nestedResourceInfo.Name.Should().Be("ProductBeingViewed");
             Assert.NotNull(nestedResource);
-            nestedResource.Id.Should().Be(new Uri("http://host/service/Products/10"));
             nestedResource.Properties.Count().Should().Be(2);
             nestedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(10);
             nestedResource.Properties.First(p => p.Name == "Name").Value.Should().Be("Scissors");
         }
 
-        [Fact]
-        public void ReadNestedDeletedEntryIn41DeletedEntry()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedDeletedEntryIn41DeletedEntry(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"ProductBeingViewed\":{\"@removed\":{\"reason\":\"deleted\"},\"Name\":\"Scissors\",\"Id\":10}}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataDeletedResource nestedResource = null;
@@ -799,18 +843,19 @@ namespace Microsoft.OData.Tests.JsonLight
             nestedResourceInfo.Name.Should().Be("ProductBeingViewed");
             Assert.NotNull(nestedResource);
             nestedResource.Reason.Should().Be(DeltaDeletedEntryReason.Deleted);
-            nestedResource.Id.Should().Be(new Uri("http://host/service/Products/10"));
             nestedResource.Properties.Count().Should().Be(2);
             nestedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(10);
             nestedResource.Properties.First(p => p.Name == "Name").Value.Should().Be("Scissors");
         }
 
-        [Fact]
-        public void ReadNestedDerivedDeletedEntryIn41DeletedEntry()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedDerivedDeletedEntryIn41DeletedEntry(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"ProductBeingViewed\":{\"@removed\":{\"reason\":\"deleted\"},\"@type\":\"#MyNS.PhysicalProduct\",\"Id\":10,\"Name\":\"car\",\"Material\":\"gold\"}}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataDeletedResource nestedResource = null;
@@ -840,19 +885,20 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.NotNull(nestedResource);
             nestedResource.TypeName.Should().Be("MyNS.PhysicalProduct");
             nestedResource.Reason.Should().Be(DeltaDeletedEntryReason.Deleted);
-            nestedResource.Id.Should().Be(new Uri("http://host/service/Products/10"));
             nestedResource.Properties.Count().Should().Be(3);
             nestedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(10);
             nestedResource.Properties.First(p => p.Name == "Name").Value.Should().Be("car");
             nestedResource.Properties.First(p => p.Name == "Material").Value.Should().Be("gold");
         }
 
-        [Fact]
-        public void ReadNestedDeletedEntryIn41DeltaResource()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedDeletedEntryIn41DeltaResource(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"Id\":1,\"ProductBeingViewed\":{\"@removed\":{\"reason\":\"deleted\"},\"Name\":\"Scissors\",\"Id\":10}}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataResource deltaResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataDeletedResource nestedDeletedResource = null;
@@ -877,18 +923,21 @@ namespace Microsoft.OData.Tests.JsonLight
             nestedResourceInfo.Name.Should().Be("ProductBeingViewed");
             Assert.NotNull(nestedDeletedResource);
             nestedDeletedResource.Reason.Should().Be(DeltaDeletedEntryReason.Deleted);
-            nestedDeletedResource.Id.Should().Be(new Uri("http://host/service/Products/10"));
             nestedDeletedResource.Properties.Count().Should().Be(2);
             nestedDeletedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(10);
             nestedDeletedResource.Properties.First(p => p.Name == "Name").Value.Should().Be("Scissors");
         }
 
-        [Fact]
-        public void ReadNestedDeltaResourceSetIn41DeletedEntry()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedDeltaResourceSetIn41DeletedEntry(bool isResponse)
         {
-            string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"FavouriteProducts@count\":5,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts@delta\":[{\"Id\":1,\"Name\":\"Car\"},{\"@removed\":{\"reason\":\"deleted\"},\"Id\":10}]}]}";
+            string payload = isResponse ?
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"FavouriteProducts@count\":5,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts@delta\":[{\"Id\":1,\"Name\":\"Car\"},{\"@removed\":{\"reason\":\"deleted\"},\"Id\":10}]}]}" :
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"FavouriteProducts@delta\":[{\"Id\":1,\"Name\":\"Car\"},{\"@removed\":{\"reason\":\"deleted\"},\"Id\":10}]}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataResource nestedResource = null;
@@ -927,27 +976,31 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.NotNull(nestedResourceInfo);
             nestedResourceInfo.Name.Should().Be("FavouriteProducts");
             Assert.NotNull(nestedDeltaResourceSet);
-            nestedDeltaResourceSet.Count.Should().Be(5);
-            nestedDeltaResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            if (isResponse)
+            {
+                nestedDeltaResourceSet.Count.Should().Be(5);
+                nestedDeltaResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            }
             Assert.NotNull(nestedResource);
-            nestedResource.Id.Should().Be(new Uri("http://host/service/Products/1"));
             nestedResource.Properties.Count().Should().Be(2);
             nestedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(1);
             nestedResource.Properties.First(p => p.Name == "Name").Value.Should().Be("Car");
             Assert.NotNull(nestedDeletedResource);
             nestedDeletedResource.Reason.Should().Be(DeltaDeletedEntryReason.Deleted);
-            nestedDeletedResource.Id.Should().Be(new Uri("http://host/service/Products/10"));
             nestedDeletedResource.Properties.Count().Should().Be(1);
             nestedDeletedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(10);
         }
 
-
-        [Fact]
-        public void ReadEmptyDeltaResourceSetIn41DeletedEntry()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadEmptyDeltaResourceSetIn41DeletedEntry(bool isResponse)
         {
-            string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"FavouriteProducts@count\":2,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts@delta\":[]}]}";
+            string payload = isResponse ?
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"FavouriteProducts@count\":2,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts@delta\":[]}]}" :
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"FavouriteProducts@delta\":[]}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataDeltaResourceSet nestedDeltaResourceSet = null;
@@ -974,16 +1027,23 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.NotNull(nestedResourceInfo);
             nestedResourceInfo.Name.Should().Be("FavouriteProducts");
             Assert.NotNull(nestedDeltaResourceSet);
-            nestedDeltaResourceSet.Count.Should().Be(2);
-            nestedDeltaResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            if (isResponse)
+            {
+                nestedDeltaResourceSet.Count.Should().Be(2);
+                nestedDeltaResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            }
         }
 
-        [Fact]
-        public void ReadNestedDeltaResourceSetIn41DeltaResource()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedDeltaResourceSetIn41DeltaResource(bool isResponse)
         {
-            string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"Id\":1,\"FavouriteProducts@count\":5,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts@delta\":[{\"Id\":1,\"Name\":\"Car\"},{\"@removed\":{\"reason\":\"deleted\"},\"Id\":10}]}]}";
+            string payload = isResponse ?
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"Id\":1,\"FavouriteProducts@count\":5,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts@delta\":[{\"Id\":1,\"Name\":\"Car\"},{\"@removed\":{\"reason\":\"deleted\"},\"Id\":10}]}]}" :
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"Id\":1,\"FavouriteProducts@delta\":[{\"Id\":1,\"Name\":\"Car\"},{\"@removed\":{\"reason\":\"deleted\"},\"Id\":10}]}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataResource deltaResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataResource nestedResource = null;
@@ -1022,26 +1082,31 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.NotNull(nestedResourceInfo);
             nestedResourceInfo.Name.Should().Be("FavouriteProducts");
             Assert.NotNull(nestedDeltaResourceSet);
-            nestedDeltaResourceSet.Count.Should().Be(5);
-            nestedDeltaResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            if (isResponse)
+            {
+                nestedDeltaResourceSet.Count.Should().Be(5);
+                nestedDeltaResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            }
             Assert.NotNull(nestedResource);
-            nestedResource.Id.Should().Be(new Uri("http://host/service/Products/1"));
             nestedResource.Properties.Count().Should().Be(2);
             nestedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(1);
             nestedResource.Properties.First(p => p.Name == "Name").Value.Should().Be("Car");
             Assert.NotNull(nestedDeletedResource);
             nestedDeletedResource.Reason.Should().Be(DeltaDeletedEntryReason.Deleted);
-            nestedDeletedResource.Id.Should().Be(new Uri("http://host/service/Products/10"));
             nestedDeletedResource.Properties.Count().Should().Be(1);
             nestedDeletedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(10);
         }
 
-        [Fact]
-        public void ReadNestedResourceSetIn41DeletedEntry()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedResourceSetIn41DeletedEntry(bool isResponse)
         {
-            string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"FavouriteProducts@count\":5,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts\":[{\"Id\":1,\"Name\":\"Car\"},{\"Id\":10}]}]}";
+            string payload = isResponse ?
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"FavouriteProducts@count\":5,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts\":[{\"Id\":1,\"Name\":\"Car\"},{\"Id\":10}]}]}" :
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"Id\":1,\"FavouriteProducts\":[{\"Id\":1,\"Name\":\"Car\"},{\"Id\":10}]}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataResource nestedResource = null;
@@ -1077,25 +1142,30 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.NotNull(nestedResourceInfo);
             nestedResourceInfo.Name.Should().Be("FavouriteProducts");
             Assert.NotNull(nestedResourceSet);
-            nestedResourceSet.Count.Should().Be(5);
-            nestedResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            if (isResponse)
+            {
+                nestedResourceSet.Count.Should().Be(5);
+                nestedResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            }
             Assert.NotNull(nestedResource);
-            nestedResource.Id.Should().Be(new Uri("http://host/service/Products/1"));
             nestedResource.Properties.Count().Should().Be(2);
             nestedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(1);
             nestedResource.Properties.First(p => p.Name == "Name").Value.Should().Be("Car");
             Assert.NotNull(nestedResource2);
-            nestedResource2.Id.Should().Be(new Uri("http://host/service/Products/10"));
             nestedResource2.Properties.Count().Should().Be(1);
             nestedResource2.Properties.First(p => p.Name == "Id").Value.Should().Be(10);
         }
 
-        [Fact]
-        public void ReadNestedResourceSetIn41DeltaResource()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedResourceSetIn41DeltaResource(bool isResponse)
         {
-            string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"Id\":1,\"FavouriteProducts@count\":5,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts\":[{\"Id\":1,\"Name\":\"Car\"},{\"Id\":10}]}]}";
+            string payload = isResponse ?
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"Id\":1,\"FavouriteProducts@count\":5,\"FavouriteProducts@nextLink\":\"http://host/service/Customers?$skipToken=5\",\"FavouriteProducts\":[{\"Id\":1,\"Name\":\"Car\"},{\"Id\":10}]}]}" :
+                "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"Id\":1,\"FavouriteProducts\":[{\"Id\":1,\"Name\":\"Car\"},{\"Id\":10}]}]}";
 
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataResource deltaResource = null;
             ODataNestedResourceInfo nestedResourceInfo = null;
             ODataResource nestedResource = null;
@@ -1132,24 +1202,27 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.NotNull(nestedResourceInfo);
             nestedResourceInfo.Name.Should().Be("FavouriteProducts");
             Assert.NotNull(nestedResourceSet);
-            nestedResourceSet.Count.Should().Be(5);
-            nestedResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            if (isResponse)
+            {
+                nestedResourceSet.Count.Should().Be(5);
+                nestedResourceSet.NextPageLink.Should().Be("http://host/service/Customers?$skipToken=5");
+            }
             Assert.NotNull(nestedResource);
-            nestedResource.Id.Should().Be(new Uri("http://host/service/Products/1"));
             nestedResource.Properties.Count().Should().Be(2);
             nestedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(1);
             nestedResource.Properties.First(p => p.Name == "Name").Value.Should().Be("Car");
             Assert.NotNull(nestedResource2);
-            nestedResource2.Id.Should().Be(new Uri("http://host/service/Products/10"));
             nestedResource2.Properties.Count().Should().Be(1);
             nestedResource2.Properties.First(p => p.Name == "Id").Value.Should().Be(10);
         }
 
-        [Fact]
-        public void ReadDeletedEntryFromDifferentSetIn41()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadDeletedEntryFromDifferentSetIn41(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@id\":\"Customers('BOTTM')\",\"ContactName\":\"Susan Halvenstern\"},{\"@context\":\"http://host/service/$metadata#Orders/$deletedEntity\",\"@removed\":{\"reason\":\"changed\"},\"Id\":1}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while (reader.Read())
             {
@@ -1162,16 +1235,17 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             Assert.NotNull(deletedResource);
-            deletedResource.Id.Should().Be(new Uri("http://host/service/Orders/1"));
             deletedResource.Properties.Count().Should().Be(1);
             deletedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(1);
         }
 
-        [Fact]
-        public void ReadDerivedDeletedResourceIn41()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadDerivedDeletedResourceIn41(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@removed\":{\"reason\":\"changed\"},\"@odata.type\":\"#MyNS.PreferredCustomer\",\"Id\":1,\"HonorLevel\":\"Gold\"}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
             ODataDeletedResource deletedResource = null;
             while (reader.Read())
             {
@@ -1184,18 +1258,19 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             Assert.NotNull(deletedResource);
-            deletedResource.Id.Should().Be(new Uri("http://host/service/Customers/1"));
             deletedResource.Properties.Count().Should().Be(2);
             deletedResource.TypeName.Should().Be("MyNS.PreferredCustomer");
             deletedResource.Properties.First(p => p.Name == "Id").Value.Should().Be(1);
             deletedResource.Properties.First(p => p.Name == "HonorLevel").Value.Should().Be("Gold");
         }
 
-        [Fact]
-        public void ReadNestedDeletedEntryFromDifferentSetShouldFail()
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void ReadNestedDeletedEntryFromDifferentSetShouldFail(bool isResponse)
         {
             string payload = "{\"@context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@id\":\"Customers('BOTTM')\",\"ContactName\":\"Susan Halvenstern\",\"Orders\":[{\"@context\":\"http://host/service/$metadata#Customers/$deletedEntity\",\"@removed\":{\"reason\":\"changed\"},\"Id\":1}]}]}";
-            ODataReader reader = GetODataReader(payload, this.Model, customers, customer);
+            ODataReader reader = GetODataReader(payload, this.Model, customers, customer, isResponse);
 
             Action readAction = () =>
             {
@@ -1318,7 +1393,7 @@ namespace Microsoft.OData.Tests.JsonLight
             }
         }
 
-        private IEnumerable<Tuple<ODataItem, ODataDeltaReaderState, ODataReaderState>> ReadItem(string payload, IEdmModel model = null, IEdmNavigationSource navigationSource = null, IEdmEntityType entityType = null, bool enableReadingODataAnnotationWithoutPrefix = false)
+        private IEnumerable<Tuple<ODataItem, ODataDeltaReaderState, ODataReaderState>> ReadItem(string payload, IEdmModel model = null, IEdmNavigationSource navigationSource = null, IEdmEntityType entityType = null, bool isResponse = true, bool enableReadingODataAnnotationWithoutPrefix = false)
         {
             var settings = new ODataMessageReaderSettings
             {
@@ -1327,7 +1402,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
             var messageInfo = new ODataMessageInfo
             {
-                IsResponse = true,
+                IsResponse = isResponse,
                 MediaType = new ODataMediaType("application", "json"),
                 IsAsync = false,
                 Model = model ?? new EdmModel(),
@@ -1347,7 +1422,7 @@ namespace Microsoft.OData.Tests.JsonLight
             }
         }
 
-        private async Task<IEnumerable<Tuple<ODataItem, ODataDeltaReaderState, ODataReaderState>>> ReadItemAsync(string payload, IEdmModel model = null, IEdmNavigationSource navigationSource = null, IEdmEntityType entityType = null, bool enableReadingODataAnnotationWithoutPrefix = false)
+        private async Task<IEnumerable<Tuple<ODataItem, ODataDeltaReaderState, ODataReaderState>>> ReadItemAsync(string payload, IEdmModel model = null, IEdmNavigationSource navigationSource = null, IEdmEntityType entityType = null, bool isResponse = true, bool enableReadingODataAnnotationWithoutPrefix = false)
         {
             List<Tuple<ODataItem, ODataDeltaReaderState, ODataReaderState>> tuples = new List<Tuple<ODataItem, ODataDeltaReaderState, ODataReaderState>>();
             var settings = new ODataMessageReaderSettings
@@ -1357,7 +1432,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
             var messageInfo = new ODataMessageInfo
             {
-                IsResponse = true,
+                IsResponse = isResponse,
                 MediaType = new ODataMediaType("application", "json"),
                 IsAsync = true,
                 Model = model ?? new EdmModel(),
@@ -1507,7 +1582,7 @@ namespace Microsoft.OData.Tests.JsonLight
             }
         }
 
-        private ODataReader GetODataReader(string deltaPayload, IEdmModel model, IEdmNavigationSource navigationSource, IEdmEntityType entityType, bool keyAsSegment = true)
+        private ODataReader GetODataReader(string deltaPayload, IEdmModel model, IEdmNavigationSource navigationSource, IEdmEntityType entityType, bool isResponse, bool keyAsSegment = true)
         {
             var settings = new ODataMessageReaderSettings
             {
@@ -1516,7 +1591,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
             var messageInfo = new ODataMessageInfo
             {
-                IsResponse = true,
+                IsResponse = isResponse,
                 MediaType = new ODataMediaType("application", "json"),
                 IsAsync = false,
                 Model = model ?? new EdmModel(),

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
@@ -381,8 +381,8 @@ namespace Microsoft.OData.Tests
                 }, true, version: version);
 
             string expected = version == ODataVersion.V4 ?
-                //OData V4.01
-                "{\"@odata.context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2())\"," +
+                //OData V4.0
+                "{\"@odata.context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2)\"," +
                     "\"value\":[" +
                     "{" +
                         "\"UserName\":\"abc\"," +
@@ -431,7 +431,7 @@ namespace Microsoft.OData.Tests
         }
 
         private const string v4MinimalMetadataPayload =
-                                               "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav())/$entity\"," +
+                                               "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav)/$entity\"," +
                                                        "\"ID\":\"abc\"," +
                                                         "\"Complex\":{" +
                                                         "\"Prop1\":123," +
@@ -444,7 +444,7 @@ namespace Microsoft.OData.Tests
                                                     "}" +
                                                 "}";
         private const string v4FullMetadataPayload =
-                                         "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav())/$entity\"," +
+                                         "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav)/$entity\"," +
                                              "\"@odata.id\":\"Entities('abc')\"," +
                                              "\"@odata.editLink\":\"Entities('abc')\"," +
                                              "\"ID\":\"abc\"," +
@@ -671,7 +671,7 @@ namespace Microsoft.OData.Tests
 
             string expectedPayload = version == ODataVersion.V4 ?
                 // OData version 4.0
-                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(ZipCode,Region()))\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(ZipCode,Region))\"," +
                 "\"@odata.type\":\"#DefaultNs.WorkAddress\"," +
                 "\"Road\":\"Ziyue\"," +
                 "\"City2\":{" +
@@ -737,7 +737,7 @@ namespace Microsoft.OData.Tests
 
             string expectedPayload = version == ODataVersion.V4 ?
                 // OData V4 Version
-                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(Region()))\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(Region))\"," +
                 "\"@odata.type\":\"#DefaultNs.WorkAddress\"," +
                 "\"Road\":\"Ziyue\"," +
                 "\"City2\":{" +
@@ -815,7 +815,7 @@ namespace Microsoft.OData.Tests
 
             string expectedPayload = version == ODataVersion.V4 ?
                 // OData version 4.0
-                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address(WorkAddress/DefaultNs.WorkAddress/City2(ZipCode,Region()))\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address(WorkAddress/DefaultNs.WorkAddress/City2(ZipCode,Region))\"," +
                 "\"Road\":\"Zixing\"," +
                 "\"WorkAddress\":{" +
                     "\"@odata.type\":\"#DefaultNs.WorkAddress\"," +

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -221,31 +221,26 @@ namespace Microsoft.OData.Tests
         [InlineData("TestModel.CapitolCity/Districts($select=Name)", "TestModel.CapitolCity/Districts(Name)", ODataVersion.V4)]
         public void FeedContextUriWithSingleExpandString(string expandClause, string expectedClause, ODataVersion version)
         {
-           this.CreateFeedContextUri("", expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
+            this.CreateFeedContextUri("", expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
 
         [Theory]
         // $select=A&$expand=B
-        [InlineData("Name", "Districts", "Name,Districts()", ODataVersion.V401)]
+        [InlineData(ODataVersion.V4, "Name", "Districts", "Name,Districts")]
+        [InlineData(ODataVersion.V401, "Name", "Districts", "Name,Districts()")]
         // $select=A&$expand=A
-        [InlineData("Districts", "Districts", "Districts,Districts()", ODataVersion.V401)]
+        [InlineData(ODataVersion.V4, "Districts", "Districts", "Districts")]
+        [InlineData(ODataVersion.V401, "Districts", "Districts", "Districts,Districts()")]
         // $select=A,B,C&$expand=A
-        [InlineData("Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()", ODataVersion.V401)]
+        [InlineData(ODataVersion.V4, "Name,Districts,Size", "Districts", "Name,Districts,Size")]
+        [InlineData(ODataVersion.V401, "Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()")]
         // $select=A&$expand=A,B
-        [InlineData("Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()", ODataVersion.V401)]
+        [InlineData(ODataVersion.V4, "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,TestModel.CapitolCity/CapitolDistrict")]
+        [InlineData(ODataVersion.V401, "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()")]
         // $select=A,B&$expand=B($select=C)
-        [InlineData("Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)", ODataVersion.V401)]
-        // $select=A&$expand=B
-        [InlineData("Name", "Districts", "Name,Districts", ODataVersion.V4)]
-        // $select=A&$expand=A
-        [InlineData("Districts", "Districts", "Districts,Districts", ODataVersion.V4)]
-        // $select=A,B,C&$expand=A
-        [InlineData("Name,Districts,Size", "Districts", "Name,Districts,Size,Districts", ODataVersion.V4)]
-        // $select=A&$expand=A,B
-        [InlineData("Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts,TestModel.CapitolCity/CapitolDistrict", ODataVersion.V4)]
-        // $select=A,B&$expand=B($select=C)
-        [InlineData("Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)", ODataVersion.V4)]
-        public void FeedContextUriWithSelectAndExpandString(string selectClause, string expandClause, string expectedClause, ODataVersion version)
+        [InlineData(ODataVersion.V4, "Name,Districts", "Districts($select=Name)", "Name,Districts(Name)")]
+        [InlineData(ODataVersion.V401, "Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)")]
+        public void FeedContextUriWithSelectAndExpandString(ODataVersion version, string selectClause, string expandClause, string expectedClause)
         {
 
             string uriString = this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString;
@@ -253,23 +248,24 @@ namespace Microsoft.OData.Tests
 
         }
 
-        [Fact]
-        public void EntryContextUriWithExpandNestedSelectString()
+        [Theory]
+        [InlineData(ODataVersion.V4, "Districts(Name,Zip)")]
+        [InlineData(ODataVersion.V401, "Districts,Districts(Name,Zip)")]
+        public void EntryContextUriWithExpandNestedSelectString(ODataVersion version, string nestedExpectedClause)
         {
-            foreach (ODataVersion version in Versions)
-            {
-                // With out $select in same level, $expand=A($select=B)
-                string selectClause = "";
-                string expandClause = "Districts($select=Name,Zip)";
-                string expectedClause = "Districts(Name,Zip)";
-                this.CreateEntryContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedClause));
 
-                // With $select in same level, $select=A&$expand=A($select=B,C)
-                selectClause = "Districts";
-                expandClause = "Districts($select=Name,Zip)";
-                expectedClause = "Districts,Districts(Name,Zip)";
-                this.CreateEntryContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedClause));
-            }
+            // With out $select in same level, $expand=A($select=B)
+            string selectClause = "";
+            string expandClause = "Districts($select=Name,Zip)";
+            string expectedClause = "Districts(Name,Zip)";
+            this.CreateEntryContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedClause));
+
+            // With $select in same level, $select=A&$expand=A($select=B,C)
+            selectClause = "Districts";
+            expandClause = "Districts($select=Name,Zip)";
+            expectedClause = nestedExpectedClause; 
+            this.CreateEntryContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedClause));
+
         }
 
         [Theory]
@@ -299,7 +295,7 @@ namespace Microsoft.OData.Tests
         }
 
         [Theory]
-        [InlineData(ODataVersion.V4, "Size,Name,Districts(Zip,City,City(Name,Districts))")]
+        [InlineData(ODataVersion.V4, "Size,Name,Districts(Zip,City(Name,Districts))")]
         [InlineData(ODataVersion.V401, "Size,Name,Districts(Zip,City,City(Name,Districts()))")]
         public void FeedContextUriWithMixedSelectAndExpandString(ODataVersion version, string expectedClause)
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -211,36 +211,46 @@ namespace Microsoft.OData.Tests
 
         [Theory]
         // expand without select, $expand=A
-        [InlineData("TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts()")]
+        [InlineData("TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts()", ODataVersion.V401)]
+        [InlineData("TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts", ODataVersion.V4)]
         // expands without select, $expand=A,B
-        [InlineData("TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", "TestModel.CapitolCity/CapitolDistrict(),TestModel.CapitolCity/Districts()")]
+        [InlineData("TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", "TestModel.CapitolCity/CapitolDistrict(),TestModel.CapitolCity/Districts()", ODataVersion.V401)]
+        [InlineData("TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", "TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", ODataVersion.V4)]
         // expand with nested select, $expand=A($select=B)
-        [InlineData("TestModel.CapitolCity/Districts($select=Name)", "TestModel.CapitolCity/Districts(Name)")]
-
-        public void FeedContextUriWithSingleExpandString(string expandClause, string expectedClause)
+        [InlineData("TestModel.CapitolCity/Districts($select=Name)", "TestModel.CapitolCity/Districts(Name)", ODataVersion.V401)]
+        [InlineData("TestModel.CapitolCity/Districts($select=Name)", "TestModel.CapitolCity/Districts(Name)", ODataVersion.V4)]
+        public void FeedContextUriWithSingleExpandString(string expandClause, string expectedClause, ODataVersion version)
         {
-            foreach (ODataVersion version in Versions)
-            this.CreateFeedContextUri("", expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
+           this.CreateFeedContextUri("", expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
 
         [Theory]
         // $select=A&$expand=B
-        [InlineData( "Name", "Districts", "Name,Districts()")]
+        [InlineData("Name", "Districts", "Name,Districts()", ODataVersion.V401)]
         // $select=A&$expand=A
-        [InlineData( "Districts", "Districts", "Districts,Districts()")]
+        [InlineData("Districts", "Districts", "Districts,Districts()", ODataVersion.V401)]
         // $select=A,B,C&$expand=A
-        [InlineData( "Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()")]
+        [InlineData("Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()", ODataVersion.V401)]
         // $select=A&$expand=A,B
-        [InlineData( "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()")]
+        [InlineData("Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()", ODataVersion.V401)]
         // $select=A,B&$expand=B($select=C)
-        [InlineData( "Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)")]
-        public void FeedContextUriWithSelectAndExpandString(string selectClause, string expandClause, string expectedClause)
+        [InlineData("Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)", ODataVersion.V401)]
+        // $select=A&$expand=B
+        [InlineData("Name", "Districts", "Name,Districts", ODataVersion.V4)]
+        // $select=A&$expand=A
+        [InlineData("Districts", "Districts", "Districts,Districts", ODataVersion.V4)]
+        // $select=A,B,C&$expand=A
+        [InlineData("Name,Districts,Size", "Districts", "Name,Districts,Size,Districts", ODataVersion.V4)]
+        // $select=A&$expand=A,B
+        [InlineData("Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts,TestModel.CapitolCity/CapitolDistrict", ODataVersion.V4)]
+        // $select=A,B&$expand=B($select=C)
+        [InlineData("Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)", ODataVersion.V4)]
+        public void FeedContextUriWithSelectAndExpandString(string selectClause, string expandClause, string expectedClause, ODataVersion version)
         {
-            foreach (ODataVersion version in Versions)
-            {
-                string uriString = this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString;
-                uriString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
-            }
+
+            string uriString = this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString;
+            uriString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
+
         }
 
         [Fact]
@@ -267,9 +277,10 @@ namespace Microsoft.OData.Tests
         [InlineData(ODataVersion.V401)]
         public void EntryContextUriWithExpandNestedExpandString(ODataVersion version)
         {
+            string emptyParens = version == ODataVersion.V401 ? "()" : "";
             // Without inner $select, $expand=A($expand=B($expand=C))
             string expandClause = "Districts($expand=City($expand=Districts))";
-            string expectedClause = "Districts(City(Districts()))";
+            string expectedClause = "Districts(City(Districts" + emptyParens + "))";
             string urlString = this.CreateEntryContextUri(null, expandClause, version).OriginalString;
             urlString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedClause));
 
@@ -296,7 +307,7 @@ namespace Microsoft.OData.Tests
         {
             const string selectClause = "Size,Name";
             const string expandClause = "Districts($select=Zip,City;$expand=City($expand=Districts;$select=Name))";
-            const string expectedClause = "Size,Name,Districts(Zip,City,City(Name,Districts()))";
+            string expectedClause = version == ODataVersion.V401 ? "Size,Name,Districts(Zip,City,City(Name,Districts()))" : "Size,Name,Districts(Zip,City,City(Name,Districts))";
             this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
         #endregion context uri with $select and $expand

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -273,14 +273,12 @@ namespace Microsoft.OData.Tests
         }
 
         [Theory]
-        [InlineData(ODataVersion.V4)]
-        [InlineData(ODataVersion.V401)]
-        public void EntryContextUriWithExpandNestedExpandString(ODataVersion version)
+        [InlineData(ODataVersion.V4, "Districts(City(Districts))")]
+        [InlineData(ODataVersion.V401, "Districts(City(Districts()))")]
+        public void EntryContextUriWithExpandNestedExpandString(ODataVersion version, string expectedClause)
         {
-            string emptyParens = version == ODataVersion.V401 ? "()" : "";
             // Without inner $select, $expand=A($expand=B($expand=C))
             string expandClause = "Districts($expand=City($expand=Districts))";
-            string expectedClause = "Districts(City(Districts" + emptyParens + "))";
             string urlString = this.CreateEntryContextUri(null, expandClause, version).OriginalString;
             urlString.Should().Be(BuildExpectedContextUri("#Cities", true, expectedClause));
 
@@ -301,13 +299,12 @@ namespace Microsoft.OData.Tests
         }
 
         [Theory]
-        [InlineData(ODataVersion.V4)]
-        [InlineData(ODataVersion.V401)]
-        public void FeedContextUriWithMixedSelectAndExpandString(ODataVersion version)
+        [InlineData(ODataVersion.V4, "Size,Name,Districts(Zip,City,City(Name,Districts))")]
+        [InlineData(ODataVersion.V401, "Size,Name,Districts(Zip,City,City(Name,Districts()))")]
+        public void FeedContextUriWithMixedSelectAndExpandString(ODataVersion version, string expectedClause)
         {
             const string selectClause = "Size,Name";
             const string expandClause = "Districts($select=Zip,City;$expand=City($expand=Districts;$select=Name))";
-            string expectedClause = version == ODataVersion.V401 ? "Size,Name,Districts(Zip,City,City(Name,Districts()))" : "Size,Name,Districts(Zip,City,City(Name,Districts))";
             this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
         #endregion context uri with $select and $expand

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
@@ -912,7 +912,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                     writer.WriteStart(entry);
                     writer.WriteEnd();
                 },
-                string.Format("\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany)/$entity\"", TestBaseUri),
+                string.Format("\"{0}$metadata#Employees(AssociatedCompany)/$entity\"", TestBaseUri),
                 out payload, out contentType);
 
                 this.ReadPayload(payload, contentType, model, omReader =>
@@ -927,7 +927,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
         // V4 Protocol Spec Chapter 10.10: Projected Expanded Entities (not contain select)
         // Sample Request: http://host/service/Employees(0)?$expand=AssociatedCompany
         [Theory]
-        [InlineData(ODataVersion.V4, "\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany)/$entity\"")]
+        [InlineData(ODataVersion.V4, "\"{0}$metadata#Employees(AssociatedCompany)/$entity\"")]
         [InlineData(ODataVersion.V401, "\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany())/$entity\"")]
         public void ExpandedMultiSegmentEntity(ODataVersion version, string contextString)
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
@@ -876,7 +876,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
             {
                 TypeName = TestNameSpace + ".Employee",
                 Properties = new[]
-           {
+                {
                     new ODataProperty {Name = "PersonId", Value = 1},
                     new ODataProperty {Name = "Name", Value = "Test1"},
                     new ODataProperty {Name = "Age", Value = 20},

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
@@ -317,7 +317,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedCollectionNavProp,ContainedCollectionNavProp()))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedCollectionNavProp,ContainedCollectionNavProp))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -357,7 +357,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp(ContainedNavProp,ContainedNavProp()))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp(ContainedNavProp,ContainedNavProp))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -392,7 +392,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp()))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -427,7 +427,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp,ExpandedCollectionNavProp(ContainedNavProp,ContainedNavProp()))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp,ExpandedCollectionNavProp(ContainedNavProp,ContainedNavProp))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ExpandedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ExpandedCollectionNavProp\":" +
@@ -442,7 +442,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
                                             "]" +
 
                                     "}";
-            result.Should().Be(expectedPayload);
+            Assert.Equal(expectedPayload, result);
         }
 
         [Fact]
@@ -463,7 +463,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ExpandedNavProp,ExpandedNavProp()))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ExpandedNavProp,ExpandedNavProp))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -500,7 +500,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp()))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -539,7 +539,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=Namespace.DerivedType/ContainedNavProp;$expand=Namespace.DerivedType/ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, DerivedType, selectClause, expandClause, "EntitySet/Namespace.DerivedType");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp,ContainedNavProp(Namespace.DerivedType/ContainedNavProp,Namespace.DerivedType/ContainedNavProp()))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp,ContainedNavProp(Namespace.DerivedType/ContainedNavProp,Namespace.DerivedType/ContainedNavProp))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -574,7 +574,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "Namespace.DerivedType/ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp()))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -659,7 +659,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ExpandedNavProp,ContainedCollectionNavProp($select=ID),ContainedNavProp($select=ID,Name)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ID,Name,ExpandedNavProp(),ContainedCollectionNavProp(ID),ContainedNavProp(ID,Name))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ID,Name,ExpandedNavProp,ContainedCollectionNavProp(ID),ContainedNavProp(ID,Name))/$entity\"," +
                                             "\"ID\":101,\"Name\":\"Alice\"," +
                                             "\"ExpandedNavProp\":{\"ID\":102,\"Name\":\"Bob\"}," +
                                             "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
@@ -953,7 +953,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp())/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp)/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":[{\"ID\":102,\"Name\":\"Bob\"}]" +

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
@@ -317,7 +317,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedCollectionNavProp,ContainedCollectionNavProp))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ContainedCollectionNavProp))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -357,7 +357,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp(ContainedNavProp,ContainedNavProp))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp(ContainedNavProp))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -392,7 +392,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ContainedNavProp))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -427,7 +427,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp,ExpandedCollectionNavProp(ContainedNavProp,ContainedNavProp))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp(ContainedNavProp))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ExpandedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ExpandedCollectionNavProp\":" +
@@ -442,7 +442,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
                                             "]" +
 
                                     "}";
-            Assert.Equal(expectedPayload, result);
+            result.Should().Be(expectedPayload);
         }
 
         [Fact]
@@ -463,7 +463,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ExpandedNavProp,ExpandedNavProp))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp(ExpandedNavProp))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -500,7 +500,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -539,7 +539,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=Namespace.DerivedType/ContainedNavProp;$expand=Namespace.DerivedType/ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, DerivedType, selectClause, expandClause, "EntitySet/Namespace.DerivedType");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp,ContainedNavProp(Namespace.DerivedType/ContainedNavProp,Namespace.DerivedType/ContainedNavProp))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp(Namespace.DerivedType/ContainedNavProp))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -574,7 +574,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "Namespace.DerivedType/ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -953,7 +953,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp)/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp)/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":[{\"ID\":102,\"Name\":\"Bob\"}]" +


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1383 .*

### Description

This pull request reverts some of the changes made by #1286 to fix the above-mentioned issue.
The reader and writer will not support empty parentheses unless the version is specified to be greater than v4. 

The controversial piece is regarding this change is when a navigation property is selected as well as expanded. We now will include the property twice in the context URI, which is not as obvious as it was with empty parentheses. Due to this, we may omit writing some navigational links for v4 which was a preexisting bug prior to # 1286.  

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Note for the reviewers
My expectation was that simply reverting the changes made by the PR should restore the expected behavior. However, it ended up being more than that. 