### PR TITLE
Fix/1316 add cancellation token

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceActionQuerySingleOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceActionQuerySingleOfT.cs
@@ -8,6 +8,7 @@ namespace Microsoft.OData.Client
 {
     using System;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -70,7 +71,15 @@ namespace Microsoft.OData.Client
         /// <returns>A task represents the result of the operation. </returns>
         public Task<T> GetValueAsync()
         {
-            return Task<T>.Factory.FromAsync(this.BeginGetValue, this.EndGetValue, null);
+            return GetValueAsync(CancellationToken.None);
+        }
+
+        /// <summary>Asynchronously sends the request so that this call does not block processing while waiting for the results from the service.</summary>
+        /// <returns>A task represents the result of the operation. </returns>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public Task<T> GetValueAsync(CancellationToken cancellationToken)
+        {
+            return this.context.FromAsync(this.BeginGetValue, this.EndGetValue, cancellationToken);
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceActionQuery{T}.BeginExecute(AsyncCallback,Object)" />.</summary>

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -21,6 +21,7 @@ namespace Microsoft.OData.Client
     using System.Linq.Expressions;
     using System.Net;
     using System.Reflection;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.OData;
     using Microsoft.OData.Client.Annotation;
@@ -1138,17 +1139,27 @@ namespace Microsoft.OData.Client
         /// <param name="propertyName">The name of the property on the specified entity to load.</param>
         public virtual Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName)
         {
-            return Task<QueryOperationResponse>.Factory.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, null);
+            return this.LoadPropertyAsync(entity, propertyName, CancellationToken.None);
         }
 
-        /// <summary>Asynchronously loads a page of related entities from the data service by using the supplied next link URI.</summary>
-        /// <returns>An <see cref="System.IAsyncResult" /> object that is used to track the status of the asynchronous operation. </returns>
+        /// <summary>Asynchronously loads the value of the specified property from the data service.</summary>
+        /// <returns>A task that represents the response to the load operation.</returns>
         /// <param name="entity">The entity that contains the property to load.</param>
-        /// <param name="propertyName">The name of the property of the specified entity to load.</param>
-        /// <param name="nextLinkUri">The URI used to load the next results page.</param>
-        /// <param name="callback">Delegate to invoke when results are available for client consumption.</param>
-        /// <param name="state">User-defined state object passed to the callback.</param>
-        public virtual IAsyncResult BeginLoadProperty(object entity, string propertyName, Uri nextLinkUri, AsyncCallback callback, object state)
+        /// <param name="propertyName">The name of the property on the specified entity to load.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, CancellationToken cancellationToken)
+        {
+            return this.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, cancellationToken);
+        }
+
+    /// <summary>Asynchronously loads a page of related entities from the data service by using the supplied next link URI.</summary>
+    /// <returns>An <see cref="System.IAsyncResult" /> object that is used to track the status of the asynchronous operation. </returns>
+    /// <param name="entity">The entity that contains the property to load.</param>
+    /// <param name="propertyName">The name of the property of the specified entity to load.</param>
+    /// <param name="nextLinkUri">The URI used to load the next results page.</param>
+    /// <param name="callback">Delegate to invoke when results are available for client consumption.</param>
+    /// <param name="state">User-defined state object passed to the callback.</param>
+    public virtual IAsyncResult BeginLoadProperty(object entity, string propertyName, Uri nextLinkUri, AsyncCallback callback, object state)
         {
             LoadPropertyResult result = this.CreateLoadPropertyRequest(entity, propertyName, callback, state, nextLinkUri, null);
             result.BeginExecuteQuery();
@@ -1162,7 +1173,18 @@ namespace Microsoft.OData.Client
         /// <param name="nextLinkUri">The URI used to load the next results page.</param>
         public virtual Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, Uri nextLinkUri)
         {
-            return Task<QueryOperationResponse>.Factory.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, nextLinkUri, null);
+            return this.LoadPropertyAsync(entity, propertyName, nextLinkUri, CancellationToken.None);
+        }
+
+        /// <summary>Asynchronously loads a page of related entities from the data service by using the supplied next link URI.</summary>
+        /// <returns>A task that represents the response to the load operation.</returns>
+        /// <param name="entity">The entity that contains the property to load.</param>
+        /// <param name="propertyName">The name of the property on the specified entity to load.</param>
+        /// <param name="nextLinkUri">The URI used to load the next results page.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, Uri nextLinkUri, CancellationToken cancellationToken)
+        {
+            return this.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, nextLinkUri, cancellationToken);
         }
 
         /// <summary>Asynchronously loads the next page of related entities from the data service by using the supplied query continuation object.</summary>
@@ -1187,13 +1209,24 @@ namespace Microsoft.OData.Client
         /// <param name="continuation">A <see cref="Microsoft.OData.Client.DataServiceQueryContinuation{T}" /> object that represents the next page of related entity data to return from the data service.</param>
         public virtual Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, DataServiceQueryContinuation continuation)
         {
-            return Task<QueryOperationResponse>.Factory.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, continuation, null);
+            return this.LoadPropertyAsync(entity, propertyName, continuation, CancellationToken.None);
         }
 
