### PR TITLE
different null validation messages for complex and primitive collections

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -422,7 +422,7 @@ namespace Microsoft.OData.JsonLight
 
                 // Complex property or collection of complex property.
                 bool isCollection = payloadTypeReference.IsCollection();
-                ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName);
+                ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName, payloadTypeReference);
                 if (isCollection)
                 {
                     readerNestedResourceInfo = this.ReadingResponse
@@ -473,7 +473,8 @@ namespace Microsoft.OData.JsonLight
         /// <param name="jsonReader">The IJsonReader.</param>
         /// <param name="isCollection">true if the property is entity set reference property; false for a resource reference property, null if unknown.</param>
         /// <param name="propertyName">Name for the navigation property, used in error message only.</param>
-        protected static void ValidateExpandedNestedResourceInfoPropertyValue(IJsonReader jsonReader, bool? isCollection, string propertyName)
+        /// <param name="typeReference">Type of navigation property</param>
+        protected static void ValidateExpandedNestedResourceInfoPropertyValue(IJsonReader jsonReader, bool? isCollection, string propertyName, IEdmTypeReference typeReference)
         {
             // an expanded link with resource requires a StartObject node here;
             // an expanded link with resource set requires a StartArray node here;
@@ -491,7 +492,16 @@ namespace Microsoft.OData.JsonLight
                 // Expanded resource (null or non-null)
                 if (isCollection == true)
                 {
-                    throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_CannotReadCollectionNestedResource(nodeType, propertyName));
+                    if (typeReference.IsNonEntityCollectionType())
+                    {
+                        ReaderValidationUtils.ValidateNullValue(typeReference, true,
+                                                  true, propertyName, false);
+                    }
+                    else
+                    {
+                        throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_CannotReadCollectionNestedResource(nodeType, propertyName));
+                    }
+                    
                 }
             }
             else

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
@@ -1232,7 +1232,7 @@ namespace Microsoft.OData.JsonLight
                     ODataJsonLightReaderNestedResourceInfo readerNestedResourceInfo = null;
 
                     // Complex property or collection of complex property.
-                    ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName);
+                    ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName, edmProperty.Type);
 
                     if (isCollection)
                     {
@@ -1251,7 +1251,7 @@ namespace Microsoft.OData.JsonLight
                     ODataJsonLightReaderNestedResourceInfo readerNestedResourceInfo = null;
 
                     // Expanded link
-                    ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName);
+                    ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName, edmProperty.Type);
                     if (isCollection)
                     {
                         readerNestedResourceInfo = this.ReadingResponse || isDeltaResourceSet
@@ -1548,7 +1548,7 @@ namespace Microsoft.OData.JsonLight
             if (payloadTypeOrItemType != null)
             {
                 // Complex property or collection of complex property.
-                ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName);
+                ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName, payloadTypeReference);
                 if (isCollection)
                 {
                     return ReadNonExpandedResourceSetNestedResourceInfo(resourceState, null, payloadTypeOrItemType, propertyName);
@@ -1668,7 +1668,7 @@ namespace Microsoft.OData.JsonLight
                 // If the property is expanded, ignore the content if we're asked to do so.
                 if (propertyWithValue)
                 {
-                    ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, null, propertyName);
+                    ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, null, propertyName, resourceState.ResourceType.ToTypeReference());
 
                     // Since we marked the nested resource info as deferred the reader will not try to read its content
                     // instead it will behave as if it was a real deferred link (without a property value).
@@ -1679,7 +1679,6 @@ namespace Microsoft.OData.JsonLight
 
                 return navigationLinkInfo;
             }
