### PR TITLE
Remove the nested expand supporting in $select

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
@@ -120,7 +120,6 @@ namespace Microsoft.OData.UriParser
             bool? countOption = null;
             QueryToken searchOption = null;
             SelectToken selectOption = null;
-            ExpandToken expandOption = null;
             ComputeToken computeOption = null;
 
             if (this.lexer.CurrentToken.Kind == ExpressionTokenKind.OpenParen)
@@ -177,10 +176,6 @@ namespace Microsoft.OData.UriParser
                             selectOption = ParseInnerSelect(pathToken);
                             break;
 
-                        case ExpressionConstants.QueryOptionExpand: // inner $expand
-                            expandOption = ParseInnerExpand(pathToken);
-                            break;
-
                         case ExpressionConstants.QueryOptionCompute: // inner $compute
                             computeOption = ParseInnerCompute();
                             break;
@@ -200,7 +195,7 @@ namespace Microsoft.OData.UriParser
                 throw new ODataException(ODataErrorStrings.UriSelectParser_TermIsNotValid(this.lexer.ExpressionText));
             }
 
-            return new SelectTermToken(pathToken, filterOption, orderByOptions, topOption, skipOption, countOption, searchOption, selectOption, expandOption, computeOption);
+            return new SelectTermToken(pathToken, filterOption, orderByOptions, topOption, skipOption, countOption, searchOption, selectOption, computeOption);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/ExpandTermToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/ExpandTermToken.cs
@@ -116,8 +116,9 @@ namespace Microsoft.OData.UriParser
             ExpandToken expandOption,
             ComputeToken computeOption,
             IEnumerable<QueryToken> applyOptions)
-            : base(pathToNavigationProp, filterOption, orderByOptions, topOption, skipOption, countQueryOption, searchOption, selectOption, expandOption, computeOption)
+            : base(pathToNavigationProp, filterOption, orderByOptions, topOption, skipOption, countQueryOption, searchOption, selectOption, computeOption)
         {
+            ExpandOption = expandOption;
             LevelsOption = levelsOption;
             ApplyOptions = applyOptions;
         }
@@ -132,6 +133,11 @@ namespace Microsoft.OData.UriParser
                 return PathToProperty;
             }
         }
+
+        /// <summary>
+        /// Gets the expand option for this select or expand term.
+        /// </summary>
+        public ExpandToken ExpandOption { get; private set; }
 
         /// <summary>
         /// Gets the levels option for this expand term.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/SelectExpandTermToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/SelectExpandTermToken.cs
@@ -31,8 +31,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="countQueryOption">the query count option for this select or expand term</param>
         /// <param name="searchOption">the search option for this select or expand term</param>
         /// <param name="selectOption">the select option for this select or expand term</param>
-        /// <param name="expandOption">the expand option for this select or expand term</param>
-        /// <param name="computeOption">the compute option for this select or expand term.</param>
+        /// <param name="computeOption">the compute option for this select or expand term</param>
         protected SelectExpandTermToken(
             PathSegmentToken pathToProperty,
             QueryToken filterOption,
@@ -42,7 +41,6 @@ namespace Microsoft.OData.UriParser
             bool? countQueryOption,
             QueryToken searchOption,
             SelectToken selectOption,
-            ExpandToken expandOption,
             ComputeToken computeOption)
         {
             ExceptionUtils.CheckArgumentNotNull(pathToProperty, "property");
@@ -55,7 +53,6 @@ namespace Microsoft.OData.UriParser
             CountQueryOption = countQueryOption;
             SearchOption = searchOption;
             SelectOption = selectOption;
-            ExpandOption = expandOption;
             ComputeOption = computeOption;
         }
 
@@ -98,11 +95,6 @@ namespace Microsoft.OData.UriParser
         /// Gets the select option for this select or expand term.
         /// </summary>
         public SelectToken SelectOption { get; private set; }
-
-        /// <summary>
-        /// Gets the expand option for this select or expand term.
-        /// </summary>
-        public ExpandToken ExpandOption { get; private set; }
 
         /// <summary>
         /// Gets the compute option for this select or expand term.

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/SelectTermToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/SelectTermToken.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="pathToProperty">the path to the property for this select term</param>
         public SelectTermToken(PathSegmentToken pathToProperty)
-            : this(pathToProperty, null, null)
+            : this(pathToProperty, null)
         {
         }
 
@@ -33,9 +33,8 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="pathToProperty">the path to the property for this select term</param>
         /// <param name="selectOption">the sub select for this token</param>
-        /// <param name="expandOption">the sub expand for this token</param>
-        public SelectTermToken(PathSegmentToken pathToProperty, SelectToken selectOption, ExpandToken expandOption)
-            : this(pathToProperty, null, null, null, null, null, null, selectOption, expandOption, null)
+        public SelectTermToken(PathSegmentToken pathToProperty, SelectToken selectOption)
+            : this(pathToProperty, null, null, null, null, null, null, selectOption, null)
         {
         }
 
