### PR TITLE
Key attribute support on Primary Key field when using POCO classes with the client

### DIFF
--- a/src/Microsoft.OData.Client/Build.NetStandard/project.json
+++ b/src/Microsoft.OData.Client/Build.NetStandard/project.json
@@ -3,6 +3,7 @@
   "dependencies": {
     "NETStandard.Library": "1.6.0",
     "System.ComponentModel": "4.3.0",
+    "System.ComponentModel.Annotations": "4.3.0",
     "System.ComponentModel.EventBasedAsync": "4.3.0",
     "System.Dynamic.Runtime": "4.3.0",
     "System.Linq.Queryable": "4.3.0",

--- a/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
+++ b/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OData.Client.Metadata
     using Microsoft.OData.Edm;
     using c = Microsoft.OData.Client;
 
-    #endregion Namespaces.
+#endregion Namespaces.
 
     /// <summary>
     /// Utility methods for client types.
@@ -439,8 +439,8 @@ namespace Microsoft.OData.Client.Metadata
             KeyAttribute dataServiceKeyAttribute = customAttributes.OfType<KeyAttribute>().FirstOrDefault();
             List<PropertyInfo> keyProperties = new List<PropertyInfo>();
             PropertyInfo[] properties = ClientTypeUtil.GetPropertiesOnType(type, false /*declaredOnly*/).ToArray();
+ 
             hasProperties = properties.Length > 0;
-
             KeyKind currentKeyKind = KeyKind.NotKey;
             KeyKind newKeyKind = KeyKind.NotKey;
             foreach (PropertyInfo propertyInfo in properties)
@@ -478,7 +478,7 @@ namespace Microsoft.OData.Client.Metadata
                 }
             }
 
-            if (newKeyKind == KeyKind.AttributedKey && keyProperties.Count != dataServiceKeyAttribute.KeyNames.Count)
+            if (newKeyKind == KeyKind.AttributedKey && keyProperties.Count != dataServiceKeyAttribute?.KeyNames.Count)
             {
                 var m = (from string a in dataServiceKeyAttribute.KeyNames
                          where null == (from b in properties
@@ -704,6 +704,12 @@ namespace Microsoft.OData.Client.Metadata
             {
                 keyKind = KeyKind.AttributedKey;
             }
+#if !PORTABLELIB
+            else if (propertyInfo.GetCustomAttributes().OfType<System.ComponentModel.DataAnnotations.KeyAttribute>().Any())
+            {
+                keyKind = KeyKind.AttributedKey;              
+            }
+#endif
             else if (propertyName.EndsWith("ID", StringComparison.Ordinal))
             {
                 string declaringTypeName = propertyInfo.DeclaringType.Name;

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.NetStandard.VS2017.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.NetStandard.VS2017.csproj
@@ -60,6 +60,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -19,6 +19,7 @@
   <Import Project="..\Build.props" />
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
     <Reference Include="System.Web" />

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
@@ -1,0 +1,55 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ClientTypeUtilTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Client.Metadata;
+using System;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.Metadata
+{
+    /// <summary>
+    /// A class test to test whether the use of Key Attribute on a Type property can identify a type as an entity when the conventional key naming methods are not used.
+    /// </summary>
+    public class ClientTypeUtilTests
+    {
+#if !PORTABLELIB
+        [Fact]
+        public void IFTypeProperty_HasKeyAttribute_TypeIsEntity()
+        {
+            //Arrange
+            Type person = typeof(Person);
+            //Act
+            bool actualResult = ClientTypeUtil.TypeOrElementTypeIsEntity(person);
+            //Assert
+            Assert.True(actualResult);
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasNoKeyAttribute_TypeIsNotEntity()
+        {
+            //Arrange
+            Type student = typeof(Student);
+            //Act
+            bool actualResult = ClientTypeUtil.TypeOrElementTypeIsEntity(student);
+            //Assert
+            Assert.False(actualResult);
+        }
+
+        public class Person
+        {
+            [System.ComponentModel.DataAnnotations.Key]
+            public int PId { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class Student
+        {
+            public int SId { get; set; }
+            public string Name { get; set; }
+        }
+#endif
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Microsoft.OData.Client.Tests.Netcore.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Microsoft.OData.Client.Tests.Netcore.csproj
@@ -9,8 +9,8 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\..\tools\StrongNamePublicKeys\testkey.snk</AssemblyOriginatorKeyFile>
     <OutputPath>..\..\..\bin\AnyCPU\$(Configuration)\Test\.NETPortable</OutputPath>
+    <DefineConstants>$(DefineConstants);PORTABLELIB;</DefineConstants>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Microsoft.OData.Client.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Microsoft.OData.Client.Tests.csproj
@@ -46,6 +46,7 @@
       <HintPath>..\..\..\sln\packages\FluentAssertions.2.0.0.1\lib\net40\FluentAssertions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
@@ -70,6 +71,7 @@
     <Compile Include="ALinq\SelectExpandPathToStringVisitorTests.cs" />
     <Compile Include="ALinq\RemoveWildcardVisitorTests.cs" />
     <Compile Include="ALinq\SelectExpandPathBuilderTests.cs" />
+    <Compile Include="Metadata\ClientTypeUtilTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1332 and #543*

### Description
OData client supports 3 ways of defining an entity key:
1. ID
2. type+ID
3. KeyAttribute
 Currently, the client does not support the use of the Key  attribute annotation on a type property when using POCO classes.  Like below: 
<pre>
//POCO class
public class ProductDetails
{
    [Key]
    public string NonStandardId { get; set; }
    public string OtherField { get; set; }
}</pre>
This PR adds support for the use of the Key attribute on a primary key field. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
