### PR TITLE
Fix naming of DataModification* terms and types in vocabulary.

### DIFF
--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
@@ -227,12 +227,12 @@
     </Property>
   </ComplexType>
 
-  <Term Name="ModificationException" Type="Core.ModificationExceptionType" Nullable="false">
+  <Term Name="DataModificationException" Type="Core.DataModificationExceptionType" Nullable="false">
     <Annotation Term="Core.Description"
       String="A modification operation failed on the annotated instance or collection within a success payload" />
   </Term>
-  <ComplexType Name="ModificationExceptionType" BaseType="Core.ExceptionType">
-    <Property Name="failedOperation" Type="Core.ModificationOperationKind" Nullable="false">
+  <ComplexType Name="DataModificationExceptionType" BaseType="Core.ExceptionType">
+    <Property Name="failedOperation" Type="Core.DataModificationOperationKind" Nullable="false">
       <Annotation Term="Core.Description" String="The kind of modification operation that failed" />
     </Property>
     <Property Name="responseCode" Type="Edm.Int16" Nullable="true">
@@ -241,7 +241,7 @@
       <Annotation Term="Validation.Maximum" Decimal="599" />
     </Property>
   </ComplexType>
-  <EnumType Name="ModificationOperationKind" UnderlyingType="Edm.Int32">
+  <EnumType Name="DataModificationOperationKind" UnderlyingType="Edm.Int32">
     <Member Name="insert">
       <Annotation Term="Core.Description" String="Insert new instance" />
     </Member>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
@@ -139,8 +139,8 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.IsURL"" Bool=""true"" />
     </Property>
   </ComplexType>
-  <ComplexType Name=""ModificationExceptionType"" BaseType=""Core.ExceptionType"">
-    <Property Name=""failedOperation"" Type=""Core.ModificationOperationKind"" Nullable=""false"">
+  <ComplexType Name=""DataModificationExceptionType"" BaseType=""Core.ExceptionType"">
+    <Property Name=""failedOperation"" Type=""Core.DataModificationOperationKind"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""The kind of modification operation that failed"" />
     </Property>
     <Property Name=""responseCode"" Type=""Edm.Int16"">
@@ -183,7 +183,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.Description"" String=""Model element was deprecated"" />
     </Member>
   </EnumType>
-  <EnumType Name=""ModificationOperationKind"">
+  <EnumType Name=""DataModificationOperationKind"">
     <Member Name=""insert"">
       <Annotation Term=""Core.Description"" String=""Insert new instance"" />
     </Member>
@@ -260,7 +260,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""ResourceException"" Type=""Core.ResourceExceptionType"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""The annotated instance within a success payload is problematic"" />
   </Term>
-  <Term Name=""ModificationException"" Type=""Core.ModificationExceptionType"" Nullable=""false"">
+  <Term Name=""DataModificationException"" Type=""Core.DataModificationExceptionType"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""A modification operation failed on the annotated instance or collection within a success payload"" />
   </Term>
   <Term Name=""IsLanguageDependent"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Term Property"" Nullable=""false"">


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

As part of bringing OData 4.01 to committee specification and on towards publication as an OASIS standard, the OASIS TC updated the Core vocabulary to renamed:
"ModificationException"=>"DataModificationException"
"ModificationExceptionType"=>"DataModificationExceptionType"
"ModificationOperationKind"=>"DataModificationOperationKind"

This change updates our vocabulary to align with the new naming.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary