### PR TITLE
Perf improvements in FunctionOverloadResolver

### DIFF
--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -8,6 +8,7 @@ namespace Microsoft.OData.Metadata
 {
     #region Namespaces
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
@@ -25,6 +26,7 @@ namespace Microsoft.OData.Metadata
 #endif
 #if !ODATA_SERVICE && !ODATA_CLIENT
     using Microsoft.OData.JsonLight;
+    using Microsoft.OData.UriParser;
     using ErrorStrings = Microsoft.OData.Strings;
     using PlatformHelper = Microsoft.OData.PlatformHelper;
 #endif
@@ -252,17 +254,117 @@ namespace Microsoft.OData.Metadata
         }
 
         /// <summary>
-        /// Filters the operations by parameter names.
+        /// Filters the operations by parameter count.
         /// </summary>
-        /// <param name="functions">The operations.</param>
-        /// <param name="parameters">The list of non-binding parameter names to match.</param>
-        /// <param name="caseInsensitive">Whether case insensitive.</param>
+        /// <param name="operations">The operations.</param>
+        /// <param name="parameterCount">The count of non-binding parameter names to match.</param>
         /// <returns>The best matching operations based on parameters.</returns>
-        internal static IEnumerable<IEdmOperation> FindBestOverloadBasedOnParameters(this IEnumerable<IEdmOperation> functions, IEnumerable<string> parameters, bool caseInsensitive = false)
+        internal static IEnumerable<IEdmOperation> FilterOverloadsBasedOnParameterCount(this IEnumerable<IEdmOperation> operations, int parameterCount)
         {
             // The best match out of a list of candidates is the one that has the same number of (non-binding) parameters as specified.
-            IEnumerable<IEdmOperation> exactMatches = functions.Where(f => f.Parameters.Count() == parameters.Count() + (f.IsBound ? 1 : 0));
-            return exactMatches.Count() > 0 ? exactMatches : functions;
+            IEnumerable<IEdmOperation> exactMatches = operations.Where(f => f.Parameters.Count() == parameterCount + (f.IsBound ? 1 : 0));
+            return exactMatches.Count() > 0 ? exactMatches : operations;
+        }
+
+        /// <summary>
+        /// Filters the operations by parameter count.
+        /// </summary>
+        /// <param name="operations">The operations.</param>
+        /// <param name="parameterCount">The count of non-binding parameter names to match.</param>
+        /// <returns>The best matching operations based on parameters.</returns>
+        internal static IList<IEdmOperation> FilterOverloadsBasedOnParameterCount(this IList<IEdmOperation> operations, int parameterCount)
+        {
+            IList<IEdmOperation> exactMatches = null;
+
+            // The best match out of a list of candidates is the one that has the same number of (non-binding) parameters as specified.
+            for (int i = 0; i < operations.Count; i++)
+            {
+                if (operations[i].Parameters.Count() == parameterCount + (operations[i].IsBound ? 1 : 0))
+                {
+                    if (exactMatches == null)
+                    {
+                        exactMatches = new List<IEdmOperation>();
+                    }
+
+                    exactMatches.Add(operations[i]);
+                }
+            }
+
+            return exactMatches == null ? operations : exactMatches;
+        }
+
+        /// <summary>
+        /// Filters the operations candidates based on parameters.
+        /// </summary>
+        /// <param name="operations">The operations.</param>
+        /// <param name="bindingType">Binding type for the operation.</param>
+        /// <param name="parameterNameList">The parameters.</param>
+        /// <param name="caseInsensitive">Whether case insensitive.</param>
+        /// <param name="actionItems">outputs the actions found while matching functions</param>
+        /// <returns>Operations filtered by parameter.</returns>
+        internal static IList<IEdmOperation> FilterOperationCandidatesBasedOnParameterList(this IEnumerable<IEdmOperation> operations, IEdmType bindingType, IList<string> parameterNameList, bool caseInsensitive, out bool actionItemsExists)
+        {
+            Debug.Assert(operations != null, "operations");
+            Debug.Assert(parameterNameList != null, "parameters");
+
+            bool hasParameters = parameterNameList.Count > 0;
+            actionItemsExists = false;
+            IList<IEdmOperation> operationCandidates = new List<IEdmOperation>();
+
+            foreach (var operation in operations)
+            {
+                Debug.Assert(bindingType == null || (bindingType != null && operation.IsBound && operation.Parameters.Any()));
+                bool suitableCandidate = true;
+
+                // If the number of parameters specified in the url is > 0 then we should only keep functions as actions can't have parameters on the uri, only in the payload. Filter further by parameters in this case, otherwise don't.
+                if (hasParameters)
+                {
+                    if (operation.IsAction())
+                    {
+                        actionItemsExists = true;
+                        suitableCandidate = false;
+                    }
+                    else if (!ParametersSatisfyFunction(operation, parameterNameList, caseInsensitive))
+                    {
+                        suitableCandidate = false;
+                    }
+                }
+                else
+                {
+                    // If it is a bound function without required parameters, then the parameter list should only have one parameter and any others as optional.
+                    if (operation.IsFunction())
+                    {
+                        // Binding type requires atleast one parameter for a function. 
+                        bool parameterFound = bindingType != null ? false : true;
+                        foreach (IEdmOperationParameter param in operation.Parameters)
+                        {
+                            // If multiple required parameters found then mark as unsuitable. 
+                            bool isParamOptional = param is IEdmOptionalParameter;
+                            if (parameterFound && !(isParamOptional))
+                            {
+                                suitableCandidate = false;
+                                break;
+                            }
+                            else if (!(isParamOptional))
+                            {
+                                parameterFound = true;
+                            }
+                        }
+
+                        if (!parameterFound)
+                        {
+                            suitableCandidate = false;
+                        }
+                    }
+                }
+
+                if (suitableCandidate)
+                {
+                    operationCandidates.Add(operation);
+                }
+            }
+
+            return operationCandidates;
         }
 
         /// <summary>
