### PR TITLE
Fix decoding single quote within double-quoted string in action/function parameter alias

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -64,6 +64,9 @@ namespace Microsoft.OData.UriParser
         /// <summary>Token being processed.</summary>
         protected ExpressionToken token;
 
+        /// <summary>Indicates whether a double-quoted string is being parsed.</summary>
+        protected bool parsingDoubleQuotedString;
+
         /// <summary>
         /// For an identifier, EMD supports chars that match the regex  [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]
         /// IsLetterOrDigit covers Ll, Lu, Lt, Lo, Lm, Nd, this set covers the rest
@@ -1231,7 +1234,12 @@ namespace Microsoft.OData.UriParser
 
             while (currentBracketDepth > 0)
             {
-                if (this.ch == '\'')
+                if (this.ch == '"')
+                {
+                    this.DoubleQuotedStringCheckpoint();
+                }
+
+                if (this.ch == '\'' && !this.parsingDoubleQuotedString)
                 {
                     this.AdvanceToNextOccurenceOf('\'');
                 }
@@ -1282,6 +1290,14 @@ namespace Microsoft.OData.UriParser
             if (!this.IsValidDigit)
             {
                 throw ParseError(ODataErrorStrings.ExpressionLexer_DigitExpected(this.textPos, this.Text));
+            }
+        }
+
+        private void DoubleQuotedStringCheckpoint()
+        {
+            if (this.textPos != 0 && this.Text[this.textPos - 1] != '\\')
+            {
+                this.parsingDoubleQuotedString = !this.parsingDoubleQuotedString;
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -64,9 +64,6 @@ namespace Microsoft.OData.UriParser
         /// <summary>Token being processed.</summary>
         protected ExpressionToken token;
 
-        /// <summary>Indicates whether a double-quoted string is being parsed.</summary>
-        protected bool parsingDoubleQuotedString;
-
         /// <summary>
         /// For an identifier, EMD supports chars that match the regex  [\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]
         /// IsLetterOrDigit covers Ll, Lu, Lt, Lo, Lm, Nd, this set covers the rest
@@ -88,6 +85,9 @@ namespace Microsoft.OData.UriParser
 
         /// <summary>Lexer ignores whitespace</summary>
         private bool ignoreWhitespace;
+
+        /// <summary>Indicates whether a double-quoted string is being parsed.</summary>
+        private bool parsingDoubleQuotedString;
 
         #endregion Protected and Private fields
 
@@ -116,6 +116,7 @@ namespace Microsoft.OData.UriParser
             this.TextLen = this.Text.Length;
             this.useSemicolonDelimiter = useSemicolonDelimiter;
             this.parsingFunctionParameters = parsingFunctionParameters;
+            this.parsingDoubleQuotedString = false;
 
             this.SetTextPos(0);
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
@@ -206,54 +206,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             parseUri.Throws<ODataException>(ODataErrorStrings.MetadataBinder_CannotConvertToType("Edm.Int32", "Edm.Int16"));
         }
 
-        [Fact]
-        public void ParsePath_AliasInUnboundFunction_SingleQuoteWithinDoubleQuotedString()
-        {
-            const string uri = "http://gobbledygook/GetRating(film=@p)?@p={\"@odata.type\":\"%23Fully.Qualified.Namespace.Film\",\"ID\":1,\"Title\":\"The Ogre's Lair\"}";
-
-            ParseUriAndVerify(
-                new Uri(uri),
-                (oDataPath, filterClause, orderByClause, selectExpandClause, aliasNodes) =>
-                {
-                    oDataPath.LastSegment.ShouldBeOperationImportSegment(HardCodedTestModel.GetFunctionImportForGetRating());
-
-                    var constNode = Assert.IsType<ConstantNode>(aliasNodes["@p"]);
-                    Assert.Equal("{\"@odata.type\":\"#Fully.Qualified.Namespace.Film\",\"ID\":1,\"Title\":\"The Ogre's Lair\"}", constNode.Value);
-                });
-        }
-
-        [Fact]
-        public void ParsePath_AliasInUnboundFunction_EscapedDoubleQuotesWithinDoubleQuotedString()
-        {
-            const string uri = "http://gobbledygook/GetRating(film=@p)?@p={\"@odata.type\":\"%23Fully.Qualified.Namespace.Film\",\"ID\":2,\"Title\":\"The \\\"Benevolent\\\" Dictator\"}";
-
-            ParseUriAndVerify(
-                new Uri(uri),
-                (oDataPath, filterClause, orderByClause, selectExpandClause, aliasNodes) =>
-                {
-                    oDataPath.LastSegment.ShouldBeOperationImportSegment(HardCodedTestModel.GetFunctionImportForGetRating());
-
-                    var constNode = Assert.IsType<ConstantNode>(aliasNodes["@p"]);
-                    Assert.Equal("{\"@odata.type\":\"#Fully.Qualified.Namespace.Film\",\"ID\":2,\"Title\":\"The \\\"Benevolent\\\" Dictator\"}", constNode.Value);
-                });
-        }
-
-        [Fact]
-        public void ParsePath_AliasInUnboundFunction_SingleAndEscapedDoubleQuotesWithinDoubleQuotedString()
-        {
-            const string uri = "http://gobbledygook/GetRating(film=@p)?@p={\"@odata.type\":\"%23Fully.Qualified.Namespace.Film\",\"ID\":3,\"Title\":\"The \\\"Gardener's\\\" Story\"}";
-
-            ParseUriAndVerify(
-                new Uri(uri),
-                (oDataPath, filterClause, orderByClause, selectExpandClause, aliasNodes) =>
-                {
-                    oDataPath.LastSegment.ShouldBeOperationImportSegment(HardCodedTestModel.GetFunctionImportForGetRating());
-
-                    var constNode = Assert.IsType<ConstantNode>(aliasNodes["@p"]);
-                    Assert.Equal("{\"@odata.type\":\"#Fully.Qualified.Namespace.Film\",\"ID\":3,\"Title\":\"The \\\"Gardener's\\\" Story\"}", constNode.Value);
-                });
-        }
-
         [Theory]
         [InlineData("{\"@odata.type\":\"%23Fully.Qualified.Namespace.Film\",\"ID\":1,\"Title\":\"The Ogre's Lair\"}")]
         [InlineData("{\"@odata.type\":\"%23Fully.Qualified.Namespace.Film\",\"ID\":2,\"Title\":\"The \\\"Benevolent\\\" Dictator\"}")]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -102,6 +102,7 @@ namespace Microsoft.OData.Tests.UriParser
             var FullyQualifiedNamespaceHomeAddress = new EdmComplexType("Fully.Qualified.Namespace", "HomeAddress", FullyQualifiedNamespaceAddress);
 
             var FullyQualifiedNamespaceHeartbeat = new EdmComplexType("Fully.Qualified.Namespace", "Heartbeat");
+            var FullyQualifiedNamespaceFilm = new EdmEntityType("Fully.Qualified.Namespace", "Film", null, false, false);
 
             var FullyQualifiedNamespacePersonTypeReference = new EdmEntityTypeReference(FullyQualifiedNamespacePerson, true);
             var FullyQualifiedNamespaceEmployeeTypeReference = new EdmEntityTypeReference(FullyQualifiedNamespaceEmployee, true);
@@ -118,6 +119,7 @@ namespace Microsoft.OData.Tests.UriParser
             var FullyQualifiedNamespacePaintingTypeReference = new EdmEntityTypeReference(FullyQualifiedNamespacePainting, true);
             var FullyQualifiedNamespaceFramedPaintingTypeReference = new EdmEntityTypeReference(FullyQualifiedNamespaceFramedPainting, true);
             var FullyQualifiedNamespaceUserAccountTypeReference = new EdmEntityTypeReference(FullyQualifiedNamespaceUserAccount, true);
+            var FullyQualifiedNamespaceFilmTypeReference = new EdmEntityTypeReference(FullyQualifiedNamespaceFilm, true);
 
             var FullyQualifiedNamespaceLion_ID1 = FullyQualifiedNamespaceLion.AddStructuralProperty("ID1", EdmCoreModel.Instance.GetInt32(false));
             var FullyQualifiedNamespaceLion_ID2 = FullyQualifiedNamespaceLion.AddStructuralProperty("ID2", EdmCoreModel.Instance.GetInt32(false));
@@ -379,6 +381,10 @@ namespace Microsoft.OData.Tests.UriParser
             // entity type with enum as key
             var fullyQualifiedNamespaceShape = new EdmEntityType("Fully.Qualified.Namespace", "Shape", null, false, false);
             fullyQualifiedNamespaceShape.AddKeys(fullyQualifiedNamespaceShape.AddStructuralProperty("Color", colorTypeReference));
+
+            FullyQualifiedNamespaceFilm.AddKeys(FullyQualifiedNamespaceFilm.AddStructuralProperty("ID", EdmPrimitiveTypeKind.Int32, false));
+            FullyQualifiedNamespaceFilm.AddStructuralProperty("Title", EdmPrimitiveTypeKind.String);
+            model.AddElement(FullyQualifiedNamespaceFilm);
             #endregion
 
             #region Annotation Terms
@@ -694,6 +700,14 @@ namespace Microsoft.OData.Tests.UriParser
             FullyQualifiedNamespaceGetFullNameFunction.AddParameter("nickname", FullyQualifiedNamespaceNameTypeReference);
             model.AddElement(FullyQualifiedNamespaceGetFullNameFunction);
 
+            var FullyQualifiedNamespaceGetRatingFunction = new EdmFunction("Fully.Qualified.Namespace", "GetRating", EdmCoreModel.Instance.GetInt32(true), false, null, true);
+            FullyQualifiedNamespaceGetRatingFunction.AddParameter("film", FullyQualifiedNamespaceFilmTypeReference);
+            model.AddElement(FullyQualifiedNamespaceGetRatingFunction);
+
+            var FullyQualifiedNamespaceGetRatingsFunction = new EdmFunction("Fully.Qualified.Namespace", "GetRatings", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(true))), false, null, true);
+            FullyQualifiedNamespaceGetRatingsFunction.AddParameter("films", new EdmCollectionTypeReference(new EdmCollectionType(FullyQualifiedNamespaceFilmTypeReference)));
+            model.AddElement(FullyQualifiedNamespaceGetRatingsFunction);
+
             #endregion
 
             #region Context Container
