### PR TITLE
Fix #1465: Support validating out-of-line annotations targeting enumMember

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -738,6 +738,9 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             IEdmModel model = GetEdmModel(types: types);
             Assert.NotNull(model);
 
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors), String.Format("Errors in validating model. {0}", String.Concat(errors.Select(e => e.ErrorMessage))));
+
             var color = model.SchemaElements.OfType<IEdmEnumType>().FirstOrDefault(c => c.Name == "Color");
             Assert.NotNull(color);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1465.*

### Description

*We weren't handling resolving members of an enumType when resolving target. Now we do.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

None.
