### PR TITLE
Fix DataServiceContext can't work with POCO's due to Missing IEdmModel

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceClientFormat.cs
+++ b/src/Microsoft.OData.Client/DataServiceClientFormat.cs
@@ -338,7 +338,7 @@ namespace Microsoft.OData.Client
                 httpRequest = new HttpWebRequestMessage(args);
             }
 
-            Descriptor descriptor = requestEventArgs?.Descriptor;
+            Descriptor descriptor = requestEventArgs != null ? requestEventArgs.Descriptor : null;
 
             // fire the right events if they exist
             if (context.HasSendingRequest2EventHandlers)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/Microsoft.OData.Core.Tests.csproj
@@ -45,6 +45,15 @@
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard1.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\..\..\sln\packages\System.Threading.Tasks.Extensions.4.5.1\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
@@ -461,6 +470,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\Microsoft.OData.Client\Microsoft.OData.Client.csproj">
+      <Project>{D1567C63-4A0D-4E18-A14E-79699B9BFFFF}</Project>
+      <Name>Microsoft.OData.Client</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\..\..\src\Microsoft.OData.Core\Microsoft.OData.Core.csproj">
       <Project>{989a83cc-b864-4a75-8bf3-5eda99203a86}</Project>
       <Name>Microsoft.OData.Core</Name>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/packages.config
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Build.NetFramework/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.0" targetFramework="net451" />
   <package id="xunit" version="2.1.0" targetFramework="net45" />
   <package id="xunit.abstractions" version="2.0.0" targetFramework="net45" />
   <package id="xunit.assert" version="2.1.0" targetFramework="net45" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/DataServiceContextUtil.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/DataServiceContextUtil.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.OData.Client.TDDUnitTests.Tests;
+
+namespace Microsoft.OData.Client.TDDUnitTests
+{
+    public static class DataServiceContextUtil
+    {
+        private const string ValidEdmx = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""Test"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityContainer Name=""Container"" />
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+
+        public static DataServiceContext ReConfigureForNetworkLoadingTests(this DataServiceContext context)
+        {
+            context.Format.InjectMetadataHttpNetworkRequest = InjectFakeEdmxRequest;
+            return context;
+        }
+        internal static HttpWebRequestMessage InjectFakeEdmxRequest()
+        {
+            return new CustomizedHttpWebRequestMessage(
+                new DataServiceClientRequestMessageArgs(
+                    "GET",
+                    new Uri("http://temp.org/"),
+                    false,
+                    false,
+                    new Dictionary<string, string>()),
+                ValidEdmx,
+                new Dictionary<string, string>());
+        }
+    }
+ 
+}

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Microsoft.OData.Client.TDDUnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Microsoft.OData.Client.TDDUnitTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="..\ClientExtensions\TestDataServiceClientRequestMessage.cs">
       <Link>TestDataServiceClientRequestMessage.cs</Link>
     </Compile>
+    <Compile Include="DataServiceContextUtil.cs" />
     <Compile Include="DateTimePrimitiveTypeReference.cs" />
     <Compile Include="Tests\Annotation\AnnotationTargetingOperationTestsProxy.cs" />
     <Compile Include="Tests\Annotation\ClientAnnotationTests.cs" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientPropertyTrackingTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientPropertyTrackingTests.cs
@@ -199,7 +199,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
         [TestInitialize]
         public void Init()
         {
-            this.context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            this.context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
         }
 
         [TestMethod]

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientSerializerTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientSerializerTests.cs
@@ -11,9 +11,9 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using System.IO;
     using System.Linq;
     using System.Xml;
+    using FluentAssertions;
     using Microsoft.OData.Client;
     using Microsoft.OData.Client.Metadata;
-    using FluentAssertions;
     using Microsoft.OData;
     using Microsoft.OData.Edm;
     using Microsoft.Spatial;
@@ -26,6 +26,13 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     [TestClass]
     public class ClientSerializerTests
     {
+        private DataServiceContext context;
+
+        [TestInitialize]
+        public void Init()
+        {
+            context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
+        }
         [TestMethod]
         public void ClientShouldNotIncludeIdInJsonLightUpdates()
         {
@@ -109,7 +116,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteNullUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -121,7 +127,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteOneUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -134,7 +139,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteTwoUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -148,7 +152,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteStringAndBoolUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -162,7 +165,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WritePrimitiveUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -179,7 +181,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteDateAndTimeUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -195,7 +196,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteGeographyUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -210,8 +210,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteCollectionUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"))
-                .ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -226,7 +224,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteEnumUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri functionBaseRequestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -248,7 +245,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteComplexTypeUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -263,7 +259,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteCollectionOfComplexTypeInUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -283,7 +278,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteCollectionOfComplexTypeInBody()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             List<Address> addresses = new List<Address>()
@@ -302,7 +296,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteEntryAsBodyOperationParameter()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Customer customer = new Customer()
@@ -322,7 +315,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteNullAsBodyOperationParameter()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             List<BodyOperationParameter> parameters = new List<BodyOperationParameter> { new BodyOperationParameter("customer", null) };
@@ -335,7 +327,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteFeedAsBodyOperationParameter()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Customer customer1 = new Customer()
@@ -361,7 +352,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteEmptyFeedAsBodyOperationParameter()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             List<BodyOperationParameter> parameters = new List<BodyOperationParameter> { new BodyOperationParameter("customer", new List<Customer>()) };
@@ -391,7 +381,6 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteEnumTypeUriOperationParameterWithNonExistingValueShouldThrow()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientSerializerTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientSerializerTests.cs
@@ -18,6 +18,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using Microsoft.OData.Edm;
     using Microsoft.Spatial;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.OData.Client.TDDUnitTests;
 
     /// <summary>
     /// Unit tests for client request serialization code.
@@ -108,7 +109,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteNullUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -120,7 +121,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteOneUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -133,7 +134,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteTwoUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -147,7 +148,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteStringAndBoolUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -161,7 +162,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WritePrimitiveUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -178,7 +179,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteDateAndTimeUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -194,7 +195,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteGeographyUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -209,7 +210,8 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteCollectionUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"))
+                .ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -224,7 +226,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteEnumUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri functionBaseRequestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -246,7 +248,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteComplexTypeUriOperationParametersToUriShouldReturnUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName };
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -261,7 +263,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteCollectionOfComplexTypeInUri()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName };
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");
@@ -281,7 +283,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteCollectionOfComplexTypeInBody()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName };
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             List<Address> addresses = new List<Address>()
@@ -300,7 +302,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteEntryAsBodyOperationParameter()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName };
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Customer customer = new Customer()
@@ -320,7 +322,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteNullAsBodyOperationParameter()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName };
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             List<BodyOperationParameter> parameters = new List<BodyOperationParameter> { new BodyOperationParameter("customer", null) };
@@ -333,7 +335,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteFeedAsBodyOperationParameter()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName };
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Customer customer1 = new Customer()
@@ -359,7 +361,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteEmptyFeedAsBodyOperationParameter()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName };
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")) { ResolveName = type => type.FullName }.ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             List<BodyOperationParameter> parameters = new List<BodyOperationParameter> { new BodyOperationParameter("customer", new List<Customer>()) };
@@ -389,7 +391,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void WriteEnumTypeUriOperationParameterWithNonExistingValueShouldThrow()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);
             Uri requestUri = new Uri("http://www.odata.org/service.svc/Function");

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/CustomizedHttpWebRequestMessage.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/CustomizedHttpWebRequestMessage.cs
@@ -17,7 +17,6 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
 
     public class CustomizedHttpWebRequestMessage : HttpWebRequestMessage
     {
-        private MockResponse responseCreator;
         public string Response { get; set; }
         public Dictionary<string, string> CutomizedHeaders { get; set; }
 
@@ -31,8 +30,6 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
         {
             this.Response = response;
             this.CutomizedHeaders = headers;
-            responseCreator = new MockResponse(GetResponse);
-
         }
 
 #if (NETCOREAPP1_0 || NETCOREAPP2_0)
@@ -51,11 +48,13 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
                 });
         }
 
