### PR TITLE
Copy over metadata selector when creating a copy of messagewritersetting

### DIFF
--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -418,6 +418,7 @@ namespace Microsoft.OData
             this.useFormat = other.useFormat;
             this.Version = other.Version;
             this.LibraryCompatibility = other.LibraryCompatibility;
+            this.MetadataSelector = other.MetadataSelector;
 
             this.validations = other.validations;
             this.ThrowIfTypeConflictsWithMetadata = other.ThrowIfTypeConflictsWithMetadata;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.OData.UriParser;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Evaluation;
 using Xunit;
 using ODataErrorStrings = Microsoft.OData.Strings;
 
@@ -286,6 +287,14 @@ namespace Microsoft.OData.Tests
             this.settings.SetServiceDocumentUri(new Uri("http://test.org"));
             var newSetting = this.settings.Clone();
             newSetting.MetadataDocumentUri.Should().Be(new Uri("http://test.org/$metadata"));
+        }
+
+        [Fact]
+        public void CopyConstructorShouldCopyMetadataSelector()
+        {
+            this.settings.MetadataSelector = new TestMetadataSelector() { PropertyToOmit = "TestProperty" };
+            var newSetting = this.settings.Clone();
+            (newSetting.MetadataSelector as TestMetadataSelector).PropertyToOmit.Should().Be("TestProperty");
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes metadata selector feature if the message writer is used to create an odata writer. 

### Description

The copy method for the message writer settings was not copying over the metadata selector property. 
