### PR TITLE
Fix Select Expand Issue of selecting all navigation properties for Full Metadata request and fixing Odata Context

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClause.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClause.cs
@@ -71,7 +71,7 @@ namespace Microsoft.OData.UriParser
         /// Add a select item to the current list of selection items
         /// </summary>
         /// <param name="itemToAdd">The item to add</param>
-        internal void AddToSelectedItems(SelectItem itemToAdd)
+        internal void AddToSelectedItems(SelectItem itemToAdd, bool getOnlySubset =false)
         {
             ExceptionUtils.CheckArgumentNotNull(itemToAdd, "itemToAdd");
 
@@ -91,6 +91,14 @@ namespace Microsoft.OData.UriParser
                     if (!IsStructuralSelectionItem(selectedItem))
                     {
                         newSelectedItems.Add(selectedItem);
+                    }
+                    else if(getOnlySubset)
+                    {
+                        var pathItem = selectedItem as PathSelectItem;
+                        if(pathItem != null && pathItem.SelectAndExpand != null)
+                        {
+                            newSelectedItems.Add(selectedItem);
+                        }
                     }
                 }
                 else

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -201,7 +201,7 @@ namespace Microsoft.OData.UriParser
                 nextLevelSelectList = GetCurrentLevelSelectList(pathSelectItem.SelectAndExpand);
             }
 
