### PR TITLE
Validate the buffer returned from the pool

### DIFF
--- a/src/Microsoft.OData.Core/Buffers/BufferUtils.cs
+++ b/src/Microsoft.OData.Core/Buffers/BufferUtils.cs
@@ -45,6 +45,11 @@ namespace Microsoft.OData.Buffers
             }
 
             char[] buffer = bufferPool.Rent(minSize);
+            if (buffer == null || buffer.Length < minSize)
+            {
+                throw new ODataException(Strings.BufferUtils_InvalidBufferOrSize(minSize));
+            }
+
             return buffer;
         }
 

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -99,8 +99,8 @@ namespace Microsoft.OData {
         internal const string ODataWriterCore_WriteEndCalledInInvalidState = "ODataWriterCore_WriteEndCalledInInvalidState";
         internal const string ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties = "ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties";
         internal const string ODataWriterCore_QueryCountInRequest = "ODataWriterCore_QueryCountInRequest";
-        internal const string ODataWriterCore_QueryDeltaLinkInRequest = "ODataWriterCore_QueryDeltaLinkInRequest";
         internal const string ODataWriterCore_QueryNextLinkInRequest = "ODataWriterCore_QueryNextLinkInRequest";
+        internal const string ODataWriterCore_QueryDeltaLinkInRequest = "ODataWriterCore_QueryDeltaLinkInRequest";
         internal const string ODataWriterCore_CannotWriteDeltaWithResourceSetWriter = "ODataWriterCore_CannotWriteDeltaWithResourceSetWriter";
         internal const string ODataWriterCore_NestedContentNotAllowedIn40DeletedEntry = "ODataWriterCore_NestedContentNotAllowedIn40DeletedEntry";
         internal const string ODataWriterCore_CannotWriteTopLevelResourceSetWithResourceWriter = "ODataWriterCore_CannotWriteTopLevelResourceSetWithResourceWriter";
@@ -854,6 +854,7 @@ namespace Microsoft.OData {
         internal const string JsonReaderExtensions_CannotReadValueAsString = "JsonReaderExtensions_CannotReadValueAsString";
         internal const string JsonReaderExtensions_CannotReadValueAsDouble = "JsonReaderExtensions_CannotReadValueAsDouble";
         internal const string JsonReaderExtensions_UnexpectedInstanceAnnotationName = "JsonReaderExtensions_UnexpectedInstanceAnnotationName";
+        internal const string BufferUtils_InvalidBufferOrSize = "BufferUtils_InvalidBufferOrSize";
         internal const string ServiceProviderExtensions_NoServiceRegistered = "ServiceProviderExtensions_NoServiceRegistered";
 
         static TextRes loader = null;

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -955,4 +955,6 @@ JsonReaderExtensions_CannotReadValueAsString=Cannot read the value '{0}' as a qu
 JsonReaderExtensions_CannotReadValueAsDouble=Cannot read the value '{0}' as a double numeric value.
 JsonReaderExtensions_UnexpectedInstanceAnnotationName=An unexpected instance annotation name '{0}' was found when reading from the JSON reader, In OData, Instance annotation name must start with @.
 
+BufferUtils_InvalidBufferOrSize=The buffer from pool cannot be null or less than the required minimal size '{0}'.
+
 ServiceProviderExtensions_NoServiceRegistered=No service for type '{0}' has been registered.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -249,25 +249,21 @@ namespace Microsoft.OData {
             }
         }
 
-
-        /// A string like "The DeltaLink must be null for request payloads. Delta links are only supported in responses."
+        /// <summary>
+        /// A string like "The NextPageLink must be null for request payloads. Next page links are only supported in responses."
         /// </summary>
-        internal static string ODataWriterCore_QueryDeltaLinkInRequest
-        {
-            get
-            {
-                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataWriterCore_QueryDeltaLinkInRequest);
+        internal static string ODataWriterCore_QueryNextLinkInRequest {
+            get {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataWriterCore_QueryNextLinkInRequest);
             }
         }
 
         /// <summary>
-        /// A string like "The NextPageLink must be null for request payloads. Next page links are only supported in responses."
+        /// A string like "The DeltaLink must be null for request payloads. Delta links are only supported in responses."
         /// </summary>
-        internal static string ODataWriterCore_QueryNextLinkInRequest
-        {
-            get
-            {
-                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataWriterCore_QueryNextLinkInRequest);
+        internal static string ODataWriterCore_QueryDeltaLinkInRequest {
+            get {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataWriterCore_QueryDeltaLinkInRequest);
             }
         }
 
@@ -6022,6 +6018,13 @@ namespace Microsoft.OData {
         /// </summary>
         internal static string JsonReaderExtensions_UnexpectedInstanceAnnotationName(object p0) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.JsonReaderExtensions_UnexpectedInstanceAnnotationName, p0);
+        }
+
+        /// <summary>
+        /// A string like "The buffer from pool cannot be null or less than the required minimal size '{0}'."
+        /// </summary>
+        internal static string BufferUtils_InvalidBufferOrSize(object p0) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.BufferUtils_InvalidBufferOrSize, p0);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/BufferUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/BufferUtilsTests.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.OData.Tests
 {
+    using System;
     using FluentAssertions;
     using Microsoft.OData.Buffers;
     using Xunit;
@@ -34,6 +35,52 @@ namespace Microsoft.OData.Tests
             char[] buffer = new char[10];
             buffer = BufferUtils.InitializeBufferIfRequired(buffer);
             buffer.ShouldBeEquivalentTo(buffer);
+        }
+
+        [Fact]
+        public void RentFromBufferShouldThrowsIfNullBufferReturns()
+        {
+            // Arrange
+            Action test = () => BufferUtils.RentFromBuffer(new BadCharArrayPool(), 1024);
+
+            // Act & Assert
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.BufferUtils_InvalidBufferOrSize(1024), exception.Message);
+        }
+
+        public class BadCharArrayPool : ICharArrayPool
+        {
+            public char[] Rent(int minSize)
+            {
+                return null;
+            }
+
+            public void Return(char[] array)
+            {
+            }
+        }
+
+        [Fact]
+        public void RentFromBufferShouldThrowsIfStringyBufferReturns()
+        {
+            // Arrange
+            Action test = () => BufferUtils.RentFromBuffer(new StingyCharArrayPool(), 1024);
+
+            // Act & Assert
+            var exception = Assert.Throws<ODataException>(test);
+            Assert.Equal(Strings.BufferUtils_InvalidBufferOrSize(1024), exception.Message);
+        }
+
+        public class StingyCharArrayPool : ICharArrayPool
+        {
+            public char[] Rent(int minSize)
+            {
+                return new char[minSize - 1];
+            }
+
+            public void Return(char[] array)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1410.*

### Description

* Enable to validate the buffer size returned from the array pool.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