@@ -292,22 +394,38 @@ namespace Microsoft.OData.Metadata
         }
 
         /// <summary>
+        /// Filters the operations by parameter names.
+        /// </summary>
+        /// <param name="operations">The operations.</param>
+        /// <param name="parameterNameList">The parameters.</param>
+        /// <param name="caseInsensitive">Whether case insensitive.</param>
+        /// <returns>Operations filtered by parameter.</returns>
+        internal static IEnumerable<IEdmOperation> FilterOperationsByParameterNames(this IList<IEdmOperation> operations, IList<string> parameterNameList, bool caseInsensitive)
+        {
+            Debug.Assert(operations != null, "operations");
+            Debug.Assert(parameterNameList != null, "parameters");
+
+            // TODO: update code that is duplicate between operation and operation import, add more tests.
+            for (int i = 0; i < operations.Count; i++)
+            {
+                if (!ParametersSatisfyFunction(operations[i], parameterNameList, caseInsensitive))
+                {
+                    continue;
+                }
+
+                yield return operations[i];
+            }
+        }
+
+        /// <summary>
         /// Ensures that operations are bound and have a binding parameter, other wise throws an exception.
         /// </summary>
         /// <param name="operations">The operations.</param>
         internal static void EnsureOperationsBoundWithBindingParameter(this IEnumerable<IEdmOperation> operations)
         {
-            foreach (IEdmOperation operation in operations)
+            foreach (var operation in operations)
             {
-                if (!operation.IsBound)
-                {
-                    throw new ODataException(ErrorStrings.EdmLibraryExtensions_UnBoundOperationsFoundFromIEdmModelFindMethodIsInvalid(operation.Name));
-                }
-
-                if (operation.Parameters.FirstOrDefault() == null)
-                {
-                    throw new ODataException(ErrorStrings.EdmLibraryExtensions_NoParameterBoundOperationsFoundFromIEdmModelFindMethodIsInvalid(operation.Name));
-                }
+                operation.EnsureOperationBoundWithBindingParameter();
             }
         }
 
@@ -427,32 +545,6 @@ namespace Microsoft.OData.Metadata
             Debug.Assert(operationImport != null, "operationImport != null");
 
             return operationImport.FullName() + operationImport.ParameterTypesToString();
