### PR TITLE
Add EdmAnnotationPathExpression class and related verification, test case

### DIFF
--- a/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
+++ b/src/Microsoft.OData.Edm/Build.Net35/Microsoft.OData.Edm.NetFX35.csproj
@@ -1292,6 +1292,9 @@
     <Compile Include="..\Vocabularies\EdmToClrEvaluator.cs">
       <Link>Microsoft\OData\Edm\Vocabularies\EdmToClrEvaluator.cs</Link>
     </Compile>
+    <Compile Include="..\Vocabularies\Expressions\EdmAnnotationPathExpression.cs">
+      <Link>Microsoft\OData\Edm\Vocabularies\Expressions\EdmAnnotationPathExpression.cs</Link>
+    </Compile>
     <Compile Include="..\Vocabularies\Expressions\EdmApplyExpression.cs">
       <Link>Microsoft\OData\Edm\Vocabularies\Expressions\EdmApplyExpression.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
+++ b/src/Microsoft.OData.Edm/Build.NetStandard/Microsoft.OData.Edm.NetStandard.csproj
@@ -1282,6 +1282,9 @@
     <Compile Include="..\Vocabularies\EdmToClrEvaluator.cs">
       <Link>Vocabularies\EdmToClrEvaluator.cs</Link>
     </Compile>
+    <Compile Include="..\Vocabularies\Expressions\EdmAnnotationPathExpression.cs">
+      <Link>Vocabularies\Expressions\EdmAnnotationPathExpression.cs</Link>
+    </Compile>
     <Compile Include="..\Vocabularies\Expressions\EdmApplyExpression.cs">
       <Link>Vocabularies\Expressions\EdmApplyExpression.cs</Link>
     </Compile>

--- a/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
@@ -142,6 +142,7 @@ namespace Microsoft.OData.Edm.Csdl
         internal const string Element_NavigationProperty = "NavigationProperty";
         internal const string Element_NavigationPropertyBinding = "NavigationPropertyBinding";
         internal const string Element_NavigationPropertyPath = "NavigationPropertyPath";
+        internal const string Element_AnnotationPath = "AnnotationPath";
         internal const string Element_Null = "Null";
         internal const string Element_OnDelete = "OnDelete";
         internal const string Element_Parameter = "Parameter";

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaWriter.cs
@@ -468,6 +468,9 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                 case EdmExpressionKind.NavigationPropertyPath:
                     this.WriteRequiredAttribute(CsdlConstants.Attribute_NavigationPropertyPath, ((IEdmPathExpression)expression).PathSegments, PathAsXml);
                     break;
+                case EdmExpressionKind.AnnotationPath:
+                    this.WriteRequiredAttribute(CsdlConstants.Attribute_AnnotationPath, ((IEdmPathExpression)expression).PathSegments, PathAsXml);
+                    break;
                 case EdmExpressionKind.StringConstant:
                     this.WriteRequiredAttribute(CsdlConstants.Attribute_String, ((IEdmStringConstantExpression)expression).Value, EdmValueWriter.StringAsXml);
                     break;
@@ -623,6 +626,13 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         internal void WriteNavigationPropertyPathExpressionElement(IEdmPathExpression expression)
         {
             this.xmlWriter.WriteStartElement(CsdlConstants.Element_NavigationPropertyPath);
+            this.xmlWriter.WriteString(PathAsXml(expression.PathSegments));
+            this.WriteEndElement();
+        }
+
+        internal void WriteAnnotationPathExpressionElement(IEdmPathExpression expression)
+        {
+            this.xmlWriter.WriteStartElement(CsdlConstants.Element_AnnotationPath);
             this.xmlWriter.WriteString(PathAsXml(expression.PathSegments));
             this.WriteEndElement();
         }

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
@@ -405,6 +405,11 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.schemaWriter.WriteNavigationPropertyPathExpressionElement(expression);
         }
 
