### PR TITLE
Refactor & Improve the ODataMediaTypeResolver

### DIFF
--- a/src/Microsoft.OData.Core/MediaTypeUtils.cs
+++ b/src/Microsoft.OData.Core/MediaTypeUtils.cs
@@ -58,7 +58,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Max size to cache match info.
         /// </summary>
-        private const int MatchInfoCacheMaxSize = 1024;
+        private const int MatchInfoCacheMaxSize = 256;
 
         /// <summary>
         /// Concurrent cache to cache match info.
@@ -897,7 +897,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Class representing key of match info cache.
         /// </summary>
-        private sealed class MatchInfoCacheKey
+        private sealed class MatchInfoCacheKey : IEquatable<MatchInfoCacheKey>
         {
             /// <summary>
             /// Constructor.
@@ -934,11 +934,29 @@ namespace Microsoft.OData
             /// <returns>true if obj is equal to this instance; otherwise, false.</returns>
             public override bool Equals(object obj)
             {
-                MatchInfoCacheKey cacheKey = obj as MatchInfoCacheKey;
-                return cacheKey != null &&
-                    this.MediaTypeResolver == cacheKey.MediaTypeResolver &&
-                    this.PayloadKind == cacheKey.PayloadKind &&
-                    this.ContentTypeName == cacheKey.ContentTypeName;
+                return this.Equals(obj as MatchInfoCacheKey);
+            }
+
+            /// <summary>
+            /// Returns a value indicating whether this instance is equal to a specified <see cref="MatchInfoCacheKey"/>.
+            /// </summary>
+            /// <param name="other">An object to compare with this instance.</param>
+            /// <returns>true if obj is equal to this instance; otherwise, false.</returns>
+            public bool Equals(MatchInfoCacheKey other)
+            {
+                if (ReferenceEquals(other, null))
+                {
+                    return false;
+                }
+
+                if (ReferenceEquals(this, other))
+                {
+                    return true;
+                }
+
+                return this.MediaTypeResolver == other.MediaTypeResolver &&
+                    this.PayloadKind == other.PayloadKind &&
+                    this.ContentTypeName == other.ContentTypeName;
             }
 
             /// <summary>

--- a/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
+++ b/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
@@ -41,41 +41,23 @@ namespace Microsoft.OData
         {
             {
                 ODataPayloadKind.Batch,
-                new List<ODataMediaTypeFormat>
-                {
-                    new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeMultipartType, MimeConstants.MimeMixedSubType), ODataFormat.Batch)
-                }
+                new [] { new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeMultipartType, MimeConstants.MimeMixedSubType), ODataFormat.Batch) }
             },
             {
                 ODataPayloadKind.Value,
-                new List<ODataMediaTypeFormat>
-                {
-                    new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeTextType, MimeConstants.MimePlainSubType), ODataFormat.RawValue)
-                }
+                new [] { new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeTextType, MimeConstants.MimePlainSubType), ODataFormat.RawValue) }
             },
             {
                 ODataPayloadKind.BinaryValue,
-                new List<ODataMediaTypeFormat>
-                {
-                    new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeOctetStreamSubType), ODataFormat.RawValue)
-                }
+                new [] { new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeOctetStreamSubType), ODataFormat.RawValue) }
             },
             {
                 ODataPayloadKind.MetadataDocument,
-                new List<ODataMediaTypeFormat>
-                {
-                    new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeXmlSubType), ODataFormat.Metadata)
-                }
+                new [] { new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeXmlSubType), ODataFormat.Metadata) }
             },
             {
                 ODataPayloadKind.Asynchronous,
-                new List<ODataMediaTypeFormat>
-                {
-                    new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeHttpSubType), ODataFormat.RawValue)
-                }
-            },
-            {
-                ODataPayloadKind.Delta, new List<ODataMediaTypeFormat>()
+                new [] { new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeHttpSubType), ODataFormat.RawValue) }
             }
         };
 

--- a/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
+++ b/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
@@ -106,7 +106,7 @@ namespace Microsoft.OData
         {
             var minimal = new KeyValuePair<string, string>(MimeConstants.MimeMetadataParameterName, MimeConstants.MimeMetadataParameterValueMinimal);
             var full = new KeyValuePair<string, string>(MimeConstants.MimeMetadataParameterName, MimeConstants.MimeMetadataParameterValueFull);
-            var non = new KeyValuePair<string, string>(MimeConstants.MimeMetadataParameterName, MimeConstants.MimeMetadataParameterValueNone);
+            var none = new KeyValuePair<string, string>(MimeConstants.MimeMetadataParameterName, MimeConstants.MimeMetadataParameterValueNone);
 
             var streamTrue = new KeyValuePair<string, string>(MimeConstants.MimeStreamingParameterName, MimeConstants.MimeParameterValueTrue);
             var streamFalse = new KeyValuePair<string, string>(MimeConstants.MimeStreamingParameterName, MimeConstants.MimeParameterValueFalse);
@@ -143,17 +143,17 @@ namespace Microsoft.OData
                 new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { full }), ODataFormat.Json),
 
                 // none
