### PR TITLE
Fix issue #1547: Remove the prefix for SrsName in GmlWriter

### DIFF
--- a/src/Microsoft.Spatial/GmlWriter.cs
+++ b/src/Microsoft.Spatial/GmlWriter.cs
@@ -287,7 +287,7 @@ namespace Microsoft.Spatial
             {
                 this.coordinateSystemWritten = true;
                 var crsValue = GmlConstants.SrsPrefix + this.currentCoordinateSystem.Id;
-                this.writer.WriteAttributeString(GmlConstants.GmlPrefix, GmlConstants.SrsName, GmlConstants.GmlNamespace, crsValue);
+                this.writer.WriteAttributeString(GmlConstants.SrsName, crsValue);
             }
         }
 

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/Build.NetFramework/Microsoft.Spatial.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/Build.NetFramework/Microsoft.Spatial.Tests.csproj
@@ -40,10 +40,6 @@
     <AssemblyOriginatorKeyFile>..\..\..\..\tools\StrongNamePublicKeys\testkey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\sln\packages\FluentAssertions.2.0.0.1\lib\net40\FluentAssertions.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/GmlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/GmlWriterTests.cs
@@ -355,10 +355,10 @@ namespace Microsoft.Spatial.Tests
             GeographyGmlWriterTest(p =>
             {
                 p.SetCoordinateSystem(CoordinateSystem.DefaultGeography);
-                p.BeginGeography(SpatialType.FullGlobe);    
-                p.EndGeography();  
+                p.BeginGeography(SpatialType.FullGlobe);
+                p.EndGeography(); 
             },
-            "sqlgeo:FullGlobe[@gml:srsName = 'http://www.opengis.net/def/crs/EPSG/0/4326' and not(text())]");
+            "sqlgeo:FullGlobe[@srsName = 'http://www.opengis.net/def/crs/EPSG/0/4326' and not(text())]");
         }
 
         private static void GeographyGmlWriterTest(Action<GeographyPipeline> pipelineCalls, params string[] expectedXPaths)
@@ -388,9 +388,9 @@ namespace Microsoft.Spatial.Tests
 
             var xDoc = new XmlDocument(nt);
             xDoc.Load(ms);
-            
+
             var nav = xDoc.CreateNavigator();
-            SpatialTestUtils.VerifyXPaths(nav, xnm, "/node()[@gml:srsName = '" + GmlConstants.SrsPrefix + CoordinateSystem.DefaultGeography.EpsgId + "']");                                          
+            SpatialTestUtils.VerifyXPaths(nav, xnm, "/node()[@srsName = '" + GmlConstants.SrsPrefix + CoordinateSystem.DefaultGeography.EpsgId + "']");
             SpatialTestUtils.VerifyXPaths(nav, xnm, expectedXPaths);
         }
 
@@ -757,7 +757,7 @@ namespace Microsoft.Spatial.Tests
             xDoc.Load(ms);
 
             var nav = xDoc.CreateNavigator();
-            SpatialTestUtils.VerifyXPaths(nav, xnm, "/node()[@gml:srsName = '" + GmlConstants.SrsPrefix + CoordinateSystem.DefaultGeometry.EpsgId + "']");
+            SpatialTestUtils.VerifyXPaths(nav, xnm, "/node()[@srsName = '" + GmlConstants.SrsPrefix + CoordinateSystem.DefaultGeometry.EpsgId + "']");
 
             SpatialTestUtils.VerifyXPaths(nav, xnm, expectedXPaths);
         }

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.NetCore.csproj
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.NetCore.csproj
@@ -18,7 +18,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

* [GML - Geography Markup Language](https://gdal.org/drivers/vector/gml.html)

The GmlFormatter Write method is appending the "gml" prefix to the "srsName" attribute.
The "srsName" attribute should not have the "gml" prefix based on  [GML - Geography Markup Language](https://gdal.org/drivers/vector/gml.html)

* remove the unused package reference to "FluentAssertions"

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
