### PR TITLE
added extension method to add Vocabulary Terms

### DIFF
--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1261,7 +1261,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Creates and adds a new instance of the EdmTerm class from a primitive type.
+        /// Creates and adds a new instance of the <see cref="EdmTerm"/> class from a primitive type.
         /// </summary>
         /// <param name="model">The EdmModel.</param>
         /// <param name="namespaceName">Namespace of the term.</param>
@@ -1276,7 +1276,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Creates and adds a new instance of the EdmTerm class from a type reference.
+        /// Creates and adds a new instance of the <see cref="EdmTerm"/> class from a type reference.
         /// </summary>
         /// <param name="model">The EdmModel.</param>
         /// <param name="namespaceName">Namespace of the term.</param>

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1261,6 +1261,34 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Creates and adds a new instance of the Microsoft.OData.Edm.Vocabularies.EdmTerm class with a primitive type.
+        /// </summary>
+        /// <param name="model">The EdmModel.</param>
+        /// <param name="namespaceName">Namespace of the term.</param>
+        /// <param name="type">The primitive type of the term.</param>
+        /// <returns>The created term.</returns>
+        public static EdmTerm AddTerm(this EdmModel model, string namespaceName, EdmPrimitiveTypeKind type)
+        {
+            var term = new EdmTerm(namespaceName, name, type);
+            model.AddElement(term);
+            return term;
+        }
+
+        /// <summary>
+        /// Creates and adds a new instance of the Microsoft.OData.Edm.Vocabularies.EdmTerm class.
+        /// </summary>
+        /// <param name="model">The EdmModel.</param>
+        /// <param name="namespaceName">Namespace of the term.</param>
+        /// <param name="name">The type of the term.</param>
+        /// <returns>The created term.</returns>
+        public static EdmTerm AddTerm(this EdmModel model, string namespaceName, IEdmTypeReference type)
+        {
+            var term = new EdmTerm(namespaceName, name, type);
+            model.AddElement(term);
+            return term;
+        }
+
+        /// <summary>
         /// Set annotation Org.OData.Core.V1.OptimisticConcurrency to EntitySet
         /// </summary>
         /// <param name="model">The model to add annotation</param>

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1261,13 +1261,14 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Creates and adds a new instance of the Microsoft.OData.Edm.Vocabularies.EdmTerm class with a primitive type.
+        /// Creates and adds a new instance of the EdmTerm class from a primitive type.
         /// </summary>
         /// <param name="model">The EdmModel.</param>
         /// <param name="namespaceName">Namespace of the term.</param>
+        /// <param name="name">The name of the newly created term</param>
         /// <param name="type">The primitive type of the term.</param>
         /// <returns>The created term.</returns>
-        public static EdmTerm AddTerm(this EdmModel model, string namespaceName, EdmPrimitiveTypeKind type)
+        public static EdmTerm AddTerm(this EdmModel model, string namespaceName, string name, EdmPrimitiveTypeKind type)
         {
             var term = new EdmTerm(namespaceName, name, type);
             model.AddElement(term);
@@ -1275,13 +1276,14 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Creates and adds a new instance of the Microsoft.OData.Edm.Vocabularies.EdmTerm class.
+        /// Creates and adds a new instance of the EdmTerm class from a type reference.
         /// </summary>
         /// <param name="model">The EdmModel.</param>
         /// <param name="namespaceName">Namespace of the term.</param>
-        /// <param name="name">The type of the term.</param>
+        /// <param name="name">The name of the newly created term</param>
+        /// <param name="type">The type of the term.</param>
         /// <returns>The created term.</returns>
-        public static EdmTerm AddTerm(this EdmModel model, string namespaceName, IEdmTypeReference type)
+        public static EdmTerm AddTerm(this EdmModel model, string namespaceName, string name, IEdmTypeReference type)
         {
             var term = new EdmTerm(namespaceName, name, type);
             model.AddElement(term);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Build.NetFramework/EdmTermTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Build.NetFramework/EdmTermTests.cs
@@ -1,0 +1,36 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="EdmEntityContainerTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Microsoft.OData.Edm.Tests.Library
+{
+
+    public class EdmTermTests
+    {
+        [Fact]
+        public void EdmModelAddTermPrimitiveTypeTest()
+        {
+            var model = new EdmModel();
+            Assert.Equal(
+                model.AddTerm("NS", "Term1", EdmPrimitiveTypeKind.String),
+                model.FindTerm("NS.Term1"));
+        }
+
+        [Fact]
+        public void EdmModelAddTermTypeReferenceTest()
+        {
+            var boolType = EdmCoreModel.Instance.GetBoolean(false);
+
+            var model = new EdmModel();
+            Assert.Equal(
+                model.AddTerm("NS", "Term1", boolType),
+                model.FindTerm("NS.Term1"));
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Build.NetFramework/Microsoft.OData.Edm.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Build.NetFramework/Microsoft.OData.Edm.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="..\Vocabularies\AuthorizationVocabularyTests.cs" />
     <Compile Include="..\Vocabularies\ValidationVocabularyTests.cs" />
     <Compile Include="..\Vocabularies\CommunityVocabularyTests.cs" />
+    <Compile Include="EdmTermTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\packages.config" />


### PR DESCRIPTION
extension method to add Vocabulary Terms analog to AddComplexType and AddEntityType

<!-- markdownlint-disable MD002 MD041 -->

### Issues

No issues, just adding more of the types extensions analog to others.

### Description

Added two extension method to add Vocabulary Terms that wrap the two main Microsoft.OData.Edm.Vocabularies.EdmTerm constructors

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