-        /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceContext.BeginLoadProperty(System.Object,System.String,System.AsyncCallback,System.Object)" /> operation.</summary>
-        /// <returns>The response to the load operation.</returns>
-        /// <param name="asyncResult">An <see cref="System.IAsyncResult" /> that represents the status of the asynchronous operation.</param>
-        public virtual QueryOperationResponse EndLoadProperty(IAsyncResult asyncResult)
+        /// <summary>Asynchronously loads the next page of related entities from the data service by using the supplied query continuation object.</summary>
+        /// <returns>A Task that represents the response to the load operation.</returns>
+        /// <param name="entity">The entity that contains the property to load.</param>
+        /// <param name="propertyName">The name of the property on the specified entity to load.</param>
+        /// <param name="continuation">A <see cref="Microsoft.OData.Client.DataServiceQueryContinuation{T}" /> object that represents the next page of related entity data to return from the data service.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual Task<QueryOperationResponse> LoadPropertyAsync(object entity, string propertyName, DataServiceQueryContinuation continuation, CancellationToken cancellationToken)
+        {
+            return this.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, continuation, cancellationToken);
+        }
+
+    /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceContext.BeginLoadProperty(System.Object,System.String,System.AsyncCallback,System.Object)" /> operation.</summary>
+    /// <returns>The response to the load operation.</returns>
+    /// <param name="asyncResult">An <see cref="System.IAsyncResult" /> that represents the status of the asynchronous operation.</param>
+    public virtual QueryOperationResponse EndLoadProperty(IAsyncResult asyncResult)
         {
             LoadPropertyResult response = BaseAsyncResult.EndExecute<LoadPropertyResult>(this, Util.LoadPropertyMethodName, asyncResult);
             return response.LoadProperty();
@@ -1390,7 +1423,19 @@ namespace Microsoft.OData.Client
         /// <exception cref="System.ArgumentException">The <paramref name="entity" /> is not tracked by this <see cref="Microsoft.OData.Client.DataServiceContext" />.-or-The <paramref name="entity" /> is in the <see cref="Microsoft.OData.Client.EntityStates.Added" /> state.-or-The <paramref name="entity" /> is not a Media Link Entry and does not have a related binary data stream.</exception>
         public virtual Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, DataServiceRequestArgs args)
         {
-            return Task<DataServiceStreamResponse>.Factory.FromAsync(this.BeginGetReadStream, this.EndGetReadStream, entity, args, null);
+            return this.GetReadStreamAsync(entity, args, CancellationToken.None);
+        }
+
+        /// <summary>Asynchronously gets the binary data stream that belongs to the specified entity, by using the specified message headers.</summary>
+        /// <returns>A Task that represents an instance of <see cref="Microsoft.OData.Client.DataServiceStreamResponse" /> which contains the response stream along with its metadata.</returns>
+        /// <param name="entity">The entity that has a the binary data stream to retrieve. </param>
+        /// <param name="args">Instance of the <see cref="Microsoft.OData.Client.DataServiceRequestArgs" /> class that contains settings for the HTTP request message.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <exception cref="System.ArgumentNullException">Any of the parameters supplied to the method is null.</exception>
+        /// <exception cref="System.ArgumentException">The <paramref name="entity" /> is not tracked by this <see cref="Microsoft.OData.Client.DataServiceContext" />.-or-The <paramref name="entity" /> is in the <see cref="Microsoft.OData.Client.EntityStates.Added" /> state.-or-The <paramref name="entity" /> is not a Media Link Entry and does not have a related binary data stream.</exception>
+        public virtual Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, DataServiceRequestArgs args, CancellationToken cancellationToken)
+        {
+            return this.FromAsync(this.BeginGetReadStream, this.EndGetReadStream, entity, args, cancellationToken);
         }
 
         /// <summary>Asynchronously gets a named binary data stream that belongs to the specified entity, by using the specified message headers.</summary>
@@ -1416,7 +1461,18 @@ namespace Microsoft.OData.Client
         /// <param name="args">Instance of the <see cref="Microsoft.OData.Client.DataServiceRequestArgs" /> class that contains settings for the HTTP request message.</param>
         public virtual Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, string name, DataServiceRequestArgs args)
         {
-            return Task<DataServiceStreamResponse>.Factory.FromAsync(this.BeginGetReadStream, this.EndGetReadStream, entity, name, args, null);
+            return this.GetReadStreamAsync(entity, name, args, CancellationToken.None);
+        }
+
+        /// <summary>Asynchronously gets the binary data stream that belongs to the specified entity, by using the specified message headers.</summary>
+        /// <returns>A task that represents an instance of <see cref="Microsoft.OData.Client.DataServiceStreamResponse" /> which contains the response stream along with its metadata.</returns>
+        /// <param name="entity">The entity that has a the binary data stream to retrieve. </param>
+        /// <param name="name">The name of the binary stream to request.</param>
+        /// <param name="args">Instance of the <see cref="Microsoft.OData.Client.DataServiceRequestArgs" /> class that contains settings for the HTTP request message.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual Task<DataServiceStreamResponse> GetReadStreamAsync(object entity, string name, DataServiceRequestArgs args, CancellationToken cancellationToken)
+        {
+            return this.FromAsync(this.BeginGetReadStream, this.EndGetReadStream, entity, name, args, cancellationToken);
         }
 
         /// <summary>Called to complete the asynchronous operation of retrieving a binary data stream.</summary>
@@ -1644,7 +1700,16 @@ namespace Microsoft.OData.Client
         /// <param name="queries">The array of query requests to include in the batch request.</param>
         public virtual Task<DataServiceResponse> ExecuteBatchAsync(params DataServiceRequest[] queries)
         {
-            return Task<DataServiceResponse>.Factory.FromAsync((callback, state) => this.BeginExecuteBatch(callback, state, queries), this.EndExecuteBatch, null);
+            return this.ExecuteBatchAsync(SaveChangesOptions.BatchWithSingleChangeset, CancellationToken.None, queries);
+        }
+
+        /// <summary>Asynchronously submits a group of queries as a batch to the data service.</summary>
+        /// <returns>An Task that represents the DataServiceResult object that indicates the result of the batch operation.</returns>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="queries">The array of query requests to include in the batch request.</param>
+        public virtual Task<DataServiceResponse> ExecuteBatchAsync(CancellationToken cancellationToken, params DataServiceRequest[] queries)
+        {
+            return this.ExecuteBatchAsync(SaveChangesOptions.BatchWithSingleChangeset, cancellationToken, queries);
         }
 
         /// <summary>Asynchronously submits a group of queries as a batch to the data service.</summary>
@@ -1658,7 +1723,22 @@ namespace Microsoft.OData.Client
                 throw new InvalidOperationException();
             }
 