@@ -774,6 +788,9 @@ namespace Microsoft.OData.Tests.UriParser
             FullyQualifiedNamespaceContext.AddFunctionImport("GetMostImporantPerson", FullyQualifiedNamespaceGetMostImporantPersonFunction2);
 
             FullyQualifiedNamespaceContext.AddActionImport("MoveEveryone", FullyQualifiedNamespaceMoveEveryoneAction);
+
+            FullyQualifiedNamespaceContext.AddFunctionImport("GetRating", FullyQualifiedNamespaceGetRatingFunction);
+            FullyQualifiedNamespaceContext.AddFunctionImport("GetRatings", FullyQualifiedNamespaceGetRatingsFunction);
 
             #endregion
 
@@ -913,6 +930,8 @@ namespace Microsoft.OData.Tests.UriParser
         <ActionImport Name=""ResetAllData"" Action=""Fully.Qualified.Namespace.ResetAllData"" />
         <FunctionImport Name=""GetMostImporantPerson"" Function=""Fully.Qualified.Namespace.GetMostImporantPerson"" />
         <ActionImport Name=""MoveEveryone"" Action=""Fully.Qualified.Namespace.MoveEveryone"" />
+        <FunctionImport Name=""GetRating"" Function=""Fully.Qualified.Namespace.GetRating"" />
+        <FunctionImport Name=""GetRatings"" Function=""Fully.Qualified.Namespace.GetRatings"" />
       </EntityContainer>
     </Schema>
   </edmx:DataServices>
