### PR TITLE
Properties defined in $compute and $apply can be used in a following query options ($select, $compute, $filter or $orderby)

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -51,13 +51,12 @@ namespace Microsoft.OData.UriParser.Aggregation
                         AggregateTransformationNode aggregate = BindAggregateToken((AggregateToken)(token));
                         transformations.Add(aggregate);
                         aggregateExpressionsCache = aggregate.AggregateExpressions;
-                        state.AggregatedPropertyNames =
-                            aggregate.AggregateExpressions.Select(statement => statement.Alias).ToList();
+                        state.AggregatedPropertyNames = aggregate.AggregateExpressions.Select(statement => statement.Alias).ToList();
+                        state.IsCollapsed = true;
                         break;
                     case QueryTokenKind.AggregateGroupBy:
                         GroupByTransformationNode groupBy = BindGroupByToken((GroupByToken)(token));
                         transformations.Add(groupBy);
-                        state.AggregatedPropertyNames = groupBy.GroupingProperties.Select(g => g.Name).ToList();
                         state.IsCollapsed = true;
                         break;
                     case QueryTokenKind.Compute:
@@ -148,11 +147,6 @@ namespace Microsoft.OData.UriParser.Aggregation
                     EntitySetAggregateToken token = aggregateToken as EntitySetAggregateToken;
                     QueryNode boundPath = this.bindMethod(token.EntitySet);
                     
-                    if (boundPath.Kind != QueryNodeKind.CollectionNavigationNode)
-                    {
-                        throw new ODataException(ODataErrorStrings.ApplyBinder_UnsupportedForEntitySetAggregation((token.EntitySet as EndPathToken)?.Identifier ?? string.Empty, boundPath.Kind));
-                    }
-
                     IEnumerable<AggregateExpressionBase> children = token.Expressions.Select(x => BindAggregateExpressionToken(x)).ToList();
                     return new EntitySetAggregateExpression((CollectionNavigationNode)boundPath, children);
                 }

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -65,7 +65,7 @@ namespace Microsoft.OData.UriParser.Aggregation
                         state.AggregatedPropertyNames = compute.Expressions.Select(statement => statement.Alias).ToList();
                         break;
                     case QueryTokenKind.Expand:
-                        SelectExpandClause expandClause = SelectExpandSemanticBinder.Bind(this.odataPathInfo,  (ExpandToken)token, null, this.configuration, null, false);
+                        SelectExpandClause expandClause = SelectExpandSemanticBinder.Bind(this.odataPathInfo,  (ExpandToken)token, null, this.configuration, null);
                         ExpandTransformationNode expandNode = new ExpandTransformationNode(expandClause);
                         transformations.Add(expandNode);
                         break;

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -64,7 +64,7 @@ namespace Microsoft.OData.UriParser.Aggregation
                         state.AggregatedPropertyNames = compute.Expressions.Select(statement => statement.Alias).ToList();
                         break;
                     case QueryTokenKind.Expand:
-                        SelectExpandClause expandClause = SelectExpandSemanticBinder.Bind(this.odataPathInfo,  (ExpandToken)token, null, this.configuration);
+                        SelectExpandClause expandClause = SelectExpandSemanticBinder.Bind(this.odataPathInfo,  (ExpandToken)token, null, this.configuration, null);
                         ExpandTransformationNode expandNode = new ExpandTransformationNode(expandClause);
                         transformations.Add(expandNode);
                         break;

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -51,18 +51,20 @@ namespace Microsoft.OData.UriParser.Aggregation
                         AggregateTransformationNode aggregate = BindAggregateToken((AggregateToken)(token));
                         transformations.Add(aggregate);
                         aggregateExpressionsCache = aggregate.AggregateExpressions;
-                        state.AggregatedPropertyNames = aggregate.AggregateExpressions.Select(statement => statement.Alias).ToList();
+                        state.AggregatedPropertyNames = new HashSet<EndPathToken>(aggregate.AggregateExpressions.Select(statement => new EndPathToken(statement.Alias, null)));
                         state.IsCollapsed = true;
                         break;
                     case QueryTokenKind.AggregateGroupBy:
-                        GroupByTransformationNode groupBy = BindGroupByToken((GroupByToken)(token));
+                        GroupByToken groupByToken = (GroupByToken)(token);
+                        GroupByTransformationNode groupBy = BindGroupByToken(groupByToken);
                         transformations.Add(groupBy);
+                        state.AggregatedPropertyNames = new HashSet<EndPathToken>(groupByToken.Properties);
                         state.IsCollapsed = true;
                         break;
                     case QueryTokenKind.Compute:
                         var compute = BindComputeToken((ComputeToken)token);
                         transformations.Add(compute);
-                        state.AggregatedPropertyNames = compute.Expressions.Select(statement => statement.Alias).ToList();
+                        state.AggregatedPropertyNames = new HashSet<EndPathToken>(compute.Expressions.Select(statement => new EndPathToken(statement.Alias, null)));
                         break;
                     case QueryTokenKind.Expand:
                         SelectExpandClause expandClause = SelectExpandSemanticBinder.Bind(this.odataPathInfo,  (ExpandToken)token, null, this.configuration, null);