-            return Task<DataServiceResponse>.Factory.FromAsync((callback, state) => this.BeginExecuteBatch(callback, state, options, queries), this.EndExecuteBatch, null);
+            return this.ExecuteBatchAsync(options, CancellationToken.None, queries);
+        }
+
+        /// <summary>Asynchronously submits a group of queries as a batch to the data service.</summary>
+        /// <returns>An Task that represents the DataServiceResult object that indicates the result of the batch operation.</returns>
+        /// <param name="options">A member of the <see cref="Microsoft.OData.Client.SaveChangesOptions" /> enumeration for how the client can save the pending set of changes.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="queries">The array of query requests to include in the batch request.</param>
+        public virtual Task<DataServiceResponse> ExecuteBatchAsync(SaveChangesOptions options, CancellationToken cancellationToken, params DataServiceRequest[] queries)
+        {
+            if (!Util.IsBatch(options))
+            {
+                throw new InvalidOperationException();
+            }
+
+            return this.FromAsync((callback, state) => this.BeginExecuteBatch(callback, state, options, queries), this.EndExecuteBatch, cancellationToken);
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceContext.BeginExecuteBatch(System.AsyncCallback,System.Object,Microsoft.OData.Client.DataServiceRequest[])" />.</summary>
@@ -1720,7 +1800,17 @@ namespace Microsoft.OData.Client
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
         public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri)
         {
-            return Task<IEnumerable<TElement>>.Factory.FromAsync(this.BeginExecute<TElement>, this.EndExecute<TElement>, requestUri, null);
+            return this.ExecuteAsync<TElement>(requestUri, CancellationToken.None);
+        }
+
+        /// <summary>Asynchronously sends the request so that this call does not block processing while waiting for the results from the service.</summary>
+        /// <returns>A task represents the result of the operation. </returns>
+        /// <param name="requestUri">The URI to which the query request will be sent. The URI may be any valid data service URI; it can contain $ query parameters.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <typeparam name="TElement">The type returned by the query.</typeparam>
+        public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, CancellationToken cancellationToken)
+        {
+            return this.FromAsync(this.BeginExecute<TElement>, this.EndExecute<TElement>, requestUri, cancellationToken);
         }
 
         /// <summary>Asynchronously sends a request to the data service to execute a specific URI.</summary>
@@ -1746,7 +1836,18 @@ namespace Microsoft.OData.Client
         /// <param name="operationParameters">The operation parameters used.</param>
         public virtual Task<OperationResponse> ExecuteAsync(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters)
         {
-            return Task<OperationResponse>.Factory.FromAsync((callback, state) => this.BeginExecute(requestUri, callback, state, httpMethod, operationParameters), this.EndExecute, null);
+            return this.ExecuteAsync(requestUri, httpMethod, CancellationToken.None, operationParameters);
+        }
+
+        /// <summary>Asynchronously sends the request so that this call does not block processing while waiting for the results from the service.</summary>
+        /// <returns>A task represents the result of the operation. </returns>
+        /// <param name="requestUri">The URI to which the query request will be sent. The URI may be any valid data service URI; it can contain $ query parameters.</param>
+        /// <param name="httpMethod">The HTTP data transfer method used by the client.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <param name="operationParameters">The operation parameters used.</param>
+        public virtual Task<OperationResponse> ExecuteAsync(Uri requestUri, string httpMethod, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
+        {
+            return this.FromAsync((callback, state) => this.BeginExecute(requestUri, callback, state, httpMethod, operationParameters), this.EndExecute, cancellationToken);
         }
 
         /// <summary>Asynchronously sends a request to the data service to execute a specific URI.</summary>
@@ -1773,18 +1874,31 @@ namespace Microsoft.OData.Client
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
         public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, bool singleResult, params OperationParameter[] operationParameters)
         {
-            return Task<IEnumerable<TElement>>.Factory.FromAsync((callback, state) => this.BeginExecute<TElement>(requestUri, callback, state, httpMethod, singleResult, operationParameters), this.EndExecute<TElement>, null);
+            return this.ExecuteAsync<TElement>(requestUri, httpMethod, singleResult, CancellationToken.None, operationParameters);
         }
 
-        /// <summary>Asynchronously sends a request to the data service to execute a specific URI.</summary>
-        /// <returns>The result of the operation.</returns>
-        /// <param name="requestUri">The URI to which the query request will be sent.</param>
-        /// <param name="callback">Delegate to invoke when results are available for client consumption.</param>
-        /// <param name="state">User-defined state object passed to the callback.</param>
+        /// <summary>Asynchronously sends the request so that this call does not block processing while waiting for the results from the service.</summary>
+        /// <returns>A task represents the result of the operation. </returns>
+        /// <param name="requestUri">The URI to which the query request will be sent. The URI may be any valid data service URI; it can contain $ query parameters.</param>
         /// <param name="httpMethod">The HTTP data transfer method used by the client.</param>
+        /// <param name="singleResult">Attribute used on service operations to specify that they return a single instance of their return element.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         /// <param name="operationParameters">The operation parameters used.</param>
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Type is used to infer result")]
+        public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, bool singleResult, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
+        {
+            return this.FromAsync((callback, state) => this.BeginExecute<TElement>(requestUri, callback, state, httpMethod, singleResult, operationParameters), this.EndExecute<TElement>, cancellationToken);
+        }
+
+            /// <summary>Asynchronously sends a request to the data service to execute a specific URI.</summary>
+            /// <returns>The result of the operation.</returns>
+            /// <param name="requestUri">The URI to which the query request will be sent.</param>
+            /// <param name="callback">Delegate to invoke when results are available for client consumption.</param>
+            /// <param name="state">User-defined state object passed to the callback.</param>
+            /// <param name="httpMethod">The HTTP data transfer method used by the client.</param>
+            /// <param name="operationParameters">The operation parameters used.</param>
+            /// <typeparam name="TElement">The type returned by the query.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Type is used to infer result")]
         public virtual IAsyncResult BeginExecute<TElement>(Uri requestUri, AsyncCallback callback, object state, string httpMethod, params OperationParameter[] operationParameters)
         {
             bool? singleResult = this.IsSingletonType<TElement>();
@@ -1799,16 +1913,28 @@ namespace Microsoft.OData.Client
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
         public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, params OperationParameter[] operationParameters)
         {
-            return Task<IEnumerable<TElement>>.Factory.FromAsync((callback, state) => this.BeginExecute<TElement>(requestUri, callback, state, httpMethod, operationParameters), this.EndExecute<TElement>, null);
+            return this.ExecuteAsync<TElement>(requestUri, httpMethod, CancellationToken.None, operationParameters);
         }
 
