### PR TITLE
Add a validation rule about target of the annotation should be allowed in the AppliesTo of the term

### DIFF
--- a/src/Microsoft.OData.Edm/EdmUtil.cs
+++ b/src/Microsoft.OData.Edm/EdmUtil.cs
@@ -79,6 +79,123 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Gets the symbolic string of an annotated element.
+        /// In the next breaking change, it's better to add a property into <see cref="IEdmVocabularyAnnotatable"/>.
+        /// </summary>
+        /// <param name="annotatedElement">The annotatable element.</param>
+        /// <returns>null or a symbolic string.</returns>
+        public static string GetSymbolicString(this IEdmVocabularyAnnotatable annotatedElement)
+        {
+            IEdmSchemaElement schemaElement = annotatedElement as IEdmSchemaElement;
+            if (schemaElement != null)
+            {
+                // EntityType, ComplexType, EnumType, TypeDefinition
+                if (schemaElement.SchemaElementKind == EdmSchemaElementKind.TypeDefinition)
+                {
+                    IEdmType edmType = (IEdmType)schemaElement;
+                    switch (edmType.TypeKind)
+                    {
+                        case EdmTypeKind.Complex:
+                            return "ComplexType";
+                        case EdmTypeKind.Entity:
+                            return "EntityType";
+                        case EdmTypeKind.Enum:
+                            return "EnumType";
+                        case EdmTypeKind.TypeDefinition:
+                            return "TypeDefinition";
+                        default:
+                            return null;
+                    }
+                }
+                else
+                {
+                    // Action, Function, Term, EntityContainer
+                    return schemaElement.SchemaElementKind.ToString();
+                }
+            }
+
+            IEdmEntityContainerElement containerElement = annotatedElement as IEdmEntityContainerElement;
+            if (containerElement != null)
+            {
+                // ActionImport, FunctionImport, EntitySet, Singleton
+                return containerElement.ContainerElementKind.ToString();
+            }
+
+            IEdmProperty property = annotatedElement as IEdmProperty;
+            if (property != null)
+            {
+                // NavigationProperty, Property
+                switch (property.PropertyKind)
+                {
+                    case EdmPropertyKind.Navigation:
+                        return "NavigationProperty";
+                    case EdmPropertyKind.Structural:
+                        return "Property";
+                    default:
+                        return null;
+                }
+            }
+
+            IEdmExpression expression = annotatedElement as IEdmExpression;
+            if (expression != null)
+            {
+                switch(expression.ExpressionKind)
+                {
+                    case EdmExpressionKind.FunctionApplication:
+                        return "Apply";
+                    case EdmExpressionKind.IsType:
+                        return "IsOf";
+                    case EdmExpressionKind.Labeled:
+                        return "LabeledElement";
+                    case EdmExpressionKind.Cast:
+                    case EdmExpressionKind.Collection:
+                    case EdmExpressionKind.If:
+                    case EdmExpressionKind.Null:
+                    case EdmExpressionKind.Record:
+                        return expression.ExpressionKind.ToString();
+                    default:
+                        return null;
+                }
+            }
+
+            if (annotatedElement is IEdmOperationParameter)
+            {
+                return "Parameter";
+            }
+            else if (annotatedElement is IEdmOperationReturn)
+            {
+                return "ReturnType";
+            }
+            else if (annotatedElement is IEdmReference)
+            {
+                return "Reference";
+            }
+            else if (annotatedElement is IEdmInclude)
+            {
+                return "Include";
+            }
+            else if (annotatedElement is IEdmReferentialConstraint)
+            {
+                return "ReferentialConstraint";
+            }
+            else if (annotatedElement is IEdmEnumMember)
+            {
+                return "Member";
+            }
+            else if (annotatedElement is IEdmVocabularyAnnotation)
+            {
+                return "Annotation";
+            }
+            else if (annotatedElement is IEdmPropertyConstructor)
+            {
+                return "PropertyValue";
+            }
+
+            // It's not supported "Schema, UrlRef, OnDelete"
+            return null;
+        }
+
+        /// <summary>
         /// Sets the MIME type annotation of the <paramref name="annotatableOperation"/> to <paramref name="mimeType"/>.
         /// </summary>
         /// <param name="model">The <see cref="IEdmModel"/> containing the annotation.</param>

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
@@ -210,6 +210,7 @@ namespace Microsoft.OData.Edm {
         internal const string EdmModel_Validator_Semantic_EnumMustHaveIntegralUnderlyingType = "EdmModel_Validator_Semantic_EnumMustHaveIntegralUnderlyingType";
         internal const string EdmModel_Validator_Semantic_InaccessibleTerm = "EdmModel_Validator_Semantic_InaccessibleTerm";
         internal const string EdmModel_Validator_Semantic_InaccessibleTarget = "EdmModel_Validator_Semantic_InaccessibleTarget";
+        internal const string EdmModel_Validator_Semantic_VocabularyAnnotationApplyToNotAllowedAnnotatable = "EdmModel_Validator_Semantic_VocabularyAnnotationApplyToNotAllowedAnnotatable";
         internal const string EdmModel_Validator_Semantic_ElementDirectValueAnnotationFullNameMustBeUnique = "EdmModel_Validator_Semantic_ElementDirectValueAnnotationFullNameMustBeUnique";
         internal const string EdmModel_Validator_Semantic_NoEntitySetsFoundForType = "EdmModel_Validator_Semantic_NoEntitySetsFoundForType";
         internal const string EdmModel_Validator_Semantic_CannotInferEntitySetWithMultipleSetsPerType = "EdmModel_Validator_Semantic_CannotInferEntitySetWithMultipleSetsPerType";

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -148,6 +148,7 @@ EdmModel_Validator_Semantic_TypeAnnotationHasExtraProperties=They type of the ty
 EdmModel_Validator_Semantic_EnumMustHaveIntegralUnderlyingType=The underlying type of '{0}' is not valid. The underlying type of an enum type must be an integral type. 
 EdmModel_Validator_Semantic_InaccessibleTerm=The term '{0}' could not be found from the model being validated.
 EdmModel_Validator_Semantic_InaccessibleTarget=The target '{0}' could not be found from the model being validated.
+EdmModel_Validator_Semantic_VocabularyAnnotationApplyToNotAllowedAnnotatable=The target '{0}' of the annotation is not allowed in the AppliesTo '{1}' of the term '{2}'.".
 EdmModel_Validator_Semantic_ElementDirectValueAnnotationFullNameMustBeUnique=An element already has a direct annotation with the namespace '{0}' and name '{1}'.
 EdmModel_Validator_Semantic_NoEntitySetsFoundForType=The association set '{0}' cannot assume an entity set for the role '{2}' because there are no entity sets for the role type '{1}'.
 EdmModel_Validator_Semantic_CannotInferEntitySetWithMultipleSetsPerType=The association set '{0}' must specify an entity set for the role '{2}' because there are multiple entity sets for the role type '{1}'.

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -1073,6 +1073,13 @@ namespace Microsoft.OData.Edm {
         }
 
         /// <summary>
+        /// A string like "The target '{0}' of the annotation is not allowed in the AppliesTo '{1}' of the term '{2}'."."
+        /// </summary>
+        internal static string EdmModel_Validator_Semantic_VocabularyAnnotationApplyToNotAllowedAnnotatable(object p0, object p1, object p2) {
+            return Microsoft.OData.Edm.EntityRes.GetString(Microsoft.OData.Edm.EntityRes.EdmModel_Validator_Semantic_VocabularyAnnotationApplyToNotAllowedAnnotatable, p0, p1, p2);
+        }
+
+        /// <summary>
         /// A string like "An element already has a direct annotation with the namespace '{0}' and name '{1}'."
         /// </summary>
         internal static string EdmModel_Validator_Semantic_ElementDirectValueAnnotationFullNameMustBeUnique(object p0, object p1) {

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmSchemaElement.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmSchemaElement.cs
@@ -28,7 +28,6 @@ namespace Microsoft.OData.Edm
         /// </summary>
         Term,
 
-
         /// <summary>
         /// Represents a schema element implementing <see cref="IEdmAction"/>.
         /// </summary>

--- a/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
+++ b/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
@@ -1381,6 +1381,11 @@ namespace Microsoft.OData.Edm.Validation
         /// <summary>
         /// The non-composable escape bound function should not declare more than one.
         /// </summary>
-        EntityNoncomposableBoundEscapeFunctionMustBeLessOne = 390
+        EntityNoncomposableBoundEscapeFunctionMustBeLessOne = 390,
+
+        /// <summary>
+        /// The vocabulary annotation applies to not allowed annotatable element.
+        /// </summary>
+        AnnotationApplyToNotAllowedAnnotatable = 400,
     }
 }

