### PR TITLE
Enable Where clause to generate $filter query options for key predicates

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -45,9 +45,9 @@ namespace Microsoft.OData.Client
         private readonly DataServiceContext context;
 
         /// <summary>
-        /// /// <summary>Whether a Where clause that just compares the id property becomes a by-key request instead of using $filter.</summary>
+        /// /// <summary>Whether a Where clause that just compares the id property generates a $filter query option.</summary>
         /// </summary>
-        private static bool makeIdPredicateByKey;
+        private static bool idPredicateGeneratesFilterQueryOption;
 
         /// <summary>Convenience property: model.</summary>
         private ClientEdmModel Model
@@ -62,7 +62,7 @@ namespace Microsoft.OData.Client
         private ResourceBinder(DataServiceContext context)
         {
             this.context = context;
-            makeIdPredicateByKey = context.MakeIdPredicateByKey;
+            idPredicateGeneratesFilterQueryOption = context.IdPredicateGeneratesFilterQueryOption;
         }
 
         /// <summary>Analyzes and binds the specified expression.</summary>
@@ -280,8 +280,8 @@ namespace Microsoft.OData.Client
                     keyPredicates = ExtractKeyPredicate(input, currentPredicates, model, out nonKeyPredicates);
                 }
 
-                // A key predicate can only be applied if makeIdPredicateByKey=true
-                if (keyPredicates != null && makeIdPredicateByKey)
+                // A key predicate can only be applied if IdPredicateGeneratesFilterQueryOption=false
+                if (keyPredicates != null && !idPredicateGeneratesFilterQueryOption)
                 {
                     input.SetKeyPredicate(keyPredicates);
                     input.RemoveFilterExpression();
@@ -294,7 +294,7 @@ namespace Microsoft.OData.Client
                     input.ConvertKeyToFilterExpression();
                 }
 
-                if (keyPredicates == null || !makeIdPredicateByKey)
+                if (keyPredicates == null || idPredicateGeneratesFilterQueryOption)
                 {
                     input.ConvertKeyToFilterExpression();
                     input.AddFilter(inputPredicates);

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -269,13 +269,12 @@ namespace Microsoft.OData.Client
                     currentPredicates = currentPredicates.Union(inputPredicates).ToList();
                 }
 
-                if (!input.UseFilterAsPredicate)
+                if (!input.UseFilterAsPredicate && !context.KeyComparisonGeneratesFilterQuery)
                 {
                     keyPredicates = ExtractKeyPredicate(input, currentPredicates, model, out nonKeyPredicates);
                 }
 
-                // A key predicate should only be applied if keyComparisonGeneratesFilterQuery=false
-                if (keyPredicates != null && !context.KeyComparisonGeneratesFilterQuery)
+                if (keyPredicates != null)
                 {
                     input.SetKeyPredicate(keyPredicates);
                     input.RemoveFilterExpression();
@@ -288,7 +287,7 @@ namespace Microsoft.OData.Client
                     input.ConvertKeyToFilterExpression();
                 }
 
-                if (keyPredicates == null || context.KeyComparisonGeneratesFilterQuery)
+                if (keyPredicates == null)
                 {
                     input.ConvertKeyToFilterExpression();
                     input.AddFilter(inputPredicates);

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -45,9 +45,9 @@ namespace Microsoft.OData.Client
         private readonly DataServiceContext context;
 
         /// <summary>
-        /// /// <summary>Whether a Where clause that just compares the id property generates a $filter query option.</summary>
+        /// If true, a Where clause that compares only the key property, will generate a $filter query option.
         /// </summary>
-        private static bool idPredicateGeneratesFilterQueryOption;
+        private static bool keyComparisonGeneratesFilterQuery;
 
         /// <summary>Convenience property: model.</summary>
         private ClientEdmModel Model
@@ -62,7 +62,7 @@ namespace Microsoft.OData.Client
         private ResourceBinder(DataServiceContext context)
         {
             this.context = context;
-            idPredicateGeneratesFilterQueryOption = context.IdPredicateGeneratesFilterQueryOption;
+            keyComparisonGeneratesFilterQuery = context.KeyComparisonGeneratesFilterQuery;
         }
 
         /// <summary>Analyzes and binds the specified expression.</summary>
@@ -280,8 +280,8 @@ namespace Microsoft.OData.Client
                     keyPredicates = ExtractKeyPredicate(input, currentPredicates, model, out nonKeyPredicates);
                 }
 