@@ -50,10 +49,9 @@ namespace Microsoft.OData.UriParser
         /// <param name="countQueryOption">the query count option for this select term</param>
         /// <param name="searchOption">the search option for this select term</param>
         /// <param name="selectOption">the select option for this select term</param>
-        /// <param name="expandOption">the expand option for this select term</param>
         public SelectTermToken(PathSegmentToken pathToProperty,
-            QueryToken filterOption, IEnumerable<OrderByToken> orderByOptions, long? topOption, long? skipOption, bool? countQueryOption, QueryToken searchOption, SelectToken selectOption, ExpandToken expandOption, ComputeToken computeOption)
-            : base(pathToProperty, filterOption, orderByOptions, topOption, skipOption, countQueryOption, searchOption, selectOption, expandOption, computeOption)
+            QueryToken filterOption, IEnumerable<OrderByToken> orderByOptions, long? topOption, long? skipOption, bool? countQueryOption, QueryToken searchOption, SelectToken selectOption, ComputeToken computeOption)
+            : base(pathToProperty, filterOption, orderByOptions, topOption, skipOption, countQueryOption, searchOption, selectOption, computeOption)
         {
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandOptionParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandOptionParserTests.cs
@@ -51,7 +51,6 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             Assert.Null(selectTerm.CountQueryOption);
             Assert.Null(selectTerm.SearchOption);
             Assert.Null(selectTerm.SelectOption);
-            Assert.Null(selectTerm.ExpandOption);
         }
 
         [Theory]
@@ -183,42 +182,10 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
 
         [Fact]
