### PR TITLE
Add the IEdmOperationReturnType interface and enable annotation on return type of operation

### DIFF
--- a/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
+++ b/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
@@ -298,8 +298,8 @@
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\SerializationExtensionMethods.cs">
       <Link>Microsoft\OData\Edm\Csdl\SerializationExtensionMethods.cs</Link>
     </Compile>
-    <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Parsing\Ast\CsdlOperationReturnType.cs">
-      <Link>Microsoft\OData\Edm\Csdl\Parsing\Ast\CsdlOperationReturnType.cs</Link>
+    <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Parsing\Ast\CsdlOperationReturn.cs">
+      <Link>Microsoft\OData\Edm\Csdl\Parsing\Ast\CsdlOperationReturn.cs</Link>
     </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\CsdlSemanticsEntityReferenceTypeExpression.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\CsdlSemanticsEntityReferenceTypeExpression.cs</Link>
@@ -533,6 +533,9 @@
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\CsdlSemanticsOperationParameter.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\CsdlSemanticsOperationParameter.cs</Link>
     </Compile>
+    <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\CsdlSemanticsOperationReturn.cs">
+      <Link>Microsoft\OData\Edm\Csdl\Semantics\CsdlSemanticsOperationReturn.cs</Link>
+    </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\CsdlSemanticsOptionalParameter.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\CsdlSemanticsOptionalParameter.cs</Link>
     </Compile>
@@ -553,6 +556,9 @@
     </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\BadElements\UnresolvedParameter.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\BadElements\UnresolvedParameter.cs</Link>
+    </Compile>
+    <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\BadElements\UnresolvedReturn.cs">
+      <Link>Microsoft\OData\Edm\Csdl\Semantics\BadElements\UnresolvedReturn.cs</Link>
     </Compile>
     <Compile Include="$(EdmLibCrossTargettingSourcePath)\Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs">
       <Link>Microsoft\OData\Edm\Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs</Link>
@@ -941,6 +947,9 @@
     <Compile Include="..\Schema\EdmOperationParameter.cs">
       <Link>Microsoft\OData\Edm\Schema\EdmOperationParameter.cs</Link>
     </Compile>
+    <Compile Include="..\Schema\EdmOperationReturn.cs">
+      <Link>Microsoft\OData\Edm\Schema\EdmOperationReturn.cs</Link>
+    </Compile>
     <Compile Include="..\Schema\EdmOptionalParameter.cs">
       <Link>Microsoft\OData\Edm\Schema\EdmOptionalParameter.cs</Link>
     </Compile>
@@ -1144,6 +1153,9 @@
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmOperationParameter.cs">
       <Link>Microsoft\OData\Edm\Schema\Interfaces\IEdmOperationParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\Schema\Interfaces\IEdmOperationReturn.cs">
+      <Link>Microsoft\OData\Edm\Schema\Interfaces\IEdmOperationReturn.cs</Link>
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmOptionalParameter.cs">
       <Link>Microsoft\OData\Edm\Schema\Interfaces\IEdmOptionalParameter.cs</Link>

--- a/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
+++ b/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
@@ -208,8 +208,8 @@
     <Compile Include="..\Csdl\Parsing\Ast\CsdlOperationParameter.cs">
       <Link>Csdl\Parsing\Ast\CsdlOperationParameter.cs</Link>
     </Compile>
-    <Compile Include="..\Csdl\Parsing\Ast\CsdlOperationReturnType.cs">
-      <Link>Csdl\Parsing\Ast\CsdlOperationReturnType.cs</Link>
+    <Compile Include="..\Csdl\Parsing\Ast\CsdlOperationReturn.cs">
+      <Link>Csdl\Parsing\Ast\CsdlOperationReturn.cs</Link>
     </Compile>
     <Compile Include="..\Csdl\Parsing\Ast\CsdlPathExpression.cs">
       <Link>Csdl\Parsing\Ast\CsdlPathExpression.cs</Link>
@@ -337,6 +337,9 @@
     </Compile>
     <Compile Include="..\Csdl\Semantics\BadElements\UnresolvedParameter.cs">
       <Link>Csdl\Semantics\BadElements\UnresolvedParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\Csdl\Semantics\BadElements\UnresolvedReturn.cs">
+      <Link>Csdl\Semantics\BadElements\UnresolvedReturn.cs</Link>
     </Compile>
     <Compile Include="..\Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs">
       <Link>Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs</Link>
@@ -490,6 +493,9 @@
     </Compile>
     <Compile Include="..\Csdl\Semantics\CsdlSemanticsOperationParameter.cs">
       <Link>Csdl\Semantics\CsdlSemanticsOperationParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\Csdl\Semantics\CsdlSemanticsOperationReturn.cs">
+      <Link>Csdl\Semantics\CsdlSemanticsOperationReturn.cs</Link>
     </Compile>
     <Compile Include="..\Csdl\Semantics\CsdlSemanticsOptionalParameter.cs">
       <Link>Csdl\Semantics\CsdlSemanticsOptionalParameter.cs</Link>
@@ -852,6 +858,9 @@
     <Compile Include="..\Schema\EdmOperationParameter.cs">
       <Link>Schema\EdmOperationParameter.cs</Link>
     </Compile>
+    <Compile Include="..\Schema\EdmOperationReturn.cs">
+      <Link>Schema\EdmOperationReturn.cs</Link>
+    </Compile>
     <Compile Include="..\Schema\EdmOptionalParameter.cs">
       <Link>Schema\EdmOptionalParameter.cs</Link>
     </Compile>
@@ -1056,6 +1065,9 @@
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmOperationParameter.cs">
       <Link>Schema\Interfaces\IEdmOperationParameter.cs</Link>
+    </Compile>
+    <Compile Include="..\Schema\Interfaces\IEdmOperationReturn.cs">
+      <Link>Schema\Interfaces\IEdmOperationReturn.cs</Link>
     </Compile>
     <Compile Include="..\Schema\Interfaces\IEdmOptionalParameter.cs">
       <Link>Schema\Interfaces\IEdmOptionalParameter.cs</Link>

--- a/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
@@ -232,6 +232,8 @@ namespace Microsoft.OData.Edm.Csdl
         internal const string Element_IncludeAnnotations = "IncludeAnnotations";
         internal const string Element_DataServices = "DataServices";
 
+        internal const string OperationReturnExternalTarget = "$ReturnType";
+
         #endregion
 
         internal static Dictionary<Version, string[]> SupportedVersions = new Dictionary<Version, string[]>()

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAction.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAction.cs
@@ -18,18 +18,18 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         /// </summary>
         /// <param name="name">The name.</param>
         /// <param name="parameters">The parameters.</param>
-        /// <param name="returnType">The return type of the function.</param>
+        /// <param name="operationReturn">The return of the action.</param>
         /// <param name="isBound">if set to <c>true</c> [is bound].</param>
         /// <param name="entitySetPath">The entity set path.</param>
