### PR TITLE
Validate and throw exception for invalid (empty) collections 

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -123,6 +123,10 @@ namespace Microsoft.OData.UriParser
                 }
 
                 object collection = ODataUriConversionUtils.ConvertFromCollectionValue(bracketLiteralText, model, expectedType);
+                if (((ODataCollectionValue)collection).Items.Count() == 0)
+                {
+                    throw new ODataException(ODataErrorStrings.MetadataBinder_RightOperandNotCollectionValue);
+                }
                 LiteralToken collectionLiteralToken = new LiteralToken(collection, originalLiteralText, expectedType);
                 operand = this.bindMethod(collectionLiteralToken) as CollectionConstantNode;
             }

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -97,6 +97,10 @@ namespace Microsoft.OData.UriParser
                 {
                     Debug.Assert(bracketLiteralText[bracketLiteralText.Length - 1] == ')',
                         "Collection with opening '(' should have corresponding ')'");
+                    if (bracketLiteralText.Replace(" ", String.Empty) == "()")
+                    {
+                        throw new ODataException(ODataErrorStrings.MetadataBinder_RightOperandNotCollectionValue);
+                    }
 
                     StringBuilder replacedText = new StringBuilder(bracketLiteralText);
                     replacedText[0] = '[';
@@ -123,10 +127,6 @@ namespace Microsoft.OData.UriParser
                 }
 
                 object collection = ODataUriConversionUtils.ConvertFromCollectionValue(bracketLiteralText, model, expectedType);
-                if (((ODataCollectionValue)collection).Items.Count() == 0)
-                {
-                    throw new ODataException(ODataErrorStrings.MetadataBinder_RightOperandNotCollectionValue);
-                }
                 LiteralToken collectionLiteralToken = new LiteralToken(collection, originalLiteralText, expectedType);
                 operand = this.bindMethod(collectionLiteralToken) as CollectionConstantNode;
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2020,11 +2020,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Theory]
-        [InlineData("()")]
-        [InlineData("(  )")]
-        public void FilterWithInOperationWithEmptyCollection(string collection)
+        [InlineData("ID in ()")]
+        [InlineData("ID in (  )")]
+        [InlineData("SSN in (  )")]     // Edm.String
+        [InlineData("MyGuid in (  )")]  // Edm.Guid
+        public void FilterWithInOperationWithEmptyCollection(string filterClause)
         {
-            string filterClause = $"ID in {collection}";
             Action parse = () => ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
             parse.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.MetadataBinder_RightOperandNotCollectionValue);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2019,6 +2019,16 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal("[1,2,3]", Assert.IsType<CollectionConstantNode>(inNode.Right).LiteralText);
         }
 
+        [Theory]
+        [InlineData("()")]
+        [InlineData("(  )")]
+        public void FilterWithInOperationWithEmptyCollection(string collection)
+        {
+            string filterClause = $"ID in {collection}";
+            Action parse = () => ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+            parse.ShouldThrow<ODataException>().WithMessage(ODataErrorStrings.MetadataBinder_RightOperandNotCollectionValue);
+        }
+
         [Fact]
         public void FilterWithInOperationWithMismatchedClosureCollection()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes: validate the IN expression and throw exception.*
Original Work Item: [Bug 1574507: Internal error instead of ODataException for queries likes /WorkItems?$filter=IterationSK in ()](https://dev.azure.com/mseng/AzureDevOps/_boards/board/t/Atlas/Stories/?workitem=1574507)

### Description

*Previously, query that includes "$filter=IterationSK in ()" throws 500 error with uncaught exception from OData: `System.IndexOutOfRangeException`.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [] *Build and test with one-click build and test script passed* -- IN PROGRESS (I'm looking into how to do this.)

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
