### PR TITLE
Fixes for Csdl.GetNamespaceAlias extension method.

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/SerializationExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/Csdl/SerializationExtensionMethods.cs
@@ -272,7 +272,8 @@ namespace Microsoft.OData.Edm.Csdl
         {
             EdmUtil.CheckArgumentNull(model, "model");
             VersioningDictionary<string, string> mappings = model.GetAnnotationValue<VersioningDictionary<string, string>>(model, EdmConstants.InternalUri, CsdlConstants.NamespaceAliasAnnotation);
-            if (mappings != null && mappings.TryGetValue(namespaceName, out string namespaceAlias))
+            string namespaceAlias;
+            if (mappings != null && mappings.TryGetValue(namespaceName, out namespaceAlias))
             {
                 return namespaceAlias;
             }

--- a/src/Microsoft.OData.Edm/Csdl/SerializationExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/Csdl/SerializationExtensionMethods.cs
@@ -270,8 +270,14 @@ namespace Microsoft.OData.Edm.Csdl
         /// <returns>The alias of the given namespace, or null if one does not exist.</returns>
         public static string GetNamespaceAlias(this IEdmModel model, string namespaceName)
         {
+            EdmUtil.CheckArgumentNull(model, "model");
             VersioningDictionary<string, string> mappings = model.GetAnnotationValue<VersioningDictionary<string, string>>(model, EdmConstants.InternalUri, CsdlConstants.NamespaceAliasAnnotation);
-            return mappings.Get(namespaceName);
+            if (mappings != null && mappings.TryGetValue(namespaceName, out string namespaceAlias))
+            {
+                return namespaceAlias;
+            }
+
+            return null;
         }
 
         // This internal method exists so we can get a consistent view of the mappings through the entire serialization process.

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -950,6 +950,13 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
             Assert.Null(model.GetNamespaceAlias("SomeNamespace"));
         }
 
+        [Fact]
+        public void GetNamespaceAliasForNamespaceWithAlias()
+        {
+            Assert.Equal(TestModel.TestModelAlias, TestModel.Instance.Model.GetNamespaceAlias(TestModel.TestModelNameSpace));
+            Assert.Equal(TestModel.TestModelAlias2, TestModel.Instance.Model.GetNamespaceAlias(TestModel.TestModelNameSpace2));
+        }
+        
         internal class TestModel
         {
             public static TestModel Instance = new TestModel();

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -937,6 +937,19 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
             Assert.Null(unknownType);
         }
 
+        [Fact]
+        public void GetNamespaceAliasReturnsNullForNamespaceWithoutAlias()
+        {
+            Assert.Null(TestModel.Instance.Model.GetNamespaceAlias("SomeNamespace.NotIn.Model"));
+        }
+
+        [Fact]
+        public void GetNamespaceAliasReturnsNullForModelsWithoutAliases()
+        {
+            EdmModel model = new EdmModel(false);
+            Assert.Null(model.GetNamespaceAlias("SomeNamespace"));
+        }
+
         internal class TestModel
         {
             public static TestModel Instance = new TestModel();


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1587 .

### Description

- GetNamespace now returns null if the namespace doesn't have an alias, as advertised in the documentation (the actual behavior was to throw a KeyNotFoundException instead, as it was calling VersioningDictionary.Get).
- GetNamespace now returns null if the model doesn't define any alias (the actual behavior was to throw NullReferenceException, as GetAnnotationValue returned null and it wasn't checked).

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
