### PR TITLE
Combine Dispose methods on JsonWriter

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -482,21 +482,6 @@ namespace Microsoft.OData.Json
             }
         }
 
-        void IDisposable.Dispose()
-        {
-            if (this.binaryValueStream != null)
-            {
-                try
-                {
-                    this.binaryValueStream.Dispose();
-                }
-                finally
-                {
-                    this.binaryValueStream = null;
-                }
-            }
-        }
-
         /// <summary>
         /// Dispose the writer
         /// </summary>
@@ -507,6 +492,18 @@ namespace Microsoft.OData.Json
                 BufferUtils.ReturnToBuffer(this.ArrayPool, this.buffer);
                 this.ArrayPool = null;
                 this.buffer = null;
+            }
+
+            if (this.binaryValueStream != null)
+            {
+                try
+                {
+                    this.binaryValueStream.Dispose();
+                }
+                finally
+                {
+                    this.binaryValueStream = null;
+                }
             }
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Two separate but simultaneous PRs added Dispose functionality to JsonWriter. One used an explicit method interface implementation (IDisposable.Dispose) and the other a direct implementation (Dispose), so there wasn't a conflict when merging, but it means that a caller directly calling Dispose() will get a different set of resources freed than if called through the interface (i.e., in a Using statement). Neither method cleans up all of the resources.

This PR merges the two definitions so that all resources will be freed regardless of how Dispose is called.