+        protected override void ProcessAnnotationPathExpression(IEdmPathExpression expression)
+        {
+            this.schemaWriter.WriteAnnotationPathExpressionElement(expression);
+        }
+
         protected override void ProcessCollectionExpression(IEdmCollectionExpression expression)
         {
             this.BeginElement(expression, this.schemaWriter.WriteCollectionExpressionElementHeader);
@@ -539,6 +544,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                 case EdmExpressionKind.Path:
                 case EdmExpressionKind.PropertyPath:
                 case EdmExpressionKind.NavigationPropertyPath:
+                case EdmExpressionKind.AnnotationPath:
                 case EdmExpressionKind.StringConstant:
                 case EdmExpressionKind.TimeOfDayConstant:
                     return true;

--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -169,6 +169,9 @@ namespace Microsoft.OData.Edm
                 case EdmExpressionKind.NavigationPropertyPath:
                     this.ProcessNavigationPropertyPathExpression((IEdmPathExpression)expression);
                     break;
+                case EdmExpressionKind.AnnotationPath:
+                    this.ProcessAnnotationPathExpression((IEdmPathExpression)expression);
+                    break;
                 case EdmExpressionKind.Record:
                     this.ProcessRecordExpression((IEdmRecordExpression)expression);
                     break;
@@ -679,6 +682,11 @@ namespace Microsoft.OData.Edm
         }
 
         protected virtual void ProcessNavigationPropertyPathExpression(IEdmPathExpression expression)
+        {
+            this.ProcessExpression(expression);
+        }
+
+        protected virtual void ProcessAnnotationPathExpression(IEdmPathExpression expression)
         {
             this.ProcessExpression(expression);
         }

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -273,6 +273,7 @@
     <Compile Include="Vocabularies\EdmToClrEvaluator.cs" />
     <Compile Include="Vocabularies\ValidationVocabularyModel.cs" />
     <Compile Include="Vocabularies\VocabularyModelProvider.cs" />
+    <Compile Include="Vocabularies\Expressions\EdmAnnotationPathExpression.cs" />
     <Compile Include="Vocabularies\Expressions\EdmApplyExpression.cs" />
     <Compile Include="Vocabularies\Expressions\EdmCastExpression.cs" />
     <Compile Include="Vocabularies\Expressions\EdmCollectionExpression.cs" />

--- a/src/Microsoft.OData.Edm/Validation/ExpressionTypeChecker.cs
+++ b/src/Microsoft.OData.Edm/Validation/ExpressionTypeChecker.cs
@@ -82,6 +82,7 @@ namespace Microsoft.OData.Edm.Validation
                 case EdmExpressionKind.Path:
                 case EdmExpressionKind.PropertyPath:
                 case EdmExpressionKind.NavigationPropertyPath:
+                case EdmExpressionKind.AnnotationPath:
                     return TryCastPathAsType((IEdmPathExpression)expression, type, context, matchExactly, out discoveredErrors);
                 case EdmExpressionKind.FunctionApplication:
                     IEdmApplyExpression applyExpression = (IEdmApplyExpression)expression;

--- a/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
+++ b/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
@@ -1354,6 +1354,7 @@ namespace Microsoft.OData.Edm.Validation
                         case EdmExpressionKind.Path:
                         case EdmExpressionKind.PropertyPath:
                         case EdmExpressionKind.NavigationPropertyPath:
+                        case EdmExpressionKind.AnnotationPath:
                             expressionKindError = CheckForInterfaceKindValueMismatchError<IEdmExpression, EdmExpressionKind, IEdmPathExpression>(expression, expression.ExpressionKind, "ExpressionKind");
                             break;
 

--- a/src/Microsoft.OData.Edm/Vocabularies/EdmExpressionEvaluator.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/EdmExpressionEvaluator.cs
@@ -405,6 +405,7 @@ namespace Microsoft.OData.Edm.Vocabularies
                 case EdmExpressionKind.Null:
                     return (IEdmNullExpression)expression;
                 case EdmExpressionKind.Path:
+                case EdmExpressionKind.AnnotationPath:
                     {
                         if (context == null)
                         {

--- a/src/Microsoft.OData.Edm/Vocabularies/Expressions/EdmAnnotationPathExpression.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Expressions/EdmAnnotationPathExpression.cs
@@ -1,0 +1,51 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="EdmAnnotationPathExpression.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.OData.Edm.Vocabularies
+{
+    /// <summary>
+    /// Represents an EDM annotation path expression.
+    /// </summary>
+    public class EdmAnnotationPathExpression : EdmPathExpression
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmAnnotationPathExpression"/> class.
+        /// </summary>
+        /// <param name="path">Path string containing segments separated by '/'. For example: "A.B/C/D.E/Func1(NS.T,NS.T2)/P1".</param>
+        public EdmAnnotationPathExpression(string path)
+            : base(path)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmAnnotationPathExpression"/> class.
+        /// </summary>
+        /// <param name="pathSegments">Path segments.</param>
+        public EdmAnnotationPathExpression(params string[] pathSegments)
+            : base(pathSegments)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmPropertyPathExpression"/> class.
+        /// </summary>
+        /// <param name="pathSegments">Path segments.</param>
+        public EdmAnnotationPathExpression(IEnumerable<string> pathSegments)
+            : base(pathSegments)
+        {
+        }
+
+        /// <summary>
+        /// Gets the kind of this expression.
+        /// </summary>
+        public override EdmExpressionKind ExpressionKind
+        {
+            get { return EdmExpressionKind.AnnotationPath; }
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -1201,6 +1201,46 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Assert.Equal(expected, csdlStr);
         }
 
+        [Fact]
+        public void CanWriteAnnotationPathExpression()
+        {
+            string expected =
+            "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+            "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+              "<edmx:DataServices>" +
+                "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                  "<ComplexType Name=\"Complex\">" +
+                    "<Annotation Term=\"NS.MyAnnotationPathTerm\" AnnotationPath=\"abc/efg\" />" +
+                    "<Annotation Term=\"NS.MyNavigationPathTerm\" NavigationPropertyPath=\"123/456.t\" />" +
+                  "</ComplexType>" +
+                  "<Term Name=\"MyAnnotationPathTerm\" Type=\"Edm.AnnotationPath\" Nullable=\"false\" />" +
+                  "<Term Name=\"MyNavigationPathTerm\" Type=\"Edm.NavigationPropertyPath\" Nullable=\"false\" />" +
+                "</Schema>" +
+              "</edmx:DataServices>" +
+            "</edmx:Edmx>";
+
+            EdmModel model = new EdmModel();
+            EdmComplexType complex = new EdmComplexType("NS", "Complex");
+            model.AddElement(complex);
+            EdmTerm term1 = new EdmTerm("NS", "MyAnnotationPathTerm", EdmCoreModel.Instance.GetAnnotationPath(false));
+            EdmTerm term2 = new EdmTerm("NS", "MyNavigationPathTerm", EdmCoreModel.Instance.GetNavigationPropertyPath(false));
+            model.AddElement(term1);
+            model.AddElement(term2);
+
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(complex, term1, new EdmAnnotationPathExpression("abc/efg"));
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+            model.SetVocabularyAnnotation(annotation);
+
+            annotation = new EdmVocabularyAnnotation(complex, term2, new EdmNavigationPropertyPathExpression("123/456.t"));
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+            model.SetVocabularyAnnotation(annotation);
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors));
+            string csdlStr = GetCsdl(model, CsdlTarget.OData);
+            Assert.Equal(expected, csdlStr);
+        }
+
         [Theory]
         [InlineData("4.0")]
         [InlineData("4.01")]

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -3682,6 +3682,14 @@ public abstract class Microsoft.OData.Edm.Vocabularies.EdmValue : IEdmElement, I
 	Microsoft.OData.Edm.Vocabularies.EdmValueKind ValueKind  { public abstract get; }
 }
 
+public class Microsoft.OData.Edm.Vocabularies.EdmAnnotationPathExpression : Microsoft.OData.Edm.EdmPathExpression, IEdmElement, IEdmExpression, IEdmPathExpression {
+	public EdmAnnotationPathExpression (System.Collections.Generic.IEnumerable`1[[System.String]] pathSegments)
+	public EdmAnnotationPathExpression (string path)
+	public EdmAnnotationPathExpression (string[] pathSegments)
+
+	Microsoft.OData.Edm.EdmExpressionKind ExpressionKind  { public virtual get; }
+}
+
 public class Microsoft.OData.Edm.Vocabularies.EdmApplyExpression : Microsoft.OData.Edm.EdmElement, IEdmElement, IEdmExpression, IEdmApplyExpression {
 	public EdmApplyExpression (Microsoft.OData.Edm.IEdmFunction appliedFunction, Microsoft.OData.Edm.IEdmExpression[] arguments)
 	public EdmApplyExpression (Microsoft.OData.Edm.IEdmFunction appliedFunction, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmExpression]] arguments)


### PR DESCRIPTION
…cases

<!-- markdownlint-disable MD002 MD041 -->

### Description

We have CsdlSemanticAnnotationPathExpression, but without "EdmAnnotationPathExpression"

* Add the EdmAnnotationPathExpression class

1) So, now, we can annotation an element using AnnotationPath
2) we can read the AnnotationPath (It's already supported).

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