-
         public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
         {
             // using this as APM was deprecated in.net core
-            return Task.Run((() => callback.Invoke(Task.Run((() => GetResponse())))));
+            return Task.Run((() => callback.Invoke(Task.Run((() =>
+            {
+                // simplified as in the EndResponse we ignore the return of this method
+            })))));
         }
 
         public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
@@ -63,6 +62,5 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             return GetResponse();
         }
 
-        private delegate IODataResponseMessage MockResponse();
     }
 }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/CustomizedHttpWebRequestMessage.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/CustomizedHttpWebRequestMessage.cs
@@ -6,14 +6,14 @@
 
 namespace Microsoft.OData.Client.TDDUnitTests.Tests
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Text;
-    using Microsoft.OData.Client;
+    using System.Threading.Tasks;
     using Microsoft.OData;
-    using System;
-	using System.Runtime.InteropServices;
-	using System.Threading.Tasks;
+    using Microsoft.OData.Client;
+   
 
     public class CustomizedHttpWebRequestMessage : HttpWebRequestMessage
     {
@@ -50,17 +50,16 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
 
         public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
         {
-            // using this as APM was deprecated in.net core
-            return Task.Run((() => callback.Invoke(Task.Run((() =>
-            {
-                // simplified as in the EndResponse we ignore the return of this method
-            })))));
+            // using this as APM was deprecated in.net core and Task.CompletedTask is not available in 4.5
+            callback.Invoke(Task.FromResult(0));
+            return Task.FromResult(0);
+
+
         }
 
         public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
         {
             return GetResponse();
         }
-
     }
 }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceClientFormatTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceClientFormatTests.cs
@@ -8,15 +8,15 @@ namespace AstoriaUnitTests.TDD.Tests.Client
 {
     using System;
     using System.Collections.Generic;
-    using Microsoft.OData.Client;
-    using Microsoft.OData.Client.Metadata;
+    using System.IO;
     using AstoriaUnitTests.TDD.Common;
     using FluentAssertions;
     using Microsoft.OData.Edm;
     using Microsoft.OData;
-    using System.IO;
-    using Microsoft.OData.Client.TDDUnitTests.Tests;
+    using Microsoft.OData.Client;
+    using Microsoft.OData.Client.Metadata;
     using Microsoft.OData.Client.TDDUnitTests;
+    using Microsoft.OData.Client.TDDUnitTests.Tests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using ClientStrings = Microsoft.OData.Client.Strings;
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceClientFormatTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceClientFormatTests.cs
@@ -14,6 +14,9 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using FluentAssertions;
     using Microsoft.OData.Edm;
     using Microsoft.OData;
+    using System.IO;
+    using Microsoft.OData.Client.TDDUnitTests.Tests;
+    using Microsoft.OData.Client.TDDUnitTests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using ClientStrings = Microsoft.OData.Client.Strings;
 
@@ -23,6 +26,8 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         private readonly IEdmModel serviceModel = new EdmModel();
         private DataServiceClientFormat v3TestSubject;
         private DataServiceContext v3Context;
+
+
 #if (NETCOREAPP1_0 || NETCOREAPP2_0)
         private readonly QueryComponents queryComponentsWithSelect = new QueryComponents(new Uri("http://temp.org/?$select=foo"), new Version(1, 1, 1, 1), typeof(object), null, null);
         private readonly QueryComponents queryComponentsWithoutSelect = new QueryComponents(new Uri("http://temp.org/"), new Version(1, 1, 1, 1), typeof(object), null, null);
@@ -46,7 +51,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestInitialize]
         public void Init()
         {
-            this.v3Context = new DataServiceContext(new Uri("http://temp.org/"), ODataProtocolVersion.V4);
+            this.v3Context = new DataServiceContext(new Uri("http://temp.org/"), ODataProtocolVersion.V4).ReConfigureForNetworkLoadingTests();
             this.v3TestSubject = this.v3Context.Format;
         }
 
@@ -85,6 +90,16 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         public void AtomShouldBeTheDefault()
         {
             this.v3TestSubject.ODataFormat.Should().BeSameAs(ODataFormat.Json);
+        }
+
+        [TestMethod]
+        public void TestNetworkLoading()
+        {
+
+            // forces metadata to be loaded
+            this.v3Context.Format.UseJson();
+            this.v3Context.Format.ServiceModel.Should().NotBeNull();
+
         }
 
         [TestMethod]
@@ -183,10 +198,10 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         }
 
         [TestMethod]
-        public void UseJsonOverloadWithNoParameterShouldFailIfNoDelegateProvided()
+        public void UseJsonOverloadWithNoParameterShouldPassIfNoDelegateProvided()
         {
-            Action callOverload = () => this.v3Context.Format.UseJson();
-            callOverload.ShouldThrow<InvalidOperationException>().WithMessage(ClientStrings.DataServiceClientFormat_LoadServiceModelRequired);
+             this.v3Context.Format.UseJson();
+             this.v3TestSubject.ServiceModel.Should().NotBeNull();
         }
 
         [TestMethod]

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceContextTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceContextTests.cs
@@ -7,9 +7,9 @@
 namespace AstoriaUnitTests.TDD.Tests.Client
 {
     using System;
-    using Microsoft.OData.Client;
     using System.IO;
     using System.Linq;
+    using Microsoft.OData.Client;
     using Microsoft.OData.Client.TDDUnitTests;
 
 #if !PORTABLELIB
@@ -242,9 +242,8 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void DisposeShouldBeCalledOnResponseMessageForExecuteWithNoContent()
         {
-            DataServiceContext context = new DataServiceContext().ReConfigureForNetworkLoadingTests();
             bool responseMessageDisposed = false;
-            context.Configurations.RequestPipeline.OnMessageCreating = args =>
+            testSubject.Configurations.RequestPipeline.OnMessageCreating = args =>
             {
                 var requestMessage = new InMemoryMessage { Url = args.RequestUri, Method = args.Method, Stream = new MemoryStream() };
                 var responseMessage = new InMemoryMessage { StatusCode = 204, Stream = new MemoryStream() };
@@ -252,7 +251,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
                 return new TestDataServiceClientRequestMessage(requestMessage, () => responseMessage);
             };
 
-            context.Execute(new Uri("http://host/voidAction", UriKind.Absolute), "POST").StatusCode.Should().Be(204);
+            testSubject.Execute(new Uri("http://host/voidAction", UriKind.Absolute), "POST").StatusCode.Should().Be(204);
             responseMessageDisposed.Should().BeTrue();
         }
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceContextTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceContextTests.cs
@@ -10,6 +10,8 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using Microsoft.OData.Client;
     using System.IO;
     using System.Linq;
+    using Microsoft.OData.Client.TDDUnitTests;
+
 #if !PORTABLELIB
     using AstoriaUnitTests.ClientExtensions;
 #endif
@@ -33,7 +35,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
 #if SILVERLIGHT
             usePostTunnelingDefault = true;
 #endif
-            var context = new DataServiceContext();
+            var context = new DataServiceContext().ReConfigureForNetworkLoadingTests();
             context.UsePostTunneling.Should().Be(usePostTunnelingDefault);
         }
 
@@ -44,7 +46,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestInitialize]
         public void Init()
         {
-            this.testSubject = new DataServiceContext(new Uri("http://base.org/"));
+            this.testSubject = new DataServiceContext(new Uri("http://base.org/")).ReConfigureForNetworkLoadingTests();
         }
 
         [TestMethod]
