### PR TITLE
Add support for relative and absolute uris in json batch requests

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/AsyncBatchRoundtripJsonLightTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/AsyncBatchRoundtripJsonLightTests.cs
@@ -1026,7 +1026,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
         }
 
         [Fact]
-        public void AsyncBatchJsonLightWritingAbsoluteResourcePathAndHostTest()
+        public void AsyncBatchMultipartMixedWritingAbsoluteResourcePathAndHostTest()
         {
             var requestPayload = this.ClientWriteAsyncBatchRequest(BatchPayloadUriOption.AbsoluteUriUsingHostHeader, batchContentTypeMultipartMixed);
 
@@ -1045,7 +1045,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
         }
 
         [Fact]
-        public void AsyncBatchJsonLightWritingRelativeResourcePathTest()
+        public void AsyncBatchMultipartMixedWritingRelativeResourcePathTest()
         {
             var requestPayload = this.ClientWriteAsyncBatchRequest(BatchPayloadUriOption.RelativeUri, batchContentTypeMultipartMixed);
 
@@ -1062,20 +1062,66 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
             var responsePayload = this.ServiceReadAsyncBatchRequestAndWriteAsyncResponse(requestPayload, batchContentTypeMultipartMixed);
             this.ClientReadAsyncBatchResponse(responsePayload, batchContentTypeMultipartMixed);
         }