@@ -260,8 +262,7 @@ namespace Microsoft.OData.UriParser.Aggregation
                 {
                     aggregate = BindAggregateToken((AggregateToken)token.Child);
                     aggregateExpressionsCache = ((AggregateTransformationNode)aggregate).AggregateExpressions;
-                    state.AggregatedPropertyNames =
-                        aggregateExpressionsCache.Select(statement => statement.Alias).ToList();
+                    state.AggregatedPropertyNames = new HashSet<EndPathToken>(aggregateExpressionsCache.Select(statement => new EndPathToken(statement.Alias, null)));
                 }
                 else
                 {

--- a/src/Microsoft.OData.Core/UriParser/Binders/BindingState.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/BindingState.cs
@@ -142,6 +142,11 @@ namespace Microsoft.OData.UriParser
         internal List<string> AggregatedPropertyNames { get; set; }
 
         /// <summary>
+        /// The property set when group by or aggregation is done and properties are collapsed out of scope
+        /// </summary>
+        internal bool IsCollapsed { get; set; }
+
+        /// <summary>
         /// The parsed segments in path and query option.
         /// </summary>
         internal List<ODataPathSegment> ParsedSegments

--- a/src/Microsoft.OData.Core/UriParser/Binders/BindingState.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/BindingState.cs
@@ -139,7 +139,7 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Collection of aggregated property names after applying an aggregate transformation.
         /// </summary>
-        internal List<string> AggregatedPropertyNames { get; set; }
+        internal HashSet<EndPathToken> AggregatedPropertyNames { get; set; }
 
         /// <summary>
         /// The property set when group by or aggregation is done and properties are collapsed out of scope

--- a/src/Microsoft.OData.Core/UriParser/Binders/BindingState.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/BindingState.cs
@@ -147,6 +147,12 @@ namespace Microsoft.OData.UriParser
         internal bool IsCollapsed { get; set; }
 
         /// <summary>
+        /// The property set when entering entity set aggregation context
+        /// </summary>
+
+        internal bool InEntitySetAggregation { get; set; }
+
+        /// <summary>
         /// The parsed segments in path and query option.
         /// </summary>
         internal List<ODataPathSegment> ParsedSegments

--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -230,9 +230,6 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="endPath">EndPathToken to check in the list of aggregated properties.</param>
         /// <returns>Whether the token represents an aggregated property.</returns>
-        private bool IsAggregatedProperty(EndPathToken endPath)
-        {
-            return (state.AggregatedPropertyNames != null && state.AggregatedPropertyNames.Contains(endPath));
-        }
+        private bool IsAggregatedProperty(EndPathToken endPath) => state?.AggregatedPropertyNames?.Contains(endPath) ?? false;
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -113,7 +113,7 @@ namespace Microsoft.OData.UriParser
         {
             if (parentNode.TypeReference == null ||
                 parentNode.TypeReference.Definition.IsOpen() ||
-                IsAggregatedProperty(endPathToken.Identifier))
+                IsAggregatedProperty(endPathToken))
             {
                 return new SingleValueOpenPropertyAccessNode(parentNode, endPathToken.Identifier);
             }
@@ -145,7 +145,7 @@ namespace Microsoft.OData.UriParser
             {
                 if (state.IsCollapsed)
                 {
-                    if (IsAggregatedProperty(endPathToken.Identifier))
+                    if (IsAggregatedProperty(endPathToken))
                     {
                         return new SingleValueOpenPropertyAccessNode(singleValueParent, endPathToken.Identifier);
                     }
@@ -235,11 +235,11 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Determines the token if represents an aggregated property or not.
         /// </summary>
-        /// <param name="identifier">Tokon identifier.</param>
+        /// <param name="endPath">EndPathToken to check in the list of aggregated properties.</param>
         /// <returns>Whether the token represents an aggregated property.</returns>
-        private bool IsAggregatedProperty(string identifier)
+        private bool IsAggregatedProperty(EndPathToken endPath)
         {
-            return (state.AggregatedPropertyNames != null && state.AggregatedPropertyNames.Contains(identifier));
+            return (state.AggregatedPropertyNames != null && state.AggregatedPropertyNames.Contains(endPath));
         }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -143,16 +143,9 @@ namespace Microsoft.OData.UriParser
             SingleValueNode singleValueParent = parent as SingleValueNode;
             if (singleValueParent != null)
             {
-                if (state.IsCollapsed)
+                if (state.IsCollapsed && !IsAggregatedProperty(endPathToken))
                 {
-                    if (IsAggregatedProperty(endPathToken))
-                    {
-                        return new SingleValueOpenPropertyAccessNode(singleValueParent, endPathToken.Identifier);
-                    }
-                    else
-                    {
-                        throw new ODataException(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue(endPathToken.Identifier));
-                    }
+                    throw new ODataException(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue(endPathToken.Identifier));
                 }
 
                 // Now that we have the parent type, can find its corresponding EDM type

--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -189,7 +189,8 @@ namespace Microsoft.OData.UriParser
                 IEdmProperty property = this.Resolver.ResolveProperty(parentType.StructuredDefinition(), endPathToken.Identifier);
 
                 if (property.PropertyKind == EdmPropertyKind.Structural
-                    && !property.Type.IsCollection())
+                    && !property.Type.IsCollection()
+                    && this.state.InEntitySetAggregation)
                 {
                     return new AggregatedCollectionPropertyNode(collectionParent, property);
                 }

--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -151,7 +151,7 @@ namespace Microsoft.OData.UriParser
                     }
                     else
                     {
-                        throw ExceptionUtil.CreatePropertyNotFoundException(endPathToken.Identifier, singleValueParent.TypeReference.FullName(), state.IsCollapsed);
+                        throw new ODataException(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue(endPathToken.Identifier));
                     }
                 }
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="edmType">The entity type that the $select is being applied to.</param>
         /// <param name="maxDepth">the maximum recursive depth.</param>
         /// <param name="expandClauseToDecorate">The already built expand clause to decorate</param>
-       /// <param name="resolver">Resolver for uri parser.</param>
+        /// <param name="resolver">Resolver for uri parser.</param>
         public SelectBinder(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, List<string> generatedProperties = null)
         {
             ExceptionUtils.CheckArgumentNotNull(model, "tokenIn");

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
@@ -29,13 +29,13 @@ namespace Microsoft.OData.UriParser
         /// <param name="maxDepth">the maximum recursive depth.</param>
         /// <param name="expandClauseToDecorate">The already built expand clause to decorate</param>
         /// <param name="resolver">Resolver for uri parser.</param>
-        public SelectBinder(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, List<string> generatedProperties = null, bool collapsed = false)
+        public SelectBinder(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, BindingState state = null)
         {
             ExceptionUtils.CheckArgumentNotNull(model, "tokenIn");
             ExceptionUtils.CheckArgumentNotNull(edmType, "entityType");
             ExceptionUtils.CheckArgumentNotNull(resolver, "resolver");
 
-            this.visitor = new SelectPropertyVisitor(model, edmType, maxDepth, expandClauseToDecorate, resolver, generatedProperties, collapsed);
+            this.visitor = new SelectPropertyVisitor(model, edmType, maxDepth, expandClauseToDecorate, resolver, state);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
@@ -6,7 +6,6 @@
 
 namespace Microsoft.OData.UriParser
 {
-    using System.Collections.Generic;
     using System.Linq;
     using Microsoft.OData.Edm;
 
@@ -29,7 +28,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="maxDepth">the maximum recursive depth.</param>
         /// <param name="expandClauseToDecorate">The already built expand clause to decorate</param>
         /// <param name="resolver">Resolver for uri parser.</param>
-        public SelectBinder(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, BindingState state = null)
+        public SelectBinder(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, BindingState state)
         {
             ExceptionUtils.CheckArgumentNotNull(model, "tokenIn");
             ExceptionUtils.CheckArgumentNotNull(edmType, "entityType");

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
@@ -29,13 +29,13 @@ namespace Microsoft.OData.UriParser
         /// <param name="maxDepth">the maximum recursive depth.</param>
         /// <param name="expandClauseToDecorate">The already built expand clause to decorate</param>
         /// <param name="resolver">Resolver for uri parser.</param>
-        public SelectBinder(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, List<string> generatedProperties = null)
+        public SelectBinder(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, List<string> generatedProperties = null, bool collapsed = false)
         {
             ExceptionUtils.CheckArgumentNotNull(model, "tokenIn");
             ExceptionUtils.CheckArgumentNotNull(edmType, "entityType");
             ExceptionUtils.CheckArgumentNotNull(resolver, "resolver");
 
-            this.visitor = new SelectPropertyVisitor(model, edmType, maxDepth, expandClauseToDecorate, resolver, generatedProperties);
+            this.visitor = new SelectPropertyVisitor(model, edmType, maxDepth, expandClauseToDecorate, resolver, generatedProperties, collapsed);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectBinder.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.OData.UriParser
 {
+    using System.Collections.Generic;
     using System.Linq;
     using Microsoft.OData.Edm;
 
@@ -28,13 +29,13 @@ namespace Microsoft.OData.UriParser
         /// <param name="maxDepth">the maximum recursive depth.</param>
         /// <param name="expandClauseToDecorate">The already built expand clause to decorate</param>
        /// <param name="resolver">Resolver for uri parser.</param>
-        public SelectBinder(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver)
+        public SelectBinder(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, List<string> generatedProperties = null)
         {
             ExceptionUtils.CheckArgumentNotNull(model, "tokenIn");
             ExceptionUtils.CheckArgumentNotNull(edmType, "entityType");
             ExceptionUtils.CheckArgumentNotNull(resolver, "resolver");
 
-            this.visitor = new SelectPropertyVisitor(model, edmType, maxDepth, expandClauseToDecorate, resolver);
+            this.visitor = new SelectPropertyVisitor(model, edmType, maxDepth, expandClauseToDecorate, resolver, generatedProperties);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -104,7 +104,7 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="tokenIn">the token to visit</param>
         /// <returns>a SelectExpand clause based on this ExpandToken</returns>
-        public SelectExpandClause Bind(ExpandToken tokenIn)
+        public SelectExpandClause Bind(ExpandToken tokenIn, List<string> generatedProperties = null)
         {
             ExceptionUtils.CheckArgumentNotNull(tokenIn, "tokenIn");
 
@@ -120,7 +120,7 @@ namespace Microsoft.OData.UriParser
             SelectExpandClause topLevelExpand = new SelectExpandClause(expandedTerms, isAllSelected);
             if (!isAllSelected)
             {
-                SelectBinder selectBinder = new SelectBinder(this.Model, this.EdmType, this.Configuration.Settings.SelectExpandLimit, topLevelExpand, this.configuration.Resolver);
+                SelectBinder selectBinder = new SelectBinder(this.Model, this.EdmType, this.Configuration.Settings.SelectExpandLimit, topLevelExpand, configuration.Resolver, generatedProperties);
                 selectBinder.Bind(tokenIn.ExpandTerms.Single().SelectOption);
             }
 
@@ -159,7 +159,7 @@ namespace Microsoft.OData.UriParser
         /// <returns>A new SelectExpand clause decorated with the select token.</returns>
         private SelectExpandClause DecorateExpandWithSelect(SelectExpandClause subExpand, IEdmNavigationProperty currentNavProp, SelectToken select)
         {
-            SelectBinder selectBinder = new SelectBinder(this.Model, currentNavProp.ToEntityType(), this.Settings.SelectExpandLimit, subExpand, this.configuration.Resolver);
+            SelectBinder selectBinder = new SelectBinder(this.Model, currentNavProp.ToEntityType(), this.Settings.SelectExpandLimit, subExpand, this.configuration.Resolver, null);
             return selectBinder.Bind(select);
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -317,9 +317,9 @@ namespace Microsoft.OData.UriParser
             return new ExpandedNavigationSelectItem(pathToNavProp, targetNavigationSource, subSelectExpand, filterOption, orderbyOption, tokenIn.TopOption, tokenIn.SkipOption, tokenIn.CountQueryOption, searchOption, levelsOption, computeOption, applyOption);
         }
 
-        private static List<string> GetGeneratedProperties(ComputeClause computeOption, ApplyClause applyOption)
+        private static HashSet<EndPathToken> GetGeneratedProperties(ComputeClause computeOption, ApplyClause applyOption)
         {
-            List<string> generatedProperties = null;
+            HashSet<EndPathToken> generatedProperties = null;
 
             if (applyOption != null)
             {
@@ -328,14 +328,14 @@ namespace Microsoft.OData.UriParser
 
             if (computeOption != null)
             {
-                var computedProperties = computeOption.ComputedItems.Select(i => i.Alias).ToList();
+                var computedProperties = new HashSet<EndPathToken>(computeOption.ComputedItems.Select(i => new EndPathToken(i.Alias, null)));
                 if (generatedProperties == null)
                 {
                     generatedProperties = computedProperties;
                 }
                 else
                 {
-                    generatedProperties.AddRange(computedProperties);
+                    generatedProperties.UnionWith(computedProperties);
                 }
             }
 
@@ -425,13 +425,13 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="targetNavigationSource">The navigation source being expanded.</param>
         /// <returns>A new MetadataBinder ready to bind a Filter or Orderby clause.</returns>
-        private MetadataBinder BuildNewMetadataBinder(IEdmNavigationSource targetNavigationSource, List<string> generatedProperties = null, bool collapsed = false)
+        private MetadataBinder BuildNewMetadataBinder(IEdmNavigationSource targetNavigationSource, HashSet<EndPathToken> generatedProperties = null, bool collapsed = false)
         {
             BindingState state = CreateBindingState(targetNavigationSource, generatedProperties, collapsed);
             return new MetadataBinder(state);
         }
 
-        private BindingState CreateBindingState(IEdmNavigationSource targetNavigationSource, List<string> generatedProperties, bool collapsed)
+        private BindingState CreateBindingState(IEdmNavigationSource targetNavigationSource, HashSet<EndPathToken> generatedProperties, bool collapsed)
         {
             if (targetNavigationSource == null)
             {

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
@@ -5,7 +5,6 @@
 //---------------------------------------------------------------------
 
 using Microsoft.OData.Edm;
-using System.Collections.Generic;
 
 namespace Microsoft.OData.UriParser
 {
@@ -21,6 +20,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="expandToken">the syntactically parsed expand token</param>
         /// <param name="selectToken">the syntactically parsed select token</param>
         /// <param name="configuration">The configuration to use for parsing.</param>
+        /// <param name="state">The state of binding.</param>
         /// <returns>A select expand clause bound to metadata.</returns>
         public static SelectExpandClause Bind(
             ODataPathInfo odataPathInfo,

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
@@ -27,14 +27,15 @@ namespace Microsoft.OData.UriParser
             ExpandToken expandToken,
             SelectToken selectToken,
             ODataUriParserConfiguration configuration,
-            List<string> generatedProperties)
+            List<string> generatedProperties,
+            bool isCollapsed)
         {
             ExpandToken unifiedSelectExpandToken = SelectExpandSyntacticUnifier.Combine(expandToken, selectToken);
 
             ExpandTreeNormalizer expandTreeNormalizer = new ExpandTreeNormalizer();
             ExpandToken normalizedSelectExpandToken = expandTreeNormalizer.NormalizeExpandTree(unifiedSelectExpandToken);
 
-            SelectExpandBinder selectExpandBinder = new SelectExpandBinder(configuration, odataPathInfo, generatedProperties);
+            SelectExpandBinder selectExpandBinder = new SelectExpandBinder(configuration, odataPathInfo, generatedProperties, isCollapsed);
             SelectExpandClause clause = selectExpandBinder.Bind(normalizedSelectExpandToken);
 
             SelectExpandClauseFinisher.AddExplicitNavPropLinksWhereNecessary(clause);

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
@@ -27,15 +27,14 @@ namespace Microsoft.OData.UriParser
             ExpandToken expandToken,
             SelectToken selectToken,
             ODataUriParserConfiguration configuration,
-            List<string> generatedProperties,
-            bool isCollapsed)
+            BindingState state)
         {
             ExpandToken unifiedSelectExpandToken = SelectExpandSyntacticUnifier.Combine(expandToken, selectToken);
 
             ExpandTreeNormalizer expandTreeNormalizer = new ExpandTreeNormalizer();
             ExpandToken normalizedSelectExpandToken = expandTreeNormalizer.NormalizeExpandTree(unifiedSelectExpandToken);
 
-            SelectExpandBinder selectExpandBinder = new SelectExpandBinder(configuration, odataPathInfo, generatedProperties, isCollapsed);
+            SelectExpandBinder selectExpandBinder = new SelectExpandBinder(configuration, odataPathInfo, state);
             SelectExpandClause clause = selectExpandBinder.Bind(normalizedSelectExpandToken);
 
             SelectExpandClauseFinisher.AddExplicitNavPropLinksWhereNecessary(clause);

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 using Microsoft.OData.Edm;
+using System.Collections.Generic;
 
 namespace Microsoft.OData.UriParser
 {
@@ -25,7 +26,8 @@ namespace Microsoft.OData.UriParser
             ODataPathInfo odataPathInfo,
             ExpandToken expandToken,
             SelectToken selectToken,
-            ODataUriParserConfiguration configuration)
+            ODataUriParserConfiguration configuration,
+            List<string> generatedProperties)
         {
             ExpandToken unifiedSelectExpandToken = SelectExpandSyntacticUnifier.Combine(expandToken, selectToken);
 
@@ -33,7 +35,7 @@ namespace Microsoft.OData.UriParser
             ExpandToken normalizedSelectExpandToken = expandTreeNormalizer.NormalizeExpandTree(unifiedSelectExpandToken);
 
             SelectExpandBinder selectExpandBinder = new SelectExpandBinder(configuration, odataPathInfo);
-            SelectExpandClause clause = selectExpandBinder.Bind(normalizedSelectExpandToken);
+            SelectExpandClause clause = selectExpandBinder.Bind(normalizedSelectExpandToken, generatedProperties);
 
             SelectExpandClauseFinisher.AddExplicitNavPropLinksWhereNecessary(clause);
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandSemanticBinder.cs
@@ -34,8 +34,8 @@ namespace Microsoft.OData.UriParser
             ExpandTreeNormalizer expandTreeNormalizer = new ExpandTreeNormalizer();
             ExpandToken normalizedSelectExpandToken = expandTreeNormalizer.NormalizeExpandTree(unifiedSelectExpandToken);
 
-            SelectExpandBinder selectExpandBinder = new SelectExpandBinder(configuration, odataPathInfo);
-            SelectExpandClause clause = selectExpandBinder.Bind(normalizedSelectExpandToken, generatedProperties);
+            SelectExpandBinder selectExpandBinder = new SelectExpandBinder(configuration, odataPathInfo, generatedProperties);
+            SelectExpandClause clause = selectExpandBinder.Bind(normalizedSelectExpandToken);
 
             SelectExpandClauseFinisher.AddExplicitNavPropLinksWhereNecessary(clause);
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="edmType">the type of the current scope based on type segments.</param>
         /// <param name="resolver">Resolver for uri parser.</param>
         /// <returns>The segment created from the token.</returns>
-        public static ODataPathSegment ConvertNonTypeTokenToSegment(PathSegmentToken tokenIn, IEdmModel model, IEdmStructuredType edmType, ODataUriResolver resolver)
+        public static ODataPathSegment ConvertNonTypeTokenToSegment(PathSegmentToken tokenIn, IEdmModel model, IEdmStructuredType edmType, ODataUriResolver resolver, HashSet<string> generatedProperties = null)
         {
             ExceptionUtils.CheckArgumentNotNull(resolver, "resolver");
 
@@ -76,7 +76,7 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
-            if (edmType.IsOpen)
+            if (edmType.IsOpen  || (generatedProperties?.Contains(tokenIn.Identifier) ?? false))
             {
                 return new DynamicPathSegment(tokenIn.Identifier);
             }

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="edmType">the type of the current scope based on type segments.</param>
         /// <param name="resolver">Resolver for uri parser.</param>
         /// <returns>The segment created from the token.</returns>
-        public static ODataPathSegment ConvertNonTypeTokenToSegment(PathSegmentToken tokenIn, IEdmModel model, IEdmStructuredType edmType, ODataUriResolver resolver, HashSet<string> generatedProperties = null, bool collapsed = false)
+        public static ODataPathSegment ConvertNonTypeTokenToSegment(PathSegmentToken tokenIn, IEdmModel model, IEdmStructuredType edmType, ODataUriResolver resolver, BindingState state = null)
         {
             ExceptionUtils.CheckArgumentNotNull(resolver, "resolver");
 
@@ -55,7 +55,7 @@ namespace Microsoft.OData.UriParser
                 return new AnnotationSegment(new EdmTerm(namespaceName, termName, EdmCoreModel.Instance.GetUntyped()));
             }
 
-            if (collapsed && !(generatedProperties?.Contains(tokenIn.Identifier) ?? false))
+            if ((state?.IsCollapsed ?? false) && !(state?.AggregatedPropertyNames?.Contains(tokenIn.Identifier) ?? false))
             {
                 throw new ODataException(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue(tokenIn.Identifier));
             }
@@ -81,7 +81,7 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
-            if (edmType.IsOpen  || (generatedProperties?.Contains(tokenIn.Identifier) ?? false))
+            if (edmType.IsOpen  || (state?.AggregatedPropertyNames?.Contains(tokenIn.Identifier) ?? false))
             {
                 return new DynamicPathSegment(tokenIn.Identifier);
             }

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OData.UriParser
 
             if (collapsed && !(generatedProperties?.Contains(tokenIn.Identifier) ?? false))
             {
-                throw ExceptionUtil.CreatePropertyNotFoundException(tokenIn.Identifier, edmType.FullTypeName());
+                throw new ODataException(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue(tokenIn.Identifier));
             }
 
             if (TryBindAsDeclaredProperty(tokenIn, edmType, resolver, out nextSegment))

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
@@ -55,7 +55,9 @@ namespace Microsoft.OData.UriParser
                 return new AnnotationSegment(new EdmTerm(namespaceName, termName, EdmCoreModel.Instance.GetUntyped()));
             }
 
-            if ((state?.IsCollapsed ?? false) && !(state?.AggregatedPropertyNames?.Contains(tokenIn.Identifier) ?? false))
+            EndPathToken endPathToken = new EndPathToken(tokenIn.Identifier, null);
+
+            if ((state?.IsCollapsed ?? false) && !(state?.AggregatedPropertyNames?.Contains(endPathToken) ?? false))
             {
                 throw new ODataException(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue(tokenIn.Identifier));
             }
@@ -81,7 +83,7 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
-            if (edmType.IsOpen  || (state?.AggregatedPropertyNames?.Contains(tokenIn.Identifier) ?? false))
+            if (edmType.IsOpen  || (state?.AggregatedPropertyNames?.Contains(endPathToken) ?? false))
             {
                 return new DynamicPathSegment(tokenIn.Identifier);
             }

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
@@ -29,7 +29,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="edmType">the type of the current scope based on type segments.</param>
         /// <param name="resolver">Resolver for uri parser.</param>
         /// <returns>The segment created from the token.</returns>
-        public static ODataPathSegment ConvertNonTypeTokenToSegment(PathSegmentToken tokenIn, IEdmModel model, IEdmStructuredType edmType, ODataUriResolver resolver, HashSet<string> generatedProperties = null)
+        public static ODataPathSegment ConvertNonTypeTokenToSegment(PathSegmentToken tokenIn, IEdmModel model, IEdmStructuredType edmType, ODataUriResolver resolver, HashSet<string> generatedProperties = null, bool collapsed = false)
         {
             ExceptionUtils.CheckArgumentNotNull(resolver, "resolver");
 
@@ -53,6 +53,11 @@ namespace Microsoft.OData.UriParser
                 }
 
                 return new AnnotationSegment(new EdmTerm(namespaceName, termName, EdmCoreModel.Instance.GetUntyped()));
+            }
+
+            if (collapsed && !(generatedProperties?.Contains(tokenIn.Identifier) ?? false))
+            {
+                throw ExceptionUtil.CreatePropertyNotFoundException(tokenIn.Identifier, edmType.FullTypeName());
             }
 
             if (TryBindAsDeclaredProperty(tokenIn, edmType, resolver, out nextSegment))

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -629,7 +629,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="configuration">The configuration used for binding.</param>
         /// <param name="odataPathInfo">The path info from Uri path.</param>
         /// <returns>A <see cref="ComputeClause"/> representing the metadata bound compute expression.</returns>
-        private static ComputeClause ParseComputeImplementation(string compute, ODataUriParserConfiguration configuration, ODataPathInfo odataPathInfo)
+        private ComputeClause ParseComputeImplementation(string compute, ODataUriParserConfiguration configuration, ODataPathInfo odataPathInfo)
         {
             ExceptionUtils.CheckArgumentNotNull(configuration, "configuration");
             ExceptionUtils.CheckArgumentNotNull(compute, "compute");
@@ -639,9 +639,7 @@ namespace Microsoft.OData.UriParser
             ComputeToken computeToken = expressionParser.ParseCompute(compute);
 
             // Bind it to metadata
-            BindingState state = new BindingState(configuration);
-            state.ImplicitRangeVariable = NodeFactory.CreateImplicitRangeVariable(odataPathInfo.TargetEdmType.ToTypeReference(), odataPathInfo.TargetNavigationSource);
-            state.RangeVariables.Push(state.ImplicitRangeVariable);
+            BindingState state = CreateBindingState(configuration, odataPathInfo);
             MetadataBinder binder = new MetadataBinder(state);
             ComputeBinder computeBinder = new ComputeBinder(binder.Bind);
             ComputeClause boundNode = computeBinder.BindCompute(computeToken);

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -447,7 +447,7 @@ namespace Microsoft.OData.UriParser
 
             // semantic pass
             BindingState state = CreateBindingState(configuration, odataPathInfo);
-            return SelectExpandSemanticBinder.Bind(odataPathInfo, expandTree, selectTree, configuration, state.AggregatedPropertyNames, state.IsCollapsed);
+            return SelectExpandSemanticBinder.Bind(odataPathInfo, expandTree, selectTree, configuration, state);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -388,13 +388,7 @@ namespace Microsoft.OData.UriParser
             QueryToken filterToken = expressionParser.ParseFilter(filter);
 
             // Bind it to metadata
-            BindingState state = new BindingState(configuration, odataPathInfo.Segments.ToList());
-            state.ImplicitRangeVariable = NodeFactory.CreateImplicitRangeVariable(odataPathInfo.TargetEdmType.ToTypeReference(), odataPathInfo.TargetNavigationSource);
-            state.RangeVariables.Push(state.ImplicitRangeVariable);
-            if (applyClause != null)
-            {
-                state.AggregatedPropertyNames = applyClause.GetLastAggregatedPropertyNames();
-            }
+            BindingState state = CreateBindingState(configuration, odataPathInfo);
 
             MetadataBinder binder = new MetadataBinder(state);
             FilterBinder filterBinder = new FilterBinder(binder.Bind, state);
@@ -440,7 +434,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="configuration">The configuration used for binding.</param>
         /// <param name="odataPathInfo">The path info from Uri path.</param>
         /// <returns>A <see cref="SelectExpandClause"/> representing the metadata bound select and expand expression.</returns>
-        private static SelectExpandClause ParseSelectAndExpandImplementation(string select, string expand, ODataUriParserConfiguration configuration, ODataPathInfo odataPathInfo)
+        private SelectExpandClause ParseSelectAndExpandImplementation(string select, string expand, ODataUriParserConfiguration configuration, ODataPathInfo odataPathInfo)
         {
             ExceptionUtils.CheckArgumentNotNull(configuration, "configuration");
             ExceptionUtils.CheckArgumentNotNull(configuration.Model, "model");
@@ -452,7 +446,8 @@ namespace Microsoft.OData.UriParser
             SelectExpandSyntacticParser.Parse(select, expand, odataPathInfo.TargetStructuredType, configuration, out expandTree, out selectTree);
 
             // semantic pass
-            return SelectExpandSemanticBinder.Bind(odataPathInfo, expandTree, selectTree, configuration);
+            BindingState state = CreateBindingState(configuration, odataPathInfo);
+            return SelectExpandSemanticBinder.Bind(odataPathInfo, expandTree, selectTree, configuration, state.AggregatedPropertyNames);
         }
 
         /// <summary>
@@ -474,6 +469,17 @@ namespace Microsoft.OData.UriParser
             var orderByQueryTokens = expressionParser.ParseOrderBy(orderBy);
 
             // Bind it to metadata
+            BindingState state = CreateBindingState(configuration, odataPathInfo);
+
+            MetadataBinder binder = new MetadataBinder(state);
+            OrderByBinder orderByBinder = new OrderByBinder(binder.Bind);
+            OrderByClause orderByClause = orderByBinder.BindOrderBy(state, orderByQueryTokens);
+
+            return orderByClause;
+        }
+
+        private BindingState CreateBindingState(ODataUriParserConfiguration configuration, ODataPathInfo odataPathInfo)
+        {
             BindingState state = new BindingState(configuration, odataPathInfo.Segments.ToList());
             state.ImplicitRangeVariable = NodeFactory.CreateImplicitRangeVariable(odataPathInfo.TargetEdmType.ToTypeReference(), odataPathInfo.TargetNavigationSource);
             state.RangeVariables.Push(state.ImplicitRangeVariable);
@@ -482,11 +488,20 @@ namespace Microsoft.OData.UriParser
                 state.AggregatedPropertyNames = applyClause.GetLastAggregatedPropertyNames();
             }
 
-            MetadataBinder binder = new MetadataBinder(state);
-            OrderByBinder orderByBinder = new OrderByBinder(binder.Bind);
-            OrderByClause orderByClause = orderByBinder.BindOrderBy(state, orderByQueryTokens);
+            if (computeClause != null)
+            {
+                var computedProperties = computeClause.ComputedItems.Select(i => i.Alias).ToList();
+                if(state.AggregatedPropertyNames == null)
+                {
+                    state.AggregatedPropertyNames = computedProperties;
+                }
+                else
+                {
+                    state.AggregatedPropertyNames.AddRange(computedProperties);
+                }
+            }
 
-            return orderByClause;
+            return state;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -486,6 +486,10 @@ namespace Microsoft.OData.UriParser
             if (applyClause != null)
             {
                 state.AggregatedPropertyNames = applyClause.GetLastAggregatedPropertyNames();
+                if (applyClause.Transformations.Any(x => x.Kind == TransformationNodeKind.GroupBy || x.Kind == TransformationNodeKind.Aggregate))
+                {
+                    state.IsCollapsed = true;
+                }
             }
 
             if (computeClause != null)

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -447,7 +447,7 @@ namespace Microsoft.OData.UriParser
 
             // semantic pass
             BindingState state = CreateBindingState(configuration, odataPathInfo);
-            return SelectExpandSemanticBinder.Bind(odataPathInfo, expandTree, selectTree, configuration, state.AggregatedPropertyNames);
+            return SelectExpandSemanticBinder.Bind(odataPathInfo, expandTree, selectTree, configuration, state.AggregatedPropertyNames, state.IsCollapsed);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataQueryOptionParser.cs
@@ -490,14 +490,14 @@ namespace Microsoft.OData.UriParser
 
             if (computeClause != null)
             {
-                var computedProperties = computeClause.ComputedItems.Select(i => i.Alias).ToList();
+                var computedProperties = new HashSet<EndPathToken>(computeClause.ComputedItems.Select(i => new EndPathToken(i.Alias, null)));
                 if(state.AggregatedPropertyNames == null)
                 {
                     state.AggregatedPropertyNames = computedProperties;
                 }
                 else
                 {
-                    state.AggregatedPropertyNames.AddRange(computedProperties);
+                    state.AggregatedPropertyNames.UnionWith(computedProperties);
                 }
             }
 

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathToken.cs
@@ -27,5 +27,38 @@ namespace Microsoft.OData.UriParser
         /// The name of the property to access.
         /// </summary>
         public abstract string Identifier { get; }
+
+        // TODO: Implement Generic Equals to improve performance
+        public override bool Equals(object obj)
+        {
+            var otherPath = obj as PathToken;
+            if (otherPath == null)
+            {
+                return false;
+            }
+
+            return this.Identifier.Equals(otherPath.Identifier) 
+                && (this.NextToken == null && otherPath.NextToken == null
+                    || this.NextToken.Equals(otherPath.NextToken));
+        }
+
+        public override int GetHashCode()
+        {
+            int identifierHashCode = this.Identifier.GetHashCode();
+            if (this.NextToken != null)
+            {
+                identifierHashCode = Combine(identifierHashCode, this.NextToken.GetHashCode());
+            }
+            return identifierHashCode;
+        }
+
+        private static int Combine(int h1, int h2)
+        {
+            // RyuJIT optimizes this to use the ROL instruction
+            // Related GitHub pull request: dotnet/coreclr#1830
+            // Based on https://github.com/dotnet/coreclr/blob/master/src/System.Private.CoreLib/shared/System/Numerics/Hashing/HashHelpers.cs
+            uint rol5 = ((uint)h1 << 5) | ((uint)h1 >> 27);
+            return ((int)rol5 + h1) ^ h2;
+        }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathToken.cs
@@ -28,7 +28,6 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         public abstract string Identifier { get; }
 
-        // TODO: Implement Generic Equals to improve performance
         public override bool Equals(object obj)
         {
             var otherPath = obj as PathToken;

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/PathToken.cs
@@ -28,6 +28,9 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         public abstract string Identifier { get; }
 
+        /// <summary>Indicates the Equals overload.</summary>
+        /// <returns>True if equal.</returns>
+        /// <param name="obj">The other PathToken.</param>
         public override bool Equals(object obj)
         {
             var otherPath = obj as PathToken;
@@ -41,6 +44,8 @@ namespace Microsoft.OData.UriParser
                     || this.NextToken.Equals(otherPath.NextToken));
         }
 
+        /// <summary>Returns a hash code for this instance.</summary>
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
         public override int GetHashCode()
         {
             int identifierHashCode = this.Identifier.GetHashCode();

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/RangeVariableToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/RangeVariableToken.cs
@@ -57,5 +57,22 @@ namespace Microsoft.OData.UriParser
         {
             return visitor.Visit(this);
         }
+
+        // TODO: Implement Generic Equals to improve performance
+        public override bool Equals(object obj)
+        {
+            var otherPath = obj as RangeVariableToken;
+            if (otherPath == null)
+            {
+                return false;
+            }
+
+            return this.Name.Equals(otherPath.Name);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.Name.GetHashCode();
+        }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/RangeVariableToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/RangeVariableToken.cs
@@ -58,7 +58,6 @@ namespace Microsoft.OData.UriParser
             return visitor.Visit(this);
         }
 
-        // TODO: Implement Generic Equals to improve performance
         public override bool Equals(object obj)
         {
             var otherPath = obj as RangeVariableToken;

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/RangeVariableToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/RangeVariableToken.cs
@@ -58,6 +58,9 @@ namespace Microsoft.OData.UriParser
             return visitor.Visit(this);
         }
 
+        /// <summary>Indicates the Equals overload.</summary>
+        /// <returns>True if equal.</returns>
+        /// <param name="obj">The other RangeVariableToken.</param>
         public override bool Equals(object obj)
         {
             var otherPath = obj as RangeVariableToken;
@@ -69,6 +72,8 @@ namespace Microsoft.OData.UriParser
             return this.Name.Equals(otherPath.Name);
         }
 
+        /// <summary>Returns a hash code for this instance.</summary>
+        /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
         public override int GetHashCode()
         {
             return this.Name.GetHashCode();

--- a/src/Microsoft.OData.Core/UriParser/Visitors/SelectPropertyVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/SelectPropertyVisitor.cs
@@ -46,12 +46,7 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Properties generated in $apply or $compute
         /// </summary>
-        private readonly HashSet<string> generatedProperties;
-
-        /// <summary>
-        /// $apply was evaluated before and we must consider only generatedProperties
-        /// </summary>
-        private readonly bool collapsed;
+        private BindingState state;
 
         /// <summary>
         /// Build a property visitor to visit the select tree and decorate a SelectExpandClause
@@ -61,15 +56,14 @@ namespace Microsoft.OData.UriParser
         /// <param name="maxDepth">the maximum recursive depth.</param>
         /// <param name="expandClauseToDecorate">The already built expand clause to decorate</param>
         /// <param name="resolver">Resolver for uri parser.</param>
-        public SelectPropertyVisitor(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, List<string> generatedProperties, bool collapsed)
+        public SelectPropertyVisitor(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, BindingState state)
         {
             this.model = model;
             this.edmType = edmType;
             this.maxDepth = maxDepth;
             this.expandClauseToDecorate = expandClauseToDecorate;
             this.resolver = resolver;
-            this.generatedProperties =  new HashSet<string>(generatedProperties ?? new List<string>());
-            this.collapsed = collapsed;
+            this.state = state;
         }
 
         /// <summary>
@@ -138,7 +132,7 @@ namespace Microsoft.OData.UriParser
             }
 
             // next, create a segment for the first non-type segment in the path.
-            ODataPathSegment lastSegment = SelectPathSegmentTokenBinder.ConvertNonTypeTokenToSegment(tokenIn, this.model, currentLevelType, resolver, this.generatedProperties, this.collapsed);
+            ODataPathSegment lastSegment = SelectPathSegmentTokenBinder.ConvertNonTypeTokenToSegment(tokenIn, this.model, currentLevelType, resolver, this.state);
 
             // next, create an ODataPath and add the segments to it.
             if (lastSegment != null)

--- a/src/Microsoft.OData.Core/UriParser/Visitors/SelectPropertyVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/SelectPropertyVisitor.cs
@@ -49,6 +49,11 @@ namespace Microsoft.OData.UriParser
         private readonly HashSet<string> generatedProperties;
 
         /// <summary>
+        /// $apply was evaluated before and we must consider only generatedProperties
+        /// </summary>
+        private readonly bool collapsed;
+
+        /// <summary>
         /// Build a property visitor to visit the select tree and decorate a SelectExpandClause
         /// </summary>
         /// <param name="model">The model used for binding.</param>
@@ -56,7 +61,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="maxDepth">the maximum recursive depth.</param>
         /// <param name="expandClauseToDecorate">The already built expand clause to decorate</param>
         /// <param name="resolver">Resolver for uri parser.</param>
-        public SelectPropertyVisitor(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, List<string> generatedProperties)
+        public SelectPropertyVisitor(IEdmModel model, IEdmStructuredType edmType, int maxDepth, SelectExpandClause expandClauseToDecorate, ODataUriResolver resolver, List<string> generatedProperties, bool collapsed)
         {
             this.model = model;
             this.edmType = edmType;
@@ -64,6 +69,7 @@ namespace Microsoft.OData.UriParser
             this.expandClauseToDecorate = expandClauseToDecorate;
             this.resolver = resolver;
             this.generatedProperties =  new HashSet<string>(generatedProperties ?? new List<string>());
+            this.collapsed = collapsed;
         }
 
         /// <summary>
@@ -132,7 +138,7 @@ namespace Microsoft.OData.UriParser
             }
 
             // next, create a segment for the first non-type segment in the path.
-            ODataPathSegment lastSegment = SelectPathSegmentTokenBinder.ConvertNonTypeTokenToSegment(tokenIn, this.model, currentLevelType, resolver, this.generatedProperties);
+            ODataPathSegment lastSegment = SelectPathSegmentTokenBinder.ConvertNonTypeTokenToSegment(tokenIn, this.model, currentLevelType, resolver, this.generatedProperties, this.collapsed);
 
             // next, create an ODataPath and add the segments to it.
             if (lastSegment != null)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -1250,6 +1250,22 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void NavigationPropertiesTreatedAsOpenPropertyInOrderBy()
+        {
+            var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,
+                HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet(),
+                new Dictionary<string, string>()
+                {
+                    {"$orderby", "MyDog/Color"},
+                    {"$apply", "groupby((MyDog/Color))"}
+                });
+            odataQueryOptionParser.ParseApply();
+            var orderByClause = odataQueryOptionParser.ParseOrderBy();
+            orderByClause.Direction.Should().Be(OrderByDirection.Ascending);
+            orderByClause.Expression.ShouldBeSingleValueOpenPropertyAccessQueryNode("Color");
+        }
+
+        [Fact]
         public void MultipleComputePropertiesTreatedAsOpenPropertyInOrderBy()
         {
             var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -1201,7 +1201,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                 {
                     {"$filter", "DoubleTotal gt Total"},
                     {"$apply", "aggregate(FavoriteNumber with sum as Total)"},
-                    {"$compute", "FavoriteNumber mul 2 as DoubleTotal"}
+                    {"$compute", "Total mul 2 as DoubleTotal"}
                 });
             odataQueryOptionParser.ParseApply();
             odataQueryOptionParser.ParseCompute();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -1262,7 +1262,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             odataQueryOptionParser.ParseApply();
             var orderByClause = odataQueryOptionParser.ParseOrderBy();
             orderByClause.Direction.Should().Be(OrderByDirection.Ascending);
-            orderByClause.Expression.ShouldBeSingleValueOpenPropertyAccessQueryNode("Color");
+            orderByClause.Expression.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetDogColorProp());
         }
 
         [Fact]
@@ -1312,7 +1312,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                     {"$apply", "compute(FavoriteNumber mul 2 as DoubleFavorite)/aggregate(DoubleFavorite with sum as Total)"}
                 });
             Action parseAction = () => { odataQueryOptionParser.ParseApply(); odataQueryOptionParser.ParseOrderBy(); };
-            parseAction.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.MetadataBinder_PropertyNotDeclared("Fully.Qualified.Namespace.Person", "DoubleFavorite"));
+            parseAction.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue("DoubleFavorite"));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -1308,6 +1308,20 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             odataQueryOptionParser.ParseCompute();
             var selectClause = odataQueryOptionParser.ParseSelectAndExpand();
         }
+
+        [Fact]
+        public void ApplyComputedPropertyTreatedAsOpenPropertyInSelect()
+        {
+            var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,
+                HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet(),
+                new Dictionary<string, string>()
+                {
+                    {"$select", "DoubleTotal"},
+                    {"$apply", "compute(FavoriteNumber mul 2 as DoubleTotal)"}
+                });
+            odataQueryOptionParser.ParseApply();
+            var selectClause = odataQueryOptionParser.ParseSelectAndExpand();
+        }
         #endregion
         #region Test Running Helpers
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -1294,6 +1294,21 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
         #endregion
 
+        #region "$select and generated properties"
+        [Fact]
+        public void DollarComputedPropertyTreatedAsOpenPropertyInSelect()
+        {
+            var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,
+                HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet(),
+                new Dictionary<string, string>()
+                {
+                    {"$select", "DoubleTotal"},
+                    {"$compute", "FavoriteNumber mul 2 as DoubleTotal"}
+                });
+            odataQueryOptionParser.ParseCompute();
+            var selectClause = odataQueryOptionParser.ParseSelectAndExpand();
+        }
+        #endregion
         #region Test Running Helpers
 
         private static SelectExpandClause RunParseSelectExpand(string select, string expand, IEdmStructuredType type, IEdmEntitySet enitytSet)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -1322,6 +1322,24 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             odataQueryOptionParser.ParseApply();
             var selectClause = odataQueryOptionParser.ParseSelectAndExpand();
         }
