### PR TITLE
Rename "Message" to "Info" to align with Core.Message vocabulary term

### DIFF
--- a/src/Microsoft.OData.Edm/Validation/Severity.cs
+++ b/src/Microsoft.OData.Edm/Validation/Severity.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OData.Edm.Validation
         /// <summary>
         /// Informational Message
         /// </summary>
-        Message = 1,
+        Info = 1,
 
         /// <summary>
         /// Warning

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/EdmErrorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/EdmErrorTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData.Edm.Tests.Validation
         new List<object[]>
         {
             new object[] { null, EdmErrorCode.AlreadyDefined, "Already Defined", Severity.Error},
-            new object[] { null, EdmErrorCode.BadAmbiguousElementBinding, "Bad Ambiguous Element Binding", Severity.Message},
+            new object[] { null, EdmErrorCode.BadAmbiguousElementBinding, "Bad Ambiguous Element Binding", Severity.Info},
             new object[] { null, EdmErrorCode.BadUnresolvedEntitySet, "Bad Unresolved Entity Set", Severity.Warning},
         };
 
@@ -58,7 +58,7 @@ namespace Microsoft.OData.Edm.Tests.Validation
         {
             new object[] { new CsdlLocation(1, 2), EdmErrorCode.EnumMemberMustHaveValue, "Enum Member Must Have Value", Severity.Error},
             new object[] { new CsdlLocation(3, 2), EdmErrorCode.AllNavigationPropertiesMustBeMapped, "All Navigation Properties Must Be Mapped", Severity.Warning },
-            new object[] { new CsdlLocation(7, 2), EdmErrorCode.BadCyclicComplex, "Bad Cyclic Complex", Severity.Message},
+            new object[] { new CsdlLocation(7, 2), EdmErrorCode.BadCyclicComplex, "Bad Cyclic Complex", Severity.Info},
         };
 
         [Theory]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

*After some back-and-forth on the names of the Severity enum members, decided to align
with the severity defined for the MessageType in the Core vocabulary by renaming "Message" to "Info". Made similar change to severity enum used for urlvalidation.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
