### PR TITLE
Added Interfaces to some of the OData Client Library classes to Support Mocking 

### DIFF
--- a/src/Microsoft.OData.Client/Build.NetStandard/Microsoft.OData.Client.NetStandard.csproj
+++ b/src/Microsoft.OData.Client/Build.NetStandard/Microsoft.OData.Client.NetStandard.csproj
@@ -844,6 +844,18 @@
     <Compile Include="$(EnlistmentRoot)\src\PlatformHelper.cs">
       <Link>PlatformHelper.cs</Link>
     </Compile>
+   <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuerySingle.cs">
+      <Link>IDataServiceQuerySingle.cs</Link>
+    </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQueryOfT.cs">
+      <Link>IDataServiceQueryOfT.cs</Link>
+    </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuery.cs">
+      <Link>IDataServiceQuery.cs</Link>
+    </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceContext.cs">
+      <Link>IDataServiceContext.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Files that are specific to this project and are not updated by the cross targetting task -->
   <ItemGroup>

--- a/src/Microsoft.OData.Client/Build.NetStandard/Microsoft.OData.Client.NetStandard.csproj
+++ b/src/Microsoft.OData.Client/Build.NetStandard/Microsoft.OData.Client.NetStandard.csproj
@@ -844,8 +844,8 @@
     <Compile Include="$(EnlistmentRoot)\src\PlatformHelper.cs">
       <Link>PlatformHelper.cs</Link>
     </Compile>
-   <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuerySingle.cs">
-      <Link>IDataServiceQuerySingle.cs</Link>
+   <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuerySingleOfT.cs">
+      <Link>IDataServiceQuerySingleOfT.cs</Link>
     </Compile>
     <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQueryOfT.cs">
       <Link>IDataServiceQueryOfT.cs</Link>

--- a/src/Microsoft.OData.Client/Build.Portable/Microsoft.OData.Client.Portable.csproj
+++ b/src/Microsoft.OData.Client/Build.Portable/Microsoft.OData.Client.Portable.csproj
@@ -833,6 +833,18 @@
     <Compile Include="$(EnlistmentRoot)\src\PlatformHelper.cs">
       <Link>PlatformHelper.cs</Link>
     </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuerySingle.cs">
+      <Link>IDataServiceQuerySingle.cs</Link>
+    </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQueryOfT.cs">
+      <Link>IDataServiceQueryOfT.cs</Link>
+    </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuery.cs">
+      <Link>IDataServiceQuery.cs</Link>
+    </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceContext.cs">
+      <Link>IDataServiceContext.cs</Link>
+    </Compile>
   </ItemGroup>
   <!-- Files that are specific to this project and are not updated by the cross targetting task -->
   <ItemGroup>

--- a/src/Microsoft.OData.Client/Build.Portable/Microsoft.OData.Client.Portable.csproj
+++ b/src/Microsoft.OData.Client/Build.Portable/Microsoft.OData.Client.Portable.csproj
@@ -833,8 +833,8 @@
     <Compile Include="$(EnlistmentRoot)\src\PlatformHelper.cs">
       <Link>PlatformHelper.cs</Link>
     </Compile>
-    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuerySingle.cs">
-      <Link>IDataServiceQuerySingle.cs</Link>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuerySingleOfT.cs">
+      <Link>IDataServiceQuerySingleOfT.cs</Link>
     </Compile>
     <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQueryOfT.cs">
       <Link>IDataServiceQueryOfT.cs</Link>

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OData.Client
     /// The <see cref="T:Microsoft.OData.Client.DataServiceContext" /> represents the runtime context of the data service.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506", Justification = "Central class of the API, likely to have many cross-references")]
-    public class DataServiceContext
+    public class DataServiceContext : IDataServiceContext
     {
         /// <summary>Same version as <see cref="maxProtocolVersion"/> but stored as instance of <see cref="Version"/> for easy comparisons.</summary>
         internal Version MaxProtocolVersionAsVersion;

--- a/src/Microsoft.OData.Client/DataServiceQuery.cs
+++ b/src/Microsoft.OData.Client/DataServiceQuery.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.Client
     /// <summary>non-generic placeholder for generic implementation</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1010", Justification = "required for this feature")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710", Justification = "required for this feature")]
-    public abstract class DataServiceQuery : DataServiceRequest, IQueryable
+    public abstract class DataServiceQuery : DataServiceRequest, IQueryable, IDataServiceQuery
     {
         /// <summary>internal constructor so that only our assembly can provide an implementation</summary>
         internal DataServiceQuery()

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.Client
     /// </summary>
     /// <typeparam name="TElement">type of object to materialize</typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "required for this feature")]
-    public class DataServiceQuery<TElement> : DataServiceQuery, IQueryable<TElement>
+    public class DataServiceQuery<TElement> : DataServiceQuery, IQueryable<TElement>, IDataServiceQueryOfT<TElement>
     {
         #region Private fields
 

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.Client
     /// </summary>
     /// <typeparam name="TElement">type of object to materialize</typeparam>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Justification = "required for this feature")]
-    public class DataServiceQuery<TElement> : DataServiceQuery, IQueryable<TElement>, IDataServiceQueryOfT<TElement>
+    public class DataServiceQuery<TElement> : DataServiceQuery, IQueryable<TElement>, IDataServiceQuery<TElement>
     {
         #region Private fields
 

--- a/src/Microsoft.OData.Client/DataServiceQuerySingleOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQuerySingleOfT.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.Client
     /// Query object of a single item.
     /// </summary>
     /// <typeparam name="TElement">Type of object to materialize.</typeparam>
-    public class DataServiceQuerySingle<TElement>
+    public class DataServiceQuerySingle<TElement> : IDataServiceQuerySingle<TElement>
     {
         /// <summary>
         /// Query object.

--- a/src/Microsoft.OData.Client/IDataServiceContext.cs
+++ b/src/Microsoft.OData.Client/IDataServiceContext.cs
@@ -29,7 +29,9 @@ namespace Microsoft.OData.Client
         Func<Type, string> ResolveName { get; set; }
         Func<string, Type> ResolveType { get; set; }
         SaveChangesOptions SaveChangesDefaultOptions { get; set; }
+#if !PORTABLELIB
         int Timeout { get; set; }
+#endif
         DataServiceUrlKeyDelimiter UrlKeyDelimiter { get; set; }
         bool UsePostTunneling { get; set; }
 
@@ -77,39 +79,49 @@ namespace Microsoft.OData.Client
         DataServiceStreamResponse EndGetReadStream(IAsyncResult asyncResult);
         QueryOperationResponse EndLoadProperty(IAsyncResult asyncResult);
         DataServiceResponse EndSaveChanges(IAsyncResult asyncResult);
+#if !PORTABLELIB
         OperationResponse Execute(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
         QueryOperationResponse<T> Execute<T>(DataServiceQueryContinuation<T> continuation);
         IEnumerable<TElement> Execute<TElement>(Uri requestUri);
         IEnumerable<TElement> Execute<TElement>(Uri requestUri, string httpMethod, bool singleResult, params OperationParameter[] operationParameters);
         IEnumerable<TElement> Execute<TElement>(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
+#endif
         Task<OperationResponse> ExecuteAsync(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
         Task<IEnumerable<TElement>> ExecuteAsync<TElement>(DataServiceQueryContinuation<TElement> continuation);
         Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri);
         Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, bool singleResult, params OperationParameter[] operationParameters);
         Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
+#if !PORTABLELIB
         DataServiceResponse ExecuteBatch(params DataServiceRequest[] queries);
+#endif
         Task<DataServiceResponse> ExecuteBatchAsync(params DataServiceRequest[] queries);
         EntityDescriptor GetEntityDescriptor(object entity);
         LinkDescriptor GetLinkDescriptor(object source, string sourceProperty, object target);
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Uri GetMetadataUri();
+#if !PORTABLELIB
         DataServiceStreamResponse GetReadStream(object entity);
         DataServiceStreamResponse GetReadStream(object entity, DataServiceRequestArgs args);
         DataServiceStreamResponse GetReadStream(object entity, string acceptContentType);
         DataServiceStreamResponse GetReadStream(object entity, string name, DataServiceRequestArgs args);
+#endif
         Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, DataServiceRequestArgs args);
         Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, string name, DataServiceRequestArgs args);
         Uri GetReadStreamUri(object entity);
         Uri GetReadStreamUri(object entity, string name);
+#if !PORTABLELIB
         QueryOperationResponse LoadProperty(object entity, string propertyName);
         QueryOperationResponse LoadProperty(object entity, string propertyName, DataServiceQueryContinuation continuation);
         QueryOperationResponse LoadProperty(object entity, string propertyName, Uri nextLinkUri);
         QueryOperationResponse<T> LoadProperty<T>(object entity, string propertyName, DataServiceQueryContinuation<T> continuation);
+#endif
         Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName);
         Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, DataServiceQueryContinuation continuation);
         Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, Uri nextLinkUri);
+#if !PORTABLELIB 
         DataServiceResponse SaveChanges();
         DataServiceResponse SaveChanges(SaveChangesOptions options);
+#endif
         Task<DataServiceResponse> SaveChangesAsync();
         Task<DataServiceResponse> SaveChangesAsync(SaveChangesOptions options);
         void SetLink(object source, string sourceProperty, object target);

--- a/src/Microsoft.OData.Client/IDataServiceContext.cs
+++ b/src/Microsoft.OData.Client/IDataServiceContext.cs
@@ -1,141 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.IO;
-using System.Linq.Expressions;
-using System.Net;
-using System.Threading.Tasks;
+﻿//---------------------------------------------------------------------
+// <copyright file="IDataServiceContext.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
 
 namespace Microsoft.OData.Client
 {
+    /// <summary>
+    /// The <see cref="T:Microsoft.OData.Client.IDataServiceContext" /> represents the runtime context of the data service.
+    /// </summary>
     public interface IDataServiceContext
     {
-        DataServiceResponsePreference AddAndUpdateResponsePreference { get; set; }
-        bool ApplyingChanges { get; }
-        Uri BaseUri { get; set; }
-        DataServiceClientConfigurations Configurations { get; }
-        ICredentials Credentials { get; set; }
-        bool DisableInstanceAnnotationMaterialization { get; set; }
-        bool EnableWritingODataAnnotationWithoutPrefix { get; set; }
-        ReadOnlyCollection<EntityDescriptor> Entities { get; }
-        EntityParameterSendOption EntityParameterSendOption { get; set; }
-        EntityTracker EntityTracker { get; set; }
-        DataServiceClientFormat Format { get; }
-        bool IgnoreResourceNotFoundException { get; set; }
-        ReadOnlyCollection<LinkDescriptor> Links { get; }
-        ODataProtocolVersion MaxProtocolVersion { get; }
-        MergeOption MergeOption { get; set; }
-        Func<string, Uri> ResolveEntitySet { get; set; }
-        Func<Type, string> ResolveName { get; set; }
-        Func<string, Type> ResolveType { get; set; }
-        SaveChangesOptions SaveChangesDefaultOptions { get; set; }
-#if !PORTABLELIB
-        int Timeout { get; set; }
-#endif
-        DataServiceUrlKeyDelimiter UrlKeyDelimiter { get; set; }
-        bool UsePostTunneling { get; set; }
 
-        event EventHandler<BuildingRequestEventArgs> BuildingRequest;
-        event EventHandler<ReceivingResponseEventArgs> ReceivingResponse;
-        event EventHandler<SendingRequest2EventArgs> SendingRequest2;
-
-        void AddLink(object source, string sourceProperty, object target);
+        /// <summary>Adds the specified object to the set of objects that the context is tracking.</summary>
+        /// <param name="entitySetName">The name of the entity set to which the resource will be added.</param>
+        /// <param name="entity">The object to be tracked by the context.</param>
         void AddObject(string entitySetName, object entity);
-        void AddRelatedObject(object source, string sourceProperty, object target);
-        void AttachLink(object source, string sourceProperty, object target);
-        void AttachTo(string entitySetName, object entity);
-        void AttachTo(string entitySetName, object entity, string etag);
-        IAsyncResult BeginExecute(Uri requestUri, AsyncCallback callback, object state, string httpMethod, params OperationParameter[] operationParameters);
-        IAsyncResult BeginExecute<T>(DataServiceQueryContinuation<T> continuation, AsyncCallback callback, object state);
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
-        IAsyncResult BeginExecute<TElement>(Uri requestUri, AsyncCallback callback, object state);
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
-        IAsyncResult BeginExecute<TElement>(Uri requestUri, AsyncCallback callback, object state, string httpMethod, bool singleResult, params OperationParameter[] operationParameters);
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
-        IAsyncResult BeginExecute<TElement>(Uri requestUri, AsyncCallback callback, object state, string httpMethod, params OperationParameter[] operationParameters);
-        IAsyncResult BeginExecuteBatch(AsyncCallback callback, object state, params DataServiceRequest[] queries);
-        IAsyncResult BeginGetReadStream(object entity, DataServiceRequestArgs args, AsyncCallback callback, object state);
-        IAsyncResult BeginGetReadStream(object entity, string name, DataServiceRequestArgs args, AsyncCallback callback, object state);
-        IAsyncResult BeginLoadProperty(object entity, string propertyName, AsyncCallback callback, object state);
-        IAsyncResult BeginLoadProperty(object entity, string propertyName, DataServiceQueryContinuation continuation, AsyncCallback callback, object state);
-        IAsyncResult BeginLoadProperty(object entity, string propertyName, Uri nextLinkUri, AsyncCallback callback, object state);
-        IAsyncResult BeginSaveChanges(AsyncCallback callback, object state);
-        IAsyncResult BeginSaveChanges(SaveChangesOptions options, AsyncCallback callback, object state);
-        void CancelRequest(IAsyncResult asyncResult);
-        void ChangeState(object entity, EntityStates state);
-        DataServiceQuery<T> CreateFunctionQuery<T>();
-        DataServiceQuery<T> CreateFunctionQuery<T>(string path, string functionName, bool isComposable, params UriOperationParameter[] parameters);
-        DataServiceQuerySingle<T> CreateFunctionQuerySingle<T>(string path, string functionName, bool isComposable, params UriOperationParameter[] parameters);
-        DataServiceQuery<T> CreateQuery<T>(string entitySetName);
-        DataServiceQuery<T> CreateQuery<T>(string resourcePath, bool isComposable);
-        DataServiceQuery<T> CreateSingletonQuery<T>(string singletonName);
-        void DeleteLink(object source, string sourceProperty, object target);
+
+        /// <summary>Changes the state of the specified object to be deleted in the context class.</summary>
+        /// <param name="entity">The tracked entity to be changed to the deleted state.</param>
         void DeleteObject(object entity);
-        bool Detach(object entity);
-        bool DetachLink(object source, string sourceProperty, object target);
-        OperationResponse EndExecute(IAsyncResult asyncResult);
-        IEnumerable<TElement> EndExecute<TElement>(IAsyncResult asyncResult);
-        DataServiceResponse EndExecuteBatch(IAsyncResult asyncResult);
-        DataServiceStreamResponse EndGetReadStream(IAsyncResult asyncResult);
-        QueryOperationResponse EndLoadProperty(IAsyncResult asyncResult);
-        DataServiceResponse EndSaveChanges(IAsyncResult asyncResult);
-#if !PORTABLELIB
-        OperationResponse Execute(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
-        QueryOperationResponse<T> Execute<T>(DataServiceQueryContinuation<T> continuation);
-        IEnumerable<TElement> Execute<TElement>(Uri requestUri);
-        IEnumerable<TElement> Execute<TElement>(Uri requestUri, string httpMethod, bool singleResult, params OperationParameter[] operationParameters);
-        IEnumerable<TElement> Execute<TElement>(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
-#endif
-        Task<OperationResponse> ExecuteAsync(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
-        Task<IEnumerable<TElement>> ExecuteAsync<TElement>(DataServiceQueryContinuation<TElement> continuation);
-        Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri);
-        Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, bool singleResult, params OperationParameter[] operationParameters);
-        Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
-#if !PORTABLELIB
-        DataServiceResponse ExecuteBatch(params DataServiceRequest[] queries);
-#endif
-        Task<DataServiceResponse> ExecuteBatchAsync(params DataServiceRequest[] queries);
-        EntityDescriptor GetEntityDescriptor(object entity);
-        LinkDescriptor GetLinkDescriptor(object source, string sourceProperty, object target);
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        Uri GetMetadataUri();
-#if !PORTABLELIB
-        DataServiceStreamResponse GetReadStream(object entity);
-        DataServiceStreamResponse GetReadStream(object entity, DataServiceRequestArgs args);
-        DataServiceStreamResponse GetReadStream(object entity, string acceptContentType);
-        DataServiceStreamResponse GetReadStream(object entity, string name, DataServiceRequestArgs args);
-#endif
-        Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, DataServiceRequestArgs args);
-        Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, string name, DataServiceRequestArgs args);
-        Uri GetReadStreamUri(object entity);
-        Uri GetReadStreamUri(object entity, string name);
-#if !PORTABLELIB
-        QueryOperationResponse LoadProperty(object entity, string propertyName);
-        QueryOperationResponse LoadProperty(object entity, string propertyName, DataServiceQueryContinuation continuation);
-        QueryOperationResponse LoadProperty(object entity, string propertyName, Uri nextLinkUri);
-        QueryOperationResponse<T> LoadProperty<T>(object entity, string propertyName, DataServiceQueryContinuation<T> continuation);
-#endif
-        Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName);
-        Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, DataServiceQueryContinuation continuation);
-        Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, Uri nextLinkUri);
-#if !PORTABLELIB 
-        DataServiceResponse SaveChanges();
-        DataServiceResponse SaveChanges(SaveChangesOptions options);
-#endif
-        Task<DataServiceResponse> SaveChangesAsync();
-        Task<DataServiceResponse> SaveChangesAsync(SaveChangesOptions options);
-        void SetLink(object source, string sourceProperty, object target);
-        void SetSaveStream(object entity, Stream stream, bool closeStream, DataServiceRequestArgs args);
-        void SetSaveStream(object entity, Stream stream, bool closeStream, string contentType, string slug);
-        void SetSaveStream(object entity, string name, Stream stream, bool closeStream, DataServiceRequestArgs args);
-        void SetSaveStream(object entity, string name, Stream stream, bool closeStream, string contentType);
-        bool TryGetAnnotation<TFunc, TResult>(Expression<TFunc> expression, string term, out TResult annotation);
-        bool TryGetAnnotation<TFunc, TResult>(Expression<TFunc> expression, string term, string qualifier, out TResult annotation);
-        bool TryGetAnnotation<TResult>(object source, string term, out TResult annotation);
-        bool TryGetAnnotation<TResult>(object source, string term, string qualifier, out TResult annotation);
-        bool TryGetEntity<TEntity>(Uri identity, out TEntity entity) where TEntity : class;
-        bool TryGetUri(object entity, out Uri identity);
+
+        /// <summary>Changes the state of the specified object in the context class to <see cref="F:Microsoft.OData.Client.EntityStates.Modified" />.</summary>
+        /// <param name="entity">The tracked entity to be assigned to the <see cref="F:Microsoft.OData.Client.EntityStates.Modified" /> state.</param>
         void UpdateObject(object entity);
