### PR TITLE
Fix issue#1530: TypeSegment class ctor and property setting mismatch

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/TypeSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/TypeSegment.cs
@@ -24,6 +24,11 @@ namespace Microsoft.OData.UriParser
         private readonly IEdmType edmType;
 
         /// <summary>
+        /// The expected edm type of this type segment.
+        /// </summary>
+        private readonly IEdmType expectedType;
+
+        /// <summary>
         /// The navigation source containing the entities that we are casting.
         /// </summary>
         private readonly IEdmNavigationSource navigationSource;
@@ -56,6 +61,8 @@ namespace Microsoft.OData.UriParser
             this.edmType = actualType;
             this.navigationSource = navigationSource;
 
+            this.expectedType = expectedType;
+
             this.TargetEdmType = expectedType;
             this.TargetEdmNavigationSource = navigationSource;
 
@@ -72,6 +79,15 @@ namespace Microsoft.OData.UriParser
         public override IEdmType EdmType
         {
             get { return this.edmType; }
+        }
+
+        /// <summary>
+        /// Gets the expected <see cref="IEdmType"/> of this <see cref="TypeSegment"/>.
+        /// The type is reflected from model and same as the EdmType of previous segment.
+        /// </summary>
+        public IEdmType ExpectedType
+        {
+            get { return this.expectedType; }
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SegmentAssertions.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SegmentAssertions.cs
@@ -77,7 +77,7 @@ namespace Microsoft.OData.Tests.UriParser
             segment.Should().BeOfType<TypeSegment>();
             TypeSegment typeSegment = segment.As<TypeSegment>();
             typeSegment.EdmType.ShouldBeEquivalentTo(actualType);
-            typeSegment.TargetEdmType.ShouldBeEquivalentTo(expectType);
+            typeSegment.ExpectedType.ShouldBeEquivalentTo(expectType);
             return new AndConstraint<TypeSegment>(typeSegment);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/TypeSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/TypeSegmentTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void TargetEdmTypeIsTargetType()
         {
             TypeSegment typeSegment = new TypeSegment(HardCodedTestModel.GetPersonType(), null);
-            Assert.Same(HardCodedTestModel.GetPersonType(), typeSegment.TargetEdmType);
+            Assert.Same(HardCodedTestModel.GetPersonType(), typeSegment.ExpectedType);
         }
 
         [Fact]
@@ -74,7 +74,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         {
             TypeSegment typeSegment = new TypeSegment(HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetEmployeeType(), null);
             Assert.Same(HardCodedTestModel.GetPersonType(), typeSegment.EdmType);
-            Assert.Same(HardCodedTestModel.GetEmployeeType(), typeSegment.TargetEdmType);
+            Assert.Same(HardCodedTestModel.GetEmployeeType(), typeSegment.ExpectedType);
         }
     }
 }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -7182,6 +7182,7 @@ public sealed class Microsoft.OData.UriParser.TypeSegment : Microsoft.OData.UriP
 	public TypeSegment (Microsoft.OData.Edm.IEdmType actualType, Microsoft.OData.Edm.IEdmType expectedType, Microsoft.OData.Edm.IEdmNavigationSource navigationSource)
 
 	Microsoft.OData.Edm.IEdmType EdmType  { public virtual get; }
+	Microsoft.OData.Edm.IEdmType ExpectedType  { public get; }
 	Microsoft.OData.Edm.IEdmNavigationSource NavigationSource  { public get; }
 
 	public virtual void HandleWith (Microsoft.OData.UriParser.PathSegmentHandler handler)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1530.*

### Description

* TypeSegment class constructor and property setting mismatch

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
