### PR TITLE
Allow duplicate properties in $select with no select options

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/ODataMetadataSelector.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataMetadataSelector.cs
@@ -1,4 +1,10 @@
-﻿using System.Collections.Generic;
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataMetadataSelector.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
 using Microsoft.OData.Edm;
 
 namespace Microsoft.OData.Evaluation
@@ -14,7 +20,7 @@ namespace Microsoft.OData.Evaluation
         /// </summary>
         /// <param name="type">Edm type of the resource on which the navigation property exists.</param>
         /// <param name="navigationProperties">Enumerable of selected navigation properties.</param>
-        /// <returns></returns>
+        /// <returns>The list of navigation properties to be written.</returns>
         public virtual IEnumerable<IEdmNavigationProperty> SelectNavigationProperties(IEdmStructuredType type, IEnumerable<IEdmNavigationProperty> navigationProperties)
         {
             return navigationProperties;
@@ -25,7 +31,7 @@ namespace Microsoft.OData.Evaluation
         /// </summary>
         /// <param name="type">Edm type of the resource on which the navigation property exists.</param>
         /// <param name="bindableOperations">Enumerable of the operations whose metadata gets written out by convention.</param>
-        /// <returns></returns>
+        /// <returns>The list of bound operations to be written.</returns>
         public virtual IEnumerable<IEdmOperation> SelectBindableOperations(IEdmStructuredType type, IEnumerable<IEdmOperation> bindableOperations)
         {
             return bindableOperations;
@@ -36,7 +42,7 @@ namespace Microsoft.OData.Evaluation
         /// </summary>
         /// <param name="type">Edm type of the resource on which the navigation property exists.</param>
         /// <param name="selectedStreamProperties">enumerable of the selected stream properties.</param>
-        /// <returns></returns>
+        /// <returns>The list of stream properties to be written.</returns>
         public virtual IEnumerable<IEdmStructuralProperty> SelectStreamProperties(IEdmStructuredType type, IEnumerable<IEdmStructuralProperty> selectedStreamProperties)
         {
             return selectedStreamProperties;

--- a/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
@@ -403,6 +403,7 @@ namespace Microsoft.OData.Evaluation
             /// <param name="actualResourceType">The structured type of the resource.</param>
             /// <param name="metadataContext">The metadata context to use.</param>
             /// <param name="selectedProperties">The selected properties.</param>
+            /// <param name="metadataSelector">The metadata selector to use when writing metadata.</param>
             internal ODataResourceMetadataContextWithModel(ODataResourceBase resource, IODataResourceTypeContext typeContext, IEdmStructuredType actualResourceType, IODataMetadataContext metadataContext, SelectedPropertiesNode selectedProperties, ODataMetadataSelector metadataSelector)
                 : base(resource, typeContext)
             {

--- a/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
@@ -90,6 +90,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="keyAsSegment">true if keys should go in separate segments in auto-generated URIs, false if they should go in parentheses.
         /// A null value means the user hasn't specified a preference and we should look for an annotation in the entity container, if available.</param>
         /// <param name="odataUri">The OData Uri.</param>
+        /// <param name="settings">The settings to use when creating the resource builder.</param>
         /// <returns>The created metadata builder.</returns>
         internal abstract ODataResourceMetadataBuilder CreateResourceMetadataBuilder(
             ODataResourceBase resource,

--- a/src/Microsoft.OData.Core/JsonLight/JsonMinimalMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonMinimalMetadataLevel.cs
@@ -40,6 +40,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="isResponse">true if the resource metadata builder to create should be for a response payload; false for a request.</param>
         /// <param name="keyAsSegment">true if keys should go in separate segments in auto-generated URIs, false if they should go in parentheses.</param>
         /// <param name="odataUri">The OData Uri.</param>
+        /// <param name="settings">The settings to use when creating the resource builder.</param>
         /// <returns>The created metadata builder.</returns>
         internal override ODataResourceMetadataBuilder CreateResourceMetadataBuilder(
             ODataResourceBase resource,

--- a/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
@@ -40,6 +40,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="isResponse">true if the resource metadata builder to create should be for a response payload; false for a request.</param>
         /// <param name="keyAsSegment">true if keys should go in separate segments in auto-generated URIs, false if they should go in parentheses.</param>
         /// <param name="odataUri">The OData Uri.</param>
+        /// <param name="settings">The settings to use when creating the resource builder.</param>
         /// <returns>The created metadata builder.</returns>
         internal override ODataResourceMetadataBuilder CreateResourceMetadataBuilder(
             ODataResourceBase resource,

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -798,7 +798,7 @@ Nodes_SingleValueFunctionCallNode_ItemTypeMustBePrimitiveOrComplexOrEnum=An inst
 Nodes_InNode_CollectionItemTypeMustBeSameAsSingleItemType=An instance of InNode can only be created where the item types of the right operand '{0}' and the left operand '{1}' can be compared.
 
 ExpandTreeNormalizer_NonPathInPropertyChain=Found a segment that isn't a path while parsing the path within a select or expand query option.
-SelectTreeNormalizer_MultipleSelecTermWithSamePathFound=Found mutliple select terms with same select path '{0}' at one $select, please combine them together.
+SelectTreeNormalizer_MultipleSelecTermWithSamePathFound=Found multiple select terms with same select path '{0}' at one $select, please combine them together.
 
 UriExpandParser_TermIsNotValidForStar=Term '{0}' is not valid in a $expand expression, as only $level option is allowed when the expanded navigation property is star.
 UriExpandParser_TermIsNotValidForStarRef=Term '{0}' is not valid in a $expand expression, no option is allowed when the expanded navigation property is */$ref.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -5137,7 +5137,7 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "Found mutliple select terms with same select path '{0}' at one $select, please combine them together."
+        /// A string like "Found multiple select terms with same select path '{0}' at one $select, please combine them together."
         /// </summary>
         internal static string SelectTreeNormalizer_MultipleSelecTermWithSamePathFound(object p0) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.SelectTreeNormalizer_MultipleSelecTermWithSamePathFound, p0);

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectTreeNormalizer.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectTreeNormalizer.cs
@@ -4,11 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using ODataErrorStrings = Microsoft.OData.Strings;
-
 namespace Microsoft.OData.UriParser
 {
     /// <summary>
@@ -23,90 +18,11 @@ namespace Microsoft.OData.UriParser
         /// <returns>Normalized SelectToken</returns>
         public static SelectToken NormalizeSelectTree(SelectToken selectToken)
         {
-            // Be noted: It's not allowed have multple select clause with same path.
-            // For example: $select=abc($top=2),abc($skip=2) is not allowed by design.
-            // Cusotmer should combine them together, for example: $select=abc($top=2;$skip=2).
-            // The logic is different with ExpandTreeNormalizer. We should change the logic in ExpandTreeNormalizer
-            // in next breaking change version.
-            VerifySelectToken(selectToken);
-
             // To normalize the select tree we need to:
             // invert the path tree on each of its select term tokens
             selectToken = NormalizeSelectPaths(selectToken);
 
             return selectToken;
-        }
-
-        private static void VerifySelectToken(SelectToken selectToken)
-        {
-            if (selectToken == null)
-            {
-                return;
-            }
-
-            HashSet<PathSegmentToken> pathTerms = new HashSet<PathSegmentToken>(new PathSegmentTokenEqualityComparer());
-            foreach (SelectTermToken term in selectToken.SelectTerms)
-            {
-                if (pathTerms.Contains(term.PathToProperty))
-                {
-                    throw new ODataException(ODataErrorStrings.SelectTreeNormalizer_MultipleSelecTermWithSamePathFound(ToPathString(term.PathToProperty)));
-                }
-                else
-                {
-                    pathTerms.Add(term.PathToProperty);
-                }
-
-                // Verify at next level
-                if (term.SelectOption != null)
-                {
-                    VerifySelectToken(term.SelectOption);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Get the path string for a path segment token.
-        /// </summary>
-        /// <param name="head">The head of the path</param>
-        /// <returns>The path string.</returns>
-        private static string ToPathString(PathSegmentToken head)
-        {
-            StringBuilder sb = new StringBuilder();
-            PathSegmentToken curr = head;
-            while (curr != null)
-            {
-                sb.Append(curr.Identifier);
-
-                NonSystemToken nonSystem = curr as NonSystemToken;
-                if (nonSystem != null && nonSystem.NamedValues != null)
-                {
-                    sb.Append("(");
-                    bool first = true;
-                    foreach (var item in nonSystem.NamedValues)
-                    {
-                        if (first)
-                        {
-                            first = false;
-                        }
-                        else
-                        {
-                            sb.Append(",");
-                        }
-
-                        sb.Append(item.Name).Append("=").Append(item.Value.Value);
-                    }
-
-                    sb.Append(")");
-                }
-
-                curr = curr.NextToken;
-                if (curr != null)
-                {
-                    sb.Append("/");
-                }
-            }
-
-            return sb.ToString();
         }
 
         private static SelectToken NormalizeSelectPaths(SelectToken selectToken)

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/PathSelectItem.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/PathSelectItem.cs
@@ -133,5 +133,24 @@ namespace Microsoft.OData.UriParser
         {
             handler.Handle(this);
         }
+
+        /// <summary>
+        /// Returns whether or not the path select item has any options applied
+        /// </summary>
+        internal bool HasOptions
+        {
+            get
+            {
+                return
+                    FilterOption != null ||
+                    ComputeOption != null ||
+                    SearchOption != null ||
+                    TopOption != null ||
+                    SkipOption != null ||
+                    CountOption != null ||
+                    OrderByOption != null ||
+                    (SelectAndExpand != null && !SelectAndExpand.AllSelected);
+            }
+        }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/PathSelectItem.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/PathSelectItem.cs
@@ -112,6 +112,26 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         public ComputeClause ComputeOption { get; internal set; }
 
+
+        /// <summary>
+        /// Returns whether or not the path select item has any options applied
+        /// </summary>
+        public bool HasOptions
+        {
+            get
+            {
+                return
+                    FilterOption != null ||
+                    ComputeOption != null ||
+                    SearchOption != null ||
+                    TopOption != null ||
+                    SkipOption != null ||
+                    CountOption != null ||
+                    OrderByOption != null ||
+                    (SelectAndExpand != null && !SelectAndExpand.AllSelected);
+            }
+        }
+
         /// <summary>
         /// Translate using a <see cref="SelectItemTranslator{T}"/>.
         /// </summary>
@@ -132,25 +152,6 @@ namespace Microsoft.OData.UriParser
         public override void HandleWith(SelectItemHandler handler)
         {
             handler.Handle(this);
-        }
-
-        /// <summary>
-        /// Returns whether or not the path select item has any options applied
-        /// </summary>
-        internal bool HasOptions
-        {
-            get
-            {
-                return
-                    FilterOption != null ||
-                    ComputeOption != null ||
-                    SearchOption != null ||
-                    TopOption != null ||
-                    SkipOption != null ||
-                    CountOption != null ||
-                    OrderByOption != null ||
-                    (SelectAndExpand != null && !SelectAndExpand.AllSelected);
-            }
         }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/SelectTermToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/SelectTermToken.cs
@@ -49,6 +49,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="countQueryOption">the query count option for this select term</param>
         /// <param name="searchOption">the search option for this select term</param>
         /// <param name="selectOption">the select option for this select term</param>
+        /// <param name="computeOption">the compute option for this select term</param>
         public SelectTermToken(PathSegmentToken pathToProperty,
             QueryToken filterOption, IEnumerable<OrderByToken> orderByOptions, long? topOption, long? skipOption, bool? countQueryOption, QueryToken searchOption, SelectToken selectOption, ComputeToken computeOption)
             : base(pathToProperty, filterOption, orderByOptions, topOption, skipOption, countQueryOption, searchOption, selectOption, computeOption)

--- a/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
@@ -507,6 +507,7 @@ namespace Microsoft.OData.UriParser
                 {
                     return false;
                 }
+
                 // for structured types, use IsAssignableFrom
                 return EdmLibraryExtensions.IsAssignableFrom(
                     (IEdmStructuredType)targetReference.Definition,

--- a/src/Microsoft.Spatial/Microsoft.Spatial.csproj
+++ b/src/Microsoft.Spatial/Microsoft.Spatial.csproj
@@ -163,7 +163,6 @@
       <DependentUpon>Microsoft.Spatial.tt</DependentUpon>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
-    <None Include="packages.config" />
     <None Include="Parameterized.Microsoft.Spatial.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Parameterized.Microsoft.Spatial.cs</LastGenOutput>
@@ -177,14 +176,6 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-  </ItemGroup>
-  <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\MSTest.TestFramework.2.0.0\lib\netstandard1.0\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\sln\packages\MSTest.TestFramework.2.0.0\lib\netstandard1.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <Import Project="$(BuildExtensionsPath)\Portable.targets" />
 </Project>

--- a/src/Microsoft.Spatial/Microsoft.Spatial.csproj
+++ b/src/Microsoft.Spatial/Microsoft.Spatial.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyName>Microsoft.Spatial</AssemblyName>
@@ -163,6 +163,7 @@
       <DependentUpon>Microsoft.Spatial.tt</DependentUpon>
       <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
+    <None Include="packages.config" />
     <None Include="Parameterized.Microsoft.Spatial.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Parameterized.Microsoft.Spatial.cs</LastGenOutput>
@@ -176,6 +177,14 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\MSTest.TestFramework.2.0.0\lib\netstandard1.0\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\sln\packages\MSTest.TestFramework.2.0.0\lib\netstandard1.0\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(BuildExtensionsPath)\Portable.targets" />
 </Project>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
@@ -25,6 +25,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var baseNavigation1 = this.baseType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "Navigation1", Target = this.baseType, TargetMultiplicity = EdmMultiplicity.ZeroOrOne });
             var baseNavigation2 = this.baseType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "Navigation2", Target = this.baseType, TargetMultiplicity = EdmMultiplicity.ZeroOrOne });
 
+            var addressType = new EdmComplexType("FQ.NS", "Address");
+            addressType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
+            addressType.AddStructuralProperty("Region", EdmPrimitiveTypeKind.String);
+            addressType.AddStructuralProperty("NearestAirports", new EdmCollectionTypeReference(new EdmCollectionType(new EdmComplexTypeReference(addressType, false))));
+            addressType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "Residents", Target = this.baseType, TargetMultiplicity = EdmMultiplicity.Many });
+
+            this.baseType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, false));
+
             this.derivedType = new EdmEntityType("FQ.NS", "Derived", this.baseType);
             this.derivedType.AddStructuralProperty("Derived", EdmPrimitiveTypeKind.Int32);
             var derivedNavigation = this.derivedType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "DerivedNavigation", Target = this.derivedType, TargetMultiplicity = EdmMultiplicity.ZeroOrOne });
@@ -168,12 +176,107 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
-        public void SelectDuplicatePropertyThrows()
+        public void SelectDuplicatePropertySucceeds()
         {
-            const string selectClauseText = "Id,Id";
-            const string expectedSelectClauseText = "Id";
-            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: expectedSelectClauseText, expectedExpandClauseFromOM: null);
-            test.Throws<ODataException>("Found mutliple select terms with same select path 'Id' at one $select, please combine them together.");
+            const string selectClauseText = "Address,Address";
+            const string expectedSelectClauseText = "Address";
+            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: expectedSelectClauseText, expectedExpandClauseFromOM: null);
+        }
+
+        [Fact]
+        public void SelectAndExpandOnComplexIncludesBoth()
+        {
+            const string selectClauseText = "Address/City";
+            const string expandClauseText = "Address/Residents";
+            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: expandClauseText, expectedSelectClauseFromOM: selectClauseText, expectedExpandClauseFromOM: expandClauseText);
+        }
+
+
+        [Fact]
+        public void MultipleSelectPathsSucceed()
+        {
+            const string selectClauseText = "Address/City,Address/Region";
+            this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: selectClauseText, expectedExpandClauseFromOM: null);
+        }
+
+        [Fact]
+        public void SelectDuplicatePropertyWithOptionsFails()
+        {
+            const string selectClauseText = "Address($select=City),Address($select=Region)";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'Address' at one $select, please combine them together.");
+        }
+
+        [Fact(Skip = "Currently succeeds with extra top-level 'Address' node due to known issue.")]
+        public void DifferentPathsToSamePropertyFails()
+        {
+            const string selectClauseText = "Address($select=NearestAirports),Address/NearestAirports";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'Address/NearestAirports' at one $select, please combine them together.");
+        }
+
+        [Fact(Skip = "Currently succeeds with extra top-level 'Address' node due to known issue.")]
+        public void DifferentPathsToSamePropertyWithOptionsFails()
+        {
+            const string selectClauseText = "Address($select=NearestAirports($top=2)),Address/NearestAirports";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'Address/NearestAirports' at one $select, please combine them together.");
+        }
+
+        [Fact(Skip = "Currently succeeds with extra top-level 'Address' node due to known issue.")]
+        public void DifferentPathsToSamePropertyWithOptionsOnBothFails()
+        {
+            const string selectClauseText = "Address($select=NearestAirports($top=2)),Address/NearestAirports($skip=2)";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'Address/NearestAirports' at one $select, please combine them together.");
+        }
+
+        [Fact(Skip = "Currently succeeds with extra top-level 'Address' node due to known issue.")]
+        public void DifferentPathsToSamePropertyWithSubselectsOnBothFails()
+        {
+            const string selectClauseText = "Address($select=NearestAirports($select=City)),Address/NearestAirports($select=Region)";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'Address/NearestAirports' at one $select, please combine them together.");
+        }
+
+        [Fact]
+        public void SelectDuplicatePropertyWithOptionsFirstFails()
+        {
+            const string selectClauseText = "Address($select=City),Address";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'Address' at one $select, please combine them together.");
+        }
+
+        [Fact]
+        public void SelectDuplicatePropertyWithOptionsLastFails()
+        {
+            const string selectClauseText = "Address,Address($select=City)";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'Address' at one $select, please combine them together.");
+        }
+
+        [Fact]
+        public void SelectDuplicatePropertyWithSubselectAndOptionsFails()
+        {
+            const string selectClauseText = "Address/NearestAirports($select=City),Address/NearestAirports($top=2)";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'Address/NearestAirports' at one $select, please combine them together.");
+        }
+
+        [Fact]
+        public void SelectDuplicatePropertyWithTopFails()
+        {
+            const string selectClauseText = "Address/NearestAirports($top=2),Address/NearestAirports";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'Address/NearestAirports' at one $select, please combine them together.");
+        }
+
+        [Fact]
+        public void DuplicateDeepSelectOptionsFails()
+        {
+            const string selectClauseText = "Address($select=NearestAirports($select=City),NearestAirports($select=Region))";
+            System.Action test = () => this.ParseAndExtract(selectClauseText: selectClauseText, expandClauseText: null, expectedSelectClauseFromOM: null, expectedExpandClauseFromOM: null);
+            test.Throws<ODataException>("Found multiple select terms with same select path 'NearestAirports' at one $select, please combine them together.");
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ExpandAndSelectPathExtractingTests.cs
@@ -207,7 +207,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             test.Throws<ODataException>("Found multiple select terms with same select path 'Address' at one $select, please combine them together.");
         }
 
