### PR TITLE
Fix how composite async methods invoke lower level methods.

### DIFF
--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -242,14 +242,14 @@ namespace Microsoft.OData
         /// Asynchronously creates an <see cref="ODataWriter" /> to write a resource set.
         /// </summary>
         /// <param name="entitySet">The entity set we are going to write entities for.</param>
-        /// <param name="entityType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
+        /// <param name="structuredType">The structured type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
         /// <returns>A running task for the created writer.</returns>
-        public Task<ODataWriter> CreateODataResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmEntityType entityType)
+        public Task<ODataWriter> CreateODataResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmStructuredType structuredType)
         {
             this.VerifyCanCreateODataResourceSetWriter();
             return this.WriteToOutputAsync(
                 ODataPayloadKind.ResourceSet,
-                (context) => context.CreateODataResourceSetWriterAsync(entitySet, entityType));
+                (context) => context.CreateODataResourceSetWriterAsync(entitySet, structuredType));
         }
 
         /// <summary> Creates an <see cref="T:Microsoft.OData.ODataWriter" /> to write a delta resource set. </summary>
@@ -306,14 +306,14 @@ namespace Microsoft.OData
         /// Asynchronously creates an <see cref="ODataWriter" /> to write a delta resource set.
         /// </summary>
         /// <param name="entitySet">The entity set we are going to write entities for.</param>
-        /// <param name="entityType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
+        /// <param name="structuredType">The structured type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
         /// <returns>A running task for the created writer.</returns>
-        public Task<ODataWriter> CreateODataDeltaResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmEntityType entityType)
+        public Task<ODataWriter> CreateODataDeltaResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmStructuredType structuredType)
         {
             this.VerifyCanCreateODataResourceSetWriter();
             return this.WriteToOutputAsync(
                 ODataPayloadKind.ResourceSet,
-                (context) => context.CreateODataDeltaResourceSetWriterAsync(entitySet, entityType));
+                (context) => context.CreateODataDeltaResourceSetWriterAsync(entitySet, structuredType));
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -306,14 +306,14 @@ namespace Microsoft.OData
         /// Asynchronously creates an <see cref="ODataWriter" /> to write a delta resource set.
         /// </summary>
         /// <param name="entitySet">The entity set we are going to write entities for.</param>
-        /// <param name="structuredType">The structured type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
+        /// <param name="entityType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
         /// <returns>A running task for the created writer.</returns>
-        public Task<ODataWriter> CreateODataDeltaResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmStructuredType structuredType)
+        public Task<ODataWriter> CreateODataDeltaResourceSetWriterAsync(IEdmEntitySetBase entitySet, IEdmEntityType entityType)
         {
             this.VerifyCanCreateODataResourceSetWriter();
             return this.WriteToOutputAsync(
                 ODataPayloadKind.ResourceSet,
-                (context) => context.CreateODataDeltaResourceSetWriterAsync(entitySet, structuredType));
+                (context) => context.CreateODataDeltaResourceSetWriterAsync(entitySet, entityType));
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataWriter.cs
+++ b/src/Microsoft.OData.Core/ODataWriter.cs
@@ -324,7 +324,7 @@ namespace Microsoft.OData
         /// <summary> Asynchronously write a primitive property within a resource. </summary>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
         /// <param name="primitiveProperty">The primitive property to write.</param>
-        public virtual Task WriteStartAsync(ODataProperty primitiveProperty)
+        public virtual Task WriteStartAsync(ODataPropertyInfo primitiveProperty)
         {
             return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteStart(primitiveProperty));
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightInheritComplexCollectionWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightInheritComplexCollectionWriterTests.cs
@@ -11,6 +11,9 @@ using System.Text;
 using Microsoft.OData.JsonLight;
 using Microsoft.OData.Edm;
 using Xunit;
+using System.Globalization;
+using System.ComponentModel;
+using System.Linq;
 
 namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
 {
@@ -202,7 +205,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
         private static void WriteAndValidate(ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse = true, IEdmTypeReference itemTypeReference = null)
         {
             WriteAndValidateSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
-            //WriteAndValidateAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
+            WriteAndValidateAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
+            WriteAndValidatePrimitivesSync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
+            WriteAndValidatePrimitivesAsync(itemTypeReference, collectionStart, items, expectedPayload, writingResponse);
         }
 
         private static void WriteAndValidateSync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)
@@ -221,23 +226,83 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             ValidateWrittenPayload(stream, expectedPayload);
         }
 
