### PR TITLE
Fix bug where open types are not identified as such during serialization

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceClientFormat.cs
+++ b/src/Microsoft.OData.Client/DataServiceClientFormat.cs
@@ -100,15 +100,7 @@ namespace Microsoft.OData.Client
                     serviceModel = LoadServiceModelFromNetwork();
                 }
 
-                // Safe to assume we'll get here only once for each initialized data service context?
-                // Each data service context owns a service model and client edm model
-                if (serviceModel != null && this.context.Model != null)
-                {
-                    foreach (var element in serviceModel.SchemaElements.Where(el => el is IEdmStructuredType))
-                    {
-                        this.context.Model.EdmStructuredSchemaElements.TryAdd(element.Name, element);
-                    }
-                }
+                PopulateEdmStructuredSchemaElements();
                 return serviceModel;
             }
         }
@@ -129,6 +121,7 @@ namespace Microsoft.OData.Client
 
             this.ODataFormat = ODataFormat.Json;
             this.serviceModel = serviceModel;
+            PopulateEdmStructuredSchemaElements();
         }
 
         /// <summary>
@@ -375,6 +368,20 @@ namespace Microsoft.OData.Client
             using (XmlReader xmlReader = XmlReader.Create(streamReader))
             {
                 return CsdlReader.Parse(xmlReader);
+            }
+        }
+
+        /// <summary>
+        /// Populates the client edm model EdmStructuredSchemaElements dictionary with the schema elements in the service model
+        /// </summary>
+        private void PopulateEdmStructuredSchemaElements()
+        {
+            if (serviceModel != null && this.context.Model != null)
+            {
+                foreach (var element in serviceModel.SchemaElements.Where(el => el is IEdmStructuredType))
+                {
+                    this.context.Model.EdmStructuredSchemaElements.TryAdd(element.Name, element);
+                }
             }
         }
     }

--- a/src/Microsoft.OData.Client/DataServiceClientFormat.cs
+++ b/src/Microsoft.OData.Client/DataServiceClientFormat.cs
@@ -11,6 +11,7 @@ namespace Microsoft.OData.Client
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
+    using System.Linq;
     using System.Threading.Tasks;
     using System.Xml;
     using Microsoft.OData;
@@ -97,6 +98,16 @@ namespace Microsoft.OData.Client
                 else
                 {
                     serviceModel = LoadServiceModelFromNetwork();
+                }
+
+                // Safe to assume we'll get here only once for each initialized data service context?
+                // Each data service context owns a service model and client edm model
+                if (serviceModel != null && this.context.Model != null)
+                {
+                    foreach (var element in serviceModel.SchemaElements.Where(el => el is IEdmStructuredType))
+                    {
+                        this.context.Model.EdmStructuredSchemaElements.TryAdd(element.Name, element);
+                    }
                 }
                 return serviceModel;
             }

--- a/src/Microsoft.OData.Client/TypeResolver.cs
+++ b/src/Microsoft.OData.Client/TypeResolver.cs
@@ -58,14 +58,6 @@ namespace Microsoft.OData.Client
             this.resolveNameFromType = resolveNameFromType;
             this.serviceModel = serviceModel;
             this.clientEdmModel = model;
-
-            if (serviceModel != null && clientEdmModel != null)
-            {
-                foreach (var element in serviceModel.SchemaElements.Where(se => se is IEdmStructuredType))
-                {
-                    clientEdmModel.EdmStructuredSchemaElements.TryAdd(element.Name, element);
-                }
-            }
         }
 
         /// <summary>

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientOpenTypeUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientOpenTypeUpdateTests.cs
@@ -44,6 +44,20 @@ namespace Microsoft.Test.OData.Tests.Client
             // No more check, this case is to make sure that client doesn't throw exception.
         }
 
+        [TestMethod]
+        public void AddOpenTypeWithUndeclaredProperties()
+        {
+            SetContextWrapper();
+            
+            var row = Row.CreateRow(Guid.NewGuid());
+
+            contextWrapper.Configurations.RequestPipeline.OnEntryStarting(ea => EntryStarting(ea));
+
+            contextWrapper.AddObject("Row", row);
+            contextWrapper.SaveChanges();
+            // All clear if no exception is thrown
+        }
+
         private void EntryStarting(WritingEntryArgs ea)
         {
             var odataProps = ea.Entry.Properties as List<ODataProperty>;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1726.*

### Description

This PR fixes a bug  in OData client library where open types `IsOpen` property get initialized to `false` specifically in a Post scenario where no query operation to the service has been done prior. This later causes an exception to be thrown during serialization since the owning type isn't recognized as open and the undeclared property won't also be interpreted as an open property.

The fix involved moving the code for populating the `EdmStructuredSchemaElements` property of `ClientEdmModel` to a position right after the service model has been loaded

Bug was inadvertently introduced in this [PR](https://github.com/OData/odata.net/pull/161) and only occurs if query operation is done prior to a post operation.
Another user dissected and raised the issue here

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*