-        [Fact(Skip = "Currently succeeds with extra top-level 'Address' node due to known issue.")]
+        [Fact]
         public void DifferentPathsToSamePropertyFails()
         {
             const string selectClauseText = "Address($select=NearestAirports),Address/NearestAirports";
@@ -215,7 +215,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             test.Throws<ODataException>("Found multiple select terms with same select path 'Address/NearestAirports' at one $select, please combine them together.");
         }
 
-        [Fact(Skip = "Currently succeeds with extra top-level 'Address' node due to known issue.")]
+        [Fact]
         public void DifferentPathsToSamePropertyWithOptionsFails()
         {
             const string selectClauseText = "Address($select=NearestAirports($top=2)),Address/NearestAirports";
@@ -223,7 +223,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             test.Throws<ODataException>("Found multiple select terms with same select path 'Address/NearestAirports' at one $select, please combine them together.");
         }
 
-        [Fact(Skip = "Currently succeeds with extra top-level 'Address' node due to known issue.")]
+        [Fact]
         public void DifferentPathsToSamePropertyWithOptionsOnBothFails()
         {
             const string selectClauseText = "Address($select=NearestAirports($top=2)),Address/NearestAirports($skip=2)";
@@ -231,7 +231,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             test.Throws<ODataException>("Found multiple select terms with same select path 'Address/NearestAirports' at one $select, please combine them together.");
         }
 