+
+        [Fact]
+        public void ComputeAfterApplyPropertyTreatedAsOpenPropertyInSelect()
+        {
+            var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,
+                HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet(),
+                new Dictionary<string, string>()
+                {
+                    {"$select", "DoubleTotal, NewTotal"},
+                    {"$apply", "aggregate(FavoriteNumber with sum as DoubleTotal)"},
+                    {"$compute", "DoubleTotal as NewTotal"},
+                });
+            odataQueryOptionParser.ParseApply();
+            odataQueryOptionParser.ParseCompute();
+            var selectClause = odataQueryOptionParser.ParseSelectAndExpand();
+        }
+
+
         #endregion
         #region Test Running Helpers
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -1307,6 +1307,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                 });
             odataQueryOptionParser.ParseCompute();
             var selectClause = odataQueryOptionParser.ParseSelectAndExpand();
+            AssertSelectString("DoubleTotal", selectClause);
         }
 
         [Fact]
@@ -1321,6 +1322,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                 });
             odataQueryOptionParser.ParseApply();
             var selectClause = odataQueryOptionParser.ParseSelectAndExpand();
+            AssertSelectString("DoubleTotal", selectClause);
         }
 
         [Fact]
@@ -1337,8 +1339,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             odataQueryOptionParser.ParseApply();
             odataQueryOptionParser.ParseCompute();
             var selectClause = odataQueryOptionParser.ParseSelectAndExpand();
