### PR TITLE
Enable OData client to send IEEE754Compatible parameter in the reques…

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -3007,6 +3007,10 @@ namespace Microsoft.OData.Client
                 {
                     this.IsIeee754Compatible = true;
                 }
+                else
+                {
+                    this.IsIeee754Compatible = false;
+                }
 
                 // The reason to clone it is so that users can change the
                 // value after this event is fired.

--- a/src/Microsoft.OData.Client/RequestInfo.cs
+++ b/src/Microsoft.OData.Client/RequestInfo.cs
@@ -205,6 +205,16 @@ namespace Microsoft.OData.Client
         {
             get { return this.Context.UseDefaultCredentials; }
         }
+
+        /// <summary>
+        /// Gets IsIeee754Compatible header value.
+        /// This value determines if the request should be treated as IEEE 754 Compatible.
+        /// </summary>
+        internal bool IsIeee754Compatible 
+        {
+            get { return this.Context.IsIeee754Compatible; }
+        }
+
         #endregion Properties
 
         #region Methods

--- a/src/Microsoft.OData.Client/Serialization/Serializer.cs
+++ b/src/Microsoft.OData.Client/Serialization/Serializer.cs
@@ -750,7 +750,8 @@ namespace Microsoft.OData.Client
             // to determine which IEdmOperationImport to pass to the ODL writer. So the ODL writer is
             // serializing the parameter payload without metadata. Setting the model to null so ODL doesn't
             // do unnecessary validations when writing without metadata.
-            string literal = ODataUriUtils.ConvertToUriLiteral(valueInODataFormat, CommonUtil.ConvertToODataVersion(this.requestInfo.MaxProtocolVersionAsVersion), null /* edmModel */);
+            bool isIeee754Compatible = this.requestInfo.IsIeee754Compatible;
+            string literal = ODataUriUtils.ConvertToUriLiteral(valueInODataFormat, CommonUtil.ConvertToODataVersion(this.requestInfo.MaxProtocolVersionAsVersion), null /* edmModel */, isIeee754Compatible);
 
             // The value from ConvertToUriValue will not be escaped, but will already contain literal delimiters like single quotes, so we
             // need to use our own escape method that will preserve those characters instead of directly calling Uri.EscapeDataString that may escape them.

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -132,7 +132,8 @@ namespace Microsoft.OData.JsonLight
             Debug.Assert(messageWriterSettings != null, "messageWriterSettings != null");
 
             this.textWriter = textWriter;
-            this.jsonWriter = CreateJsonWriter(messageInfo.Container, textWriter, true /*isIeee754Compatible*/, messageWriterSettings);
+            bool ieee754CompatibleSetToTrue = (messageInfo.MediaType != null) ? messageInfo.MediaType.HasIeee754CompatibleSetToTrue() : false;
+            this.jsonWriter = CreateJsonWriter(messageInfo.Container, textWriter, ieee754CompatibleSetToTrue, messageWriterSettings);
             this.metadataLevel = new JsonMinimalMetadataLevel();
             this.propertyCacheHandler = new PropertyCacheHandler();
         }

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -426,13 +426,13 @@ namespace Microsoft.OData
             this.Version = other.Version;
             this.LibraryCompatibility = other.LibraryCompatibility;
             this.MetadataSelector = other.MetadataSelector;
+            this.IsIeee754Compatible = other.IsIeee754Compatible;
 
             this.validations = other.validations;
             this.ThrowIfTypeConflictsWithMetadata = other.ThrowIfTypeConflictsWithMetadata;
             this.ThrowOnDuplicatePropertyNames = other.ThrowOnDuplicatePropertyNames;
             this.ThrowOnUndeclaredPropertyForNonOpenType = other.ThrowOnUndeclaredPropertyForNonOpenType;
             this.ArrayPool = other.ArrayPool;
-            this.IsIeee754Compatible = other.IsIeee754Compatible;
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -216,6 +216,13 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// isIEEE754Compatible is used to determine if the message follows IEEE 754 standard.
+
+        /// If this is set to true then long and decimals will be serialized as strings.
+        /// </summary>
+        internal bool IsIeee754Compatible { get; set; }
+
+        /// <summary>
         /// The acceptable charsets used to the determine the encoding of the message.
         /// This is a comma separated list of charsets as specified in RFC 2616, Section 14.2
         /// </summary>
@@ -425,6 +432,7 @@ namespace Microsoft.OData
             this.ThrowOnDuplicatePropertyNames = other.ThrowOnDuplicatePropertyNames;
             this.ThrowOnUndeclaredPropertyForNonOpenType = other.ThrowOnUndeclaredPropertyForNonOpenType;
             this.ArrayPool = other.ArrayPool;
+            this.IsIeee754Compatible = other.IsIeee754Compatible;
         }
     }
 }

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -280,6 +280,19 @@ namespace Microsoft.OData
         /// <returns>A string representation of <paramref name="collectionValue"/> to be added to a Url.</returns>
         internal static string ConvertToUriCollectionLiteral(ODataCollectionValue collectionValue, IEdmModel model, ODataVersion version)
         {
+            return ConvertToUriCollectionLiteral(collectionValue, model, version, true);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="ODataCollectionValue"/> to a string for use in a Url.
+        /// </summary>
+        /// <param name="collectionValue">Instance to convert.</param>
+        /// <param name="model">Model to be used for validation. User model is optional. The EdmLib core model is expected as a minimum.</param>
+        /// <param name="version">Version to be compliant with. Collection requires >= V3.</param>
+        /// <param name="isIeee754Compatible">true if value should be IEEE 754 compatible.</param>
+        /// <returns>A string representation of <paramref name="collectionValue"/> to be added to a Url.</returns>
+        internal static string ConvertToUriCollectionLiteral(ODataCollectionValue collectionValue, IEdmModel model, ODataVersion version, bool isIeee754Compatible)
+        {
             ExceptionUtils.CheckArgumentNotNull(collectionValue, "collectionValue");
             ExceptionUtils.CheckArgumentNotNull(model, "model");
 
@@ -292,7 +305,8 @@ namespace Microsoft.OData
                     Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType,
 
                     // TBD: Should write instance annotations for the literal???
-                    ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*")
+                    ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*"),
+                    IsIeee754Compatible = isIeee754Compatible
                 };
 
                 WriteJsonLightLiteral(
@@ -536,6 +550,13 @@ namespace Microsoft.OData
         /// <param name="writeValue">Delegate to use to actually write the value.</param>
         private static void WriteJsonLightLiteral(IEdmModel model, ODataMessageWriterSettings messageWriterSettings, TextWriter textWriter, Action<ODataJsonLightValueSerializer> writeValue)
         {
+
+            IEnumerable<KeyValuePair<string,string>> parameters = new Dictionary<string, string>
+            {
+                { MimeConstants.MimeIeee754CompatibleParameterName, messageWriterSettings.IsIeee754Compatible.ToString() }
+            };
+            ODataMediaType mediaType = new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType, parameters);
+
             // Calling dispose since it's the right thing to do, but when created from a custom-built TextWriter
             // the output context Dispose will not actually dispose anything, it will just cleanup itself.
             // TODO: URI parser will also support DI container in the future but set the container to null at this moment.
@@ -543,7 +564,9 @@ namespace Microsoft.OData
             {
                 Model = model,
                 IsAsync = false,
-                IsResponse = false
+                IsResponse = false,
+                MediaType = mediaType
+
             };
 
             using (ODataJsonLightOutputContext jsonOutputContext =

--- a/src/Microsoft.OData.Core/Uri/ODataUriUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriUtils.cs
@@ -95,11 +95,39 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="value">Value to be converted.</param>
         /// <param name="version">Version to be compliant with.</param>
+        /// <param name="isIeee754Compatible">true if value should be IEEE 754 compatible.</param>
+        /// <returns>A string representation of <paramref name="value"/> for use in a Url.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "designed to aid the creation on a URI, not create a full one")]
+        public static string ConvertToUriLiteral(object value, ODataVersion version, bool isIeee754Compatible)
+        {
+            return ODataUriUtils.ConvertToUriLiteral(value, version, null, isIeee754Compatible);
+        }
+
+        /// <summary>
+        /// Converts the given object to a string for use in a Uri. Does not perform any of the escaping that <see cref="Uri"/> provides.
+        /// No type verification is used.
+        /// </summary>
+        /// <param name="value">Value to be converted.</param>
+        /// <param name="version">Version to be compliant with.</param>
         /// <returns>A string representation of <paramref name="value"/> for use in a Url.</returns>
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "designed to aid the creation on a URI, not create a full one")]
         public static string ConvertToUriLiteral(object value, ODataVersion version)
         {
-            return ODataUriUtils.ConvertToUriLiteral(value, version, null);
+            return ODataUriUtils.ConvertToUriLiteral(value, version, null, true);
+        }
+
+        /// <summary>
+        /// Converts the given object to a string in the specified format for use in a Uri. Does not perform any of the escaping that <see cref="Uri"/> provides.
+        /// Will perform type verification based on the given model if possible.
+        /// </summary>
+        /// <param name="value">Value to be converted (can be EnumNode).</param>
+        /// <param name="version">Version to be compliant with.</param>
+        /// <param name="model">Optional model to perform verification against.</param>
+        /// <returns>A string representation of <paramref name="value"/> for use in a Url.</returns>
+        [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "designed to aid the creation on a URI, not create a full one")]
+        public static string ConvertToUriLiteral(object value, ODataVersion version, IEdmModel model)
+        {
+            return ODataUriUtils.ConvertToUriLiteral(value, version, model, true /*isIeee754Compatible*/);
         }
 
         /// <summary>
@@ -109,9 +137,10 @@ namespace Microsoft.OData
         /// <param name="value">Value to be converted (can be EnumNode).</param>
         /// <param name="version">Version to be compliant with.</param>
         /// <param name="model">Optional model to perform verification against.</param>
+        /// <param name="isIeee754Compatible">true if value should be IEEE 754 compatible.</param>
         /// <returns>A string representation of <paramref name="value"/> for use in a Url.</returns>
         [SuppressMessage("Microsoft.Design", "CA1055:UriReturnValuesShouldNotBeStrings", Justification = "designed to aid the creation on a URI, not create a full one")]
-        public static string ConvertToUriLiteral(object value, ODataVersion version, IEdmModel model)
+        public static string ConvertToUriLiteral(object value, ODataVersion version, IEdmModel model, bool isIeee754Compatible)
         {
             if (value == null)
             {
@@ -138,7 +167,7 @@ namespace Microsoft.OData
             ODataCollectionValue collectionValue = value as ODataCollectionValue;
             if (collectionValue != null)
             {
-                return ODataUriConversionUtils.ConvertToUriCollectionLiteral(collectionValue, model, version);
+                return ODataUriConversionUtils.ConvertToUriCollectionLiteral(collectionValue, model, version, isIeee754Compatible);
             }
 
             ODataEnumValue enumValue = value as ODataEnumValue;

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -4870,6 +4870,8 @@ public sealed class Microsoft.OData.ODataUriUtils {
 	public static object ConvertFromUriLiteral (string value, Microsoft.OData.ODataVersion version, Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmTypeReference typeReference)
 	public static string ConvertToUriLiteral (object value, Microsoft.OData.ODataVersion version)
 	public static string ConvertToUriLiteral (object value, Microsoft.OData.ODataVersion version, Microsoft.OData.Edm.IEdmModel model)
+	public static string ConvertToUriLiteral (object value, Microsoft.OData.ODataVersion version, bool isIeee754Compatible)
+	public static string ConvertToUriLiteral (object value, Microsoft.OData.ODataVersion version, Microsoft.OData.Edm.IEdmModel model, bool isIeee754Compatible)
 }
 
 [

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/ConvertToUriLiteralTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/ConvertToUriLiteralTests.cs
@@ -466,6 +466,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests
                     ExpectedValue = "[{\"type\":\"Point\",\"coordinates\":[-10.0,5.0],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}]",
                 });
 
+            //For collection the if ieee754Compatible parameter is not set, the expected result is a collection of primitive types.
             // collection with multiple items
             testCases.Add(
                 new ConvertToUriLiteralTestCase()
@@ -484,6 +485,25 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests
             this.RunTestCases(testCases);
         }
 
+
+        [TestMethod]
+        public void ConvertToUriLiteralWhenIeee754CompatibleSetTrue()
+        {
+            string expectedWhenieee754ParamSetFalse = "[-9223372036854775808,9223372036854775807]";
+            string expectedWhenieee754ParamSetTrue = "[\"-9223372036854775808\",\"9223372036854775807\"]";
+
+            ODataCollectionValue parameter = new ODataCollectionValue
+            {
+                TypeName = EntityModelUtils.GetCollectionTypeName("Edm.Int64"),
+                Items = new object[] { Int64.MinValue, Int64.MaxValue }
+            };
+
+            string actualWhenieee754ParamSetFalse = ODataUriUtils.ConvertToUriLiteral(parameter, ODataVersion.V4, null, false);
+            string actualWhenieee754ParamSetTrue = ODataUriUtils.ConvertToUriLiteral(parameter, ODataVersion.V4, null, true);
+
+            Assert.AreEqual(expectedWhenieee754ParamSetFalse, actualWhenieee754ParamSetFalse, "Ieee754Compatible was not properly set");
+            Assert.AreEqual(expectedWhenieee754ParamSetTrue, actualWhenieee754ParamSetTrue, "Ieee754Compatible was not properly set");
+        }
         /// <summary>
         /// Tests that ODataUtils.ConvertToUriLiteral produces correct null values.
         /// </summary>


### PR DESCRIPTION
…t header to an OData service.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #725 and  #522  *

### Description

*Enable OData client to send IEEE754Compatible parameter in the request header. This is to ensure that both the service and the client are in sync on how long and decimal values in a collection are serialized. In the header, this value can be set to true or false. If set to true then long and decimals will be serialized as strings.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