-
 
             if (resourceState.ResourceType.IsOpen)
             {

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -251,7 +251,9 @@ namespace Microsoft.OData
         internal const string ODataUtils_ModelDoesNotHaveContainer = "ODataUtils_ModelDoesNotHaveContainer";
         internal const string ReaderUtils_EnumerableModified = "ReaderUtils_EnumerableModified";
         internal const string ReaderValidationUtils_NullValueForNonNullableType = "ReaderValidationUtils_NullValueForNonNullableType";
+        internal const string ReaderValidationUtils_NullValueForNullableType = "ReaderValidationUtils_NullValueForNullableType";
         internal const string ReaderValidationUtils_NullNamedValueForNonNullableType = "ReaderValidationUtils_NullNamedValueForNonNullableType";
+        internal const string ReaderValidationUtils_NullNamedValueForNullableType = "ReaderValidationUtils_NullNamedValueForNullableType";
         internal const string ReaderValidationUtils_EntityReferenceLinkMissingUri = "ReaderValidationUtils_EntityReferenceLinkMissingUri";
         internal const string ReaderValidationUtils_ValueWithoutType = "ReaderValidationUtils_ValueWithoutType";
         internal const string ReaderValidationUtils_ResourceWithoutType = "ReaderValidationUtils_ResourceWithoutType";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -275,7 +275,9 @@ ODataUtils_ModelDoesNotHaveContainer=The provided model does not contain an enti
 ReaderUtils_EnumerableModified=The value returned by the '{0}' property cannot be modified until the end of the owning resource is reported by the reader.
 
 ReaderValidationUtils_NullValueForNonNullableType=A null value was found with the expected type '{0}[Nullable=False]'. The expected type '{0}[Nullable=False]' does not allow null values.
+ReaderValidationUtils_NullValueForNullableType=A null value was found for a collection of type '{0}[Nullable=True]. Collection-valued properties with Nullable=True can contain null values, but collection-valued properties cannot themselves be null.
 ReaderValidationUtils_NullNamedValueForNonNullableType=A null value was found for the property named '{0}', which has the expected type '{1}[Nullable=False]'. The expected type '{1}[Nullable=False]' does not allow null values.
+ReaderValidationUtils_NullNamedValueForNullableType=A null value was found for the property named '{0}', which has the expected type '{1}[Nullable=True]'. The expected type '{1}[Nullable=True]' cannot be null but it can have null values.
 ReaderValidationUtils_EntityReferenceLinkMissingUri=No URI value was found for an entity reference link. A single URI value was expected.
 ReaderValidationUtils_ValueWithoutType=A value without a type name was found and no expected type is available. When the model is specified, each value in the payload must have a type which can be either specified in the payload, explicitly by the caller or implicitly inferred from the parent value.
 ReaderValidationUtils_ResourceWithoutType=A resource without a type name was found, but no expected type was specified. To allow entries without type information, the expected type must also be specified when the model is specified.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -2148,11 +2148,25 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "A null value was found for a collection of type '{0}[Nullable=True]. Collection-valued properties with Nullable=True can contain null values, but collection-valued properties cannot themselves be null."
+        /// </summary>
+        internal static string ReaderValidationUtils_NullValueForNullableType(object p0) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ReaderValidationUtils_NullValueForNullableType, p0);
+        }
+
+        /// <summary>
         /// A string like "A null value was found for the property named '{0}', which has the expected type '{1}[Nullable=False]'. The expected type '{1}[Nullable=False]' does not allow null values."
         /// </summary>
         internal static string ReaderValidationUtils_NullNamedValueForNonNullableType(object p0, object p1)
         {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ReaderValidationUtils_NullNamedValueForNonNullableType, p0, p1);
+        }
+
+        /// <summary>
+        /// A string like "A null value was found for the property named '{0}', which has the expected type '{1}[Nullable=True]'. The expected type '{1}[Nullable=True]' cannot be null but it can have null values."
+        /// </summary>
+        internal static string ReaderValidationUtils_NullNamedValueForNullableType(object p0, object p1) {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ReaderValidationUtils_NullNamedValueForNullableType, p0, p1);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ReaderValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ReaderValidationUtils.cs
@@ -1115,7 +1115,11 @@ namespace Microsoft.OData
                 {
                     if (isDynamicProperty != true)
                     {
-                        ThrowNullValueForNonNullableTypeException(expectedValueTypeReference, propertyName);
+                        if (!expectedValueTypeReference.IsNullable)
+                        {
+                            ThrowNullValueForNonNullableTypeException(expectedValueTypeReference, propertyName);
+                        }
+                        ThrowNullValueForNullableTypeException(expectedValueTypeReference, propertyName);
                     }
                 }
                 else if (expectedValueTypeReference.IsODataComplexTypeKind())
