### PR TITLE
Change to use buffer when writing binary/byte[]

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -352,16 +352,16 @@ namespace Microsoft.OData.Json
             // Try to hold base64 string as much as possible in one converting.
             int bufferByteSize = bufferLength * 3 / 4;
 
-            for (int i = 0; i < value.Length; i += bufferByteSize)
+            for (int offsetIn = 0; offsetIn < value.Length; offsetIn += bufferByteSize)
             {
                 int length = bufferByteSize;
-                if (i + length > value.Length)
+                if (offsetIn + length > value.Length)
                 {
-                    length = value.Length - i;
+                    length = value.Length - offsetIn;
                 }
 
-                int output = Convert.ToBase64CharArray(value, i, length, buffer, 0);
-                writer.Write(new string(buffer, 0, output));
+                int output = Convert.ToBase64CharArray(value, offsetIn, length, buffer, 0);
+                writer.Write(buffer, 0, output);
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -374,7 +374,7 @@ namespace Microsoft.OData.Json
         public void WriteValue(byte[] value)
         {
             this.WriteValueSeparator();
-            JsonValueUtils.WriteValue(this.writer, value);
+            JsonValueUtils.WriteValue(this.writer, value, ref this.buffer);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsTests.cs
@@ -241,8 +241,22 @@ namespace Microsoft.OData.Tests.Json
         {
             this.TestInit();
             var byteArray = new byte[] { 1, 2, 3 };
-            JsonValueUtils.WriteValue(this.writer, byteArray);
+            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
             this.StreamToString().Should().Be("\"AQID\"");
+        }
+
+        [Fact]
+        public void WriteLongBytesShouldWork()
+        {
+            this.TestInit();
+            byte[] byteArray = new byte[1000];
+            for (int i = 0; i < byteArray.Length; i++)
+            {
+                byteArray[i] = (byte)(i % 255);
+            }
+
+            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
+            this.StreamToString().Should().Be("\"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6g==\"");
         }
 
         [Fact]
@@ -250,7 +264,7 @@ namespace Microsoft.OData.Tests.Json
         {
             this.TestInit();
             var byteArray = new byte[] { };
-            JsonValueUtils.WriteValue(this.writer, byteArray);
+            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
             this.StreamToString().Should().Be("\"\"");
         }
 
@@ -258,7 +272,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteNullByteShouldWork()
         {
             this.TestInit();
-            JsonValueUtils.WriteValue(this.writer, (byte[])null);
+            JsonValueUtils.WriteValue(this.writer, (byte[])null, ref this.buffer);
             this.StreamToString().Should().Be("null");
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -248,6 +249,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public void WriteLongBytesShouldWork()
         {
+            // Arrange
             this.TestInit();
             byte[] byteArray = new byte[1000];
             for (int i = 0; i < byteArray.Length; i++)
@@ -255,8 +257,46 @@ namespace Microsoft.OData.Tests.Json
                 byteArray[i] = (byte)(i % 255);
             }
 
+            // Act, Get Base64 string from OData library
             JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
-            this.StreamToString().Should().Be("\"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6g==\"");
+            string convertedBase64String = this.StreamToString();
+
+            // Get Base64 string directly calling the converter.
+            string actualBase64String = JsonConstants.QuoteCharacter + Convert.ToBase64String(byteArray) + JsonConstants.QuoteCharacter;
+
+            // Assert
+            Assert.Equal(convertedBase64String, actualBase64String);
+            Assert.Equal("\"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6g==\"", convertedBase64String);
+        }
+
+        [Fact]
+        public void WriteBytesLengthSameAsBufferSizeShouldWork()
+        {
+            // Arrange
+            this.TestInit();
+
+            // Initialize the buffer
+            int bufferLength = 40;
+            this.buffer = new char[bufferLength];
+            int byteSize = bufferLength * 3 / 4;
+
+            // Make the output Base64 string length same as the buffer size.
+            byte[] byteArray = new byte[byteSize];
+            for (int i = 0; i < byteArray.Length; i++)
+            {
+                byteArray[i] = (byte)(i % 255);
+            }
+
+            // Act, Get Base64 string from OData library
+            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
+            string convertedBase64String = this.StreamToString();
+
+            // Get Base64 string directly calling the converter.
+            string actualBase64String = JsonConstants.QuoteCharacter + Convert.ToBase64String(byteArray) + JsonConstants.QuoteCharacter;
+
+            // Assert
+            Assert.Equal(convertedBase64String, actualBase64String);
+            Assert.Equal("\"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwd\"", convertedBase64String);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/NonIndentedTextWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/NonIndentedTextWriterTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.OData.Tests.Json
         {
             this.TestInit();
             var byteArray = new byte[] { 1, 2, 3 };
-            JsonValueUtils.WriteValue(this.writer, byteArray);
+            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
             this.StreamToString().Should().Be("\"AQID\"");
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Improve the json writer process for the binary/byte[].

### Description

* Improve the json writer process for the binary/byte[].

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