-        }
-
-        /// <summary>
-        /// Removes the actions.
-        /// </summary>
-        /// <param name="source">The source.</param>
-        /// <param name="actionItems">The action items.</param>
-        /// <returns>Only the functions from the operation sequence.</returns>
-        internal static IEnumerable<IEdmOperation> RemoveActions(this IEnumerable<IEdmOperation> source, out IList<IEdmOperation> actionItems)
-        {
-            List<IEdmOperation> functions = new List<IEdmOperation>();
-
-            actionItems = new List<IEdmOperation>();
-            foreach (var item in source)
-            {
-                if (item.IsAction())
-                {
-                    actionItems.Add(item);
-                }
-                else
-                {
-                    functions.Add(item);
-                }
-            }
-
-            return functions;
         }
 
         /// <summary>
@@ -1826,23 +1918,33 @@ namespace Microsoft.OData.Metadata
                 parametersToMatch = parametersToMatch.Skip(1);
             }
 
-            List<IEdmOperationParameter> functionParameters = parametersToMatch.ToList();
-
             // if any required parameters are missing, don't consider it a match.
-            if (functionParameters.Where(
-                p => !(p is IEdmOptionalParameter)).Any(
-                    p => parameterNameList.All(
-                        k => !string.Equals(k, p.Name, caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))))
+            BitArray matchedUrlParameters = new BitArray(parameterNameList.Count);
+            foreach (var functionParameter in parametersToMatch)
             {
-                return false;
+                bool matched = false;
+                for (int j = 0; j < parameterNameList.Count; j++)
+                {
+                    if (string.Equals(parameterNameList[j], functionParameter.Name, caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                    {
+                        matched = true;
+                        matchedUrlParameters[j] = true;
+                    }
+                }
+
+                if (!matched && !(functionParameter is IEdmOptionalParameter))
+                {
+                    return false;
+                }
             }
 
             // if any specified parameters don't match, don't consider it a match.
-            if (parameterNameList.Any(
-                k => functionParameters.All(
-                    p => !string.Equals(k, p.Name, caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))))
+            for (int i = 0; i < parameterNameList.Count; i++)
             {
-                return false;
+                if (!matchedUrlParameters[i])
+                {
+                    return false;
+                }
             }
 
             return true;
@@ -1867,6 +1969,19 @@ namespace Microsoft.OData.Metadata
             }
 
             return inheritanceLevelsFromBase;
+        }
+
+        private static void EnsureOperationBoundWithBindingParameter(this IEdmOperation operation)
+        {
+            if (!operation.IsBound)
+            {
+                throw new ODataException(ErrorStrings.EdmLibraryExtensions_UnBoundOperationsFoundFromIEdmModelFindMethodIsInvalid(operation.Name));
+            }
+
+            if (!operation.Parameters.Any())
+            {
+                throw new ODataException(ErrorStrings.EdmLibraryExtensions_NoParameterBoundOperationsFoundFromIEdmModelFindMethodIsInvalid(operation.Name));
+            }
         }
 #endif
         #endregion

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectPathSegmentTokenBinder.cs
@@ -186,7 +186,7 @@ namespace Microsoft.OData.UriParser
             // If more than one overload matches, try to select based on optional parameters
             if (possibleFunctions.Count() > 1 && parameterNames.Count > 0)
             {
-                possibleFunctions = possibleFunctions.FindBestOverloadBasedOnParameters(parameterNames);
+                possibleFunctions = possibleFunctions.FilterOverloadsBasedOnParameterCount(parameterNames.Count);
             }
 
             if (!possibleFunctions.HasAny())

--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -99,14 +100,23 @@ namespace Microsoft.OData.UriParser
             }
 
             var result = container.Elements.OfType<IEdmNavigationSource>()
-                .Where(source => string.Equals(identifier, source.Name, StringComparison.OrdinalIgnoreCase)).ToList();
+                .Where(source => string.Equals(identifier, source.Name, StringComparison.OrdinalIgnoreCase));
 
-            if (result.Count > 1)
+            IEdmNavigationSource resolvedNavigationSource = null;
+
+            foreach (IEdmNavigationSource candidate in result)
             {
-                throw new ODataException(Strings.UriParserMetadata_MultipleMatchingNavigationSourcesFound(identifier));
+                if (resolvedNavigationSource == null)
+                {
+                    resolvedNavigationSource = candidate;
+                }
+                else
+                {
+                    throw new ODataException(Strings.UriParserMetadata_MultipleMatchingNavigationSourcesFound(identifier));
+                }
             }
 
