### PR TITLE
Fix how composite async methods invoke lower level methods.

### DIFF
--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -242,14 +242,14 @@ namespace Microsoft.OData
         /// Asynchronously creates an <see cref="ODataWriter" /> to write a resource set.
         /// </summary>
         /// <param name="entitySet">The entity set we are going to write entities for.</param>
-        /// <param name="entityType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
+        /// <param name="structuredType">The structured type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
         /// <returns>A running task for the created writer.</returns>
-        public Task<ODataWriter> CreateODataResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmEntityType entityType)
+        public Task<ODataWriter> CreateODataResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmStructuredType structuredType)
         {
             this.VerifyCanCreateODataResourceSetWriter();
             return this.WriteToOutputAsync(
                 ODataPayloadKind.ResourceSet,
-                (context) => context.CreateODataResourceSetWriterAsync(entitySet, entityType));
+                (context) => context.CreateODataResourceSetWriterAsync(entitySet, structuredType));
         }
 
         /// <summary> Creates an <see cref="T:Microsoft.OData.ODataWriter" /> to write a delta resource set. </summary>
@@ -306,14 +306,14 @@ namespace Microsoft.OData
         /// Asynchronously creates an <see cref="ODataWriter" /> to write a delta resource set.
         /// </summary>
         /// <param name="entitySet">The entity set we are going to write entities for.</param>
-        /// <param name="entityType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
+        /// <param name="structuredType">The structured type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
         /// <returns>A running task for the created writer.</returns>
-        public Task<ODataWriter> CreateODataDeltaResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmEntityType entityType)
+        public Task<ODataWriter> CreateODataDeltaResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmStructuredType structuredType)
         {
             this.VerifyCanCreateODataResourceSetWriter();
             return this.WriteToOutputAsync(
                 ODataPayloadKind.ResourceSet,
-                (context) => context.CreateODataDeltaResourceSetWriterAsync(entitySet, entityType));
+                (context) => context.CreateODataDeltaResourceSetWriterAsync(entitySet, structuredType));
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -546,10 +546,7 @@ namespace Microsoft.OData
         public override Task WriteDeltaLinkAsync(ODataDeltaLink deltaLink)
         {
             this.VerifyCanWriteLink(false, deltaLink);
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-            {
-                this.WriteDeltaLinkImplementation(deltaLink);
-            });
+            return this.WriteDeltaLinkAsyncImplementation(deltaLink);
         }
 
         /// <summary>
@@ -571,10 +568,7 @@ namespace Microsoft.OData
         public override Task WriteDeltaDeletedLinkAsync(ODataDeltaDeletedLink deltaLink)
         {
             this.VerifyCanWriteLink(false, deltaLink);
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-            {
-                this.WriteDeltaLinkImplementation(deltaLink);
-            });
+            return this.WriteDeltaLinkAsyncImplementation(deltaLink);
         }
 
         /// <summary>
@@ -596,7 +590,7 @@ namespace Microsoft.OData
         public sealed override Task WritePrimitiveAsync(ODataPrimitiveValue primitiveValue)
         {
             this.VerifyCanWritePrimitive(false, primitiveValue);
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WritePrimitiveValueImplementation(primitiveValue));
+            return this.WritePrimitiveValueAsyncImplementation(primitiveValue);
         }
 
         /// <summary>Writes a primitive property within a resource.</summary>
@@ -1512,6 +1506,19 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Start writing a delta link or delta deleted link - implementation of the actual functionality.
+        /// </summary>
+        /// <param name="deltaLink">Delta (deleted) link to write.</param>
+        private async Task WriteDeltaLinkAsyncImplementation(ODataDeltaLinkBase deltaLink)
+        {
+            await TaskUtils.GetTaskForSynchronousOperation(() =>
+            {
+                this.EnterScope(deltaLink is ODataDeltaLink ? WriterState.DeltaLink : WriterState.DeltaDeletedLink, deltaLink);
+                this.StartDeltaLink(deltaLink);
+            }).FollowOnSuccessWith((t)=>this.WriteEndAsync());
+        }
+        
+        /// <summary>
         /// Verifies that calling WriteStart nested resource info is valid.
         /// </summary>
         /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
@@ -1574,6 +1581,29 @@ namespace Microsoft.OData
             });
         }
 
+        /// <summary>
+        /// Write primitive value asynchronously - implementation of the actual functionality.
+        /// </summary>
+        /// <param name="primitiveValue">Primitive value to write.</param>
+        private async Task WritePrimitiveValueAsyncImplementation(ODataPrimitiveValue primitiveValue)
+        {
+            await this.InterceptExceptionAsync(async () =>
+               {
+                   await TaskUtils.GetTaskForSynchronousOperation(() =>
+                   {
+                       this.EnterScope(WriterState.Primitive, primitiveValue);
+                       if (!(this.CurrentResourceSetValidator == null) && primitiveValue != null)
+                       {
+                           Debug.Assert(primitiveValue.Value != null, "PrimitiveValue.Value should never be null!");
+                           IEdmType itemType = EdmLibraryExtensions.GetPrimitiveTypeReference(primitiveValue.Value.GetType()).Definition;
+                           this.CurrentResourceSetValidator.ValidateResource(itemType);
+                       }
+                       this.WritePrimitiveValue(primitiveValue);
+                   }
+                   ).FollowOnSuccessWith((t) => this.WriteEndAsync());
+               });
+        }
+        
         /// <summary>
         /// Verifies that calling CreateWriteStream is valid.
         /// </summary>
@@ -2073,6 +2103,29 @@ namespace Microsoft.OData
             }
         }
 
+
+        /// <summary>
+        /// Catch any exception thrown by the action passed in; in the exception case move the writer into
+        /// state ExceptionThrown and then rethrow the exception.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        private async Task InterceptExceptionAsync(Func<Task> action)
+        {
+            try
+            {
+                await action();
+            }
+            catch
+            {
+                if (!IsErrorState(this.State))
+                {
+                    this.EnterScope(WriterState.Error, this.CurrentScope.Item);
+                }
+
+                throw;
+            }
+        }
+        
         /// <summary>
         /// Increments the nested resource count by one and fails if the new value exceeds the maximum nested resource depth limit.
         /// </summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1604.*

### Description

*Some of the async fluent APIs incorrectly call lower level APIs.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

