### PR TITLE
Correct @odata.context for combination of $select/$apply/$compute/$expand

### DIFF
--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -394,7 +394,7 @@ namespace Microsoft.OData
             if (selectExpandClause != null)
             {
                 string contextUri;
-                selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, out contextUri);
+                selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, ProcessApply, out contextUri);
                 if (!string.IsNullOrEmpty(contextUri))
                 {
                     return ODataConstants.ContextUriProjectionStart + contextUri + ODataConstants.ContextUriProjectionEnd;
@@ -402,6 +402,16 @@ namespace Microsoft.OData
             }
 
             return string.Empty;
+        }
+
+        private static string ProcessApply(ApplyClause applyClause)
+        {
+            if (applyClause != null)
+            {
+                return applyClause.GetContextUri();
+            }
+
+            return null;
         }
 
         /// <summary>Process sub expand node, contact with subexpand result</summary>

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -373,7 +373,11 @@ namespace Microsoft.OData
         {
             if (applyClause != null)
             {
-                return applyClause.GetContextUri();
+                string contextUri = applyClause.GetContextUri();
+                if (!string.IsNullOrEmpty(contextUri))
+                {
+                    return ODataConstants.ContextUriProjectionStart + contextUri + ODataConstants.ContextUriProjectionEnd;
+                }
             }
 
             return string.Empty;

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -284,7 +284,7 @@ namespace Microsoft.OData
                 {
                     return CreateSelectExpandContextUriSegment(odataUri.SelectAndExpand);
                 }
-                else
+                else if (odataUri.Apply != null)
                 {
                     return CreateApplyUriSegment(odataUri.Apply);
                 }

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -280,14 +280,13 @@ namespace Microsoft.OData
         {
             if (odataUri != null)
             {
-                // TODO: Figure out how to deal with $select after $apply
-                if (odataUri.Apply != null)
+                if (odataUri.SelectAndExpand != null)
                 {
-                    return CreateApplyUriSegment(odataUri.Apply);
+                    return CreateSelectExpandContextUriSegment(odataUri.SelectAndExpand);
                 }
                 else
                 {
-                    return CreateSelectExpandContextUriSegment(odataUri.SelectAndExpand);
+                    return CreateApplyUriSegment(odataUri.Apply);
                 }
             }
 

--- a/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
+++ b/src/Microsoft.OData.Core/SelectedPropertiesNode.cs
@@ -809,7 +809,7 @@ namespace Microsoft.OData
         private static SelectedPropertiesNode CreateFromSelectExpandClause(SelectExpandClause selectExpandClause)
         {
             SelectedPropertiesNode node;
-            selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, out node);
+            selectExpandClause.Traverse(ProcessSubExpand, CombineSelectAndExpandResult, null, out node);
             return node;
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.OData.UriParser.Aggregation
 {
+    using System;
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
@@ -128,11 +129,20 @@ namespace Microsoft.OData.UriParser.Aggregation
             IEnumerable<AggregateExpressionBase> aggregateExpressions,
             IEnumerable<ComputeExpression> computeExpressions)
         {
+            Func<GroupByPropertyNode, string> func = (prop) =>
+           {
+               var children = CreatePropertiesUriSegment(prop.ChildTransformations, null, null);
+
+               return string.IsNullOrEmpty(children)
+                      ? prop.Name
+                      : prop.Name + ODataConstants.ContextUriProjectionStart + children + ODataConstants.ContextUriProjectionEnd;
+           };
+
             string result = string.Empty;
             if (groupByPropertyNodes != null)
             {
                 var groupByPropertyArray =
-                    groupByPropertyNodes.Select(prop => prop.Name + CreatePropertiesUriSegment(prop.ChildTransformations, null, null))
+                    groupByPropertyNodes.Select(prop => func(prop))
                         .ToArray();
                 result = string.Join(",", groupByPropertyArray);
                 result = aggregateExpressions == null
@@ -155,9 +165,7 @@ namespace Microsoft.OData.UriParser.Aggregation
                 }
             }
 
-            return string.IsNullOrEmpty(result)
-                ? result
-                : ODataConstants.ContextUriProjectionStart + result + ODataConstants.ContextUriProjectionEnd;
+            return result;
         }
 
         private static string CreateAggregatePropertiesUriSegment(IEnumerable<AggregateExpressionBase> aggregateExpressions)

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyClause.cs
@@ -146,14 +146,12 @@ namespace Microsoft.OData.UriParser.Aggregation
                     : CreateAggregatePropertiesUriSegment(aggregateExpressions);
             }
 
