### PR TITLE
Support for enum in Uri functions

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OData.UriParser
                 Debug.Assert(argumentNodes[i] is SingleValueNode, "We should have already verified that all arguments are single values.");
                 SingleValueNode argumentNode = (SingleValueNode)argumentNodes[i];
                 IEdmTypeReference signatureArgumentType = signature.ArgumentTypes[i];
-                Debug.Assert(signatureArgumentType.IsODataPrimitiveTypeKind(), "Only primitive types should be able to get here.");
+                Debug.Assert(signatureArgumentType.IsODataPrimitiveTypeKind() || signatureArgumentType.IsODataEnumTypeKind(), "Only primitive or enum types should be able to get here.");
                 argumentNodes[i] = MetadataBindingUtils.ConvertToTypeIfNeeded(argumentNode, signatureArgumentType);
             }
         }

--- a/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
@@ -521,6 +521,11 @@ namespace Microsoft.OData.UriParser
                 return false;
             }
 
+            if (targetReference.IsEnum() && sourceReference.IsString())
+            {
+                return true;
+            }
+
             IEdmPrimitiveTypeReference sourcePrimitiveTypeReference = sourceReference.AsPrimitiveOrNull();
             IEdmPrimitiveTypeReference targetPrimitiveTypeReference = targetReference.AsPrimitiveOrNull();
 
@@ -801,7 +806,7 @@ namespace Microsoft.OData.UriParser
         private static bool CanPromoteNodeTo(SingleValueNode sourceNodeOrNull, IEdmTypeReference sourceType, IEdmTypeReference targetType)
         {
             Debug.Assert(targetType != null, "targetType != null");
-            Debug.Assert(targetType.IsODataPrimitiveTypeKind(), "Type promotion only supported for primitive types.");
+            Debug.Assert(targetType.IsODataPrimitiveTypeKind() || targetType.IsODataEnumTypeKind(), "Type promotion only supported for primitive or enum types.");
 
             if (sourceType == null)
             {

--- a/src/Microsoft.OData.Edm/ExtensionMethods/EdmElementComparer.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/EdmElementComparer.cs
@@ -112,7 +112,9 @@ namespace Microsoft.OData.Edm
         {
             // ODataLib requires to register signatures for custom uri functions in static class
             // If we generate multiple models that use the same enum we will have different object refs
-            return thisType.FullName() == otherType.FullName();
+            return thisType.FullName() == otherType.FullName() 
+                && thisType.UnderlyingType.IsEquivalentTo(otherType.UnderlyingType)
+                && thisType.IsFlags == otherType.IsFlags;
         }
 
         private static bool IsEquivalentTo(this IEdmSchemaType thisType, IEdmSchemaType otherType)

--- a/src/Microsoft.OData.Edm/ExtensionMethods/EdmElementComparer.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/EdmElementComparer.cs
@@ -46,8 +46,9 @@ namespace Microsoft.OData.Edm
                     return ((IEdmPrimitiveType)thisType).IsEquivalentTo((IEdmPrimitiveType)otherType);
                 case EdmTypeKind.Complex:
                 case EdmTypeKind.Entity:
-                case EdmTypeKind.Enum:
                     return ((IEdmSchemaType)thisType).IsEquivalentTo((IEdmSchemaType)otherType);
+                case EdmTypeKind.Enum:
+                    return ((IEdmEnumType)thisType).IsEquivalentTo((IEdmEnumType)otherType);
                 case EdmTypeKind.Collection:
                     return ((IEdmCollectionType)thisType).IsEquivalentTo((IEdmCollectionType)otherType);
                 case EdmTypeKind.EntityReference:
@@ -105,6 +106,13 @@ namespace Microsoft.OData.Edm
             // See "src\Web\Client\System\Data\Services\Client\Serialization\PrimitiveType.cs:CreateEdmPrimitiveType()" for more info.
             return thisType.PrimitiveKind == otherType.PrimitiveKind &&
                    thisType.FullName() == otherType.FullName();
+        }
+
+        private static bool IsEquivalentTo(this IEdmEnumType thisType, IEdmEnumType otherType)
+        {
+            // ODataLib requires to register signatures for custom uri functions in static class
+            // If we generate multiple models that use the same enum we will have different object refs
+            return thisType.FullName() == otherType.FullName();
         }
 
         private static bool IsEquivalentTo(this IEdmSchemaType thisType, IEdmSchemaType otherType)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/TypePromotionUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/TypePromotionUtilsTests.cs
@@ -462,6 +462,16 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.True(TypePromotionUtils.CanConvertTo(null, primitiveType, stringType));
         }
 
+
+        [Fact]
+        public void EnumTypesOfSameFullNameAndStructureCanConvertToEachOther()
+        {
+            var enumType1 = new EdmEnumTypeReference(new EdmEnumType("MyNS", "MyName", false), false);
+            var enumType2 = new EdmEnumTypeReference(new EdmEnumType("MyNS", "MyName", false), false);
+            Assert.True(TypePromotionUtils.CanConvertTo(null, enumType1, enumType2));
+            Assert.True(TypePromotionUtils.CanConvertTo(null, enumType2, enumType1));
+        }
+
         [Fact]
         public void DefaultTypeFacetsPromotionRulesTest()
         {

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/TypeSemanticsUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/TypeSemanticsUnitTests.cs
@@ -567,7 +567,7 @@ namespace EdmLibTests.FunctionalTests
             this.VerifyThrowsException(typeof(ArgumentNullException), () => new EdmEnumType("NS", "Baseline", null, true));
 
             Assert.IsTrue(baseline.IsEquivalentTo(baseline), "Is the same.");
-            Assert.IsFalse(baseline.IsEquivalentTo(match), "Same but different obj refs");
+            Assert.IsTrue(baseline.IsEquivalentTo(match), "Same but different obj refs");
             Assert.IsFalse(baseline.IsEquivalentTo(differentNamespace), "Different namespace.");
             Assert.IsFalse(baseline.IsEquivalentTo(differentName), "Different name.");
             Assert.IsFalse(baseline.IsEquivalentTo(differentPrimitiveType), "Different primitive type.");


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1467.*

### Description

ODataLib requires to register signatures for custom uri functions in static class
If we generate multiple models that use the same enum we will have different object refs, as a result we have to compare fullnames

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