+            AssertSelectString("DoubleTotal, NewTotal", selectClause);
         }
-
 
         #endregion
         #region Test Running Helpers

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -1340,7 +1340,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             odataQueryOptionParser.ParseApply();
             Action action = () => odataQueryOptionParser.ParseSelectAndExpand();
 
-            action.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.MetadataBinder_PropertyNotDeclared("Fully.Qualified.Namespace.Person", "FavoriteNumber"));
+            action.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue("FavoriteNumber"));
         }
 
         [Fact]
@@ -1446,7 +1446,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             Action action = () => odataQueryOptionParser.ParseSelectAndExpand();
 
-            action.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.MetadataBinder_PropertyNotDeclared("Fully.Qualified.Namespace.Dog", "Color"));
+            action.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue("Color"));
         }
 
         #endregion

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/EndPathBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/EndPathBinderTests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             SingleValueNode parentNode = new ResourceRangeVariableReferenceNode("a", new ResourceRangeVariable("a", HardCodedTestModel.GetPersonTypeReference(), entityCollectionNode));
 
             var state = new BindingState(this.configuration);
-            state.AggregatedPropertyNames = new List<string> { "Color" };
+            state.AggregatedPropertyNames = new HashSet<EndPathToken> { new EndPathToken("Color", new RangeVariableToken("a")) };
             var metadataBinder = new MetadataBinder(state);
             var endPathBinder = new EndPathBinder(metadataBinder.Bind, state);
             var propertyNode = endPathBinder.GeneratePropertyAccessQueryForOpenType(

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/ExpandBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/ExpandBinderTests.cs
@@ -23,22 +23,22 @@ namespace Microsoft.OData.Tests.UriParser.Binders
 
         public ExpandBinderTests()
         {
-            this.binderForPerson = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()));
-            this.binderForAddress = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetAddressType(), null));
+            this.binderForPerson = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()), null);
+            this.binderForAddress = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetAddressType(), null), null);
         }
 
         [Fact]
         public void TopLevelEntityTypeCannotBeNull()
         {
             Action createWithNullTopLevelEntityType =
-                () => new SelectExpandBinder(this.V4configuration, new ODataPathInfo(null, HardCodedTestModel.GetPeopleSet()));
+                () => new SelectExpandBinder(this.V4configuration, new ODataPathInfo(null, HardCodedTestModel.GetPeopleSet()), null);
             createWithNullTopLevelEntityType.ShouldThrow<Exception>(Error.ArgumentNull("topLevelEntityType").ToString());
         }
 
         [Fact]
         public void TopLevelEntitySetCanBeNull()
         {
-            SelectExpandBinder binder = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(ModelBuildingHelpers.BuildValidEntityType(), null));
+            SelectExpandBinder binder = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(ModelBuildingHelpers.BuildValidEntityType(), null), null);
             binder.NavigationSource.Should().BeNull();
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/ExpandBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/ExpandBinderTests.cs
@@ -23,22 +23,22 @@ namespace Microsoft.OData.Tests.UriParser.Binders
 
         public ExpandBinderTests()
         {
-            this.binderForPerson = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()), null);
-            this.binderForAddress = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetAddressType(), null), null);
+            this.binderForPerson = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()), null, false);
+            this.binderForAddress = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetAddressType(), null), null, false);
         }
 
         [Fact]
         public void TopLevelEntityTypeCannotBeNull()
         {
             Action createWithNullTopLevelEntityType =
-                () => new SelectExpandBinder(this.V4configuration, new ODataPathInfo(null, HardCodedTestModel.GetPeopleSet()), null);
+                () => new SelectExpandBinder(this.V4configuration, new ODataPathInfo(null, HardCodedTestModel.GetPeopleSet()), null, false);
             createWithNullTopLevelEntityType.ShouldThrow<Exception>(Error.ArgumentNull("topLevelEntityType").ToString());
         }
 
         [Fact]
         public void TopLevelEntitySetCanBeNull()
         {
-            SelectExpandBinder binder = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(ModelBuildingHelpers.BuildValidEntityType(), null), null);
+            SelectExpandBinder binder = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(ModelBuildingHelpers.BuildValidEntityType(), null), null, false);
             binder.NavigationSource.Should().BeNull();
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/ExpandBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/ExpandBinderTests.cs
@@ -23,22 +23,22 @@ namespace Microsoft.OData.Tests.UriParser.Binders
 
         public ExpandBinderTests()
         {
-            this.binderForPerson = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()), null, false);
-            this.binderForAddress = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetAddressType(), null), null, false);
+            this.binderForPerson = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()), null);
+            this.binderForAddress = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(HardCodedTestModel.GetAddressType(), null), null);
         }
 
         [Fact]
         public void TopLevelEntityTypeCannotBeNull()
         {
             Action createWithNullTopLevelEntityType =
-                () => new SelectExpandBinder(this.V4configuration, new ODataPathInfo(null, HardCodedTestModel.GetPeopleSet()), null, false);
+                () => new SelectExpandBinder(this.V4configuration, new ODataPathInfo(null, HardCodedTestModel.GetPeopleSet()), null);
             createWithNullTopLevelEntityType.ShouldThrow<Exception>(Error.ArgumentNull("topLevelEntityType").ToString());
         }
 
         [Fact]
         public void TopLevelEntitySetCanBeNull()
         {
-            SelectExpandBinder binder = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(ModelBuildingHelpers.BuildValidEntityType(), null), null, false);
+            SelectExpandBinder binder = new SelectExpandBinder(this.V4configuration, new ODataPathInfo(ModelBuildingHelpers.BuildValidEntityType(), null), null);
             binder.NavigationSource.Should().BeNull();
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/SelectBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/SelectBinderTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void NonSystemTokenTranslatedToSelectionItem()
         {
             var expandTree = new SelectExpandClause(new Collection<SelectItem>(), false);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>() { new NonSystemToken("Shoe", null, null) });
 
             binder.Bind(selectToken).SelectedItems.Single().ShouldBePathSelectionItem(new ODataPath(new PropertySegment(HardCodedTestModel.GetPersonShoeProp())));
