### PR TITLE
Revert "Return empty enumerable from FindDeclaredOperationImports instead of null "

### DIFF
--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1082,7 +1082,7 @@ namespace Microsoft.OData.Edm
         /// <returns>All operation imports that can be found by the specified name, returns an empty enumerable if no operation import exists.</returns>
         public static IEnumerable<IEdmOperationImport> FindDeclaredOperationImports(this IEdmModel model, string qualifiedName)
         {
-            IEnumerable<IEdmOperationImport> foundOperationImports;
+            IEnumerable<IEdmOperationImport> foundOperationImports = null;
             if (!model.TryFindContainerQualifiedOperationImports(qualifiedName, out foundOperationImports))
             {
                 // try searching by operation import name in container and extended containers:
@@ -1093,7 +1093,7 @@ namespace Microsoft.OData.Edm
                 }
             }
 
-            return foundOperationImports ?? Enumerable.Empty<IEdmOperationImport>();
+            return foundOperationImports;
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -889,14 +889,6 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         }
 
         [Fact]
-        public void FindDeclaredOperationImportsReturnsEmptyEnumerableForNoEntityContainerInModel()
-        {
-            var operationImportName = "NonExistingOperationImports";
-            var result = new EdmModel().FindDeclaredOperationImports(operationImportName);
-            Assert.Empty(result);
-        }
-
-        [Fact]
         public void FindTypeByAliasName()
         {
             Assert.Equal("TestModelNameSpace.T1", TestModel.Instance.Model.FindType("TestModelAlias.T1").FullName());


### PR DESCRIPTION
Reverts OData/odata.net#1696 to first troubleshoot why rolling build broke after I merged to master