### PR TITLE
Fix parsing of floats in $apply/aggregate/average expression

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -182,6 +182,8 @@ namespace Microsoft.OData.UriParser.Aggregation
                             return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Double, expressionType.IsNullable);
                         case EdmPrimitiveTypeKind.Decimal:
                             return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Decimal, expressionType.IsNullable);
+                        case EdmPrimitiveTypeKind.Single:
+                            return EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Single, expressionType.IsNullable);
                         case EdmPrimitiveTypeKind.None:
                             return expressionType;
                         default:

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/FakeBindMethods.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/FakeBindMethods.cs
@@ -40,7 +40,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public static readonly SingleValueNode FakeSingleIntPrimitive =
             new ConstantNode(100);
 
-        public static readonly SingleValueNode FakeSingleSinglePrimitive =
+        public static readonly SingleValueNode FakeSingleFloatPrimitive =
             new ConstantNode(100.50f);
 
         public static readonly SingleValueNode FakeSingleOpenProperty =
@@ -93,9 +93,9 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             return FakeSingleIntPrimitive;
         }
 
-        public static SingleValueNode BindMethodReturningASingleSinglePrimitive(QueryToken token)
+        public static SingleValueNode BindMethodReturningASingleFloatPrimitive(QueryToken token)
         {
-            return FakeSingleSinglePrimitive;
+            return FakeSingleFloatPrimitive;
         }
 
         public static SingleValueNode BindMethodReturningASingleOpenProperty(QueryToken token)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/FakeBindMethods.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/FakeBindMethods.cs
@@ -40,6 +40,9 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public static readonly SingleValueNode FakeSingleIntPrimitive =
             new ConstantNode(100);
 
+        public static readonly SingleValueNode FakeSingleSinglePrimitive =
+            new ConstantNode(100.50f);
+
         public static readonly SingleValueNode FakeSingleOpenProperty =
             new SingleValueOpenPropertyAccessNode(new ConstantNode(null), "A_OPENPROPERTY");
 
@@ -88,6 +91,11 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         public static SingleValueNode BindMethodReturningASingleIntPrimitive(QueryToken token)
         {
             return FakeSingleIntPrimitive;
+        }
+
+        public static SingleValueNode BindMethodReturningASingleSinglePrimitive(QueryToken token)
+        {
+            return FakeSingleSinglePrimitive;
         }
 
         public static SingleValueNode BindMethodReturningASingleOpenProperty(QueryToken token)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -60,6 +60,27 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         }
 
         [Fact]
+        public void BindApplyWithAverageInAggregateShouldReturnApplyClause()
+        {
+            IEnumerable<QueryToken> tokens = _parser.ParseApply("aggregate(UnitPrice with average as AveragePrice)");
+
+            ApplyBinder binder = new ApplyBinder(FakeBindMethods.BindMethodReturningASingleSinglePrimitive, _bindingState);
+            ApplyClause actual = binder.BindApply(tokens);
+
+            Assert.NotNull(actual);
+            AggregateTransformationNode aggregate = Assert.IsType<AggregateTransformationNode>(Assert.Single(actual.Transformations));
+
+            Assert.Equal(TransformationNodeKind.Aggregate, aggregate.Kind);
+            Assert.NotNull(aggregate.AggregateExpressions);
+
+            AggregateExpression statement = Assert.IsType<AggregateExpression>(Assert.Single(aggregate.AggregateExpressions));
+            Assert.NotNull(statement.Expression);
+            Assert.Same(FakeBindMethods.FakeSingleSinglePrimitive, statement.Expression);
+            Assert.Equal(AggregationMethod.Average, statement.Method);
+            Assert.Equal("AveragePrice", statement.Alias);
+        }
+
+        [Fact]
         public void BindApplyWithCountInAggregateShouldReturnApplyClause()
         {
             IEnumerable<QueryToken> tokens = _parser.ParseApply("aggregate($count as TotalCount)");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         {
             IEnumerable<QueryToken> tokens = _parser.ParseApply("aggregate(UnitPrice with average as AveragePrice)");
 
-            ApplyBinder binder = new ApplyBinder(FakeBindMethods.BindMethodReturningASingleSinglePrimitive, _bindingState);
+            ApplyBinder binder = new ApplyBinder(FakeBindMethods.BindMethodReturningASingleFloatPrimitive, _bindingState);
             ApplyClause actual = binder.BindApply(tokens);
 
             Assert.NotNull(actual);
@@ -75,7 +75,7 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
 
             AggregateExpression statement = Assert.IsType<AggregateExpression>(Assert.Single(aggregate.AggregateExpressions));
             Assert.NotNull(statement.Expression);
-            Assert.Same(FakeBindMethods.FakeSingleSinglePrimitive, statement.Expression);
+            Assert.Same(FakeBindMethods.FakeSingleFloatPrimitive, statement.Expression);
             Assert.Equal(AggregationMethod.Average, statement.Method);
             Assert.Equal("AveragePrice", statement.Alias);
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1809.*

### Description

Fixes a bug where `ApplyBinder` does not cater for float/single for the average aggregate method. This causes the following **average** expression to be rejected:
```
$apply=aggregate(SingleProp with average as AverageSingleProp)
```
while related **sum**, **min**, and **max** are accepted
```
$apply=aggregate(SingleProp with sum as SumSingleProp)
$apply=aggregate(SingleProp with min as MinSingleProp)
$apply=aggregate(SingleProp with min as MaxSingleProp)
```

**Note**: The return value from averaging floats should be a float
https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.average?view=netcore-3.1#System_Linq_Enumerable_Average__1_System_Collections_Generic_IEnumerable___0__System_Func___0_System_Single__
https://docs.microsoft.com/en-us/dotnet/api/system.linq.enumerable.average?view=netcore-3.1#System_Linq_Enumerable_Average__1_System_Collections_Generic_IEnumerable___0__System_Func___0_System_Nullable_System_Single___

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