-        void UpdateRelatedObject(object source, string sourceProperty, object target);
     }
 }

--- a/src/Microsoft.OData.Client/IDataServiceContext.cs
+++ b/src/Microsoft.OData.Client/IDataServiceContext.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Linq.Expressions;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.Client
+{
+    public interface IDataServiceContext
+    {
+        DataServiceResponsePreference AddAndUpdateResponsePreference { get; set; }
+        bool ApplyingChanges { get; }
+        Uri BaseUri { get; set; }
+        DataServiceClientConfigurations Configurations { get; }
+        ICredentials Credentials { get; set; }
+        bool DisableInstanceAnnotationMaterialization { get; set; }
+        bool EnableWritingODataAnnotationWithoutPrefix { get; set; }
+        ReadOnlyCollection<EntityDescriptor> Entities { get; }
+        EntityParameterSendOption EntityParameterSendOption { get; set; }
+        EntityTracker EntityTracker { get; set; }
+        DataServiceClientFormat Format { get; }
+        bool IgnoreResourceNotFoundException { get; set; }
+        ReadOnlyCollection<LinkDescriptor> Links { get; }
+        ODataProtocolVersion MaxProtocolVersion { get; }
+        MergeOption MergeOption { get; set; }
+        Func<string, Uri> ResolveEntitySet { get; set; }
+        Func<Type, string> ResolveName { get; set; }
+        Func<string, Type> ResolveType { get; set; }
+        SaveChangesOptions SaveChangesDefaultOptions { get; set; }
+        int Timeout { get; set; }
+        DataServiceUrlKeyDelimiter UrlKeyDelimiter { get; set; }
+        bool UsePostTunneling { get; set; }
+
+        event EventHandler<BuildingRequestEventArgs> BuildingRequest;
+        event EventHandler<ReceivingResponseEventArgs> ReceivingResponse;
+        event EventHandler<SendingRequest2EventArgs> SendingRequest2;
+
+        void AddLink(object source, string sourceProperty, object target);
+        void AddObject(string entitySetName, object entity);
+        void AddRelatedObject(object source, string sourceProperty, object target);
+        void AttachLink(object source, string sourceProperty, object target);
+        void AttachTo(string entitySetName, object entity);
+        void AttachTo(string entitySetName, object entity, string etag);
+        IAsyncResult BeginExecute(Uri requestUri, AsyncCallback callback, object state, string httpMethod, params OperationParameter[] operationParameters);
+        IAsyncResult BeginExecute<T>(DataServiceQueryContinuation<T> continuation, AsyncCallback callback, object state);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
+        IAsyncResult BeginExecute<TElement>(Uri requestUri, AsyncCallback callback, object state);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
+        IAsyncResult BeginExecute<TElement>(Uri requestUri, AsyncCallback callback, object state, string httpMethod, bool singleResult, params OperationParameter[] operationParameters);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter")]
+        IAsyncResult BeginExecute<TElement>(Uri requestUri, AsyncCallback callback, object state, string httpMethod, params OperationParameter[] operationParameters);
+        IAsyncResult BeginExecuteBatch(AsyncCallback callback, object state, params DataServiceRequest[] queries);
+        IAsyncResult BeginGetReadStream(object entity, DataServiceRequestArgs args, AsyncCallback callback, object state);
+        IAsyncResult BeginGetReadStream(object entity, string name, DataServiceRequestArgs args, AsyncCallback callback, object state);
+        IAsyncResult BeginLoadProperty(object entity, string propertyName, AsyncCallback callback, object state);
+        IAsyncResult BeginLoadProperty(object entity, string propertyName, DataServiceQueryContinuation continuation, AsyncCallback callback, object state);
+        IAsyncResult BeginLoadProperty(object entity, string propertyName, Uri nextLinkUri, AsyncCallback callback, object state);
+        IAsyncResult BeginSaveChanges(AsyncCallback callback, object state);
+        IAsyncResult BeginSaveChanges(SaveChangesOptions options, AsyncCallback callback, object state);
+        void CancelRequest(IAsyncResult asyncResult);
+        void ChangeState(object entity, EntityStates state);
+        DataServiceQuery<T> CreateFunctionQuery<T>();
+        DataServiceQuery<T> CreateFunctionQuery<T>(string path, string functionName, bool isComposable, params UriOperationParameter[] parameters);
+        DataServiceQuerySingle<T> CreateFunctionQuerySingle<T>(string path, string functionName, bool isComposable, params UriOperationParameter[] parameters);
+        DataServiceQuery<T> CreateQuery<T>(string entitySetName);
+        DataServiceQuery<T> CreateQuery<T>(string resourcePath, bool isComposable);
+        DataServiceQuery<T> CreateSingletonQuery<T>(string singletonName);
+        void DeleteLink(object source, string sourceProperty, object target);
+        void DeleteObject(object entity);
+        bool Detach(object entity);
+        bool DetachLink(object source, string sourceProperty, object target);
+        OperationResponse EndExecute(IAsyncResult asyncResult);
+        IEnumerable<TElement> EndExecute<TElement>(IAsyncResult asyncResult);
+        DataServiceResponse EndExecuteBatch(IAsyncResult asyncResult);
+        DataServiceStreamResponse EndGetReadStream(IAsyncResult asyncResult);
+        QueryOperationResponse EndLoadProperty(IAsyncResult asyncResult);
+        DataServiceResponse EndSaveChanges(IAsyncResult asyncResult);
+        OperationResponse Execute(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
+        QueryOperationResponse<T> Execute<T>(DataServiceQueryContinuation<T> continuation);
+        IEnumerable<TElement> Execute<TElement>(Uri requestUri);
+        IEnumerable<TElement> Execute<TElement>(Uri requestUri, string httpMethod, bool singleResult, params OperationParameter[] operationParameters);
+        IEnumerable<TElement> Execute<TElement>(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
+        Task<OperationResponse> ExecuteAsync(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
+        Task<IEnumerable<TElement>> ExecuteAsync<TElement>(DataServiceQueryContinuation<TElement> continuation);
+        Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri);
+        Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, bool singleResult, params OperationParameter[] operationParameters);
+        Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters);
+        DataServiceResponse ExecuteBatch(params DataServiceRequest[] queries);
+        Task<DataServiceResponse> ExecuteBatchAsync(params DataServiceRequest[] queries);
+        EntityDescriptor GetEntityDescriptor(object entity);
+        LinkDescriptor GetLinkDescriptor(object source, string sourceProperty, object target);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Uri GetMetadataUri();
+        DataServiceStreamResponse GetReadStream(object entity);
+        DataServiceStreamResponse GetReadStream(object entity, DataServiceRequestArgs args);
+        DataServiceStreamResponse GetReadStream(object entity, string acceptContentType);
+        DataServiceStreamResponse GetReadStream(object entity, string name, DataServiceRequestArgs args);
+        Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, DataServiceRequestArgs args);
+        Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, string name, DataServiceRequestArgs args);
+        Uri GetReadStreamUri(object entity);
+        Uri GetReadStreamUri(object entity, string name);
+        QueryOperationResponse LoadProperty(object entity, string propertyName);
+        QueryOperationResponse LoadProperty(object entity, string propertyName, DataServiceQueryContinuation continuation);
+        QueryOperationResponse LoadProperty(object entity, string propertyName, Uri nextLinkUri);
+        QueryOperationResponse<T> LoadProperty<T>(object entity, string propertyName, DataServiceQueryContinuation<T> continuation);
+        Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName);
+        Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, DataServiceQueryContinuation continuation);
+        Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, Uri nextLinkUri);
+        DataServiceResponse SaveChanges();
+        DataServiceResponse SaveChanges(SaveChangesOptions options);
+        Task<DataServiceResponse> SaveChangesAsync();
+        Task<DataServiceResponse> SaveChangesAsync(SaveChangesOptions options);
+        void SetLink(object source, string sourceProperty, object target);
+        void SetSaveStream(object entity, Stream stream, bool closeStream, DataServiceRequestArgs args);
+        void SetSaveStream(object entity, Stream stream, bool closeStream, string contentType, string slug);
+        void SetSaveStream(object entity, string name, Stream stream, bool closeStream, DataServiceRequestArgs args);
+        void SetSaveStream(object entity, string name, Stream stream, bool closeStream, string contentType);
+        bool TryGetAnnotation<TFunc, TResult>(Expression<TFunc> expression, string term, out TResult annotation);
+        bool TryGetAnnotation<TFunc, TResult>(Expression<TFunc> expression, string term, string qualifier, out TResult annotation);
+        bool TryGetAnnotation<TResult>(object source, string term, out TResult annotation);
+        bool TryGetAnnotation<TResult>(object source, string term, string qualifier, out TResult annotation);
+        bool TryGetEntity<TEntity>(Uri identity, out TEntity entity) where TEntity : class;
+        bool TryGetUri(object entity, out Uri identity);
+        void UpdateObject(object entity);
+        void UpdateRelatedObject(object source, string sourceProperty, object target);
+    }
+}

--- a/src/Microsoft.OData.Client/IDataServiceQuery.cs
+++ b/src/Microsoft.OData.Client/IDataServiceQuery.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.Client
+{
+    public interface IDataServiceQuery
+    {
+        Expression Expression { get; }
+        IQueryProvider Provider { get; }
+
+        IAsyncResult BeginExecute(AsyncCallback callback, object state);
+        IEnumerable EndExecute(IAsyncResult asyncResult);
+        IEnumerable Execute();
+        Task<IEnumerable> ExecuteAsync();
+    }
+}

--- a/src/Microsoft.OData.Client/IDataServiceQuery.cs
+++ b/src/Microsoft.OData.Client/IDataServiceQuery.cs
@@ -13,7 +13,9 @@ namespace Microsoft.OData.Client
 
         IAsyncResult BeginExecute(AsyncCallback callback, object state);
         IEnumerable EndExecute(IAsyncResult asyncResult);
+#if !PORTABLELIB
         IEnumerable Execute();
+#endif
         Task<IEnumerable> ExecuteAsync();
     }
 }

--- a/src/Microsoft.OData.Client/IDataServiceQuery.cs
+++ b/src/Microsoft.OData.Client/IDataServiceQuery.cs
@@ -1,11 +1,17 @@
-﻿using System;
-using System.Collections;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
+﻿//---------------------------------------------------------------------
+// <copyright file="IDataServiceQuery.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
 
 namespace Microsoft.OData.Client
 {
+    using System;
+    using System.Collections;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
+
     public interface IDataServiceQuery
     {
         Expression Expression { get; }

--- a/src/Microsoft.OData.Client/IDataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/IDataServiceQueryOfT.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.Client
+{
+    public interface IDataServiceQueryOfT<TElement>
+    {
+        DataServiceContext Context { get; }
+        Type ElementType { get; }
+        Expression Expression { get; }
+        bool IsComposable { get; }
+        IQueryProvider Provider { get; }
+        Uri RequestUri { get; }
+
+        DataServiceQuery<TElement> AddQueryOption(string name, object value);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings")]
+        string AppendRequestUri(string nextSegment);
+        IAsyncResult BeginExecute(AsyncCallback callback, object state);
+        DataServiceQuery<T> CreateFunctionQuery<T>(string functionName, bool isComposable, params UriOperationParameter[] parameters);
+        DataServiceQuerySingle<T> CreateFunctionQuerySingle<T>(string functionName, bool isComposable, params UriOperationParameter[] parameters);
+        IEnumerable<TElement> EndExecute(IAsyncResult asyncResult);
+        IEnumerable<TElement> Execute();
+        Task<IEnumerable<TElement>> ExecuteAsync();
+        DataServiceQuery<TElement> Expand(string path);
+        DataServiceQuery<TElement> Expand<TTarget>(Expression<Func<TElement, TTarget>> navigationPropertyAccessor);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IEnumerable<TElement> GetAllPages();
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<IEnumerable<TElement>> GetAllPagesAsync();
+        IEnumerator<TElement> GetEnumerator();
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", MessageId = "string")]
+        string GetKeyPath(string keyString);
+        string GetPath(string nextSegment);
+        DataServiceQuery<TElement> IncludeTotalCount();
+        string ToString();
+    }
+}

--- a/src/Microsoft.OData.Client/IDataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/IDataServiceQueryOfT.cs
@@ -17,17 +17,20 @@ namespace Microsoft.OData.Client
 
         DataServiceQuery<TElement> AddQueryOption(string name, object value);
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings")]
         string AppendRequestUri(string nextSegment);
         IAsyncResult BeginExecute(AsyncCallback callback, object state);
         DataServiceQuery<T> CreateFunctionQuery<T>(string functionName, bool isComposable, params UriOperationParameter[] parameters);
         DataServiceQuerySingle<T> CreateFunctionQuerySingle<T>(string functionName, bool isComposable, params UriOperationParameter[] parameters);
         IEnumerable<TElement> EndExecute(IAsyncResult asyncResult);
+#if !PORTABLELIB
         IEnumerable<TElement> Execute();
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        IEnumerable<TElement> GetAllPages();
+#endif
         Task<IEnumerable<TElement>> ExecuteAsync();
         DataServiceQuery<TElement> Expand(string path);
         DataServiceQuery<TElement> Expand<TTarget>(Expression<Func<TElement, TTarget>> navigationPropertyAccessor);
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
-        IEnumerable<TElement> GetAllPages();
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<IEnumerable<TElement>> GetAllPagesAsync();
         IEnumerator<TElement> GetEnumerator();

--- a/src/Microsoft.OData.Client/IDataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/IDataServiceQueryOfT.cs
@@ -1,12 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
+﻿//---------------------------------------------------------------------
+// <copyright file="IDataServiceQueryOfT.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
 
 namespace Microsoft.OData.Client
 {
-    public interface IDataServiceQueryOfT<TElement>
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
+
+    public interface IDataServiceQuery<TElement>
     {
         DataServiceContext Context { get; }
         Type ElementType { get; }

--- a/src/Microsoft.OData.Client/IDataServiceQuerySingle.cs
+++ b/src/Microsoft.OData.Client/IDataServiceQuerySingle.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.Client
+{
+    public interface IDataServiceQuerySingle<TElement>
+    {
+        DataServiceContext Context { get; }
+        bool IsComposable { get; }
+        Uri RequestUri { get; }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings")]
+        string AppendRequestUri(string nextSegment);
+        IAsyncResult BeginGetValue(AsyncCallback callback, object state);
+        DataServiceQuerySingle<TResult> CastTo<TResult>();
+        DataServiceQuery<T> CreateFunctionQuery<T>(string functionName, bool isComposable, params UriOperationParameter[] parameters);
+        DataServiceQuerySingle<T> CreateFunctionQuerySingle<T>(string functionName, bool isComposable, params UriOperationParameter[] parameters);
+        TElement EndGetValue(IAsyncResult asyncResult);
+        DataServiceQuerySingle<TElement> Expand(string path);
+        DataServiceQuerySingle<TElement> Expand<TTarget>(Expression<Func<TElement, TTarget>> navigationPropertyAccessor);
+        string GetPath(string nextSegment);
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        TElement GetValue();
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
+        Task<TElement> GetValueAsync();
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Select")]
+        DataServiceQuerySingle<TResult> Select<TResult>(Expression<Func<TElement, TResult>> selector);
+    }
+}

--- a/src/Microsoft.OData.Client/IDataServiceQuerySingle.cs
+++ b/src/Microsoft.OData.Client/IDataServiceQuerySingle.cs
@@ -20,8 +20,10 @@ namespace Microsoft.OData.Client
         DataServiceQuerySingle<TElement> Expand(string path);
         DataServiceQuerySingle<TElement> Expand<TTarget>(Expression<Func<TElement, TTarget>> navigationPropertyAccessor);
         string GetPath(string nextSegment);
+#if !PORTABLELIB
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         TElement GetValue();
+#endif
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
         Task<TElement> GetValueAsync();
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Select")]

--- a/src/Microsoft.OData.Client/IDataServiceQuerySingleOfT.cs
+++ b/src/Microsoft.OData.Client/IDataServiceQuerySingleOfT.cs
@@ -1,9 +1,15 @@
-﻿using System;
-using System.Linq.Expressions;
-using System.Threading.Tasks;
+﻿//---------------------------------------------------------------------
+// <copyright file="IDataServiceQuerySingleOfT.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
 
 namespace Microsoft.OData.Client
 {
+    using System;
+    using System.Linq.Expressions;
+    using System.Threading.Tasks;
+
     public interface IDataServiceQuerySingle<TElement>
     {
         DataServiceContext Context { get; }

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -453,18 +453,6 @@
     <Compile Include="..\PlatformHelper.cs">
       <Link>PlatformHelper.cs</Link>
     </Compile>
-    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuerySingle.cs">
-      <Link>IDataServiceQuerySingle.cs</Link>
-    </Compile>
-    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQueryOfT.cs">
-      <Link>IDataServiceQueryOfT.cs</Link>
-    </Compile>
-    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuery.cs">
-      <Link>IDataServiceQuery.cs</Link>
-    </Compile>
-    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceContext.cs">
-      <Link>IDataServiceContext.cs</Link>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ShippingAssemblyAttributes.cs">

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -453,6 +453,18 @@
     <Compile Include="..\PlatformHelper.cs">
       <Link>PlatformHelper.cs</Link>
     </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuerySingle.cs">
+      <Link>IDataServiceQuerySingle.cs</Link>
+    </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQueryOfT.cs">
+      <Link>IDataServiceQueryOfT.cs</Link>
+    </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceQuery.cs">
+      <Link>IDataServiceQuery.cs</Link>
+    </Compile>
+    <Compile Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\IDataServiceContext.cs">
+      <Link>IDataServiceContext.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ShippingAssemblyAttributes.cs">

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -243,6 +243,10 @@
     <Compile Include="ContentStream.cs" />
     <Compile Include="ConventionalODataEntityMetadataBuilder.cs" />
     <Compile Include="DataServiceQuerySingleOfT.cs" />
+    <Compile Include="IDataServiceContext.cs" />
+    <Compile Include="IDataServiceQuery.cs" />
+    <Compile Include="IDataServiceQueryOfT.cs" />
+    <Compile Include="IDataServiceQuerySingle.cs" />
     <Compile Include="Materialization\EnumValueMaterializationPolicy.cs" />
     <Compile Include="Materialization\InstanceAnnotationMaterializationPolicy.cs" />
     <Compile Include="Materialization\ODataLoadNavigationPropertyMaterializer.cs" />

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -246,7 +246,7 @@
     <Compile Include="IDataServiceContext.cs" />
     <Compile Include="IDataServiceQuery.cs" />
     <Compile Include="IDataServiceQueryOfT.cs" />
-    <Compile Include="IDataServiceQuerySingle.cs" />
+    <Compile Include="IDataServiceQuerySingleOfT.cs" />
     <Compile Include="Materialization\EnumValueMaterializationPolicy.cs" />
     <Compile Include="Materialization\InstanceAnnotationMaterializationPolicy.cs" />
     <Compile Include="Materialization\ODataLoadNavigationPropertyMaterializer.cs" />

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -7510,6 +7510,176 @@ public enum Microsoft.OData.Client.TrackingMode : int {
 	None = 0
 }
 
+public interface Microsoft.OData.Client.IDataServiceContext {
+	Microsoft.OData.Client.DataServiceResponsePreference AddAndUpdateResponsePreference  { public abstract get; public abstract set; }
+	bool ApplyingChanges  { public abstract get; }
+	System.Uri BaseUri  { public abstract get; public abstract set; }
+	Microsoft.OData.Client.DataServiceClientConfigurations Configurations  { public abstract get; }
+	System.Net.ICredentials Credentials  { public abstract get; public abstract set; }
+	bool DisableInstanceAnnotationMaterialization  { public abstract get; public abstract set; }
+	bool EnableWritingODataAnnotationWithoutPrefix  { public abstract get; public abstract set; }
+	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.EntityDescriptor]] Entities  { public abstract get; }
+	Microsoft.OData.Client.EntityParameterSendOption EntityParameterSendOption  { public abstract get; public abstract set; }
+	Microsoft.OData.Client.EntityTracker EntityTracker  { public abstract get; public abstract set; }
+	Microsoft.OData.Client.DataServiceClientFormat Format  { public abstract get; }
+	bool IgnoreResourceNotFoundException  { public abstract get; public abstract set; }
+	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.LinkDescriptor]] Links  { public abstract get; }
+	Microsoft.OData.Client.ODataProtocolVersion MaxProtocolVersion  { public abstract get; }
+	Microsoft.OData.Client.MergeOption MergeOption  { public abstract get; public abstract set; }
+	System.Func`2[[System.String],[System.Uri]] ResolveEntitySet  { public abstract get; public abstract set; }
+	System.Func`2[[System.Type],[System.String]] ResolveName  { public abstract get; public abstract set; }
+	System.Func`2[[System.String],[System.Type]] ResolveType  { public abstract get; public abstract set; }
+	Microsoft.OData.Client.SaveChangesOptions SaveChangesDefaultOptions  { public abstract get; public abstract set; }
+	int Timeout  { public abstract get; public abstract set; }
+	Microsoft.OData.Client.DataServiceUrlKeyDelimiter UrlKeyDelimiter  { public abstract get; public abstract set; }
+	bool UsePostTunneling  { public abstract get; public abstract set; }
+
+	System.EventHandler`1[[Microsoft.OData.Client.BuildingRequestEventArgs]] BuildingRequest {public abstract add;public abstract remove; }
+	System.EventHandler`1[[Microsoft.OData.Client.ReceivingResponseEventArgs]] ReceivingResponse {public abstract add;public abstract remove; }
+	System.EventHandler`1[[Microsoft.OData.Client.SendingRequest2EventArgs]] SendingRequest2 {public abstract add;public abstract remove; }
+
+	void AddLink (object source, string sourceProperty, object target)
+	void AddObject (string entitySetName, object entity)
+	void AddRelatedObject (object source, string sourceProperty, object target)
+	void AttachLink (object source, string sourceProperty, object target)
+	void AttachTo (string entitySetName, object entity)
+	void AttachTo (string entitySetName, object entity, string etag)
+	System.IAsyncResult BeginExecute (DataServiceQueryContinuation`1 continuation, System.AsyncCallback callback, object state)
+	System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state)
+	System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	System.IAsyncResult BeginExecuteBatch (System.AsyncCallback callback, object state, Microsoft.OData.Client.DataServiceRequest[] queries)
+	System.IAsyncResult BeginGetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
+	System.IAsyncResult BeginGetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
+	System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.AsyncCallback callback, object state)
+	System.IAsyncResult BeginLoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation, System.AsyncCallback callback, object state)
+	System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.Uri nextLinkUri, System.AsyncCallback callback, object state)
+	System.IAsyncResult BeginSaveChanges (System.AsyncCallback callback, object state)
+	System.IAsyncResult BeginSaveChanges (Microsoft.OData.Client.SaveChangesOptions options, System.AsyncCallback callback, object state)
+	void CancelRequest (System.IAsyncResult asyncResult)
+	void ChangeState (object entity, Microsoft.OData.Client.EntityStates state)
+	DataServiceQuery`1 CreateFunctionQuery ()
+	DataServiceQuery`1 CreateFunctionQuery (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	DataServiceQuerySingle`1 CreateFunctionQuerySingle (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	DataServiceQuery`1 CreateQuery (string entitySetName)
+	DataServiceQuery`1 CreateQuery (string resourcePath, bool isComposable)
+	DataServiceQuery`1 CreateSingletonQuery (string singletonName)
+	void DeleteLink (object source, string sourceProperty, object target)
+	void DeleteObject (object entity)
+	bool Detach (object entity)
+	bool DetachLink (object source, string sourceProperty, object target)
+	Microsoft.OData.Client.OperationResponse EndExecute (System.IAsyncResult asyncResult)
+	IEnumerable`1 EndExecute (System.IAsyncResult asyncResult)
+	Microsoft.OData.Client.DataServiceResponse EndExecuteBatch (System.IAsyncResult asyncResult)
+	Microsoft.OData.Client.DataServiceStreamResponse EndGetReadStream (System.IAsyncResult asyncResult)
+	Microsoft.OData.Client.QueryOperationResponse EndLoadProperty (System.IAsyncResult asyncResult)
+	Microsoft.OData.Client.DataServiceResponse EndSaveChanges (System.IAsyncResult asyncResult)
+	QueryOperationResponse`1 Execute (DataServiceQueryContinuation`1 continuation)
+	IEnumerable`1 Execute (System.Uri requestUri)
+	Microsoft.OData.Client.OperationResponse Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	Task`1 ExecuteAsync (DataServiceQueryContinuation`1 continuation)
+	Task`1 ExecuteAsync (System.Uri requestUri)
+	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.OperationResponse]] ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	Microsoft.OData.Client.DataServiceResponse ExecuteBatch (Microsoft.OData.Client.DataServiceRequest[] queries)
+	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] ExecuteBatchAsync (Microsoft.OData.Client.DataServiceRequest[] queries)
+	Microsoft.OData.Client.EntityDescriptor GetEntityDescriptor (object entity)
+	Microsoft.OData.Client.LinkDescriptor GetLinkDescriptor (object source, string sourceProperty, object target)
+	System.Uri GetMetadataUri ()
+	Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity)
+	Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
+	Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string acceptContentType)
+	Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
+	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
+	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
+	System.Uri GetReadStreamUri (object entity)
+	System.Uri GetReadStreamUri (object entity, string name)
+	Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName)
+	QueryOperationResponse`1 LoadProperty (object entity, string propertyName, DataServiceQueryContinuation`1 continuation)
+	Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
+	Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, System.Uri nextLinkUri)
+	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName)
+	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
+	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, System.Uri nextLinkUri)
+	Microsoft.OData.Client.DataServiceResponse SaveChanges ()
+	Microsoft.OData.Client.DataServiceResponse SaveChanges (Microsoft.OData.Client.SaveChangesOptions options)
+	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync ()
+	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync (Microsoft.OData.Client.SaveChangesOptions options)
+	void SetLink (object source, string sourceProperty, object target)
+	void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
+	void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, string contentType, string slug)
+	void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
+	void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, string contentType)
+	bool TryGetAnnotation (Expression`1 expression, string term, out TResult& annotation)
+	bool TryGetAnnotation (object source, string term, out TResult& annotation)
+	bool TryGetAnnotation (Expression`1 expression, string term, string qualifier, out TResult& annotation)
+	bool TryGetAnnotation (object source, string term, string qualifier, out TResult& annotation)
+	bool TryGetEntity (System.Uri identity, out TEntity& entity)
+	bool TryGetUri (object entity, out System.Uri& identity)
+	void UpdateObject (object entity)
+	void UpdateRelatedObject (object source, string sourceProperty, object target)
+}
+
+public interface Microsoft.OData.Client.IDataServiceQuery {
+	System.Linq.Expressions.Expression Expression  { public abstract get; }
+	System.Linq.IQueryProvider Provider  { public abstract get; }
+
+	System.IAsyncResult BeginExecute (System.AsyncCallback callback, object state)
+	System.Collections.IEnumerable EndExecute (System.IAsyncResult asyncResult)
+	System.Collections.IEnumerable Execute ()
+	System.Threading.Tasks.Task`1[[System.Collections.IEnumerable]] ExecuteAsync ()
+}
+
+public interface Microsoft.OData.Client.IDataServiceQueryOfT`1 {
+	Microsoft.OData.Client.DataServiceContext Context  { public abstract get; }
+	System.Type ElementType  { public abstract get; }
+	System.Linq.Expressions.Expression Expression  { public abstract get; }
+	bool IsComposable  { public abstract get; }
+	System.Linq.IQueryProvider Provider  { public abstract get; }
+	System.Uri RequestUri  { public abstract get; }
+
+	DataServiceQuery`1 AddQueryOption (string name, object value)
+	string AppendRequestUri (string nextSegment)
+	System.IAsyncResult BeginExecute (System.AsyncCallback callback, object state)
+	DataServiceQuery`1 CreateFunctionQuery (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	DataServiceQuerySingle`1 CreateFunctionQuerySingle (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	IEnumerable`1 EndExecute (System.IAsyncResult asyncResult)
+	IEnumerable`1 Execute ()
+	Task`1 ExecuteAsync ()
+	DataServiceQuery`1 Expand (Expression`1 navigationPropertyAccessor)
+	DataServiceQuery`1 Expand (string path)
+	IEnumerable`1 GetAllPages ()
+	Task`1 GetAllPagesAsync ()
+	IEnumerator`1 GetEnumerator ()
+	string GetKeyPath (string keyString)
+	string GetPath (string nextSegment)
+	DataServiceQuery`1 IncludeTotalCount ()
+	string ToString ()
+}
+
+public interface Microsoft.OData.Client.IDataServiceQuerySingle`1 {
+	Microsoft.OData.Client.DataServiceContext Context  { public abstract get; }
+	bool IsComposable  { public abstract get; }
+	System.Uri RequestUri  { public abstract get; }
+
+	string AppendRequestUri (string nextSegment)
+	System.IAsyncResult BeginGetValue (System.AsyncCallback callback, object state)
+	DataServiceQuerySingle`1 CastTo ()
+	DataServiceQuery`1 CreateFunctionQuery (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	DataServiceQuerySingle`1 CreateFunctionQuerySingle (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	TElement EndGetValue (System.IAsyncResult asyncResult)
+	DataServiceQuerySingle`1 Expand (Expression`1 navigationPropertyAccessor)
+	DataServiceQuerySingle`1 Expand (string path)
+	string GetPath (string nextSegment)
+	TElement GetValue ()
+	Task`1 GetValueAsync ()
+	DataServiceQuerySingle`1 Select (Expression`1 selector)
+}
+
 public abstract class Microsoft.OData.Client.DataServiceClientRequestMessage : IODataRequestMessage {
 	public DataServiceClientRequestMessage (string actualMethod)
 
@@ -7532,16 +7702,16 @@ public abstract class Microsoft.OData.Client.DataServiceClientRequestMessage : I
 	public abstract void SetHeader (string headerName, string headerValue)
 }
 
-public abstract class Microsoft.OData.Client.DataServiceQuery : Microsoft.OData.Client.DataServiceRequest, IEnumerable, IQueryable {
+public abstract class Microsoft.OData.Client.DataServiceQuery : Microsoft.OData.Client.DataServiceRequest, IEnumerable, IQueryable, IDataServiceQuery {
 	System.Linq.Expressions.Expression Expression  { public abstract get; }
 	System.Linq.IQueryProvider Provider  { public abstract get; }
 
-	public System.IAsyncResult BeginExecute (System.AsyncCallback callback, object state)
+	public virtual System.IAsyncResult BeginExecute (System.AsyncCallback callback, object state)
 	internal abstract System.IAsyncResult BeginExecuteInternal (System.AsyncCallback callback, object state)
-	public System.Collections.IEnumerable EndExecute (System.IAsyncResult asyncResult)
+	public virtual System.Collections.IEnumerable EndExecute (System.IAsyncResult asyncResult)
 	internal abstract System.Collections.IEnumerable EndExecuteInternal (System.IAsyncResult asyncResult)
-	public System.Collections.IEnumerable Execute ()
-	public System.Threading.Tasks.Task`1[[System.Collections.IEnumerable]] ExecuteAsync ()
+	public virtual System.Collections.IEnumerable Execute ()
+	public virtual System.Threading.Tasks.Task`1[[System.Collections.IEnumerable]] ExecuteAsync ()
 	internal abstract System.Collections.IEnumerable ExecuteInternal ()
 	System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
 }
@@ -7694,186 +7864,186 @@ public class Microsoft.OData.Client.DataServiceCollection`1 : ObservableCollecti
 	public bool LoadNextPartialSetAsync ()
 }
 
-public class Microsoft.OData.Client.DataServiceContext {
+public class Microsoft.OData.Client.DataServiceContext : IDataServiceContext {
 	public DataServiceContext ()
 	public DataServiceContext (System.Uri serviceRoot)
 	public DataServiceContext (System.Uri serviceRoot, Microsoft.OData.Client.ODataProtocolVersion maxProtocolVersion)
 
-	Microsoft.OData.Client.DataServiceResponsePreference AddAndUpdateResponsePreference  { public get; public set; }
-	bool ApplyingChanges  { public get; }
-	System.Uri BaseUri  { public get; public set; }
-	Microsoft.OData.Client.DataServiceClientConfigurations Configurations  { public get; }
-	System.Net.ICredentials Credentials  { public get; public set; }
-	bool DisableInstanceAnnotationMaterialization  { public get; public set; }
-	bool EnableWritingODataAnnotationWithoutPrefix  { public get; public set; }
-	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.EntityDescriptor]] Entities  { public get; }
-	Microsoft.OData.Client.EntityParameterSendOption EntityParameterSendOption  { public get; public set; }
-	Microsoft.OData.Client.EntityTracker EntityTracker  { public get; public set; }
-	Microsoft.OData.Client.DataServiceClientFormat Format  { public get; }
-	bool IgnoreResourceNotFoundException  { public get; public set; }
-	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.LinkDescriptor]] Links  { public get; }
-	Microsoft.OData.Client.ODataProtocolVersion MaxProtocolVersion  { public get; }
-	Microsoft.OData.Client.MergeOption MergeOption  { public get; public set; }
-	System.Func`2[[System.String],[System.Uri]] ResolveEntitySet  { public get; public set; }
-	System.Func`2[[System.Type],[System.String]] ResolveName  { public get; public set; }
-	System.Func`2[[System.String],[System.Type]] ResolveType  { public get; public set; }
-	Microsoft.OData.Client.SaveChangesOptions SaveChangesDefaultOptions  { public get; public set; }
-	int Timeout  { public get; public set; }
-	Microsoft.OData.Client.DataServiceUrlKeyDelimiter UrlKeyDelimiter  { public get; public set; }
-	bool UsePostTunneling  { public get; public set; }
+	Microsoft.OData.Client.DataServiceResponsePreference AddAndUpdateResponsePreference  { public virtual get; public virtual set; }
+	bool ApplyingChanges  { public virtual get; }
+	System.Uri BaseUri  { public virtual get; public virtual set; }
+	Microsoft.OData.Client.DataServiceClientConfigurations Configurations  { public virtual get; }
+	System.Net.ICredentials Credentials  { public virtual get; public virtual set; }
+	bool DisableInstanceAnnotationMaterialization  { public virtual get; public virtual set; }
+	bool EnableWritingODataAnnotationWithoutPrefix  { public virtual get; public virtual set; }
+	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.EntityDescriptor]] Entities  { public virtual get; }
+	Microsoft.OData.Client.EntityParameterSendOption EntityParameterSendOption  { public virtual get; public virtual set; }
+	Microsoft.OData.Client.EntityTracker EntityTracker  { public virtual get; public virtual set; }
+	Microsoft.OData.Client.DataServiceClientFormat Format  { public virtual get; }
+	bool IgnoreResourceNotFoundException  { public virtual get; public virtual set; }
+	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.LinkDescriptor]] Links  { public virtual get; }
+	Microsoft.OData.Client.ODataProtocolVersion MaxProtocolVersion  { public virtual get; }
+	Microsoft.OData.Client.MergeOption MergeOption  { public virtual get; public virtual set; }
+	System.Func`2[[System.String],[System.Uri]] ResolveEntitySet  { public virtual get; public virtual set; }
+	System.Func`2[[System.Type],[System.String]] ResolveName  { public virtual get; public virtual set; }
+	System.Func`2[[System.String],[System.Type]] ResolveType  { public virtual get; public virtual set; }
+	Microsoft.OData.Client.SaveChangesOptions SaveChangesDefaultOptions  { public virtual get; public virtual set; }
+	int Timeout  { public virtual get; public virtual set; }
+	Microsoft.OData.Client.DataServiceUrlKeyDelimiter UrlKeyDelimiter  { public virtual get; public virtual set; }
+	bool UsePostTunneling  { public virtual get; public virtual set; }
 
-	System.EventHandler`1[[Microsoft.OData.Client.BuildingRequestEventArgs]] BuildingRequest {public add;public remove; }
-	System.EventHandler`1[[Microsoft.OData.Client.ReceivingResponseEventArgs]] ReceivingResponse {public add;public remove; }
-	System.EventHandler`1[[Microsoft.OData.Client.SendingRequest2EventArgs]] SendingRequest2 {public add;public remove; }
+	System.EventHandler`1[[Microsoft.OData.Client.BuildingRequestEventArgs]] BuildingRequest {public virtual add;public virtual remove; }
+	System.EventHandler`1[[Microsoft.OData.Client.ReceivingResponseEventArgs]] ReceivingResponse {public virtual add;public virtual remove; }
+	System.EventHandler`1[[Microsoft.OData.Client.SendingRequest2EventArgs]] SendingRequest2 {public virtual add;public virtual remove; }
 
-	public void AddLink (object source, string sourceProperty, object target)
-	public void AddObject (string entitySetName, object entity)
-	public void AddRelatedObject (object source, string sourceProperty, object target)
-	public void AttachLink (object source, string sourceProperty, object target)
-	public void AttachTo (string entitySetName, object entity)
-	public void AttachTo (string entitySetName, object entity, string etag)
-	public System.IAsyncResult BeginExecute (DataServiceQueryContinuation`1 continuation, System.AsyncCallback callback, object state)
-	public System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state)
-	public System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public System.IAsyncResult BeginExecuteBatch (System.AsyncCallback callback, object state, Microsoft.OData.Client.DataServiceRequest[] queries)
-	public System.IAsyncResult BeginGetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
-	public System.IAsyncResult BeginGetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
-	public System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.AsyncCallback callback, object state)
-	public System.IAsyncResult BeginLoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation, System.AsyncCallback callback, object state)
-	public System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.Uri nextLinkUri, System.AsyncCallback callback, object state)
-	public System.IAsyncResult BeginSaveChanges (System.AsyncCallback callback, object state)
-	public System.IAsyncResult BeginSaveChanges (Microsoft.OData.Client.SaveChangesOptions options, System.AsyncCallback callback, object state)
-	public void CancelRequest (System.IAsyncResult asyncResult)
-	public void ChangeState (object entity, Microsoft.OData.Client.EntityStates state)
-	public DataServiceQuery`1 CreateFunctionQuery ()
-	public DataServiceQuery`1 CreateFunctionQuery (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	public DataServiceQuerySingle`1 CreateFunctionQuerySingle (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	public DataServiceQuery`1 CreateQuery (string entitySetName)
-	public DataServiceQuery`1 CreateQuery (string resourcePath, bool isComposable)
-	public DataServiceQuery`1 CreateSingletonQuery (string singletonName)
+	public virtual void AddLink (object source, string sourceProperty, object target)
+	public virtual void AddObject (string entitySetName, object entity)
+	public virtual void AddRelatedObject (object source, string sourceProperty, object target)
+	public virtual void AttachLink (object source, string sourceProperty, object target)
+	public virtual void AttachTo (string entitySetName, object entity)
+	public virtual void AttachTo (string entitySetName, object entity, string etag)
+	public virtual System.IAsyncResult BeginExecute (DataServiceQueryContinuation`1 continuation, System.AsyncCallback callback, object state)
+	public virtual System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state)
+	public virtual System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public virtual System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public virtual System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public virtual System.IAsyncResult BeginExecuteBatch (System.AsyncCallback callback, object state, Microsoft.OData.Client.DataServiceRequest[] queries)
+	public virtual System.IAsyncResult BeginGetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
+	public virtual System.IAsyncResult BeginGetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
+	public virtual System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.AsyncCallback callback, object state)
+	public virtual System.IAsyncResult BeginLoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation, System.AsyncCallback callback, object state)
+	public virtual System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.Uri nextLinkUri, System.AsyncCallback callback, object state)
+	public virtual System.IAsyncResult BeginSaveChanges (System.AsyncCallback callback, object state)
+	public virtual System.IAsyncResult BeginSaveChanges (Microsoft.OData.Client.SaveChangesOptions options, System.AsyncCallback callback, object state)
+	public virtual void CancelRequest (System.IAsyncResult asyncResult)
+	public virtual void ChangeState (object entity, Microsoft.OData.Client.EntityStates state)
+	public virtual DataServiceQuery`1 CreateFunctionQuery ()
+	public virtual DataServiceQuery`1 CreateFunctionQuery (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	public virtual DataServiceQuerySingle`1 CreateFunctionQuerySingle (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	public virtual DataServiceQuery`1 CreateQuery (string entitySetName)
+	public virtual DataServiceQuery`1 CreateQuery (string resourcePath, bool isComposable)
+	public virtual DataServiceQuery`1 CreateSingletonQuery (string singletonName)
 	protected System.Type DefaultResolveType (string typeName, string fullNamespace, string languageDependentNamespace)
-	public void DeleteLink (object source, string sourceProperty, object target)
-	public void DeleteObject (object entity)
-	public bool Detach (object entity)
-	public bool DetachLink (object source, string sourceProperty, object target)
-	public Microsoft.OData.Client.OperationResponse EndExecute (System.IAsyncResult asyncResult)
-	public IEnumerable`1 EndExecute (System.IAsyncResult asyncResult)
-	public Microsoft.OData.Client.DataServiceResponse EndExecuteBatch (System.IAsyncResult asyncResult)
-	public Microsoft.OData.Client.DataServiceStreamResponse EndGetReadStream (System.IAsyncResult asyncResult)
-	public Microsoft.OData.Client.QueryOperationResponse EndLoadProperty (System.IAsyncResult asyncResult)
-	public Microsoft.OData.Client.DataServiceResponse EndSaveChanges (System.IAsyncResult asyncResult)
-	public QueryOperationResponse`1 Execute (DataServiceQueryContinuation`1 continuation)
-	public IEnumerable`1 Execute (System.Uri requestUri)
-	public Microsoft.OData.Client.OperationResponse Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public Task`1 ExecuteAsync (DataServiceQueryContinuation`1 continuation)
-	public Task`1 ExecuteAsync (System.Uri requestUri)
-	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.OperationResponse]] ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public Microsoft.OData.Client.DataServiceResponse ExecuteBatch (Microsoft.OData.Client.DataServiceRequest[] queries)
-	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] ExecuteBatchAsync (Microsoft.OData.Client.DataServiceRequest[] queries)
+	public virtual void DeleteLink (object source, string sourceProperty, object target)
+	public virtual void DeleteObject (object entity)
+	public virtual bool Detach (object entity)
+	public virtual bool DetachLink (object source, string sourceProperty, object target)
+	public virtual Microsoft.OData.Client.OperationResponse EndExecute (System.IAsyncResult asyncResult)
+	public virtual IEnumerable`1 EndExecute (System.IAsyncResult asyncResult)
+	public virtual Microsoft.OData.Client.DataServiceResponse EndExecuteBatch (System.IAsyncResult asyncResult)
+	public virtual Microsoft.OData.Client.DataServiceStreamResponse EndGetReadStream (System.IAsyncResult asyncResult)
+	public virtual Microsoft.OData.Client.QueryOperationResponse EndLoadProperty (System.IAsyncResult asyncResult)
+	public virtual Microsoft.OData.Client.DataServiceResponse EndSaveChanges (System.IAsyncResult asyncResult)
+	public virtual QueryOperationResponse`1 Execute (DataServiceQueryContinuation`1 continuation)
+	public virtual IEnumerable`1 Execute (System.Uri requestUri)
+	public virtual Microsoft.OData.Client.OperationResponse Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public virtual IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public virtual IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public virtual Task`1 ExecuteAsync (DataServiceQueryContinuation`1 continuation)
+	public virtual Task`1 ExecuteAsync (System.Uri requestUri)
+	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.OperationResponse]] ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public virtual Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public virtual Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public virtual Microsoft.OData.Client.DataServiceResponse ExecuteBatch (Microsoft.OData.Client.DataServiceRequest[] queries)
+	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] ExecuteBatchAsync (Microsoft.OData.Client.DataServiceRequest[] queries)
 	internal virtual Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable GetEdmOperationOrOperationImport (System.Reflection.MethodInfo methodInfo)