-                // A key predicate can only be applied if IdPredicateGeneratesFilterQueryOption=false
-                if (keyPredicates != null && !idPredicateGeneratesFilterQueryOption)
+                // A key predicate should only be applied if keyComparisonGeneratesFilterQuery=false
+                if (keyPredicates != null && !keyComparisonGeneratesFilterQuery)
                 {
                     input.SetKeyPredicate(keyPredicates);
                     input.RemoveFilterExpression();
@@ -294,7 +294,7 @@ namespace Microsoft.OData.Client
                     input.ConvertKeyToFilterExpression();
                 }
 
-                if (keyPredicates == null || idPredicateGeneratesFilterQueryOption)
+                if (keyPredicates == null || keyComparisonGeneratesFilterQuery)
                 {
                     input.ConvertKeyToFilterExpression();
                     input.AddFilter(inputPredicates);

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -142,8 +142,8 @@ namespace Microsoft.OData.Client
         /// <summary>The HTTP stack to use for requests.</summary>
         private HttpStack httpStack;
 
-        /// <summary>Whether a Where clause that just compares the id property becomes a by-key request instead of using $filter.</summary>
-        private bool makeIdPredicateByKey;
+        /// <summary>Whether a Where clause that just compares the id property generates a $filter query option.</summary>
+        private bool idPredicateGeneratesFilterQueryOption;
 
         #region Test hooks for header and payload verification
 
@@ -256,7 +256,7 @@ namespace Microsoft.OData.Client
             this.httpStack = HttpStack.Auto;
             this.UsingDataServiceCollection = false;
             this.UsePostTunneling = false;
-            this.makeIdPredicateByKey = true;
+            this.idPredicateGeneratesFilterQueryOption = false;
 
             // Need to use the same defaults when running sl in portable lib as when running in SL normally.
 #if PORTABLELIB
@@ -663,12 +663,12 @@ namespace Microsoft.OData.Client
         public virtual bool EnableWritingODataAnnotationWithoutPrefix { get; set; }
 
         /// <summary>
-        /// Indicates whether a Where clause that just compares the id property becomes a by-key request instead of using $filter.
+        /// Indicates whether a Where clause that just compares the id property generates a $filter query option.
         /// </summary>
-        public virtual bool MakeIdPredicateByKey
+        public virtual bool IdPredicateGeneratesFilterQueryOption
         {
-            get { return this.makeIdPredicateByKey; }
-            set { this.makeIdPredicateByKey = value; }
+            get { return this.idPredicateGeneratesFilterQueryOption; }
+            set { this.idPredicateGeneratesFilterQueryOption = value; }
         }
         /// <summary>Gets or sets whether to support undeclared properties.</summary>
         /// <returns>UndeclaredPropertyBehavior.</returns>

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -142,8 +142,8 @@ namespace Microsoft.OData.Client
         /// <summary>The HTTP stack to use for requests.</summary>
         private HttpStack httpStack;
 
-        /// <summary>Whether a Where clause that just compares the id property generates a $filter query option.</summary>
-        private bool idPredicateGeneratesFilterQueryOption;
+        /// <summary>Whether a Where clause that compares only the key property, will generate a $filter query option.</summary>
+        private bool keyComparisonGeneratesFilterQuery;
 
         #region Test hooks for header and payload verification
 
@@ -256,7 +256,7 @@ namespace Microsoft.OData.Client
             this.httpStack = HttpStack.Auto;
             this.UsingDataServiceCollection = false;
             this.UsePostTunneling = false;
-            this.idPredicateGeneratesFilterQueryOption = false;
+            this.keyComparisonGeneratesFilterQuery = false;
 
             // Need to use the same defaults when running sl in portable lib as when running in SL normally.
 #if PORTABLELIB
@@ -663,12 +663,12 @@ namespace Microsoft.OData.Client
         public virtual bool EnableWritingODataAnnotationWithoutPrefix { get; set; }
 
         /// <summary>
-        /// Indicates whether a Where clause that just compares the id property generates a $filter query option.
+        /// Indicates whether a Where clause that just compares the key property generates a $filter query option.
         /// </summary>
-        public virtual bool IdPredicateGeneratesFilterQueryOption
+        public virtual bool KeyComparisonGeneratesFilterQuery
         {
-            get { return this.idPredicateGeneratesFilterQueryOption; }
-            set { this.idPredicateGeneratesFilterQueryOption = value; }
+            get { return this.keyComparisonGeneratesFilterQuery; }
+            set { this.keyComparisonGeneratesFilterQuery = value; }
         }
         /// <summary>Gets or sets whether to support undeclared properties.</summary>
         /// <returns>UndeclaredPropertyBehavior.</returns>

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -142,6 +142,9 @@ namespace Microsoft.OData.Client
         /// <summary>The HTTP stack to use for requests.</summary>
         private HttpStack httpStack;
 
+        /// <summary>Whether a Where clause that just compares the id property becomes a by-key request instead of using $filter.</summary>
+        private bool makeIdPredicateByKey;
+
         #region Test hooks for header and payload verification
 
 #pragma warning disable 0169, 0649
@@ -253,6 +256,7 @@ namespace Microsoft.OData.Client
             this.httpStack = HttpStack.Auto;
             this.UsingDataServiceCollection = false;
             this.UsePostTunneling = false;
+            this.makeIdPredicateByKey = true;
 
             // Need to use the same defaults when running sl in portable lib as when running in SL normally.
 #if PORTABLELIB
@@ -658,6 +662,14 @@ namespace Microsoft.OData.Client
         /// </summary>
         public virtual bool EnableWritingODataAnnotationWithoutPrefix { get; set; }
 
+        /// <summary>
+        /// Indicates whether a Where clause that just compares the id property becomes a by-key request instead of using $filter.
+        /// </summary>
+        public virtual bool MakeIdPredicateByKey
+        {
+            get { return this.makeIdPredicateByKey; }
+            set { this.makeIdPredicateByKey = value; }
+        }
         /// <summary>Gets or sets whether to support undeclared properties.</summary>
         /// <returns>UndeclaredPropertyBehavior.</returns>
         internal UndeclaredPropertyBehavior UndeclaredPropertyBehavior

--- a/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1219,7 +1219,7 @@ namespace Microsoft.OData.E2E.Profile111.AsynchronousTests
         public void Linq_Where_Generates_Filter_By_Id_When_MakeIdPredicateByKey_Is_True()
         {
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            context.MakeIdPredicateByKey = false;
+            context.MakeIdPredicateByKey = true;
             var query = (from c in context.Customer
                          where c.CustomerId == -10
                          select new Customer { Name = c.Name, CustomerId = c.CustomerId }) as DataServiceQuery<Customer>;

--- a/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1198,33 +1198,6 @@ namespace Microsoft.OData.E2E.Profile111.AsynchronousTests
         }
 
         /// <summary>
-        /// When DataServiceContext.KeyComparisonGeneratesFilterQuery=true, An expression that compares only the key property, will generate a $filter query option.
-        /// </summary>
-        [Fact]
-        public void Linq_Where_Generates_Filter_When_KeyComparisonGeneratesFilterQuery_Is_True()
-        {
-            var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            context.KeyComparisonGeneratesFilterQuery = true;
-            var query = context.Customer.Where(c => c.CustomerId == -10);
-            var uri = query.ToString();
-            Assert.Equal("$filter=CustomerId eq -10", uri);
-        }
-
-        /// <summary>
-        /// When DataServiceContext.KeyComparisonGeneratesFilterQuery=false, An expression that compares only the key property, should create a ByKey Uri.
-        /// </summary>
-        [Fact]
-        public void Linq_Where_Generates_ByKey_When_KeyComparisonGeneratesFilterQuery_Is_False()
-        {
-            var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            // By default context.KeyComparisonGeneratesFilterQuery = false; 
-            // So we don't need to set it
-            var query = context.Customer.Where(c => c.CustomerId == -10);
-            var uri = query.ToString();
-            Assert.Equal("Customer(-10)", uri);
-        }
-
-        /// <summary>
         /// Custom Data Service Entity
         /// </summary>
         [KeyAttribute("CustomerId")]

--- a/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1198,34 +1198,29 @@ namespace Microsoft.OData.E2E.Profile111.AsynchronousTests
         }
 
         /// <summary>
