### PR TITLE
Rename AddError to AddMessage

### DIFF
--- a/src/Microsoft.OData.Core/UrlValidation/ODataUrlValidationContext.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ODataUrlValidationContext.cs
@@ -55,12 +55,12 @@ namespace Microsoft.OData.UriParser.Validation
         }
 
         /// <summary>
-        /// Add an <see cref="ODataUrlValidationMessage"/> to the collection of validation errors.
+        /// Add an <see cref="ODataUrlValidationMessage"/> to the collection of validation messages.
         /// </summary>
-        /// <param name="code">The error code of the error.</param>
-        /// <param name="message">The error message.</param>
-        /// <param name="severity">The severity of the error.</param>
-        public void AddError(string code, string message, Severity severity)
+        /// <param name="code">The message code of the message.</param>
+        /// <param name="message">The human readable message.</param>
+        /// <param name="severity">The severity of the message.</param>
+        public void AddMessage(string code, string message, Severity severity)
         {
             this.Messages.Add(new ODataUrlValidationMessage(code, message, severity));
         }

--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/ODataUrlValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/ODataUrlValidator.cs
@@ -199,7 +199,7 @@ namespace Microsoft.OData.UriParser.Validation
                         }
                         catch (Exception e)
                         {
-                            validationContext.AddError(ODataUrlValidationMessageCodes.InvalidRule, Strings.ODataUrlValidationError_InvalidRule(rule.RuleName, e.Message), Severity.Warning);
+                            validationContext.AddMessage(ODataUrlValidationMessageCodes.InvalidRule, Strings.ODataUrlValidationError_InvalidRule(rule.RuleName, e.Message), Severity.Warning);
                         }
                     }
                 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UrlValidation/DeprecationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UrlValidation/DeprecationTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OData.Tests
             int iError = 0;
             foreach(ODataUrlValidationMessage error in errors)
             {
-                Assert.Equal("deprecated", error.MessageCode);
+                Assert.Equal(ODataUrlValidationMessageCodes.DeprecatedElement, error.MessageCode);
                 object elementName;
                 Assert.True(error.ExtendedProperties.TryGetValue("ElementName", out elementName));
                 Assert.Equal(elementName as string, expectedErrors[iError++]);

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -7552,7 +7552,7 @@ public sealed class Microsoft.OData.UriParser.Validation.ODataUrlValidationConte
     System.Collections.Generic.List`1[[Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage]] Messages  { public get; }
     Microsoft.OData.Edm.IEdmModel Model  { public get; }
 
-    public void AddError (string code, string message, Microsoft.OData.UriParser.Validation.Severity severity)
+    public void AddMessage (string code, string message, Microsoft.OData.UriParser.Validation.Severity severity)
 }
 
 public sealed class Microsoft.OData.UriParser.Validation.ODataUrlValidationRule`1 : Microsoft.OData.UriParser.Validation.ODataUrlValidationRule {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -7552,7 +7552,7 @@ public sealed class Microsoft.OData.UriParser.Validation.ODataUrlValidationConte
     System.Collections.Generic.List`1[[Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage]] Messages  { public get; }
     Microsoft.OData.Edm.IEdmModel Model  { public get; }
 
-    public void AddError (string code, string message, Microsoft.OData.UriParser.Validation.Severity severity)
+    public void AddMessage (string code, string message, Microsoft.OData.UriParser.Validation.Severity severity)
 }
 
 public sealed class Microsoft.OData.UriParser.Validation.ODataUrlValidationRule`1 : Microsoft.OData.UriParser.Validation.ODataUrlValidationRule {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -7582,7 +7582,7 @@ public sealed class Microsoft.OData.UriParser.Validation.ODataUrlValidationConte
     System.Collections.Generic.List`1[[Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage]] Messages  { public get; }
     Microsoft.OData.Edm.IEdmModel Model  { public get; }
 
-    public void AddError (string code, string message, Microsoft.OData.UriParser.Validation.Severity severity)
+    public void AddMessage (string code, string message, Microsoft.OData.UriParser.Validation.Severity severity)
 }
 
 public sealed class Microsoft.OData.UriParser.Validation.ODataUrlValidationRule`1 : Microsoft.OData.UriParser.Validation.ODataUrlValidationRule {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

When I renamed validation "errors" to validation "warnings" i missed renaming the AddError method in ODataUrlValidationContext.

This fixes that.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
