### PR TITLE
$count is a valid path after collapsed inputs

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -143,6 +143,11 @@ namespace Microsoft.OData.UriParser
             SingleValueNode singleValueParent = parent as SingleValueNode;
             if (singleValueParent != null)
             {
+                if (endPathToken.Identifier == ExpressionConstants.QueryOptionCount)
+                {
+                    return new CountVirtualPropertyNode();
+                }
+
                 if (state.IsCollapsed && !IsAggregatedProperty(endPathToken))
                 {
                     throw new ODataException(ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue(endPathToken.Identifier));
@@ -163,11 +168,6 @@ namespace Microsoft.OData.UriParser
                 if (functionCallBinder.TryBindEndPathAsFunctionCall(endPathToken, singleValueParent, state, out boundFunction))
                 {
                     return boundFunction;
-                }
-
-                if (endPathToken.Identifier == ExpressionConstants.QueryOptionCount)
-                {
-                    return new CountVirtualPropertyNode();
                 }
 
                 return GeneratePropertyAccessQueryForOpenType(endPathToken, singleValueParent);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Allow up PR for https://github.com/OData/odata.net/pull/1425

### Description

$count should be allowed after groupby in expressions like `groupby((ID))/aggregate($count as Count)`
Before fix it was failing with Microsoft.OData.ODataException : $apply/groupby grouping expression '$count' must evaluate to a property access value. 

Fix moves check for $coutn count special case before lookup in the list of properties that are available after collapsing inputs.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*


