### PR TITLE
One drive escape function for key as segment staring with colon

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -822,6 +822,7 @@ namespace Microsoft.OData {
         internal const string RequestUriProcessor_OperationSegmentBoundToANonEntityType = "RequestUriProcessor_OperationSegmentBoundToANonEntityType";
         internal const string RequestUriProcessor_NoBoundEscapeFunctionSupported = "RequestUriProcessor_NoBoundEscapeFunctionSupported";
         internal const string RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter = "RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter";
+        internal const string RequestUriProcessor_ComposableEscapeFunctionShouldHaveValidParameter = "RequestUriProcessor_ComposableEscapeFunctionShouldHaveValidParameter";
         internal const string General_InternalError = "General_InternalError";
         internal const string ExceptionUtils_CheckIntegerNotNegative = "ExceptionUtils_CheckIntegerNotNegative";
         internal const string ExceptionUtils_CheckIntegerPositive = "ExceptionUtils_CheckIntegerPositive";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -894,8 +894,9 @@ RequestUriProcessor_ResourceNotFound=Resource not found for the segment '{0}'.
 RequestUriProcessor_BatchedActionOnEntityCreatedInSameChangeset=Batched service action '{0}' cannot be invoked because it was bound to an entity created in the same changeset.
 RequestUriProcessor_Forbidden=Forbidden
 RequestUriProcessor_OperationSegmentBoundToANonEntityType=Found an operation bound to a non-entity type.
-RequestUriProcessor_NoBoundEscapeFunctionSupported=The request URI is not valid. The bound function binding to '{0}' does not support the escape function annotation.
+RequestUriProcessor_NoBoundEscapeFunctionSupported=The request URI is not valid. The bound function binding to '{0}' does not match the composability of the escape function in the URI.  
 RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter=The UrlEscape function '{0}' must have exactly one non-binding parameter of type 'Edm.String'.
+RequestUriProcessor_ComposableEscapeFunctionShouldHaveValidParameter=A composable escape function must have a valid operation passed as a parameter.
 
 ; Note: The below list of error messages are common to both the OData and the OData.Query project.
 General_InternalError=An internal error '{0}' occurred.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -425,10 +425,9 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "Unable to serialize an object in a collection as it is not an ODataPrimitve or ODataResourceValue."
+        /// A string like "Unable to serialize an object in a collection as it is not a supported ODataValue."
         /// </summary>
-        internal static string ODataJsonWriter_UnsupportedValueInCollection
-        {
+        internal static string ODataJsonWriter_UnsupportedValueInCollection {
             get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataJsonWriter_UnsupportedValueInCollection);
             }
@@ -3588,10 +3587,8 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "Encountered a deleted entity when reading a non-delta response payload. Deleted entities are only supported in request payloads and delta responses."
         /// </summary>
-        internal static string ODataJsonLightResourceDeserializer_UnexpectedDeletedEntryInResponsePayload
-        {
-            get
-            {
+        internal static string ODataJsonLightResourceDeserializer_UnexpectedDeletedEntryInResponsePayload {
+            get {
                 return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataJsonLightResourceDeserializer_UnexpectedDeletedEntryInResponsePayload);
             }
         }
@@ -5768,7 +5765,7 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "The request URI is not valid. The bound function binding to '{0}' does not support the escape function annotation."
+        /// A string like "The request URI is not valid. The bound function binding to '{0}' does not match the composability of the escape function in the URI."
         /// </summary>
         internal static string RequestUriProcessor_NoBoundEscapeFunctionSupported(object p0) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_NoBoundEscapeFunctionSupported, p0);
@@ -5779,6 +5776,15 @@ namespace Microsoft.OData {
         /// </summary>
         internal static string RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter(object p0) {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_EscapeFunctionMustHaveOneStringParameter, p0);
+        }
+
+        /// <summary>
+        /// A string like "A composable escape function must have a valid operation passed as a parameter."
+        /// </summary>
+        internal static string RequestUriProcessor_ComposableEscapeFunctionShouldHaveValidParameter {
+            get {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.RequestUriProcessor_ComposableEscapeFunctionShouldHaveValidParameter);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriPathParser.cs
@@ -75,7 +75,6 @@ namespace Microsoft.OData.UriParser
                 string[] uriSegments = uri.Segments;
 #endif
 
-                int escapedStart = -1;
                 List<string> segments = new List<string>();
                 for (int i = numberOfSegmentsToSkip; i < uriSegments.Length; i++)
                 {
@@ -99,57 +98,7 @@ namespace Microsoft.OData.UriParser
                         throw new ODataException(Strings.UriQueryPathParser_TooManySegments);
                     }
 
-                    // Handle the "root...::/{xyz}"
-                    if (segment.Length >= 2 && segment.EndsWith("::", StringComparison.Ordinal))
-                    {
-                        // It should be the terminal of the previous escape segment and the start of next escape segment.
-                        // Otherwise, it's an invalid Uri.
-                        if (escapedStart == -1)
-                        {
-                            throw new ODataException(Strings.UriQueryPathParser_InvalidEscapeUri(segment));
-                        }
-                        else
-                        {
-                            string value = String.Join("/", uriSegments, escapedStart, i - escapedStart + 1);
-                            segments.Add(":" + value.Substring(0, value.Length - 1)); // because the last one has "::", remove one.
-                            escapedStart = i + 1;
-                        }
-                    }
-                    else if (segment.Length >= 1 && segment[segment.Length - 1] == ':')
-                    {
-                        // root:/{abc}....
-                        if (escapedStart == -1)
-                        {
-                            if (segment != ":")
-                            {
-                                segments.Add(segment.Substring(0, segment.Length - 1)); // remove the last ':'
-                            }
-
-                            escapedStart = i + 1;
-                        }
-                        else
-                        {
-                            // root:/{abc}:....
-                            string escapedSegment = ":" + String.Join("/", uriSegments, escapedStart, i - escapedStart + 1); // the last has one ":";
-                            segments.Add(escapedSegment);
-                            escapedStart = -1;
-                        }
-                    }
-                    else
-                    {
-                        // if we didn't find a starting escape, the current segment is normal segment, accept it.
-                        // otherwise, it's part of the escape, skip it and process it when we find the ending delimiter.
-                        if (escapedStart == -1)
-                        {
-                            segments.Add(Uri.UnescapeDataString(segment));
-                        }
-                    }
-                }
-
-                if (escapedStart != -1 && escapedStart < uriSegments.Length)
-                {
-                    string escapedSegment = ":" + String.Join("/", uriSegments, escapedStart, uriSegments.Length - escapedStart);
-                    segments.Add(escapedSegment); // We should not use "segments.Add(Uri.UnescapeDataString(escapedSegment));" to keep the original string.
+                    segments.Add(Uri.UnescapeDataString(segment));
                 }
 
                 return segments.ToArray();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPathParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPathParserTests.cs
@@ -200,38 +200,41 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
 
         [Theory]
         [InlineData("root", new[] { "root" })]
-        [InlineData("root:/", new[] { "root", ":" })]
-        [InlineData("root:/:", new[] { "root", "::" })]
-        [InlineData("root:/abc", new[] { "root", ":abc" })]
-        [InlineData("root:/abc:", new[] { "root", ":abc:" })]
-        [InlineData("root:/::/", new[] { "root", "::", ":" })]
-        [InlineData("root:/:/:/", new[] { "root", "::", ":" })]
-        [InlineData("root:/:///////////:/", new[] { "root", "::", ":" })]
-        [InlineData("root:/::/:", new[] { "root", "::", "::" })]
-        [InlineData("root:/abc:/property", new[] { "root", ":abc:", "property" })]
-        [InlineData("root:/abc:/property:/", new[] { "root", ":abc:", "property", ":" })]
-        [InlineData("root:/abc:/property:/:", new[] { "root", ":abc:", "property", "::" })]
-        [InlineData("root:/abc:/property:/::/", new[] { "root", ":abc:", "property", "::", ":" })]
-        [InlineData("root:/:/property", new[] { "root", "::", "property" })]
-        [InlineData("root:/photos/2018/February", new[] { "root", ":photos/2018/February" } )]
-        [InlineData("root:/photos%2f2018%2fFebruary", new[] { "root", ":photos%2f2018%2fFebruary" } )]
-        [InlineData("root:/photos%2f2018%2fFebruary/Others", new[] { "root", ":photos%2f2018%2fFebruary/Others" } )]
-        [InlineData("root:/photos%2f2018%2f/////February/Others", new[] { "root", ":photos%2f2018%2f/////February/Others" } )]
-        [InlineData("root:/photos/2018%2fFebruary:/permissions", new[] { "root", ":photos/2018%2fFebruary:", "permissions" } )]
-        [InlineData("root:/photos:2018:/permissions:/abc", new[] { "root", ":photos:2018:", "permissions", ":abc" } )]
-        [InlineData("root:/photos::::::2018:/permissions:/abc", new[] { "root", ":photos::::::2018:", "permissions", ":abc" })]
-        [InlineData("root:/photos/::::::2018:/permissions:/abc", new[] { "root", ":photos/::::::2018:", "permissions", ":abc" })]
-        [InlineData("EntitySet('key'):/xyz:/perm", new[] { "EntitySet('key')", ":xyz:", "perm" } )]
-        [InlineData("EntitySet('key'):/xyz::/perm", new[] { "EntitySet('key')", ":xyz:", ":perm" } )]
-        [InlineData("EntitySet('key'):/xyz/abc:", new[] { "EntitySet('key')", ":xyz/abc:" } )]
-        [InlineData("EntitySet('key%2fvalue'):/xyz", new[] { "EntitySet('key%2fvalue')", ":xyz" })]
-        [InlineData("EntitySet/key%2fvalue:/xyz", new[] { "EntitySet", "key%2fvalue", ":xyz" })]
-        [InlineData("EntitySet/key:%2fvalue:/xyz", new[] { "EntitySet", "key:%2fvalue", ":xyz" })]
-        [InlineData("EntitySet('key'):/xyz::/perm", new[] { "EntitySet('key')", ":xyz:", ":perm" })]
-        [InlineData("EntitySet('key'):/xyz:/:/perm", new[] { "EntitySet('key')", ":xyz:", ":perm" })]
-        [InlineData(":/xyz::/perm", new[] { ":xyz:", ":perm" })]
-        [InlineData(":/xyz:/:/perm", new[] { ":xyz:", ":perm" })]
-        [InlineData(":/xyz://///:/perm", new[] { ":xyz:", ":perm" })]
+        [InlineData("root:/", new[] { "root:"})]
+        [InlineData("root:/:", new[] { "root:", ":" })]
+        [InlineData("root:/abc", new[] { "root:", "abc" })]
+        [InlineData("root:/abc:", new[] { "root:", "abc:" })]
+        [InlineData("root:/::/", new[] { "root:", "::"})]
+        [InlineData("root:/:/:/", new[] { "root:", ":", ":" })]
+        [InlineData("root:/:///////////:/", new[] { "root:", ":", ":" })]
+        [InlineData("root:/::/:", new[] { "root:", "::", ":" })]
+        [InlineData("root:/abc:/property", new[] { "root:", "abc:", "property" })]
+        [InlineData("root:/abc:/property:/", new[] { "root:", "abc:", "property:"})]
+        [InlineData("root:/abc:/property:/:", new[] { "root:", "abc:", "property:", ":" })]
+        [InlineData("root:/abc:/property:/::/", new[] { "root:", "abc:", "property:", "::" })]
+        [InlineData("root:/:/property", new[] { "root:", ":", "property" })]
+        [InlineData("root:/photos/2018/February", new[] { "root:", "photos", "2018", "February" })]
+        [InlineData("root:/photos%2f2018%2fFebruary", new[] { "root:", "photos/2018/February" })]
+        [InlineData("root:/photos%2f2018%2fFebruary/Others", new[] { "root:", "photos/2018/February", "Others" })]
+        [InlineData("root:/photos%2f2018%2f/////February/Others", new[] { "root:", "photos/2018/", "February", "Others" })]
+        [InlineData("root:/photos/2018%2fFebruary:/permissions", new[] { "root:", "photos", "2018/February:", "permissions" })]
+        [InlineData("root:/photos:2018:/permissions:/abc", new[] { "root:", "photos:2018:", "permissions:", "abc" })]
+        [InlineData("root:/photos::::::2018:/permissions:/abc", new[] { "root:", "photos::::::2018:", "permissions:", "abc" })]
+        [InlineData("root:/photos/::::::2018:/permissions:/abc", new[] { "root:", "photos","::::::2018:", "permissions:", "abc" })]
+        [InlineData("EntitySet('key'):/xyz:/perm", new[] { "EntitySet('key'):", "xyz:", "perm" })]
+        [InlineData("EntitySet('key'):/xyz::/perm", new[] { "EntitySet('key'):", "xyz::", "perm" })]
+        [InlineData("EntitySet('key'):/xyz/abc:", new[] { "EntitySet('key'):", "xyz", "abc:" })]
+        [InlineData("EntitySet('key%2fvalue'):/xyz", new[] { "EntitySet('key/value'):", "xyz" })]
+        [InlineData("EntitySet/key%2fvalue:/xyz", new[] { "EntitySet", "key/value:", "xyz" })]
+        [InlineData("EntitySet/key:%2fvalue:/xyz", new[] { "EntitySet", "key:/value:", "xyz" })]
+        [InlineData("EntitySet('key'):/xyz::/perm", new[] { "EntitySet('key'):", "xyz::", "perm" })]
+        [InlineData("EntitySet('key'):/xyz:/:/perm", new[] { "EntitySet('key'):", "xyz:", ":", "perm" })]
+        [InlineData(":/xyz::/perm", new[] { ":", "xyz::", "perm" })]
+        [InlineData(":/xyz:/:/perm", new[] { ":", "xyz:", ":", "perm" })]
+        [InlineData(":/xyz://///:/perm", new[] { ":", "xyz:", ":", "perm" })]
+        [InlineData("root::/abc", new[] { "root::", "abc" })]
+        [InlineData("EntitySet('key')::/abc", new[] { "EntitySet('key')::", "abc" })]
+        [InlineData("EntitySet/key:/abc", new[] { "EntitySet","key:", "abc" })]
         public void ParsePathShouldAllowEscapeFunctionPattern(string pattern, string[] expected)
         {
             // Arrange
@@ -242,22 +245,6 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
 
             // Assert
             Assert.Equal(expected, actual);
-        }
-
-        [Theory]
-        [InlineData("root::/abc", "root::")]
-        [InlineData("EntitySet('key')::/abc", "EntitySet('key')::")]
-        public void ParseInvalidEscapeUriPathShouldThrow(string pattern, string segment)
-        {
-            // Arrange
-            var fullUrl = new Uri(this.baseUri.AbsoluteUri + pattern);
-
-            // Act
-            Action test = () => this.pathParser.ParsePathIntoSegments(fullUrl, this.baseUri);
-
-            // Assert
-            var exception = Assert.Throws<ODataException>(test);
-            Assert.Equal(Strings.UriQueryPathParser_InvalidEscapeUri(segment), exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes the escape function uri. 

### Description

The previous implementation of escape function uri was not able to distinguish if a request intended to use an escape function or a key-value began with a  ':' when the key is expressed as a segment. Therefore, the parsing would fail for the requests with key as segment with value starting with ':' with an error that no escape function was found for the type. 

Now, we change how we parse segments and give precedence to an escape function if one exists for the type otherwise treat it as a key-value. 

This pull requests 
### Additional work necessary

Release notes need to mention these changes when merged. 