-            return result.SingleOrDefault();
+            return resolvedNavigationSource;
         }
 
         /// <summary>
@@ -124,15 +134,23 @@ namespace Microsoft.OData.UriParser
             }
 
             var result = type.Properties()
-            .Where(_ => string.Equals(propertyName, _.Name, StringComparison.OrdinalIgnoreCase))
-            .ToList();
+            .Where(_ => string.Equals(propertyName, _.Name, StringComparison.OrdinalIgnoreCase));
 
-            if (result.Count > 1)
+            IEdmProperty resolvedProperty = null;
+
+            foreach(IEdmProperty candidate in result)
             {
-                throw new ODataException(Strings.UriParserMetadata_MultipleMatchingPropertiesFound(propertyName, type.FullTypeName()));
+                if (resolvedProperty == null)
+                {
+                    resolvedProperty = candidate;
+                }
+                else
+                {
+                    throw new ODataException(Strings.UriParserMetadata_MultipleMatchingPropertiesFound(propertyName, type.FullTypeName()));
+                }
             }
 
-            return result.SingleOrDefault();
+            return resolvedProperty;
         }
 
         /// <summary>
@@ -151,12 +169,17 @@ namespace Microsoft.OData.UriParser
 
             IList<IEdmTerm> results = FindAcrossModels<IEdmTerm>(model, termName, /*caseInsensitive*/ true);
 
+            if (results == null || results.Count == 0)
+            {
+                return null;
+            }
+
             if (results.Count > 1)
             {
                 throw new ODataException(Strings.UriParserMetadata_MultipleMatchingTypesFound(termName));
             }
 
-            return results.SingleOrDefault();
+            return results[0];
         }
 
         /// <summary>
@@ -174,12 +197,18 @@ namespace Microsoft.OData.UriParser
             }
 
             IList<IEdmSchemaType> results = FindAcrossModels<IEdmSchemaType>(model, typeName, /*caseInsensitive*/ true);
+
+            if (results == null || results.Count == 0)
+            {
+                return null;
+            }
+
             if (results.Count > 1)
             {
                 throw new ODataException(Strings.UriParserMetadata_MultipleMatchingTypesFound(typeName));
             }
 
-            return results.SingleOrDefault();
+            return results[0];
         }
 
         /// <summary>
@@ -198,10 +227,10 @@ namespace Microsoft.OData.UriParser
             }
 
             IList<IEdmOperation> operations = FindAcrossModels<IEdmOperation>(model, identifier, /*caseInsensitive*/ true);
