### PR TITLE
Fix #1493: Enable the $expand=* after the complex type

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -736,7 +736,7 @@ namespace Microsoft.OData {
         internal const string ExpandTreeNormalizer_NonPathInPropertyChain = "ExpandTreeNormalizer_NonPathInPropertyChain";
         internal const string UriExpandParser_TermIsNotValidForStar = "UriExpandParser_TermIsNotValidForStar";
         internal const string UriExpandParser_TermIsNotValidForStarRef = "UriExpandParser_TermIsNotValidForStarRef";
-        internal const string UriExpandParser_ParentEntityIsNull = "UriExpandParser_ParentEntityIsNull";
+        internal const string UriExpandParser_ParentStructuredTypeIsNull = "UriExpandParser_ParentStructuredTypeIsNull";
         internal const string UriExpandParser_TermWithMultipleStarNotAllowed = "UriExpandParser_TermWithMultipleStarNotAllowed";
         internal const string UriSelectParser_TermIsNotValid = "UriSelectParser_TermIsNotValid";
         internal const string UriSelectParser_InvalidTopOption = "UriSelectParser_InvalidTopOption";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -799,7 +799,7 @@ ExpandTreeNormalizer_NonPathInPropertyChain=Found a segment that isn't a path wh
 
 UriExpandParser_TermIsNotValidForStar=Term '{0}' is not valid in a $expand expression, as only $level option is allowed when the expanded navigation property is star.
 UriExpandParser_TermIsNotValidForStarRef=Term '{0}' is not valid in a $expand expression, no option is allowed when the expanded navigation property is */$ref.
-UriExpandParser_ParentEntityIsNull=Cannot get parent entity type for term '{0}' to auto populate all navigation properties.
+UriExpandParser_ParentStructuredTypeIsNull=Cannot get parent structured type for term '{0}' to auto populate all navigation properties.
 UriExpandParser_TermWithMultipleStarNotAllowed=Term '{0}' is not valid in a $expand expression as multiple stars are not allowed.
 UriSelectParser_TermIsNotValid=Term '{0}' is not valid in a $select or $expand expression.
 UriSelectParser_InvalidTopOption=Top option must be a non-negative integer, it is set to '{0}' instead.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -5129,10 +5129,10 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "Cannot get parent entity type for term '{0}' to auto populate all navigation properties."
+        /// A string like "Cannot get parent structured type for term '{0}' to auto populate all navigation properties."
         /// </summary>
-        internal static string UriExpandParser_ParentEntityIsNull(object p0) {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriExpandParser_ParentEntityIsNull, p0);
+        internal static string UriExpandParser_ParentStructuredTypeIsNull(object p0) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriExpandParser_ParentStructuredTypeIsNull, p0);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
@@ -332,6 +332,11 @@ namespace Microsoft.OData.UriParser
         /// <returns>An expand term token based on the path token, and all available expand options.</returns>
         private List<ExpandTermToken> BuildStarExpandTermToken(PathSegmentToken pathToken)
         {
+            if (this.parentStructuredType == null)
+            {
+                throw new ODataException(ODataErrorStrings.UriExpandParser_ParentStructuredTypeIsNull(this.lexer.ExpressionText));
+            }
+
             List<ExpandTermToken> expandTermTokenList = new List<ExpandTermToken>();
             long? levelsOption = null;
             bool isRefExpand = (pathToken.Identifier == UriQueryConstants.RefSegment);
@@ -402,14 +407,7 @@ namespace Microsoft.OData.UriParser
                 throw new ODataException(ODataErrorStrings.UriSelectParser_TermIsNotValid(this.lexer.ExpressionText));
             }
 
-            // As 2016/1/8, the navigation property is only supported in entity type, and will support in ComplexType in future.
-            var entityType = this.parentStructuredType as IEdmEntityType;
-            if (entityType == null)
-            {
-                throw new ODataException(ODataErrorStrings.UriExpandParser_ParentEntityIsNull(this.lexer.ExpressionText));
-            }
-
-            foreach (var navigationProperty in entityType.NavigationProperties())
+            foreach (var navigationProperty in this.parentStructuredType.NavigationProperties())
             {
                 var tmpPathToken = default(PathSegmentToken);
 

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
@@ -23,9 +23,9 @@ namespace Microsoft.OData.UriParser
         private readonly ODataUriResolver resolver;
 
         /// <summary>
-        /// The parent entity type for expand option in case expand option is star, get all parent entity navigation properties, it is an IEdmStructuredType.
+        /// The parent structured type for expand option in case expand option is star, get all parent structured navigation properties, it is an IEdmStructuredType.
         /// </summary>
-        private readonly IEdmStructuredType parentEntityType;
+        private readonly IEdmStructuredType parentStructuredType;
 
         /// <summary>
         /// The maximum allowable recursive depth.
@@ -93,21 +93,21 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="resolver">the URI resolver which will resolve different kinds of Uri parsing context</param>
         /// <param name="clauseToParse">the clause to parse</param>
-        /// <param name="parentEntityType">the parent entity type for expand option</param>
+        /// <param name="parentStructuredType">the parent structured type for expand option</param>
         /// <param name="maxRecursiveDepth">max recursive depth</param>
         /// <param name="enableCaseInsensitiveBuiltinIdentifier">Whether to allow case insensitive for builtin identifier.</param>
         /// <param name="enableNoDollarQueryOptions">Whether to enable no dollar query options.</param>
         public SelectExpandParser(
             ODataUriResolver resolver,
             string clauseToParse,
-            IEdmStructuredType parentEntityType,
+            IEdmStructuredType parentStructuredType,
             int maxRecursiveDepth,
             bool enableCaseInsensitiveBuiltinIdentifier = false,
             bool enableNoDollarQueryOptions = false)
             : this(clauseToParse, maxRecursiveDepth, enableCaseInsensitiveBuiltinIdentifier, enableNoDollarQueryOptions)
         {
             this.resolver = resolver;
-            this.parentEntityType = parentEntityType;
+            this.parentStructuredType = parentStructuredType;
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace Microsoft.OData.UriParser
                 {
                     this.selectExpandOptionParser = new SelectExpandOptionParser(
                         this.resolver,
-                        this.parentEntityType,
+                        this.parentStructuredType,
                         this.maxRecursiveDepth,
                         this.enableCaseInsensitiveBuiltinIdentifier,
                         this.enableNoDollarQueryOptions)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1493.*

### Description

* Enable $expand=* after the complex type.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
