### PR TITLE
Specifying culture agnostic formatting for some integer string conver…

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -78,9 +78,9 @@
     <PackagesConfig>$(NuGetToolsPath)\packages.config</PackagesConfig>
   </PropertyGroup>
 
-  <Target Name="RestoreNuGetPackages" BeforeTargets="$(GenerateTextStringResourcesDependsOn)">
+  <!--<Target Name="RestoreNuGetPackages" BeforeTargets="$(GenerateTextStringResourcesDependsOn)">
     <Exec Command="&quot;$(NuGetExePath)&quot; restore &quot;$(PackagesConfig)&quot; -PackageSaveMode nuspec -SolutionDirectory &quot;$(SolutionDir)\&quot;" />
-  </Target>
+  </Target>-->
 
   <!-- StyleCop settings -->
   <PropertyGroup>

--- a/src/Microsoft.OData.Client/ALinq/UriWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriWriter.cs
@@ -354,7 +354,7 @@ namespace Microsoft.OData.Client
                         int count = 1;
                         while (this.alias.ContainsKey(aliasName))
                         {
-                            aliasName = UriHelper.ATSIGN + param.Key + count;
+                            aliasName = UriHelper.ATSIGN + param.Key + count.ToString(CultureInfo.InvariantCulture);
                             count++;
                         }
 
@@ -408,7 +408,7 @@ namespace Microsoft.OData.Client
                                 this.VisitQueryOptionExpression((FilterQueryOptionExpression)e);
                                 break;
                             default:
-                                Debug.Assert(false, "Unexpected expression type " + (int)et);
+                                Debug.Assert(false, "Unexpected expression type " + ((int)et).ToString(CultureInfo.InvariantCulture));
                                 break;
                         }
                     }

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -18,24 +18,24 @@
   <!-- References -->
   <Import Project="..\Build.props" />
   <ItemGroup>
+    <Reference Include="Microsoft.OData.Core, Version=7.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.OData.Core.7.6.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.OData.Edm, Version=7.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.OData.Edm.7.6.1\lib\portable-net45+win8+wpa81\Microsoft.OData.Edm.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Spatial, Version=7.6.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\packages\Microsoft.Spatial.7.6.1\lib\portable-net45+win8+wpa81\Microsoft.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <ProjectReference Include="..\Microsoft.OData.Edm\Microsoft.OData.Edm.csproj">
-      <Project>{7D921888-FE03-4C3F-80FE-2F624505461C}</Project>
-      <Name>Microsoft.OData.Edm</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.Spatial\Microsoft.Spatial.csproj">
-      <Project>{5D921888-FE03-4C3F-40FE-2F624505461D}</Project>
-      <Name>Microsoft.Spatial</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\Microsoft.OData.Core\Microsoft.OData.Core.csproj">
-      <Project>{989A83CC-B864-4A75-8BF3-5EDA99203A86}</Project>
-      <Name>Microsoft.OData.Core</Name>
-    </ProjectReference>
   </ItemGroup>
   <!-- Generated files -->
   <ItemGroup>
@@ -486,6 +486,7 @@
       <DependentUpon>Microsoft.OData.Client.tt</DependentUpon>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Parameterized.Microsoft.OData.Client.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Parameterized.Microsoft.OData.Client.cs</LastGenOutput>

--- a/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
+++ b/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
@@ -19,6 +19,7 @@ namespace Microsoft.OData.Client
     using System.Reflection;
     using Microsoft.OData.Client.Materialization;
     using Microsoft.OData.Client.Metadata;
+    using System.Globalization;
 
     #endregion Namespaces
 
@@ -401,8 +402,8 @@ namespace Microsoft.OData.Client
             {
                 this.topLevelProjectionFound = true;
 
-                ParameterExpression expectedTypeParameter = Expression.Parameter(typeof(Type), "type" + this.identifierId);
-                ParameterExpression entryParameter = Expression.Parameter(typeof(object), "entry" + this.identifierId);
+                ParameterExpression expectedTypeParameter = Expression.Parameter(typeof(Type), "type" + (this.identifierId).ToString(CultureInfo.InvariantCulture));
+                ParameterExpression entryParameter = Expression.Parameter(typeof(object), "entry" + (this.identifierId).ToString(CultureInfo.InvariantCulture));
                 this.identifierId++;
 
                 this.pathBuilder.EnterLambdaScope(lambda, entryParameter, expectedTypeParameter);
@@ -628,7 +629,7 @@ namespace Microsoft.OData.Client
             {
                 entryToInitValue = this.GetDeepestEntry(expressions);
                 expectedParamValue = projectedTypeExpression;
-                entryParameterForMembers = Expression.Parameter(typeof(object), "subentry" + this.identifierId++);
+                entryParameterForMembers = Expression.Parameter(typeof(object), "subentry" + (this.identifierId++).ToString(CultureInfo.InvariantCulture));
                 expectedParameterForMembers = (ParameterExpression)this.pathBuilder.ExpectedParamTypeInScope;
 
                 // Annotate the entry expression with 'how we get to it' information.
@@ -668,7 +669,7 @@ namespace Microsoft.OData.Client
                         Expression.Constant(assignment.Member.Name, typeof(string)));
                     ParameterExpression nestedEntryParameter = Expression.Parameter(
                         typeof(object),
-                        "subentry" + this.identifierId++);
+                        "subentry" + (this.identifierId++).ToString(CultureInfo.InvariantCulture));
 
                     // Register the rewrite from the top to the entry if necessary.
                     ProjectionPath entryPath;

--- a/src/Microsoft.OData.Client/packages.config
+++ b/src/Microsoft.OData.Client/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.OData.Core" version="7.6.1" targetFramework="net45" />
+  <package id="Microsoft.OData.Edm" version="7.6.1" targetFramework="net45" />
+  <package id="Microsoft.Spatial" version="7.6.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
…sions

<!-- markdownlint-disable MD002 MD041 -->

### Issues

There is no issue logged for this. In my configuration this warning is being treated as error and breaking the build with the following error:

`CA130: Because the behavior of 'int.ToString()' could vary based on the current user's locale settings, replace this call in 'UriWriter.VisitOperationInvocation(QueryableResourceExpression)' with a call to 'int.ToString(IFormatProvider)'. If the result of 'int.ToString(IFormatProvider)' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.`

### Description

Fixed the warning by adding `ToString(CultureInfo.InvariantCulture)__`

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added* __N/A, build error, not feature.__
- [x] *Build and test with one-click build and test script passed*: 

### Additional work necessary
N/A