-            var selectListItem = String.Join("/", pathSelectItem.SelectedPath.WalkWith(PathSegmentToStringTranslator.Instance));
+            var selectListItem = String.Join("/", pathSelectItem.SelectedPath.WalkWith(PathSegmentToStringTranslator.Instance).ToArray());
 
             if (nextLevelSelectList != null && nextLevelSelectList.Any())
             {

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -109,7 +109,7 @@ namespace Microsoft.OData.UriParser
                 {
                     IList<string> pathSelectItems = GetSelectStringFromPathSelectItem(pathSelectItem);
 
-                    for(int i=0; i< pathSelectItems.Count; i++)
+                    for (int i = 0; i< pathSelectItems.Count; i++)
                     {
                         levelSelectList.Add(pathSelectItems[i]);
                     }
@@ -201,7 +201,7 @@ namespace Microsoft.OData.UriParser
                 nextLevelSelectList = GetCurrentLevelSelectList(pathSelectItem.SelectAndExpand);
             }
 
-            var selectListItem = String.Join("/", pathSelectItem.SelectedPath.WalkWith(PathSegmentToStringTranslator.Instance).ToArray());
+            string selectListItem = String.Join("/", pathSelectItem.SelectedPath.WalkWith(PathSegmentToStringTranslator.Instance).ToArray());
 
             if (nextLevelSelectList != null && nextLevelSelectList.Any())
             {

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -166,7 +166,7 @@ namespace Microsoft.OData.UriParser
             // level).
             return String.Join(",", selectExpandClause.GetCurrentLevelSelectList().ToArray());
         }
-         
+
         /// <summary>
         /// Get the string representation of a select item (that isn't an expandedNavPropSelectItem
         /// </summary>

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -86,8 +86,9 @@ namespace Microsoft.OData.UriParser
         /// <returns>String list generated from selected items</returns>
         internal static List<string> GetCurrentLevelSelectList(this SelectExpandClause selectExpandClause)
         {
-            List<string> levelSelectList = new List<string>();
-          
+            HashSet<string> levelSelectList = new HashSet<string>();
+            List<string> masterSelectList = new List<string>();
+
             foreach (var selectItem in selectExpandClause.SelectedItems)
             {
                 if (selectItem is WildcardSelectItem)
@@ -110,12 +111,32 @@ namespace Microsoft.OData.UriParser
 
                     for (int i = 0; i< pathSelectItems.Count; i++)
                     {
-                        levelSelectList.Add(pathSelectItems[i]);
+                        levelSelectList.Add(pathSelectItems[i]);                       
                     }
                 }
             }
 
-            return levelSelectList;
+            foreach(var item in levelSelectList)
+            {
+                if (!levelSelectList.Contains(GetPreviousSegments(item)))
+                {
+                    masterSelectList.Add(item);
+                }
+            }
+
+            return masterSelectList;
+        }
+
+        private static string GetPreviousSegments(string item)
+        {
+            int index = item.LastIndexOf('/');
+
+            if(index > 0)
+            {
+                return item.Substring(0, index);
+            }
+
+            return string.Empty;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -90,8 +90,7 @@ namespace Microsoft.OData.UriParser
           
             foreach (var selectItem in selectExpandClause.SelectedItems)
             {
-                WildcardSelectItem wildcardSelect = selectItem as WildcardSelectItem;
-                if (wildcardSelect != null)
+                if (selectItem is WildcardSelectItem)
                 {
                     levelSelectList.Add("*");
                     continue;

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -116,7 +116,7 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
-            foreach(var item in levelSelectList)
+            foreach(string item in levelSelectList)
             {
                 if (!levelSelectList.Contains(GetPreviousSegments(item)))
                 {

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -116,7 +116,9 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
-            foreach(string item in levelSelectList)
+            // If a select item is a child of a complex property, and that complex property already has all properties selected,
+            // then the child is redundant and should not be included in the contextUrl. i.e.; $select=address,address/city => address
+            foreach (string item in levelSelectList)
             {
                 if (!levelSelectList.Contains(GetPreviousSegments(item)))
                 {
@@ -220,6 +222,8 @@ namespace Microsoft.OData.UriParser
         private static IList<string> GetSelectStringFromPathSelectItem(PathSelectItem pathSelectItem)
         {
             IList<string> nextLevelSelectList = null;
+
+            //Recursively call next level to get all the nested select items
             if (pathSelectItem.SelectAndExpand != null)
             {
                 nextLevelSelectList = GetCurrentLevelSelectList(pathSelectItem.SelectAndExpand);

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SelectExpandClauseExtensions.cs
@@ -136,7 +136,6 @@ namespace Microsoft.OData.UriParser
             foreach (SelectItem selectItem in selectExpandClause.SelectedItems)
             {
                 // $expand=..../$ref
-                ExpandedReferenceSelectItem expandRefItem = selectItem as ExpandedReferenceSelectItem;
                 ExpandedNavigationSelectItem expandSelectItem = selectItem as ExpandedNavigationSelectItem;
 
                 if (expandSelectItem != null)
@@ -159,15 +158,20 @@ namespace Microsoft.OData.UriParser
                         expandList.Add(expandItem);
                     }
                 }
-                else if (expandRefItem != null)
+                else
                 {
-                    string currentExpandClause = String.Join("/", expandRefItem.PathToNavigationProperty.WalkWith(PathSegmentToStringTranslator.Instance).ToArray());
-                    currentExpandClause += "/$ref";
+                    ExpandedReferenceSelectItem expandRefItem = selectItem as ExpandedReferenceSelectItem;
 
-                    var expandItem = processSubResult(currentExpandClause, default(T));
-                    if (expandItem != null)
+                    if (expandRefItem != null)
                     {
-                        expandList.Add(expandItem);
+                        string currentExpandClause = String.Join("/", expandRefItem.PathToNavigationProperty.WalkWith(PathSegmentToStringTranslator.Instance).ToArray());
+                        currentExpandClause += "/$ref";
+
+                        var expandItem = processSubResult(currentExpandClause, default(T));
+                        if (expandItem != null)
+                        {
+                            expandList.Add(expandItem);
+                        }
                     }
                 }
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/SelectExpandClauseExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/SelectExpandClauseExtensionsTests.cs
@@ -1,0 +1,138 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="SelectExpandClauseExtensionsTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Tests.UriParser;
+using Microsoft.OData.Tests.UriParser.Binders;
+using Microsoft.OData.UriParser;
+using Microsoft.OData.Edm;
+using Xunit;
+using ODataErrorStrings = Microsoft.OData.Strings;
+using Microsoft.OData.UriParser.Aggregation;
+
+namespace Microsoft.OData.Tests
+{
+    public class SelectExpandClauseExtensionsTests
+    {
+        [Fact]
+        public void GetCurrentLevelSelectListTestMultiSelect()
+        {
+            //Arrange
+            var expected = new List<string>();
+            expected.Add("Name");
+            expected.Add("Shoe");
+
+            //Act
+            var clause = CreateSelectExpandClauseMultiSelect();
+            var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
+
+            //Assert
+            Assert.Equal(expected.Count, actual.Count);
+            Assert.Equal(0,expected.Except(actual).Count());
+            Assert.Equal(0,actual.Except(expected).Count());
+        }
+
+        [Fact]
+        public void GetCurrentLevelSelectListTestNestedSelect()
+        {
+            //Arrange
+            var expected = new List<string>();
+            expected.Add("Name");
+            expected.Add("FavoriteDate");
+            expected.Add("MyAddress/City");
+
+            //Act
+            var clause = CreateSelectExpandClauseNestedSelect();
+            var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
+
+            //Assert
+            Assert.Equal(expected.Count, actual.Count);
+            Assert.Equal(0, expected.Except(actual).Count());
+            Assert.Equal(0, actual.Except(expected).Count());
+        }
+
+        [Fact]
+        public void GetCurrentLevelSelectListTestAllSelected()
+        {
+            //Arrange
+            var expected = new List<string>();
+            expected.Add("*");
+            
+            //Act
+            var clause = CreateSelectExpandClauseAllSelected();
+            var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
+
+            //Assert
+            Assert.Equal(expected.Count, actual.Count);
+            Assert.Equal(expected[0], actual[0]);            
+        }
+
+        [Fact]
+        public void GetCurrentLevelSelectListTestAllSelectedWithNamespace()
+        {
+            //Arrange
+            var expected = new List<string>();
+            expected.Add("namespace.*");
+
+            //Act
+            var clause = CreateSelectExpandClauseAllSelectedWithNamespace();
+            var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
+
+            //Assert
+            Assert.Equal(expected.Count, actual.Count);
+            Assert.Equal(expected[0], actual[0]);
+        }
+
+        private SelectExpandClause CreateSelectExpandClauseMultiSelect()
+        {
+            ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));
+            ODataSelectPath personShoePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonShoeProp()));
+
+            var clause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), false);
+            clause.AddToSelectedItems(new PathSelectItem(personShoePath));
+            clause.AddToSelectedItems(new PathSelectItem(personNamePath));
+
+            return clause;
+        }
+
+        private SelectExpandClause CreateSelectExpandClauseNestedSelect()
+        {
+            ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));
+            ODataSelectPath personShoePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonFavoriteDateProp()));
+            ODataSelectPath addrPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp()));
+            ODataSelectPath cityPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetAddressCityProperty()));
+
+            var cityClause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), false);
+            cityClause.AddToSelectedItems(new PathSelectItem(cityPath));
+            var addritem = new PathSelectItem(addrPath);
+            addritem.SelectAndExpand = cityClause;
+
+            var clause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), false);
+            clause.AddToSelectedItems(new PathSelectItem(personShoePath));
+            clause.AddToSelectedItems(new PathSelectItem(personNamePath));
+            clause.AddToSelectedItems(addritem);
+
+            return clause;
+        }
+
+        private SelectExpandClause CreateSelectExpandClauseAllSelected()
+        {
+            var clause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), true);
+            clause.AddToSelectedItems(new WildcardSelectItem()); 
+            return clause;
+        }
+
+        private SelectExpandClause CreateSelectExpandClauseAllSelectedWithNamespace()
+        {
+            var clause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), true);
+            clause.AddToSelectedItems(new NamespaceQualifiedWildcardSelectItem("namespace"));
+            return clause;
+        }
+
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
@@ -413,7 +413,7 @@ namespace Microsoft.OData.Tests
             }, true,isFullMetadata:true, version: version);
 
             string expected = version == ODataVersion.V4 ?