--- a/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
@@ -102,7 +102,6 @@ namespace Microsoft.OData.Edm.Validation
                 ValidationRules.PropertyValueBindingValueIsCorrectType,
                 ValidationRules.EnumMustHaveIntegerUnderlyingType,
                 ValidationRules.AnnotationInaccessibleTerm,
-                ValidationRules.VocabularyAnnotationTargetAllowedApplyToElement,
                 ValidationRules.ElementDirectValueAnnotationFullNameMustBeUnique,
                 ValidationRules.VocabularyAnnotationInaccessibleTarget,
                 ValidationRules.EntitySetRecursiveNavigationPropertyMappingsMustPointBackToSourceEntitySet,

--- a/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
@@ -102,6 +102,7 @@ namespace Microsoft.OData.Edm.Validation
                 ValidationRules.PropertyValueBindingValueIsCorrectType,
                 ValidationRules.EnumMustHaveIntegerUnderlyingType,
                 ValidationRules.AnnotationInaccessibleTerm,
+                ValidationRules.VocabularyAnnotationTargetAllowedApplyToElement,
                 ValidationRules.ElementDirectValueAnnotationFullNameMustBeUnique,
                 ValidationRules.VocabularyAnnotationInaccessibleTarget,
                 ValidationRules.EntitySetRecursiveNavigationPropertyMappingsMustPointBackToSourceEntitySet,