-        /// <summary>Asynchronously sends a request to the data service to retrieve the next page of data in a paged query result.</summary>
-        /// <returns>An <see cref="System.IAsyncResult" /> that represents the status of the operation.</returns>
-        /// <param name="continuation">A <see cref="Microsoft.OData.Client.DataServiceQueryContinuation{T}" /> object that represents the next page of data to return from the data service.</param>
-        /// <param name="callback">Delegate to invoke when results are available for client consumption.</param>
-        /// <param name="state">User-defined state object passed to the callback.</param>
-        /// <typeparam name="T">The type returned by the query.</typeparam>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Type is used to infer result")]
+        /// <summary>Asynchronously sends the request so that this call does not block processing while waiting for the results from the service.</summary>
+        /// <returns>A task represents the result of the operation. </returns>
+        /// <param name="requestUri">The URI to which the query request will be sent. The URI may be any valid data service URI; it can contain $ query parameters.</param>
+        /// <param name="httpMethod">The HTTP data transfer method used by the client.</param>
+        /// <param name="operationParameters">The operation parameters used.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <typeparam name="TElement">The type returned by the query.</typeparam>
+        public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(Uri requestUri, string httpMethod, CancellationToken cancellationToken, params OperationParameter[] operationParameters)
+        {
+            return this.FromAsync((callback, state) => this.BeginExecute<TElement>(requestUri, callback, state, httpMethod, operationParameters), this.EndExecute<TElement>, cancellationToken);
+        }
+
+            /// <summary>Asynchronously sends a request to the data service to retrieve the next page of data in a paged query result.</summary>
+            /// <returns>An <see cref="System.IAsyncResult" /> that represents the status of the operation.</returns>
+            /// <param name="continuation">A <see cref="Microsoft.OData.Client.DataServiceQueryContinuation{T}" /> object that represents the next page of data to return from the data service.</param>
+            /// <param name="callback">Delegate to invoke when results are available for client consumption.</param>
+            /// <param name="state">User-defined state object passed to the callback.</param>
+            /// <typeparam name="T">The type returned by the query.</typeparam>
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Type is used to infer result")]
         public virtual IAsyncResult BeginExecute<T>(DataServiceQueryContinuation<T> continuation, AsyncCallback callback, object state)
         {
             Util.CheckArgumentNull(continuation, "continuation");
@@ -1823,13 +1949,23 @@ namespace Microsoft.OData.Client
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
         public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(DataServiceQueryContinuation<TElement> continuation)
         {
-            return Task<IEnumerable<TElement>>.Factory.FromAsync(this.BeginExecute, this.EndExecute<TElement>, continuation, null);
+            return this.ExecuteAsync<TElement>(continuation, CancellationToken.None);
+        }
+
+        /// <summary>Asynchronously sends a request to the data service to retrieve the next page of data in a paged query result.</summary>
+        /// <returns>A task that represents the results returned by the query operation.</returns>
+        /// <param name="continuation">A <see cref="Microsoft.OData.Client.DataServiceQueryContinuation{T}" /> object that represents the next page of data to return from the data service.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <typeparam name="TElement">The type returned by the query.</typeparam>
+        public virtual Task<IEnumerable<TElement>> ExecuteAsync<TElement>(DataServiceQueryContinuation<TElement> continuation, CancellationToken cancellationToken)
+        {
+            return this.FromAsync(this.BeginExecute, this.EndExecute<TElement>, continuation, cancellationToken);
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceContext.BeginExecute{TElement}(System.Uri,System.AsyncCallback,System.Object)" />.</summary>
         /// <returns>The results returned by the query operation.</returns>
         /// <param name="asyncResult">
-        ///   <see cref="System.IAsyncResult" /> object.</param>
+        /// <see cref="System.IAsyncResult" /> object.</param>
         /// <typeparam name="TElement">The type returned by the query.</typeparam>
         /// <exception cref="System.ArgumentNullException">When<paramref name=" asyncResult" /> is null.</exception>
         /// <exception cref="System.ArgumentException">When<paramref name=" asyncResult" /> did not originate from this <see cref="Microsoft.OData.Client.DataServiceContext" /> instance. -or- When the <see cref="Microsoft.OData.Client.DataServiceContext.EndExecute{TElement}(System.IAsyncResult)" /> method was previously called.</exception>
@@ -1969,7 +2105,7 @@ namespace Microsoft.OData.Client
         /// <returns>A task that represents a <see cref="Microsoft.OData.Client.DataServiceResponse" /> object that indicates the result of the batch operation.</returns>
         public virtual Task<DataServiceResponse> SaveChangesAsync()
         {
-            return SaveChangesAsync(this.SaveChangesDefaultOptions);
+            return SaveChangesAsync(CancellationToken.None);
         }
 
         /// <summary>Asynchronously submits the pending changes to the data service collected by the <see cref="Microsoft.OData.Client.DataServiceContext" /> since the last time changes were saved.</summary>
@@ -2002,7 +2138,24 @@ namespace Microsoft.OData.Client
         /// <param name="options">A member of the <see cref="Microsoft.OData.Client.SaveChangesOptions" /> enumeration for how the client can save the pending set of changes.</param>
         public virtual Task<DataServiceResponse> SaveChangesAsync(SaveChangesOptions options)
         {
-            return Task<DataServiceResponse>.Factory.FromAsync(this.BeginSaveChanges, this.EndSaveChanges, options, null);
+            return SaveChangesAsync(options, CancellationToken.None);
+        }
+
+        /// <summary>Asynchronously submits the pending changes to the data service collected by the <see cref="Microsoft.OData.Client.DataServiceContext" /> since the last time changes were saved.</summary>
+        /// <returns>A task that represents a <see cref="Microsoft.OData.Client.DataServiceResponse" /> object that indicates the result of the batch operation.</returns>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual Task<DataServiceResponse> SaveChangesAsync(CancellationToken cancellationToken)
+        {
+            return SaveChangesAsync(this.SaveChangesDefaultOptions, cancellationToken);
+        }
+
+        /// <summary>Asynchronously submits the pending changes to the data service collected by the <see cref="Microsoft.OData.Client.DataServiceContext" /> since the last time changes were saved.</summary>
+        /// <returns>A task that represents a <see cref="Microsoft.OData.Client.DataServiceResponse" /> object that indicates the result of the batch operation.</returns>
+        /// <param name="options">A member of the <see cref="Microsoft.OData.Client.SaveChangesOptions" /> enumeration for how the client can save the pending set of changes.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual Task<DataServiceResponse> SaveChangesAsync(SaveChangesOptions options, CancellationToken cancellationToken)
+        {
+            return FromAsync(this.BeginSaveChanges, this.EndSaveChanges, options, cancellationToken);
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceContext.BeginSaveChanges(System.AsyncCallback,System.Object)" /> operation.</summary>
@@ -2536,6 +2689,133 @@ namespace Microsoft.OData.Client
 
         #endregion
 
+        #region FromAsync
+
+        /// <summary>Creates a task that represents a pair of begin and end methods that conform to the Asynchronous Programming Model pattern.</summary>
+        /// <param name="beginMethod">The delegate that begins the asynchronous operation.</param>
+        /// <param name="endMethod">The delegate that ends the asynchronous operation.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <typeparam name="TResult">The type of the result in the task returned from this operation.</typeparam>
+        /// <returns>The created task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="beginMethod" /> argument is <see langword="null" />.-or-The <paramref name="endMethod" /> argument is <see langword="null" />.</exception>
+        internal Task<TResult> FromAsync<TResult>(
+            Func<AsyncCallback, object, IAsyncResult> beginMethod,
+            Func<IAsyncResult, TResult> endMethod,
+            CancellationToken cancellationToken)
+        {
+            return Task<TResult>.Factory.FromAsync(
+                (callback, state) =>
+                {
+                    IAsyncResult asyncResult = beginMethod(callback, state);
+                    cancellationToken.Register(() => this.CancelRequest(asyncResult));
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return asyncResult;
+                },
+                endMethod,
+                state: null);
+        }
+
+        /// <summary>
+        /// Creates a task that represents a pair of begin and end methods that conform to the Asynchronous Programming Model pattern.
+        /// Observes a cancellation token for cancellation.
+        /// </summary>
+        /// <param name="beginMethod">The delegate that begins the asynchronous operation.</param>
+        /// <param name="endMethod">The delegate that ends the asynchronous operation.</param>
+        /// <param name="arg">The first argument passed to the <paramref name="beginMethod" /> delegate.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <typeparam name="TArg">The type of the first argument passed to the <paramref name="beginMethod" /> delegate.</typeparam>
+        /// <typeparam name="TResult">The type of the result in the task returned from this operation.</typeparam>
+        /// <returns>The created task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="beginMethod" /> argument is <see langword="null" />.-or-The <paramref name="endMethod" /> argument is <see langword="null" />.</exception>
+        internal Task<TResult> FromAsync<TArg, TResult>(
+            Func<TArg, AsyncCallback, object, IAsyncResult> beginMethod,
+            Func<IAsyncResult, TResult> endMethod,
+            TArg arg,
+            CancellationToken cancellationToken)
+        {
+            return Task<TResult>.Factory.FromAsync(
+                (arg1, callback, state) =>
+                {
+                    IAsyncResult asyncResult = beginMethod(arg1, callback, state);
+                    cancellationToken.Register(() => this.CancelRequest(asyncResult));
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return asyncResult;
+                },
+                endMethod,
+                arg,
+                state: null);
+        }
+
+        /// <summary>Creates a task that represents a pair of begin and end methods that conform to the Asynchronous Programming Model pattern.</summary>
+        /// <param name="beginMethod">The delegate that begins the asynchronous operation.</param>
+        /// <param name="endMethod">The delegate that ends the asynchronous operation.</param>
+        /// <param name="arg1">The first argument passed to the <paramref name="beginMethod" /> delegate.</param>
+        /// <param name="arg2">The second argument passed to the <paramref name="beginMethod" /> delegate.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <typeparam name="TArg1">The type of the second argument passed to <paramref name="beginMethod" /> delegate.</typeparam>
+        /// <typeparam name="TArg2">The type of the first argument passed to the <paramref name="beginMethod" /> delegate.</typeparam>
+        /// <typeparam name="TResult">The type of the result in the task returned from this operation.</typeparam>
+        /// <returns>The created task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="beginMethod" /> argument is <see langword="null" />.-or-The <paramref name="endMethod" /> argument is <see langword="null" />.</exception>
+        internal Task<TResult> FromAsync<TArg1, TArg2, TResult>(
+            Func<TArg1, TArg2, AsyncCallback, object, IAsyncResult> beginMethod,
+            Func<IAsyncResult, TResult> endMethod,
+            TArg1 arg1,
+            TArg2 arg2,
+            CancellationToken cancellationToken)
+        {
+            return Task<TResult>.Factory.FromAsync(
+                (a1, a2, callback, state) =>
+                {
+                    IAsyncResult asyncResult = beginMethod(a1, a2, callback, state);
+                    cancellationToken.Register(() => this.CancelRequest(asyncResult));
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return asyncResult;
+                },
+                endMethod,
+                arg1,
+                arg2,
+                state: null);
+        }
+
+        /// <summary>Creates a task that represents a pair of begin and end methods that conform to the Asynchronous Programming Model pattern.</summary>
+        /// <param name="beginMethod">The delegate that begins the asynchronous operation.</param>
+        /// <param name="endMethod">The delegate that ends the asynchronous operation.</param>
+        /// <param name="arg1">The first argument passed to the <paramref name="beginMethod" /> delegate.</param>
+        /// <param name="arg2">The second argument passed to the <paramref name="beginMethod" /> delegate.</param>
+        /// <param name="arg3">The third argument passed to the <paramref name="beginMethod" /> delegate.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <typeparam name="TArg1">The type of the second argument passed to <paramref name="beginMethod" /> delegate.</typeparam>
+        /// <typeparam name="TArg2">The type of the third argument passed to <paramref name="beginMethod" /> delegate.</typeparam>
+        /// <typeparam name="TArg3">The type of the first argument passed to the <paramref name="beginMethod" /> delegate.</typeparam>
+        /// <typeparam name="TResult">The type of the result in the task returned from this operation.</typeparam>
+        /// <returns>The created task that represents the asynchronous operation.</returns>
+        /// <exception cref="System.ArgumentNullException">The <paramref name="beginMethod" /> argument is <see langword="null" />.-or-The <paramref name="endMethod" /> argument is <see langword="null" />.</exception>
+        internal Task<TResult> FromAsync<TArg1, TArg2, TArg3, TResult>(
+            Func<TArg1, TArg2, TArg3, AsyncCallback, object, IAsyncResult> beginMethod,
+            Func<IAsyncResult, TResult> endMethod,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3,
+            CancellationToken cancellationToken)
+        {
+            return Task<TResult>.Factory.FromAsync(
+                (a1, a2, a3, callback, state) =>
+                {
+                    IAsyncResult asyncResult = beginMethod(a1, a2, a3, callback, state);
+                    cancellationToken.Register(() => this.CancelRequest(asyncResult));
+                    cancellationToken.ThrowIfCancellationRequested();
+                    return asyncResult;
+                },
+                endMethod,
+                arg1,
+                arg2,
+                arg3,
+                state: null);
+        }
+
+        #endregion
+
         /// <summary>
         /// Get the bound <see cref="IEdmOperation"/> or <see cref="IEdmOperationImport"/> according to the client MethodInfo.
         /// </summary>
@@ -2560,9 +2840,23 @@ namespace Microsoft.OData.Client
         /// <returns>An instance of <see cref="Microsoft.OData.Client.QueryOperationResponse{T}" /> that contains the results of the last page request.</returns>
         internal Task<QueryOperationResponse> LoadPropertyAllPagesAsync(object entity, string propertyName)
         {
-            var currentTask = Task<QueryOperationResponse>.Factory.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, null);
-            var nextTask = currentTask.ContinueWith(t => this.ContinuePage(t.Result, entity, propertyName));
-            return nextTask;
+            return LoadPropertyAllPagesAsync(entity, propertyName, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously loads all pages of related entities for a specified property from the data service.
+        /// </summary>
+        /// <param name="entity">The entity that contains the property to load.</param>
+        /// <param name="propertyName">The name of the property of the specified entity to load.</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        /// <returns>An object representing an asynchronous operation resulting in an instance of <see cref="T:Microsoft.OData.Client.QueryOperationResponse`1" /> that contains the results of the last page request.</returns>
+        internal Task<QueryOperationResponse> LoadPropertyAllPagesAsync(object entity, string propertyName, CancellationToken cancellationToken)
+        {
+            var currentTask = this.FromAsync(this.BeginLoadProperty, this.EndLoadProperty, entity, propertyName, cancellationToken);
+
+            return currentTask.ContinueWith(
+                t => ContinuePageAsync(t.Result, entity, propertyName, cancellationToken),
+                cancellationToken).Unwrap();
         }
 
 #if !PORTABLELIB
@@ -2949,6 +3243,24 @@ namespace Microsoft.OData.Client
             }
 
             return response;
+        }
+
+        private Task<QueryOperationResponse> ContinuePageAsync(QueryOperationResponse response, object entity, string propertyName, CancellationToken cancellationToken)
+        {
+            var continuation = response.GetContinuation();
+            if (continuation != null)
+            {
+                IAsyncResult beginLoadPropertyResult = this.BeginLoadProperty(entity, propertyName, continuation, null, null);
+                cancellationToken.Register(() => this.CancelRequest(beginLoadPropertyResult));
+                var currentTask = Task<QueryOperationResponse>.Factory.FromAsync(beginLoadPropertyResult, this.EndLoadProperty);
+
+                return currentTask.ContinueWith(
+                    t => this.ContinuePageAsync(t.Result, entity, propertyName, cancellationToken), cancellationToken).Unwrap();
+            }
+
+            var taskSource = new TaskCompletionSource<QueryOperationResponse>();
+            taskSource.SetResult(response);
+            return taskSource.Task;
         }
 
         /// <summary

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -13,6 +13,7 @@ namespace Microsoft.OData.Client
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -219,7 +220,15 @@ namespace Microsoft.OData.Client
         /// <returns>A task that represents an <see cref="System.Collections.Generic.IEnumerable{T}" />  that contains the results of the query operation.</returns>
         public virtual new Task<IEnumerable<TElement>> ExecuteAsync()
         {
-            return Task<IEnumerable<TElement>>.Factory.FromAsync(this.BeginExecute, this.EndExecute, null);
+            return ExecuteAsync(CancellationToken.None);
+        }
+
+        /// <summary>Starts an asynchronous network operation that executes the query represented by this object instance.</summary>
+        /// <returns>A task that represents an <see cref="System.Collections.Generic.IEnumerable{T}" />  that contains the results of the query operation.</returns>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual new Task<IEnumerable<TElement>> ExecuteAsync(CancellationToken cancellationToken)
+        {
+            return this.Context.FromAsync(this.BeginExecute, this.EndExecute, cancellationToken);
         }
 
         /// <summary>Ends an asynchronous query request to a data service.</summary>
@@ -244,8 +253,18 @@ namespace Microsoft.OData.Client
         /// <returns>A task that represents an <see cref="System.Collections.Generic.IEnumerable{T}" /> that contains the results of the query operation.</returns>
         public virtual Task<IEnumerable<TElement>> GetAllPagesAsync()
         {
-            var currentTask = Task<IEnumerable<TElement>>.Factory.FromAsync(this.BeginExecute, this.EndExecute, null);
-            var nextTask = currentTask.ContinueWith(t => this.ContinuePage(t.Result));
+            return GetAllPagesAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Asynchronously sends a request to get all items by auto iterating all pages
+        /// </summary>
+        /// <returns>A task that represents an <see cref="System.Collections.Generic.IEnumerable{T}" /> that contains the results of the query operation.</returns>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual Task<IEnumerable<TElement>> GetAllPagesAsync(CancellationToken cancellationToken)
+        {
+            var currentTask = this.Context.FromAsync(this.BeginExecute, this.EndExecute, cancellationToken);
+            var nextTask = currentTask.ContinueWith(t => this.ContinuePage(t.Result, cancellationToken), cancellationToken);
             return nextTask;
         }
 
@@ -466,7 +485,7 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="response">The response of the previous page</param>
         /// <returns>The items retrieved</returns>
-        private IEnumerable<TElement> ContinuePage(IEnumerable<TElement> response)
+        private IEnumerable<TElement> ContinuePage(IEnumerable<TElement> response, CancellationToken cancellationToken)
         {
             foreach (var element in response)
             {
@@ -476,9 +495,11 @@ namespace Microsoft.OData.Client
             var continuation = (response as QueryOperationResponse).GetContinuation() as DataServiceQueryContinuation<TElement>;
             if (continuation != null)
             {
-                var currentTask = Task<IEnumerable<TElement>>.Factory.FromAsync(this.Context.BeginExecute(continuation, null, null), this.Context.EndExecute<TElement>);
-                var nextTask = currentTask.ContinueWith(t => this.ContinuePage(t.Result));
-                nextTask.Wait();
+                var asyncResult = this.Context.BeginExecute(continuation, null, null);
+                cancellationToken.Register(() => this.Context.CancelRequest(asyncResult));
+                var currentTask = Task<IEnumerable<TElement>>.Factory.FromAsync(asyncResult, this.Context.EndExecute<TElement>);
+                var nextTask = currentTask.ContinueWith(t => ContinuePage(t.Result, cancellationToken), cancellationToken);
+                nextTask.Wait(cancellationToken);
                 foreach (var element in nextTask.Result)
                 {
                     yield return element;

--- a/src/Microsoft.OData.Client/DataServiceQuerySingleOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQuerySingleOfT.cs
@@ -9,6 +9,7 @@ namespace Microsoft.OData.Client
     using System;
     using System.Linq;
     using System.Linq.Expressions;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -160,7 +161,15 @@ namespace Microsoft.OData.Client
         /// <returns>A task that represents the result of the query operation.</returns>
         public virtual Task<TElement> GetValueAsync()
         {
-            return Task<TElement>.Factory.FromAsync(this.BeginGetValue, this.EndGetValue, null);
+            return GetValueAsync(CancellationToken.None);
+        }
+
+        /// <summary>Starts an asynchronous network operation that executes the query represented by this object instance.</summary>
+        /// <returns>A task that represents the result of the query operation.</returns>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public virtual Task<TElement> GetValueAsync(CancellationToken cancellationToken)
+        {
+            return this.Context.FromAsync(this.BeginGetValue, this.EndGetValue, cancellationToken);
         }
 
         /// <summary>Ends an asynchronous query request to a data service.</summary>

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/CancellationTokenTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/CancellationTokenTests.cs
@@ -1,0 +1,232 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CancellationTokenTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.OData.Client;
+    using Microsoft.Test.OData.Services.TestServices;
+    using Microsoft.Test.OData.Services.TestServices.AstoriaDefaultServiceReference;
+    using Xunit;
+    using Xunit.Abstractions;
+
+    /// <summary>
+    /// CancellationToken tests using asynchronous APIs
+    /// </summary>
+    public class CancellationTokenTests : EndToEndTestBase
+    {
+        public CancellationTokenTests(ITestOutputHelper helper)
+            : base(ServiceDescriptors.AstoriaDefaultService, helper)
+        {
+        }
+
+        [Fact, Asynchronous]
+        public async Task SaveChangesAsyncCancellationTokenTest()
+        {
+            var source = new CancellationTokenSource();
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            Customer c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+            context.AddToCustomer(c1);
+
+            Task response() => context.SaveChangesAsync(source.Token);
+            source.Cancel();
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+            Assert.Equal("The operation was canceled.", exception.Message);
+
+            // SaveChangesAsync with SaveChangesOptions
+            Customer c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
+            Customer c3 = new Customer { CustomerId = 33, Name = "customerThree" };
+            context.AddToCustomer(c2);
+            context.AddToCustomer(c3);
+
+            Task response2() => context.SaveChangesAsync(SaveChangesOptions.BatchWithIndependentOperations, source.Token);
+            source.Cancel();
+            var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
+            Assert.Equal("The operation was canceled.", exception2.Message);
+
+            this.EnqueueTestComplete();
+        }
+
+        [Fact, Asynchronous]
+        public async Task GetValueAsyncCancellationTokenTest()
+        {
+            var source = new CancellationTokenSource();
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            Customer c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+            context.AddToCustomer(c1);
+            await context.SaveChangesAsync();
+
+            Task response() => context.Customer.ByKey(11).GetValueAsync(source.Token);
+            source.Cancel();
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+            Assert.Equal("The operation was canceled.", exception.Message);
+
+            this.EnqueueTestComplete();
+        }
+
+        [Fact, Asynchronous]
+        public async Task ExecuteAsyncCancellationTokenTest()
+        {
+            var source = new CancellationTokenSource();
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            Customer c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+            context.AddToCustomer(c1);
+            Customer c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
+            context.AddToCustomer(c2);
+            await context.SaveChangesAsync();
+
+            Task response() => context.Customer.ExecuteAsync(source.Token);
+            source.Cancel();
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+            Assert.Equal("The operation was canceled.", exception.Message);
+
+            // ExecuteAsync by continuation
+            var customers = (await context.Customer.ExecuteAsync()) as QueryOperationResponse<Customer>;
+            var count = customers.Count(); // continuation is only available when the result has been enumerated. Hence we call Count()
+            var continuation = customers.GetContinuation();
+
+            Task response2() => context.ExecuteAsync(continuation, source.Token);
+            source.Cancel();
+            var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
+            Assert.Equal("The operation was canceled.", exception2.Message);
+
+            // ExecuteAsync by nextLink
+            var customers2 = (await context.Customer.ExecuteAsync()) as QueryOperationResponse<Customer>;
+            var count2 = customers2.Count(); // continuation is only available when the result has been enumerated. Hence we call Count()
+            var continuation2 = (customers2 as QueryOperationResponse<Customer>).GetContinuation();
+
+            Task response3() => context.ExecuteAsync<Customer>(continuation2.NextLinkUri, source.Token);
+            source.Cancel();
+            var exception3 = await Assert.ThrowsAsync<OperationCanceledException>(response3);
+            Assert.Equal("The operation was canceled.", exception3.Message);
+
+            this.EnqueueTestComplete();
+        }
+
+        [Fact, Asynchronous]
+        public async Task GetAllPagesAsyncCancellationTokenTest()
+        {
+            var source = new CancellationTokenSource();
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            Customer c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+            context.AddToCustomer(c1);
+            Customer c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
+            context.AddToCustomer(c2);
+            await context.SaveChangesAsync();
+
+            Task response() => context.Customer.GetAllPagesAsync(source.Token);
+            source.Cancel();
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+            Assert.Equal("The operation was canceled.", exception.Message);
+
+            this.EnqueueTestComplete();
+        }
+
+        [Fact, Asynchronous]
+        public async Task LoadPropertyAsyncCancellationTokenTest()
+        {
+            var source = new CancellationTokenSource();
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            context.MergeOption = MergeOption.OverwriteChanges;
+            Customer c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+            context.AddToCustomer(c1);
+            await context.SaveChangesAsync();
+
+            for (int i = 1; i <= 9; i++)
+            {
+                Order order = new Order() { OrderId = 1000 + i };
+                context.AddToOrder(order);
+                context.AddLink(c1, "Orders", order);
+            }
+
+            await context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset);
+
+            Task response() => context.LoadPropertyAsync(c1, "Orders", source.Token);
+            source.Cancel();
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+            Assert.Equal("The operation was canceled.", exception.Message);
+
+            //Get Entity by DataServiceQuery.ExecuteAsync
+            var resp = (await ((DataServiceQuery<Customer>)(context.Customer.Expand(c => c.Orders).Where(c => c.CustomerId == 11))).ExecuteAsync()) as QueryOperationResponse<Customer>;
+            var customer = resp.First();
+
+            //Load navigation property by using continuation
+            var continuation = resp.GetContinuation(customer.Orders);
+            Task response2() => context.LoadPropertyAsync(customer, "Orders", continuation, source.Token);
+            source.Cancel();
+            var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
+            Assert.Equal("The operation was canceled.", exception2.Message);
+
+            Task response3() => context.LoadPropertyAsync(customer, "Orders", continuation.NextLinkUri, source.Token);
+            source.Cancel();
+            var exception3 = await Assert.ThrowsAsync<OperationCanceledException>(response3);
+            Assert.Equal("The operation was canceled.", exception3.Message);
+
+            this.EnqueueTestComplete();
+        }
+
+        [Fact]
+        public async Task GetReadStreamAsyncCancellationTokenTest()
+        {
+            var source = new CancellationTokenSource();
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            var car = new Car { VIN = 1000 };
+            context.AddToCar(car);
+
+            var mediaEntry = new MemoryStream(new byte[] { 64, 65, 66 });
+
+            context.SetSaveStream(car, mediaEntry, true, "image/png", "UnitTestLogo.png");
+            await context.SaveChangesAsync();
+
+            Task response() => context.GetReadStreamAsync(car, new DataServiceRequestArgs(), source.Token);
+            source.Cancel();
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+            Assert.Equal("The operation was canceled.", exception.Message);
+
+            mediaEntry = new MemoryStream(new byte[] { 64, 65, 66 });
+            context.SetSaveStream(car, "Photo", mediaEntry, true, new DataServiceRequestArgs { ContentType = "application/binary" });
+            await context.SaveChangesAsync();
+
+            Task response2() => context.GetReadStreamAsync(car, "Photo", new DataServiceRequestArgs { AcceptContentType = "application/binary" }, source.Token);
+            source.Cancel();
+            var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
+            Assert.Equal("The operation was canceled.", exception.Message);
+
+            this.EnqueueTestComplete();
+        }
+
+        [Fact, Asynchronous]
+        public async Task ExecuteBatchAsyncCancellationTokenTest()
+        {
+            var source = new CancellationTokenSource();
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            Customer c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+            context.AddToCustomer(c1);
+            Customer c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
+            context.AddToCustomer(c2);
+            await context.SaveChangesAsync();
+
+            Task response() => context.ExecuteBatchAsync(
+                SaveChangesOptions.BatchWithIndependentOperations | SaveChangesOptions.UseRelativeUri,
+                source.Token,
+                new DataServiceRequest[]
+                {
+                    new DataServiceRequest<Customer>(((context.Customer.Where(c => c.CustomerId == 11)) as DataServiceQuery<Customer>).RequestUri),
+                    new DataServiceRequest<Customer>(((context.Customer.Where(c => c.CustomerId == 22)) as DataServiceQuery<Customer>).RequestUri)
+                });
+
+            source.Cancel();
+            var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+            Assert.Equal("The operation was canceled.", exception.Message);
+
+            this.EnqueueTestComplete();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/Microsoft.Test.OData.Tests.Client.csproj
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/Microsoft.Test.OData.Tests.Client.csproj
@@ -81,6 +81,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>ODataT4CodeGenerator.tt</DependentUpon>
     </Compile>
+    <Compile Include="CancellationTokenTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="ODataItemWrapper.cs" />
     <Compile Include="ODataNestedResourceInfoWrapper.cs" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1316*
Original PR #1317

### Description

*Briefly describe the changes of this pull request.*
Add `CancellationToken` overloads to the Async Task-based programming model methods. When a cancel is signaled on the token, the request will be canceled through the source `DataServiceContext`.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
