### PR TITLE
Fix Issue #1315 Add custom header feature

### DIFF
--- a/src/CodeGen/ODataT4CodeGenerator.cs
+++ b/src/CodeGen/ODataT4CodeGenerator.cs
@@ -441,10 +441,22 @@ public void ValidateAndSetIgnoreUnexpectedElementsAndAttributesFromString(string
 }
 
 /// <summary>
-/// Set the CustomHttpHeaders property from the custom http headers string.
+/// Validate the supplied custom http header string.
 /// </summary>
-/// <param name="stringValue">The value to set.</param>
-public void ValidateAndSetCustomHttpHeadersFromString(string headersValue) 
+/// <param name="header">Custom http header string.</param>
+public void ValidateCustomHttpHeaderString(string header) 
+{
+    if (!header.Contains(':'))
+    {
+        throw new ArgumentException("A http header string must have a colon delimeter");
+    }
+}
+
+/// <summary>
+/// Set the CustomHttpHeaders property using supplied custom http headers string.
+/// </summary>
+/// <param name="headersValue">Custom http headers string.</param>
+public void SetCustomHttpHeadersFromString(string headersValue) 
 {
     if (String.IsNullOrWhiteSpace(headersValue))
     {
@@ -458,16 +470,8 @@ public void ValidateAndSetCustomHttpHeadersFromString(string headersValue)
     {
         // Trim header for empty spaces
         var header = headerElement.Trim();
-
-        // A header string must have atleast one colon
-        if (header.Contains(':'))
-        {
-            CustomHttpHeaders.Add(header);
-        }
-        else
-        {
-            throw new ArgumentException("A http header string must have a colon delimeter");
-        }
+        ValidateCustomHttpHeaderString(header);
+        CustomHttpHeaders.Add(header);
     }
 
 }
@@ -484,7 +488,7 @@ private void ApplyParametersFromConfigurationClass()
     this.EnableNamingAlias = Configuration.EnableNamingAlias;
     this.TempFilePath = Configuration.TempFilePath;
     this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
-    this.ValidateAndSetCustomHttpHeadersFromString(Configuration.CustomHttpHeaders);
+    this.SetCustomHttpHeadersFromString(Configuration.CustomHttpHeaders);
 }
 
 /// <summary>

--- a/src/CodeGen/ODataT4CodeGenerator.tt
+++ b/src/CodeGen/ODataT4CodeGenerator.tt
@@ -28,6 +28,12 @@ public static class Configuration
 	// This flag indicates whether to ignore unexpected elements and attributes in the metadata document and generate
 	// the client code if any. The value must be set to true or false.
 	public const bool IgnoreUnexpectedElementsAndAttributes = true;
+
+	// (Optional) Custom http headers as a verbatim string in the format below: 
+	// CustomHttpHeaders = @"headerKey:headerValue
+	// headerKey:headerValue
+	// headerKey:headerValue";
+	public const string CustomHttpHeaders = "";
 }
 
 public static class Customization

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -60,7 +60,7 @@ THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
             this.ApplyParametersFromConfigurationClass();
         }
 
-        context = new CodeGenerationContext(new Uri(this.MetadataDocumentUri, UriKind.Absolute), this.NamespacePrefix)
+        context = new CodeGenerationContext(new Uri(this.MetadataDocumentUri, UriKind.Absolute), this.NamespacePrefix, this.CustomHttpHeaders)
         {
             UseDataServiceCollection = this.UseDataServiceCollection,
             TargetLanguage = this.TargetLanguage,
@@ -238,6 +238,15 @@ public enum LanguageOption
 }
 
 /// <summary>
+/// Stores Custom Http Headers to be added to the WebRequest.Headers property.
+/// </summary>
+public virtual IList<string> CustomHttpHeaders
+{
+    get;
+    set;
+}
+
+/// <summary>
 /// Set the UseDataServiceCollection property with the given value.
 /// </summary>
 /// <param name="stringValue">The value to set.</param>
@@ -318,6 +327,38 @@ public void ValidateAndSetIgnoreUnexpectedElementsAndAttributesFromString(string
 }
 
 /// <summary>
