### PR TITLE
Fix #1318 - unescaped colons in relative Uri cause Invalid URI exception

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchReader.cs
@@ -169,8 +169,9 @@ namespace Microsoft.OData.JsonLight
             ValidateRequiredProperty(url, ODataJsonLightBatchPayloadItemPropertiesCache.PropertyNameUrl);
 
             // escape any colons in the query string portion of the url
-            int queryOptionSeparator = url.IndexOf("?", StringComparison.OrdinalIgnoreCase);
-            if (queryOptionSeparator > 0)
+            int queryOptionSeparator = url.IndexOf('?');
+            int firstColon = url.IndexOf(':');
+            if (queryOptionSeparator > 0 && firstColon > 0 && queryOptionSeparator < firstColon)
             {
                 url = url.Substring(0, queryOptionSeparator) + url.Substring(queryOptionSeparator).Replace(":", "%3A");
             }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchReader.cs
@@ -167,6 +167,14 @@ namespace Microsoft.OData.JsonLight
             string url = (string)this.messagePropertiesCache.GetPropertyValue(
                 ODataJsonLightBatchPayloadItemPropertiesCache.PropertyNameUrl);
             ValidateRequiredProperty(url, ODataJsonLightBatchPayloadItemPropertiesCache.PropertyNameUrl);
+
+            // escape any colons in the query string portion of the url
+            int queryOptionSeparator = url.IndexOf("?", StringComparison.OrdinalIgnoreCase);
+            if (queryOptionSeparator > 0)
+            {
+                url = url.Substring(0, queryOptionSeparator) + url.Substring(queryOptionSeparator).Replace(":", "%3A");
+            }
+
             Uri requestUri = new Uri(url, UriKind.RelativeOrAbsolute);
 
             // Reset the request property cache since all data in cache has been processed.


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1318.*

### Description

If the first unescaped colon in a relative URL within a JSON Batch is more than 1,000 characters into the string, System.Uri throws an Invalid URI exception.  This is because System.Uri is reading everything up to the first colon as the scheme, even if that colon is within the query string.

Fix is to replace any colons in the query string with an escaped colon character.

### Checklist (Uncheck if it is not completed)

- [x ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
