### PR TITLE
Add setting to control RawValueWriter's line ending

### DIFF
--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -77,6 +77,7 @@ namespace Microsoft.OData
             this.Validations = ValidationKinds.All;
             this.Validator = new WriterValidator(this);
             this.LibraryCompatibility = ODataLibraryCompatibility.Latest;
+            this.MultipartNewLine = "\r\n";
         }
 
         /// <summary>
@@ -180,6 +181,13 @@ namespace Microsoft.OData
         /// Informs the metadata builder which properties, functions, actions, links to omit.
         /// </summary>
         public ODataMetadataSelector MetadataSelector { get; set; }
+
+        /// <summary>
+        /// Gets or sets the new line character sequence used when writing multipart messages
+        /// see https://tools.ietf.org/html/rfc2046#section-5.1.1
+        /// A TextWriter uses OS specific newline but rfc2046 requires it to be CRLF.
+        /// </summary>
+        public string MultipartNewLine { get; set; }
 
         /// <summary>
         /// Gets the validator corresponding to the validation settings.

--- a/src/Microsoft.OData.Core/RawValueWriter.cs
+++ b/src/Microsoft.OData.Core/RawValueWriter.cs
@@ -173,8 +173,8 @@ namespace Microsoft.OData
             {
                 nonDisposingStream = MessageStreamWrapper.CreateNonDisposingStream(this.stream);
             }
-
-            this.textWriter = new StreamWriter(nonDisposingStream, this.encoding);
+            
+            this.textWriter = new StreamWriter(nonDisposingStream, this.encoding) { NewLine = this.settings.MultipartNewLine };
             this.jsonWriter = new JsonWriter(this.textWriter, isIeee754Compatible: false);
         }
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue https://github.com/OData/odata.net/issues/1842 .

### Description

By default RawValueWriter create a TextWriter with the standard line ending which is OS specific.
RFC2064 requires this to be CRLF  https://tools.ietf.org/html/rfc2046#section-5.1.1
Added setting to ODataMessageWriterSettings to control how RawValueWriter creates the underlying TextWriter.


### Checklist 

- [ ] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

none