+/// Set the CustomHttpHeaders property from the custom http headers string.
+/// </summary>
+/// <param name="stringValue">The value to set.</param>
+public void ValidateAndSetCustomHttpHeadersFromString(string headersValue) 
+{
+    if (String.IsNullOrWhiteSpace(headersValue))
+    {
+        return;
+    }
+
+    this.CustomHttpHeaders = new List<string>();
+
+    string[] headerElements = headersValue.Split(new string[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+    foreach (var headerElement in headerElements)
+    {
+        // Trim header for empty spaces
+        var header = headerElement.Trim();
+
+        // A header string must have atleast one colon
+        if (header.Contains(':'))
+        {
+            CustomHttpHeaders.Add(header);
+        }
+        else
+        {
+            throw new ArgumentException("A http header string must have a colon delimeter");
+        }
+    }
+
+}
+
+/// <summary>
 /// Reads the parameter values from the Configuration class and applies them.
 /// </summary>
 private void ApplyParametersFromConfigurationClass()
@@ -329,6 +370,7 @@ private void ApplyParametersFromConfigurationClass()
     this.EnableNamingAlias = Configuration.EnableNamingAlias;
     this.TempFilePath = Configuration.TempFilePath;
     this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
+    this.ValidateAndSetCustomHttpHeadersFromString(Configuration.CustomHttpHeaders);
 }
 
 /// <summary>
@@ -450,8 +492,8 @@ public class CodeGenerationContext
     /// Constructs an instance of <see cref="CodeGenerationContext"/>.
     /// </summary>
     /// <param name="metadataUri">The Uri to the metadata document. The supported scheme are File, http and https.</param>
-    public CodeGenerationContext(Uri metadataUri, string namespacePrefix)
-        : this(GetEdmxStringFromMetadataPath(metadataUri), namespacePrefix)
+    public CodeGenerationContext(Uri metadataUri, string namespacePrefix, IList<string> CustomHttpHeaders = null)
+        : this(GetEdmxStringFromMetadataPath(metadataUri, CustomHttpHeaders), namespacePrefix)
     {
     }
 
@@ -847,10 +889,10 @@ public class CodeGenerationContext
     /// Reads the edmx string from a file path or a http/https path.
     /// </summary>
     /// <param name="metadataUri">The Uri to the metadata document. The supported scheme are File, http and https.</param>
-    private static string GetEdmxStringFromMetadataPath(Uri metadataUri)
+    private static string GetEdmxStringFromMetadataPath(Uri metadataUri, IList<string> CustomHttpHeaders = null)
     {
         string content = null;
-        using (StreamReader streamReader = new StreamReader(GetEdmxStreamFromUri(metadataUri)))
+        using (StreamReader streamReader = new StreamReader(GetEdmxStreamFromUri(metadataUri, CustomHttpHeaders)))
         {
             content = streamReader.ReadToEnd();
         }
@@ -862,7 +904,7 @@ public class CodeGenerationContext
     /// Get the metadata stream from a file path or a http/https path.
     /// </summary>
     /// <param name="metadataUri">The Uri to the stream. The supported scheme are File, http and https.</param>
-    private static Stream GetEdmxStreamFromUri(Uri metadataUri)
+    private static Stream GetEdmxStreamFromUri(Uri metadataUri, IList<string> CustomHttpHeaders  = null)
     {
         Debug.Assert(metadataUri != null, "metadataUri != null");
         Stream metadataStream = null;
@@ -875,6 +917,13 @@ public class CodeGenerationContext
             try
             {
                 HttpWebRequest webRequest = (HttpWebRequest)WebRequest.Create(metadataUri);
+                if (CustomHttpHeaders != null)
+                {
+                    foreach (var header in CustomHttpHeaders)
+                    {
+                        webRequest.Headers.Add(header);
+                    }
+                }
                 WebResponse webResponse = webRequest.GetResponse();
                 metadataStream = webResponse.GetResponseStream();
             }

--- a/src/CodeGen/ODataT4CodeGenerator.ttinclude
+++ b/src/CodeGen/ODataT4CodeGenerator.ttinclude
@@ -327,10 +327,22 @@ public void ValidateAndSetIgnoreUnexpectedElementsAndAttributesFromString(string
 }
 
 /// <summary>
-/// Set the CustomHttpHeaders property from the custom http headers string.
+/// Validate the supplied custom http header string.
 /// </summary>
-/// <param name="stringValue">The value to set.</param>
-public void ValidateAndSetCustomHttpHeadersFromString(string headersValue) 
+/// <param name="header">Custom http header string.</param>
+public void ValidateCustomHttpHeaderString(string header) 
+{
+    if (!header.Contains(':'))
+    {
+        throw new ArgumentException("A http header string must have a colon delimeter");
+    }
+}
+
+/// <summary>
+/// Set the CustomHttpHeaders property using supplied custom http headers string.
+/// </summary>
+/// <param name="headersValue">Custom http headers string.</param>
+public void SetCustomHttpHeadersFromString(string headersValue) 
 {
     if (String.IsNullOrWhiteSpace(headersValue))
     {
@@ -344,16 +356,8 @@ public void ValidateAndSetCustomHttpHeadersFromString(string headersValue)
     {
         // Trim header for empty spaces
         var header = headerElement.Trim();
-
-        // A header string must have atleast one colon
-        if (header.Contains(':'))
-        {
-            CustomHttpHeaders.Add(header);
-        }
-        else
-        {
-            throw new ArgumentException("A http header string must have a colon delimeter");
-        }
+        ValidateCustomHttpHeaderString(header);
+        CustomHttpHeaders.Add(header);
     }
 
 }
@@ -370,7 +374,7 @@ private void ApplyParametersFromConfigurationClass()
     this.EnableNamingAlias = Configuration.EnableNamingAlias;
     this.TempFilePath = Configuration.TempFilePath;
     this.IgnoreUnexpectedElementsAndAttributes = Configuration.IgnoreUnexpectedElementsAndAttributes;
-    this.ValidateAndSetCustomHttpHeadersFromString(Configuration.CustomHttpHeaders);
+    this.SetCustomHttpHeadersFromString(Configuration.CustomHttpHeaders);
 }
 
 /// <summary>

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGenerationContextTest.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGenerationContextTest.cs
@@ -294,5 +294,84 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
                 Assert.AreEqual(ex.Message, "Only file, http, https schemes are supported for paths to metadata source locations.");
             }
         }
+
+        [TestMethod]
+        public void SetOneCustomHeaderCorrectlyShouldNotThrowException()
+        {
+            ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
+            string customHeaderString = @"Authorization:Bearer bearer-token";
+            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            Assert.IsNotNull(codegen.CustomHttpHeaders);
+            Assert.AreEqual(1, codegen.CustomHttpHeaders.Count);
+            Assert.AreEqual("Authorization:Bearer bearer-token", codegen.CustomHttpHeaders.FirstOrDefault());
+        }
+
+        [TestMethod]
+        public void SetMultipleCustomHeadersCorrectlyShouldNotThrowException()
+        {
+            ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
+            string customHeaderString = @"Authorization:Bearer bearer-token
+                                          odata.continue-on-error:true";
+            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            Assert.IsNotNull(codegen.CustomHttpHeaders);
+            Assert.AreEqual(2, codegen.CustomHttpHeaders.Count);
+            Assert.AreEqual("Authorization:Bearer bearer-token", codegen.CustomHttpHeaders.FirstOrDefault());
+            Assert.AreEqual("odata.continue-on-error:true", codegen.CustomHttpHeaders.LastOrDefault());
+        }
+
+        [TestMethod]
+        public void SetCustomHeaderInCorrectlyShouldThrowException()
+        {
+            ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
+            string customHeaderString = @"Authorization Bearer bearer-token";
+            
+            try
+            {
+                codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            }
+            catch(ArgumentException exception)
+            {
+                StringAssert.Contains(exception.Message, "A http header string must have a colon delimeter");
+                return;
+            }
+            Assert.Fail("Expected ArgumentException is not thrown");
+            
+        }
+
+        [TestMethod]
+        public void SetNullCustomHeaderShouldNotThrowException()
+        {
+            ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
+            string customHeaderString = null;
+            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            Assert.IsNull(codegen.CustomHttpHeaders);
+        }
+
+        [TestMethod]
+        public void SetCustomHeadersWithQuotesShouldNotThrowException()
+        {
+            // Quotes are sent as part of the header value
+            ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
+            string customHeaderString = @"If-Match:'67ab43'";
+            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            Assert.IsNotNull(codegen.CustomHttpHeaders);
+            Assert.AreEqual(1, codegen.CustomHttpHeaders.Count);
+            Assert.AreEqual("If-Match:'67ab43'", codegen.CustomHttpHeaders.FirstOrDefault());
+        }
+
+        [TestMethod]
+        public void SetMultipleCustomHeadersWithEmptyNewLinesShouldNotThrowError()
+        {
+            ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
+            string customHeaderString = @"Authorization:Bearer bearer-token
+
+
+                                          odata.continue-on-error:true";
+            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            Assert.IsNotNull(codegen.CustomHttpHeaders);
+            Assert.AreEqual(2, codegen.CustomHttpHeaders.Count);
+            Assert.AreEqual("Authorization:Bearer bearer-token", codegen.CustomHttpHeaders.FirstOrDefault());
+            Assert.AreEqual("odata.continue-on-error:true", codegen.CustomHttpHeaders.LastOrDefault());
+        }
     }
 }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGenerationContextTest.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGenerationContextTest.cs
