### PR TITLE
fix async message write

### DIFF
--- a/src/Microsoft.OData.Core/MessageStreamWrapper.cs
+++ b/src/Microsoft.OData.Core/MessageStreamWrapper.cs
@@ -166,6 +166,14 @@ namespace Microsoft.OData
                 this.innerStream.Flush();
             }
 
+#if PORTABLELIB
+            /// <inheritdoc />
+            public override Task FlushAsync(CancellationToken cancellationToken)
+            {
+                return this.innerStream.FlushAsync(cancellationToken);
+            }
+#endif
+
             /// <summary>
             /// Reads data from the stream.
             /// </summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues
Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead #1514

### Description
Invoke Stream.FlushAsync redirect to MessageStreamWrappingStream.Flush

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