-                //OData V4.01
+                //OData V4.0
                 "{\"@odata.context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2())\",\"value\":[{\"@odata.id\":\"People('abc')\",\"@odata.editLink\":\"People('abc')\",\"UserName\":\"abc\",\"Address\":{\"Road\":\"Zixing\",\"WorkAddress\":{\"@odata.type\":\"#DefaultNs.WorkAddress\",\"Road\":\"Ziyue\",\"City2@odata.associationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2/$ref\",\"City2@odata.navigationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2\",\"City2\":{\"@odata.id\":\"City(222)\",\"@odata.editLink\":\"City(222)\",\"ZipCode\":222}}}}]}" :
                 //OData V4.01
                 "{\"@context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2())\",\"value\":[{\"@id\":\"People('abc')\",\"@editLink\":\"People('abc')\",\"UserName\":\"abc\",\"Address\":{\"Road\":\"Zixing\",\"WorkAddress\":{\"@type\":\"#DefaultNs.WorkAddress\",\"Road\":\"Ziyue\",\"City2@associationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2/$ref\",\"City2@navigationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2\",\"City2\":{\"@id\":\"City(222)\",\"@editLink\":\"City(222)\",\"ZipCode\":222}}}}]}";

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
@@ -370,7 +370,11 @@ namespace Microsoft.OData.Tests
                 writer.WriteEnd();
             },isFullMetadata:true);
 