@@ -35,7 +35,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                                         {
                                             new PathSelectItem(new ODataSelectPath(new PropertySegment( HardCodedTestModel.GetPersonNameProp()))),
                                         }, false);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>() { new NonSystemToken("*", null, null) });
 
             binder.Bind(selectToken).SelectedItems.Single().ShouldBeWildcardSelectionItem();
@@ -53,7 +53,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                                             new PathSelectItem(stuffPath),
                                             new PathSelectItem(new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPaintingColorsProperty())))
                                         }, false);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPaintingType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPaintingType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>() { new NonSystemToken("*", null, null) });
             var item = binder.Bind(selectToken);
             item.SelectedItems.Should().HaveCount(4)
@@ -70,7 +70,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                                         {
                                             new WildcardSelectItem()
                                         }, false);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>() { new NonSystemToken("Name", null, null) });
             binder.Bind(selectToken).SelectedItems.Single().ShouldBeWildcardSelectionItem();
         }
@@ -79,7 +79,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void AllSelectedIsSetIfSelectIsEmpty()
         {
             var expandTree = new SelectExpandClause(new Collection<SelectItem>(), false);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>());
             binder.Bind(selectToken).AllSelected.Should().BeTrue();
         }
@@ -88,7 +88,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void AllSelectedIsNotSetIfSelectedIsNotEmpty()
         {
             var expandTree = new SelectExpandClause(new Collection<SelectItem>(), true);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>(){new NonSystemToken("Name", null, null)});
             binder.Bind(selectToken).AllSelected.Should().BeFalse();
         }
