### PR TITLE
Fix issue #1415, keep conditions priority for queries with Convert node in NodeToStringBuilder

### DIFF
--- a/src/Microsoft.OData.Core/Uri/NodeToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/NodeToStringBuilder.cs
@@ -67,13 +67,17 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentNotNull(node, "node");
 
             var left = this.TranslateNode(node.Left);
-            if (node.Left.Kind == QueryNodeKind.BinaryOperator && TranslateBinaryOperatorPriority(((BinaryOperatorNode)node.Left).OperatorKind) < TranslateBinaryOperatorPriority(node.OperatorKind))
+            if (node.Left.Kind == QueryNodeKind.BinaryOperator && TranslateBinaryOperatorPriority(((BinaryOperatorNode)node.Left).OperatorKind) < TranslateBinaryOperatorPriority(node.OperatorKind) || 
+                node.Left.Kind == QueryNodeKind.Convert && ((ConvertNode)node.Left).Source.Kind == QueryNodeKind.BinaryOperator && 
+                TranslateBinaryOperatorPriority(((BinaryOperatorNode)((ConvertNode)node.Left).Source).OperatorKind) < TranslateBinaryOperatorPriority(node.OperatorKind))
             {
                 left = String.Concat(ExpressionConstants.SymbolOpenParen, left, ExpressionConstants.SymbolClosedParen);
             }
 
             var right = this.TranslateNode(node.Right);
-            if (node.Right.Kind == QueryNodeKind.BinaryOperator && TranslateBinaryOperatorPriority(((BinaryOperatorNode)node.Right).OperatorKind) < TranslateBinaryOperatorPriority(node.OperatorKind))
+            if (node.Right.Kind == QueryNodeKind.BinaryOperator && TranslateBinaryOperatorPriority(((BinaryOperatorNode)node.Right).OperatorKind) < TranslateBinaryOperatorPriority(node.OperatorKind) || 
+                node.Right.Kind == QueryNodeKind.Convert && ((ConvertNode)node.Right).Source.Kind == QueryNodeKind.BinaryOperator && 
+                TranslateBinaryOperatorPriority(((BinaryOperatorNode)((ConvertNode)node.Right).Source).OperatorKind) < TranslateBinaryOperatorPriority(node.OperatorKind))
             {
                 right = String.Concat(ExpressionConstants.SymbolOpenParen, right, ExpressionConstants.SymbolClosedParen);
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/FilterAndOrderByBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/FilterAndOrderByBuilderTests.cs
@@ -253,6 +253,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
 
         [Fact]
+        public void BuildFilterWithOpenPropertyInsideAnyAndOr()
+        {
+            Uri queryUri = new Uri("People?$filter=MyPaintings%2Fany(p%3Ap%2FOpenProperty) and (ID eq 1 or ID eq 2)", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(new Uri("http://gobbledygook/People?$filter=MyPaintings%2Fany(p%3Ap%2FOpenProperty) and (ID eq 1 or ID eq 2)"), actualUri);
+        }
+
+        [Fact]
         public void BuildFilterWithControlCharactersShouldBeIgnored()
         {
             Uri queryUri = new Uri("People?$filter=length(Name) \neq 30", UriKind.Relative);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1415 .*

### Description

The problem in the `NodeToStringBuilder` appears when the filter query contains a condition of type `nullable boolean` such as `any` as a part of `BinaryOperatorNode` with another `BinaryOperatorNode` as another part. The latter `BinaryOperatorNode` is converted into `ConvertNode` in that case, and it's not tested for the priority of the internal binary operator. 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*