-            if (computeExpressions != null)
+            if (computeExpressions != null && !string.IsNullOrEmpty(result) /* don't add compute if only compute() is present */)
             {
                 string computeProperties = string.Join(",", computeExpressions.Select(e => e.Alias).ToArray());
                 if (!string.IsNullOrEmpty(computeProperties))
                 {
-                    result = string.IsNullOrEmpty(result)
-                        ? computeProperties
-                        : string.Format(CultureInfo.InvariantCulture, "{0},{1}", result, computeProperties);
+                    result = string.Format(CultureInfo.InvariantCulture, "{0},{1}", result, computeProperties);
                 }
             }
 

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -97,7 +97,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="processSubResult">The method to deal with sub expand result.</param>
         /// <param name="combineSelectAndExpand">The method to combine select and expand result lists.</param>
         /// <param name="result">The result of the traversing.</param>
-        internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, T> processSubResult, Func<IList<string>, IList<T>, T> combineSelectAndExpand, Func<ApplyClause, T> processApply, out T result) where T: class
+        internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, T> processSubResult, Func<IList<string>, IList<T>, T> combineSelectAndExpand, Func<ApplyClause, T> processApply, out T result)
         {
             List<string> selectList = selectExpandClause.GetCurrentLevelSelectList();
             List<T> expandList = new List<T>();

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -114,7 +114,7 @@ namespace Microsoft.OData.UriParser
                 // TODO: That's PoC we need to handle bunch of cases.
                 if (expandSelectItem.ApplyOption != null)
                 {
-                    subResult = expandSelectItem.ApplyOption.GetContextUri().Trim('(',')') as T;
+                    subResult = expandSelectItem.ApplyOption.GetContextUri() as T;
                 }
 
                 var expandItem = processSubResult(currentExpandClause, subResult);

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -95,8 +95,8 @@ namespace Microsoft.OData.UriParser
         /// <typeparam name="T">Type of the sub processing result for expand items.</typeparam>
         /// <param name="selectExpandClause">The select expand clause for evaluation.</param>
         /// <param name="processSubResult">The method to deal with sub expand result.</param>
-        /// <param name="combineSelectAndExpand">The method to deal with apply result.</param>
-        /// <param name="processApply">The method to combine select and expand result lists.</param>
+        /// <param name="combineSelectAndExpand">The method to combine select and expand result lists.</param>
+        /// <param name="processApply">The method to deal with apply result.</param>
         /// <param name="result">The result of the traversing.</param>
         internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, T> processSubResult, Func<IList<string>, IList<T>, T> combineSelectAndExpand, Func<ApplyClause, T> processApply, out T result)
         {
@@ -112,7 +112,6 @@ namespace Microsoft.OData.UriParser
                     Traverse(expandSelectItem.SelectAndExpand, processSubResult, combineSelectAndExpand, processApply, out subResult);
                 }
 
-                // TODO: That's PoC we need to handle bunch of cases.
                 if (expandSelectItem.ApplyOption != null && processApply != null)
                 {
                     subResult = processApply(expandSelectItem.ApplyOption);

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -96,7 +96,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="processSubResult">The method to deal with sub expand result.</param>
         /// <param name="combineSelectAndExpand">The method to combine select and expand result lists.</param>
         /// <param name="result">The result of the traversing.</param>
-        internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, T> processSubResult, Func<IList<string>, IList<T>, T> combineSelectAndExpand, out T result)
+        internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, T> processSubResult, Func<IList<string>, IList<T>, T> combineSelectAndExpand, out T result) where T: class
         {
             List<string> selectList = selectExpandClause.GetCurrentLevelSelectList();
             List<T> expandList = new List<T>();
@@ -111,8 +111,13 @@ namespace Microsoft.OData.UriParser
                         out subResult);
                 }
 
