### PR TITLE
Fix issue#1651, In operator with null not working

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -218,6 +218,31 @@ namespace Microsoft.OData.UriParser
                         sb.Append(',');
                         break;
 
+                    case 'n':
+                        // it maybe null
+                        int index = normalizedText.IndexOf(',', i + 1);
+                        string subStr;
+                        if (index < 0)
+                        {
+                            subStr = normalizedText.Substring(i).TrimEnd(' ');
+                            i = length - 1;
+                        }
+                        else
+                        {
+                            subStr = normalizedText.Substring(i, index - i).TrimEnd(' ');
+                            i = index - 1;
+                        }
+
+                        if (subStr == "null")
+                        {
+                            sb.Append("null");
+                        }
+                        else
+                        {
+                            throw new ODataException(ODataErrorStrings.StringItemShouldBeQuoted(subStr));
+                        }
+                        break;
+
                     default:
                         // any other character between items is not valid.
                         throw new ODataException(ODataErrorStrings.StringItemShouldBeQuoted(ch));


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1651.*

### Description

Enable In operator to work with "null" value.

For example: $filter=SSN in (null).

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