@@ -300,10 +300,10 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
         {
             ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
             string customHeaderString = @"Authorization:Bearer bearer-token";
-            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            codegen.SetCustomHttpHeadersFromString(customHeaderString);
             Assert.IsNotNull(codegen.CustomHttpHeaders);
             Assert.AreEqual(1, codegen.CustomHttpHeaders.Count);
-            Assert.AreEqual("Authorization:Bearer bearer-token", codegen.CustomHttpHeaders.FirstOrDefault());
+            Assert.AreEqual("Authorization:Bearer bearer-token", codegen.CustomHttpHeaders.First());
         }
 
         [TestMethod]
@@ -312,11 +312,11 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
             ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
             string customHeaderString = @"Authorization:Bearer bearer-token
                                           odata.continue-on-error:true";
-            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            codegen.SetCustomHttpHeadersFromString(customHeaderString);
             Assert.IsNotNull(codegen.CustomHttpHeaders);
             Assert.AreEqual(2, codegen.CustomHttpHeaders.Count);
-            Assert.AreEqual("Authorization:Bearer bearer-token", codegen.CustomHttpHeaders.FirstOrDefault());
-            Assert.AreEqual("odata.continue-on-error:true", codegen.CustomHttpHeaders.LastOrDefault());
+            Assert.AreEqual("Authorization:Bearer bearer-token", codegen.CustomHttpHeaders.First());
+            Assert.AreEqual("odata.continue-on-error:true", codegen.CustomHttpHeaders.Last());
         }
 
         [TestMethod]