-        /// When DataServiceContext.IdPredicateGeneratesFilterQueryOption=true, An expression with an Id as a predicate should create an Uri with a $filter in query options
+        /// When DataServiceContext.KeyComparisonGeneratesFilterQuery=true, An expression that compares only the key property, will generate a $filter query option.
         /// </summary>
         [Fact]
-        public void Linq_Where_Generates_Filter_When_IdPredicateGeneratesFilterQueryOption_Is_True()
+        public void Linq_Where_Generates_Filter_When_KeyComparisonGeneratesFilterQuery_Is_True()
         {
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            context.IdPredicateGeneratesFilterQueryOption = true;
-            var query = (from c in context.Customer
-                         where c.CustomerId == -10
-                         select new Customer { Name = c.Name, CustomerId = c.CustomerId }) as DataServiceQuery<Customer>;
+            context.KeyComparisonGeneratesFilterQuery = true;
+            var query = context.Customer.Where(c => c.CustomerId == -10);
             var uri = query.ToString();
-            Assert.Contains("$filter=CustomerId eq -10", uri);
             Assert.Equal("$filter=CustomerId eq -10", uri);
         }
 
         /// <summary>
-        /// When DataServiceContext.IdPredicateGeneratesFilterQueryOption=false, An expression with an Id as a predicate should create a ByKey Uri
+        /// When DataServiceContext.KeyComparisonGeneratesFilterQuery=false, An expression that compares only the key property, should create a ByKey Uri.
         /// </summary>
         [Fact]