--- a/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
@@ -2541,13 +2541,39 @@ namespace Microsoft.OData.Edm.Validation
                     }
                 });
 
+        /// <summary>
+        /// Validates that a vocabulary annotations target can be allowed in the AppliesTo of the term.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes")]
+        public static readonly ValidationRule<IEdmVocabularyAnnotation> VocabularyAnnotationTargetAllowedApplyToElement =
+            new ValidationRule<IEdmVocabularyAnnotation>(
+                (context, annotation) =>
+                {
+                    IEdmTerm term = annotation.Term;
+                    if (term.AppliesTo == null)
+                    {
+                        return;
+                    }
+
+                    var hash = new HashSet<string>(term.AppliesTo.Split(' ').Select(e => e.Trim()));
+                    string symbolicString = annotation.Target.GetSymbolicString();
+                    if (hash.Contains(symbolicString))
+                    {
+                        return;
+                    }
+
+                    context.AddError(
+                        annotation.Location(),
+                        EdmErrorCode.AnnotationApplyToNotAllowedAnnotatable,
+                        Strings.EdmModel_Validator_Semantic_VocabularyAnnotationApplyToNotAllowedAnnotatable(EdmUtil.FullyQualifiedName(annotation.Target), term.AppliesTo, term.FullName()));
+                });
         #endregion
 
         #region IEdmPropertyValueBinding
 
