### PR TITLE
Change AssemblyVersionAttribute without revision

### DIFF
--- a/tools/CustomMSBuild/After.Common.targets
+++ b/tools/CustomMSBuild/After.Common.targets
@@ -84,7 +84,7 @@ using System.Resources;
 [assembly: AssemblyDefaultAlias("%AssemblyNameFull%")]
 [assembly: AssemblyFileVersion("%VersionFull%")]
 [assembly: AssemblyInformationalVersion("%VersionFull%")]
-[assembly: AssemblyVersion("%VersionFull%")]
+[assembly: AssemblyVersion("%VersionFullSemantic%")]
 [assembly: SatelliteContractVersion("%VersionFull%")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
       </GenerateAssemblyAttributeTemplateCSharp>
@@ -137,13 +137,13 @@ using System.Resources;
 internal static class VersionConstants
 {
     internal const string ReleaseVersion = "%VersionFullSemantic%";
-    internal const string AssemblyVersion = "%VersionFull%";
+    internal const string AssemblyVersion = "%VersionFullSemantic%";
 }
       </GenerateVersionConstantsTemplateCSharp>
       <GenerateVersionConstantsTemplateVB>
 Friend Class VersionConstants
     Friend Shared ReleaseVersion As String = "%VersionFullSemantic%"
-    Friend Shared AssemblyVersion As String = "%VersionFull%"
+    Friend Shared AssemblyVersion As String = "%VersionFullSemantic%"
 End Class
       </GenerateVersionConstantsTemplateVB>
     </PropertyGroup>

--- a/tools/CustomMSBuild/After.Common.targets
+++ b/tools/CustomMSBuild/After.Common.targets
@@ -99,7 +99,7 @@ using System.Resources;
     <PropertyGroup>
       <AssemblyAttributeOutputFile>$(IntermediateOutputPath.TrimEnd("\\"))\AssemblyAttributes$(DefaultLanguageSourceExtension)</AssemblyAttributeOutputFile>
       <AssemblyNameFull>$(AssemblyName)$(TargetExt)</AssemblyNameFull>
-      <AssemblyAttributeFileContentsTransformed>$([System.String]::Copy('$(GenerateAssemblyAttributeTemplate)').Replace("%25AssemblyNameFull%25",$(AssemblyNameFull)).Replace("%25VersionFull%25",$(VersionFull)))</AssemblyAttributeFileContentsTransformed>
+      <AssemblyAttributeFileContentsTransformed>$([System.String]::Copy('$(GenerateAssemblyAttributeTemplate)').Replace("%25AssemblyNameFull%25",$(AssemblyNameFull)).Replace("%25VersionFull%25",$(VersionFull)).Replace("%25VersionFullSemantic%25",$(VersionFullSemantic)))</AssemblyAttributeFileContentsTransformed>
     </PropertyGroup>
 
     <Message Text="GenerateAssemblyAttributeFile: Generating $(AssemblyAttributeOutputFile)" Importance="high" Condition="'$(DebugMessages)' == 'true'"/>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* Fix #1540

### Description

MSDN says:

- AssemblyVersion:

Specifies the version of the assembly being attributed.

- AssemblyFileVersion:

Instructs a compiler to use a specific version number for the Win32 file version resource. The Win32 file version is not required to be the same as the assembly's version number.

- AssemblyInformationalVersion:

Defines additional version information for an assembly manifest.

---

Before 7.6.1-beta, the OData library version has the following pattern for all above three version:

` *Version = {Major}.{Minor}.{BuildNumber}.{ Now.Year - 2017 + 1}{MM}{DD} `

From the issue #1540, the AssemblyVersion should  stop changing between minor releases. So, this PR is changing ‘AssemblyVersion’ as

`AssemblyVersion = {Major}.{Minor}.{BuildNumber}`

Meanwhile, leave other two unchanged.

## Test

If i have the following codes running on .NET Core 3.0 or .NET Framework
```C#

Assembly asm = typeof(IEdmModel).Assembly;
Console.WriteLine(asm.GetName().Name);
string assemblyVersion = asm.GetName().Version.ToString();
string fileVersion = FileVersionInfo.GetVersionInfo(asm.Location).FileVersion;
string productVersion = FileVersionInfo.GetVersionInfo(asm.Location).ProductVersion;

Console.WriteLine($"AssemblyVersion :\t {assemblyVersion}\nAssemblyFileVersion:\t {fileVersion}\nAssemblyProductVersion:\t {productVersion}");

```

If i use the version [6.0 from Nuget.org](https://www.nuget.org/packages/Microsoft.OData.Edm/7.6.0), i can get the following:

 Category|.NET Core  | .NET Framework
---|--------|---------
Assembly.Name|Microsoft.OData.Edm|Microsoft.OData.Edm
AssemblyVersion        | 7.6.0.30605 | 7.6.0.30605
AssemblyFileVersion   |  7.6.0.30605 | 7.6.0.30605
AssemblyProductVersion |  7.6.0.30605| 7.6.0.30605


If i use the build with this PR, i have the following output:

 Category|.NET Core  | .NET Framework
---|--------|---------
Assembly.Name|Microsoft.OData.Edm|Microsoft.OData.Edm
AssemblyVersion        | 7.6.1.0 | 7.6.1.0
AssemblyFileVersion   |  7.6.1.30927 | 7.6.1.30927
AssemblyProductVersion |  7.6.1.30927| 7.6.1.30927

Check the difference of Assembly Version.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