@@ -1187,6 +1206,13 @@ namespace Microsoft.OData.Tests.UriParser
         <Property Name=""Name"" Type=""Edm.String"" />
         <Property Name=""PetCategorysColorPattern"" Type=""Fully.Qualified.Namespace.ColorPattern"" Nullable=""false"" />
       </EntityType>
+      <EntityType Name=""Film"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Title"" Type=""Edm.String"" />
+      </EntityType>
       <Function Name=""GetPersonByDate"" IsComposable=""true"">
         <Parameter Name=""date"" Type=""Edm.Date"" Nullable=""false"" />
         <ReturnType Type=""Fully.Qualified.Namespace.Person"" />
@@ -1218,6 +1244,14 @@ namespace Microsoft.OData.Tests.UriParser
       <Function Name=""GetPet6"" IsComposable=""true"">
         <Parameter Name=""id"" Type=""Fully.Qualified.Namespace.IdType"" Nullable=""false"" />
         <ReturnType Type=""Fully.Qualified.Namespace.Pet6"" />
+      </Function>
+      <Function Name=""GetRating"">
+        <Parameter Name=""film"" Type=""Fully.Qualified.Namespace.Film"" />
+        <ReturnType Type=""Edm.Int32"" Nullable=""false"" />
+      </Function>
+      <Function Name=""GetRatings"">
+        <Parameter Name=""films"" Type=""Collection(Fully.Qualified.Namespace.Film)"" />
+        <ReturnType Type=""Collection(Edm.Int32)"" Nullable=""false"" />
       </Function>
       <Term Name=""PrimitiveTerm"" Type=""Edm.String""/>
       <Term Name=""ComplexTerm"" Type=""Fully.Qualified.Namespace.Address""/>
@@ -2464,6 +2498,16 @@ namespace Microsoft.OData.Tests.UriParser
         public static IEdmTerm GetComplexAnnotationTerm()
         {
             return TestModel.FindTerm("Fully.Qualified.Namespace.ComplexTerm") as IEdmTerm;
+        }
+
+        public static IEdmOperationImport GetFunctionImportForGetRating()
+        {
+            return TestModel.EntityContainer.FindOperationImports("GetRating").Single();
+        }
+
+        public static IEdmOperationImport GetFunctionImportForGetRatings()
+        {
+            return TestModel.EntityContainer.FindOperationImports("GetRatings").Single();
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue reported on OData Web API project https://github.com/OData/WebApi/issues/2051.*

### Description

Fixes decoding of single quote within a double-quoted string in action/function parameter alias, e.g. `http://ServiceRoot/UnboundFunction(param=@p)?@p={"@odata.type":"%23NS.Film","Id":1,"Title":"The Ogre's Lair"}`

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
