### PR TITLE
Return empty enumerable from FindDeclaredOperationImports and ResolveOperationImports

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -293,7 +293,7 @@ namespace Microsoft.OData.UriParser
             IEdmEntityContainer container = model.EntityContainer;
             if (container == null)
             {
-                return null;
+                return Enumerable.Empty<IEdmOperationImport>();
             }
 
             return container.Elements.OfType<IEdmOperationImport>()

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1082,7 +1082,7 @@ namespace Microsoft.OData.Edm
         /// <returns>All operation imports that can be found by the specified name, returns an empty enumerable if no operation import exists.</returns>
         public static IEnumerable<IEdmOperationImport> FindDeclaredOperationImports(this IEdmModel model, string qualifiedName)
         {
-            IEnumerable<IEdmOperationImport> foundOperationImports = null;
+            IEnumerable<IEdmOperationImport> foundOperationImports;
             if (!model.TryFindContainerQualifiedOperationImports(qualifiedName, out foundOperationImports))
             {
                 // try searching by operation import name in container and extended containers:
@@ -1093,7 +1093,7 @@ namespace Microsoft.OData.Edm
                 }
             }
 
-            return foundOperationImports;
+            return foundOperationImports ?? Enumerable.Empty<IEdmOperationImport>();
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
@@ -287,6 +287,15 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
                "Segments with multiple key values must specify them in 'name=value' form.");
         }
 
+        [Fact]
+        public void ResolveOperationImportsReturnsEmptyEnumerableForNoEntityContainerInModel()
+        {
+            var operationImportName = "NonExistingOperationImport";
+            var odataUriResolver = new ODataUriResolver { EnableCaseInsensitive = true };
+            var result = odataUriResolver.ResolveOperationImports(new EdmModel(), operationImportName);
+            Assert.Empty(result);
+        }
+
         private void TestPos<TResult>(string originalStr, string caseInsensitiveStr, Func<ODataUriParser, TResult> parse, Action<TResult> verify, string errorMessage)
         {
             TestUriParserExtension(originalStr, caseInsensitiveStr, parse, verify, errorMessage, Model, parser => parser.Resolver = new Pos());

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -889,6 +889,14 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         }
 
         [Fact]
+        public void FindDeclaredOperationImportsReturnsEmptyEnumerableForNoEntityContainerInModel()
+        {
+            var operationImportName = "NonExistingOperationImport";
+            var result = new EdmModel().FindDeclaredOperationImports(operationImportName);
+            Assert.Empty(result);
+        }
+
+        [Fact]
         public void FindTypeByAliasName()
         {
             Assert.Equal("TestModelNameSpace.T1", TestModel.Instance.Model.FindType("TestModelAlias.T1").FullName());


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1671 .*

### Description

Based on the docstring for `FindDeclaredOperationImports` and `ResolveOperationImports` functions, an empty enumerable should be returned if no operation imports are found.
```<returns>All operation imports that can be found by the specified name, returns an empty enumerable if no operation import exists.</returns>```
In a scenario where the method is invoked against an Edm model that has no entity container, a `null` is returned instead. This PR addresses that issue such that all execution paths for the method always return a non-null enumerable.

Previous [PR](https://github.com/OData/odata.net/pull/1699) did not include a fix for `ResolveOperationImports` and that caused the build to fail after merge to master

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