@@ -324,7 +324,7 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
         {
             ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
             string customHeaderString = @"Authorization Bearer bearer-token";
-            Action act = () => codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            Action act = () => codegen.SetCustomHttpHeadersFromString(customHeaderString);
             act.ShouldThrow<ArgumentException>().WithMessage("A http header string must have a colon delimeter");
         }
 
@@ -333,7 +333,7 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
         {
             ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
             string customHeaderString = null;
-            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            codegen.SetCustomHttpHeadersFromString(customHeaderString);
             Assert.IsNull(codegen.CustomHttpHeaders);
         }
 
@@ -343,10 +343,10 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
             // Quotes are sent as part of the header value
             ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
             string customHeaderString = @"If-Match:'67ab43'";
-            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            codegen.SetCustomHttpHeadersFromString(customHeaderString);
             Assert.IsNotNull(codegen.CustomHttpHeaders);
             Assert.AreEqual(1, codegen.CustomHttpHeaders.Count);
-            Assert.AreEqual("If-Match:'67ab43'", codegen.CustomHttpHeaders.FirstOrDefault());
+            Assert.AreEqual("If-Match:'67ab43'", codegen.CustomHttpHeaders.First());
         }
 
         [TestMethod]
@@ -357,11 +357,11 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
 
 
                                           odata.continue-on-error:true";
-            codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            codegen.SetCustomHttpHeadersFromString(customHeaderString);
             Assert.IsNotNull(codegen.CustomHttpHeaders);
             Assert.AreEqual(2, codegen.CustomHttpHeaders.Count);
-            Assert.AreEqual("Authorization:Bearer bearer-token", codegen.CustomHttpHeaders.FirstOrDefault());
-            Assert.AreEqual("odata.continue-on-error:true", codegen.CustomHttpHeaders.LastOrDefault());
+            Assert.AreEqual("Authorization:Bearer bearer-token", codegen.CustomHttpHeaders.First());
+            Assert.AreEqual("odata.continue-on-error:true", codegen.CustomHttpHeaders.Last());
         }
     }
 }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGenerationContextTest.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/CodeGenerationContextTest.cs
@@ -324,18 +324,8 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
         {
             ODataT4CodeGenerator codegen = new ODataT4CodeGenerator();
             string customHeaderString = @"Authorization Bearer bearer-token";
-            
-            try
-            {
-                codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
-            }
-            catch(ArgumentException exception)
-            {
-                StringAssert.Contains(exception.Message, "A http header string must have a colon delimeter");
-                return;
-            }
-            Assert.Fail("Expected ArgumentException is not thrown");
-            
+            Action act = () => codegen.ValidateAndSetCustomHttpHeadersFromString(customHeaderString);
+            act.ShouldThrow<ArgumentException>().WithMessage("A http header string must have a colon delimeter");
         }
 
         [TestMethod]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1315.*

### Description

*Briefly describe the changes of this pull request.*
Add support to add custom headers for the code generation. Now you can set the property CustomHttpHeaders in the Configuration class with your custom headers.
CustomHttpHeader are set in this format "{key:value},{key:value}"

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
