### PR TITLE
update read write timeout value when timeout value is set

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -112,10 +112,11 @@ namespace Microsoft.OData.Client
         /// <summary>resolve typename from a type</summary>
         private Func<string, Type> resolveType;
 
-#if !PORTABLELIB // Timeout not available
         /// <summary>time-out value in seconds, 0 for default</summary>
         private int timeout;
-#endif
+
+        /// <summary>read or write time-out value in seconds, 0 for default</summary>
+        private int readWriteTimeout;
         /// <summary>whether to use post-tunneling for PUT/DELETE</summary>
         private bool postTunneling;
 
@@ -480,7 +481,6 @@ namespace Microsoft.OData.Client
             set { this.resolveType = value; }
         }
 
-#if !PORTABLELIB // Timeout not available
         /// <summary>Gets or sets the time-out option (in seconds) that is used for the underlying HTTP request to the data service.</summary>
         /// <returns>An integer that indicates the time interval (in seconds) before time-out of a service request.</returns>
         /// <remarks>
@@ -507,7 +507,33 @@ namespace Microsoft.OData.Client
                 this.timeout = value;
             }
         }
-#endif
+
+        /// <summary>Gets or sets the readwrite time-out option (in seconds) that is used for the underlying HTTP request to the data service.</summary>
+        /// <returns>An integer that indicates the time interval (in seconds) before readwritetime-out of a service request.</returns>
+        /// <remarks>
+        /// A value of 0 will use the default readwritetimeout of the underlying HTTP request.
+        /// This value must be set before executing any query or update operations against
+        /// the target data service for it to have effect on the on the request.
+        /// The value may be changed between requests to a data service and the new value
+        /// will be picked up by the next data service request.
+        /// </remarks>
+        public virtual int ReadWriteTimeout
+        {
+            get
+            {
+                return this.readWriteTimeout;
+            }
+
+            set
+            {
+                if (value < 0)
+                {
+                    throw Error.ArgumentOutOfRange("ReadWriteTimeout");
+                }
+
+                this.readWriteTimeout = value;
+            }
+        }
 
         /// <summary>Gets or sets a Boolean value that indicates whether to use post tunneling.</summary>
         /// <returns>A Boolean value that indicates whether to use post tunneling.</returns>

--- a/src/Microsoft.OData.Client/InternalODataRequestMessage.cs
+++ b/src/Microsoft.OData.Client/InternalODataRequestMessage.cs
@@ -105,11 +105,19 @@ namespace Microsoft.OData.Client
             set { throw new NotSupportedException(); }
         }
 
-#if !PORTABLELIB
         /// <summary>
         /// Gets or sets the timeout (in seconds) for this request.
         /// </summary>
         public override int Timeout
+        {
+            get { throw new NotSupportedException(); }
+            set { throw new NotSupportedException(); }
+        }
+
+        /// <summary>
+        /// Gets or sets the read and write timeout (in seconds) for this request.
+        /// </summary>
+        public override int ReadWriteTimeout
         {
             get { throw new NotSupportedException(); }
             set { throw new NotSupportedException(); }
@@ -131,7 +139,6 @@ namespace Microsoft.OData.Client
                 throw new NotImplementedException();
             }
         }
-#endif
 
         /// <summary>
         /// internal headers dictionary

--- a/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
+++ b/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
@@ -157,12 +157,16 @@ namespace Microsoft.OData.Client
                 requestMessage.Credentials = requestInfo.Credentials;
             }
 
-#if !PORTABLELIB // Timeout not available
             if (requestInfo.Timeout != 0)
             {
                 requestMessage.Timeout = requestInfo.Timeout;
+               
             }
-#endif
+
+            if (requestInfo.ReadWriteTimeout != 0)
+            {
+                requestMessage.ReadWriteTimeout = requestInfo.ReadWriteTimeout;
+            }
 
             return new TopLevelRequestMessageWrapper(requestMessage, requestInfo, requestMessageArgs.Descriptor);
         }

--- a/src/Microsoft.OData.Client/RequestInfo.cs
+++ b/src/Microsoft.OData.Client/RequestInfo.cs
@@ -148,7 +148,6 @@ namespace Microsoft.OData.Client
             get { return this.Context.Credentials; }
         }
 
-#if !PORTABLELIB
         /// <summary>
         /// Get the timeout span in seconds to use for the underlying HTTP request to the data service.
         /// </summary>
