### PR TITLE
ODataMessageWriter can't dispose the stream if there's no write method called

### DIFF
--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -1212,6 +1212,13 @@ namespace Microsoft.OData
                     {
                         this.outputContext.Dispose();
                     }
+                    else if (!this.writeMethodCalled)
+                    {
+                        if (this.settings.EnableMessageStreamDisposal)
+                        {
+                            this.message.GetStream().Dispose();
+                        }
+                    }
                 }
                 finally
                 {

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -1212,11 +1212,12 @@ namespace Microsoft.OData
                     {
                         this.outputContext.Dispose();
                     }
-                    else if (!this.writeMethodCalled)
+                    else if (this.settings.EnableMessageStreamDisposal)
                     {
-                        if (this.settings.EnableMessageStreamDisposal)
+                        Stream stream = this.message.GetStream();
+                        if (stream != null)
                         {
-                            this.message.GetStream().Dispose();
+                            stream.Dispose();
                         }
                     }
                 }


### PR DESCRIPTION
### Issues

*This pull request fixes issue #xxx.*

### Description

Exchange reports an issue that:
**Looks like there are certain conditions under which ODataMessageWriter is not disposing the stream returned by IODataResponseMessage.GetStream. Are there any known bugs in this area?**

After investigation, we found this edge case. This is an edge case only happens when customer creates the message writer without writing anything. However, if there's some control to prevent the
message writer from writing anything, the outside stream still needs to
dispose. This PR is to resolve this edge problem.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