-	public Microsoft.OData.Client.EntityDescriptor GetEntityDescriptor (object entity)
+	public virtual Microsoft.OData.Client.EntityDescriptor GetEntityDescriptor (object entity)
 	internal virtual Microsoft.OData.Client.ODataResourceMetadataBuilder GetEntityMetadataBuilder (string entitySetName, Microsoft.OData.Edm.Vocabularies.IEdmStructuredValue entityInstance)
-	public Microsoft.OData.Client.LinkDescriptor GetLinkDescriptor (object source, string sourceProperty, object target)
-	public System.Uri GetMetadataUri ()
-	public Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity)
-	public Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string acceptContentType)
-	public Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public System.Uri GetReadStreamUri (object entity)
-	public System.Uri GetReadStreamUri (object entity, string name)
-	public Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName)
-	public QueryOperationResponse`1 LoadProperty (object entity, string propertyName, DataServiceQueryContinuation`1 continuation)
-	public Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
-	public Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, System.Uri nextLinkUri)
-	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName)
-	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
-	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, System.Uri nextLinkUri)
-	public Microsoft.OData.Client.DataServiceResponse SaveChanges ()
-	public Microsoft.OData.Client.DataServiceResponse SaveChanges (Microsoft.OData.Client.SaveChangesOptions options)
-	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync ()
-	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync (Microsoft.OData.Client.SaveChangesOptions options)
-	public void SetLink (object source, string sourceProperty, object target)
-	public void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, string contentType, string slug)
-	public void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, string contentType)
-	public bool TryGetAnnotation (Expression`1 expression, string term, out TResult& annotation)
-	public bool TryGetAnnotation (object source, string term, out TResult& annotation)
-	public bool TryGetAnnotation (Expression`1 expression, string term, string qualifier, out TResult& annotation)
-	public bool TryGetAnnotation (object source, string term, string qualifier, out TResult& annotation)
-	public bool TryGetEntity (System.Uri identity, out TEntity& entity)
-	public bool TryGetUri (object entity, out System.Uri& identity)
-	public void UpdateObject (object entity)
-	public void UpdateRelatedObject (object source, string sourceProperty, object target)
+	public virtual Microsoft.OData.Client.LinkDescriptor GetLinkDescriptor (object source, string sourceProperty, object target)
+	public virtual System.Uri GetMetadataUri ()
+	public virtual Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity)
+	public virtual Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public virtual Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string acceptContentType)
+	public virtual Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public virtual System.Uri GetReadStreamUri (object entity)
+	public virtual System.Uri GetReadStreamUri (object entity, string name)
+	public virtual Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName)
+	public virtual QueryOperationResponse`1 LoadProperty (object entity, string propertyName, DataServiceQueryContinuation`1 continuation)
+	public virtual Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
+	public virtual Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, System.Uri nextLinkUri)
+	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName)
+	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
+	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, System.Uri nextLinkUri)
+	public virtual Microsoft.OData.Client.DataServiceResponse SaveChanges ()
+	public virtual Microsoft.OData.Client.DataServiceResponse SaveChanges (Microsoft.OData.Client.SaveChangesOptions options)
+	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync ()
+	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync (Microsoft.OData.Client.SaveChangesOptions options)
+	public virtual void SetLink (object source, string sourceProperty, object target)
+	public virtual void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public virtual void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, string contentType, string slug)
+	public virtual void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public virtual void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, string contentType)
+	public virtual bool TryGetAnnotation (Expression`1 expression, string term, out TResult& annotation)
+	public virtual bool TryGetAnnotation (object source, string term, out TResult& annotation)
+	public virtual bool TryGetAnnotation (Expression`1 expression, string term, string qualifier, out TResult& annotation)
+	public virtual bool TryGetAnnotation (object source, string term, string qualifier, out TResult& annotation)
+	public virtual bool TryGetEntity (System.Uri identity, out TEntity& entity)
+	public virtual bool TryGetUri (object entity, out System.Uri& identity)
+	public virtual void UpdateObject (object entity)
+	public virtual void UpdateRelatedObject (object source, string sourceProperty, object target)
 }
 