@@ -100,7 +100,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                                                                                                 new ODataExpandPath(new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), null)), 
                                                                                                 HardCodedTestModel.GetPeopleSet(),
                                                                                                 new SelectExpandClause(new Collection<SelectItem>(), true))}, true);
-            SelectBinder binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            SelectBinder binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             SelectToken selectToken = new SelectToken(new List<PathSegmentToken>() { new NonSystemToken("MyDog", null, new NonSystemToken("Color", null, null)) });
 
             Action bindWithMultiLevelPath = () => binder.Bind(selectToken);
@@ -114,7 +114,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                                                                                                                 new ODataExpandPath(new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), null)),
                                                                                                                 HardCodedTestModel.GetPeopleSet(),
                                                                                                                 new SelectExpandClause(new Collection<SelectItem>(), false))}, false);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>() { new NonSystemToken("Name", null, null) });
             var result = binder.Bind(selectToken);
             result.SelectedItems.Last().ShouldBePathSelectionItem(new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp())));
@@ -129,7 +129,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                                                                                                 new ODataExpandPath(new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), null)), 
                                                                                                 HardCodedTestModel.GetPeopleSet(),
                                                                                                 new SelectExpandClause(new Collection<SelectItem>(), true))}, true);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>());
             var result = binder.Bind(selectToken);
             result.AllSelected.Should().BeTrue();
