### PR TITLE
Fix build errors by adding IFormatProvider

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/UriWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriWriter.cs
@@ -354,7 +354,7 @@ namespace Microsoft.OData.Client
                         int count = 1;
                         while (this.alias.ContainsKey(aliasName))
                         {
-                            aliasName = UriHelper.ATSIGN + param.Key + count;
+                            aliasName = UriHelper.ATSIGN + param.Key + count.ToString(CultureInfo.InvariantCulture);
                             count++;
                         }
 
@@ -408,7 +408,7 @@ namespace Microsoft.OData.Client
                                 this.VisitQueryOptionExpression((FilterQueryOptionExpression)e);
                                 break;
                             default:
-                                Debug.Assert(false, "Unexpected expression type " + (int)et);
+                                Debug.Assert(false, "Unexpected expression type " + ((int)et).ToString(CultureInfo.InvariantCulture));
                                 break;
                         }
                     }

--- a/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
+++ b/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
@@ -7,6 +7,8 @@
 //// Uncomment the following line to trace projection building activity.
 ////#define TRACE_CLIENT_PROJECTIONS
 
+using System.Globalization;
+
 namespace Microsoft.OData.Client
 {
     #region Namespaces
@@ -401,8 +403,8 @@ namespace Microsoft.OData.Client
             {
                 this.topLevelProjectionFound = true;
 
-                ParameterExpression expectedTypeParameter = Expression.Parameter(typeof(Type), "type" + this.identifierId);
-                ParameterExpression entryParameter = Expression.Parameter(typeof(object), "entry" + this.identifierId);
+                ParameterExpression expectedTypeParameter = Expression.Parameter(typeof(Type), "type" + this.identifierId.ToString(CultureInfo.InvariantCulture));
+                ParameterExpression entryParameter = Expression.Parameter(typeof(object), "entry" + this.identifierId.ToString(CultureInfo.InvariantCulture));
                 this.identifierId++;
 
                 this.pathBuilder.EnterLambdaScope(lambda, entryParameter, expectedTypeParameter);
@@ -628,7 +630,7 @@ namespace Microsoft.OData.Client
             {
                 entryToInitValue = this.GetDeepestEntry(expressions);
                 expectedParamValue = projectedTypeExpression;
-                entryParameterForMembers = Expression.Parameter(typeof(object), "subentry" + this.identifierId++);
+                entryParameterForMembers = Expression.Parameter(typeof(object), "subentry" + this.identifierId++.ToString(CultureInfo.InvariantCulture));
                 expectedParameterForMembers = (ParameterExpression)this.pathBuilder.ExpectedParamTypeInScope;
 
                 // Annotate the entry expression with 'how we get to it' information.
@@ -668,7 +670,7 @@ namespace Microsoft.OData.Client
                         Expression.Constant(assignment.Member.Name, typeof(string)));
                     ParameterExpression nestedEntryParameter = Expression.Parameter(
                         typeof(object),
-                        "subentry" + this.identifierId++);
+                        "subentry" + this.identifierId++.ToString(CultureInfo.InvariantCulture));
 
                     // Register the rewrite from the top to the entry if necessary.
                     ProjectionPath entryPath;

--- a/src/Microsoft.OData.Core/ODataBatchReaderStreamBuffer.cs
+++ b/src/Microsoft.OData.Core/ODataBatchReaderStreamBuffer.cs
@@ -4,6 +4,8 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System.Globalization;
+
 namespace Microsoft.OData
 {
     #region Namespaces
@@ -585,7 +587,7 @@ namespace Microsoft.OData
                 currentIx++;
             }
 
-            Debug.Assert(trailingDashes <= TwoDashesLength, "Should never look for more than " + TwoDashesLength + " trailing dashes.");
+            Debug.Assert(trailingDashes <= TwoDashesLength, "Should never look for more than " + TwoDashesLength.ToString(CultureInfo.InvariantCulture) + " trailing dashes.");
             isEndBoundary = trailingDashes == TwoDashesLength;
             return true;
         }

--- a/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
@@ -239,7 +239,7 @@ namespace Microsoft.OData.Edm.Validation
                             }
 
                             // OperationImports of the same name can exist as long as they reference different operations.
-                            string operationImportUniqueString = operationImport.Name + "_" + operationImport.Operation.GetHashCode();
+                            string operationImportUniqueString = operationImport.Name + "_" + operationImport.Operation.GetHashCode().ToString(CultureInfo.InvariantCulture);
                             if (operationImportOperationList.Contains(operationImportUniqueString))
                             {
                                 duplicate = true;

--- a/src/Microsoft.Spatial/CoordinateSystem.cs
+++ b/src/Microsoft.Spatial/CoordinateSystem.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Spatial
                     return r;
                 }
 
-                r = new CoordinateSystem(epsgId, "ID " + epsgId, topology);
+                r = new CoordinateSystem(epsgId, "ID " + epsgId.ToString(CultureInfo.InvariantCulture), topology);
                 AddRef(r);
             }
 

--- a/src/Microsoft.Spatial/LexerToken.cs
+++ b/src/Microsoft.Spatial/LexerToken.cs
@@ -4,6 +4,8 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System.Globalization;
+
 namespace Microsoft.Spatial
 {
     using System;
@@ -41,7 +43,7 @@ namespace Microsoft.Spatial
         /// <returns>String representation of this token</returns>
         public override string ToString()
         {
-            return "Type:[" + this.Type + "] Text:[" + this.Text + "]";
+            return "Type:[" + this.Type.ToString(CultureInfo.InvariantCulture) + "] Text:[" + this.Text + "]";
         }
     }
 }


### PR DESCRIPTION
### Description

It's currently not possible to build the OData.Net45 solution due to the error below.

> Because the behavior of 'int.ToString()' could vary based on the current user's locale settings, replace this call in 'UriWriter.VisitOperationInvocation(QueryableResourceExpression)' with a call to 'int.ToString(IFormatProvider)'. If the result of 'int.ToString(IFormatProvider)' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*
