### PR TITLE
Support for abstract complex types with no properties

### DIFF
--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -323,12 +323,12 @@ namespace Microsoft.OData.Client
             }
             else
             {
-                // type is a complex type. Return all types on the hierarchy where there are properties defined.
+                // type is a complex type. Return all types on the hierarchy with or without properties defined.
                 do
                 {
                     hierarchy.Insert(0, type);
                 }
-                while ((type = c.PlatformHelper.GetBaseType(type)) != null && ClientTypeUtil.GetPropertiesOnType(type, false /*declaredOnly*/).Any());
+                while ((type = c.PlatformHelper.GetBaseType(type)) != null);
             }
 
             return hierarchy.ToArray();

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ClientEdmModelTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ClientEdmModelTests.cs
@@ -1,0 +1,68 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ClientEdmModelTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests
+{
+    public class ClientEdmModelTests
+    {
+        /// <summary>
+        /// A test to show that an abstract complex type with no properties defined is 
+        /// assignable from a concrete complex type that extends it.
+        /// Product is the abstract complex type with no properties defined and
+        /// ProductA is the concrete complex type that extends the abstract 
+        /// complex type(Product) with no properties defined. 
+        /// </summary>
+        [Fact]
+        public void BaseTypeOfProductAIsProduct()
+        {
+            //Arrange
+            Type productA = typeof(ProductA);
+            Type product = typeof(Product);
+            var expectedBaseTypeOfProductA = product.FullName;
+
+            //Act
+            ClientEdmModel clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V401);
+            IEdmStructuredType type = clientEdmModel.GetOrCreateEdmType(productA) as IEdmStructuredType;
+            var resultingBaseTypeOfProductA = type.BaseType.ToString();
+
+            //Assert
+            Assert.Equal(expectedBaseTypeOfProductA, resultingBaseTypeOfProductA);
+        }
+      
+    }
+
+    /// <summary>
+    /// an abstract complex type without properties defined
+    /// </summary>
+    public abstract class Product
+    {
+
+    }
+    /// <summary>
+    /// an concrete complex type that extends an abstract complex type with no properties defined.
+    /// </summary>
+    public class ProductA : Product
+    {
+        public string Name { get; set; }
+        public double Price { get; set; }
+        public string Category { get; set; }
+        public string DetailsA { get; set; }
+
+    }
+    //Entity Type
+    public class ProductEntity
+    {
+        public int Id { get; set; }
+        public Product Product { get; set; }
+    }
+
+
+
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1581.*

### Description
Since Web API OData V5.5-beta, it is allowed to:

1. define abstract type (entity & complex) without any properties.

But in this case, when you define an abstract complex type without any properties  an exception is thrown. 


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