-                var expandItem = processSubResult(currentExpandClause, subResult);
+                // TODO: That's PoC we need to handle bunch of cases.
+                if (expandSelectItem.ApplyOption != null)
+                {
+                    subResult = expandSelectItem.ApplyOption.GetContextUri().Trim('(',')') as T;
+                }
 
+                var expandItem = processSubResult(currentExpandClause, subResult);
                 if (expandItem != null)
                 {
                     expandList.Add(expandItem);

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -6,12 +6,12 @@
 
 namespace Microsoft.OData.UriParser
 {
-    using Microsoft.OData.UriParser.Aggregation;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
     using System.Text;
+    using Microsoft.OData.UriParser.Aggregation;
 
     /// <summary>
     /// Extension methods for <see cref="SelectExpandClause"/>.
@@ -95,7 +95,8 @@ namespace Microsoft.OData.UriParser
         /// <typeparam name="T">Type of the sub processing result for expand items.</typeparam>
         /// <param name="selectExpandClause">The select expand clause for evaluation.</param>
         /// <param name="processSubResult">The method to deal with sub expand result.</param>
-        /// <param name="combineSelectAndExpand">The method to combine select and expand result lists.</param>
+        /// <param name="combineSelectAndExpand">The method to deal with apply result.</param>
+        /// <param name="processApply">The method to combine select and expand result lists.</param>
         /// <param name="result">The result of the traversing.</param>
         internal static void Traverse<T>(this SelectExpandClause selectExpandClause, Func<string, T, T> processSubResult, Func<IList<string>, IList<T>, T> combineSelectAndExpand, Func<ApplyClause, T> processApply, out T result)
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -105,6 +105,17 @@ namespace Microsoft.OData.Tests
                 this.CreateFeedContextUri(selectClause, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectClause));
             }
         }
+
+        [Fact]
+        public void FeedContextUriWithExpandApply()
+        {
+            string expectClause = "Districts($apply=aggregate($count as Count))";
+            foreach (ODataVersion version in Versions)
+            {
+                this.CreateFeedContextUri(null, expectClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, "Districts(Count)"));
+            }
+        }
+
         [Fact]
         public void FeedContextUriWithApplyAggreagate()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -190,6 +190,16 @@ namespace Microsoft.OData.Tests
             }
         }
 
+        [Fact]
+        public void FeedContextUriWithApplyExpand()
+        {
+            string applyClause = "expand(Districts, filter(true))";
+            foreach (ODataVersion version in Versions)
+            {
+                this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities");
+            }
+        }
+
 
         [Fact]
         public void FeedContextUriWithApplyCompute()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.OData.Tests
         {
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(default(string), null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities"));
+                this.CreateFeedContextUri(default(string), null, null, null,version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities"));
             }
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.OData.Tests
         {
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(string.Empty, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, string.Empty));
+                this.CreateFeedContextUri(string.Empty, null, null, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, string.Empty));
             }
         }
 
@@ -94,7 +94,7 @@ namespace Microsoft.OData.Tests
             string expectClause = "Name";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(selectClause, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectClause));
+                this.CreateFeedContextUri(selectClause, null, null, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectClause));
             }
 
             // Select single navigation property
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Tests
             expectClause = "Districts";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(selectClause, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectClause));
+                this.CreateFeedContextUri(selectClause, null, null, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectClause));
             }
         }
 
@@ -112,7 +112,7 @@ namespace Microsoft.OData.Tests
             string expectClause = "Districts($apply=aggregate($count as Count))";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(null, expectClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, "Districts(Count)"));
+                this.CreateFeedContextUri(null, expectClause, null, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, "Districts(Count)"));
             }
         }
 
