### PR TITLE
Ensure that we could use aliases created in compute() in groupby

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
@@ -80,7 +80,7 @@ namespace Microsoft.OData.UriParser.Aggregation
 
         internal List<string> GetLastAggregatedPropertyNames()
         {
-            if (lastAggregateExpressions == null && lastComputeExpressions == null)
+            if (lastAggregateExpressions == null && lastComputeExpressions == null && lastGroupByPropertyNodes == null)
             {
                 return null;
             }
@@ -94,6 +94,12 @@ namespace Microsoft.OData.UriParser.Aggregation
             {
                 result.AddRange(lastComputeExpressions.Select(statement => statement.Alias));
             }
+
+            if (lastGroupByPropertyNodes != null)
+            {
+                result.AddRange(lastGroupByPropertyNodes.Select(statement => statement.Name));
+            }
+
             return result;
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -1217,6 +1217,23 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             orderByClause.Expression.ShouldBeSingleValueOpenPropertyAccessQueryNode("DoubleTotal2");
         }
 
+
+        [Fact]
+        public void GroupedByComputePropertiesTreatedAsOpenPropertyInOrderBy()
+        {
+            var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,
+                HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet(),
+                new Dictionary<string, string>()
+                {
+                    {"$orderby", "Median asc"},
+                    {"$apply", "compute(1 as Median)/groupby((Median))"}
+                });
+            odataQueryOptionParser.ParseApply();
+            var orderByClause = odataQueryOptionParser.ParseOrderBy();
+            orderByClause.Direction.Should().Be(OrderByDirection.Ascending);
+            orderByClause.Expression.ShouldBeSingleValueOpenPropertyAccessQueryNode("Median");
+        }
+
         [Fact]
         public void ReferenceComputeAliasCreatedBeforeAggrageteThrows()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes one more edge case from issue #1368.*

### Description

Collecting aliases generated in compute() transformation followed by groupby to make them visible for following transformations and/or query options ($orderby, $filter)

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
