### PR TITLE
Fix #1640 - Set IEEE754Compatible parameter from the batch request

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchBodyContentReaderStream.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchBodyContentReaderStream.cs
@@ -253,7 +253,7 @@ namespace Microsoft.OData.JsonLight
             // Reader is on the value node after the "body" property name node.
             IJsonWriter jsonWriter = new JsonWriter(
                 new StreamWriter(this),
-                true /*isIeee754Compatible*/);
+                reader.IsIeee754Compatible);
 
             WriteCurrentJsonObject(reader, jsonWriter);
             this.Flush();


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1640 .*

### Description

*Set IEEE754Compatible parameter from the batch request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*ODataJsonLightBatchBodyContentReaderStream assumes that batch part body is IEEE754Compatible. This pull request ensures IEEE754Compatible parameter is set from the batch request sent from the client*