-        public void NestedExpandInSelectIsAllowed()
-        {
-            // Arrange & Act
-            SelectTermToken selectTerm = this.ParseSelectOptions("($expand=two)");
-
-            // Assert
-            Assert.NotNull(selectTerm);
-            Assert.NotNull(selectTerm.ExpandOption);
-            ExpandTermToken two = Assert.Single(selectTerm.ExpandOption.ExpandTerms);
-            two.PathToNavigationProp.ShouldBeNonSystemToken("two");
-        }
-
-        [Theory]
-        [InlineData("($expand=two($expand=three))")]
-        [InlineData("($expand=two($expand=three;);)")] // Deep nested expands with semicolon
-        public void DeepNestedExpandsInSelectAreAllowed(string optionsText)
-        {
-            // Arrange & Act
-            SelectTermToken selectTerm = this.ParseSelectOptions(optionsText);
-
-            // Assert
-            Assert.NotNull(selectTerm);
-            Assert.NotNull(selectTerm.ExpandOption);
-
-            ExpandTermToken two = Assert.Single(selectTerm.ExpandOption.ExpandTerms);
-            two.PathToNavigationProp.ShouldBeNonSystemToken("two");
-
-            ExpandTermToken three = Assert.Single(two.ExpandOption.ExpandTerms);
-            three.PathToNavigationProp.ShouldBeNonSystemToken("three");
-        }
-
-        [Fact]
         public void AllNestedQueryOptionsInSelectAreAllowed()
         {
             // Arrange & Act
-            SelectTermToken selectTerm = this.ParseSelectOptions("($select=one($select=subone);$filter=true;$count=true;$top=1;$skip=2;$expand=two($expand=three))");
+            SelectTermToken selectTerm = this.ParseSelectOptions("($select=one($select=subone);$filter=true;$count=true;$top=1;$skip=2)");
 
             // Assert
             Assert.NotNull(selectTerm);
@@ -246,14 +213,6 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             // $skip
             Assert.NotNull(selectTerm.SkipOption);
             Assert.Equal(2, selectTerm.SkipOption);
-
-            // $expand
-            Assert.NotNull(selectTerm.ExpandOption);
-            ExpandTermToken two = Assert.Single(selectTerm.ExpandOption.ExpandTerms);
-            two.PathToNavigationProp.ShouldBeNonSystemToken("two");
-
-            ExpandTermToken three = Assert.Single(two.ExpandOption.ExpandTerms);
-            three.PathToNavigationProp.ShouldBeNonSystemToken("three");
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
@@ -299,10 +299,10 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
 
         [Fact]
-        public void ParseNestedSelectAndExpandInSelectWorks()
+        public void ParseNestedSelectInSelectWorks()
         {
             // Arrange & Act
-            SelectToken selectToken = ParseSelectClause("Address($select=abc;$expand=xyz)");
+            SelectToken selectToken = ParseSelectClause("Address($select=abc,xyz)");
 
             // Assert
             Assert.NotNull(selectToken);
@@ -310,19 +310,19 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             selectTermToken.PathToProperty.ShouldBeNonSystemToken("Address");
 
             Assert.NotNull(selectTermToken.SelectOption);
-            SelectTermToken nestedSelectTermToken = Assert.Single(selectTermToken.SelectOption.SelectTerms);
+            Assert.Equal(2, selectTermToken.SelectOption.SelectTerms.Count());
+            SelectTermToken nestedSelectTermToken = selectTermToken.SelectOption.SelectTerms.First();
             nestedSelectTermToken.PathToProperty.ShouldBeNonSystemToken("abc");
 
-            Assert.NotNull(selectTermToken.ExpandOption);
-            ExpandTermToken nestedExpandTermToken = Assert.Single(selectTermToken.ExpandOption.ExpandTerms);
-            nestedExpandTermToken.PathToProperty.ShouldBeNonSystemToken("xyz");
+            nestedSelectTermToken = selectTermToken.SelectOption.SelectTerms.Last();
+            nestedSelectTermToken.PathToProperty.ShouldBeNonSystemToken("xyz");
         }
 
         [Fact]
-        public void ParseDeepNestedSelectAndExpandInSelectWorks()
+        public void ParseDeepNestedSelectInSelectWorks()
         {
             // Arrange & Act
-            SelectToken selectToken = ParseSelectClause("Address($select=one($expand=two)),City($expand=three($select=four))");
+            SelectToken selectToken = ParseSelectClause("Address($select=one($select=two)),City($select=three($select=four))");
 
             // Assert
             Assert.NotNull(selectToken);
@@ -338,21 +338,21 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             nestedSelectToken.PathToProperty.ShouldBeNonSystemToken("one");
 
             // #1 Depth 2
-            Assert.NotNull(nestedSelectToken.ExpandOption);
-            ExpandTermToken nestedExpandTermToken = Assert.Single(nestedSelectToken.ExpandOption.ExpandTerms);
-            nestedExpandTermToken.PathToProperty.ShouldBeNonSystemToken("two");
+            Assert.NotNull(nestedSelectToken.SelectOption);
+            nestedSelectToken = Assert.Single(nestedSelectToken.SelectOption.SelectTerms);
+            nestedSelectToken.PathToProperty.ShouldBeNonSystemToken("two");
 
             // #2 Depth 0
             selectTermTokens[1].PathToProperty.ShouldBeNonSystemToken("City");
 
             // #2 Depth 1
-            Assert.NotNull(selectTermTokens[1].ExpandOption);
-            nestedExpandTermToken = Assert.Single(selectTermTokens[1].ExpandOption.ExpandTerms);
-            nestedExpandTermToken.PathToProperty.ShouldBeNonSystemToken("three");
+            Assert.NotNull(selectTermTokens[1].SelectOption);
+            nestedSelectToken = Assert.Single(selectTermTokens[1].SelectOption.SelectTerms);
+            nestedSelectToken.PathToProperty.ShouldBeNonSystemToken("three");
 
             // #2 Depth 2
-            Assert.NotNull(nestedExpandTermToken.SelectOption);
-            nestedSelectToken = Assert.Single(nestedExpandTermToken.SelectOption.SelectTerms);
+            Assert.NotNull(nestedSelectToken.SelectOption);
+            nestedSelectToken = Assert.Single(nestedSelectToken.SelectOption.SelectTerms);
             nestedSelectToken.PathToProperty.ShouldBeNonSystemToken("four");
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SyntacticAst/SelectTermTokenTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SyntacticAst/SelectTermTokenTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
         public void PropertyCannotBeNullInFullConstructor()
         {
             // Arrange & Act
-            Action test = () => new SelectTermToken(null, null, null, null, null, null, null, null, null, null);
+            Action test = () => new SelectTermToken(null, null, null, null, null, null, null, null, null);
 
             // Assert
             Assert.Throws<ArgumentNullException>("property", test);
@@ -37,7 +37,7 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
         {
             // Arrange & Act
             SelectTermToken selectTermToken = new SelectTermToken(new NonSystemToken("stuff", null, null),
-                null, null, null, null, null, null, null, null, null);
+                null, null, null, null, null, null, null, null);
 
             // Assert
             Assert.Null(selectTermToken.FilterOption);
@@ -47,7 +47,6 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
             Assert.Null(selectTermToken.CountQueryOption);
             Assert.Null(selectTermToken.SearchOption);
             Assert.Null(selectTermToken.SelectOption);
-            Assert.Null(selectTermToken.ExpandOption);
         }
 
         [Fact]
@@ -55,7 +54,7 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
         {
             // Arrange & Act
             SelectTermToken selectTermToken1 = new SelectTermToken(new NonSystemToken("stuff", null, null));
-            SelectTermToken selectTermToken2 = new SelectTermToken(new NonSystemToken("stuff", null, null), null, null);
+            SelectTermToken selectTermToken2 = new SelectTermToken(new NonSystemToken("stuff", null, null), null);
 
             // Assert
             Assert.NotNull(selectTermToken1.PathToProperty);
@@ -73,7 +72,7 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
             // Arrange & Act
             QueryToken filter = new LiteralToken(21);
             SelectTermToken selectTerm = new SelectTermToken(new NonSystemToken("stuff", null, null),
-                filter, null, null, null, null, null, null, null, null);
+                filter, null, null, null, null, null, null, null);
 
             // Assert
             Assert.NotNull(selectTerm.FilterOption);
@@ -88,7 +87,7 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
             // Arrange & Act
             OrderByToken orderBy = new OrderByToken(new LiteralToken(42), OrderByDirection.Descending);
             SelectTermToken selectTerm = new SelectTermToken(new NonSystemToken("stuff", null, null),
-                null, new OrderByToken[] { orderBy }, null, null, null, null, null,null, null);
+                null, new OrderByToken[] { orderBy }, null, null, null, null, null, null);
 
             // Assert
             Assert.NotNull(selectTerm.OrderByOptions);
@@ -107,7 +106,7 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
             // Arrange & Act
             long top = 42;
             SelectTermToken selectTerm = new SelectTermToken(new NonSystemToken("stuff", null, null),
-                null, null, top, null, null, null, null, null, null);
+                null, null, top, null, null, null, null, null);
 
             // Assert
             Assert.NotNull(selectTerm.TopOption);
