### PR TITLE
#1676 Fixed IncludeInServiceDocument overload for Container.AddEntity…

### DIFF
--- a/src/Microsoft.OData.Edm/Schema/EdmEntitySet.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmEntitySet.cs
@@ -25,11 +25,6 @@ namespace Microsoft.OData.Edm
         public EdmEntitySet(IEdmEntityContainer container, string name, IEdmEntityType elementType)
             : this(container, name, elementType, true)
         {
-            EdmUtil.CheckArgumentNull(container, "container");
-
-            this.container = container;
-            this.type = new EdmCollectionType(new EdmEntityTypeReference(elementType, false));
-            this.path = new EdmPathExpression(this.container.FullName() + "." + this.Name);
         }
 
         /// <summary>
@@ -42,6 +37,11 @@ namespace Microsoft.OData.Edm
         public EdmEntitySet(IEdmEntityContainer container, string name, IEdmEntityType elementType, bool includeInServiceDocument)
             : base(name, elementType)
         {
+            EdmUtil.CheckArgumentNull(container, "container");
+
+            this.container = container;
+            this.type = new EdmCollectionType(new EdmEntityTypeReference(elementType, false));
+            this.path = new EdmPathExpression(this.container.FullName() + "." + this.Name);
             this.includeInServiceDocument = includeInServiceDocument;
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmEntityContainerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmEntityContainerTests.cs
@@ -99,5 +99,50 @@ namespace Microsoft.OData.Edm.Tests.Library
             Assert.Same(actionImport, container.Elements.ToArray()[0]);
         }
         #endregion
+
+        #region AddEntitySet tests
+
+        [Fact]
+        public void EnsureAddedEntitySetHasAllPropertiesSet()
+        {
+            EdmModel model = new EdmModel();
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Container");
+            model.AddElement(container);
+            EdmEntityType entityType = model.AddEntityType("NS", "Entity");
+
+            EdmEntitySet entitySetDefault = container.AddEntitySet("DefaultEntities", entityType);
+            EdmEntitySet entitySetIncludeInServiceDocumentTrue = container.AddEntitySet("IncludeInServiceDocumentTrueEntities", entityType, true);
+            EdmEntitySet entitySetIncludeInServiceDocumentFalse = container.AddEntitySet("IncludeInServiceDocumentFalseEntities", entityType, false);
+
+            Assert.NotNull(entitySetDefault.Container);
+            Assert.NotNull(entitySetIncludeInServiceDocumentTrue.Container);
+            Assert.NotNull(entitySetIncludeInServiceDocumentFalse.Container);
+
+            Assert.NotNull(entitySetDefault.Type);
+            Assert.NotNull(entitySetIncludeInServiceDocumentTrue.Type);
+            Assert.NotNull(entitySetIncludeInServiceDocumentFalse.Type);
+
+            Assert.NotNull(entitySetDefault.Path);
+            Assert.NotNull(entitySetIncludeInServiceDocumentTrue.Path);
+            Assert.NotNull(entitySetIncludeInServiceDocumentFalse.Path);
+
+            Assert.Same(entitySetDefault.Container, container);
+            Assert.Same(entitySetIncludeInServiceDocumentTrue.Container, container);
+            Assert.Same(entitySetIncludeInServiceDocumentFalse.Container, container);
+
+            Assert.Same(entitySetDefault.Type.AsElementType(), entityType);
+            Assert.Same(entitySetIncludeInServiceDocumentTrue.Type.AsElementType(), entityType);
+            Assert.Same(entitySetIncludeInServiceDocumentFalse.Type.AsElementType(), entityType);
+
+            Assert.Equal(entitySetDefault.Path.Path, "NS.Container.DefaultEntities");
+            Assert.Equal(entitySetIncludeInServiceDocumentTrue.Path.Path, "NS.Container.IncludeInServiceDocumentTrueEntities");
+            Assert.Equal(entitySetIncludeInServiceDocumentFalse.Path.Path, "NS.Container.IncludeInServiceDocumentFalseEntities");
+
+            Assert.True(entitySetDefault.IncludeInServiceDocument);
+            Assert.True(entitySetIncludeInServiceDocumentTrue.IncludeInServiceDocument);
+            Assert.False(entitySetIncludeInServiceDocumentFalse.IncludeInServiceDocument);
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1676*

### Description
Fixed the EntitySet constructors. All properties now set properly.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