@@ -145,7 +145,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                                                                                         new ODataExpandPath(new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), null)), 
                                                                                         HardCodedTestModel.GetPeopleSet(),
                                                                                         new SelectExpandClause(new Collection<SelectItem>(), false))}, false);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>() { new NonSystemToken("MyDog", null, null) });
             var result = binder.Bind(selectToken);
             result.SelectedItems.Single(x => x is ExpandedNavigationSelectItem).ShouldBeExpansionFor(HardCodedTestModel.GetPersonMyDogNavProp()).And.SelectAndExpand.AllSelected.Should().BeFalse();
@@ -156,7 +156,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void NavPropEndPathResultsInNavPropLinkSelectionItem()
         {
             SelectExpandClause expandTree = new SelectExpandClause(new Collection<SelectItem>(), false);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>() { new NonSystemToken("MyDog", null, null) });
             var result = binder.Bind(selectToken);
             result.SelectedItems.Single().ShouldBePathSelectionItem(new ODataPath(new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), null)));
@@ -170,7 +170,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                                                             new ODataExpandPath(new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), null)), 
                                                             HardCodedTestModel.GetPeopleSet(),
                                                             new SelectExpandClause(null, false))}, true);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>()
                 {
                     new NonSystemToken("substring", null, null)
@@ -188,7 +188,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                                                                 new ODataExpandPath(new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), null)), 
                                                                 HardCodedTestModel.GetPeopleSet(),
                                                                 new SelectExpandClause(null, false))}, true);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>()
                 {
                     new NonSystemToken("GetCoolPeople", null, null)
@@ -201,7 +201,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public void MustFindNonTypeSegmentBeforeTheEndOfTheChain()
         {
             SelectExpandClause expandTree = new SelectExpandClause(new Collection<SelectItem>(), false);
-            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver);
+            var binder = new SelectBinder(HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), 800, expandTree, DefaultUriResolver, null);
             var selectToken = new SelectToken(new List<PathSegmentToken>()
                 {
                     new NonSystemToken("Fully.Qualified.Namespace.Employee", null, null)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -323,23 +323,6 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
             entitySetAggregate.Should().NotBeNull();
         }
 
-        [Fact]
-        public void BindApplyWithEntitySetAggregationOnSingleNavigationThrows()
-        {
-            IEnumerable<QueryToken> tokens =
-                _parser.ParseApply(
-                    "aggregate(MyDog($count as Count))");
-
-            BindingState state = new BindingState(_configuration);
-            MetadataBinder metadataBiner = new MetadataBinder(_bindingState);
-
-            ApplyBinder binder = new ApplyBinder(metadataBiner.Bind, _bindingState);
-            Action bind = () => binder.BindApply(tokens);
-
-            bind.ShouldThrow<ODataException>().Where(e => e.Message == ErrorStrings.ApplyBinder_UnsupportedForEntitySetAggregation("MyDog", QueryNodeKind.SingleNavigationNode));
-            
-        }
-
         private readonly ODataUriParserConfiguration V4configuration = new ODataUriParserConfiguration(HardCodedTestModel.TestModel);
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -221,6 +221,74 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         }
 
         [Fact]