-public class Microsoft.OData.Client.DataServiceQuery`1 : Microsoft.OData.Client.DataServiceQuery, IEnumerable`1, IQueryable`1, IEnumerable, IQueryable {
+public class Microsoft.OData.Client.DataServiceQuery`1 : Microsoft.OData.Client.DataServiceQuery, IDataServiceQueryOfT`1, IEnumerable`1, IQueryable`1, IEnumerable, IQueryable, IDataServiceQuery {
 	public DataServiceQuery`1 (System.Linq.Expressions.Expression expression, Microsoft.OData.Client.DataServiceQueryProvider provider)
 	public DataServiceQuery`1 (System.Linq.Expressions.Expression expression, Microsoft.OData.Client.DataServiceQueryProvider provider, bool isComposable)
 
-	Microsoft.OData.Client.DataServiceContext Context  { public get; }
+	Microsoft.OData.Client.DataServiceContext Context  { public virtual get; }
 	System.Type ElementType  { public virtual get; }
 	System.Linq.Expressions.Expression Expression  { public virtual get; }
-	bool IsComposable  { public get; }
+	bool IsComposable  { public virtual get; }
 	System.Linq.IQueryProvider Provider  { public virtual get; }
 	System.Uri RequestUri  { public virtual get; }
 
-	public Microsoft.OData.Client.DataServiceQuery`1 AddQueryOption (string name, object value)
-	public string AppendRequestUri (string nextSegment)
-	public System.IAsyncResult BeginExecute (System.AsyncCallback callback, object state)
+	public virtual Microsoft.OData.Client.DataServiceQuery`1 AddQueryOption (string name, object value)
+	public virtual string AppendRequestUri (string nextSegment)
+	public virtual System.IAsyncResult BeginExecute (System.AsyncCallback callback, object state)
 	internal virtual System.IAsyncResult BeginExecuteInternal (System.AsyncCallback callback, object state)
-	public DataServiceQuery`1 CreateFunctionQuery (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	public DataServiceQuerySingle`1 CreateFunctionQuerySingle (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	public IEnumerable`1 EndExecute (System.IAsyncResult asyncResult)
+	public virtual DataServiceQuery`1 CreateFunctionQuery (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	public virtual DataServiceQuerySingle`1 CreateFunctionQuerySingle (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	public virtual IEnumerable`1 EndExecute (System.IAsyncResult asyncResult)
 	internal virtual System.Collections.IEnumerable EndExecuteInternal (System.IAsyncResult asyncResult)
-	public IEnumerable`1 Execute ()
-	public Task`1 ExecuteAsync ()
+	public virtual IEnumerable`1 Execute ()
+	public virtual Task`1 ExecuteAsync ()
 	internal virtual System.Collections.IEnumerable ExecuteInternal ()
-	public Microsoft.OData.Client.DataServiceQuery`1 Expand (Expression`1 navigationPropertyAccessor)
-	public Microsoft.OData.Client.DataServiceQuery`1 Expand (string path)
-	public IEnumerable`1 GetAllPages ()
-	public Task`1 GetAllPagesAsync ()
+	public virtual Microsoft.OData.Client.DataServiceQuery`1 Expand (Expression`1 navigationPropertyAccessor)
+	public virtual Microsoft.OData.Client.DataServiceQuery`1 Expand (string path)
+	public virtual IEnumerable`1 GetAllPages ()
+	public virtual Task`1 GetAllPagesAsync ()
 	public virtual IEnumerator`1 GetEnumerator ()
-	public string GetKeyPath (string keyString)
-	public string GetPath (string nextSegment)
-	public Microsoft.OData.Client.DataServiceQuery`1 IncludeTotalCount ()
+	public virtual string GetKeyPath (string keyString)
+	public virtual string GetPath (string nextSegment)
+	public virtual Microsoft.OData.Client.DataServiceQuery`1 IncludeTotalCount ()
 	internal virtual Microsoft.OData.Client.QueryComponents QueryComponents (Microsoft.OData.Client.ClientEdmModel model)
 	System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator ()
 	public virtual string ToString ()
 }
 
-public class Microsoft.OData.Client.DataServiceQuery`1+DataServiceOrderedQuery : DataServiceQuery`1, IEnumerable`1, IOrderedQueryable`1, IQueryable`1, IEnumerable, IOrderedQueryable, IQueryable {
+public class Microsoft.OData.Client.DataServiceQuery`1+DataServiceOrderedQuery : DataServiceQuery`1, IDataServiceQueryOfT`1, IEnumerable`1, IOrderedQueryable`1, IQueryable`1, IEnumerable, IOrderedQueryable, IQueryable, IDataServiceQuery {
 }
 
-public class Microsoft.OData.Client.DataServiceQuerySingle`1 {
+public class Microsoft.OData.Client.DataServiceQuerySingle`1 : IDataServiceQuerySingle`1 {
 	public DataServiceQuerySingle`1 (Microsoft.OData.Client.DataServiceQuerySingle`1 query)
 	public DataServiceQuerySingle`1 (Microsoft.OData.Client.DataServiceContext context, string path)
 	public DataServiceQuerySingle`1 (Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
 
-	Microsoft.OData.Client.DataServiceContext Context  { public get; }
-	bool IsComposable  { public get; }
-	System.Uri RequestUri  { public get; }
+	Microsoft.OData.Client.DataServiceContext Context  { public virtual get; }
+	bool IsComposable  { public virtual get; }
+	System.Uri RequestUri  { public virtual get; }
 
-	public string AppendRequestUri (string nextSegment)
-	public System.IAsyncResult BeginGetValue (System.AsyncCallback callback, object state)
-	public DataServiceQuerySingle`1 CastTo ()
-	public DataServiceQuery`1 CreateFunctionQuery (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	public DataServiceQuerySingle`1 CreateFunctionQuerySingle (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	public TElement EndGetValue (System.IAsyncResult asyncResult)
-	public Microsoft.OData.Client.DataServiceQuerySingle`1 Expand (Expression`1 navigationPropertyAccessor)
-	public Microsoft.OData.Client.DataServiceQuerySingle`1 Expand (string path)
-	public string GetPath (string nextSegment)
-	public TElement GetValue ()
-	public Task`1 GetValueAsync ()
-	public DataServiceQuerySingle`1 Select (Expression`1 selector)
+	public virtual string AppendRequestUri (string nextSegment)
+	public virtual System.IAsyncResult BeginGetValue (System.AsyncCallback callback, object state)
+	public virtual DataServiceQuerySingle`1 CastTo ()
+	public virtual DataServiceQuery`1 CreateFunctionQuery (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	public virtual DataServiceQuerySingle`1 CreateFunctionQuerySingle (string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	public virtual TElement EndGetValue (System.IAsyncResult asyncResult)
+	public virtual Microsoft.OData.Client.DataServiceQuerySingle`1 Expand (Expression`1 navigationPropertyAccessor)
+	public virtual Microsoft.OData.Client.DataServiceQuerySingle`1 Expand (string path)
+	public virtual string GetPath (string nextSegment)
+	public virtual TElement GetValue ()
+	public virtual Task`1 GetValueAsync ()
+	public virtual DataServiceQuerySingle`1 Select (Expression`1 selector)
 }
 
 public class Microsoft.OData.Client.DataServiceRequestArgs {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -7634,7 +7634,7 @@ public interface Microsoft.OData.Client.IDataServiceQuery {
 	System.Threading.Tasks.Task`1[[System.Collections.IEnumerable]] ExecuteAsync ()
 }
 
-public interface Microsoft.OData.Client.IDataServiceQueryOfT`1 {
+public interface Microsoft.OData.Client.IDataServiceQuery`1 {
 	Microsoft.OData.Client.DataServiceContext Context  { public abstract get; }
 	System.Type ElementType  { public abstract get; }
 	System.Linq.Expressions.Expression Expression  { public abstract get; }
@@ -7985,7 +7985,7 @@ public class Microsoft.OData.Client.DataServiceContext : IDataServiceContext {
 	public virtual void UpdateRelatedObject (object source, string sourceProperty, object target)
 }
 
-public class Microsoft.OData.Client.DataServiceQuery`1 : Microsoft.OData.Client.DataServiceQuery, IDataServiceQueryOfT`1, IEnumerable`1, IQueryable`1, IEnumerable, IQueryable, IDataServiceQuery {
+public class Microsoft.OData.Client.DataServiceQuery`1 : Microsoft.OData.Client.DataServiceQuery, IDataServiceQuery`1, IEnumerable`1, IQueryable`1, IEnumerable, IQueryable, IDataServiceQuery {
 	public DataServiceQuery`1 (System.Linq.Expressions.Expression expression, Microsoft.OData.Client.DataServiceQueryProvider provider)
 	public DataServiceQuery`1 (System.Linq.Expressions.Expression expression, Microsoft.OData.Client.DataServiceQueryProvider provider, bool isComposable)
 
@@ -8020,7 +8020,7 @@ public class Microsoft.OData.Client.DataServiceQuery`1 : Microsoft.OData.Client.
 	public virtual string ToString ()
 }
 
-public class Microsoft.OData.Client.DataServiceQuery`1+DataServiceOrderedQuery : DataServiceQuery`1, IDataServiceQueryOfT`1, IEnumerable`1, IOrderedQueryable`1, IQueryable`1, IEnumerable, IOrderedQueryable, IQueryable, IDataServiceQuery {
+public class Microsoft.OData.Client.DataServiceQuery`1+DataServiceOrderedQuery : DataServiceQuery`1, IDataServiceQuery`1, IEnumerable`1, IOrderedQueryable`1, IQueryable`1, IEnumerable, IOrderedQueryable, IQueryable, IDataServiceQuery {
 }
 
 public class Microsoft.OData.Client.DataServiceQuerySingle`1 : IDataServiceQuerySingle`1 {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -7511,117 +7511,9 @@ public enum Microsoft.OData.Client.TrackingMode : int {
 }
 
 public interface Microsoft.OData.Client.IDataServiceContext {
-	Microsoft.OData.Client.DataServiceResponsePreference AddAndUpdateResponsePreference  { public abstract get; public abstract set; }
-	bool ApplyingChanges  { public abstract get; }
-	System.Uri BaseUri  { public abstract get; public abstract set; }
-	Microsoft.OData.Client.DataServiceClientConfigurations Configurations  { public abstract get; }
-	System.Net.ICredentials Credentials  { public abstract get; public abstract set; }
-	bool DisableInstanceAnnotationMaterialization  { public abstract get; public abstract set; }
-	bool EnableWritingODataAnnotationWithoutPrefix  { public abstract get; public abstract set; }
-	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.EntityDescriptor]] Entities  { public abstract get; }
-	Microsoft.OData.Client.EntityParameterSendOption EntityParameterSendOption  { public abstract get; public abstract set; }
-	Microsoft.OData.Client.EntityTracker EntityTracker  { public abstract get; public abstract set; }
-	Microsoft.OData.Client.DataServiceClientFormat Format  { public abstract get; }
-	bool IgnoreResourceNotFoundException  { public abstract get; public abstract set; }
-	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.LinkDescriptor]] Links  { public abstract get; }
-	Microsoft.OData.Client.ODataProtocolVersion MaxProtocolVersion  { public abstract get; }
-	Microsoft.OData.Client.MergeOption MergeOption  { public abstract get; public abstract set; }
-	System.Func`2[[System.String],[System.Uri]] ResolveEntitySet  { public abstract get; public abstract set; }
-	System.Func`2[[System.Type],[System.String]] ResolveName  { public abstract get; public abstract set; }
-	System.Func`2[[System.String],[System.Type]] ResolveType  { public abstract get; public abstract set; }
-	Microsoft.OData.Client.SaveChangesOptions SaveChangesDefaultOptions  { public abstract get; public abstract set; }
-	int Timeout  { public abstract get; public abstract set; }
-	Microsoft.OData.Client.DataServiceUrlKeyDelimiter UrlKeyDelimiter  { public abstract get; public abstract set; }
-	bool UsePostTunneling  { public abstract get; public abstract set; }
-
-	System.EventHandler`1[[Microsoft.OData.Client.BuildingRequestEventArgs]] BuildingRequest {public abstract add;public abstract remove; }
-	System.EventHandler`1[[Microsoft.OData.Client.ReceivingResponseEventArgs]] ReceivingResponse {public abstract add;public abstract remove; }
-	System.EventHandler`1[[Microsoft.OData.Client.SendingRequest2EventArgs]] SendingRequest2 {public abstract add;public abstract remove; }
-
-	void AddLink (object source, string sourceProperty, object target)
 	void AddObject (string entitySetName, object entity)
-	void AddRelatedObject (object source, string sourceProperty, object target)
-	void AttachLink (object source, string sourceProperty, object target)
-	void AttachTo (string entitySetName, object entity)
-	void AttachTo (string entitySetName, object entity, string etag)
-	System.IAsyncResult BeginExecute (DataServiceQueryContinuation`1 continuation, System.AsyncCallback callback, object state)
-	System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state)
-	System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	System.IAsyncResult BeginExecuteBatch (System.AsyncCallback callback, object state, Microsoft.OData.Client.DataServiceRequest[] queries)
-	System.IAsyncResult BeginGetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
-	System.IAsyncResult BeginGetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
-	System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.AsyncCallback callback, object state)
-	System.IAsyncResult BeginLoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation, System.AsyncCallback callback, object state)
-	System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.Uri nextLinkUri, System.AsyncCallback callback, object state)
-	System.IAsyncResult BeginSaveChanges (System.AsyncCallback callback, object state)
-	System.IAsyncResult BeginSaveChanges (Microsoft.OData.Client.SaveChangesOptions options, System.AsyncCallback callback, object state)
-	void CancelRequest (System.IAsyncResult asyncResult)
-	void ChangeState (object entity, Microsoft.OData.Client.EntityStates state)
-	DataServiceQuery`1 CreateFunctionQuery ()
-	DataServiceQuery`1 CreateFunctionQuery (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	DataServiceQuerySingle`1 CreateFunctionQuerySingle (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	DataServiceQuery`1 CreateQuery (string entitySetName)
-	DataServiceQuery`1 CreateQuery (string resourcePath, bool isComposable)
-	DataServiceQuery`1 CreateSingletonQuery (string singletonName)
-	void DeleteLink (object source, string sourceProperty, object target)
 	void DeleteObject (object entity)
-	bool Detach (object entity)
-	bool DetachLink (object source, string sourceProperty, object target)
-	Microsoft.OData.Client.OperationResponse EndExecute (System.IAsyncResult asyncResult)
-	IEnumerable`1 EndExecute (System.IAsyncResult asyncResult)
-	Microsoft.OData.Client.DataServiceResponse EndExecuteBatch (System.IAsyncResult asyncResult)
-	Microsoft.OData.Client.DataServiceStreamResponse EndGetReadStream (System.IAsyncResult asyncResult)
-	Microsoft.OData.Client.QueryOperationResponse EndLoadProperty (System.IAsyncResult asyncResult)
-	Microsoft.OData.Client.DataServiceResponse EndSaveChanges (System.IAsyncResult asyncResult)
-	QueryOperationResponse`1 Execute (DataServiceQueryContinuation`1 continuation)
-	IEnumerable`1 Execute (System.Uri requestUri)
-	Microsoft.OData.Client.OperationResponse Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	Task`1 ExecuteAsync (DataServiceQueryContinuation`1 continuation)
-	Task`1 ExecuteAsync (System.Uri requestUri)
-	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.OperationResponse]] ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	Microsoft.OData.Client.DataServiceResponse ExecuteBatch (Microsoft.OData.Client.DataServiceRequest[] queries)
-	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] ExecuteBatchAsync (Microsoft.OData.Client.DataServiceRequest[] queries)
-	Microsoft.OData.Client.EntityDescriptor GetEntityDescriptor (object entity)
-	Microsoft.OData.Client.LinkDescriptor GetLinkDescriptor (object source, string sourceProperty, object target)
-	System.Uri GetMetadataUri ()
-	Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity)
-	Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
-	Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string acceptContentType)
-	Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
-	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
-	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
-	System.Uri GetReadStreamUri (object entity)
-	System.Uri GetReadStreamUri (object entity, string name)
-	Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName)
-	QueryOperationResponse`1 LoadProperty (object entity, string propertyName, DataServiceQueryContinuation`1 continuation)
-	Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
-	Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, System.Uri nextLinkUri)
-	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName)
-	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
-	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, System.Uri nextLinkUri)
-	Microsoft.OData.Client.DataServiceResponse SaveChanges ()
-	Microsoft.OData.Client.DataServiceResponse SaveChanges (Microsoft.OData.Client.SaveChangesOptions options)
-	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync ()
-	System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync (Microsoft.OData.Client.SaveChangesOptions options)
-	void SetLink (object source, string sourceProperty, object target)
-	void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
-	void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, string contentType, string slug)
-	void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
-	void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, string contentType)
-	bool TryGetAnnotation (Expression`1 expression, string term, out TResult& annotation)
-	bool TryGetAnnotation (object source, string term, out TResult& annotation)
-	bool TryGetAnnotation (Expression`1 expression, string term, string qualifier, out TResult& annotation)
-	bool TryGetAnnotation (object source, string term, string qualifier, out TResult& annotation)
-	bool TryGetEntity (System.Uri identity, out TEntity& entity)
-	bool TryGetUri (object entity, out System.Uri& identity)
 	void UpdateObject (object entity)