-        public void Linq_Where_Generates_ByKey_When_IdPredicateGeneratesFilterQueryOption_Is_False()
+        public void Linq_Where_Generates_ByKey_When_KeyComparisonGeneratesFilterQuery_Is_False()
         {
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            context.IdPredicateGeneratesFilterQueryOption = false;
-            var query = (from c in context.Customer
-                         where c.CustomerId == -10
-                         select new Customer { Name = c.Name, CustomerId = c.CustomerId }) as DataServiceQuery<Customer>;
+            // By default context.KeyComparisonGeneratesFilterQuery = false; 
+            // So we don't need to set it
+            var query = context.Customer.Where(c => c.CustomerId == -10);
             var uri = query.ToString();
-            Assert.Contains("Customer(-10)", uri);
             Assert.Equal("Customer(-10)", uri);
         }
 

--- a/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1198,6 +1198,36 @@ namespace Microsoft.OData.E2E.Profile111.AsynchronousTests
         }
 
         /// <summary>
+        /// When DataServiceContext.MakeIdPredicateByKey=false, An expression with an Id as a predicate should create an Uri with a $filter in query options
+        /// </summary>
+        [Fact]
+        public void Linq_Where_Generates_Filter_By_Id_When_MakeIdPredicateByKey_Is_False()
+        {
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            context.MakeIdPredicateByKey = false;
+            var query = (from c in context.Customer
+                         where c.CustomerId == -10
+                         select new Customer { Name = c.Name, CustomerId = c.CustomerId }) as DataServiceQuery<Customer>;
+            var uri = query.ToString();
+            Assert.Contains("$filter=CustomerId eq -10", uri);
+        }
+
+        /// <summary>
+        /// When DataServiceContext.MakeIdPredicateByKey=true, An expression with an Id as a predicate should create a ByKey Uri
+        /// </summary>
+        [Fact]
+        public void Linq_Where_Generates_Filter_By_Id_When_MakeIdPredicateByKey_Is_True()
+        {
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            context.MakeIdPredicateByKey = false;
+            var query = (from c in context.Customer
+                         where c.CustomerId == -10
+                         select new Customer { Name = c.Name, CustomerId = c.CustomerId }) as DataServiceQuery<Customer>;
+            var uri = query.ToString();
+            Assert.Contains("Customer(-10)", uri);
+        }
+
+        /// <summary>
         /// Custom Data Service Entity
         /// </summary>
         [KeyAttribute("CustomerId")]

--- a/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1198,33 +1198,35 @@ namespace Microsoft.OData.E2E.Profile111.AsynchronousTests
         }
 
         /// <summary>
-        /// When DataServiceContext.MakeIdPredicateByKey=false, An expression with an Id as a predicate should create an Uri with a $filter in query options
+        /// When DataServiceContext.IdPredicateGeneratesFilterQueryOption=true, An expression with an Id as a predicate should create an Uri with a $filter in query options
         /// </summary>
         [Fact]