@@ -1149,6 +1153,21 @@ namespace Microsoft.OData
             }
 
             throw new ODataException(Strings.ReaderValidationUtils_NullNamedValueForNonNullableType(propertyName, expectedValueTypeReference.FullName()));
+        }
+
+        /// <summary>
+        /// Create and throw exception that a null value was found when the expected type is non-nullable.
+        /// </summary>
+        /// <param name="expectedValueTypeReference">The expected type for this value.</param>
+        /// <param name="propertyName">The name of the property whose value is being read, if applicable.</param>
+        private static void ThrowNullValueForNullableTypeException(IEdmTypeReference expectedValueTypeReference, string propertyName)
+        {
+            if (string.IsNullOrEmpty(propertyName))
+            {
+                throw new ODataException(Strings.ReaderValidationUtils_NullValueForNullableType(expectedValueTypeReference.FullName()));
+            }
+
+            throw new ODataException(Strings.ReaderValidationUtils_NullNamedValueForNullableType(propertyName, expectedValueTypeReference.FullName()));
         }
 
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
@@ -1510,6 +1510,7 @@ namespace Microsoft.OData.Tests
 
             person.AddStructuralProperty("Address", new EdmComplexTypeReference(complex, false));
             person.AddStructuralProperty("Addresses", new EdmCollectionTypeReference(new EdmCollectionType(new EdmComplexTypeReference(complex, false))));
+            person.AddStructuralProperty("NewAddresses", new EdmCollectionTypeReference(new EdmCollectionType(new EdmComplexTypeReference(complex, true))));
 
             model.AddElement(person);
             model.AddElement(employee);
@@ -1652,5 +1653,53 @@ namespace Microsoft.OData.Tests
         }
 
         #endregion
+        [Fact]
+        public void NullValidationErrorMessageForCollectionsofComplexTypes()
+        {
+            string expectedErrorMessage = "A null value was found for the property named 'Addresses', which has the expected type 'Collection(DefaultNs.Address)[Nullable=False]'. The expected type 'Collection(DefaultNs.Address)[Nullable=False]' does not allow null values.";
+            string actualErrorMessage = "";
+            const string payload =
+                "{" +
+                    "\"@odata.context\":\"http://host/$metadata#People/$entity\"," +
+                    "\"UserName\":\"abc\"," +
+                    "\"Addresses\":null" +
+                "}";
+
+            try
+            {
+                ReadPayload(payload, Model, EntitySet, EntityType).OfType<ODataResource>().ToList();
+            }
+            catch (Exception e)
+            {
+                actualErrorMessage = e.Message;               
+            }
+            Assert.Equal(expectedErrorMessage, actualErrorMessage);
+        }
+
+        /// <summary>
+        /// A nullable collection cannot be null but it can have null values.
+        /// </summary>
+        [Fact]
+        public void NullValidationErrorMessageForANullableCollectionsofComplexTypes()
+        {
+            string expectedErrorMessage = "A null value was found for the property named 'NewAddresses', which has the expected type 'Collection(DefaultNs.Address)[Nullable=True]'. The expected type 'Collection(DefaultNs.Address)[Nullable=True]' cannot be null but it can have null values.";
+            string actualErrorMessage = "";
+            const string payload =
+                "{" +
+                    "\"@odata.context\":\"http://host/$metadata#People/$entity\"," +
+                    "\"UserName\":\"abc\"," +
+                    "\"NewAddresses\":null" +
+                "}";
+
+            try
+            {
+                ReadPayload(payload, Model, EntitySet, EntityType).OfType<ODataResource>().ToList();
+            }
+            catch (Exception e)
+            {
+                actualErrorMessage = e.Message;
+            }
+            Assert.Equal(expectedErrorMessage, actualErrorMessage);
+        }
     }
 }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/CollectionValueReaderJsonLightTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/CollectionValueReaderJsonLightTests.cs