-	void UpdateRelatedObject (object source, string sourceProperty, object target)
 }
 
 public interface Microsoft.OData.Client.IDataServiceQuery {
@@ -7869,120 +7761,120 @@ public class Microsoft.OData.Client.DataServiceContext : IDataServiceContext {
 	public DataServiceContext (System.Uri serviceRoot)
 	public DataServiceContext (System.Uri serviceRoot, Microsoft.OData.Client.ODataProtocolVersion maxProtocolVersion)
 
-	Microsoft.OData.Client.DataServiceResponsePreference AddAndUpdateResponsePreference  { public virtual get; public virtual set; }
-	bool ApplyingChanges  { public virtual get; }
-	System.Uri BaseUri  { public virtual get; public virtual set; }
-	Microsoft.OData.Client.DataServiceClientConfigurations Configurations  { public virtual get; }
-	System.Net.ICredentials Credentials  { public virtual get; public virtual set; }
-	bool DisableInstanceAnnotationMaterialization  { public virtual get; public virtual set; }
-	bool EnableWritingODataAnnotationWithoutPrefix  { public virtual get; public virtual set; }
-	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.EntityDescriptor]] Entities  { public virtual get; }
-	Microsoft.OData.Client.EntityParameterSendOption EntityParameterSendOption  { public virtual get; public virtual set; }
-	Microsoft.OData.Client.EntityTracker EntityTracker  { public virtual get; public virtual set; }
-	Microsoft.OData.Client.DataServiceClientFormat Format  { public virtual get; }
-	bool IgnoreResourceNotFoundException  { public virtual get; public virtual set; }
-	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.LinkDescriptor]] Links  { public virtual get; }
-	Microsoft.OData.Client.ODataProtocolVersion MaxProtocolVersion  { public virtual get; }
-	Microsoft.OData.Client.MergeOption MergeOption  { public virtual get; public virtual set; }
-	System.Func`2[[System.String],[System.Uri]] ResolveEntitySet  { public virtual get; public virtual set; }
-	System.Func`2[[System.Type],[System.String]] ResolveName  { public virtual get; public virtual set; }
-	System.Func`2[[System.String],[System.Type]] ResolveType  { public virtual get; public virtual set; }
-	Microsoft.OData.Client.SaveChangesOptions SaveChangesDefaultOptions  { public virtual get; public virtual set; }
-	int Timeout  { public virtual get; public virtual set; }
-	Microsoft.OData.Client.DataServiceUrlKeyDelimiter UrlKeyDelimiter  { public virtual get; public virtual set; }
-	bool UsePostTunneling  { public virtual get; public virtual set; }
+	Microsoft.OData.Client.DataServiceResponsePreference AddAndUpdateResponsePreference  { public get; public set; }
+	bool ApplyingChanges  { public get; }
+	System.Uri BaseUri  { public get; public set; }
+	Microsoft.OData.Client.DataServiceClientConfigurations Configurations  { public get; }
+	System.Net.ICredentials Credentials  { public get; public set; }
+	bool DisableInstanceAnnotationMaterialization  { public get; public set; }
+	bool EnableWritingODataAnnotationWithoutPrefix  { public get; public set; }
+	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.EntityDescriptor]] Entities  { public get; }
+	Microsoft.OData.Client.EntityParameterSendOption EntityParameterSendOption  { public get; public set; }
+	Microsoft.OData.Client.EntityTracker EntityTracker  { public get; public set; }
+	Microsoft.OData.Client.DataServiceClientFormat Format  { public get; }
+	bool IgnoreResourceNotFoundException  { public get; public set; }
+	System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.LinkDescriptor]] Links  { public get; }
+	Microsoft.OData.Client.ODataProtocolVersion MaxProtocolVersion  { public get; }
+	Microsoft.OData.Client.MergeOption MergeOption  { public get; public set; }
+	System.Func`2[[System.String],[System.Uri]] ResolveEntitySet  { public get; public set; }
+	System.Func`2[[System.Type],[System.String]] ResolveName  { public get; public set; }
+	System.Func`2[[System.String],[System.Type]] ResolveType  { public get; public set; }
+	Microsoft.OData.Client.SaveChangesOptions SaveChangesDefaultOptions  { public get; public set; }
+	int Timeout  { public get; public set; }
+	Microsoft.OData.Client.DataServiceUrlKeyDelimiter UrlKeyDelimiter  { public get; public set; }
+	bool UsePostTunneling  { public get; public set; }
 
