### PR TITLE
Add support for Json Batch Requests in Odata Client

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceClientFormat.cs
+++ b/src/Microsoft.OData.Client/DataServiceClientFormat.cs
@@ -26,6 +26,9 @@ namespace Microsoft.OData.Client
         /// <summary>MIME type for JSON bodies in light mode (http://www.iana.org/assignments/media-types/application/).</summary>
         private const string MimeApplicationJsonODataLight = "application/json;odata.metadata=minimal";
 
+        /// <summary>MIME type for JSON (https://www.ietf.org/rfc/rfc4627.txt).</summary>
+        private const string MimeApplicationJson = "application/json";
+
         /// <summary>MIME type for JSON bodies in light mode with all metadata.</summary>
         private const string MimeApplicationJsonODataLightWithAllMetadata = "application/json;odata.metadata=full";
 
@@ -163,12 +166,15 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
-        /// Sets the value of the Accept header for a count request (will set it to 'multipart/mixed').
+        /// Sets the value of the Accept header for a batch request
+        /// Will set it to 'multipart/mixed' for a multipart batch request
+        /// Will set it to 'application/json' for a json batch request
         /// </summary>
         /// <param name="headers">The headers to modify.</param>
         internal void SetRequestAcceptHeaderForBatch(HeaderCollection headers)
         {
-            this.SetAcceptHeaderAndCharset(headers, MimeMultiPartMixed);
+            bool useJsonBatch = headers.GetHeader(XmlConstants.HttpContentType).Equals(MimeApplicationJson);
+            this.SetAcceptHeaderAndCharset(headers, useJsonBatch? MimeApplicationJson : MimeMultiPartMixed);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -3027,7 +3027,7 @@ namespace Microsoft.OData.Client
         /// <param name="options">options as specified by the user.</param>
         private void ValidateSaveChangesOptions(SaveChangesOptions options)
         {
-            const SaveChangesOptions All = SaveChangesOptions.ContinueOnError | SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.BatchWithIndependentOperations | SaveChangesOptions.ReplaceOnUpdate | SaveChangesOptions.PostOnlySetProperties | SaveChangesOptions.UseRelativeUri;
+            const SaveChangesOptions All = SaveChangesOptions.ContinueOnError | SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.BatchWithIndependentOperations | SaveChangesOptions.ReplaceOnUpdate | SaveChangesOptions.PostOnlySetProperties | SaveChangesOptions.UseRelativeUri | SaveChangesOptions.UseJsonBatch;
 
             // Make sure no higher order bits are set.
             if ((options | All) != All)
@@ -3063,6 +3063,12 @@ namespace Microsoft.OData.Client
             if (Util.IsFlagSet(options, SaveChangesOptions.UseRelativeUri) && !Util.IsBatch(options))
             {
                 throw Error.InvalidOperation(Strings.Context_MustBeUsedWith("SaveChangesOptions.UseRelativeUri", "DataServiceCollection"));
+            }
+
+            // UseJsonBatch can only be used in Batch Requests
+            if (Util.IsFlagSet(options, SaveChangesOptions.UseJsonBatch) && !Util.IsBatch(options))
+            {
+                throw Error.InvalidOperation(Strings.Context_MustBeUsedWith("SaveChangesOptions.UseJsonBatch", "DataServiceCollection"));
             }
         }
 

--- a/src/Microsoft.OData.Client/SaveChangesOptions.cs
+++ b/src/Microsoft.OData.Client/SaveChangesOptions.cs
@@ -39,6 +39,12 @@ namespace Microsoft.OData.Client
         /// Allow usage of Relative Uri.
         /// Note it can only be used in a batch request.
         /// </summary>
-        UseRelativeUri = 32
+        UseRelativeUri = 32,
+
+        /// <summary>
+        /// Allow usage of Json in batch requests.
+        /// Note it can only be used in a batch request.
+        /// </summary>
+        UseJsonBatch = 64
     }
 }

--- a/src/Microsoft.OData.Client/Util.cs
+++ b/src/Microsoft.OData.Client/Util.cs
@@ -483,6 +483,16 @@ namespace Microsoft.OData.Client
             return Util.IsFlagSet(options, SaveChangesOptions.UseRelativeUri);
         }
 
+        /// <summary>
+        /// checks whether UseJsonBatch flag is set on the options
+        /// </summary>
+        /// <param name="options">options as specified by the user.</param>
+        /// <returns>true if the given flag is set, otherwise false.</returns>
+        internal static bool UseJsonBatch(SaveChangesOptions options)
+        {
+            return Util.IsFlagSet(options, SaveChangesOptions.UseJsonBatch);
+        }
+
         /// <summary>modified or unchanged</summary>
         /// <param name="x">state to test</param>
         /// <returns>true if modified or unchanged</returns>

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -7513,6 +7513,7 @@ public enum Microsoft.OData.Client.SaveChangesOptions : int {
 	None = 0
 	PostOnlySetProperties = 8
 	ReplaceOnUpdate = 4
+	UseJsonBatch = 64
 	UseRelativeUri = 32
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Currently Odata Client only supports multipart/mixed batch requests while ODL has support for both json batch requests and multipart/mixed batch requests. We are adding support for OData Json Batch Requests in OData Client.

We are adding a new `SaveChangesOption` flag named `UseJsonBatch`. When you add the flag in batch requests when calling SaveChangesAsync, the request and response will have Content-Type as `application/json`

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