-        /// <summary>
-        /// Validates that the value of a property value binding is the correct type.
-        /// </summary>
+                /// <summary>
+                /// Validates that the value of a property value binding is the correct type.
+                /// </summary>
         public static readonly ValidationRule<IEdmPropertyValueBinding> PropertyValueBindingValueIsCorrectType =
             new ValidationRule<IEdmPropertyValueBinding>(
                 (context, binding) =>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRuleSetTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRuleSetTests.cs
@@ -24,7 +24,8 @@ namespace Microsoft.OData.Edm.Tests.Validation
             var validationRules = new Dictionary<object, string>();
             var items = typeof(ValidationRules).GetFields().Where(f =>
                 f.Name != "NavigationPropertyEntityMustNotIndirectlyContainItself" &&
-                f.Name != "EntityTypeKeyMissingOnEntityType")
+                f.Name != "EntityTypeKeyMissingOnEntityType" &&
+                f.Name != "VocabularyAnnotationTargetAllowedApplyToElement")
                 .Select(f=> new KeyValuePair<object, string>(f.GetValue(null), f.Name));
             foreach (var item in items)
             {

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
@@ -10,6 +10,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Validation;
 using Microsoft.OData.Edm.Vocabularies;
 using Xunit;
@@ -1397,6 +1398,27 @@ namespace Microsoft.OData.Edm.Tests.Validation
                 singleton,
                 EdmErrorCode.DeclaringTypeOfNavigationSourceCannotHavePathProperty,
                 Strings.EdmModel_Validator_Semantic_DeclaringTypeOfNavigationSourceCannotHavePathProperty("NS.Entity", "singleton", "Me"));
+        }
+
+        [Fact]
+        public void TargetOfAnAnnotationIsNotAllowedInAppliesToOfTheTermShouldError()
+        {
+            EdmModel model = new EdmModel();
+            var entityType = new EdmEntityType("NS", "Entity");
+            model.AddElement(entityType);
+
+            // <Term Name="ResourcePath" Type="Edm.String" AppliesTo="EntitySet Singleton ActionImport FunctionImport">
+            var term = model.FindTerm("Org.OData.Core.V1.ResourcePath");
+            var annotation = new EdmVocabularyAnnotation(entityType, term, new EdmStringConstant("4.0 4.01"));
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+            model.SetVocabularyAnnotation(annotation);
+
+            ValidateError(
+                ValidationRules.VocabularyAnnotationTargetAllowedApplyToElement,
+                annotation,
+                EdmErrorCode.AnnotationApplyToNotAllowedAnnotatable,
+                Strings.EdmModel_Validator_Semantic_VocabularyAnnotationApplyToNotAllowedAnnotatable("NS.Entity",
+                "EntitySet Singleton ActionImport FunctionImport", "Org.OData.Core.V1.ResourcePath"));
         }
 
         private static void ValidateNoError<T>(ValidationRule<T> validationRule, IEdmModel model, T item) where T : IEdmElement

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -1601,6 +1601,11 @@ public sealed class Microsoft.OData.Edm.EdmUtil {
 	[
 	ExtensionAttribute(),
 	]
+	public static string GetSymbolicString (Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable annotatedElement)
+
+	[
+	ExtensionAttribute(),
+	]
 	public static void SetMimeType (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmOperation annotatableOperation, string mimeType)
 
 	[
@@ -3001,6 +3006,7 @@ public sealed class Microsoft.OData.Edm.Csdl.CsdlReaderSettings {
 public enum Microsoft.OData.Edm.Validation.EdmErrorCode : int {
 	AllNavigationPropertiesMustBeMapped = 346
 	AlreadyDefined = 19
+	AnnotationApplyToNotAllowedAnnotatable = 400
 	BadAmbiguousElementBinding = 224
 	BadCyclicComplex = 227
 	BadCyclicEntity = 229
@@ -3391,6 +3397,7 @@ public sealed class Microsoft.OData.Edm.Validation.ValidationRules {
 	public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable]] VocabularyAnnotatableNoDuplicateAnnotations = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable]
 	public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] VocabularyAnnotationAssertCorrectExpressionType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]
 	public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] VocabularyAnnotationInaccessibleTarget = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]
+	public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] VocabularyAnnotationTargetAllowedApplyToElement = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]
 }
 
 public class Microsoft.OData.Edm.Validation.EdmError {


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

* So far, vocabulary annotation is used randomly in any element. 
* However, it should be allowed in the AppliesTo of the term.

### Description

* This PR is to add a validation rule to verify the term whether it is used correctly on the corresponding target.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