-	System.EventHandler`1[[Microsoft.OData.Client.BuildingRequestEventArgs]] BuildingRequest {public virtual add;public virtual remove; }
-	System.EventHandler`1[[Microsoft.OData.Client.ReceivingResponseEventArgs]] ReceivingResponse {public virtual add;public virtual remove; }
-	System.EventHandler`1[[Microsoft.OData.Client.SendingRequest2EventArgs]] SendingRequest2 {public virtual add;public virtual remove; }
+	System.EventHandler`1[[Microsoft.OData.Client.BuildingRequestEventArgs]] BuildingRequest {public add;public remove; }
+	System.EventHandler`1[[Microsoft.OData.Client.ReceivingResponseEventArgs]] ReceivingResponse {public add;public remove; }
+	System.EventHandler`1[[Microsoft.OData.Client.SendingRequest2EventArgs]] SendingRequest2 {public add;public remove; }
 
-	public virtual void AddLink (object source, string sourceProperty, object target)
+	public void AddLink (object source, string sourceProperty, object target)
 	public virtual void AddObject (string entitySetName, object entity)
-	public virtual void AddRelatedObject (object source, string sourceProperty, object target)
-	public virtual void AttachLink (object source, string sourceProperty, object target)
-	public virtual void AttachTo (string entitySetName, object entity)
-	public virtual void AttachTo (string entitySetName, object entity, string etag)
-	public virtual System.IAsyncResult BeginExecute (DataServiceQueryContinuation`1 continuation, System.AsyncCallback callback, object state)
-	public virtual System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state)
-	public virtual System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public virtual System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public virtual System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public virtual System.IAsyncResult BeginExecuteBatch (System.AsyncCallback callback, object state, Microsoft.OData.Client.DataServiceRequest[] queries)
-	public virtual System.IAsyncResult BeginGetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
-	public virtual System.IAsyncResult BeginGetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
-	public virtual System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.AsyncCallback callback, object state)
-	public virtual System.IAsyncResult BeginLoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation, System.AsyncCallback callback, object state)
-	public virtual System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.Uri nextLinkUri, System.AsyncCallback callback, object state)
-	public virtual System.IAsyncResult BeginSaveChanges (System.AsyncCallback callback, object state)
-	public virtual System.IAsyncResult BeginSaveChanges (Microsoft.OData.Client.SaveChangesOptions options, System.AsyncCallback callback, object state)
-	public virtual void CancelRequest (System.IAsyncResult asyncResult)
-	public virtual void ChangeState (object entity, Microsoft.OData.Client.EntityStates state)
-	public virtual DataServiceQuery`1 CreateFunctionQuery ()
-	public virtual DataServiceQuery`1 CreateFunctionQuery (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	public virtual DataServiceQuerySingle`1 CreateFunctionQuerySingle (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
-	public virtual DataServiceQuery`1 CreateQuery (string entitySetName)
-	public virtual DataServiceQuery`1 CreateQuery (string resourcePath, bool isComposable)
-	public virtual DataServiceQuery`1 CreateSingletonQuery (string singletonName)
+	public void AddRelatedObject (object source, string sourceProperty, object target)
+	public void AttachLink (object source, string sourceProperty, object target)
+	public void AttachTo (string entitySetName, object entity)
+	public void AttachTo (string entitySetName, object entity, string etag)
+	public System.IAsyncResult BeginExecute (DataServiceQueryContinuation`1 continuation, System.AsyncCallback callback, object state)
+	public System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state)
+	public System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public System.IAsyncResult BeginExecute (System.Uri requestUri, System.AsyncCallback callback, object state, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public System.IAsyncResult BeginExecuteBatch (System.AsyncCallback callback, object state, Microsoft.OData.Client.DataServiceRequest[] queries)
+	public System.IAsyncResult BeginGetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
+	public System.IAsyncResult BeginGetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args, System.AsyncCallback callback, object state)
+	public System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.AsyncCallback callback, object state)
+	public System.IAsyncResult BeginLoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation, System.AsyncCallback callback, object state)
+	public System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.Uri nextLinkUri, System.AsyncCallback callback, object state)
+	public System.IAsyncResult BeginSaveChanges (System.AsyncCallback callback, object state)
+	public System.IAsyncResult BeginSaveChanges (Microsoft.OData.Client.SaveChangesOptions options, System.AsyncCallback callback, object state)
+	public void CancelRequest (System.IAsyncResult asyncResult)
+	public void ChangeState (object entity, Microsoft.OData.Client.EntityStates state)
+	public DataServiceQuery`1 CreateFunctionQuery ()
+	public DataServiceQuery`1 CreateFunctionQuery (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	public DataServiceQuerySingle`1 CreateFunctionQuerySingle (string path, string functionName, bool isComposable, Microsoft.OData.Client.UriOperationParameter[] parameters)
+	public DataServiceQuery`1 CreateQuery (string entitySetName)
+	public DataServiceQuery`1 CreateQuery (string resourcePath, bool isComposable)
+	public DataServiceQuery`1 CreateSingletonQuery (string singletonName)
 	protected System.Type DefaultResolveType (string typeName, string fullNamespace, string languageDependentNamespace)
-	public virtual void DeleteLink (object source, string sourceProperty, object target)
+	public void DeleteLink (object source, string sourceProperty, object target)
 	public virtual void DeleteObject (object entity)
-	public virtual bool Detach (object entity)
-	public virtual bool DetachLink (object source, string sourceProperty, object target)
-	public virtual Microsoft.OData.Client.OperationResponse EndExecute (System.IAsyncResult asyncResult)
-	public virtual IEnumerable`1 EndExecute (System.IAsyncResult asyncResult)
-	public virtual Microsoft.OData.Client.DataServiceResponse EndExecuteBatch (System.IAsyncResult asyncResult)
-	public virtual Microsoft.OData.Client.DataServiceStreamResponse EndGetReadStream (System.IAsyncResult asyncResult)
-	public virtual Microsoft.OData.Client.QueryOperationResponse EndLoadProperty (System.IAsyncResult asyncResult)
-	public virtual Microsoft.OData.Client.DataServiceResponse EndSaveChanges (System.IAsyncResult asyncResult)
-	public virtual QueryOperationResponse`1 Execute (DataServiceQueryContinuation`1 continuation)
-	public virtual IEnumerable`1 Execute (System.Uri requestUri)
-	public virtual Microsoft.OData.Client.OperationResponse Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public virtual IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public virtual IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public virtual Task`1 ExecuteAsync (DataServiceQueryContinuation`1 continuation)
-	public virtual Task`1 ExecuteAsync (System.Uri requestUri)
-	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.OperationResponse]] ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public virtual Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public virtual Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
-	public virtual Microsoft.OData.Client.DataServiceResponse ExecuteBatch (Microsoft.OData.Client.DataServiceRequest[] queries)
-	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] ExecuteBatchAsync (Microsoft.OData.Client.DataServiceRequest[] queries)
+	public bool Detach (object entity)
+	public bool DetachLink (object source, string sourceProperty, object target)
+	public Microsoft.OData.Client.OperationResponse EndExecute (System.IAsyncResult asyncResult)
+	public IEnumerable`1 EndExecute (System.IAsyncResult asyncResult)
+	public Microsoft.OData.Client.DataServiceResponse EndExecuteBatch (System.IAsyncResult asyncResult)
+	public Microsoft.OData.Client.DataServiceStreamResponse EndGetReadStream (System.IAsyncResult asyncResult)
+	public Microsoft.OData.Client.QueryOperationResponse EndLoadProperty (System.IAsyncResult asyncResult)
+	public Microsoft.OData.Client.DataServiceResponse EndSaveChanges (System.IAsyncResult asyncResult)
+	public QueryOperationResponse`1 Execute (DataServiceQueryContinuation`1 continuation)
+	public IEnumerable`1 Execute (System.Uri requestUri)
+	public Microsoft.OData.Client.OperationResponse Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public IEnumerable`1 Execute (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public Task`1 ExecuteAsync (DataServiceQueryContinuation`1 continuation)
+	public Task`1 ExecuteAsync (System.Uri requestUri)
+	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.OperationResponse]] ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public Task`1 ExecuteAsync (System.Uri requestUri, string httpMethod, bool singleResult, Microsoft.OData.Client.OperationParameter[] operationParameters)
+	public Microsoft.OData.Client.DataServiceResponse ExecuteBatch (Microsoft.OData.Client.DataServiceRequest[] queries)
+	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] ExecuteBatchAsync (Microsoft.OData.Client.DataServiceRequest[] queries)
 	internal virtual Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable GetEdmOperationOrOperationImport (System.Reflection.MethodInfo methodInfo)
