### PR TITLE
Hotfix for the infinite loop if structured type has property which type is the declaring type

### DIFF
--- a/src/Microsoft.OData.Core/UrlValidation/ODataUrlValidationContext.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ODataUrlValidationContext.cs
@@ -26,6 +26,11 @@ namespace Microsoft.OData.UriParser.Validation
         public IEdmModel Model { get; private set; }
 
         /// <summary>
+        /// The validated types associated with this validation context.
+        /// </summary>
+        internal ISet<IEdmType> ValidatedTypes { get; }
+
+        /// <summary>
         /// The ODataUrlValidator associated with this validation context.
         /// </summary>
         internal ODataUrlValidator UrlValidator { get; private set; }
@@ -52,6 +57,7 @@ namespace Microsoft.OData.UriParser.Validation
             this.UrlValidator = urlValidator;
             this.ExpressionValidator = new ExpressionValidator((item) => urlValidator.ValidateItem(item, this));
             this.PathValidator = new PathSegmentValidator(this);
+            this.ValidatedTypes = new HashSet<IEdmType>();
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/ODataUrlValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/ODataUrlValidator.cs
@@ -413,14 +413,20 @@ namespace Microsoft.OData.UriParser.Validation
         // Validate all structured properties of a type, recursing through nested complex typed properties
         private void ValidateProperties(IEdmType edmType, ODataUrlValidationContext context)
         {
-            IEdmStructuredType structuredType = edmType as IEdmStructuredType;
-            if (structuredType != null)
+            // true if the element is added to the set; false if the element is already in the set.
+            if (context.ValidatedTypes.Add(edmType))
             {
-                foreach (IEdmProperty property in structuredType.StructuralProperties())
+                IEdmStructuredType structuredType = edmType as IEdmStructuredType;
+                if (structuredType != null)
                 {
-                    ValidateItem(property, context, /* impliedProperty */ true);
-                    ValidateItem(property.Type.Definition.AsElementType(), context, /* impliedProperty */ true);
-                    ValidateProperties(property.Type.Definition.AsElementType(), context);
+                    foreach (IEdmProperty property in structuredType.StructuralProperties())
+                    {
+                        IEdmType elementType = property.Type.Definition.AsElementType();
+
+                        ValidateItem(property, context, /* impliedProperty */ true);
+                        ValidateItem(elementType, context, /* impliedProperty */ true);
+                        ValidateProperties(elementType, context);
+                    }
                 }
             }
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UrlValidation/DeprecationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UrlValidation/DeprecationTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.OData.Tests
         private static IEdmModel model;
 
         [Theory]
-        [InlineData(@"company", "name","state")]
+        [InlineData(@"company", "name", "state")]
         [InlineData(@"company/employees", "employees")]
         [InlineData(@"competitors", "competitors", "name", "state")]
         [InlineData(@"company/address", "state")]
@@ -31,7 +31,7 @@ namespace Microsoft.OData.Tests
         [InlineData(@"company/address?$select=state", "state")]
         [InlineData(@"company?$expand=employees", "name", "state", "employees")]
         [InlineData(@"company?$select=name", "name")]
-        [InlineData(@"competitors?$filter=contains(name,'sprocket')", "competitors", "name","state","name")]
+        [InlineData(@"competitors?$filter=contains(name,'sprocket')", "competitors", "name", "state", "name")]
         public static void WithDeprecatedElementsGeneratesErrors(String request, params string[] expectedErrors)
         {
             string expectedDateAsString = "2020-03-30";
@@ -108,6 +108,7 @@ namespace Microsoft.OData.Tests
     <Schema xmlns = ""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Jetsons.Models"">
       <ComplexType Name = ""address"" >
         <Property Name=""city"" Type=""Edm.String""/>
+        <Property Name=""subAddress"" Type=""Jetsons.Models.address""/>
         <Property Name = ""state"" Type=""Edm.String"">
           <Annotation Term = ""Core.Revisions"" >
             <Collection>


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

The Url validation will go into Infinite loop if a structured type has the property which type is the declaring type.
Below is the call stack.

```C#
0000009d`e1986640 00007ffe`1300edc0 System_Core_ni!System.Collections.Generic.HashSet_1[[System.__Canon,_mscorlib]].SetCapacity+0x40
0000009d`e19866b0 00007ffe`1300eb72 System_Core_ni!System.Collections.Generic.HashSet_1[[System.__Canon,_mscorlib]].AddIfNotPresent+0x152
0000009d`e1986730 00007ffd`b90e99b0 Microsoft_OData_Core!Microsoft.OData.UriParser.Validation.ODataUrlValidator.ValidateTypeHierarchy+0xf0
0000009d`e19867c0 00007ffd`b90eb837 Microsoft_OData_Core!Microsoft.OData.UriParser.Validation.ODataUrlValidator.ValidateProperties+0x1a7
0000009d`e1986840 00007ffd`b90eb871 Microsoft_OData_Core!Microsoft.OData.UriParser.Validation.ODataUrlValidator.ValidateProperties+0x1e1
0000009d`e19868c0 00007ffd`b90eb871 Microsoft_OData_Core!Microsoft.OData.UriParser.Validation.ODataUrlValidator.ValidateProperties+0x1e1
```

This PR is the hot fix to fix it.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