-            string expected = "{\"@odata.context\":\"http://host/$metadata#People(Address/City(ZipCode))/$entity\",\"@odata.id\":\"People('abc')\",\"@odata.editLink\":\"People('abc')\",\"UserName\":\"abc\",\"Address\":{\"Road\":\"Zixing\",\"City@odata.associationLink\":\"http://host/People('abc')/Address/City/$ref\",\"City@odata.navigationLink\":\"http://host/People('abc')/Address/City\",\"City\":{\"@odata.id\":\"City(111)\",\"@odata.editLink\":\"City(111)\",\"ZipCode\":111}}}";
+            string expected = "{\"@odata.context\":\"http://host/$metadata#People(Address/City(ZipCode))/$entity\"," +
+                "\"@odata.id\":\"People('abc')\",\"@odata.editLink\":\"People('abc')\",\"UserName\":\"abc\"," +
+                "\"Address\":{\"Road\":\"Zixing\",\"City@odata.associationLink\"" +
+                ":\"http://host/People('abc')/Address/City/$ref\",\"City@odata.navigationLink\"" +
+                ":\"http://host/People('abc')/Address/City\",\"City\":{\"@odata.id\":\"City(111)\",\"@odata.editLink\":\"City(111)\",\"ZipCode\":111}}}";
 
             Assert.Equal(actual, expected);
         }
@@ -1196,7 +1200,7 @@ namespace Microsoft.OData.Tests
             nestInfo = itemsList[2];
             Assert.Equal(new Uri("http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City"), nestInfo.Url);
 
-            // itemsList[3] is the nested info for complex property WorkAddress, skip the validation.
+            // itemsList[3] and itemsList[4] are the nested info for complex property WorkAddress and itemsList[5] is the complex property . so skip the validation.
 
             // City under Address
             nestInfo = itemsList[6];

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
@@ -57,11 +57,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
             // $Expand =PersonCity($select =Zipcode),Address/City
 
             var resDict = RunComplexReaderTest(null, "{\"@odata.context\":\"http://test/$metadata#People(PersonCity(ZipCode),Address/City())/$entity\"," +
-            "\"PersonCity\":{\"ZipCode\":98052},"+
+            "\"PersonCity\":{\"ZipCode\":10001},"+
                 "\"Address\":{" +
                 "\"City\":{\"ZipCode\":98052}}}");
 
-            Assert.Equal(resDict["DefaultNs.PersonCity"].ToList()[0].Value, 98052);
+            Assert.Equal(resDict["DefaultNs.PersonCity"].ToList()[0].Value, 10001);
             Assert.Equal(resDict["DefaultNs.City"].ToList()[0].Value, 98052);
         }
 
@@ -347,13 +347,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                 {
                     if(reader.State == ODataReaderState.ResourceEnd)
                     {
-                        resources.Add(reader.Item as ODataResource);                     
+                        resources.Add(reader.Item as ODataResource);
                     }
                 }
 
                 return resources;
             }
         }
+
         private class TestJsonWriterFactory : IJsonWriterFactory
         {
             public IJsonWriter CreateJsonWriter(TextWriter textWriter, bool isIeee754Compatible)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
         [Fact]
         public void UseComplexJsonReaderExpandAndSelect()
         {
-            // $Expand =PersonCity($select =Zipcode),Address/City
+            // $expand =PersonCity($select=Zipcode),Address/City
 
             var resDict = RunComplexReaderTest(null, "{\"@odata.context\":\"http://test/$metadata#People(PersonCity(ZipCode),Address/City())/$entity\"," +
             "\"PersonCity\":{\"ZipCode\":10001},"+

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
@@ -4,18 +4,13 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Tests.UriParser;
-using Microsoft.OData.Tests.UriParser.Binders;
 using Microsoft.OData.UriParser;
-using Microsoft.OData.Edm;
 using Xunit;
-using ODataErrorStrings = Microsoft.OData.Strings;
-using Microsoft.OData.UriParser.Aggregation;
 
-namespace Microsoft.OData.Tests
+namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 {
     public class SelectExpandClauseExtensionsTests
     {
@@ -24,17 +19,15 @@ namespace Microsoft.OData.Tests
         {
             //Arrange
             var expected = new List<string>();
-            expected.Add("Name");
             expected.Add("Shoe");
+            expected.Add("Name");
 
             //Act
             var clause = CreateSelectExpandClauseMultiSelect();
             var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
 
             //Assert
-            Assert.Equal(expected.Count, actual.Count);
-            Assert.Equal(0,expected.Except(actual).Count());
-            Assert.Equal(0,actual.Except(expected).Count());
+            Assert.True(expected.SequenceEqual(actual));    
         }
 
         [Fact]
@@ -42,8 +35,8 @@ namespace Microsoft.OData.Tests
         {
             //Arrange
             var expected = new List<string>();
-            expected.Add("Name");
             expected.Add("FavoriteDate");
+            expected.Add("Name");
             expected.Add("MyAddress/City");
 
             //Act
@@ -51,9 +44,7 @@ namespace Microsoft.OData.Tests
             var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
 
             //Assert
-            Assert.Equal(expected.Count, actual.Count);
-            Assert.Equal(0, expected.Except(actual).Count());
-            Assert.Equal(0, actual.Except(expected).Count());
+            Assert.True(expected.SequenceEqual(actual));
         }
 
         [Fact]
@@ -88,31 +79,31 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected[0], actual[0]);
         }
 
-        private SelectExpandClause CreateSelectExpandClauseMultiSelect()
+        private static SelectExpandClause CreateSelectExpandClauseMultiSelect()
         {
             ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));
             ODataSelectPath personShoePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonShoeProp()));
 