-        [Fact(Skip = "Currently succeeds with extra top-level 'Address' node due to known issue.")]
+        [Fact]
         public void DifferentPathsToSamePropertyWithSubselectsOnBothFails()
         {
             const string selectClauseText = "Address($select=NearestAirports($select=City)),Address/NearestAirports($select=Region)";

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -1208,13 +1208,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
-        public void DuplicatePropertiesThrows()
+        public void DuplicatePropertiesWithNoOptionsReturnsSingle()
         {
             const string expandClauseText = "";
             const string selectClauseText = "Name, Name";
+            const string expectedSelect = "Name";
 
-            Action test = () => RunParseSelectExpand(selectClauseText, expandClauseText, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
-            test.Throws<ODataException>("Found mutliple select terms with same select path 'Name' at one $select, please combine them together.");
+            var results = RunParseSelectExpand(selectClauseText, expandClauseText, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            AssertSelectString(expectedSelect, results);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/SelectTreeNormalizerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/SelectTreeNormalizerTests.cs
@@ -71,48 +71,5 @@ namespace Microsoft.OData.Tests.UriParser.Binders
                 .NextToken.ShouldBeNonSystemToken("6");
             Assert.Equal("4/5/6", tokens[1].ToPathString());
         }
-
-        [Fact]
-        public void NormalizeSelectTreeThrowsForMultipleTermsWithSameSelectPath()
-        {
-            // Arrange: $select=1($count=true), 1($count=false)
-            List<SelectTermToken> selectTerms = new List<SelectTermToken>();
-            selectTerms.Add(new SelectTermToken(new NonSystemToken("1", /*namedValues*/null, /*nextToken*/null),
-                null, null, null, null, true, null, null, null));
-
-            selectTerms.Add(new SelectTermToken(new NonSystemToken("1", /*namedValues*/null, /*nextToken*/null),
-                null, null, null, null, false, null, null, null));
-
-            SelectToken select = new SelectToken(selectTerms);
-
-            // Act
-            Action test = () => SelectTreeNormalizer.NormalizeSelectTree(select);
-
-            // Assert
-            ODataException exception = Assert.Throws<ODataException>(test);
-            Assert.Equal("Found mutliple select terms with same select path '1' at one $select, please combine them together.", exception.Message);
-        }
-
-        [Fact]
-        public void NormalizeSelectTreeThrowsForMultipleSelectTermsInDeepLevel()
-        {
-            // Arrange: $select=1($select=2($top=5),2($count=true))
-            List<SelectTermToken> selectTerms = new List<SelectTermToken>();
-            selectTerms.Add(new SelectTermToken(new NonSystemToken("1", /*namedValues*/null, /*nextToken*/null),
-                new SelectToken(new List<SelectTermToken>()
-                {
-                    new SelectTermToken(new NonSystemToken("2", null, null), null, null, 5, null, null, null, null, null),
-                    new SelectTermToken(new NonSystemToken("2", null, null), null, null, null, null, true, null, null, null)
-                })));
-
-            SelectToken select = new SelectToken(selectTerms);
-
-            // Act
-            Action test = () => SelectTreeNormalizer.NormalizeSelectTree(select);
-
-            // Assert
-            ODataException exception = Assert.Throws<ODataException>(test);
-            Assert.Equal("Found mutliple select terms with same select path '2' at one $select, please combine them together.", exception.Message);
-        }
     }
 }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -6964,6 +6964,7 @@ public sealed class Microsoft.OData.UriParser.PathSelectItem : Microsoft.OData.U
 	Microsoft.OData.UriParser.ComputeClause ComputeOption  { public get; }
 	System.Nullable`1[[System.Boolean]] CountOption  { public get; }
 	Microsoft.OData.UriParser.FilterClause FilterOption  { public get; }
+	bool HasOptions  { public get; }
 	Microsoft.OData.Edm.IEdmNavigationSource NavigationSource  { public get; }
 	Microsoft.OData.UriParser.OrderByClause OrderByOption  { public get; }
 	Microsoft.OData.UriParser.SearchClause SearchOption  { public get; }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This PR allows multiple select paths to the same property if there are no query options

### Description

When we implemented select options, we disallowed multiple select paths in the select list to the same property. This was a breaking change. This change allows multiple select paths to the same property as long as none of the instances of that property contain any select options.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

Four added tests are disabled due to a known issue--selecting properties of a complex type include that complex type in the select list.  Once that issue is resolved, the two disabled tests can be re-enabled.