-        //private static void WriteAndValidateAsync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)
-        //{
-        //    MemoryStream stream = new MemoryStream();
-        //    var outputContext = CreateJsonLightOutputContext(stream, writingResponse, synchronous: false);
-        //    var createODataWriterTask = outputContext.CreateODataResourceSetWriterAsync(null, itemTypeReference == null ? null : itemTypeReference.ToStructuredType());
-        //    createODataWriterTask.Wait();
-        //    var odataWriter = createODataWriterTask.Result;
-        //    odataWriter.WriteStartAsync(collectionStart).Wait();
-        //    foreach (ODataResource item in items)
-        //    {
-        //        odataWriter.WriteStartAsync(item).Wait();
-        //        odataWriter.WriteEndAsync().Wait();
-        //    }
+        private static void WriteAndValidateAsync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)
+        {
+            MemoryStream stream = new MemoryStream();
+            var outputContext = CreateJsonLightOutputContext(stream, writingResponse, synchronous: false);
+            var createODataWriterTask = outputContext.CreateODataResourceSetWriterAsync(null, itemTypeReference == null ? null : itemTypeReference.ToStructuredType());
+            createODataWriterTask.Wait();
+            var odataWriter = createODataWriterTask.Result;
+            odataWriter.WriteStartAsync(collectionStart).Wait();
+            foreach (ODataResource item in items)
+            {
+                odataWriter.WriteStartAsync(item).Wait();
+                odataWriter.WriteEndAsync().Wait();
+            }
 
-        //    odataWriter.WriteEndAsync().Wait();
-        //    ValidateWrittenPayload(stream, expectedPayload);
-        //}
+            odataWriter.WriteEndAsync().Wait();
+            ValidateWrittenPayload(stream, expectedPayload);
+        }
+
+        private static void WriteAndValidatePrimitivesSync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)
+        {
+            MemoryStream stream = new MemoryStream();
+            var outputContext = CreateJsonLightOutputContext(stream, writingResponse, synchronous: true);
+            var odataWriter = outputContext.CreateODataResourceSetWriter(null, itemTypeReference == null ? null : itemTypeReference.ToStructuredType());
+            odataWriter.WriteStart(collectionStart);
+            foreach (ODataResource item in items)
+            {
+                odataWriter.WriteStart(new ODataResource
+                {
+                    Id = item.Id,
+                    SerializationInfo = item.SerializationInfo,
+                    InstanceAnnotations = item.InstanceAnnotations,
+                    TypeAnnotation = item.TypeAnnotation,
+                    TypeName = item.TypeName
+                });
+
+                foreach(var property in item.Properties)
+                {
+                    odataWriter.WriteStart(property);
+                    odataWriter.WriteEnd();
+                }
+
+                odataWriter.WriteEnd(); // resource
+            }
+
+            odataWriter.WriteEnd(); // collection
+            ValidateWrittenPayload(stream, expectedPayload);
+        }
+
+        private static async void WriteAndValidatePrimitivesAsync(IEdmTypeReference itemTypeReference, ODataResourceSet collectionStart, IEnumerable<ODataResource> items, string expectedPayload, bool writingResponse)
+        {
+            MemoryStream stream = new MemoryStream();
+            var outputContext = CreateJsonLightOutputContext(stream, writingResponse, synchronous: false);
+            var odataWriter = await outputContext.CreateODataResourceSetWriterAsync(null, itemTypeReference == null ? null : itemTypeReference.ToStructuredType());
+            await odataWriter.WriteStartAsync(collectionStart);
+            foreach (ODataResource item in items)
+            {
+                await odataWriter.WriteStartAsync(new ODataResource
+                {
+                    Id = item.Id,
+                    SerializationInfo = item.SerializationInfo,
+                    InstanceAnnotations = item.InstanceAnnotations,
+                    TypeAnnotation = item.TypeAnnotation,
+                    TypeName = item.TypeName
+                });
+
+                foreach (var property in item.Properties)
+                {
+                    await odataWriter.WriteStartAsync(property);
+                    await odataWriter.WriteEndAsync();
+                }
+
+                await odataWriter.WriteEndAsync(); // resource
+            }
+
+            await odataWriter.WriteEndAsync(); // collection
+            ValidateWrittenPayload(stream, expectedPayload);
+        }
 
         private static void ValidateWrittenPayload(MemoryStream stream, string expectedPayload)
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightInheritComplexCollectionWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightInheritComplexCollectionWriterTests.cs
@@ -11,9 +11,6 @@ using System.Text;
 using Microsoft.OData.JsonLight;
 using Microsoft.OData.Edm;
 using Xunit;
-using System.Globalization;
-using System.ComponentModel;
-using System.Linq;
 
 namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
 {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1604.*
*This pull request fixes issue #1776.*

### Description

*Some of the async fluent APIs incorrectly call lower level APIs.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*