+        public void BindApplyWitComputeShouldReturnApplyClause()
+        {
+            var tokens = _parser.ParseApply("compute(UnitPrice mul 5 as BigPrice)");
+
+            var binder = new ApplyBinder(FakeBindMethods.BindSingleComplexProperty, _bindingState);
+            var actual = binder.BindApply(tokens);
+
+            actual.Should().NotBeNull();
+            actual.Transformations.Should().HaveCount(1);
+
+            var transformations = actual.Transformations.ToList();
+            var compute = transformations[0] as ComputeTransformationNode;
+
+            compute.Should().NotBeNull();
+            compute.Kind.Should().Be(TransformationNodeKind.Compute);
+            compute.Expressions.Should().HaveCount(1);
+
+            var statements = compute.Expressions.ToList();
+            var statement = statements[0];
+            VerifyIsFakeSingleValueNode(statement.Expression);
+            statement.Alias.ShouldBeEquivalentTo("BigPrice");
+        }
+
+        [Fact]
+        public void BindApplyWithComputeAfterGroupByShouldReturnApplyClause()
+        {
+            var tokens = _parser.ParseApply("groupby((ID, SSN), aggregate(LifeTime with sum as TotalLife))/compute(TotalLife as TotalLife2)");
+
+            BindingState state = new BindingState(_configuration);
+            MetadataBinder metadataBiner = new MetadataBinder(_bindingState);
+
+            ApplyBinder binder = new ApplyBinder(metadataBiner.Bind, _bindingState);
+            var actual = binder.BindApply(tokens);
+
+            actual.Should().NotBeNull();
+            actual.Transformations.Should().HaveCount(2);
+
+            var compute = actual.Transformations.Last() as ComputeTransformationNode;
+
+            compute.Should().NotBeNull();
+            compute.Kind.Should().Be(TransformationNodeKind.Compute);
+            compute.Expressions.Should().HaveCount(1);
+
+            var statements = compute.Expressions.ToList();
+            var statement = statements[0];
+            statement.Alias.ShouldBeEquivalentTo("TotalLife2");
+        }
+
+
+        [Fact]
+        public void BindApplyWithMultipleGroupBysShouldReturnApplyClause()
+        {
+            var tokens = _parser.ParseApply("groupby((MyDog/Color, MyDog/Breed))/groupby((MyDog/Color), aggregate(MyDog/Breed with max as MaxBreed))");
+
+            BindingState state = new BindingState(_configuration);
+            MetadataBinder metadataBiner = new MetadataBinder(_bindingState);
+
+            ApplyBinder binder = new ApplyBinder(metadataBiner.Bind, _bindingState);
+            var actual = binder.BindApply(tokens);
+
+            actual.Should().NotBeNull();
+            actual.Transformations.Should().HaveCount(2);
+
+            var groupBy = actual.Transformations.Last() as GroupByTransformationNode;
+            groupBy.Should().NotBeNull();
+        }
+
+        [Fact]
         public void BindApplyWitMultipleTokensShouldReturnApplyClause()
         {
             IEnumerable<QueryToken> tokens =

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5833,6 +5833,9 @@ public abstract class Microsoft.OData.UriParser.PathToken : Microsoft.OData.UriP
 
 	string Identifier  { public abstract get; }
 	Microsoft.OData.UriParser.QueryToken NextToken  { public abstract get; public abstract set; }
+
+	public virtual bool Equals (object obj)
+	public virtual int GetHashCode ()
 }
 
 public abstract class Microsoft.OData.UriParser.QueryNode {
@@ -6852,6 +6855,8 @@ public sealed class Microsoft.OData.UriParser.RangeVariableToken : Microsoft.ODa
 	string Name  { public get; }
 
 	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+	public virtual bool Equals (object obj)
+	public virtual int GetHashCode ()
 }
 
 public sealed class Microsoft.OData.UriParser.ReferenceSegment : Microsoft.OData.UriParser.ODataPathSegment {
@@ -8276,6 +8281,9 @@ public abstract class Microsoft.OData.Client.ALinq.UriParser.PathToken : Microso
 
 	string Identifier  { public abstract get; }
 	Microsoft.OData.Client.ALinq.UriParser.QueryToken NextToken  { public abstract get; public abstract set; }
+
+	public virtual bool Equals (object obj)
+	public virtual int GetHashCode ()
 }
 
 public abstract class Microsoft.OData.Client.ALinq.UriParser.QueryToken {
@@ -8535,6 +8543,8 @@ public sealed class Microsoft.OData.Client.ALinq.UriParser.RangeVariableToken : 
 	string Name  { public get; }
 
 	public virtual T Accept (ISyntacticTreeVisitor`1 visitor)
+	public virtual bool Equals (object obj)
+	public virtual int GetHashCode ()
 }
 
 public sealed class Microsoft.OData.Client.ALinq.UriParser.SelectToken : Microsoft.OData.Client.ALinq.UriParser.QueryToken {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1426.*

### Description

*Makes dynamic properties generated in $apply and $compute visible for query options evaluated after them ($select, $filter, $expand, $orderby etc.)*

Also, current implementation doesn't block queries like
`$apply=groupby((Field1))&$filter=Fiield2 eq 1` during parsing and binding that leads to cryptic exceptions during IQueryable building

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

