### PR TITLE
Fixing issue #843

### DIFF
--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -244,24 +244,20 @@ namespace Microsoft.OData.Client
 
             IDictionary<string, string> headers = new Dictionary<string, string>();
 
-
             using (Stream stream = getResponseStream())
             {
                 if ((null != stream) && stream.CanRead && stream.CanSeek)
                 {
-                    Stream streamClone = new MemoryStream();
-                    stream.CopyTo(streamClone);
-                    stream.Position = 0;
-                    streamClone.Position = 0;
                     // this StreamReader can go out of scope without dispose because the underlying stream is disposed of
-                    message = new StreamReader(streamClone).ReadToEnd();
+                    message = new StreamReader(stream).ReadToEnd();
+                    stream.Position = 0;
                 }
 
                 if (string.IsNullOrEmpty(message))
                 {
                     message = statusCode.ToString();
                 }
-                else if (Util.CanBeJson(message))
+                else if (Util.MayBeJson(message))
                 {
                     headers.Add(ODataConstants.ContentTypeHeader, JsonContentTypeHeader);
                     httpWebResponseMessage = new HttpWebResponseMessage(headers, (int)statusCode, getResponseStream);

--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -249,11 +249,8 @@ namespace Microsoft.OData.Client
                 if ((null != stream) && stream.CanRead && stream.CanSeek)
                 {
                     // this StreamReader can go out of scope without dispose because the underlying stream is disposed of
-                    using (StreamReader streamReader = new StreamReader(stream))
-                    {
-                        message = streamReader.ReadToEnd();
-                        stream.Position = 0;
-                    }
+                    message = new StreamReader(stream).ReadToEnd();
+                    stream.Position = 0;
                 }
 
                 if (string.IsNullOrEmpty(message))

--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -240,13 +240,11 @@ namespace Microsoft.OData.Client
             string message = null;
             HttpWebResponseMessage httpWebResponseMessage = null;
             DataServiceClientException dataServiceClientException;
-
-            IDictionary<string, string> headers = new Dictionary<string, string>()
-            {
-                { ODataConstants.ContentTypeHeader,JsonContentTypeHeader}
-            };
-
             ODataErrorException oDataErrorException = null;
+
+            IDictionary<string, string> headers = new Dictionary<string, string>();
+
+
             using (Stream stream = getResponseStream())
             {
                 if ((null != stream) && stream.CanRead)
@@ -263,8 +261,9 @@ namespace Microsoft.OData.Client
                 {
                     message = statusCode.ToString();
                 }
-                else
+                else if (Util.IsJson(message))
                 {
+                    headers.Add(ODataConstants.ContentTypeHeader, JsonContentTypeHeader);
                     httpWebResponseMessage = new HttpWebResponseMessage(headers, (int)statusCode, getResponseStream);
                     ODataMessageReader oDataMessageReader = new ODataMessageReader(httpWebResponseMessage);
                     oDataErrorException = new ODataErrorException(oDataMessageReader.ReadError());

--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -261,7 +261,7 @@ namespace Microsoft.OData.Client
                 {
                     message = statusCode.ToString();
                 }
-                else if (Util.IsJson(message))
+                else if (Util.CanBeJson(message))
                 {
                     headers.Add(ODataConstants.ContentTypeHeader, JsonContentTypeHeader);
                     httpWebResponseMessage = new HttpWebResponseMessage(headers, (int)statusCode, getResponseStream);

--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -249,7 +249,9 @@ namespace Microsoft.OData.Client
                 message = statusCode.ToString();
             }
 
-            return new DataServiceClientException(message, (int)statusCode);
+            HttpWebResponseMessage httpWebResponseMessage = new HttpWebResponseMessage(null as IDictionary<string,string>,(int)statusCode, getResponseStream);
+            ODataMessageReader oDataMessageReader = new ODataMessageReader(httpWebResponseMessage);
+            return new DataServiceClientException(message, new ODataErrorException(oDataMessageReader.ReadError()), httpWebResponseMessage.StatusCode);
         }
 
         /// <summary>process the batch</summary>

--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -248,7 +248,7 @@ namespace Microsoft.OData.Client
             {
                 if ((null != stream) && stream.CanRead && stream.CanSeek)
                 {
-                    // this StreamReader can go out of scope without dispose because the underlying stream is disposed of
+                    // This StreamReader can go out of scope without dispose because the underlying stream is disposed of.
                     message = new StreamReader(stream).ReadToEnd();
                     stream.Position = 0;
                 }

--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -249,8 +249,11 @@ namespace Microsoft.OData.Client
                 if ((null != stream) && stream.CanRead && stream.CanSeek)
                 {
                     // this StreamReader can go out of scope without dispose because the underlying stream is disposed of
-                    message = new StreamReader(stream).ReadToEnd();
-                    stream.Position = 0;
+                    using (StreamReader streamReader = new StreamReader(stream))
+                    {
+                        message = streamReader.ReadToEnd();
+                        stream.Position = 0;
+                    }
                 }
 
                 if (string.IsNullOrEmpty(message))

--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -247,7 +247,7 @@ namespace Microsoft.OData.Client
 
             using (Stream stream = getResponseStream())
             {
-                if ((null != stream) && stream.CanRead)
+                if ((null != stream) && stream.CanRead && stream.CanSeek)
                 {
                     Stream streamClone = new MemoryStream();
                     stream.CopyTo(streamClone);

--- a/src/Microsoft.OData.Client/DataServiceRequest.cs
+++ b/src/Microsoft.OData.Client/DataServiceRequest.cs
@@ -113,16 +113,16 @@ namespace Microsoft.OData.Client
             }
             catch (DataServiceQueryException ex)
             {
-                Exception inEx = ex;
-                Exception inExPrev = null;
-                while (inEx.InnerException != null)
+                Exception currentInnerException = ex;
+                Exception previousInnerException = null;
+                while (currentInnerException.InnerException != null)
                 {
-                    inExPrev = inEx;
-                    inEx = inEx.InnerException;
+                    previousInnerException = currentInnerException;
+                    currentInnerException = currentInnerException.InnerException;
                 }
 
-                DataServiceClientException serviceEx = inEx as DataServiceClientException;
-                serviceEx = serviceEx ?? inExPrev as DataServiceClientException;
+                DataServiceClientException serviceEx = currentInnerException as DataServiceClientException;
+                serviceEx = serviceEx ?? previousInnerException as DataServiceClientException;
                 if (context.IgnoreResourceNotFoundException && serviceEx != null && serviceEx.StatusCode == (int)HttpStatusCode.NotFound)
                 {
                     QueryOperationResponse qor = new QueryOperationResponse<TElement>(ex.Response.HeaderCollection, ex.Response.Query, MaterializeAtom.EmptyResults);

--- a/src/Microsoft.OData.Client/DataServiceRequest.cs
+++ b/src/Microsoft.OData.Client/DataServiceRequest.cs
@@ -114,12 +114,15 @@ namespace Microsoft.OData.Client
             catch (DataServiceQueryException ex)
             {
                 Exception inEx = ex;
+                Exception inExPrev = null;
                 while (inEx.InnerException != null)
                 {
+                    inExPrev = inEx;
                     inEx = inEx.InnerException;
                 }
 
                 DataServiceClientException serviceEx = inEx as DataServiceClientException;
+                serviceEx = serviceEx ?? inExPrev as DataServiceClientException;
                 if (context.IgnoreResourceNotFoundException && serviceEx != null && serviceEx.StatusCode == (int)HttpStatusCode.NotFound)
                 {
                     QueryOperationResponse qor = new QueryOperationResponse<TElement>(ex.Response.HeaderCollection, ex.Response.Query, MaterializeAtom.EmptyResults);

--- a/src/Microsoft.OData.Client/Materialization/HttpWebResponseMessage.cs
+++ b/src/Microsoft.OData.Client/Materialization/HttpWebResponseMessage.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OData.Client
         private readonly Func<Stream> getResponseStream;
 
         /// <summary>The response status code.</summary>
-        private readonly int statusCode;  
+        private readonly int statusCode;
 
         /// <summary>HttpWebResponse instance.</summary>
         private HttpWebResponse httpWebResponse;

--- a/src/Microsoft.OData.Client/Materialization/HttpWebResponseMessage.cs
+++ b/src/Microsoft.OData.Client/Materialization/HttpWebResponseMessage.cs
@@ -26,15 +26,10 @@ namespace Microsoft.OData.Client
         private readonly Func<Stream> getResponseStream;
 
         /// <summary>The response status code.</summary>
-        private readonly int statusCode;
+        private readonly int statusCode;  
 
         /// <summary>HttpWebResponse instance.</summary>
         private HttpWebResponse httpWebResponse;
-
-#if DEBUG
-        /// <summary>set to true once the GetStream was called.</summary>
-        private bool streamReturned;
-#endif
 
         /// <summary>
         /// Constructor.
@@ -159,11 +154,6 @@ namespace Microsoft.OData.Client
         /// <returns>Stream from which the response payload can be read.</returns>
         public virtual Stream GetStream()
         {
-#if DEBUG
-            Debug.Assert(!this.streamReturned, "The GetStream can only be called once.");
-            this.streamReturned = true;
-#endif
-
             return this.getResponseStream();
         }
 

--- a/src/Microsoft.OData.Client/Util.cs
+++ b/src/Microsoft.OData.Client/Util.cs
@@ -600,10 +600,11 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Quick check if the <paramref name="input"> is Json.
         /// Note that this does not check if the input is a well formed Json.
+        /// This can be used to check verify that the string is not xml
         /// </summary>
         /// <param name="input">the input string.</param>
         /// <returns>Return true if the input string can be Json.</returns>
-        public static bool IsJson(string input)
+        public static bool CanBeJson(string input)
         {
             return input.Trim().Substring(0, 1).IndexOfAny(new[] { '[', '{' }) == 0;
         }

--- a/src/Microsoft.OData.Client/Util.cs
+++ b/src/Microsoft.OData.Client/Util.cs
@@ -598,6 +598,17 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
+        /// Quick check if the <paramref name="input"> is Json.
+        /// Note that this does not check if the input is a well formed Json.
+        /// </summary>
+        /// <param name="input">the input string.</param>
+        /// <returns>Return true if the input string can be Json.</returns>
+        public static bool IsJson(string input)
+        {
+            return input.Trim().Substring(0, 1).IndexOfAny(new[] { '[', '{' }) == 0;
+        }
+
+        /// <summary>
         /// A workaround to a problem with FxCop which does not recognize the CheckArgumentNotNull method
         /// as the one which validates the argument is not null.
         /// </summary>

--- a/src/Microsoft.OData.Client/Util.cs
+++ b/src/Microsoft.OData.Client/Util.cs
@@ -604,7 +604,7 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="input">the input string.</param>
         /// <returns>Return true if the input string can be Json.</returns>
-        public static bool CanBeJson(string input)
+        public static bool MayBeJson(string input)
         {
             return input.Trim().Substring(0, 1).IndexOfAny(new[] { '[', '{' }) == 0;
         }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
@@ -175,6 +175,8 @@ namespace Microsoft.Test.OData.Tests.Client
                     Assert.IsTrue(testCase.Value);
                     Assert.AreEqual(400, ex.Response.StatusCode);
                     StringResourceUtil.VerifyDataServicesString(ClientExceptionUtil.ExtractServerErrorMessage(ex), "BadRequest_KeyCountMismatch", "Microsoft.Test.OData.Services.AstoriaDefaultService.Message");
+                    //InnerException for DataServiceClientException must be set with the exception response frpom the server.
+                    Assert.IsTrue(ex.InnerException.InnerException != null, "InnerException for DataServiceClientException has not been set.");
                 }
             }
         }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Test.OData.Tests.Client
                     Assert.IsTrue(testCase.Value);
                     Assert.AreEqual(400, ex.Response.StatusCode);
                     StringResourceUtil.VerifyDataServicesString(ClientExceptionUtil.ExtractServerErrorMessage(ex), "BadRequest_KeyCountMismatch", "Microsoft.Test.OData.Services.AstoriaDefaultService.Message");
-                    //InnerException for DataServiceClientException must be set with the exception response frpom the server.
+                    //InnerException for DataServiceClientException must be set with the exception response from the server.
                     ODataErrorException oDataErrorException = ex.InnerException.InnerException as ODataErrorException;
                     Assert.IsTrue(oDataErrorException != null, "InnerException for DataServiceClientException has not been set.");
                     Assert.AreEqual("An error was read from the payload. See the 'Error' property for more details.", oDataErrorException.Message);

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Test.OData.Tests.Client
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using Microsoft.OData;
     using Microsoft.OData.Client;
     using Microsoft.Test.OData.Framework;
     using Microsoft.Test.OData.Framework.Client;
@@ -176,7 +177,10 @@ namespace Microsoft.Test.OData.Tests.Client
                     Assert.AreEqual(400, ex.Response.StatusCode);
                     StringResourceUtil.VerifyDataServicesString(ClientExceptionUtil.ExtractServerErrorMessage(ex), "BadRequest_KeyCountMismatch", "Microsoft.Test.OData.Services.AstoriaDefaultService.Message");
                     //InnerException for DataServiceClientException must be set with the exception response frpom the server.
-                    Assert.IsTrue(ex.InnerException.InnerException != null, "InnerException for DataServiceClientException has not been set.");
+                    ODataErrorException oDataErrorException = ex.InnerException.InnerException as ODataErrorException;
+                    Assert.IsTrue(oDataErrorException != null, "InnerException for DataServiceClientException has not been set.");
+                    Assert.AreEqual("An error was read from the payload. See the 'Error' property for more details.", oDataErrorException.Message);
+                    
                 }
             }
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #843.*

### Description

*Improving `DataServiceClientException` messages. Currently `DataServiceClientException.Message` property is set to a serialized Odata response error which means the consumer has to parse it before use. Since changing the property `DataServiceClientException.Message`  is a breaking change we would not like to do that at this point in time. Instead, `DataServiceClientException.InnerException` has been set with `Microsoft.OData.ODataErrorException`. This makes it easier to get `Microsoft.OData.ODataError` object which can be useful in getting the error message *

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