@@ -156,7 +155,14 @@ namespace Microsoft.OData.Client
         {
             get { return this.Context.Timeout; }
         }
-#endif
+
+        /// <summary>
+        /// Get the read or write timeout span in seconds to use for the underlying HTTP request to the data service.
+        /// </summary>
+        internal int ReadWriteTimeout
+        {
+            get { return this.Context.ReadWriteTimeout; }
+        }
 
         /// <summary>
         /// Whether to use post-tunneling for PUT/DELETE.

--- a/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
@@ -61,12 +61,15 @@ namespace Microsoft.OData.Client
         /// </summary>
         public abstract ICredentials Credentials { get; set; }
 
-#if !PORTABLELIB
         /// <summary>
         /// Gets or sets the timeout (in seconds) for this request.
         /// </summary>
         public abstract int Timeout { get; set; }
-#endif
+
+        /// <summary>
+        /// Gets or sets the read and write timeout (in seconds) for this request.
+        /// </summary>
+        public abstract int ReadWriteTimeout { get; set; }
 
         /// <summary>
         /// Gets or sets a value that indicates whether to send data in segments to the

--- a/src/Microsoft.OData.Client/Serialization/HttpWebRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpWebRequestMessage.cs
@@ -177,7 +177,6 @@ namespace Microsoft.OData.Client
             set { this.httpRequest.Credentials = value; }
         }
 
-#if !PORTABLELIB
         /// <summary>
         /// Gets or sets the timeout (in seconds) for this request.
         /// </summary>
@@ -185,6 +184,15 @@ namespace Microsoft.OData.Client
         {
             get { return this.httpRequest.Timeout; }
             set { this.httpRequest.Timeout = (int)Math.Min(Int32.MaxValue, new TimeSpan(0, 0, value).TotalMilliseconds); }
+        }
+
+        /// <summary>
+        /// Gets or sets the read and write timeout (in seconds) for this request.
+        /// </summary>
+        public override int ReadWriteTimeout
+        {
+            get { return this.httpRequest.ReadWriteTimeout; }
+            set { this.httpRequest.ReadWriteTimeout = (int)Math.Min(Int32.MaxValue, new TimeSpan(0, 0, value).TotalMilliseconds); }
         }
 
         /// <summary>
@@ -196,7 +204,7 @@ namespace Microsoft.OData.Client
             get { return this.httpRequest.SendChunked; }
             set { this.httpRequest.SendChunked = value; }
         }
-#endif
+
         #endregion
 
         /// <summary>

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/HttpClientRequestMessage.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/HttpClientRequestMessage.cs
@@ -137,6 +137,18 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
             }
         }
 
+        public override int ReadWriteTimeout
+        {
+            get
+            {
+                return (int)this.client.Timeout.TotalSeconds;
+            }
+            set
+            {
+                this.client.Timeout = new TimeSpan(0, 0, value);
+            }
+        }
+
         /// <summary>
         /// Gets or sets a value that indicates whether to send data in segments to the Internet resource. 
         /// </summary>

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/HttpClientRequestMessage.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/HttpClientRequestMessage.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
         /// <summary>
         /// Gets or sets the timeout (in seconds) for this request.
         /// </summary>
-#if !PORTABLELIB && !(NETCOREAPP1_0 || NETCOREAPP2_0)
+#if !(NETCOREAPP1_0 || NETCOREAPP2_0)
         public override int Timeout 
         { 
             get

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientExtensions/TestDataServiceClientRequestMessage.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientExtensions/TestDataServiceClientRequestMessage.cs
@@ -85,6 +85,18 @@ namespace AstoriaUnitTests.ClientExtensions
                 throw new NotImplementedException();
             }
         }
+
+        public override int ReadWriteTimeout
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
 #endif
 
         public override string GetHeader(string headerName)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1753.*

### Description
Currently, It is not possible to set the ReadWriteTimeout property of a request in <code> Microsoft.OData.Client </code> but you can set the Timeout property. This means that each request uses the default <code>HttpWebRequest ReadWriteTimeout </code> property which is 300seconds or 5 minutes. 

If an endpoint takes more than 5 minutes to return a response to <code> Microsoft.OData.Client </code> that response will not be received and processed by <code> Microsoft.OData.Client</code>. This is because the ReadWriteTimeout property times out after 5 mins hence the ReadWrite connection times out. 


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