@@ -240,7 +242,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void DisposeShouldBeCalledOnResponseMessageForExecuteWithNoContent()
         {
-            DataServiceContext context = new DataServiceContext();
+            DataServiceContext context = new DataServiceContext().ReConfigureForNetworkLoadingTests();
             bool responseMessageDisposed = false;
             context.Configurations.RequestPipeline.OnMessageCreating = args =>
             {

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceRequestTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceRequestTests.cs
@@ -14,6 +14,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using Microsoft.OData.Client;
     using Microsoft.OData;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.OData.Client.TDDUnitTests;
 
     [TestClass]
     public class DataServiceRequestTests
@@ -51,7 +52,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         private void MaterializeTest(HttpStatusCode statusCode, ODataPayloadKind payloadKind)
         {
             var uri = new Uri("http://any");
-            var context = new DataServiceContext();
+            var context = new DataServiceContext().ReConfigureForNetworkLoadingTests();
             var requestInfo = new RequestInfo(context);
             var responseInfo = new ResponseInfo(requestInfo, MergeOption.OverwriteChanges);
             var queryComponents = new QueryComponents(uri, new Version(4, 0), typeof(Product), null, null);

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceRequestTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DataServiceRequestTests.cs
@@ -11,10 +11,10 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using System.IO;
     using System.Linq;
     using System.Net;
-    using Microsoft.OData.Client;
     using Microsoft.OData;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.OData.Client;
     using Microsoft.OData.Client.TDDUnitTests;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class DataServiceRequestTests

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ODataMessageReadingHelperTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ODataMessageReadingHelperTests.cs
@@ -10,6 +10,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using Microsoft.OData.Client;
     using FluentAssertions;
     using Microsoft.OData;
+    using Microsoft.OData.Client.TDDUnitTests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using ClientStrings = Microsoft.OData.Client.Strings;
 
@@ -25,7 +26,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestInitialize]
         public void Init()
         {
-            this.context = new DataServiceContext(new Uri("http://temp.org/"), ODataProtocolVersion.V4);
+            this.context = new DataServiceContext(new Uri("http://temp.org/"), ODataProtocolVersion.V4).ReConfigureForNetworkLoadingTests();
             this.responseInfo = new ResponseInfo(new RequestInfo(this.context), MergeOption.NoTracking);
             this.readingHelper = new ODataMessageReadingHelper(this.responseInfo);
             this.atomResponseMessage = new ODataResponseMessageSimulator();

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ODataMessageReadingHelperTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ODataMessageReadingHelperTests.cs
@@ -7,8 +7,8 @@
 namespace AstoriaUnitTests.TDD.Tests.Client
 {
     using System;
-    using Microsoft.OData.Client;
     using FluentAssertions;
+    using Microsoft.OData.Client;
     using Microsoft.OData;
     using Microsoft.OData.Client.TDDUnitTests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ODataMessageWritingHelperTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ODataMessageWritingHelperTests.cs
@@ -10,6 +10,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using Microsoft.OData.Client;
     using FluentAssertions;
     using Microsoft.OData;
+    using Microsoft.OData.Client.TDDUnitTests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using ClientStrings = Microsoft.OData.Client.Strings;
 
@@ -25,7 +26,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestInitialize]
         public void Init()
         {
-            this.context = new DataServiceContext(new Uri("http://temp.org/"), ODataProtocolVersion.V4);
+            this.context = new DataServiceContext(new Uri("http://temp.org/"), ODataProtocolVersion.V4).ReConfigureForNetworkLoadingTests();
             this.requestInfo = new RequestInfo(context);
             this.writingHelper = new ODataMessageWritingHelper(this.requestInfo);
             this.atomRequestMessage = new ODataRequestMessageSimulator();

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Serialization/ODataWriterWrapperUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Serialization/ODataWriterWrapperUnitTests.cs
@@ -28,7 +28,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestInitialize]
         public void Init()
         {
-             context = new DataServiceContext(new Uri("http://www.odata.org/Service.svc")).ReConfigureForNetworkLoadingTests();
+             context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
 
         }
         [TestMethod]

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Serialization/ODataWriterWrapperUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Serialization/ODataWriterWrapperUnitTests.cs
@@ -15,6 +15,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using Microsoft.OData;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using FluentAssertions;
+    using Microsoft.OData.Client.TDDUnitTests;
 
     /// <summary>
     /// Unit tests for the ODataWriterWrapperUnitTests class.
@@ -26,7 +27,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         public void EndToEndShortIntegrationWriteEntryEventTest()
         {
             List<KeyValuePair<string, object>> eventArgsCalled = new List<KeyValuePair<string, object>>();
-            var dataServiceContext = new DataServiceContext(new Uri("http://www.odata.org/Service.svc"));
+            var dataServiceContext = new DataServiceContext(new Uri("http://www.odata.org/Service.svc")).ReConfigureForNetworkLoadingTests();
             dataServiceContext.Configurations.RequestPipeline.OnEntityReferenceLink((args) => eventArgsCalled.Add(new KeyValuePair<string, object>("OnEntityReferenceLink", args)));
             dataServiceContext.Configurations.RequestPipeline.OnEntryEnding((args) => eventArgsCalled.Add(new KeyValuePair<string, object>("OnEntryEnded", args)));
             dataServiceContext.Configurations.RequestPipeline.OnEntryStarting((args) => eventArgsCalled.Add(new KeyValuePair<string, object>("OnEntryStarted", args)));
@@ -90,7 +91,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [TestMethod]
         public void EntityPropertiesShouldBePopulatedBeforeCallingWriteStart()
         {
-            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext context = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             context.Configurations.RequestPipeline.OnEntryStarting(args =>
             {
                 args.Entry.Should().NotBeNull();
@@ -208,7 +209,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
             var car1 = new Car { ID = 1001 };
             var car2 = new Car { ID = 1002 };
 
-            DataServiceContext dataServiceContext = new DataServiceContext(new Uri("http://www.odata.org/service.svc"));
+            DataServiceContext dataServiceContext = new DataServiceContext(new Uri("http://www.odata.org/service.svc")).ReConfigureForNetworkLoadingTests();
             dataServiceContext.AttachTo("Persons", person);
             dataServiceContext.AttachTo("Cars", car1);
             dataServiceContext.AttachTo("Cars", car2);

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/T4/ODataT4CamelCaseTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/T4/ODataT4CamelCaseTests.cs
@@ -17,6 +17,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using Microsoft.OData.Client;
     using Microsoft.OData.Client.Materialization;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.OData.Client.TDDUnitTests;
 
     using OData = Microsoft.OData;
 
@@ -206,6 +207,12 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     {
         public const string ServerNamespace = "namespace.test";
         public Container Context = new Container(new Uri("http://www.odata.org/service.svc"));
+
+        [TestInitialize]
+        public void Init()
+        {
+            Context.ReConfigureForNetworkLoadingTests();
+        }
 
         [TestMethod]
         public void EntitySetUriShouldUseOriginalName()
@@ -465,7 +472,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         internal EntryValueMaterializationPolicy CreateEntryMaterializationPolicy(TestMaterializerContext materializerContext = null)
         {
             var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
-            var context = new DataServiceContext();
+            var context = new DataServiceContext().ReConfigureForNetworkLoadingTests();
             materializerContext = materializerContext ?? new TestMaterializerContext() { Model = clientEdmModel, Context = context };
             var adapter = new EntityTrackingAdapter(new TestEntityTracker(), MergeOption.OverwriteChanges, clientEdmModel, context);
             var lazyPrimitivePropertyConverter = new Microsoft.OData.Client.SimpleLazy<PrimitivePropertyConverter>(() => new PrimitivePropertyConverter());

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
@@ -508,14 +508,16 @@ namespace AstoriaUnitTests.Tests
             TestUtil.RunCombinations(new SaveChangesOptions[] { SaveChangesOptions.None, SaveChangesOptions.ContinueOnError },
             (options) =>
             {
-                ctx.AddAndUpdateResponsePreference = DataServiceResponsePreference.NoContent;
+                DataServiceContext context = new DataServiceContext(new Uri("http://localhost/TheTest.svc"), ODataProtocolVersion.V4);
+                context.Format.UseJson(new EdmModel());
+                context.AddAndUpdateResponsePreference = DataServiceResponsePreference.NoContent;
 
                 Customer c = new Customer() { ID = 1, Name = "Foo" };
-                ctx.AttachTo("Customers", c);
+                context.AttachTo("Customers", c);
                 MemoryStream stream = new MemoryStream(new byte[] { 0, 1, 2, 3 });
-                ctx.SetSaveStream(c, stream, true, new DataServiceRequestArgs() { ContentType = "image/bmp" });
+                context.SetSaveStream(c, stream, true, new DataServiceRequestArgs() { ContentType = "image/bmp" });
 
-                DataServiceRequestException ex = TestUtil.RunCatching<DataServiceRequestException>(() => { ctx.SaveChanges(options); });
+                DataServiceRequestException ex = TestUtil.RunCatching<DataServiceRequestException>(() => { context.SaveChanges(options); });
                 TestUtil.AssertExceptionExpected(ex, true);
                 InvalidOperationException innerEx = ex.InnerException as InvalidOperationException;
                 Assert.IsNotNull(innerEx, "Expected invalid operation exception in the inner exception");

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
@@ -25,9 +25,9 @@ namespace AstoriaUnitTests.Tests
     using AstoriaUnitTests.Stubs.DataServiceProvider;
     using Microsoft.OData;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.OData.Edm;
     using CustomDataClient = AstoriaUnitTests.Stubs.CustomDataClient;
     using DSClient = Microsoft.OData.Client;
-    using Microsoft.OData.Edm;
 
     // For comment out test cases, see github: https://github.com/OData/odata.net/issues/881
     [TestClass]
@@ -48,7 +48,14 @@ namespace AstoriaUnitTests.Tests
         // Use TestInitialize to run code before running each test 
         // [TestInitialize()]
         // public void MyTestInitialize() { }
-        //
+        private DataServiceContext ctx;
+
+        [TestInitialize]
+        public void Init()
+        {
+             ctx = new DataServiceContext(new Uri("http://localhost/test.svc"));
+             ctx.Format.UseJson(new EdmModel());
+        }
         // Use TestCleanup to run code after each test has run
         // [TestCleanup()]
         // public void MyTestCleanup() { }
@@ -129,7 +136,6 @@ namespace AstoriaUnitTests.Tests
             // LINQ Uri reserved characters
             var operation = new string[] { "eq", "contains", "key", "tolower", "orderby" };
 
-            DataServiceContext ctx = new DataServiceContext(new Uri("http://localhost/test.svc"));
 
             TestUtil.RunCombinations(restrictedChars, operation, (r, op) =>
             {
@@ -167,7 +173,6 @@ namespace AstoriaUnitTests.Tests
         public void ClientLinqUriWriterTypeInjectionTests()
         {
             // Injection hack in type resolving system
-            DataServiceContext ctx = new DataServiceContext(new Uri("http://localhost/test.svc"));
             ctx.ResolveName = (type) =>
                 {
                     return "%:/?#[]@=$&;()*+,'\" !";
@@ -503,16 +508,14 @@ namespace AstoriaUnitTests.Tests
             TestUtil.RunCombinations(new SaveChangesOptions[] { SaveChangesOptions.None, SaveChangesOptions.ContinueOnError },
             (options) =>
             {
-                DataServiceContext context = new DataServiceContext(new Uri("http://localhost/TheTest.svc"), ODataProtocolVersion.V4);
-                context.Format.UseJson(new EdmModel());
-                context.AddAndUpdateResponsePreference = DataServiceResponsePreference.NoContent;
+                ctx.AddAndUpdateResponsePreference = DataServiceResponsePreference.NoContent;
 
                 Customer c = new Customer() { ID = 1, Name = "Foo" };
-                context.AttachTo("Customers", c);
+                ctx.AttachTo("Customers", c);
                 MemoryStream stream = new MemoryStream(new byte[] { 0, 1, 2, 3 });
-                context.SetSaveStream(c, stream, true, new DataServiceRequestArgs() { ContentType = "image/bmp" });
+                ctx.SetSaveStream(c, stream, true, new DataServiceRequestArgs() { ContentType = "image/bmp" });
 
-                DataServiceRequestException ex = TestUtil.RunCatching<DataServiceRequestException>(() => { context.SaveChanges(options); });
+                DataServiceRequestException ex = TestUtil.RunCatching<DataServiceRequestException>(() => { ctx.SaveChanges(options); });
                 TestUtil.AssertExceptionExpected(ex, true);
                 InvalidOperationException innerEx = ex.InnerException as InvalidOperationException;
                 Assert.IsNotNull(innerEx, "Expected invalid operation exception in the inner exception");
@@ -1503,16 +1506,13 @@ namespace AstoriaUnitTests.Tests
             // Cancellation of LoadAsync requests should not cause a null reference exception.
             // The context does not need to return usable results. It is created with a dummy URI so
             // that there is actually time to cancel the request. It should not return promptly.
-            var context = new Microsoft.OData.Client.DataServiceContext(new Uri("http://123.32.52.1"));
-            // this helps bypass network loading in tests
-            context.Format.UseJson(new EdmModel());
-            context.UndeclaredPropertyBehavior = UndeclaredPropertyBehavior.Support;
+            ctx.UndeclaredPropertyBehavior = UndeclaredPropertyBehavior.Support;
             Uri uri = new Uri("foo", UriKind.Relative);
 
-            IAsyncResult result = context.BeginExecute<string>(uri, (_) => { }, null);
-            context.CancelRequest(result);
+            IAsyncResult result = ctx.BeginExecute<string>(uri, (_) => { }, null);
+            ctx.CancelRequest(result);
 
-            Exception expectedException = TestUtil.RunCatching(() => { context.EndExecute<string>(result); });
+            Exception expectedException = TestUtil.RunCatching(() => { ctx.EndExecute<string>(result); });
 
             Assert.IsNotNull(expectedException);
             Assert.IsTrue(expectedException is InvalidOperationException);
@@ -1523,10 +1523,9 @@ namespace AstoriaUnitTests.Tests
         [TestMethod]
         public void TestMultipleKeysOfKeyAttribute()
         {
-            Microsoft.OData.Client.DataServiceContext context = new Microsoft.OData.Client.DataServiceContext(new Uri("http://DoesNotExist/nope.svc"));
             TestType7 instance = new TestType7 { FkID = 11, TypeID = 22 };
-            context.AttachTo("Set", instance);
-            Microsoft.OData.Client.EntityDescriptor entity = context.Entities.Single();
+            ctx.AttachTo("Set", instance);
+            Microsoft.OData.Client.EntityDescriptor entity = ctx.Entities.Single();
             StringAssert.Contains(entity.Identity.AbsoluteUri, "FkID=11", "didn't get the 1st key value");
             StringAssert.Contains(entity.Identity.AbsoluteUri, "TypeID=22", "didn't get the 2nd key value");
         }
@@ -1559,8 +1558,6 @@ namespace AstoriaUnitTests.Tests
             // ensure that with an error thrown, the type cache gets deleted, and that when you try again, the same error gets thrown
             for (int i = 0; i < 2; ++i)
             {
-                DataServiceContext ctx = new DataServiceContext(new Uri("http://localhost"), ODataProtocolVersion.V4);
-                ctx.Format.UseJson(new EdmModel());
                 ctx.AddObject("Entities", new ClientTypeCacheError_EntityType());
 
                 Exception ex = TestUtil.RunCatching(() => ctx.SaveChanges());

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
@@ -4,8 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using Microsoft.OData.Edm;
-
 namespace AstoriaUnitTests.Tests
 {
     using System;
@@ -29,6 +27,7 @@ namespace AstoriaUnitTests.Tests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using CustomDataClient = AstoriaUnitTests.Stubs.CustomDataClient;
     using DSClient = Microsoft.OData.Client;
+    using Microsoft.OData.Edm;
 
     // For comment out test cases, see github: https://github.com/OData/odata.net/issues/881
     [TestClass]

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
@@ -4,6 +4,8 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using Microsoft.OData.Edm;
+
 namespace AstoriaUnitTests.Tests
 {
     using System;
@@ -503,6 +505,7 @@ namespace AstoriaUnitTests.Tests
             (options) =>
             {
                 DataServiceContext context = new DataServiceContext(new Uri("http://localhost/TheTest.svc"), ODataProtocolVersion.V4);
+                context.Format.UseJson(new EdmModel());
                 context.AddAndUpdateResponsePreference = DataServiceResponsePreference.NoContent;
 
                 Customer c = new Customer() { ID = 1, Name = "Foo" };
@@ -587,6 +590,7 @@ namespace AstoriaUnitTests.Tests
                 };
 
                 var context = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, getRequestMessage, getResponseMessage);
+                context.Format.UseJson(new EdmModel());
                 context.AddAndUpdateResponsePreference = DataServiceResponsePreference.NoContent;
 
                 CustomerWithStream c = new CustomerWithStream() { ID = 1, Name = "Foo" };
@@ -1155,9 +1159,8 @@ namespace AstoriaUnitTests.Tests
                 };
 
                 var ctx = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, getRequestMessage, getResponseMessage);
-                //ctx.EnableAtom = true;
-                //ctx.Format.UseAtom();
-
+                // disables network loading by injecting an empty model
+                ctx.Format.UseJson(new EdmModel());
                 ctx.AddObject("Entities", entity);
                 ctx.SaveChanges();
 
@@ -1502,6 +1505,8 @@ namespace AstoriaUnitTests.Tests
             // The context does not need to return usable results. It is created with a dummy URI so
             // that there is actually time to cancel the request. It should not return promptly.
             var context = new Microsoft.OData.Client.DataServiceContext(new Uri("http://123.32.52.1"));
+            // this helps bypass network loading in tests
+            context.Format.UseJson(new EdmModel());
             context.UndeclaredPropertyBehavior = UndeclaredPropertyBehavior.Support;
             Uri uri = new Uri("foo", UriKind.Relative);
 
@@ -1556,6 +1561,7 @@ namespace AstoriaUnitTests.Tests
             for (int i = 0; i < 2; ++i)
             {
                 DataServiceContext ctx = new DataServiceContext(new Uri("http://localhost"), ODataProtocolVersion.V4);
+                ctx.Format.UseJson(new EdmModel());
                 ctx.AddObject("Entities", new ClientTypeCacheError_EntityType());
 
                 Exception ex = TestUtil.RunCatching(() => ctx.SaveChanges());

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientErrorHandlingShortIntegrationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientErrorHandlingShortIntegrationTests.cs
@@ -4,8 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using Microsoft.OData.Edm;
-
 namespace AstoriaUnitTests.Tests
 {
     using System;
@@ -19,6 +17,7 @@ namespace AstoriaUnitTests.Tests
     using Microsoft.OData;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System.Text;
+    using Microsoft.OData.Edm;
 
     [TestClass]
     public class ClientErrorHandlingShortIntegrationTests

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientErrorHandlingShortIntegrationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientErrorHandlingShortIntegrationTests.cs
@@ -8,7 +8,6 @@ namespace AstoriaUnitTests.Tests
 {
     using System;
     using System.Collections.Generic;
-    using Microsoft.OData.Client;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -16,8 +15,9 @@ namespace AstoriaUnitTests.Tests
     using AstoriaUnitTests.ClientExtensions;
     using FluentAssertions;
     using Microsoft.OData;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.OData.Client;
     using Microsoft.OData.Edm;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class ClientErrorHandlingShortIntegrationTests

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientErrorHandlingShortIntegrationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientErrorHandlingShortIntegrationTests.cs
@@ -4,6 +4,8 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using Microsoft.OData.Edm;
+
 namespace AstoriaUnitTests.Tests
 {
     using System;
@@ -39,6 +41,7 @@ namespace AstoriaUnitTests.Tests
             responseMessage.SetHeader("Content-Length", "0");
 
             var context = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, requestMessage, responseMessage);
+            context.Format.UseJson(new EdmModel());
             context.AddObject("Products", new SimpleNorthwind.Product() { ID = 1 });
             Action test = () => context.SaveChanges(SaveChangesOptions.BatchWithSingleChangeset);
 
@@ -54,6 +57,7 @@ namespace AstoriaUnitTests.Tests
             IODataRequestMessage requestMessage = new ODataTestMessage();
 
             var context = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, () => requestMessage, () => { throw new WebException("web exception on getting response"); });
+            context.Format.UseJson(new EdmModel());
             context.AddObject("Products", new SimpleNorthwind.Product() { ID = 1 });
             Action test = () => context.SaveChanges(SaveChangesOptions.BatchWithSingleChangeset);
 
@@ -66,6 +70,7 @@ namespace AstoriaUnitTests.Tests
             IODataRequestMessage requestMessage = new ODataTestMessage();
 
             var context = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, () => requestMessage, () => { throw new WebException("web exception on getting response"); });
+            context.Format.UseJson(new EdmModel());
             context.AddObject("Products", new SimpleNorthwind.Product() { ID = 1 });
             Action test = () => context.SaveChanges(SaveChangesOptions.None);
 
@@ -80,6 +85,7 @@ namespace AstoriaUnitTests.Tests
             IODataRequestMessage requestMessage = new ODataTestMessage();
 
             var context = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, () => requestMessage, () => { throw new WebException("web exception on getting response"); });
+            context.Format.UseJson(new EdmModel());
             Action test = () =>  context.ExecuteBatch(context.CreateQuery<NorthwindModel.Products>("Products"));
 
             test.ShouldThrow<WebException>().WithMessage("web exception on getting response");
@@ -94,6 +100,7 @@ namespace AstoriaUnitTests.Tests
             IODataRequestMessage requestMessage = new ODataTestMessage();
 
             var context = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, () => requestMessage, () => { throw new WebException("web exception on getting response"); });
+            context.Format.UseJson(new EdmModel());
             Action test = () => context.CreateQuery<NorthwindModel.Products>("Products").ToList();
 
             var exception = test.ShouldThrow<Exception>().And;
@@ -142,6 +149,7 @@ namespace AstoriaUnitTests.Tests
             var responseMessage = CreateResponseMessageWithGetStreamThrowingObjectDisposeException();
 
             var context = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, requestMessage, responseMessage);
+            context.Format.UseJson(new EdmModel());
             context.AddObject("Products", new SimpleNorthwind.Product() { ID = 1 });
             return  () => context.SaveChanges(saveChangesOptions);
         }
@@ -152,6 +160,7 @@ namespace AstoriaUnitTests.Tests
             var responseMessage = CreateResponseMessageWithGetStreamThrowingObjectDisposeException();
 
             var context = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, requestMessage, responseMessage);
+            context.Format.UseJson(new EdmModel());
             if (useExecuteBatch)
             {
                 return () => context.ExecuteBatch(context.CreateQuery<NorthwindModel.Products>("Products"));

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientShortIntegrationRegressionTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientShortIntegrationRegressionTests.cs
@@ -229,7 +229,7 @@ namespace AstoriaUnitTests.Tests
             odataResponseMessage.SetHeader("Content-Type", "0");
 
             DataServiceContextWithCustomTransportLayer context = new DataServiceContextWithCustomTransportLayer(ODataProtocolVersion.V4, () => odataRequestMessage, () => odataResponseMessage);
-
+            context.Format.UseJson(new EdmModel());
             Action test = () => context.CreateQuery<SimpleNorthwind.Product>("Products").ToList();
             test.ShouldThrow<DataServiceQueryException>().WithInnerMessage("NotModified");
         }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/ClientRegressionTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/ClientRegressionTests.vb
@@ -23,11 +23,11 @@ Imports AstoriaUnitTests
 Imports AstoriaUnitTests.Data
 Imports AstoriaUnitTests.Stubs
 Imports AstoriaUnitTests.Tests
+Imports AstoriaUnitTests.ClientExtensions
 Imports Microsoft.Test.ModuleCore
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
-Imports NorthwindModel
-Imports AstoriaUnitTests.ClientExtensions
 Imports Microsoft.OData.Edm
+Imports NorthwindModel
 Imports <xmlns:atom="http://www.w3.org/2005/Atom">
 Imports <xmlns:d="http://docs.oasis-open.org/odata/ns/data">
 Imports <xmlns:m="http://docs.oasis-open.org/odata/ns/metadata">

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/ClientRegressionTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/ClientRegressionTests.vb
@@ -27,6 +27,7 @@ Imports Microsoft.Test.ModuleCore
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports NorthwindModel
 Imports AstoriaUnitTests.ClientExtensions
+Imports Microsoft.OData.Edm
 Imports <xmlns:atom="http://www.w3.org/2005/Atom">
 Imports <xmlns:d="http://docs.oasis-open.org/odata/ns/data">
 Imports <xmlns:m="http://docs.oasis-open.org/odata/ns/metadata">
@@ -443,6 +444,7 @@ Imports <xmlns:m="http://docs.oasis-open.org/odata/ns/metadata">
 
         <TestInitialize()> Public Sub PerTestSetup()
             Me.ctx = New DataServiceContext(web.ServiceRoot)
+            Me.ctx.Format.UseJson(New EdmModel())
             'Me.'ctx.EnableAtom = True
             'Me.'ctx.Format.UseAtom()
         End Sub

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/ClientRegressionTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/ClientRegressionTests.vb
@@ -24,6 +24,7 @@ Imports AstoriaUnitTests.Tests
 Imports AstoriaUnitTests.ClientExtensions
 Imports Microsoft.OData.Client
 Imports Microsoft.OData.Edm
+Imports Microsoft.OData.Service
 Imports Microsoft.Test.ModuleCore
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports NorthwindModel

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/ClientRegressionTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/ClientRegressionTests.vb
@@ -11,8 +11,6 @@ Imports System.Collections
 Imports System.Collections.Generic
 Imports System.Collections.ObjectModel
 Imports System.ComponentModel
-Imports Microsoft.OData.Service
-Imports Microsoft.OData.Client
 Imports System.Data.Test.Astoria
 Imports System.Diagnostics
 Imports System.IO
@@ -24,9 +22,10 @@ Imports AstoriaUnitTests.Data
 Imports AstoriaUnitTests.Stubs
 Imports AstoriaUnitTests.Tests
 Imports AstoriaUnitTests.ClientExtensions
+Imports Microsoft.OData.Client
+Imports Microsoft.OData.Edm
 Imports Microsoft.Test.ModuleCore
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
-Imports Microsoft.OData.Edm
 Imports NorthwindModel
 Imports <xmlns:atom="http://www.w3.org/2005/Atom">
 Imports <xmlns:d="http://docs.oasis-open.org/odata/ns/data">

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/EntitySetResolverTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/EntitySetResolverTests.vb
@@ -45,6 +45,8 @@ Partial Public Class ClientModule
             New Tuple(Of String, Uri)("Uri has Query", New Uri("http://foo/awesome.svc?id=10", UriKind.Absolute)),
             New Tuple(Of String, Uri)("Uri is Relative", New Uri("MySet", UriKind.Relative))}
 
+        Private context As DataServiceContext
+
         <CLSCompliant(False)>
         Public Class MyAllTypes1
             Inherits AllTypes
@@ -75,6 +77,7 @@ Partial Public Class ClientModule
             streamContentWeb.ServiceType = GetType(AstoriaUnitTests.Stubs.StreamingContentService)
             streamContentWeb.StartService()
             Dim ctx = New DataServiceContext(streamingWeb.ServiceRoot)
+            ctx.Format.UseJson(New EdmModel())
 
             ' Since we are sending $value payload, we must correctly set the accept type header.
             ' Otherwise, astoria server sends application/atom+xml as the header value and then client fails to parse.
@@ -99,6 +102,8 @@ Partial Public Class ClientModule
             Me.northwindCtx = New NorthwindSimpleModel.NorthwindContext(northwindWeb.ServiceRoot)
             'Me.northwindCtx.EnableAtom = True
             'Me.northwindCtx.Format.UseAtom()
+            Me.context = New DataServiceContext()
+            context.Format.UseJson(New EdmModel())
         End Sub
 
         '<TestCleanup()> Public Sub PerTestCleanup()
@@ -106,7 +111,7 @@ Partial Public Class ClientModule
 
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub ApiContextBeginExecute_NullBaseUri_Error()
-            Dim context = New DataServiceContext()
+
             Dim act As Action = Sub()
                                     context.BeginExecute(Of Object)(New Uri("MySet", UriKind.Relative), Sub(ar As IAsyncResult) Return, Nothing)
                                 End Sub
@@ -118,9 +123,7 @@ Partial Public Class ClientModule
 
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub ApiContextBeginExecute_NullBaseUri_AbsoluteRequestUri_Success()
-            Dim context = New DataServiceContext()
-            'context.EnableAtom = True
-            context.Format.UseJson(New EdmModel())
+
             context.BeginExecute(Of Object)(entitySet1AbsoluteUri, Sub(ar As IAsyncResult)
                                                                        CType(ar, DataServiceQuery(Of Object)).EndExecute(ar).ToList()
                                                                    End Sub,
@@ -137,9 +140,7 @@ Partial Public Class ClientModule
 
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub ApiContextExecute_NullBaseUri_Error()
-            Dim context = New DataServiceContext()
-            'context.EnableAtom = True
-            'context.Format.UseAtom()
+
             Dim act As Action = Sub()
                                     context.Execute(Of Object)(New Uri("MySet", UriKind.Relative))
                                 End Sub
@@ -150,9 +151,7 @@ Partial Public Class ClientModule
 
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub ApiContextGetMetadataUri_NullBaseUri_Error()
-            Dim context = New DataServiceContext()
-            'context.EnableAtom = True
-            'context.Format.UseAtom()
+
             Dim act As Action = Sub()
                                     context.GetMetadataUri()
                                 End Sub
@@ -169,7 +168,6 @@ Partial Public Class ClientModule
 
                 Console.WriteLine("Running variation - " + variation.Item1)
                 Dim act As Action = Sub()
-                                        Dim context = New DataServiceContext()
                                         context.BaseUri = variation.Item2
                                     End Sub
                 AssertUtil.RunCatch(Of InvalidOperationException)(act,
@@ -180,11 +178,11 @@ Partial Public Class ClientModule
 
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub ApiContextBaseUriStateEquvilentBetweenDefaultCtorAndNullPassedToBaseUriCtor()
-            Dim context = New DataServiceContext()
+
             'context.EnableAtom = True
             'context.Format.UseAtom()
             Dim contextNull = New DataServiceContext(Nothing)
-
+            
             Assert.AreEqual(context.BaseUri, contextNull.BaseUri, "the base uri's should be equivelent")
             Assert.AreEqual(context.ResolveEntitySet, contextNull.ResolveEntitySet, "the base uri's should be equivelent")
 
@@ -192,9 +190,7 @@ Partial Public Class ClientModule
 
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub ApiContextBaseUriProperty()
-            Dim context = New DataServiceContext()
-            'context.EnableAtom = True
-            'context.Format.UseAtom()
+
             Assert.IsNull(context.BaseUri, "The BaseUri property didn't default to null")
 
             Dim absoluteUri As Uri = New Uri("http://foo.com/Awesome.svc")
@@ -224,9 +220,7 @@ Partial Public Class ClientModule
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub ApiContextResolveEntitySetProperty()
             Const absoluteUri As String = "http://foo.com/Awesome.svc"
-            Dim context = New DataServiceContext()
-            'context.EnableAtom = True
-            'context.Format.UseAtom()
+
             Dim esr As Func(Of String, Uri) = Function(setName As String) New Uri(absoluteUri)
             context.ResolveEntitySet = esr
             Assert.AreEqual(esr, context.ResolveEntitySet, "the ResolveEntitySet property didn't set properly")
@@ -262,7 +256,6 @@ Partial Public Class ClientModule
                 Console.WriteLine("Running variation - " + variation.Item1)
 
                 Dim act As Action = Sub()
-                                        Dim context = New DataServiceContext()
                                         context.ResolveEntitySet = Function(setName As String)
                                                                        Dim uri = variation.Item2
                                                                        Return uri
@@ -285,7 +278,8 @@ Partial Public Class ClientModule
         Public Sub ApiContextResolveEntitySetProperty_Throws()
             ' we shouldn't catch or modify what the resolver is throwing
             Dim SetupContext As Func(Of DataServiceContext) = Function()
-                                                                  Dim context = New DataServiceContext
+                                                                  Dim context = New DataServiceContext()
+                                                                  context.Format.UseJson(New EdmModel())
                                                                   context.ResolveEntitySet = Function(setName As String)
                                                                                                  Throw New MyTestException
                                                                                              End Function
@@ -319,7 +313,7 @@ Partial Public Class ClientModule
 
             context = New DataServiceContext(New Uri("http://mudd", UriKind.Absolute))
             'context.EnableAtom = True
-            'context.Format.UseAtom()
+            context.Format.UseJson(New EdmModel())
             Assert.IsNull(context.ResolveEntitySet, "The default value of the ResolveEntitySetProperty should be null")
         End Sub
 
@@ -329,6 +323,7 @@ Partial Public Class ClientModule
             Dim context = New DataServiceContext(New Uri("http://foo/ReturnsNull"))
             'context.EnableAtom = True
             'context.Format.UseAtom()
+            context.Format.UseJson(New EdmModel())
             context.ResolveEntitySet = Function(setName As String)
                                            Return Nothing
                                        End Function
@@ -525,7 +520,7 @@ Partial Public Class ClientModule
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub NoBaseUriAndNoEntitySetResolverOnAddObject_Error()
             Dim act As Action = Sub()
-                                    Dim context As New DataServiceContext()
+
                                     context.AddObject("foo", New MyAllTypes1())
                                 End Sub
             AssertUtil.RunCatch(Of InvalidOperationException)(act,

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/EntitySetResolverTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/EntitySetResolverTests.vb
@@ -22,6 +22,7 @@ Imports AstoriaUnitTests.Data
 Imports AstoriaUnitTests
 Imports System.Web
 Imports System.IO
+Imports Microsoft.OData.Edm
 
 Partial Public Class ClientModule
 
@@ -118,8 +119,9 @@ Partial Public Class ClientModule
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub ApiContextBeginExecute_NullBaseUri_AbsoluteRequestUri_Success()
             Dim context = New DataServiceContext()
+            'context.ReConfigureForNetworkLoadingTests()
             'context.EnableAtom = True
-            'context.Format.UseAtom()
+            context.Format.UseJson(New EdmModel())
             context.BeginExecute(Of Object)(entitySet1AbsoluteUri, Sub(ar As IAsyncResult)
                                                                        CType(ar, DataServiceQuery(Of Object)).EndExecute(ar).ToList()
                                                                    End Sub,
@@ -573,7 +575,7 @@ Partial Public Class ClientModule
             ' context with good uri
             Dim context = New DataServiceContext(New Uri(web1.BaseUri, UriKind.Absolute))
             'context.EnableAtom = True
-            'context.Format.UseAtom()
+            context.Format.UseJson(New EdmModel())
             context.ResolveEntitySet = Function(entitySetName As String) New Uri(context.BaseUri.OriginalString + "/Values", UriKind.Absolute)
 
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/EntitySetResolverTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/EntitySetResolverTests.vb
@@ -11,6 +11,7 @@ Imports System.Collections
 Imports System.Collections.Generic
 Imports Microsoft.OData.Service
 Imports Microsoft.OData.Client
+Imports Microsoft.OData.Edm
 Imports System.Data.Test.Astoria
 Imports AstoriaUnitTests.Stubs
 Imports Microsoft.Test.ModuleCore
@@ -22,7 +23,6 @@ Imports AstoriaUnitTests.Data
 Imports AstoriaUnitTests
 Imports System.Web
 Imports System.IO
-Imports Microsoft.OData.Edm
 
 Partial Public Class ClientModule
 
@@ -119,7 +119,6 @@ Partial Public Class ClientModule
         <TestCategory("Partition3")> <TestMethod()>
         Public Sub ApiContextBeginExecute_NullBaseUri_AbsoluteRequestUri_Success()
             Dim context = New DataServiceContext()
-            'context.ReConfigureForNetworkLoadingTests()
             'context.EnableAtom = True
             context.Format.UseJson(New EdmModel())
             context.BeginExecute(Of Object)(entitySet1AbsoluteUri, Sub(ar As IAsyncResult)

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/StateManagementTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/StateManagementTests.vb
@@ -16,6 +16,7 @@ Imports System.Xml.Linq
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports AstoriaUnitTests.Stubs
 Imports AstoriaUnitTests.Data
+Imports Microsoft.OData.Edm
 
 Partial Public Class ClientModule
 
@@ -26,6 +27,7 @@ Partial Public Class ClientModule
 
         <TestInitialize()> Public Sub BeforeEachTestMethod()
             ctx = New DataServiceContext(New Uri("http://localhost/svc"))
+            ctx.Format.UseJson(New EdmModel())
         End Sub
 
         <TestCleanup()> Public Sub AfterEachTestMethod()

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/StateManagementTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/StateManagementTests.vb
@@ -5,18 +5,19 @@
 '---------------------------------------------------------------------
 
 Imports System
-Imports System.Diagnostics
-Imports System.Text
 Imports System.Collections
 Imports System.Collections.Generic
+Imports System.Diagnostics
+Imports System.Text
 Imports System.Xml
 Imports System.Xml.Linq
-Imports Microsoft.OData.Service
+Imports AstoriaUnitTests.Data
+Imports AstoriaUnitTests.Stubs
 Imports Microsoft.OData.Client
 Imports Microsoft.OData.Edm
+Imports Microsoft.OData.Service
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
-Imports AstoriaUnitTests.Stubs
-Imports AstoriaUnitTests.Data
+
 
 Partial Public Class ClientModule
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/StateManagementTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/StateManagementTests.vb
@@ -5,18 +5,18 @@
 '---------------------------------------------------------------------
 
 Imports System
-Imports Microsoft.OData.Service
-Imports Microsoft.OData.Client
 Imports System.Diagnostics
 Imports System.Text
 Imports System.Collections
 Imports System.Collections.Generic
 Imports System.Xml
 Imports System.Xml.Linq
+Imports Microsoft.OData.Service
+Imports Microsoft.OData.Client
+Imports Microsoft.OData.Edm
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports AstoriaUnitTests.Stubs
 Imports AstoriaUnitTests.Data
-Imports Microsoft.OData.Edm
 
 Partial Public Class ClientModule
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/UpdateTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/UpdateTests.vb
@@ -20,6 +20,7 @@ Imports AstoriaUnitTests.Data
 Imports AstoriaUnitTests.Stubs
 Imports AstoriaUnitTests.Stubs.DataServiceProvider
 Imports AstoriaUnitTests.Tests
+Imports Microsoft.OData.Edm
 Imports Microsoft.Test.ModuleCore
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports <xmlns:dns="http://docs.oasis-open.org/odata/ns/data">
@@ -55,6 +56,7 @@ Partial Public Class ClientModule
             Me.ctx = New NorthwindSimpleModel.NorthwindContext(web.ServiceRoot)
             'Me.'ctx.EnableAtom = True
             'Me.'ctx.Format.UseAtom()
+            Me.ctx.Format.UseJson(New EdmModel())
             AddHandler Me.ctx.SendingRequest2, AddressOf SendingRequestListenHttpMethod
         End Sub
 
@@ -1663,6 +1665,7 @@ Partial Public Class ClientModule
             Dim saveChangesOption = CType(values("SaveChangesOption"), SaveChangesOptions)
 
             Dim context As DataServiceContext = New DataServiceContext(web1.ServiceRoot)
+            context.Format.UseJson(New EdmModel())
             Dim location = web1.ServiceRoot.OriginalString & "/foo.svc/location/Customers(1)"
             Dim etag = "'Foo'"
 
@@ -1681,6 +1684,7 @@ Partial Public Class ClientModule
             web1.StartService()
 
             Dim context As DataServiceContext = New DataServiceContext(web1.ServiceRoot)
+            context.Format.UseJson(New EdmModel())
             Dim location = web1.ServiceRoot.OriginalString & "/foo.svc/location/Customers(key%3avalue)"
             Dim etag = "'Foo'"
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/VersionedRequests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/VersionedRequests.vb
@@ -242,8 +242,6 @@ Partial Public Class ClientModule
             ' Ensure that keys are produced in key format rather than XML format.
             Dim e = New SimpleEntityWithLong()
             e.ID = 1
-            Dim ctx = New DataServiceContext(web.ServiceRoot, ODataProtocolVersion.V4)
-            ctx.Format.UseJson(New EdmModel())
             ctx.AddAndUpdateResponsePreference = DataServiceResponsePreference.IncludeContent
             ctx.AttachTo("SimpleEntityWithLong", e)
             ctx.UpdateObject(e)
@@ -266,8 +264,6 @@ Partial Public Class ClientModule
         <TestCategory("Partition2")> <TestMethod()>
         Public Sub BytesConsistency()
             ' Astoria Client: byte[] and Binary used as keys are supported inconsistently
-            Dim ctx = New DataServiceContext(web.ServiceRoot, ODataProtocolVersion.V4)
-            ctx.Format.UseJson(New EdmModel())
             ctx.AddAndUpdateResponsePreference = DataServiceResponsePreference.IncludeContent
             Dim arr As Byte()
             ReDim arr(0)
@@ -286,8 +282,6 @@ Partial Public Class ClientModule
         <TestCategory("Partition2")> <TestMethod()>
         Public Sub BinaryConsistency()
             ' Astoria Client: byte[] and Binary used as keys are supported inconsistently
-            Dim ctx = New DataServiceContext(web.ServiceRoot, ODataProtocolVersion.V4)
-            ctx.Format.UseJson(New EdmModel())
             ctx.AddAndUpdateResponsePreference = DataServiceResponsePreference.IncludeContent
             Dim arr As Byte()
             ReDim arr(0)

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/VersionedRequests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/VersionedRequests.vb
@@ -20,6 +20,7 @@ Imports System.Web
 Imports AstoriaUnitTests.Data
 Imports AstoriaUnitTests.Stubs
 Imports Microsoft.OData
+Imports Microsoft.OData.Edm
 Imports Microsoft.Test.ModuleCore
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports NorthwindModel
@@ -49,6 +50,7 @@ Partial Public Class ClientModule
             Me.ctx = New DataServiceContext(web.ServiceRoot)
             'Me.'ctx.EnableAtom = True
             'Me.'ctx.Format.UseAtom()
+            Me.ctx.Format.UseJson(New EdmModel())
         End Sub
 
         <TestCleanup()> Public Sub PerTestCleanup()
@@ -241,6 +243,7 @@ Partial Public Class ClientModule
             Dim e = New SimpleEntityWithLong()
             e.ID = 1
             Dim ctx = New DataServiceContext(web.ServiceRoot, ODataProtocolVersion.V4)
+            ctx.Format.UseJson(New EdmModel())
             ctx.AddAndUpdateResponsePreference = DataServiceResponsePreference.IncludeContent
             ctx.AttachTo("SimpleEntityWithLong", e)
             ctx.UpdateObject(e)
@@ -264,6 +267,7 @@ Partial Public Class ClientModule
         Public Sub BytesConsistency()
             ' Astoria Client: byte[] and Binary used as keys are supported inconsistently
             Dim ctx = New DataServiceContext(web.ServiceRoot, ODataProtocolVersion.V4)
+            ctx.Format.UseJson(New EdmModel())
             ctx.AddAndUpdateResponsePreference = DataServiceResponsePreference.IncludeContent
             Dim arr As Byte()
             ReDim arr(0)
@@ -283,6 +287,7 @@ Partial Public Class ClientModule
         Public Sub BinaryConsistency()
             ' Astoria Client: byte[] and Binary used as keys are supported inconsistently
             Dim ctx = New DataServiceContext(web.ServiceRoot, ODataProtocolVersion.V4)
+            ctx.Format.UseJson(New EdmModel())
             ctx.AddAndUpdateResponsePreference = DataServiceResponsePreference.IncludeContent
             Dim arr As Byte()
             ReDim arr(0)

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/medialinkentries.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/medialinkentries.vb
@@ -20,6 +20,7 @@ Imports AstoriaUnitTests.Stubs
 Imports Microsoft.Test.ModuleCore
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
 Imports System.Web
+Imports Microsoft.OData.Edm
 
 Partial Public Class ClientModule
     ' For comment out test cases, see github: https://github.com/OData/odata.net/issues/887
@@ -375,6 +376,7 @@ Partial Public Class ClientModule
 
         <TestInitialize()> Public Sub PerTestSetup()
             Me.ctx = New SpacesPhotos.SpacesPhotosService(web.ServiceRoot)
+            Me.ctx.Format.UseJson(New EdmModel())
             'Me.'ctx.EnableAtom = True
         End Sub
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/medialinkentries.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/medialinkentries.vb
@@ -7,19 +7,19 @@
 Imports System
 Imports System.Collections
 Imports System.Collections.Generic
-Imports Microsoft.OData.Service
-Imports Microsoft.OData.Client
 Imports System.Data.Test.Astoria
 Imports System.IO
 Imports System.Linq
+Imports System.Net
 Imports System.Xml
 Imports System.Xml.Linq
-Imports System.Net
+Imports System.Web
 Imports AstoriaUnitTests.Data
 Imports AstoriaUnitTests.Stubs
+Imports Microsoft.OData.Client
+Imports Microsoft.OData.Service
 Imports Microsoft.Test.ModuleCore
 Imports Microsoft.VisualStudio.TestTools.UnitTesting
-Imports System.Web
 Imports Microsoft.OData.Edm
 
 Partial Public Class ClientModule


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1003 *

### Description

*Introduces a new action to load the metadata from the metadata Url and set the ServiceModel. The new action runs to load the metadata if the metadata had not been set before (directly by calling `context.Format.UseJson(ServiceModel)` or using a user provided Hook `context.Format.LoadServiceModel`.
This would allow people to use the syntax below to use this method in their code when not using the code generation tools or when they want to use the latest model in their code. E.g when developing new API's or when working on API's that do not publish breaking changes. 
This *does not negatively impact client code generated using the tools* (codegen and connected service) as they provide  the ServiceModel directly or provide a Hook using the exposed `context.Format.LoadServiceModel` property*. Existing users of OData Client also needed to have the service model set in order for it to function properly. 

```
// POCO class
public class Person
{
        public string Id { get; set; }
        public string UserName { get; set; }
        public string FirstName { get; set; }
        public string LastName { get; set; }
}
// Dataservice context
 public class Container : DataServiceContext
{
 public Container(Uri serviceRoot) : 
                base(serviceRoot)
        {
              this.People = base.CreateQuery<Person>("People");
        }
   public DataServiceQuery<Person> People {get; private set;}
}

...
// usage
var context = new Container(uri);
var people= context.People;

 foreach (var person in people)
 {
           Console.WriteLine(person.UserName);
  }
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Docs added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
#### Docs Needed
* Update the dataservice context usage docs to reflect how to use the DataServiceContext without using codegen tools. 
* Update documentation to show how to override this behaviour for running test cases or implementing custom logic using the two methods highlighted in the earlier section LoadServiceModel and UseJson when one wants to ship the EDMX model together with the client, e.g in Codegen