@@ -122,7 +122,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "aggregate(Id with sum as TotalId)";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(applyClause, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(TotalId)");
+                this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(TotalId)");
             }
         }
 
@@ -137,7 +137,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "aggregate(DynamicProperty with " + method + " as DynamicPropertyTotal)";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(applyClause, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)");
+                this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(DynamicPropertyTotal)");
             }
         }
 
@@ -147,7 +147,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name, Address/Street))";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(applyClause, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Name,Address(Street))");
+                this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Name,Address(Street))");
             }
         }
 
@@ -157,7 +157,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name, DynamicProperty, Address/Street))";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(applyClause, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Name,DynamicProperty,Address(Street))");
+                this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Name,DynamicProperty,Address(Street))");
             }
         }
 
@@ -167,7 +167,7 @@ namespace Microsoft.OData.Tests
             string applyClause = "filter(Id eq 1)";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(applyClause, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities");
+                this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities");
             }
         }
         [Fact]
@@ -176,7 +176,58 @@ namespace Microsoft.OData.Tests
             string applyClause = "groupby((Name), aggregate(Id with sum as TotalId))";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(applyClause, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Name,TotalId)");
+                this.CreateFeedContextUri(null, null, applyClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Name,TotalId)");
+            }
+        }
+
+        [Fact]
+        public void FeedContextUriWithApplyAndSelect()
+        {
+            string applyClause = "groupby((Name), aggregate(Id with sum as TotalId))";
+            foreach (ODataVersion version in Versions)
+            {
+                this.CreateFeedContextUri("Name", null, applyClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Name)");
+            }
+        }
+
+
+        [Fact]
+        public void FeedContextUriWithApplyCompute()
+        {
+            string computeClause = "compute('Test' as NewColumn)";
+            foreach (ODataVersion version in Versions)
+            {
+                this.CreateFeedContextUri(null, null, computeClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities");
+            }
+        }
+
+        [Fact]
+        public void FeedContextUriWithApplyComputeAndSelect()
+        {
+            string computeClause = "compute('Test' as NewColumn)";
+            foreach (ODataVersion version in Versions)
+            {
+                this.CreateFeedContextUri("Id,Name,NewColumn", null, computeClause, null, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)");
+            }
+        }
+
+        [Fact]
+        public void FeedContextUriWithCompute()
+        {
+            string computeClause = "'Test' as NewColumn";
+            foreach (ODataVersion version in Versions)
+            {
+                this.CreateFeedContextUri(null, null, null, computeClause, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities");
+            }
+        }
+
+        [Fact]
+        public void FeedContextUriWithComputeAndSelect()
+        {
+            string computeClause = "'Test' as NewColumn";
+            foreach (ODataVersion version in Versions)
+            {
+                this.CreateFeedContextUri("Id,Name,NewColumn", null, null, computeClause, version).OriginalString.Should().Be(MetadataDocumentUriString + "#Cities(Id,Name,NewColumn)");
             }
         }
 
@@ -187,7 +238,7 @@ namespace Microsoft.OData.Tests
             const string expectClause = "*";
             foreach (ODataVersion version in Versions)
             {
-                this.CreateFeedContextUri(selectClause, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectClause));
+                this.CreateFeedContextUri(selectClause, null, null, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectClause));
             }
         }
 
