### PR TITLE
Dont Enforce ContentID Uniqueness outside ChangeSet in MultipartMixed

### DIFF
--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -91,6 +91,12 @@ namespace Microsoft.OData.MultipartMixed
                     }
                 }
             }
+            else
+            {
+                // For backward compatibility, don't enforce uniqueness of Content-ID 
+                // in MultipartMixed outside of a changeset
+                this.payloadUriConverter.Reset();
+            }
 
             ODataBatchOperationRequestMessage requestMessage = BuildOperationRequestMessage(
                 () => ODataBatchUtils.CreateBatchOperationReadStream(this.batchStream, headers, this),

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -91,7 +91,7 @@ namespace Microsoft.OData.MultipartMixed
                     }
                 }
             }
-            else
+            else if (this.InputContext.MessageReaderSettings.Version <= ODataVersion.V4)
             {
                 // For backward compatibility, don't enforce uniqueness of Content-ID 
                 // in MultipartMixed outside of a changeset

--- a/src/Microsoft.OData.Core/ODataBatchReader.cs
+++ b/src/Microsoft.OData.Core/ODataBatchReader.cs
@@ -29,9 +29,6 @@ namespace Microsoft.OData
         /// <summary>True if the writer was created for synchronous operation; false for asynchronous.</summary>
         private readonly bool synchronous;
 
-        /// <summary>The batch-specific URL converter that stores the content IDs found in a changeset and supports resolving cross-referencing URLs.</summary>
-        private readonly ODataBatchPayloadUriConverter payloadUriConverter;
-
         /// <summary>The dependency injection container to get related services.</summary>
         private readonly IServiceProvider container;
 
@@ -55,6 +52,9 @@ namespace Microsoft.OData
         /// in the same changeset or other changesets.
         /// </summary>
         private string contentIdToAddOnNextRead;
+
+        /// <summary>The batch-specific URL converter that stores the content IDs found in a changeset and supports resolving cross-referencing URLs.</summary>
+        internal readonly ODataBatchPayloadUriConverter payloadUriConverter;
 
         /// <summary>
         /// Constructor.
@@ -512,7 +512,7 @@ namespace Microsoft.OData
                     this.IncreaseBatchSize();
 
                     this.State = this.ReadAtChangesetStartImplementation();
-                    if (this.inputContext.MessageReaderSettings.MaxProtocolVersion <= ODataVersion.V4)
+                    if (this.inputContext.MessageReaderSettings.Version <= ODataVersion.V4)
                     {
                         this.payloadUriConverter.Reset();
                     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/MultipartMixedBatchDependsOnIdsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/MultipartMixedBatchDependsOnIdsTests.cs
@@ -172,13 +172,20 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
             this.defaultContainer.AddElement(this.singleton);
         }
 
-        [Theory]
-        [InlineData(ODataVersion.V4)]
-        [InlineData(ODataVersion.V401)]
-        public void MultipartBatchTestDuplicateContentIdsV4(ODataVersion version)
+        [Fact]
+        public void MultipartBatchTestDuplicateContentIdsV4()
         {
-            Assert.True(ReadBatch(RequestPayloadVerifyDuplicateContentId, version), 
+            Assert.True(ReadBatch(RequestPayloadVerifyDuplicateContentId, ODataVersion.V4), 
                 "Error reading a Multi-part Batch Payload with duplicate ContentIds outside a changeset.");
+        }
+
+        [Fact]
+        public void MultipartBatchTestDuplicateContentIdsFailsV401()
+        {
+            ODataException ode = Assert.Throws<ODataException>(
+                 () => ReadBatch(RequestPayloadVerifyDuplicateContentId, ODataVersion.V401));
+            Assert.True(ode.Message.Contains(
+                 "The content ID '1' was found more than once in the same change set or same batch request. Content IDs have to be unique across all operations of a change set for OData V4.0 and have to be unique across all operations in the whole batch request for OData V4.01."));
         }
 
         private bool ReadBatch(string requestPayload, ODataVersion version)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/ODataJsonBatchAtomicityGroupTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/ODataJsonBatchAtomicityGroupTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Roundtrip.JsonLight
             }
 
             this.readerSettingsV401 = new ODataMessageReaderSettings();
-            readerSettingsV401.MaxProtocolVersion = ODataVersion.V401;
+            readerSettingsV401.Version = ODataVersion.V401;
 
             this.writerSettingsV401 = new ODataMessageWriterSettings();
             writerSettingsV401.Version = ODataVersion.V401;
@@ -644,7 +644,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Roundtrip.JsonLight
             requestMessage.SetHeader("Content-Type", batchContentTypeApplicationJson);
 
             using (ODataMessageReader messageReader =
-                new ODataMessageReader(requestMessage, new ODataMessageReaderSettings() { MaxProtocolVersion = version, BaseUri = new Uri("http://odata.org") }, this.edmModel))
+                new ODataMessageReader(requestMessage, new ODataMessageReaderSettings() { Version = version, BaseUri = new Uri("http://odata.org") }, this.edmModel))
             {
                 ODataBatchReader batchReader = messageReader.CreateODataBatchReader();
 
@@ -696,7 +696,7 @@ namespace Microsoft.OData.Core.Tests.ScenarioTests.Roundtrip.JsonLight
             MemoryStream responseStream = new MemoryStream();
 
             using (ODataMessageReader messageReader =
-                new ODataMessageReader(requestMessage, new ODataMessageReaderSettings() {MaxProtocolVersion = version}, this.edmModel))
+                new ODataMessageReader(requestMessage, new ODataMessageReaderSettings() {Version = version}, this.edmModel))
             {
 
                 IODataResponseMessage responseMessage = new InMemoryMessage { Stream = responseStream };


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Prior to the changes for JSON Batch merged in 7.4, we did not enforce uniqueness of ContentID outside of a changeset in MultipartMixed batch format.

The OData 4.0 spec states that, within a changeset, each entry must have a ContentID and that content-id MUST be unique across the batch (not just the changeset). It doesn't mention ContentIds outside of the changeset, but the previous statement implies that the scope of uniqueness is the entire batch.  In OData 4.01 we tightened the wording to clarify that all ContentIds within the batch must be unique across the batch. This is especially important for JSON Batch responses, which can come back in any order so the ContentId is required to associated a response with a request, but the statement is made as a format-independent statement in the core protocol spec.

So, while it is arguably the right thing to do to enforce uniqueness across the batch for all formats, this is technically a breaking change to add this enforcement for the multipartmixed format.

This change request removes the uniqueness check across the batch for multipart/mixed in version 4.0; Content-Id must be unique within a changeset, but not across the batch. That also means, if Version 4.0 is specified, you can't reference things outside of the current changeset. 

For 4.01, and for all versions of JSON Batch, you Content-ID must be unique across the entire batch.

### Checklist (Uncheck if it is not completed)

- [ x] *Test cases added*
- [ x] *Build and test with one-click build and test script passed*

### Additional work necessary

*None.*