-            var clause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), false);
+            var clause = new SelectExpandClause(new List<SelectItem>(), false);
             clause.AddToSelectedItems(new PathSelectItem(personShoePath));
             clause.AddToSelectedItems(new PathSelectItem(personNamePath));
 
             return clause;
         }
 
-        private SelectExpandClause CreateSelectExpandClauseNestedSelect()
+        private static SelectExpandClause CreateSelectExpandClauseNestedSelect()
         {
             ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));
             ODataSelectPath personShoePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonFavoriteDateProp()));
             ODataSelectPath addrPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp()));
             ODataSelectPath cityPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetAddressCityProperty()));
 
-            var cityClause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), false);
+            var cityClause = new SelectExpandClause(new List<SelectItem>(), false);
             cityClause.AddToSelectedItems(new PathSelectItem(cityPath));
             var addritem = new PathSelectItem(addrPath);
             addritem.SelectAndExpand = cityClause;
 
-            var clause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), false);
+            var clause = new SelectExpandClause(new List<SelectItem>(), false);
             clause.AddToSelectedItems(new PathSelectItem(personShoePath));
             clause.AddToSelectedItems(new PathSelectItem(personNamePath));
             clause.AddToSelectedItems(addritem);
@@ -120,16 +111,16 @@ namespace Microsoft.OData.Tests
             return clause;
         }
 
-        private SelectExpandClause CreateSelectExpandClauseAllSelected()
+        private static SelectExpandClause CreateSelectExpandClauseAllSelected()
         {
-            var clause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), true);
-            clause.AddToSelectedItems(new WildcardSelectItem()); 
+            var clause = new SelectExpandClause(new List<SelectItem>(), true);
+            clause.AddToSelectedItems(new WildcardSelectItem());
             return clause;
         }
 