@@ -231,7 +282,7 @@ namespace Microsoft.OData.Tests
         public void FeedContextUriWithSingleExpandString(string expandClause, string expectedClause)
         {
             foreach (ODataVersion version in Versions)
-            this.CreateFeedContextUri("", expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
+            this.CreateFeedContextUri("", expandClause, null, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
 
         [Theory]
@@ -249,7 +300,7 @@ namespace Microsoft.OData.Tests
         {
             foreach (ODataVersion version in Versions)
             {
-                string uriString = this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString;
+                string uriString = this.CreateFeedContextUri(selectClause, expandClause, null, null, version).OriginalString;
                 uriString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
             }
         }
@@ -308,7 +359,7 @@ namespace Microsoft.OData.Tests
             const string selectClause = "Size,Name";
             const string expandClause = "Districts($select=Zip,City;$expand=City($expand=Districts;$select=Name))";
             const string expectedClause = "Size,Name,Districts(Zip,City,City(Name,Districts()))";
-            this.CreateFeedContextUri(selectClause, expandClause, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
+            this.CreateFeedContextUri(selectClause, expandClause, null, null, version).OriginalString.Should().Be(BuildExpectedContextUri("#Cities", false, expectedClause));
         }
         #endregion context uri with $select and $expand
 
@@ -868,19 +919,35 @@ namespace Microsoft.OData.Tests
             return contextUrl;
         }
 
-        private Uri CreateFeedContextUri(string selectClause, string expandClause, ODataVersion version)
+        private Uri CreateFeedContextUri(string selectClause, string expandClause, string applyClauseString, string computeClauseString, ODataVersion version)
         {
-            SelectExpandClause selectExpandClause = new ODataQueryOptionParser(edmModel, this.cityType, this.citySet, new Dictionary<string, string> { { "$expand", expandClause }, { "$select", selectClause } }).ParseSelectAndExpand();
+            var parser = new ODataQueryOptionParser(edmModel, this.cityType, this.citySet, new Dictionary<string, string> {
+                { "$expand", expandClause },
+                { "$select", selectClause },
+                { "$apply", applyClauseString },
+                { "$compute", computeClauseString } });
+            ApplyClause applyClause = null;
+            ComputeClause computeClause = null;
+            SelectExpandClause selectExpandClause = null;
+            if (applyClauseString != null)
+            {
+                applyClause = parser.ParseApply();
+            }
+
+            if (computeClauseString != null)
+            {
+                computeClause = parser.ParseCompute();
+            }
+
+            if (selectClause != null || expandClause != null)
+            {
+                selectExpandClause = parser.ParseSelectAndExpand();
+            }
+
+            
             ODataResourceTypeContext typeContext = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.cityType, true);
-            ODataContextUrlInfo info = ODataContextUrlInfo.Create(typeContext, version, false, new ODataUri() { SelectAndExpand = selectExpandClause });
-            Uri contextUrl = this.responseContextUriBuilder.BuildContextUri(ODataPayloadKind.ResourceSet, info);
-            return contextUrl;
-        }
-        private Uri CreateFeedContextUri(string applyClauseString, ODataVersion version)
-        {
-            ApplyClause applyClause = new ODataQueryOptionParser(edmModel, this.cityType, this.citySet, new Dictionary<string, string> { { "$apply", applyClauseString } }).ParseApply();
-            ODataResourceTypeContext typeContext = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.cityType, true);
-            ODataContextUrlInfo info = ODataContextUrlInfo.Create(typeContext, version, false, new ODataUri() { Apply = applyClause });
+            ODataUri odataUri = new ODataUri() { SelectAndExpand = selectExpandClause, Apply = applyClause, Compute = computeClause };
+            ODataContextUrlInfo info = ODataContextUrlInfo.Create(typeContext, version, false,  odataUri);
             Uri contextUrl = this.responseContextUriBuilder.BuildContextUri(ODataPayloadKind.ResourceSet, info);
             return contextUrl;
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
@@ -975,7 +975,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string applyClause = "compute(ID mul 2 as idMul2,length(Name) as nameLenght)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, contianedEntitySet, EntityType, null, null, resourcePath, applyClause);
 
-            result.Should().StartWith("{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(123)/ContainedCollectionNavProp(idMul2,nameLenght)");
+            result.Should().StartWith("{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(123)/ContainedCollectionNavProp");
         }
 
         #region Help Methods


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Fixes to @odata.context when $select/$expand/$apply/$compute work together:

* Support for $apply inside $expand
 For `$expand=Sales($apply=aggregate(Amount with sum as Total))` @odata.context will be `$metadata#Products(Sales(Total))` (https://issues.oasis-open.org/browse/ODATA-1307)
* $select after $apply and $compute keeps only fields in $select

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