-        /// <param name="location">The location in the csdl document of the function.</param>
+        /// <param name="location">The location in the csdl document of the action.</param>
         public CsdlAction(
             string name,
             IEnumerable<CsdlOperationParameter> parameters,
-            CsdlTypeReference returnType,
+            CsdlOperationReturn operationReturn,
             bool isBound,
             string entitySetPath,
             CsdlLocation location)
-            : base(name, parameters, returnType, isBound, entitySetPath, location)
+            : base(name, parameters, operationReturn, isBound, entitySetPath, location)
         {
         }
     }

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlFunction.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlFunction.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         /// </summary>
         /// <param name="name">The name.</param>
         /// <param name="parameters">The parameters.</param>
-        /// <param name="returnType">The return type of the function.</param>
+        /// <param name="operationReturn">The return of the function.</param>
         /// <param name="isBound">if set to <c>true</c> [is bound].</param>
         /// <param name="entitySetPath">The entity set path.</param>
         /// <param name="isComposable">if set to <c>true</c> [is composable].</param>
@@ -26,12 +26,12 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         public CsdlFunction(
             string name,
             IEnumerable<CsdlOperationParameter> parameters,
-            CsdlTypeReference returnType,
+            CsdlOperationReturn operationReturn,
             bool isBound,
             string entitySetPath,
             bool isComposable,
             CsdlLocation location)
-            : base(name, parameters, returnType, isBound, entitySetPath, location)
+            : base(name, parameters, operationReturn, isBound, entitySetPath, location)
         {
             this.IsComposable = isComposable;
         }

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlFunctionBase.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlFunctionBase.cs
@@ -14,13 +14,13 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
     internal abstract class CsdlFunctionBase : CsdlNamedElement
     {
         private readonly List<CsdlOperationParameter> parameters;
-        private readonly CsdlTypeReference returnType;
+        private readonly CsdlOperationReturn operationReturn;
 
-        protected CsdlFunctionBase(string name, IEnumerable<CsdlOperationParameter> parameters, CsdlTypeReference returnType, CsdlLocation location)
+        protected CsdlFunctionBase(string name, IEnumerable<CsdlOperationParameter> parameters, CsdlOperationReturn operationReturn, CsdlLocation location)
             : base(name, location)
         {
             this.parameters = new List<CsdlOperationParameter>(parameters);
-            this.returnType = returnType;
+            this.operationReturn = operationReturn;
         }
 
         public IEnumerable<CsdlOperationParameter> Parameters
@@ -28,9 +28,9 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
             get { return this.parameters; }
         }
 