-        private SelectExpandClause CreateSelectExpandClauseAllSelectedWithNamespace()
+        private static SelectExpandClause CreateSelectExpandClauseAllSelectedWithNamespace()
         {
-            var clause = new SelectExpandClause(new List<ExpandedNavigationSelectItem>(), true);
+            var clause = new SelectExpandClause(new List<SelectItem>(), true);
             clause.AddToSelectedItems(new NamespaceQualifiedWildcardSelectItem("namespace"));
             return clause;
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void GetCurrentLevelSelectListTestNestedSelectComplexTypeWithStar_FullSet()
         {
-            //Arrange - $select=FavoriteDate,Name,MyAddress,MyAddress/City
+            //Arrange - $select=*,MyAddress/City
             var expected = new List<string>();
             expected.Add("*");
           
@@ -83,7 +83,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void GetCurrentLevelSelectListTestNestedSelectComplexTypeWithStar_SubSet()
         {
-            //Arrange - $select=FavoriteDate,Name,MyAddress,MyAddress/City
+            //Arrange - $select=*,MyAddress/City
             var expected = new List<string>();
             expected.Add("MyAddress/City");
             expected.Add("*");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void GetCurrentLevelSelectListTestNestedSelectComplexType()
         {
-            //Arrange - $select=FavoriteDate,Name,MyAddress
+            //Arrange - $select=FavoriteDate,Name,MyAddress,MyAddress/City
             var expected = new List<string>();
             expected.Add("FavoriteDate");
             expected.Add("Name");
@@ -58,6 +58,23 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             //Act
             var clause = CreateSelectExpandClauseNestedSelectWithComplexType();
+            var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
+
+            //Assert
+            Assert.True(expected.SequenceEqual(actual));
+        }
+
+        [Fact]
+        public void GetCurrentLevelSelectListTestNestedSelectComplexTypeWithStar()
+        {
+            //Arrange - $select=FavoriteDate,Name,MyAddress,MyAddress/City
+            var expected = new List<string>();
+            expected.Add("FavoriteDate");
+            expected.Add("Name");
+            expected.Add("MyAddress");
+
+            //Act
+            var clause = CreateSelectExpandClauseNestedSelectWithComplexTypeWithStar();
             var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
 
             //Assert
@@ -85,7 +102,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void GetCurrentLevelSelectListTestNestedSelectNestedTypeWithComplex()
         {
-            //Arrange - $select=FavoriteDate,Name,MyAddress
+            //Arrange - $select=FavoriteDate,Name,MyAddress,MyAddress/MyNeighbors,MyAddress/MyNeighbors/City
             var expected = new List<string>();
             expected.Add("FavoriteDate");
             expected.Add("Name");
@@ -187,7 +204,29 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             return clause;
         }
 
-        
+        private static SelectExpandClause CreateSelectExpandClauseNestedSelectWithComplexTypeWithStar()
+        {
+            ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));
+            ODataSelectPath personShoePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonFavoriteDateProp()));
+            ODataSelectPath addrPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp()));
+            ODataSelectPath cityPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetAddressCityProperty()));
+
+            var cityClause = new SelectExpandClause(new List<SelectItem>(), false);
+            cityClause.AddToSelectedItems(new PathSelectItem(cityPath));
+            var addritem1 = new PathSelectItem(addrPath);
+            addritem1.SelectAndExpand = cityClause;
+
+            var clause = new SelectExpandClause(new List<SelectItem>(), false);
+            clause.AddToSelectedItems(new PathSelectItem(personShoePath));
+            clause.AddToSelectedItems(new PathSelectItem(personNamePath));
+            
+            clause.AddToSelectedItems(addritem1);
+            clause.AddToSelectedItems(new WildcardSelectItem());
+
+            return clause;
+        }
+
+
         private static SelectExpandClause CreateSelectExpandClauseNestedSelectWithNestedType()
         {
             ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void GetCurrentLevelSelectListTestMultiSelect()
         {
-            //Arrange
+            //Arrange - $select=Shoe,Name
             var expected = new List<string>();
             expected.Add("Shoe");
             expected.Add("Name");
@@ -33,7 +33,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void GetCurrentLevelSelectListTestNestedSelect()
         {
-            //Arrange
+            //Arrange - $select=FavoriteDate,Name,MyAddress/City
             var expected = new List<string>();
             expected.Add("FavoriteDate");
             expected.Add("Name");
@@ -50,7 +50,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void GetCurrentLevelSelectListTestNestedSelectComplexType()
         {
-            //Arrange
+            //Arrange - $select=FavoriteDate,Name,MyAddress
             var expected = new List<string>();
             expected.Add("FavoriteDate");
             expected.Add("Name");
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void GetCurrentLevelSelectListTestNestedSelectNestedType()
         {
-            //Arrange
+            //Arrange - $select=FavoriteDate,Name,MyAddress,MyAddress/MyNeighbors/City
             var expected = new List<string>();
             expected.Add("FavoriteDate");
             expected.Add("Name");
@@ -85,7 +85,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void GetCurrentLevelSelectListTestNestedSelectNestedTypeWithComplex()
         {
-            //Arrange
+            //Arrange - $select=FavoriteDate,Name,MyAddress
             var expected = new List<string>();
             expected.Add("FavoriteDate");
             expected.Add("Name");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
@@ -48,6 +48,58 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void GetCurrentLevelSelectListTestNestedSelectComplexType()
+        {
+            //Arrange
+            var expected = new List<string>();
+            expected.Add("FavoriteDate");
+            expected.Add("Name");
+            expected.Add("MyAddress");
+
+            //Act
+            var clause = CreateSelectExpandClauseNestedSelectWithComplexType();
+            var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
+
+            //Assert
+            Assert.True(expected.SequenceEqual(actual));
+        }
+
+        [Fact]
+        public void GetCurrentLevelSelectListTestNestedSelectNestedType()
+        {
+            //Arrange
+            var expected = new List<string>();
+            expected.Add("FavoriteDate");
+            expected.Add("Name");
+            expected.Add("MyAddress");
+            expected.Add("MyAddress/MyNeighbors/City");
+
+            //Act
+            var clause = CreateSelectExpandClauseNestedSelectWithNestedType();
+            var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
+
+            //Assert
+            Assert.True(expected.SequenceEqual(actual));
+        }
+
+        [Fact]
+        public void GetCurrentLevelSelectListTestNestedSelectNestedTypeWithComplex()
+        {
+            //Arrange
+            var expected = new List<string>();
+            expected.Add("FavoriteDate");
+            expected.Add("Name");
+            expected.Add("MyAddress");
+
+            //Act
+            var clause = CreateSelectExpandClauseNestedSelectWithNestedAndComplex();
+            var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
+
+            //Assert
+            Assert.True(expected.SequenceEqual(actual));
+        }
+
+        [Fact]
         public void GetCurrentLevelSelectListTestAllSelected()
         {
             //Arrange
@@ -107,9 +159,108 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             clause.AddToSelectedItems(new PathSelectItem(personShoePath));
             clause.AddToSelectedItems(new PathSelectItem(personNamePath));
             clause.AddToSelectedItems(addritem);
+            
+            return clause;
+        }
+
+
+        private static SelectExpandClause CreateSelectExpandClauseNestedSelectWithComplexType()
+        {
+            ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));
+            ODataSelectPath personShoePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonFavoriteDateProp()));
+            ODataSelectPath addrPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp()));
+            ODataSelectPath cityPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetAddressCityProperty()));
+
+            var cityClause = new SelectExpandClause(new List<SelectItem>(), false);
+            cityClause.AddToSelectedItems(new PathSelectItem(cityPath));
+            var addritem = new PathSelectItem(addrPath);
+            addritem.SelectAndExpand = cityClause;
+
+            var addritem1 = new PathSelectItem(addrPath);
+
+            var clause = new SelectExpandClause(new List<SelectItem>(), false);
+            clause.AddToSelectedItems(new PathSelectItem(personShoePath));
+            clause.AddToSelectedItems(new PathSelectItem(personNamePath));
+            clause.AddToSelectedItems(addritem);
+            clause.AddToSelectedItems(addritem1);
 
             return clause;
         }
