### PR TITLE
Support the namespace alias for operation in Uri parser

### DIFF
--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -107,12 +107,14 @@ namespace Microsoft.OData.Edm
             EdmUtil.CheckArgumentNull(qualifiedName, "qualifiedName");
             EdmUtil.CheckArgumentNull(bindingType, "bindingType");
 
+            string fullyQualifiedName = model.ReplaceAlias(qualifiedName);
+
             // the below is a copy of FindAcrossModels method but Func<IEdmModel, TInput, T> finder is replaced by FindDeclaredBoundOperations.
-            IEnumerable<IEdmOperation> candidate = model.FindDeclaredBoundOperations(qualifiedName, bindingType);
+            IEnumerable<IEdmOperation> candidate = model.FindDeclaredBoundOperations(fullyQualifiedName, bindingType);
 
             foreach (IEdmModel reference in model.ReferencedModels)
             {
-                IEnumerable<IEdmOperation> fromReference = reference.FindDeclaredBoundOperations(qualifiedName, bindingType);
+                IEnumerable<IEdmOperation> fromReference = reference.FindDeclaredBoundOperations(fullyQualifiedName, bindingType);
                 if (fromReference != null)
                 {
                     candidate = candidate == null ? fromReference : mergeFunctions(candidate, fromReference);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTests.cs
@@ -427,10 +427,12 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
         #endregion
 
-        [Fact]
-        public void ActionShouldWork()
+        [Theory]
+        [InlineData("Fully.Qualified.Namespace.Walk")]
+        [InlineData("MainAlias.Walk")]
+        public void ActionShouldWork(string actionSegment)
         {
-            IList<ODataPathSegment> path = this.testSubject.ParsePath(new[] { "Dogs(1)", "Fully.Qualified.Namespace.Walk" });
+            IList<ODataPathSegment> path = this.testSubject.ParsePath(new[] { "Dogs(1)", actionSegment });
             path[2].ShouldBeOperationSegment(HardCodedTestModel.GetDogWalkAction());
         }
 
@@ -652,10 +654,12 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             path[1].ShouldBeCountSegment();
         }
 
-        [Fact]
-        public void ParseCountAfterBoundFunctionReturnsCollectionOfPrimitiveShouldWork()
+        [Theory]
+        [InlineData("Fully.Qualified.Namespace.GetPriorAddresses")]
+        [InlineData("MainAlias.GetPriorAddresses")]
+        public void ParseCountAfterBoundFunctionReturnsCollectionOfPrimitiveShouldWork(string functionSegment)
         {
-            IList<ODataPathSegment> path = this.testSubject.ParsePath(new[] { "People(1)", "Fully.Qualified.Namespace.GetPriorAddresses", "$count" });
+            IList<ODataPathSegment> path = this.testSubject.ParsePath(new[] { "People(1)", functionSegment, "$count" });
             Assert.Equal(4, path.Count);
             path[0].ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
             path[1].ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 1));

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -937,6 +937,26 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
             Assert.Null(unknownType);
         }
 
+        [Theory]
+        [InlineData("TestModelNameSpace.MyFunction")]
+        [InlineData("TestModelAlias.MyFunction")]
+        public void FindBoundFunctionByNamespaceAndAlias(string operation)
+        {
+            var operations = TestModel.Instance.Model.FindBoundOperations(operation, TestModel.Instance.T1);
+            var foundOperation = Assert.Single(operations);
+            Assert.Equal("TestModelNameSpace.MyFunction", foundOperation.FullName());
+        }
+
+        [Theory]
+        [InlineData("TestModelNameSpace.MyAction")]
+        [InlineData("TestModelAlias.MyAction")]
+        public void FindBoundActionByNamespaceAndAlias(string operation)
+        {
+            var operations = TestModel.Instance.Model.FindBoundOperations(operation, TestModel.Instance.T1);
+            var foundOperation = Assert.Single(operations);
+            Assert.Equal("TestModelNameSpace.MyAction", foundOperation.FullName());
+        }
+
         [Fact]
         public void GetNamespaceAliasReturnsNullForNamespaceWithoutAlias()
         {
@@ -982,6 +1002,14 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
                 this.Model.AddElement(this.T2);
 
                 this.Model.AddElement(new EdmEnumType(TestModelNameSpace2, "E1"));
+
+                var function = new EdmFunction(TestModelNameSpace, "MyFunction", EdmCoreModel.Instance.GetBoolean(false), true, null, false);
+                function.AddParameter("entity", new EdmEntityTypeReference(this.T1, true));
+                this.Model.AddElement(function);
+
+                var action = new EdmAction(TestModelNameSpace, "MyAction", null, true, null);
+                action.AddParameter("entity", new EdmEntityTypeReference(this.T1, true));
+                this.Model.AddElement(action);
 
                 this.functionImport = new EdmFunction(TestModelNameSpace, "Function1", new EdmEntityTypeReference(this.T1, true));
                 this.functionImport.AddParameter("id", EdmCoreModel.Instance.GetInt32(false));


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This PR is related to issue #1594. Thanks.

### Description

This PR is to enable the namespace alias for operation in the Uri parser.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