-        public CsdlTypeReference ReturnType
+        public CsdlOperationReturn Return
         {
-            get { return this.returnType; }
+            get { return this.operationReturn; }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperation.cs
@@ -18,18 +18,18 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         /// </summary>
         /// <param name="name">The name.</param>
         /// <param name="parameters">The parameters.</param>
-        /// <param name="returnType">Type of the return.</param>
+        /// <param name="operationReturn">The operation return.</param>
         /// <param name="isBound">if set to <c>true</c> [is bound].</param>
         /// <param name="entitySetPath">The entity set path.</param>
         /// <param name="location">The location.</param>
         public CsdlOperation(
             string name,
             IEnumerable<CsdlOperationParameter> parameters,
-            CsdlTypeReference returnType,
+            CsdlOperationReturn operationReturn,
             bool isBound,
             string entitySetPath,
             CsdlLocation location)
-            : base(name, parameters, returnType, location)
+            : base(name, parameters, operationReturn, location)
         {
             this.IsBound = isBound;
             this.EntitySetPath = entitySetPath;

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperationImport.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperationImport.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
             string schemaOperationQualifiedTypeName,
             string entitySet,
             IEnumerable<CsdlOperationParameter> parameters,
-            CsdlTypeReference returnType,
+            CsdlOperationReturn returnType,
             CsdlLocation location)
             : base(name, parameters, returnType, location)
         {

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperationReturn.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlOperationReturn.cs
@@ -1,21 +1,19 @@
 //---------------------------------------------------------------------
-// <copyright file="CsdlOperationReturnType.cs" company="Microsoft">
+// <copyright file="CsdlOperationReturn.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
 //---------------------------------------------------------------------
-
-using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
 {
     /// <summary>
     /// Represents a CSDL function return type.
     /// </summary>
-    internal class CsdlOperationReturnType : CsdlElement, IEdmVocabularyAnnotatable
+    internal class CsdlOperationReturn : CsdlElement
     {
         private readonly CsdlTypeReference returnType;
 
-        public CsdlOperationReturnType(CsdlTypeReference returnType, CsdlLocation location)
+        public CsdlOperationReturn(CsdlTypeReference returnType, CsdlLocation location)
             : base(location)
         {
             this.returnType = returnType;

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
@@ -340,7 +340,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
                         //// </Parameter)
 
                         //// <ReturnType>
-                        CsdlElement<CsdlOperationReturnType>(CsdlConstants.Element_ReturnType, this.OnReturnTypeElement,
+                        CsdlElement<CsdlOperationReturn>(CsdlConstants.Element_ReturnType, this.OnReturnTypeElement,
                             //// <TypeRef/>
                             CsdlElement<CsdlTypeReference>(CsdlConstants.Element_TypeRef, this.OnTypeRefElement),
                             //// <CollectionType/>
@@ -369,7 +369,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
                     //// </Parameter
 
                     //// <ReturnType>
-                    CsdlElement<CsdlOperationReturnType>(CsdlConstants.Element_ReturnType, this.OnReturnTypeElement,
+                    CsdlElement<CsdlOperationReturn>(CsdlConstants.Element_ReturnType, this.OnReturnTypeElement,
                         //// <TypeRef/>
                         CsdlElement<CsdlTypeReference>(CsdlConstants.Element_TypeRef, this.OnTypeRefElement),
                         //// <CollectionType/>
@@ -891,6 +891,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
                 case EdmPrimitiveTypeKind.Single:
                 case EdmPrimitiveTypeKind.Stream:
                 case EdmPrimitiveTypeKind.Date:
+                case EdmPrimitiveTypeKind.PrimitiveType:
                     return new CsdlPrimitiveTypeReference(kind, typeName, isNullable, parentLocation);
 
                 case EdmPrimitiveTypeKind.Binary:
@@ -1068,12 +1069,11 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
 
             IEnumerable<CsdlOperationParameter> parameters = childValues.ValuesOfType<CsdlOperationParameter>();
 
-            CsdlOperationReturnType returnTypeElement = childValues.ValuesOfType<CsdlOperationReturnType>().FirstOrDefault();
-            CsdlTypeReference returnType = returnTypeElement == null ? null : returnTypeElement.ReturnType;
+            CsdlOperationReturn returnElement = childValues.ValuesOfType<CsdlOperationReturn>().FirstOrDefault();
 
             this.ReportOperationReadErrorsIfExist(entitySetPath, isBound, name);
 
-            return new CsdlAction(name, parameters, returnType, isBound, entitySetPath, element.Location);
+            return new CsdlAction(name, parameters, returnElement, isBound, entitySetPath, element.Location);
         }
 
         internal CsdlFunction OnFunctionElement(XmlElementInfo element, XmlElementValueCollection childValues)
@@ -1085,12 +1085,11 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
 
             IEnumerable<CsdlOperationParameter> parameters = childValues.ValuesOfType<CsdlOperationParameter>();
 
-            CsdlOperationReturnType returnTypeElement = childValues.ValuesOfType<CsdlOperationReturnType>().FirstOrDefault();
-            CsdlTypeReference returnType = returnTypeElement == null ? null : returnTypeElement.ReturnType;
+            CsdlOperationReturn returnElement = childValues.ValuesOfType<CsdlOperationReturn>().FirstOrDefault();
 
             this.ReportOperationReadErrorsIfExist(entitySetPath, isBound, name);
 
-            return new CsdlFunction(name, parameters, returnType, isBound, entitySetPath, isComposable, element.Location);
+            return new CsdlFunction(name, parameters, returnElement, isBound, entitySetPath, isComposable, element.Location);
         }
 
         private void ReportOperationReadErrorsIfExist(string entitySetPath, bool isBound, string name)
@@ -1189,11 +1188,11 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             return new CsdlExpressionTypeReference(new CsdlCollectionType(elementType, element.Location), elementType.IsNullable, element.Location);
         }
 
-        private CsdlOperationReturnType OnReturnTypeElement(XmlElementInfo element, XmlElementValueCollection childValues)
+        private CsdlOperationReturn OnReturnTypeElement(XmlElementInfo element, XmlElementValueCollection childValues)
         {
             string typeName = RequiredType(CsdlConstants.Attribute_Type);
             CsdlTypeReference type = this.ParseTypeReference(typeName, childValues, element.Location, Optionality.Required);
-            return new CsdlOperationReturnType(type, element.Location);
+            return new CsdlOperationReturn(type, element.Location);
         }
 
         private CsdlEntityContainer OnEntityContainerElement(XmlElementInfo element, XmlElementValueCollection childValues)

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedReturn.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedReturn.cs
@@ -1,0 +1,36 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="UnresolvedReturn.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using Microsoft.OData.Edm.Validation;
+
+namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
+{
+    internal class UnresolvedReturn : BadElement, IEdmOperationReturn, IUnresolvedElement
+    {
+        // Type cache.
+        private readonly Cache<UnresolvedReturn, IEdmTypeReference> type = new Cache<UnresolvedReturn, IEdmTypeReference>();
+        private static readonly Func<UnresolvedReturn, IEdmTypeReference> ComputeTypeFunc = (me) => me.ComputeType();
+
+        public UnresolvedReturn(IEdmOperation declaringOperation, EdmLocation location)
+            : base(new EdmError[] { new EdmError(location, EdmErrorCode.BadUnresolvedReturn, Edm.Strings.Bad_UnresolvedReturn(declaringOperation.Name)) })
+        {
+            this.DeclaringOperation = declaringOperation;
+        }
+
+        public IEdmTypeReference Type
+        {
+            get { return this.type.GetValue(this, ComputeTypeFunc, null); }
+        }
+
+        public IEdmOperation DeclaringOperation { get; private set; }
+
+        private IEdmTypeReference ComputeType()
+        {
+            return new BadTypeReference(new BadType(Errors), true);
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperation.cs
@@ -24,8 +24,8 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         private readonly Cache<CsdlSemanticsOperation, IEdmPathExpression> entitySetPathCache = new Cache<CsdlSemanticsOperation, IEdmPathExpression>();
         private static readonly Func<CsdlSemanticsOperation, IEdmPathExpression> ComputeEntitySetPathFunc = (me) => me.ComputeEntitySetPath();
 
-        private readonly Cache<CsdlSemanticsOperation, IEdmTypeReference> returnTypeCache = new Cache<CsdlSemanticsOperation, IEdmTypeReference>();
-        private static readonly Func<CsdlSemanticsOperation, IEdmTypeReference> ComputeReturnTypeFunc = (me) => me.ComputeReturnType();
+        private readonly Cache<CsdlSemanticsOperation, IEdmOperationReturn> returnCache = new Cache<CsdlSemanticsOperation, IEdmOperationReturn>();
+        private static readonly Func<CsdlSemanticsOperation, IEdmOperationReturn> ComputeReturnFunc = (me) => me.ComputeReturn();
 
         private readonly Cache<CsdlSemanticsOperation, IEnumerable<IEdmOperationParameter>> parametersCache = new Cache<CsdlSemanticsOperation, IEnumerable<IEdmOperationParameter>>();
         private static readonly Func<CsdlSemanticsOperation, IEnumerable<IEdmOperationParameter>> ComputeParametersFunc = (me) => me.ComputeParameters();
@@ -83,7 +83,20 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
         public IEdmTypeReference ReturnType
         {
-            get { return this.returnTypeCache.GetValue(this, ComputeReturnTypeFunc, null); }
+            get
+            {
+                if (this.operation.Return == null)
+                {
+                    return null;
+                }
+
+                return Return.Type;
+            }
+        }
+
+        public IEdmOperationReturn Return
+        {
+            get { return this.returnCache.GetValue(this, ComputeReturnFunc, null); }
         }
 
         public IEnumerable<IEdmOperationParameter> Parameters
@@ -113,9 +126,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             return null;
         }
 
-        private IEdmTypeReference ComputeReturnType()
+        private IEdmOperationReturn ComputeReturn()
         {
-            return CsdlSemanticsModel.WrapTypeReference(this.Context, this.operation.ReturnType);
+            if (this.operation.Return == null)
+            {
+                return null;
+            }
+
+            return new CsdlSemanticsOperationReturn(this, this.operation.Return);
         }
 
         private IEnumerable<IEdmOperationParameter> ComputeParameters()

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperationReturn.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsOperationReturn.cs
@@ -1,0 +1,62 @@
+//---------------------------------------------------------------------
+// <copyright file="CsdlSemanticsOperationReturn.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OData.Edm.Csdl.Parsing.Ast;
+using Microsoft.OData.Edm.Vocabularies;
+
+namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
+{
+    /// <summary>
+    /// Provides semantics for a CsdlOperationReturn.
+    /// </summary>
+    internal class CsdlSemanticsOperationReturn : CsdlSemanticsElement, IEdmOperationReturn
+    {
+        private readonly CsdlSemanticsOperation declaringOperation;
+        private readonly CsdlOperationReturn operationReturn;
+
+        private readonly Cache<CsdlSemanticsOperationReturn, IEdmTypeReference> typeCache = new Cache<CsdlSemanticsOperationReturn, IEdmTypeReference>();
+        private static readonly Func<CsdlSemanticsOperationReturn, IEdmTypeReference> ComputeTypeFunc = (me) => me.ComputeType();
+
+        public CsdlSemanticsOperationReturn(CsdlSemanticsOperation declaringOperation, CsdlOperationReturn operationReturn)
+            : base(operationReturn)
+        {
+            this.declaringOperation = declaringOperation;
+            this.operationReturn = operationReturn;
+        }
+
+        public override CsdlSemanticsModel Model
+        {
+            get { return this.declaringOperation.Model; }
+        }
+
+        public override CsdlElement Element
+        {
+            get { return this.operationReturn; }
+        }
+
+        public IEdmTypeReference Type
+        {
+            get { return this.typeCache.GetValue(this, ComputeTypeFunc, null); }
+        }
+
+        public IEdmOperation DeclaringOperation
+        {
+            get { return this.declaringOperation; }
+        }
+
+        protected override IEnumerable<IEdmVocabularyAnnotation> ComputeInlineVocabularyAnnotations()
+        {
+            return this.Model.WrapInlineVocabularyAnnotations(this, this.declaringOperation.Context);
+        }
+
+        private IEdmTypeReference ComputeType()
+        {
+            return CsdlSemanticsModel.WrapTypeReference(this.declaringOperation.Context, this.operationReturn.ReturnType);
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
@@ -210,6 +210,17 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                     IEdmOperation operation = this.FindParameterizedOperation(targetSegments[0], this.Schema.FindOperations, this.CreateAmbiguousOperation);
                     if (operation != null)
                     {
+                        // $ReturnType
+                        if (targetSegments[1] == CsdlConstants.OperationReturnExternalTarget)
+                        {
+                            if (operation.ReturnType != null)
+                            {
+                                return operation.GetReturn();
+                            }
+
+                            return new UnresolvedReturn(operation, this.Location);
+                        }
+
                         IEdmOperationParameter parameter = operation.FindParameter(targetSegments[1]);
                         if (parameter != null)
                         {
@@ -224,7 +235,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
                 if (targetSegmentsCount == 3)
                 {
-                    // The only valid target with three segments is a function parameter.
+                    // The only valid target with three segments is a function parameter, or an operation return.
                     string containerName = targetSegments[0];
                     string operationName = targetSegments[1];
                     string parameterName = targetSegments[2];
@@ -235,6 +246,17 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                         IEdmOperationImport operationImport = FindParameterizedOperationImport(operationName, container.FindOperationImportsExtended, this.CreateAmbiguousOperationImport);
                         if (operationImport != null)
                         {
+                            // $ReturnType
+                            if (parameterName == CsdlConstants.OperationReturnExternalTarget)
+                            {
+                                if (operationImport.Operation.ReturnType != null)
+                                {
+                                    return operationImport.Operation.GetReturn();
+                                }
+
+                                return new UnresolvedReturn(operationImport.Operation, this.Location);
+                            }
+
                             IEdmOperationParameter parameter = operationImport.Operation.FindParameter(parameterName);
                             if (parameter != null)
                             {
@@ -247,7 +269,14 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
                     string qualifiedOperationName = containerName + "/" + operationName;
                     UnresolvedOperation unresolvedOperation = new UnresolvedOperation(qualifiedOperationName, Edm.Strings.Bad_UnresolvedOperation(qualifiedOperationName), this.Location);
-                    return new UnresolvedParameter(unresolvedOperation, parameterName, this.Location);
+                    if (parameterName == CsdlConstants.OperationReturnExternalTarget)
+                    {
+                        return new UnresolvedReturn(unresolvedOperation, this.Location);
+                    }
+                    else
+                    {
+                        return new UnresolvedParameter(unresolvedOperation, parameterName, this.Location);
+                    }
                 }
 
                 return new BadElement(new EdmError[] { new EdmError(this.Location, EdmErrorCode.ImpossibleAnnotationsTarget, Edm.Strings.CsdlSemantics_ImpossibleAnnotationsTarget(target)) });

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
@@ -276,6 +276,32 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.schemaWriter.WriteOperationParameterEndElement(element);
         }
 
+        protected override void ProcessOperationReturn(IEdmOperationReturn operationReturn)
+        {
+            if (operationReturn == null)
+            {
+                return;
+            }
+
+            bool inlineType = IsInlineType(operationReturn.Type);
+            this.BeginElement(
+                operationReturn.Type,
+                type => this.schemaWriter.WriteReturnTypeElementHeader(),
+                type =>
+                {
+                    if (inlineType)
+                    {
+                        this.schemaWriter.WriteTypeAttribute(type);
+                        this.ProcessFacets(type, true /*inlineType*/);
+                    }
+                    else
+                    {
+                        this.VisitTypeReference(type);
+                    }
+                });
+            this.EndElement(operationReturn);
+        }
+
         protected override void ProcessCollectionType(IEdmCollectionType element)
         {
             bool inlineType = IsInlineType(element.ElementType);
@@ -539,34 +565,11 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         {
             this.BeginElement(operation, writeElementAction);
             this.VisitOperationParameters(operation.Parameters);
-            this.ProcessOperationReturnType(operation.ReturnType);
+
+            IEdmOperationReturn operationReturn = operation.GetReturn();
+            this.ProcessOperationReturn(operationReturn);
+
             this.EndElement(operation);
-        }
-
-        private void ProcessOperationReturnType(IEdmTypeReference operationReturnType)
-        {
-            if (operationReturnType == null)
-            {
-                return;
-            }
-
-            bool inlineType = IsInlineType(operationReturnType);
-            this.BeginElement(
-                operationReturnType,
-                type => this.schemaWriter.WriteReturnTypeElementHeader(),
-                type =>
-                {
-                    if (inlineType)
-                    {
-                        this.schemaWriter.WriteTypeAttribute(type);
-                        this.ProcessFacets(type, true /*inlineType*/);
-                    }
-                    else
-                    {
-                        this.VisitTypeReference(type);
-                    }
-                });
-            this.EndElement(operationReturnType);
         }
 
         private void ProcessReferentialConstraint(IEdmReferentialConstraint element)

--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -841,13 +841,11 @@ namespace Microsoft.OData.Edm
 
         protected virtual void ProcessOperation(IEdmOperation operation)
         {
-            if (operation.ReturnType != null)
-            {
-                this.VisitTypeReference(operation.ReturnType);
-            }
-
             // Do not visit vocabularyAnnotatable because functions and operation imports are always going to be either a schema element or a container element and will be visited through those paths.
             this.VisitOperationParameters(operation.Parameters);
+
+            IEdmOperationReturn operationReturn = operation.GetReturn();
+            this.ProcessOperationReturn(operationReturn);
         }
 
         protected virtual void ProcessOperationParameter(IEdmOperationParameter parameter)
@@ -857,6 +855,16 @@ namespace Microsoft.OData.Edm
             this.VisitTypeReference(parameter.Type);
         }
 
+        protected virtual void ProcessOperationReturn(IEdmOperationReturn operationReturn)
+        {
+            if (operationReturn == null)
+            {
+                return;
+            }
+
+            this.ProcessVocabularyAnnotatable(operationReturn);
+            this.VisitTypeReference(operationReturn.Type);
+        }
         #endregion
 
         #endregion

--- a/src/Microsoft.OData.Edm/EdmUtil.cs
+++ b/src/Microsoft.OData.Edm/EdmUtil.cs
@@ -336,6 +336,8 @@ namespace Microsoft.OData.Edm
                     }
                     else
                     {
+                        IEdmOperationReturn operationReturn;
+                        IEdmEnumMember enumMember;
                         IEdmOperationParameter parameter = element as IEdmOperationParameter;
                         if (parameter != null)
                         {
@@ -345,16 +347,20 @@ namespace Microsoft.OData.Edm
                                 return parameterOwnerName + "/" + parameter.Name;
                             }
                         }
-                        else
+                        else if ((enumMember = element as IEdmEnumMember) != null)
                         {
-                            IEdmEnumMember enumMember = element as IEdmEnumMember;
-                            if (enumMember != null)
+                            string enumMemberOwnerName = FullyQualifiedName(enumMember.DeclaringType);
+                            if (enumMemberOwnerName != null)
                             {
-                                string enumMemberOwnerName = FullyQualifiedName(enumMember.DeclaringType);
-                                if (enumMemberOwnerName != null)
-                                {
-                                    return enumMemberOwnerName + "/" + enumMember.Name;
-                                }
+                                return enumMemberOwnerName + "/" + enumMember.Name;
+                            }
+                        }
+                        else if ((operationReturn = element as IEdmOperationReturn) != null)
+                        {
+                            string operationName = FullyQualifiedName(operationReturn.DeclaringOperation);
+                            if (operationName != null)
+                            {
+                                return operationName + "/" + CsdlConstants.OperationReturnExternalTarget;
                             }
                         }
                     }

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -2373,6 +2373,28 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Gets the <see cref="IEdmOperationReturn"/> from the specified operation.
+        /// </summary>
+        /// <param name="operation">The operation.</param>
+        /// <returns>The instance of <see cref="IEdmOperationReturn"/> or null if the operation has no return type.</returns>
+        public static IEdmOperationReturn GetReturn(this IEdmOperation operation)
+        {
+            EdmOperation edmOperation = operation as EdmOperation;
+            if (edmOperation != null)
+            {
+                return edmOperation.Return;
+            }
+
+            CsdlSemanticsOperation csdlOperation = operation as CsdlSemanticsOperation;
+            if (csdlOperation != null)
+            {
+                return csdlOperation.Return;
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Checks whether all operations have the same return type
         /// </summary>
         /// <param name="operations">the list to check</param>

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -2391,7 +2391,12 @@ namespace Microsoft.OData.Edm
                 return csdlOperation.Return;
             }
 
-            return null;
+            if (operation.ReturnType == null)
+            {
+                return null;
+            }
+
+            return new EdmOperationReturn(operation, operation.ReturnType);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -2391,7 +2391,7 @@ namespace Microsoft.OData.Edm
                 return csdlOperation.Return;
             }
 
-            if (operation.ReturnType == null)
+            if (operation == null || operation.ReturnType == null)
             {
                 return null;
             }

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
@@ -331,6 +331,7 @@ namespace Microsoft.OData.Edm {
         internal const string Bad_UnresolvedEnumMember = "Bad_UnresolvedEnumMember";
         internal const string Bad_UnresolvedProperty = "Bad_UnresolvedProperty";
         internal const string Bad_UnresolvedParameter = "Bad_UnresolvedParameter";
+        internal const string Bad_UnresolvedReturn = "Bad_UnresolvedReturn";
         internal const string Bad_UnresolvedLabeledElement = "Bad_UnresolvedLabeledElement";
         internal const string Bad_CyclicEntity = "Bad_CyclicEntity";
         internal const string Bad_CyclicComplex = "Bad_CyclicComplex";

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -134,7 +134,7 @@
     <Compile Include="Csdl\Serialization\EdmModelReferenceElementsVisitor.cs" />
     <Compile Include="Csdl\Serialization\SerializationValidator.cs" />
     <Compile Include="Csdl\SerializationExtensionMethods.cs" />
-    <Compile Include="Csdl\Parsing\Ast\CsdlOperationReturnType.cs" />
+    <Compile Include="Csdl\Parsing\Ast\CsdlOperationReturn.cs" />
     <Compile Include="Csdl\CsdlReader.cs" />
     <Compile Include="Csdl\CsdlWriter.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsEntityReferenceTypeExpression.cs" />
@@ -372,6 +372,7 @@
     <Compile Include="Csdl\Semantics\CsdlSemanticsEntityTypeDefinition.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsOperation.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsOperationParameter.cs" />
+    <Compile Include="Csdl\Semantics\CsdlSemanticsOperationReturn.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsOptionalParameter.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsModel.cs" />
     <Compile Include="Csdl\Semantics\CsdlSemanticsNavigationProperty.cs" />
@@ -381,6 +382,7 @@
     <Compile Include="Csdl\Semantics\BadElements\UnresolvedLabeledElement.cs" />
     <Compile Include="Csdl\Semantics\BadElements\UnresolvedEnumMember.cs" />
     <Compile Include="Csdl\Semantics\BadElements\UnresolvedParameter.cs" />
+    <Compile Include="Csdl\Semantics\BadElements\UnresolvedReturn.cs" />
     <Compile Include="Schema\EdmEnumTypeReference.cs" />
     <Compile Include="Csdl\Semantics\BadElements\UnresolvedPrimitiveType.cs" />
     <Compile Include="Schema\EdmCollectionType.cs" />
@@ -423,6 +425,7 @@
     <Compile Include="Schema\Interfaces\IEdmEntityTypeReference.cs" />
     <Compile Include="Schema\Interfaces\IEdmOperationImport.cs" />
     <Compile Include="Schema\Interfaces\IEdmOperationParameter.cs" />
+    <Compile Include="Schema\Interfaces\IEdmOperationReturn.cs" />
     <Compile Include="Schema\Interfaces\IEdmOptionalParameter.cs" />
     <Compile Include="Schema\Interfaces\IEdmModel.cs" />
     <Compile Include="Schema\Interfaces\IEdmNamedElement.cs" />
@@ -448,6 +451,7 @@
     <Compile Include="Schema\EdmOperation.cs" />
     <Compile Include="Schema\EdmOperationImport.cs" />
     <Compile Include="Schema\EdmOperationParameter.cs" />
+    <Compile Include="Schema\EdmOperationReturn.cs" />
     <Compile Include="Schema\EdmOptionalParameter.cs" />
     <Compile Include="Schema\EdmModel.cs" />
     <Compile Include="Schema\EdmModelBase.cs" />

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -286,6 +286,7 @@ Bad_UnresolvedEnumType=The enum type '{0}' could not be found.
 Bad_UnresolvedEnumMember=The enum member '{0}' could not be found.
 Bad_UnresolvedProperty=The property '{0}' could not be found.
 Bad_UnresolvedParameter=The parameter '{0}' could not be found.
+Bad_UnresolvedReturn=The return of operation '{0}' could not be found.
 Bad_UnresolvedLabeledElement=The labeled element '{0}' could not be found.
 Bad_CyclicEntity=The entity '{0}' is invalid because its base type is cyclic.
 Bad_CyclicComplex=The complex type '{0}' is invalid because its base type is cyclic.

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -1966,6 +1966,13 @@ namespace Microsoft.OData.Edm {
         }
 
         /// <summary>
+        /// A string like "The return of operation '{0}' could not be found."
+        /// </summary>
+        internal static string Bad_UnresolvedReturn(object p0) {
+            return Microsoft.OData.Edm.EntityRes.GetString(Microsoft.OData.Edm.EntityRes.Bad_UnresolvedReturn, p0);
+        }
+
+        /// <summary>
         /// A string like "The labeled element '{0}' could not be found."
         /// </summary>
         internal static string Bad_UnresolvedLabeledElement(object p0) {

--- a/src/Microsoft.OData.Edm/Schema/EdmOperation.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmOperation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData.Edm
         private readonly List<IEdmOperationParameter> parameters = new List<IEdmOperationParameter>();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmAction"/> class.
+        /// Initializes a new instance of the <see cref="EdmOperation"/> class.
         /// </summary>
         /// <param name="namespaceName">Name of the namespace.</param>
         /// <param name="name">The name.</param>
@@ -29,7 +29,7 @@ namespace Microsoft.OData.Edm
         {
             EdmUtil.CheckArgumentNull(namespaceName, "namespaceName");
 
-            this.ReturnType = returnType;
+            this.Return = returnType == null ? null : new EdmOperationReturn(this, returnType);
             this.Namespace = namespaceName;
             this.IsBound = isBound;
             this.EntitySetPath = entitySetPathExpression;
@@ -37,7 +37,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EdmAction"/> class.
+        /// Initializes a new instance of the <see cref="EdmOperation"/> class.
         /// </summary>
         /// <param name="namespaceName">Name of the namespace.</param>
         /// <param name="name">The name.</param>
@@ -70,7 +70,7 @@ namespace Microsoft.OData.Edm
         public abstract EdmSchemaElementKind SchemaElementKind { get; }
 
         /// <summary>
-        /// Gets the namespace of this function.
+        /// Gets the namespace of this operation.
         /// </summary>
         public string Namespace { get; private set; }
 
@@ -83,12 +83,15 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Gets the return type of this function.
+        /// Gets the return type of this operation.
         /// </summary>
-        public IEdmTypeReference ReturnType { get; private set; }
+        public IEdmTypeReference ReturnType
+        {
+            get { return Return == null ? null : Return.Type; }
+        }
 
         /// <summary>
-        /// Gets the parameters of this function.
+        /// Gets the parameters of this operation.
         /// </summary>
         public IEnumerable<IEdmOperationParameter> Parameters
         {
@@ -96,7 +99,12 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Searches for a parameter with the given name in this function and returns null if no such parameter exists.
+        /// Gets the return of this operation.
+        /// </summary>
+        internal IEdmOperationReturn Return { get; private set; }
+
+        /// <summary>
+        /// Searches for a parameter with the given name in this operation and returns null if no such parameter exists.
         /// </summary>
         /// <param name="name">The name of the parameter to be found.</param>
         /// <returns>The requested parameter, or null if no such parameter exists.</returns>
@@ -114,7 +122,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Creates and adds a parameter to this function (as the last parameter).
+        /// Creates and adds a parameter to this operation (as the last parameter).
         /// </summary>
         /// <param name="name">The name of the parameter being added.</param>
         /// <param name="type">The type of the parameter being added.</param>
@@ -127,7 +135,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Creates and adds an optional parameter to this function (as the last parameter).
+        /// Creates and adds an optional parameter to this operation (as the last parameter).
         /// </summary>
         /// <param name="name">The name of the parameter being added.</param>
         /// <param name="type">The type of the parameter being added.</param>
@@ -138,7 +146,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Creates and adds an optional parameter to this function (as the last parameter).
+        /// Creates and adds an optional parameter to this operation (as the last parameter).
         /// </summary>
         /// <param name="name">The name of the parameter being added.</param>
         /// <param name="type">The type of the parameter being added.</param>
@@ -152,7 +160,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Adds a parameter to this function (as the last parameter).
+        /// Adds a parameter to this operation (as the last parameter).
         /// </summary>
         /// <param name="parameter">The parameter being added.</param>
         public void AddParameter(IEdmOperationParameter parameter)

--- a/src/Microsoft.OData.Edm/Schema/EdmOperationParameter.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmOperationParameter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmOperationParameter"/> class.
         /// </summary>
-        /// <param name="declaringOperation">Declaring function of the parameter.</param>
+        /// <param name="declaringOperation">Declaring operation of the parameter.</param>
         /// <param name="name">Name of the parameter.</param>
         /// <param name="type">Type of the parameter.</param>
         public EdmOperationParameter(IEdmOperation declaringOperation, string name, IEdmTypeReference type)

--- a/src/Microsoft.OData.Edm/Schema/EdmOperationReturn.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmOperationReturn.cs
@@ -1,0 +1,39 @@
+//---------------------------------------------------------------------
+// <copyright file="EdmOperationReturn.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Represents an EDM operation return.
+    /// Be noted: it is marked as internal class because it's not allowed to create an instance from end user.
+    /// </summary>
+    internal class EdmOperationReturn : EdmElement, IEdmOperationReturn
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmOperationReturn"/> class.
+        /// </summary>
+        /// <param name="declaringOperation">Declaring operation of the return.</param>
+        /// <param name="type">The return type of the return.</param>
+        public EdmOperationReturn(IEdmOperation declaringOperation, IEdmTypeReference type)
+        {
+            EdmUtil.CheckArgumentNull(declaringOperation, "declaringOperation");
+            EdmUtil.CheckArgumentNull(type, "type");
+
+            this.Type = type;
+            this.DeclaringOperation = declaringOperation;
+        }
+
+        /// <summary>
+        /// Gets the return type of this return.
+        /// </summary>
+        public IEdmTypeReference Type { get; private set; }
+
+        /// <summary>
+        /// Gets the operation that declared this return.
+        /// </summary>
+        public IEdmOperation DeclaringOperation { get; private set; }
+    }
+}

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperation.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperation.cs
@@ -14,12 +14,12 @@ namespace Microsoft.OData.Edm
     public interface IEdmOperation : IEdmSchemaElement
     {
         /// <summary>
-        /// Gets the return type of this function.
+        /// Gets the return type of this operation.
         /// </summary>
         IEdmTypeReference ReturnType { get; }
 
         /// <summary>
-        /// Gets the collection of parameters for this function.
+        /// Gets the collection of parameters for this operation.
         /// </summary>
         IEnumerable<IEdmOperationParameter> Parameters { get; }
 

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperationReturn.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperationReturn.cs
@@ -1,0 +1,26 @@
+//---------------------------------------------------------------------
+// <copyright file="IEdmOperationReturn.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm.Vocabularies;
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Represents a return of an EDM operation.
+    /// </summary>
+    public interface IEdmOperationReturn : IEdmElement, IEdmVocabularyAnnotatable
+    {
+        /// <summary>
+        /// Gets the type of this operation return.
+        /// </summary>
+        IEdmTypeReference Type { get; }
+
+        /// <summary>
+        /// Gets the operation that declared this return.
+        /// </summary>
+        IEdmOperation DeclaringOperation { get; }
+    }
+}

--- a/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
+++ b/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
@@ -1366,6 +1366,11 @@ namespace Microsoft.OData.Edm.Validation
         /// <summary>
         /// The type of navigation property cannot have path type property.
         /// </summary>
-        TypeOfNavigationPropertyCannotHavePathProperty = 387
+        TypeOfNavigationPropertyCannotHavePathProperty = 387,
+
+        /// <summary>
+        /// Could not find a return on the annotated operation.
+        /// </summary>
+        BadUnresolvedReturn = 388,
     }
 }

--- a/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
+++ b/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
@@ -1097,6 +1097,34 @@ namespace Microsoft.OData.Edm.Validation
             }
         }
 
+        private sealed class VisitorOfIEdmOperationReturn : VisitorOfT<IEdmOperationReturn>
+        {
+            protected override IEnumerable<EdmError> VisitT(IEdmOperationReturn operationReturn, List<object> followup, List<object> references)
+            {
+                List<EdmError> errors = null;
+
+                if (operationReturn.Type != null)
+                {
+                    followup.Add(operationReturn.Type);
+                }
+                else
+                {
+                    CollectErrors(CreatePropertyMustNotBeNullError(operationReturn, "Type"), ref errors);
+                }
+
+                if (operationReturn.DeclaringOperation != null)
+                {
+                    references.Add(operationReturn.DeclaringOperation);
+                }
+                else
+                {
+                    CollectErrors(CreatePropertyMustNotBeNullError(operationReturn, "DeclaringOperation"), ref errors);
+                }
+
+                return errors;
+            }
+        }
+
         private sealed class VisitorOfIEdmCollectionTypeReference : VisitorOfT<IEdmCollectionTypeReference>
         {
             protected override IEnumerable<EdmError> VisitT(IEdmCollectionTypeReference typeRef, List<object> followup, List<object> references)

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -448,6 +448,59 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Assert.Equal(optionalParamWithDefault.DefaultValueString, "Smith");
         }
 
+        [Theory]
+        [InlineData(EdmVocabularyAnnotationSerializationLocation.Inline)]
+        [InlineData(EdmVocabularyAnnotationSerializationLocation.OutOfLine)]
+        public void ParsingReturnTypeAnnotationShouldSucceed(EdmVocabularyAnnotationSerializationLocation location)
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <Function Name=""TestFunction"">
+        <ReturnType Type=""Edm.PrimitiveType"" Nullable=""false"" >
+          {0}
+        </ReturnType>
+      </Function>
+      <Annotations Target=""NS.TestFunction()/$ReturnType"">
+         {1}
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+
+            string annotationString =
+                "<Annotation Term =\"Org.OData.Validation.V1.DerivedTypeConstraint\">" +
+                  "<Collection>" +
+                     "<String>Edm.Int32</String>" +
+                     "<String>Edm.Boolean</String>" +
+                   "</Collection>" +
+                 "</Annotation>";
+            string inline = location == EdmVocabularyAnnotationSerializationLocation.Inline ? annotationString : "";
+            string outLine = location == EdmVocabularyAnnotationSerializationLocation.Inline ? "" : annotationString;
+            string csdl = String.Format(template, inline, outLine);
+
+            var model = CsdlReader.Parse(XElement.Parse(csdl).CreateReader());
+            var function = model.FindDeclaredOperations("NS.TestFunction").FirstOrDefault();
+            Assert.NotNull(function);
+            Assert.NotNull(function.ReturnType);
+            IEdmOperationReturn returnType = function.GetReturn();
+            Assert.NotNull(returnType);
+            Assert.Same(returnType.DeclaringOperation, function);
+            Assert.Equal("Edm.PrimitiveType", returnType.Type.FullName());
+
+            var termType = model.FindTerm("Org.OData.Validation.V1.DerivedTypeConstraint");
+            Assert.NotNull(termType);
+
+            IEdmVocabularyAnnotation annotation = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(returnType, termType).FirstOrDefault();
+            Assert.NotNull(annotation);
+
+            Assert.True(annotation.GetSerializationLocation(model) == location);
+            IEdmCollectionExpression collectConstant = annotation.Value as IEdmCollectionExpression;
+            Assert.NotNull(collectConstant);
+
+            Assert.Equal(new[] { "Edm.Int32", "Edm.Boolean" }, collectConstant.Elements.Select(e => ((IEdmStringConstantExpression)e).Value));
+        }
+
         [Fact]
         public void ParsingValidXmlWithOneReferencesShouldSucceed()
         {

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -616,6 +616,76 @@ namespace Microsoft.OData.Edm.Tests.Csdl
         #endregion
 
         [Fact]
+        public void ShouldWriteInLineReturnTypeAnnotation()
+        {
+            string expected =
+            "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+            "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+              "<edmx:DataServices>" +
+                "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                  "<Function Name=\"TestFunction\">" +
+                    "<ReturnType Type=\"Edm.PrimitiveType\" Nullable=\"false\">" +
+                        "<Annotation Term=\"Org.OData.Validation.V1.DerivedTypeConstraint\">" +
+                          "<Collection>" +
+                            "<String>Edm.Int32</String>" +
+                            "<String>Edm.Boolean</String>" +
+                          "</Collection>" +
+                        "</Annotation>" +
+                    "</ReturnType>" +
+                  "</Function>" +
+                "</Schema>" +
+              "</edmx:DataServices>" +
+            "</edmx:Edmx>";
+
+            Assert.Equal(expected, WriteReturnTypeAnnotation(EdmVocabularyAnnotationSerializationLocation.Inline));
+        }
+
+        [Fact]
+        public void ShouldWriteOutofLineReturnTypeAnnotation()
+        {
+            string expected =
+            "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+            "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+              "<edmx:DataServices>" +
+                "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                  "<Function Name=\"TestFunction\">" +
+                    "<ReturnType Type=\"Edm.PrimitiveType\" Nullable=\"false\" />" +
+                  "</Function>" +
+                  "<Annotations Target=\"NS.TestFunction()/$ReturnType\">" +
+                    "<Annotation Term=\"Org.OData.Validation.V1.DerivedTypeConstraint\">" +
+                      "<Collection>" +
+                        "<String>Edm.Int32</String>" +
+                        "<String>Edm.Boolean</String>" +
+                      "</Collection>" +
+                    "</Annotation>" +
+                  "</Annotations>" +
+                "</Schema>" +
+              "</edmx:DataServices>" +
+            "</edmx:Edmx>";
+
+            Assert.Equal(expected, WriteReturnTypeAnnotation(EdmVocabularyAnnotationSerializationLocation.OutOfLine));
+        }
+
+        private string WriteReturnTypeAnnotation(EdmVocabularyAnnotationSerializationLocation location)
+        {
+            var primitiveTypeRef = EdmCoreModel.Instance.GetPrimitiveType(false);
+            var model = new EdmModel();
+            var termType = model.FindTerm("Org.OData.Validation.V1.DerivedTypeConstraint");
+            Assert.NotNull(termType);
+
+            var function = new EdmFunction("NS", "TestFunction", primitiveTypeRef);
+            model.AddElement(function);
+
+            IEdmCollectionExpression collectionExpression = new EdmCollectionExpression(new EdmStringConstant("Edm.Int32"), new EdmStringConstant("Edm.Boolean"));
+            IEdmOperationReturn returnType = function.GetReturn();
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(returnType, termType, collectionExpression);
+            annotation.SetSerializationLocation(model, location);
+            model.SetVocabularyAnnotation(annotation);
+
+            return GetCsdl(model, CsdlTarget.OData);
+        }
+
+        [Fact]
         public void ShouldWriteEdmComplexTypeProperty()
         {
             string expected =

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsOperationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsOperationTests.cs
@@ -39,7 +39,15 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Semantics
         [Fact]
         public void NonBoundCsdlSemanticsOperationPropertiesShouldBeCorrect()
         {
-            var function = new CsdlFunction("Checkout", Enumerable.Empty<CsdlOperationParameter>(), new CsdlNamedTypeReference("Edm.String", false, testLocation), false /*isBound*/, null /*entitySetPath*/, true /*isComposable*/, testLocation);
+            var function = new CsdlFunction(
+                "Checkout",
+                Enumerable.Empty<CsdlOperationParameter>(),
+                new CsdlOperationReturn(new CsdlNamedTypeReference("Edm.String", false, testLocation), testLocation),
+                false /*isBound*/,
+                null /*entitySetPath*/,
+                true /*isComposable*/,
+                testLocation);
+
             var semanticFunction = new CsdlSemanticsFunction(this.semanticSchema, function);
             semanticFunction.IsBound.Should().BeFalse();
             semanticFunction.Location().Should().Be(testLocation);
@@ -57,7 +65,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Semantics
             var action = new CsdlAction(
                 "Checkout",
                 new CsdlOperationParameter[] { new CsdlOperationParameter("entity", new CsdlNamedTypeReference("FQ.NS.EntityType", false, testLocation), testLocation) }, 
-                new CsdlNamedTypeReference("Edm.String", false, testLocation), 
+                new CsdlOperationReturn(new CsdlNamedTypeReference("Edm.String", false, testLocation), testLocation),
                 true /*isBound*/,
                 "entity/FakePath",
                 testLocation);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/CsdlBuilder.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/CsdlBuilder.cs
@@ -88,7 +88,7 @@ namespace Microsoft.OData.Edm.Tests
         internal static CsdlFunction Function(
             string name, 
             CsdlOperationParameter[] parameters = default(CsdlOperationParameter[]), 
-            CsdlTypeReference typeReference = null, 
+            CsdlOperationReturn typeReference = null, 
             bool isBound = false, 
             string entitySetPath = null, 
             bool isComposable = false,
@@ -112,7 +112,7 @@ namespace Microsoft.OData.Edm.Tests
         internal static CsdlAction Action(
             string name,
             CsdlOperationParameter[] parameters = default(CsdlOperationParameter[]),
-            CsdlTypeReference typeReference = null,
+            CsdlOperationReturn typeReference = null,
             bool isBound = false,
             string entitySetPath = null,
             CsdlLocation location = null)

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -228,6 +228,18 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         }
 
         [Fact]
+        public void GetReturnShouldReturnCorrectly()
+        {
+            IEdmTypeReference typeReference = EdmCoreModel.Instance.GetString(true);
+            var function = new EdmFunction("d.s", "checkout", typeReference);
+            IEdmOperationReturn operationReturn = function.GetReturn();
+            Assert.NotNull(operationReturn);
+            Assert.Same(operationReturn, function.Return);
+            Assert.Same(operationReturn.Type, function.ReturnType);
+            Assert.Same(operationReturn.DeclaringOperation, function);
+        }
+
+        [Fact]
         public void EntityTypeTypeReferenceFullNameTest()
         {
             var entityType = new EdmEntityType("n", "type");
@@ -394,7 +406,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
             var action = new CsdlAction(
                 "Checkout",
                 new CsdlOperationParameter[] { new CsdlOperationParameter("entity", new CsdlNamedTypeReference("FQ.NS.EntityType", false, testLocation), testLocation) },
-                new CsdlNamedTypeReference("Edm.String", false, testLocation),
+                new CsdlOperationReturn(new CsdlNamedTypeReference("Edm.String", false, testLocation), testLocation),
                 true /*isBound*/,
                 "entity",
                 testLocation);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmActionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmActionTests.cs
@@ -57,6 +57,9 @@ namespace Microsoft.OData.Edm.Tests.Library
             edmAction.EntitySetPath.Should().Be(entitySetPath);
             edmAction.IsBound.Should().BeTrue();
             edmAction.SchemaElementKind.Should().Be(EdmSchemaElementKind.Action);
+
+            edmAction.Return.Should().NotBeNull();
+            edmAction.Return.Type.Should().BeSameAs(edmAction.ReturnType);
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmFunctionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmFunctionTests.cs
@@ -68,6 +68,9 @@ namespace Microsoft.OData.Edm.Tests.Library
             edmFunction.IsBound.Should().BeTrue();
             edmFunction.SchemaElementKind.Should().Be(EdmSchemaElementKind.Function);
             edmFunction.IsComposable.Should().BeTrue();
+
+            edmFunction.Return.Should().NotBeNull();
+            edmFunction.Return.Type.Should().BeSameAs(edmFunction.ReturnType);
         }
     }
 }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -964,6 +964,11 @@ public interface Microsoft.OData.Edm.IEdmOperationParameter : IEdmElement, IEdmN
 	Microsoft.OData.Edm.IEdmTypeReference Type  { public abstract get; }
 }
 
+public interface Microsoft.OData.Edm.IEdmOperationReturn : IEdmElement, IEdmVocabularyAnnotatable {
+	Microsoft.OData.Edm.IEdmOperation DeclaringOperation  { public abstract get; }
+	Microsoft.OData.Edm.IEdmTypeReference Type  { public abstract get; }
+}
+
 public interface Microsoft.OData.Edm.IEdmOptionalParameter : IEdmElement, IEdmNamedElement, IEdmOperationParameter, IEdmVocabularyAnnotatable {
 	string DefaultValueString  { public abstract get; }
 }
@@ -1972,6 +1977,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
 	ExtensionAttribute(),
 	]
 	public static Microsoft.OData.Edm.IPrimitiveValueConverter GetPrimitiveValueConverter (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmTypeReference type)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static Microsoft.OData.Edm.IEdmOperationReturn GetReturn (Microsoft.OData.Edm.IEdmOperation operation)
 
 	[
 	ExtensionAttribute(),
@@ -2996,6 +3006,7 @@ public enum Microsoft.OData.Edm.Validation.EdmErrorCode : int {
 	BadUnresolvedParameter = 304
 	BadUnresolvedPrimitiveType = 226
 	BadUnresolvedProperty = 234
+	BadUnresolvedReturn = 388
 	BadUnresolvedTarget = 361
 	BadUnresolvedTerm = 352
 	BadUnresolvedType = 225


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #52.*

### Description

* Introduce the `IEdmOperationReturnType` interface
* Modify the `IEdmOperation` to use `IEdmOperationReturnType` interface.
* Enable in-line and out of line annotation on return type.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