+
+        
+        private static SelectExpandClause CreateSelectExpandClauseNestedSelectWithNestedType()
+        {
+            ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));
+            ODataSelectPath personShoePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonFavoriteDateProp()));
+            ODataSelectPath addrPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp()));
+            ODataSelectPath cityPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetAddressCityProperty()));
+            ODataSelectPath neighboursPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetAddressMyNeighborsProperty()));
+
+            var cityClause = new SelectExpandClause(new List<SelectItem>(), false);
+            cityClause.AddToSelectedItems(new PathSelectItem(cityPath));
+            var addritem = new PathSelectItem(addrPath);
+            addritem.SelectAndExpand = cityClause;
+
+            var addritem1 = new PathSelectItem(addrPath);
+
+            var nClause = new SelectExpandClause(new List<SelectItem>(), false);
+            var neighboursPathItem = new PathSelectItem(neighboursPath);
+            neighboursPathItem.SelectAndExpand = cityClause;
+            nClause.AddToSelectedItems(neighboursPathItem);
+            var addritem2 = new PathSelectItem(addrPath);
+            addritem2.SelectAndExpand = nClause;
+
+            var clause = new SelectExpandClause(new List<SelectItem>(), false);
+            clause.AddToSelectedItems(new PathSelectItem(personShoePath));
+            clause.AddToSelectedItems(new PathSelectItem(personNamePath));
+            clause.AddToSelectedItems(addritem);
+            clause.AddToSelectedItems(addritem1);
+            clause.AddToSelectedItems(addritem2);
+
+            return clause;
+        }
+
+
+        private static SelectExpandClause CreateSelectExpandClauseNestedSelectWithNestedAndComplex()
+        {
+            ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));
+            ODataSelectPath personShoePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonFavoriteDateProp()));
+            ODataSelectPath addrPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonAddressProp()));
+            ODataSelectPath cityPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetAddressCityProperty()));
+            ODataSelectPath neighboursPath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetAddressMyNeighborsProperty()));
+
+            var cityClause = new SelectExpandClause(new List<SelectItem>(), false);
+            cityClause.AddToSelectedItems(new PathSelectItem(cityPath));
+            var addritem = new PathSelectItem(addrPath);
+            addritem.SelectAndExpand = cityClause;
+
+
+            var neighboursPathClause = new SelectExpandClause(new List<SelectItem>(), false);
+            var neighboursPathItem = new PathSelectItem(neighboursPath);
+            neighboursPathItem.SelectAndExpand = cityClause;
+            neighboursPathClause.AddToSelectedItems(neighboursPathItem);
+            var addritem1 = new PathSelectItem(addrPath);
+            addritem1.SelectAndExpand = neighboursPathClause;
+
+            var neighboursPathClause2 = new SelectExpandClause(new List<SelectItem>(), false);
+            var neighboursPathItem3 = new PathSelectItem(neighboursPath);
+            neighboursPathClause2.AddToSelectedItems(neighboursPathItem3);
+            var addritem2 = new PathSelectItem(addrPath);
+            addritem2.SelectAndExpand = neighboursPathClause2;
+
+            var addritem3 = new PathSelectItem(addrPath);
+         
+            var clause = new SelectExpandClause(new List<SelectItem>(), false);
+            clause.AddToSelectedItems(new PathSelectItem(personShoePath));
+            clause.AddToSelectedItems(new PathSelectItem(personNamePath));
+            clause.AddToSelectedItems(addritem);
+            clause.AddToSelectedItems(addritem1);
+            clause.AddToSelectedItems(addritem2);
+            clause.AddToSelectedItems(addritem3);
+
+            return clause;
+        }
+
 
         private static SelectExpandClause CreateSelectExpandClauseAllSelected()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandClauseExtensionsTests.cs
