### PR TITLE
Fix/1822 depends on atomicity group id v4

### DIFF
--- a/src/Microsoft.OData.Core/Batch/ODataBatchReader.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchReader.cs
@@ -291,6 +291,13 @@ namespace Microsoft.OData
         protected abstract ODataBatchReaderState ReadAtChangesetEndImplementation();
 
         /// <summary>
+        /// Validate the dependsOnIds.
+        /// </summary>
+        /// <param name="contentId">The request Id</param>
+        /// <param name="dependsOnIds">The dependsOn ids specifying current request's prerequisites.</param>
+        protected abstract void ValidateDependsOnIds(string contentId, IEnumerable<string> dependsOnIds);
+
+        /// <summary>
         /// Instantiate an <see cref="ODataBatchOperationRequestMessage"/> instance.
         /// </summary>
         /// <param name="streamCreatorFunc">The function for stream creation.</param>
@@ -318,13 +325,7 @@ namespace Microsoft.OData
         {
             if (dependsOnRequestIds != null && dependsOnIdsValidationRequired)
             {
-                foreach (string id in dependsOnRequestIds)
-                {
-                    if (!this.PayloadUriConverter.ContainsContentId(id))
-                    {
-                        throw new ODataException(Strings.ODataBatchReader_DependsOnIdNotFound(id, contentId));
-                    }
-                }
+                ValidateDependsOnIds(contentId, dependsOnRequestIds);
             }
 
             Uri uri = ODataBatchUtils.CreateOperationRequestUri(

--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData
         private readonly ODataOutputContext outputContext;
 
         /// <summary>The batch-specific URL converter that stores the content IDs found in a changeset and supports resolving cross-referencing URLs.</summary>
-        private readonly ODataBatchPayloadUriConverter payloadUriConverter;
+        internal readonly ODataBatchPayloadUriConverter payloadUriConverter;
 
         /// <summary>The dependency injection container to get related services.</summary>
         private readonly IServiceProvider container;
@@ -499,6 +499,13 @@ namespace Microsoft.OData
         protected abstract IEnumerable<string> GetDependsOnRequestIds(IEnumerable<string> dependsOnIds);
 
         /// <summary>
+        /// Validate the dependsOnIds.
+        /// </summary>
+        /// <param name="contentId">The request Id</param>
+        /// <param name="dependsOnIds">The dependsOn ids specifying current request's prerequisites.</param>
+        protected abstract void ValidateDependsOnIds(string contentId, IEnumerable<string> dependsOnIds);
+
+        /// <summary>
         /// Wrapper method to create an operation request message that can be used to write the operation content to, utilizing
         /// private members <see cref="ODataBatchPayloadUriConverter"/> and <see cref="IServiceProvider"/>.
         /// </summary>
@@ -517,14 +524,7 @@ namespace Microsoft.OData
 
             if (dependsOnIds != null)
             {
-                // Validate explicit dependsOnIds cases.
-                foreach (string id in convertedDependsOnIds)
-                {
-                    if (!this.payloadUriConverter.ContainsContentId(id))
-                    {
-                        throw new ODataException(Strings.ODataBatchReader_DependsOnIdNotFound(id, contentId));
-                    }
-                }
+                ValidateDependsOnIds(contentId, convertedDependsOnIds);
             }
 
             // If dependsOnIds is not specified, use the <code>payloadUrlConverter</code>; otherwise use the dependOnIds converted

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchReader.cs
@@ -54,6 +54,11 @@ namespace Microsoft.OData.JsonLight
         private ODataJsonLightBatchPayloadItemPropertiesCache messagePropertiesCache = null;
 
         /// <summary>
+        /// Collection for keeping track of unique atomic group ids and member request ids.
+        /// </summary>
+        private HashSet<string> requestIds = new HashSet<string>();
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="inputContext">The input context to read the content from.</param>
@@ -123,6 +128,16 @@ namespace Microsoft.OData.JsonLight
             // atomicityGroup
             string atomicityGroupId = (string)this.messagePropertiesCache.GetPropertyValue(
                 ODataJsonLightBatchPayloadItemPropertiesCache.PropertyNameAtomicityGroup);
+
+            if (id != null)
+            {
+                this.requestIds.Add(id);
+            }
+
+            if (atomicityGroupId != null)
+            {
+                this.requestIds.Add(atomicityGroupId);
+            }
 
             // dependsOn
             // Flatten the dependsOn list by converting every groupId into request Ids, so that the caller
@@ -330,6 +345,25 @@ namespace Microsoft.OData.JsonLight
             //// NOTE: Content-IDs for cross referencing are only supported in request messages; in responses
             //// we allow a Content-ID header but don't process it (i.e., don't add the content ID to the URL resolver).
             return responseMessage;
+        }
+
+        /// <summary>
+        /// Validate the dependsOnIds.
+        /// </summary>
+        /// <param name="dependsOnIds">The dependsOn ids specifying current request's prerequisites.</param>
+        protected override void ValidateDependsOnIds(string contentId, IEnumerable<string> dependsOnIds)
+        {
+            foreach (var id in dependsOnIds)
+            {
+                // Content-ID cannot be part of dependsOnIds. This is to avoid self referencing.
+                // The dependsOnId must be an existing request ID or atomicityGroup
+                if (id == contentId ||
+                    (!this.requestIds.Contains(id) &&
+                    !this.requestIds.Contains(id)))
+                {
+                    throw new ODataException(Strings.ODataBatchReader_DependsOnIdNotFound(id, contentId));
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchWriter.cs
@@ -262,6 +262,23 @@ namespace Microsoft.OData.JsonLight
         }
 
         /// <summary>
+        /// Validate the dependsOnIds.
+        /// </summary>
+        /// <param name="dependsOnIds">The dependsOn ids specifying current request's prerequisites.</param>
+        protected override void ValidateDependsOnIds(string contentId, IEnumerable<string> dependsOnIds)
+        {
+           foreach(var id in dependsOnIds)
+            {
+                // Content-ID cannot be part of dependsOnIds. This is to avoid self referencing.
+                // The dependsOnId must be an existing request ID.
+                if (id == contentId || !this.requestIdToAtomicGroupId.ContainsKey(id))
+                {
+                    throw new ODataException(Strings.ODataBatchReader_DependsOnIdNotFound(id, contentId));
+                }
+            }
+        }
+
+        /// <summary>
         /// Ends a batch - implementation of the actual functionality.
         /// </summary>
         protected override void WriteEndBatchImplementation()

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -197,6 +197,22 @@ namespace Microsoft.OData.MultipartMixed
         }
 
         /// <summary>
+        /// Validate if the dependsOnIds are in the ContentIdCache.
+        /// </summary>
+        /// <param name="dependsOnIds">The dependsOn ids specifying current request's prerequisites.</param>
+        protected override void ValidateDependsOnIds(string contentId, IEnumerable<string> dependsOnIds)
+        {
+            // Validate explicit dependsOnIds cases.
+            foreach (string id in dependsOnIds)
+            {
+                if (!this.PayloadUriConverter.ContainsContentId(id))
+                {
+                    throw new ODataException(Strings.ODataBatchReader_DependsOnIdNotFound(id, contentId));
+                }
+            }
+        }
+
+        /// <summary>
         /// Returns the next state of the batch reader after an end boundary has been found.
         /// </summary>
         /// <returns>The next state of the batch reader.</returns>

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -215,6 +215,22 @@ namespace Microsoft.OData.MultipartMixed
         }
 
         /// <summary>
+        /// Validate if the dependsOnIds are in the ContentIdCache.
+        /// </summary>
+        /// <param name="dependsOnIds">The dependsOn ids specifying current request's prerequisites.</param>
+        protected override void ValidateDependsOnIds(string contentId, IEnumerable<string> dependsOnIds)
+        {
+            // Validate explicit dependsOnIds cases.
+            foreach (string id in dependsOnIds)
+            {
+                if (!this.payloadUriConverter.ContainsContentId(id))
+                {
+                    throw new ODataException(Strings.ODataBatchReader_DependsOnIdNotFound(id, contentId));
+                }
+            }
+        }
+
+        /// <summary>
         /// Creates an <see cref="ODataBatchOperationRequestMessage"/> for writing an operation of a batch request
         /// - implementation of the actual functionality.
         /// </summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/SingletonBatchRoundtripJsonLightTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/SingletonBatchRoundtripJsonLightTests.cs
@@ -1023,7 +1023,12 @@ Content-Type: application/json;odata.metadata=none
             Assert.True(expectedExceptionThrown, "Uri self-referencing with its Content-ID should not be allowed.");
         }
 
