### PR TITLE
Fix #1756 - Reading OData Error Response in OData Client

### DIFF
--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -262,7 +262,19 @@ namespace Microsoft.OData.Client
                     headers.Add(ODataConstants.ContentTypeHeader, JsonContentTypeHeader);
                     httpWebResponseMessage = new HttpWebResponseMessage(headers, (int)statusCode, getResponseStream);
                     ODataMessageReader messageReader = new ODataMessageReader(httpWebResponseMessage);
-                    errorException = new ODataErrorException(messageReader.ReadError());
+
+                    // If the error message response does not conform to the OData specifications
+                    // then pass the response back as a string without deserializing.
+                    // This is to take care of those clients whose response did not conform to OData spec
+                    // before this was implemented.
+                    try
+                    {
+                        errorException = new ODataErrorException(messageReader.ReadError());
+                    }
+                    catch (ODataException)
+                    {
+                        return new DataServiceClientException(message, (int)statusCode);
+                    }            
                 }
 
                 dataServiceClientException = new DataServiceClientException(message, errorException, (int)statusCode);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1756.*

### Description

*Fix error while reading error response that do not conform to OData spec.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*Recently we enable `OData Client` to deserialize OData `Error response` on behalf of the users into `ODataError `object. Before this change some users were sending back error response which can not be deserialized into `ODataError `object. To take care of this case, this fix ensures that this change do not break their code and instead send back the string response as is as it was the case initially*