-                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { non, streamTrue, ieeeFalse }), ODataFormat.Json),
-                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { non, streamTrue, ieeeTrue }), ODataFormat.Json),
-                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { non, streamTrue }), ODataFormat.Json),
+                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { none, streamTrue, ieeeFalse }), ODataFormat.Json),
+                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { none, streamTrue, ieeeTrue }), ODataFormat.Json),
+                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { none, streamTrue }), ODataFormat.Json),
 
-                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { non, streamFalse, ieeeFalse }), ODataFormat.Json),
-                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { non, streamFalse, ieeeTrue }), ODataFormat.Json),
-                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { non, streamFalse }), ODataFormat.Json),
+                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { none, streamFalse, ieeeFalse }), ODataFormat.Json),
+                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { none, streamFalse, ieeeTrue }), ODataFormat.Json),
+                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { none, streamFalse }), ODataFormat.Json),
 
-                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { non, ieeeFalse }), ODataFormat.Json),
-                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { non, ieeeTrue }), ODataFormat.Json),
-                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { non }), ODataFormat.Json),
+                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { none, ieeeFalse }), ODataFormat.Json),
+                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { none, ieeeTrue }), ODataFormat.Json),
+                new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { none }), ODataFormat.Json),
 
                 // without metadata
                 new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, new[] { streamTrue, ieeeFalse }), ODataFormat.Json),

--- a/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
+++ b/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
@@ -31,6 +31,7 @@ namespace Microsoft.OData
             ODataPayloadKind.ServiceDocument,
             ODataPayloadKind.Error,
             ODataPayloadKind.Parameter,
+            ODataPayloadKind.Delta,
             ODataPayloadKind.IndividualProperty
         };
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMediaTypeResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMediaTypeResolverTests.cs
@@ -67,9 +67,7 @@ namespace Microsoft.OData.Tests
             // individual property
             JsonMediaTypes,
             // delta
-            new ODataMediaTypeFormat[]
-            {
-            },
+            JsonMediaTypes,
             // async
             new ODataMediaTypeFormat[]
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMediaTypeResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMediaTypeResolverTests.cs
@@ -128,7 +128,6 @@ namespace Microsoft.OData.Tests
 
                 var expected = MediaTypeCollection[(int)payloadKind];
                 var actual = resolver.GetMediaTypeFormats(payloadKind);
-                Console.WriteLine(payloadKind);
                 actual.ShouldBeEquivalentTo(expected);
             }
         }
@@ -148,7 +147,6 @@ namespace Microsoft.OData.Tests
                 expected.Insert(0, MyFormat.MediaTypeWithFormatA);
 
                 var actual = resolver.GetMediaTypeFormats(payloadKind);
-                Console.WriteLine(payloadKind);
                 actual.ShouldBeEquivalentTo(expected);
             }
         }
@@ -179,7 +177,6 @@ namespace Microsoft.OData.Tests
                 ODataPayloadKind selectedPayloadKind;
                 ODataFormat actual = MediaTypeUtils.GetFormatFromContentType(contentType, new[] { payloadKind }, resolver, out mediaType, out encoding, out selectedPayloadKind);
 
-                Console.WriteLine(payloadKind);
                 actual.ShouldBeEquivalentTo(MyFormat.Instance);
                 mediaType.ShouldBeEquivalentTo(expectedMediaType);
                 encoding.ShouldBeEquivalentTo(payloadKind == ODataPayloadKind.BinaryValue ? null : Encoding.UTF8);

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/PayloadKindDetectionJsonLightTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/PayloadKindDetectionJsonLightTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
 
         /// <summary>Reusable constant of an entry detection result.</summary>
         private static readonly Func<ReaderTestConfiguration, IEnumerable<PayloadKindDetectionResult>> entryDetectionResult =
-            testConfig => CreateJsonLightFormatResult(ODataPayloadKind.Resource);
+            testConfig => CreateJsonLightFormatResult(ODataPayloadKind.Resource, ODataPayloadKind.Delta);
 
         /// <summary>Reusable constant of a feed detection result.</summary>
         private static readonly Func<ReaderTestConfiguration, IEnumerable<PayloadKindDetectionResult>> feedDetectionResult =


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Refactor & Improve the ODataMediaTypeResolver

### Description

If i use the following codes to snapshot the memory usage:
![image](https://user-images.githubusercontent.com/9426627/56243790-4dc64380-6050-11e9-9879-0aa8d7882802.png)

I can get two snapshots, one is at Line 15, the other is at line 17.

### Before my change

The old memory usage likes:
![image](https://user-images.githubusercontent.com/9426627/56243903-8534f000-6050-11e9-86dc-1c53f5a186d5.png)

### Use my changes

The new memory usage likes:
![image](https://user-images.githubusercontent.com/9426627/56243930-91b94880-6050-11e9-9188-09d75bea58da.png)

I can use the following tables to illustrate the changes:

|<div align="right">Memory item</div>|  Before my change |   With my change | Percentage down |
|:------------------|--------:|--------:|--------:|
|New Object count |+405|+167| 59% |
|New Heap Size |+23.42kb|+7.93kb| 66%|


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
