### PR TITLE
Remove code throwing DataServiceRequestException so as to properly return ChangeOperationResponse objects

### DIFF
--- a/src/Microsoft.OData.Client/SaveResult.cs
+++ b/src/Microsoft.OData.Client/SaveResult.cs
@@ -307,41 +307,28 @@ namespace Microsoft.OData.Client
         {
             List<OperationResponse> responses = new List<OperationResponse>(this.cachedResponses != null ? this.cachedResponses.Count : 0);
             DataServiceResponse service = new DataServiceResponse(null, -1, responses, false /*isBatch*/);
-            Exception ex = null;
-
-            try
+            
+            foreach (CachedResponse response in this.cachedResponses)
             {
-                foreach (CachedResponse response in this.cachedResponses)
+                Descriptor descriptor = response.Descriptor;
+                this.SaveResultProcessed(descriptor);
+                OperationResponse operationResponse = new ChangeOperationResponse(response.Headers, descriptor);
+                operationResponse.StatusCode = (int)response.StatusCode;
+                if (response.Exception != null)
                 {
-                    Descriptor descriptor = response.Descriptor;
-                    this.SaveResultProcessed(descriptor);
-                    OperationResponse operationResponse = new ChangeOperationResponse(response.Headers, descriptor);
-                    operationResponse.StatusCode = (int)response.StatusCode;
-                    if (response.Exception != null)
-                    {
-                        operationResponse.Error = response.Exception;
-
-                        if (ex == null)
-                        {
-                            ex = response.Exception;
-                        }
-                    }
-                    else
-                    {
-                        this.cachedResponse = response;
-#if DEBUG
-                        this.HandleOperationResponse(descriptor, response.Headers, response.StatusCode);
-#else
-                        this.HandleOperationResponse(descriptor, response.Headers);
-#endif
-                    }
-
-                    responses.Add(operationResponse);
+                    operationResponse.Error = response.Exception;
                 }
-            }
-            catch (InvalidOperationException e)
-            {
-                ex = e;
+                else
+                {
+                    this.cachedResponse = response;
+#if DEBUG
+                    this.HandleOperationResponse(descriptor, response.Headers, response.StatusCode);
+#else
+                    this.HandleOperationResponse(descriptor, response.Headers);
+#endif
+                }
+
+                responses.Add(operationResponse);
             }
 
             return service;

--- a/src/Microsoft.OData.Client/SaveResult.cs
+++ b/src/Microsoft.OData.Client/SaveResult.cs
@@ -344,11 +344,6 @@ namespace Microsoft.OData.Client
                 ex = e;
             }
 
-            if (ex != null)
-            {
-                throw new DataServiceRequestException(Strings.DataServiceException_GeneralError, ex, service);
-            }
-
             return service;
         }
 

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/RequestMessageArgsTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/RequestMessageArgsTests.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
             {
                 var ar2 = ctx.BeginSaveChanges(null, null).EnqueueWait(this);
                 ctx.EndSaveChanges(ar2);
-                Assert.Fail("Expected error not thrown");
+                // Assert.Fail("Expected error not thrown"); // Commented since errors should be added to COR not thrown
             }
             catch (DataServiceRequestException e)
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1611 .*

### Description
I have opted to remove the code throwing the DataServiceRequestException since errors are enumerated in the  operation responses returned by the DataServiceResponse class. This will allow both failed and successful operation responses to be returned. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
