### PR TITLE
Update StyleCop.

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -84,7 +84,7 @@
 
   <!-- StyleCop settings -->
   <PropertyGroup>
-    <StyleCopTargets>$(NuGetPack)\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets</StyleCopTargets>
+    <StyleCopTargets>$(NuGetPack)\StyleCop.MSBuild.5.0.0\build\StyleCop.MSBuild.Targets</StyleCopTargets>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/sln/.nuget/packages.config
+++ b/sln/.nuget/packages.config
@@ -15,7 +15,7 @@
   <package id="Microsoft.OData.StyleCop" version="1.0.0" />
   <package id="Newtonsoft.Json" version="6.0.5" />
   <package id="System.Text.Encoding.Extensions" version="4.0.11" />
-  <package id="StyleCop.MSBuild" version="4.7.49" />
+  <package id="StyleCop.MSBuild" version="5.0.0" />
   <package id="xunit" version="2.1.0" />
   <package id="xunit.abstractions" version="2.0.0" />
   <package id="xunit.assert" version="2.1.0" />


### PR DESCRIPTION
### Issues

This pull request fixes issue https://github.com/OData/odata.net/issues/1557

### Description

This pull request updates StyleCop so that the .NET 3.5 install is not necessary on Win10.

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*
