### PR TITLE
Return empty enumerable from FindDeclaredOperationImports instead of null 

### DIFF
--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1082,7 +1082,7 @@ namespace Microsoft.OData.Edm
         /// <returns>All operation imports that can be found by the specified name, returns an empty enumerable if no operation import exists.</returns>
         public static IEnumerable<IEdmOperationImport> FindDeclaredOperationImports(this IEdmModel model, string qualifiedName)
         {
-            IEnumerable<IEdmOperationImport> foundOperationImports = null;
+            IEnumerable<IEdmOperationImport> foundOperationImports;
             if (!model.TryFindContainerQualifiedOperationImports(qualifiedName, out foundOperationImports))
             {
                 // try searching by operation import name in container and extended containers:
@@ -1093,7 +1093,7 @@ namespace Microsoft.OData.Edm
                 }
             }
 
-            return foundOperationImports;
+            return foundOperationImports ?? Enumerable.Empty<IEdmOperationImport>();
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -889,6 +889,14 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         }
 
         [Fact]
+        public void FindDeclaredOperationImportsReturnsEmptyEnumerableForNoEntityContainerInModel()
+        {
+            var operationImportName = "NonExistingOperationImports";
+            var result = new EdmModel().FindDeclaredOperationImports(operationImportName);
+            Assert.Empty(result);
+        }
+
+        [Fact]
         public void FindTypeByAliasName()
         {
             Assert.Equal("TestModelNameSpace.T1", TestModel.Instance.Model.FindType("TestModelAlias.T1").FullName());


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1671 .*

### Description

Based on the docstring for `FindDeclaredOperationImports` function, an empty enumerable should be returned if no operation imports are found.
```<returns>All operation imports that can be found by the specified name, returns an empty enumerable if no operation import exists.</returns>```
In a scenario where the method is invoked against an Edm model that has no entity container, a `null` is returned instead. This PR addresses that issue such that all execution paths for the method always return a non-null enumerable.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