@@ -120,7 +119,7 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
             // Arrange & Act
             long skip = 42;
             SelectTermToken selectTerm = new SelectTermToken(new NonSystemToken("stuff", null, null),
-                null, null, null, skip, null, null, null, null, null);
+                null, null, null, skip, null, null, null, null);
 
             // Assert
             Assert.NotNull(selectTerm.SkipOption);
@@ -132,7 +131,7 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
         {
             // Arrange & Act
             SelectTermToken selectTerm = new SelectTermToken(new NonSystemToken("stuff", null, null),
-                null, null, null, null, false, null, null, null, null);
+                null, null, null, null, false, null, null, null);
 
             // Assert
             Assert.NotNull(selectTerm.CountQueryOption);
@@ -144,7 +143,7 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
         {
             // Arrange & Act
             SelectTermToken selectTerm = new SelectTermToken(new NonSystemToken("stuff", null, null),
-                null, null, null, null, null, new StringLiteralToken("searchMe"), null, null, null);
+                null, null, null, null, null, new StringLiteralToken("searchMe"), null, null);
 
             // Assert
             Assert.NotNull(selectTerm.SearchOption);
@@ -157,30 +156,13 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
         {
             // Arrange & Act
             SelectToken select = new SelectToken(new PathSegmentToken[] { new NonSystemToken("abc", null, null) });
-            SelectTermToken selectTerm = new SelectTermToken(new NonSystemToken("stuff", null, null), select, null);
+            SelectTermToken selectTerm = new SelectTermToken(new NonSystemToken("stuff", null, null), select);
 
             // Assert
             Assert.NotNull(selectTerm.SelectOption);
             PathSegmentToken token = Assert.Single(selectTerm.SelectOption.Properties);
             NonSystemToken nonSystemToken = Assert.IsType<NonSystemToken>(token);
             Assert.Equal("abc", nonSystemToken.Identifier);
-        }
-
-        [Fact]
-        public void InnerExpandSetCorrectly()
-        {
-            // Arrange & Act
-            ExpandTermToken innerExpandTerm = new ExpandTermToken(new NonSystemToken("abc", null, null), null, null);
-
-            ExpandToken expand = new ExpandToken(new[] { innerExpandTerm });
-
-            SelectTermToken selectTerm = new SelectTermToken(new NonSystemToken("stuff", null, null), null, expand);
-
-            // Assert
-            Assert.NotNull(selectTerm.ExpandOption);
-            ExpandTermToken token = Assert.Single(selectTerm.ExpandOption.ExpandTerms);
-            ReferenceEquals(token.PathToNavigationProp, token.PathToProperty);
-            Assert.Equal("abc", token.PathToProperty.Identifier);
         }
 
         [Fact]
@@ -196,7 +178,6 @@ namespace Microsoft.OData.Tests.UriParser.SyntacticAst
                                                              null /*countQueryOption*/,
                                                              null /*searchOption*/,
                                                              null /*selectOption*/,
-                                                             null /*expandOption*/,
                                                              compute);
 
             // Assert


### PR DESCRIPTION
Reason: 

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

* Because 
`$select=1($expand=2)` can use `$select=1&$expand=1/2` to replace. 

So far, the meaning to support $expand in $select is not clear.

to avoid ambiguous, this PR is to remove $expand in $select from Syntactic part.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
