### PR TITLE
Removed the unnecessary string allocations from hot path in JsonReader.

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -720,7 +720,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Append everything up to the \ character to the value.
-                    valueBuilder.Append(this.ConsumeTokenToString(currentCharacterTokenRelativeIndex));
+                    this.ConsumeTokenAppendToBuilder(valueBuilder, currentCharacterTokenRelativeIndex);
                     currentCharacterTokenRelativeIndex = 0;
                     Debug.Assert(this.characterBuffer[this.tokenStartIndex] == '\\', "We should have consumed everything up to the escape character.");
 
@@ -782,18 +782,21 @@ namespace Microsoft.OData.Json
                 else if (character == openingQuoteCharacter)
                 {
                     // Consume everything up to the quote character
-                    string result = this.ConsumeTokenToString(currentCharacterTokenRelativeIndex);
+                    string result;
+                    if (valueBuilder != null)
+                    {
+                        this.ConsumeTokenAppendToBuilder(valueBuilder, currentCharacterTokenRelativeIndex);
+                        result = valueBuilder.ToString();
+                    }
+                    else
+                    {
+                        result = this.ConsumeTokenToString(currentCharacterTokenRelativeIndex);
+                    }
+
                     Debug.Assert(this.characterBuffer[this.tokenStartIndex] == openingQuoteCharacter, "We should have consumed everything up to the quote character.");
 
                     // Consume the quote character as well.
                     this.tokenStartIndex++;
-
-                    if (valueBuilder != null)
-                    {
-                        valueBuilder.Append(result);
-                        result = valueBuilder.ToString();
-                    }
-
                     return result;
                 }
                 else
@@ -1226,6 +1229,21 @@ namespace Microsoft.OData.Json
             this.tokenStartIndex += characterCount;
 
             return result;
+        }
+
+        /// <summary>
+        /// Consumes the <paramref name="characterCount"/> characters starting at the start of the token
+        /// and append the token string to the <paramref name="builder"/>.
+        /// </summary>
+        /// <param name="characterCount">The number of characters after the token start to consume.</param>
+        /// <param name="builder">The StringBuilder instance to append the token to.</param>
+        private void ConsumeTokenAppendToBuilder(StringBuilder builder, int characterCount)
+        {
+            Debug.Assert(characterCount >= 0, "characterCount >= 0");
+            Debug.Assert(this.tokenStartIndex + characterCount <= this.storedCharacterCount, "characterCount specified characters outside of the available range.");
+
+            builder.Append(this.characterBuffer, this.tokenStartIndex, characterCount);
+            this.tokenStartIndex += characterCount;
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This PR resolves #1845 

### Description

Directly copy characters from source string to the StringBuilder without an extra allocation.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