-        public void Linq_Where_Generates_Filter_By_Id_When_MakeIdPredicateByKey_Is_False()
+        public void Linq_Where_Generates_Filter_When_IdPredicateGeneratesFilterQueryOption_Is_True()
         {
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            context.MakeIdPredicateByKey = false;
+            context.IdPredicateGeneratesFilterQueryOption = true;
             var query = (from c in context.Customer
                          where c.CustomerId == -10
                          select new Customer { Name = c.Name, CustomerId = c.CustomerId }) as DataServiceQuery<Customer>;
             var uri = query.ToString();
             Assert.Contains("$filter=CustomerId eq -10", uri);
+            Assert.Equal("$filter=CustomerId eq -10", uri);
         }
 
         /// <summary>
-        /// When DataServiceContext.MakeIdPredicateByKey=true, An expression with an Id as a predicate should create a ByKey Uri
+        /// When DataServiceContext.IdPredicateGeneratesFilterQueryOption=false, An expression with an Id as a predicate should create a ByKey Uri
         /// </summary>
         [Fact]
-        public void Linq_Where_Generates_Filter_By_Id_When_MakeIdPredicateByKey_Is_True()
+        public void Linq_Where_Generates_ByKey_When_IdPredicateGeneratesFilterQueryOption_Is_False()
         {
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            context.MakeIdPredicateByKey = true;
+            context.IdPredicateGeneratesFilterQueryOption = false;
             var query = (from c in context.Customer
                          where c.CustomerId == -10
                          select new Customer { Name = c.Name, CustomerId = c.CustomerId }) as DataServiceQuery<Customer>;
             var uri = query.ToString();
             Assert.Contains("Customer(-10)", uri);
+            Assert.Equal("Customer(-10)", uri);
         }
 
         /// <summary>

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1304,6 +1304,33 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
         }
 
         /// <summary>
+        /// When DataServiceContext.KeyComparisonGeneratesFilterQuery=true, An expression that compares only the key property, will generate a $filter query option.
+        /// </summary>
+        [Fact]
+        public void Linq_Where_Generates_Filter_When_KeyComparisonGeneratesFilterQuery_Is_True()
+        {
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            context.KeyComparisonGeneratesFilterQuery = true;
+            var query = context.Customer.Where(c => c.CustomerId == -10);
+            var uri = query.ToString();
+            Assert.EndsWith("$filter=CustomerId eq -10", uri);
+        }
+
+        /// <summary>
+        /// When DataServiceContext.KeyComparisonGeneratesFilterQuery=false, An expression that compares only the key property, should create a ByKey Uri.
+        /// </summary>
+        [Fact]
+        public void Linq_Where_Generates_ByKey_When_KeyComparisonGeneratesFilterQuery_Is_False()
+        {
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            // By default context.KeyComparisonGeneratesFilterQuery = false;
+            // So we don't need to set it
+            var query = context.Customer.Where(c => c.CustomerId == -10);
+            var uri = query.ToString();
+            Assert.EndsWith("Customer(-10)", uri);
+        }
+
+        /// <summary>
         /// Custom Data Service Entity
         /// </summary>
         [KeyAttribute("CustomerId")]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #851 .*

### Description
The `Where` clause generates a Uri with a $filter where we have a non-key predicate e.g
`var books = dsc.Books.Where(b => b.Title == "B1");` creates the Uri below
`https://serviceRoot/Books?$filter=Title eq 'B1'`
In this case, if the `Title` is not found, the query will return an empty collection.

When we have a key in the predicate, the `Where` clause generates a Uri with a ByKey resource path e.g 
`var books = dsc.Books.Where(b => b.Id == 1);` creates the Uri below
`https://serviceRoot/Books(1)`
In this case, if the `Id` is not found, the query will throw an exception.

By design `Where` should not throw an exception whenever the predicate does not match any value/element in the source collection.

### Solution
Changing the current behavior will be a breaking change. So I have added a `DataServiceContext.KeyComparisonGeneratesFilterQuery` property which is `false` by default.
So if a customer want to ensure that a Uri with a $filter query option is generated for key predicates in the `Where` clause, they need to set the `KeyComparisonGeneratesFilterQuery` property as `true`

```csharp
Container context = new Container(uri);
context.KeyComparisonGeneratesFilterQuery= true;
```



### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