+
+
+        [Fact]
+        public void AsyncBatchJsonLightWritingAbsoluteResourcePathAndHostTest()
+        {
+            var baseUri = "http://example.com/root/service";
+            var requestPayload = this.ClientWriteAsyncBatchRequest(BatchPayloadUriOption.AbsoluteUriUsingHostHeader, batchContentTypeApplicationJson,
+                SkipBatchWriterStep.None, baseUri);
+
+#if NETCOREAPP1_0
+            var payloadString = System.Text.Encoding.GetEncoding(0).GetString(requestPayload);
+#else
+            var payloadString = System.Text.Encoding.Default.GetString(requestPayload);
+#endif
+
+            Assert.Contains("\"url\":\"/root/service/Customers('ALFKI')\"", payloadString);
+            Assert.Contains("\"url\":\"/root/service/Customers\"", payloadString);
+            Assert.Contains("\"url\":\"/root/service/Products\"", payloadString);
+            Assert.Contains("\"headers\":{\"host\":\"example.com:80\"}}", payloadString);
+
+            var responsePayload = this.ServiceReadAsyncBatchRequestAndWriteAsyncResponse(requestPayload, batchContentTypeApplicationJson);
+            this.ClientReadAsyncBatchResponse(responsePayload, batchContentTypeApplicationJson);
+        }
+
+        [Fact]
+        public void AsyncBatchJsonLightWritingRelativeResourcePathTest()
+        {
+            var baseUri = "http://example.com/root/service";
+            var requestPayload = this.ClientWriteAsyncBatchRequest(BatchPayloadUriOption.RelativeUri, batchContentTypeApplicationJson,
+                SkipBatchWriterStep.None, baseUri);
+
+#if NETCOREAPP1_0
+            var payloadString = System.Text.Encoding.GetEncoding(0).GetString(requestPayload);
+#else
+            var payloadString = System.Text.Encoding.Default.GetString(requestPayload);
+#endif
+
+            Assert.Contains("\"url\":\"Customers('ALFKI')\"", payloadString);
+            Assert.Contains("\"url\":\"Customers\"", payloadString);
+            Assert.Contains("\"url\":\"Products\"", payloadString);
+
+            var responsePayload = this.ServiceReadAsyncBatchRequestAndWriteAsyncResponse(requestPayload, batchContentTypeApplicationJson);
+            this.ClientReadAsyncBatchResponse(responsePayload, batchContentTypeApplicationJson);
+        }
         #endregion
 
         #region Helper Functions
         private byte[] ClientWriteAsyncBatchRequest(
             BatchPayloadUriOption payloadUriOption,
             string batchContentType,
-            SkipBatchWriterStep skipBatchWriterStep = SkipBatchWriterStep.None)
+            SkipBatchWriterStep skipBatchWriterStep = SkipBatchWriterStep.None,
+            string baseUri = null)
         {
             var stream = new MemoryStream();
+            baseUri = baseUri ?? serviceDocumentUri;
 
             IODataRequestMessage requestMessage = new InMemoryMessage { Stream = stream };
             requestMessage.SetHeader("Content-Type", batchContentType);
 
-            using (var messageWriter = new ODataMessageWriter(requestMessage, new ODataMessageWriterSettings { BaseUri = new Uri(serviceDocumentUri) }))
+            using (var messageWriter = new ODataMessageWriter(requestMessage, new ODataMessageWriterSettings { BaseUri = new Uri(baseUri) }))
             {
                 var batchWriter = messageWriter.CreateODataBatchWriter();
 
@@ -1087,7 +1133,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
                 // Write a query operation.
                 if (skipBatchWriterStep != SkipBatchWriterStep.OperationCreated)
                 {
-                    batchWriter.CreateOperationRequestMessage("GET", new Uri(serviceDocumentUri + "/Customers('ALFKI')"), /*contentId*/ null, payloadUriOption);
+                    batchWriter.CreateOperationRequestMessage("GET", new Uri(baseUri + "/Customers('ALFKI')"), /*contentId*/ null, payloadUriOption);
                 }
 
                 // Write a change set with multi update operation.
@@ -1099,7 +1145,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
                 // Create a creation operation in the change set.
                 if (skipBatchWriterStep != SkipBatchWriterStep.OperationCreated)
                 {
-                    var updateOperationMessage = batchWriter.CreateOperationRequestMessage("POST", new Uri(serviceDocumentUri + "/Customers"), "1", payloadUriOption);
+                    var updateOperationMessage = batchWriter.CreateOperationRequestMessage("POST", new Uri(baseUri + "/Customers"), "1", payloadUriOption);
 
                     // Use a new message writer to write the body of this operation.
                     using (var operationMessageWriter = new ODataMessageWriter(updateOperationMessage))
@@ -1110,7 +1156,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
                         entryWriter.WriteEnd();
                     }
 
-                    updateOperationMessage = batchWriter.CreateOperationRequestMessage("PATCH", new Uri(serviceDocumentUri + "/Customers('ALFKI')"), "2", payloadUriOption);
+                    updateOperationMessage = batchWriter.CreateOperationRequestMessage("PATCH", new Uri(baseUri + "/Customers('ALFKI')"), "2", payloadUriOption);
 
                     using (var operationMessageWriter = new ODataMessageWriter(updateOperationMessage))
                     {
@@ -1129,7 +1175,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
                 // Write a query operation.
                 if (skipBatchWriterStep != SkipBatchWriterStep.OperationCreated)
                 {
-                    batchWriter.CreateOperationRequestMessage("GET", new Uri(serviceDocumentUri + "/Products"), /*contentId*/ null, payloadUriOption);
+                    batchWriter.CreateOperationRequestMessage("GET", new Uri(baseUri + "/Products"), /*contentId*/ null, payloadUriOption);
                 }
 
                 if (skipBatchWriterStep != SkipBatchWriterStep.BatchCompleted)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1737 *

### Description

the `ODataJsonLightBatchWriter`  always uses absolute uris in batch requests as if the payload uri option was set to `AbsoluteUri`, even when the uri option is set to `RelativeUri` or `AbsoluteUriUsingHostHeader`. This PR correctly handles the two latter options and makes it consistent with the `ODataMultipartMixedBatchWriter`

I would like to get a confirmation on how the different uri options should be handled (in particular the `AbsoluteUriUsingHostHeader` option).

Given the URI `https://host:1234/path/service/People(1)` and method `GET`, this PR implement the following behavior:

- `BatchPayloadUriOption.AbsoluteUri`:
```js
{
  "method": "GET",
  "url": "https://host:1234/path/service/People(1)"
}
```
- `BatchPayloadUriOption.AbsoluteUriWithHostHeader`:
```js
// absolute resource path and host header
{
  "method": "GET",
  "url": "/path/service/People(1)",
  "headers":  {
      "host": "host:1234"
  }
}
```
- `BatchPayloadUriOption.RelativeUri`:
```js
// resource path relative to the batch request uri
{
  "method": "GET",
  "url": "People(1)"
}
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary


