### PR TITLE
Replace Dictionary with IDictionary

### DIFF
--- a/src/Microsoft.OData.Client/Serialization/Serializer.cs
+++ b/src/Microsoft.OData.Client/Serialization/Serializer.cs
@@ -80,7 +80,7 @@ namespace Microsoft.OData.Client
         /// <param name="context">Wrapping context instance.</param>
         /// <param name="keys">The dictionary containing key pairs.</param>
         /// <returns>The string of keys.</returns>
-        public static string GetKeyString(DataServiceContext context, Dictionary<string, object> keys)
+        public static string GetKeyString(DataServiceContext context, IDictionary<string, object> keys)
         {
             var requestInfo = new RequestInfo(context);
             var serializer = new Serializer(requestInfo);

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -7993,7 +7993,7 @@ public class Microsoft.OData.Client.SendingRequestEventArgs : System.EventArgs {
 }
 
 public class Microsoft.OData.Client.Serializer {
-	public static string GetKeyString (Microsoft.OData.Client.DataServiceContext context, System.Collections.Generic.Dictionary`2[[System.String],[System.Object]] keys)
+	public static string GetKeyString (Microsoft.OData.Client.DataServiceContext context, System.Collections.Generic.IDictionary`2[[System.String],[System.Object]] keys)
 	public static string GetParameterString (Microsoft.OData.Client.DataServiceContext context, Microsoft.OData.Client.OperationParameter[] parameters)
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1643 .*

### Description

Allow OData Client's Serializer.GetKeyString to receive a DataServiceContext Object and an IDictionary instead of a concrete Dictionary. Since Dictionary implements IDictionary, I have updated the method as follows
public static string GetKeyString(DataServiceContext context, IDictionary<string, object> keys)
{
// Implementation
}

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