-        [Fact]
+        // This test isn't relevant in Json Batch v4.
+        // We use atomicGroup Id in dependsOn for 2 reasons:
+        // 1. To extract Request ids for use in reference Uris (in v4.01).
+        // 2. To sequence requests so that they are executed in a certain order (in both v4 and v4.01).
+        // This test made an assumption that we only use atomicityGroup for 1 above.
+        /*[Fact]
         public void BatchJsonLightReferenceUriV4TestShouldThrow()
         {
             bool exceptionThrown = true;
@@ -1040,6 +1045,16 @@ Content-Type: application/json;odata.metadata=none
 
             Assert.True(exceptionThrown, "An exception should have been thrown when trying to refer to the " +
                 "content Id of the last request of a change set or atomic group in V4.");
+        }*/
+
+        [Fact]
+        public void BatchJsonLightDependsOnAtomicityGroupV4Test()
+        {
+            byte[] requestPayload = this.CreateReferenceUriBatchRequest(ODataVersion.V4);
+            VerifyPayload(requestPayload, ExpectedReferenceUriRequestPayload);
+
+            byte[] responsePayload = this.ServiceReadReferenceUriBatchRequestAndWriteResponse(requestPayload);
+            VerifyPayload(responsePayload, ExpectedReferenceUriResponsePayload);
         }
 
         [Fact]
@@ -1643,7 +1658,7 @@ Content-Type: application/json;odata.metadata=none
                 }
                 else if (useRequestIdOfGroupForDependsOnIds)
                 {
-                    dependsOnIds = new string[] {"1", "2"};
+                    dependsOnIds = new string[] { "1", "2" };
                 }
                 else
                 {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1822 .*

### Description

Moved validations from `ODataBatchWriter` and `ODataBatchReader` to individual implementations of `ODataJsonLightBatchWriter` , `ODataJsonLightBatchReader`, `ODataMultipartMixedBatchWriter` and `ODataMultipartMixedBatchReader`

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