-            if (operations != null && operations.Count() > 0)
+            if (operations != null && operations.Count > 0)
             {
                 IList<IEdmOperation> matchedOperation = new List<IEdmOperation>();
-                for (int i = 0; i < operations.Count(); i++)
+                for (int i = 0; i < operations.Count; i++)
                 {
                     if (operations[i].HasEquivalentBindingType(bindingType))
                     {
@@ -230,10 +259,10 @@ namespace Microsoft.OData.UriParser
             }
 
             IList<IEdmOperation> operations = FindAcrossModels<IEdmOperation>(model, identifier, /*caseInsensitive*/ true);
-            if (operations != null && operations.Count() > 0)
+            if (operations != null && operations.Count > 0)
             {
                 IList<IEdmOperation> matchedOperation = new List<IEdmOperation>();
-                for (int i = 0; i < operations.Count(); i++)
+                for (int i = 0; i < operations.Count; i++)
                 {
                     if (!operations[i].IsBound)
                     {
@@ -313,22 +342,21 @@ namespace Microsoft.OData.UriParser
         /// <returns>The resolved key list.</returns>
         public virtual IEnumerable<KeyValuePair<string, object>> ResolveKeys(IEdmEntityType type, IList<string> positionalValues, Func<IEdmTypeReference, string, object> convertFunc)
         {
-            var keyProperties = type.Key().ToList();
-
             // Throw an error if key size from url doesn't match that from model.
             // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
             // should override this ResolveKeys method.
-            if (keyProperties.Count != positionalValues.Count)
+            IEnumerable<IEdmStructuralProperty> keys = type.Key();
+            if (keys.Count() != positionalValues.Count)
             {
                 throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyCountMismatch(type.FullName()));
             }
 
             var keyPairList = new List<KeyValuePair<string, object>>(positionalValues.Count);
 
-            for (int i = 0; i < keyProperties.Count; i++)
+            int i = 0;
+            foreach (IEdmProperty keyProperty in keys)
             {
-                string valueText = positionalValues[i];
-                IEdmProperty keyProperty = keyProperties[i];
+                string valueText = positionalValues[i++];
                 object convertedValue = convertFunc(keyProperty.Type, valueText);
                 if (convertedValue == null)
                 {
@@ -351,17 +379,17 @@ namespace Microsoft.OData.UriParser
         public virtual IEnumerable<KeyValuePair<string, object>> ResolveKeys(IEdmEntityType type, IDictionary<string, string> namedValues, Func<IEdmTypeReference, string, object> convertFunc)
         {
             var convertedPairs = new Dictionary<string, object>(StringComparer.Ordinal);
-            var keyProperties = type.Key().ToList();
 
             // Throw an error if key size from url doesn't match that from model.
             // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
             // should override this ResolveKeys method.
-            if (keyProperties.Count != namedValues.Count)
+            IEnumerable<IEdmStructuralProperty> keys = type.Key();
+            if (keys.Count() != namedValues.Count)
             {
                 throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyCountMismatch(type.FullName()));
             }
 
-            foreach (IEdmStructuralProperty property in keyProperties)
+            foreach (IEdmStructuralProperty property in keys)
             {
                 string valueText;
 
@@ -369,17 +397,27 @@ namespace Microsoft.OData.UriParser
                 {
                     if (EnableCaseInsensitive)
                     {
-                        var list = namedValues.Keys.Where(key => string.Equals(property.Name, key, StringComparison.OrdinalIgnoreCase)).ToList();
-                        if (list.Count > 1)
+                        var list = namedValues.Keys.Where(key => string.Equals(property.Name, key, StringComparison.OrdinalIgnoreCase));
+
+                        string caseInsensitiveKey = string.Empty;
+                        bool keyFound = false;
+                        foreach (string key in list)
                         {
-                            throw new ODataException(Strings.UriParserMetadata_MultipleMatchingKeysFound(property.Name));
+                            if (keyFound)
+                            {
+                                throw new ODataException(Strings.UriParserMetadata_MultipleMatchingKeysFound(property.Name));
+                            }
+
+                            caseInsensitiveKey = key;
+                            keyFound = true;
                         }
-                        else if (list.Count == 0)
+
+                        if (!keyFound)
                         {
                             throw ExceptionUtil.CreateSyntaxError();
                         }
 
-                        valueText = namedValues[list.Single()];
+                        valueText = namedValues[caseInsensitiveKey];
                     }
                     else
                     {
@@ -408,24 +446,28 @@ namespace Microsoft.OData.UriParser
         internal static IEdmOperationParameter ResolveOperationParameterNameCaseInsensitive(IEdmOperation operation, string identifier)
         {
             // first look for a case-sensitive match
-            var list = operation.Parameters.Where(parameter => string.Equals(identifier, parameter.Name, StringComparison.Ordinal)).ToList();
-            if (list.Count == 0)
+            var list = operation.Parameters.Where(parameter => string.Equals(identifier, parameter.Name, StringComparison.Ordinal));
+            if (!list.Any())
             {
                 // if no case sensitive, try case-insensitive
-                list = operation.Parameters.Where(parameter => string.Equals(identifier, parameter.Name, StringComparison.OrdinalIgnoreCase)).ToList();
+                list = operation.Parameters.Where(parameter => string.Equals(identifier, parameter.Name, StringComparison.OrdinalIgnoreCase));
             }
 
-            if (list.Count > 1)
+            IEdmOperationParameter resolvedOperationParameter = null;
+
+            foreach(var parameter in list)
             {
-                throw new ODataException(Strings.UriParserMetadata_MultipleMatchingParametersFound(identifier));
+                if (resolvedOperationParameter == null)
+                {
+                    resolvedOperationParameter = parameter;
+                }
+                else
+                {
+                    throw new ODataException(Strings.UriParserMetadata_MultipleMatchingParametersFound(identifier));
+                }
             }
 
-            if (list.Count == 1)
-            {
-                return list.Single();
-            }
-
-            return null;
+            return resolvedOperationParameter;
         }
 
         internal static ODataUriResolver GetUriResolver(IServiceProvider container)
@@ -438,22 +480,31 @@ namespace Microsoft.OData.UriParser
             return container.GetRequiredService<ODataUriResolver>();
         }
 
-        private static List<T> FindAcrossModels<T>(IEdmModel model, String qualifiedName, bool caseInsensitive) where T : IEdmSchemaElement
+        private static IList<T> FindAcrossModels<T>(IEdmModel model, String qualifiedName, bool caseInsensitive) where T : IEdmSchemaElement
         {
-            List<T> results = FindSchemaElements<T>(model, qualifiedName, caseInsensitive).ToList();
+            IList<T> results = new List<T>();
+            FindSchemaElements<T>(model, qualifiedName, caseInsensitive, ref results);
 
             foreach (IEdmModel reference in model.ReferencedModels)
             {
-                results.AddRange(FindSchemaElements<T>(reference, qualifiedName, caseInsensitive));
+                FindSchemaElements<T>(reference, qualifiedName, caseInsensitive, ref results);
             }
 
             return results;
         }
 
-        private static IEnumerable<T> FindSchemaElements<T>(IEdmModel model, string qualifiedName, bool caseInsensitive) where T : IEdmSchemaElement
+        private static void FindSchemaElements<T>(IEdmModel model, string qualifiedName, bool caseInsensitive, ref IList<T> results) where T : IEdmSchemaElement
         {
-            return model.SchemaElements.OfType<T>()
-            .Where(e => string.Equals(qualifiedName, e.FullName(), caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
+            foreach (IEdmSchemaElement schema in model.SchemaElements)
+            {
+                if (string.Equals(qualifiedName, schema.FullName(), caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+                {
+                    if (schema is T)
+                    {
+                        results.Add((T)schema);
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -3180,6 +3180,10 @@ namespace Microsoft.OData.Edm
             return entitySet != null;
         }
 
+        /// <summary>
+        /// Returns true if there is any element in the list or collections. 
+        /// It tries to cast to list first and then an array, this method will be performant if the callers of this extension method implement IEnumerable through lists.
+        /// </summary>
         internal static bool HasAny<T>(this IEnumerable<T> enumerable) where T : class
         {
             IList<T> list = enumerable as IList<T>;
@@ -3194,7 +3198,12 @@ namespace Microsoft.OData.Edm
                 return array.Length > 0;
             }
 
-            return enumerable.FirstOrDefault() != null;
+            if (enumerable != null)
+            {
+                return enumerable.GetEnumerator().MoveNext();
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -801,6 +801,17 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         }
 
         [Fact]
+        public void TestHasAnyParity()
+        {
+            IList<IEdmEntityType> list = new List<IEdmEntityType>();
+            for(int i=1; i <10; i++)
+            {
+                Assert.Equal(HasAnyCheap(list), HasAnyExpensive(list));
+                list.Add(new EdmEntityType("NS", "f" + i, TestModel.Instance.EntitySet.EntityType()));
+            }
+        }
+
+        [Fact]
         public void FindDeclaredEntitySetWithSingletonName()
         {
             Assert.Null(TestModel.Instance.Model.FindDeclaredEntitySet(TestModel.Instance.Singleton.Name));
@@ -1079,6 +1090,33 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
             {
                 get { return type; }
             }
+        }
+
+        internal static bool HasAnyExpensive<T>(IEnumerable<T> enumerable) where T : class
+        {
+            IList<T> list = enumerable as IList<T>;
+            if (list != null)
+            {
+                return list.Count > 0;
+            }
+
+            T[] array = enumerable as T[];
+            if (array != null)
+            {
+                return array.Length > 0;
+            }
+
+            return enumerable.FirstOrDefault() != null;
+        }
+
+        internal static bool HasAnyCheap<T>(IEnumerable<T> enumerable) where T : class
+        {
+            if (enumerable != null && enumerable.GetEnumerator().MoveNext())
+            {
+                return true;
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1392 

### Description

This PR removes some of the expensive LINQ calls without breaking the public interface. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Results
HasAny previous for enumerables - 0.3372341
HasAny now for enumerables - 0.2167854

### Additional work necessary
I would like to add tests for the changes once the initial work is reviewed. More performance improvement related data should be attached with this PR. 


