### PR TITLE
Update HttpWebRequestMessage.cs to enable TLS 1.2

### DIFF
--- a/test/PackageTests/Microsoft.OData.Tests.Nuget.Core/HttpWebRequestMessage.cs
+++ b/test/PackageTests/Microsoft.OData.Tests.Nuget.Core/HttpWebRequestMessage.cs
@@ -21,6 +21,7 @@ namespace Microsoft.OData.Tests.Nuget.Core
 
         public HttpWebRequestMessage(Uri uri)
         {
+            ServicePointManager.SecurityProtocol = System.Net.SecurityProtocolType.Tls12;
             request = (HttpWebRequest)WebRequest.Create(uri);
         }
 


### PR DESCRIPTION
This fixes the build failure that was happening for package testing for OData.