-	public virtual Microsoft.OData.Client.EntityDescriptor GetEntityDescriptor (object entity)
+	public Microsoft.OData.Client.EntityDescriptor GetEntityDescriptor (object entity)
 	internal virtual Microsoft.OData.Client.ODataResourceMetadataBuilder GetEntityMetadataBuilder (string entitySetName, Microsoft.OData.Edm.Vocabularies.IEdmStructuredValue entityInstance)
-	public virtual Microsoft.OData.Client.LinkDescriptor GetLinkDescriptor (object source, string sourceProperty, object target)
-	public virtual System.Uri GetMetadataUri ()
-	public virtual Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity)
-	public virtual Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public virtual Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string acceptContentType)
-	public virtual Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public virtual System.Uri GetReadStreamUri (object entity)
-	public virtual System.Uri GetReadStreamUri (object entity, string name)
-	public virtual Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName)
-	public virtual QueryOperationResponse`1 LoadProperty (object entity, string propertyName, DataServiceQueryContinuation`1 continuation)
-	public virtual Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
-	public virtual Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, System.Uri nextLinkUri)
-	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName)
-	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
-	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, System.Uri nextLinkUri)
-	public virtual Microsoft.OData.Client.DataServiceResponse SaveChanges ()
-	public virtual Microsoft.OData.Client.DataServiceResponse SaveChanges (Microsoft.OData.Client.SaveChangesOptions options)
-	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync ()
-	public virtual System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync (Microsoft.OData.Client.SaveChangesOptions options)
-	public virtual void SetLink (object source, string sourceProperty, object target)
-	public virtual void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public virtual void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, string contentType, string slug)
-	public virtual void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
-	public virtual void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, string contentType)
-	public virtual bool TryGetAnnotation (Expression`1 expression, string term, out TResult& annotation)
-	public virtual bool TryGetAnnotation (object source, string term, out TResult& annotation)
-	public virtual bool TryGetAnnotation (Expression`1 expression, string term, string qualifier, out TResult& annotation)
-	public virtual bool TryGetAnnotation (object source, string term, string qualifier, out TResult& annotation)
-	public virtual bool TryGetEntity (System.Uri identity, out TEntity& entity)
-	public virtual bool TryGetUri (object entity, out System.Uri& identity)
+	public Microsoft.OData.Client.LinkDescriptor GetLinkDescriptor (object source, string sourceProperty, object target)
+	public System.Uri GetMetadataUri ()
+	public Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity)
+	public Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string acceptContentType)
+	public Microsoft.OData.Client.DataServiceStreamResponse GetReadStream (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceStreamResponse]] GetReadStreamAsync (object entity, string name, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public System.Uri GetReadStreamUri (object entity)
+	public System.Uri GetReadStreamUri (object entity, string name)
+	public Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName)
+	public QueryOperationResponse`1 LoadProperty (object entity, string propertyName, DataServiceQueryContinuation`1 continuation)
+	public Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
+	public Microsoft.OData.Client.QueryOperationResponse LoadProperty (object entity, string propertyName, System.Uri nextLinkUri)
+	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName)
+	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation)
+	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.QueryOperationResponse]] LoadPropertyAsync (object entity, string propertyName, System.Uri nextLinkUri)
+	public Microsoft.OData.Client.DataServiceResponse SaveChanges ()
+	public Microsoft.OData.Client.DataServiceResponse SaveChanges (Microsoft.OData.Client.SaveChangesOptions options)
+	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync ()
+	public System.Threading.Tasks.Task`1[[Microsoft.OData.Client.DataServiceResponse]] SaveChangesAsync (Microsoft.OData.Client.SaveChangesOptions options)
+	public void SetLink (object source, string sourceProperty, object target)
+	public void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public void SetSaveStream (object entity, System.IO.Stream stream, bool closeStream, string contentType, string slug)
+	public void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args)
+	public void SetSaveStream (object entity, string name, System.IO.Stream stream, bool closeStream, string contentType)
+	public bool TryGetAnnotation (Expression`1 expression, string term, out TResult& annotation)
+	public bool TryGetAnnotation (object source, string term, out TResult& annotation)
+	public bool TryGetAnnotation (Expression`1 expression, string term, string qualifier, out TResult& annotation)
+	public bool TryGetAnnotation (object source, string term, string qualifier, out TResult& annotation)
+	public bool TryGetEntity (System.Uri identity, out TEntity& entity)
+	public bool TryGetUri (object entity, out System.Uri& identity)
 	public virtual void UpdateObject (object entity)
-	public virtual void UpdateRelatedObject (object source, string sourceProperty, object target)
+	public void UpdateRelatedObject (object source, string sourceProperty, object target)
 }
 
 public class Microsoft.OData.Client.DataServiceQuery`1 : Microsoft.OData.Client.DataServiceQuery, IDataServiceQuery`1, IEnumerable`1, IQueryable`1, IEnumerable, IQueryable, IDataServiceQuery {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1250.*
### Description
*Added interfaces to some of the classes used by the OData code generator tool to support mocking*
**The classes affected are:**
1. DataServiceContext
2. DataServiceQuery
3. DataServiceQueryOfT
4. DataServiceQuerySingleOfT

**The interfaces added are:**
1. IDataServiceContext
2. IDataServiceQuery  
3. IDataServiceQueryOfT
4. IDataServiceQuerySingle

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