@@ -67,13 +67,13 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                     PayloadElement = PayloadBuilder.Property("PrimitiveCollection",
                         PayloadBuilder.PrimitiveMultiValue("Collection(Edm.Int32)"))
                         .JsonRepresentation(
-                            "{" + 
+                            "{" +
                             "\"" + JsonLightConstants.ODataPropertyAnnotationSeparator + JsonLightConstants.ODataContextAnnotationName + "\":\"http://odata.org/test/$metadata#Collection(Edm.Int32)\"," +
                             "\"value\":null" +
                             "}")
                         .ExpectedProperty(owningType, "PrimitiveCollection"),
                     SkipTestConfiguration = tc => tc.IsRequest,
-                    ExpectedException = ODataExpectedExceptions.ODataException("ReaderValidationUtils_NullNamedValueForNonNullableType", "value", "Collection(Edm.Int32)")
+                    ExpectedException = ODataExpectedExceptions.ODataException("ReaderValidationUtils_NullNamedValueForNullableType", "value", "Collection(Edm.Int32)")
                 },
                 new PayloadReaderTestDescriptor(this.Settings)
                 {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/PropertyReaderJsonLightTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/PropertyReaderJsonLightTests.cs
@@ -247,17 +247,6 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                     },
                     new
                     {
-                        Description = "Invalid type information for top-level null - we don't allow null collections - should fail.",
-                        Json = "{ " +
-                            "\"" + JsonLightConstants.ODataPropertyAnnotationSeparator + JsonLightConstants.ODataContextAnnotationName + "\":\"http://odata.org/test/$metadata#Collection(Edm.Int32)\", " +
-                            "\"" + JsonLightConstants.ODataPropertyAnnotationSeparator + JsonLightConstants.ODataTypeAnnotationName + "\": \"Collection(Edm.Int32)\"," +
-                            "\"" + JsonLightConstants.ODataValuePropertyName + "\": null" +
-                        "}",
-                        ReaderMetadata = collectionReaderMetadata,
-                        ExpectedException = ODataExpectedExceptions.ODataException("ReaderValidationUtils_NullNamedValueForNonNullableType", "value", "Collection(Edm.Int32)")
-                    },
-                    new
-                    {
                         Description = "Type information for top-level spatial - should work.",
                         Json = "{ " +
                             "\"" + JsonLightConstants.ODataPropertyAnnotationSeparator + JsonLightConstants.ODataContextAnnotationName + "\":\"http://odata.org/test/$metadata#Edm.GeographyPoint\", " +


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1715.*

### Description

The error message returned by the null validation of a collection of primitive values and a collection of complex values is different. The expected result is for the error message for the null validation of both collections to be the same. 

A null collection of primitive values returns this error message: 
<pre>
A null value was found for the property named 'XXX', 
which has the expected type 'Collection(Edm.String)[Nullable=False]'.
The expected type 'Collection(Edm.String)[Nullable=False]' 
does not allow null values.
</pre>

while a null collections of complex values returns: 
<pre>
A node of type 'PrimitiveValue' was read from the JSON reader
when trying to read the contents of the property 'XXX';
however, a 'StartArray' node was expected
</pre>

The expected result is for the error message for both collections to be: 
<pre>
A null value was found for the property named 'XXX', 
which has the expected type 'Collection(XXX)[Nullable=False]'. 
The expected type 'Collection(XXX)[Nullable=False]' does not allow null values
</pre>

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