@@ -65,16 +65,31 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
-        public void GetCurrentLevelSelectListTestNestedSelectComplexTypeWithStar()
+        public void GetCurrentLevelSelectListTestNestedSelectComplexTypeWithStar_FullSet()
         {
             //Arrange - $select=FavoriteDate,Name,MyAddress,MyAddress/City
             var expected = new List<string>();
-            expected.Add("FavoriteDate");
-            expected.Add("Name");
-            expected.Add("MyAddress");
+            expected.Add("*");
+          
 
             //Act
-            var clause = CreateSelectExpandClauseNestedSelectWithComplexTypeWithStar();
+            var clause = CreateSelectExpandClauseNestedSelectWithComplexTypeWithStar(false);
+            var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
+
+            //Assert
+            Assert.True(expected.SequenceEqual(actual));
+        }
+
+        [Fact]
+        public void GetCurrentLevelSelectListTestNestedSelectComplexTypeWithStar_SubSet()
+        {
+            //Arrange - $select=FavoriteDate,Name,MyAddress,MyAddress/City
+            var expected = new List<string>();
+            expected.Add("MyAddress/City");
+            expected.Add("*");
+
+            //Act
+            var clause = CreateSelectExpandClauseNestedSelectWithComplexTypeWithStar(true);
             var actual = SelectExpandClauseExtensions.GetCurrentLevelSelectList(clause);
 
             //Assert
@@ -204,7 +219,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             return clause;
         }
 
-        private static SelectExpandClause CreateSelectExpandClauseNestedSelectWithComplexTypeWithStar()
+        private static SelectExpandClause CreateSelectExpandClauseNestedSelectWithComplexTypeWithStar(bool subset)
         {
             ODataSelectPath personNamePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonNameProp()));
             ODataSelectPath personShoePath = new ODataSelectPath(new PropertySegment(HardCodedTestModel.GetPersonFavoriteDateProp()));
@@ -216,12 +231,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var addritem1 = new PathSelectItem(addrPath);
             addritem1.SelectAndExpand = cityClause;
 
-            var clause = new SelectExpandClause(new List<SelectItem>(), false);
+            var clause = new SelectExpandClause(new List<SelectItem>(), true);
             clause.AddToSelectedItems(new PathSelectItem(personShoePath));
             clause.AddToSelectedItems(new PathSelectItem(personNamePath));
             
             clause.AddToSelectedItems(addritem1);
-            clause.AddToSelectedItems(new WildcardSelectItem());
+            clause.AddToSelectedItems(new WildcardSelectItem(),subset);
 
             return clause;
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/SelectedPropertiesNodeTests.cs
@@ -306,6 +306,12 @@ namespace Microsoft.OData.Tests.Evaluation
         }
 
         [Fact]
+        public void SelectTokenForNavigationPropertyOnComplexShouldHaveOnlySelectedItem()
+        {
+            SelectedPropertiesNode.Create("NearestAirport/Districts").HaveChild(this.metropolisType, "NearestAirport", c => c.HaveNavigations(this.cityType, "Districts"));
+        }
+
+        [Fact]
         public void SubPropertyOfNavigationSpecifiedInBothTypeSegmentAndDirectlyShouldNotProduceDuplicates()
         {
             SelectedPropertiesNode.Create("TestModel.City/Districts/Thumbnail,Districts/Thumbnail")


### PR DESCRIPTION
Fix Select expand and odata context issue

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1574 and #1580 

### Description

Fixed the select and expand list 
Fixed odata context which uses select and expand

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
