### PR TITLE
1498 :: Navigation properties through an entity with an Enum key segm…

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/SegmentArgumentParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SegmentArgumentParser.cs
@@ -241,7 +241,7 @@ namespace Microsoft.OData.UriParser
                 QueryNode enumNode = null;
                 if (EnumBinder.TryBindIdentifier(valueText, typeReference.AsEnum(), null, out enumNode))
                 {
-                    convertedValue = enumNode;
+                    convertedValue = ((ConstantNode)enumNode).Value;
                     return true;
                 }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
@@ -1437,8 +1437,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             path.Count.Should().Be(2);
             var keyInfo = path.Last().As<KeySegment>().Keys.Single();
             keyInfo.Key.Should().Be("PetCategorysColorPattern");
-            keyInfo.Value.As<ConstantNode>().Value.As<ODataEnumValue>().TypeName.Should().Be("Fully.Qualified.Namespace.ColorPattern");
-            keyInfo.Value.As<ConstantNode>().Value.As<ODataEnumValue>().Value.Should().Be("22");
+            keyInfo.Value.As<ODataEnumValue>().TypeName.Should().Be("Fully.Qualified.Namespace.ColorPattern");
+            keyInfo.Value.As<ODataEnumValue>().Value.Should().Be("22");
         }
         #endregion
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
@@ -210,8 +210,8 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
                 {
                     var keyInfo = path.LastSegment.As<KeySegment>().Keys.Single();
                     keyInfo.Key.Should().Be("color");
-                    keyInfo.Value.As<ConstantNode>().Value.As<ODataEnumValue>().TypeName.Should().Be("TestNS.Color");
-                    keyInfo.Value.As<ConstantNode>().Value.As<ODataEnumValue>().Value.Should().Be("2");
+                    keyInfo.Value.As<ODataEnumValue>().TypeName.Should().Be("TestNS.Color");
+                    keyInfo.Value.As<ODataEnumValue>().Value.Should().Be("2");
                 },
                 Strings.RequestUriProcessor_SyntaxError);
         }
@@ -230,8 +230,8 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
                 {
                     var keyInfo = path.LastSegment.As<KeySegment>().Keys.Single();
                     keyInfo.Key.Should().Be("color");
-                    keyInfo.Value.As<ConstantNode>().Value.As<ODataEnumValue>().TypeName.Should().Be("TestNS.Color");
-                    keyInfo.Value.As<ConstantNode>().Value.As<ODataEnumValue>().Value.Should().Be("2");
+                    keyInfo.Value.As<ODataEnumValue>().TypeName.Should().Be("TestNS.Color");
+                    keyInfo.Value.As<ODataEnumValue>().Value.Should().Be("2");
                 },
                 Strings.RequestUriProcessor_SyntaxError);
         }
@@ -249,8 +249,8 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
                     keyList.Count.Should().Be(2);
                     var keyInfo = keyList[0];
                     keyInfo.Key.Should().Be("color");
-                    keyInfo.Value.As<ConstantNode>().Value.As<ODataEnumValue>().TypeName.Should().Be("TestNS.Color");
-                    keyInfo.Value.As<ConstantNode>().Value.As<ODataEnumValue>().Value.Should().Be("2");
+                    keyInfo.Value.As<ODataEnumValue>().TypeName.Should().Be("TestNS.Color");
+                    keyInfo.Value.As<ODataEnumValue>().Value.Should().Be("2");
                     var keyInfo1 = keyList[1];
                     keyInfo1.Key.Should().Be("id");
                     keyInfo1.Value.Should().Be(1);


### PR DESCRIPTION
…ent does not work.

The OData EnumBinder turns the value of an enum type key segment value into a ‘ConstantNode’ with a value of an ODataEnumValue instance.

LiteralFormatter.FormatRawLiteral does not support a 'ConstantNode'; instead its coded for 'ODataEnumValue'.

The fix appears to be modifying the SegmentArgumentParser to return an ODataEnumValue.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1498.*

### Description

*Modify SegmentArgumentParser to return an ODataEnumValue*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
