### PR TITLE
Fix the error in the odata client generated by odata code generator due to malformed temp metadata file.

### DIFF
--- a/src/CodeGen/ODataT4CodeGenerator.cs
+++ b/src/CodeGen/ODataT4CodeGenerator.cs
@@ -1505,6 +1505,8 @@ public abstract class ODataClientTemplate : TemplateBase
     internal void WriteEntityContainer(IEdmEntityContainer container, string fullNamespace)
     {
         string camelCaseContainerName = container.Name;
+        string path = this.context.TempFilePath;
+        bool useTempFile = !String.IsNullOrEmpty(path);
         if (this.context.EnableNamingAlias)
         {
             camelCaseContainerName = Customization.CustomizeNaming(camelCaseContainerName);
@@ -1579,9 +1581,16 @@ public abstract class ODataClientTemplate : TemplateBase
                 edmNavigationSourceList.Add(singleton);
             }
         }
-
-        this.WriteGeneratedEdmModel(Utils.SerializeToString(this.context.Edmx).Replace("\"", "\"\""));
-        
+    
+        if(useTempFile) 
+        {
+            this.WriteGeneratedEdmModel(Utils.SerializeToString(this.context.Edmx));
+        }
+        else
+        {
+            this.WriteGeneratedEdmModel(Utils.SerializeToString(this.context.Edmx).Replace("\"", "\"\""));
+        }
+         
         bool hasOperationImport = container.OperationImports().OfType<IEdmOperationImport>().Any();
         foreach (IEdmFunctionImport functionImport in container.OperationImports().OfType<IEdmFunctionImport>())
         {
@@ -3757,12 +3766,10 @@ this.Write(");\r\n        }\r\n");
 
     internal override void WriteGeneratedEdmModel(string escapedEdmxString)
     {
-
-        string path = this.context.TempFilePath; 
-        
+        string path = this.context.TempFilePath;
         if (!String.IsNullOrEmpty(path))
         {
-            using (StreamWriter writer = new StreamWriter(path, true))
+            using (StreamWriter writer = new StreamWriter(path, false))
             {
                 writer.WriteLine(escapedEdmxString);
             }

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -1397,6 +1397,8 @@ public abstract class ODataClientTemplate : TemplateBase
     internal void WriteEntityContainer(IEdmEntityContainer container, string fullNamespace)
     {
         string camelCaseContainerName = container.Name;
+        string path = this.context.TempFilePath;
+        bool useTempFile = !String.IsNullOrEmpty(path);
         if (this.context.EnableNamingAlias)
         {
             camelCaseContainerName = Customization.CustomizeNaming(camelCaseContainerName);
@@ -1471,9 +1473,16 @@ public abstract class ODataClientTemplate : TemplateBase
                 edmNavigationSourceList.Add(singleton);
             }
         }
-
-        this.WriteGeneratedEdmModel(Utils.SerializeToString(this.context.Edmx).Replace("\"", "\"\""));
-        
+    
+        if(useTempFile) 
+        {
+            this.WriteGeneratedEdmModel(Utils.SerializeToString(this.context.Edmx));
+        }
+        else
+        {
+            this.WriteGeneratedEdmModel(Utils.SerializeToString(this.context.Edmx).Replace("\"", "\"\""));
+        }
+         
         bool hasOperationImport = container.OperationImports().OfType<IEdmOperationImport>().Any();
         foreach (IEdmFunctionImport functionImport in container.OperationImports().OfType<IEdmFunctionImport>())
         {
@@ -3444,12 +3453,10 @@ namespace <#= fullNamespace #>
 
     internal override void WriteGeneratedEdmModel(string escapedEdmxString)
     {
-
-        string path = this.context.TempFilePath; 
-        
+        string path = this.context.TempFilePath;
         if (!String.IsNullOrEmpty(path))
         {
-            using (StreamWriter writer = new StreamWriter(path, true))
+            using (StreamWriter writer = new StreamWriter(path, false))
             {
                 writer.WriteLine(escapedEdmxString);
             }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTestDescriptors.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTestDescriptors.cs
@@ -12,6 +12,9 @@ using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
 using FluentAssertions;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
 
 namespace Microsoft.OData.Client.Design.T4.UnitTests
 {
@@ -44,6 +47,26 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
             /// A custom verification action to perform. Takes in the generated code and runs asserts that the code was generated properly. A verification function provided here should be valid for both CodeGen using the Design DLL and T4.
             /// </summary>
             public Action<string, bool, bool> Verify { get; set; }
+        }
+
+        internal static void ValidateXMLFile(string tempFilePath)
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.Load(tempFilePath);
+        }
+
+        internal static void ValidateEdmx(string tempFilePath)
+        {
+            string edmx = File.ReadAllText(tempFilePath);
+            using (var stringReader = new StringReader(edmx)) {
+                using (var xmlReader = XmlReader.Create(stringReader)) {
+                    IEdmModel edmModel = null;
+                    IEnumerable<EdmError> edmErrors = null;
+                    CsdlReader.TryParse(xmlReader, out edmModel, out edmErrors);
+                    edmErrors.Should().BeEmpty();
+                } ;
+            } ;
+          
         }
 
         private static void VerifyGeneratedCode(string actualCode, Dictionary<string, string> expectedCode, bool isCSharp, bool useDSC, string key = null)

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataT4CodeGeneratorTests.cs
@@ -34,6 +34,7 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
         private static string T4TransformToolPath;
         private static string T4TemplatePath;
         private static string T4IncludeTemplatePath;
+        private static string TempFilePath;
 
         [TestInitialize]
         public void Init()
@@ -390,6 +391,18 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
             ODataT4CodeGeneratorTestDescriptors.AbstractEntityTypeWithoutKey.Verify(code, false/*isCSharp*/, false/*useDSC*/);
         }
 
+        [TestMethod]
+        public void CodeGenUsingTempMetadataFileTest()
+        {
+            TempFilePath = "tempMetadata.xml";
+            File.Delete(TempFilePath);
+            CodeGenWithT4Template(ODataT4CodeGeneratorTestDescriptors.AbstractEntityTypeWithoutKey.Metadata, null, true, true, false, false, null, true);
+            Action action = () => ODataT4CodeGeneratorTestDescriptors.ValidateXMLFile(TempFilePath);
+            action.ShouldNotThrow<XmlException>();
+
+            ODataT4CodeGeneratorTestDescriptors.ValidateEdmx(TempFilePath);
+        }
+
         private static string CodeGenWithT4Template(string edmx, string namespacePrefix, bool isCSharp, bool useDataServiceCollection, bool enableNamingAlias = false, bool ignoreUnexpectedElementsAndAttributes = false, Func<Uri, XmlReader> getReferencedModelReaderFunc = null, bool appendDSCSuffix = false)
         {
             if (useDataServiceCollection
@@ -415,6 +428,11 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
                 EnableNamingAlias = enableNamingAlias,
                 IgnoreUnexpectedElementsAndAttributes = ignoreUnexpectedElementsAndAttributes
             };
+
+            if(!String.IsNullOrEmpty(TempFilePath))
+            {
+                t4CodeGenerator.TempFilePath = TempFilePath;
+            }
 
             if (useDataServiceCollection)
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1475.*

### Description

*The change removes the double ""  in the temp metadata file which is created during code generation using the Odata code generator tool. These quotes caused an error while trying to instantiate the resource class.
The change also enables one to overwrite the metadata file instead of appending everytime you try to run the code generator*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
