### PR TITLE
Remove unnecessary lock in EdmStructuredType

### DIFF
--- a/ODataLib/EdmLib/Desktop/.Net4.0/Microsoft/Data/Edm/Library/EdmStructuredType.cs
+++ b/ODataLib/EdmLib/Desktop/.Net4.0/Microsoft/Data/Edm/Library/EdmStructuredType.cs
@@ -30,11 +30,6 @@ namespace Microsoft.Data.Edm.Library
     /// </summary>
     public abstract class EdmStructuredType : EdmType, IEdmStructuredType
     {
-        /// <summary>
-        /// The lock used when accessing the internal cached properties.
-        /// </summary>
-        protected readonly object LockObj = new object();
-
         private readonly IEdmStructuredType baseStructuredType;
         private readonly List<IEdmProperty> declaredProperties = new List<IEdmProperty>();
         private readonly bool isAbstract;
@@ -96,10 +91,7 @@ namespace Microsoft.Data.Edm.Library
         {
             get
             {
-                lock (LockObj)
-                {
-                    return this.propertiesDictionary.GetValue(this, ComputePropertiesDictionaryFunc, null);
-                }
+                return this.propertiesDictionary.GetValue(this, ComputePropertiesDictionaryFunc, null);
             }
         }
 
@@ -119,10 +111,7 @@ namespace Microsoft.Data.Edm.Library
 
             this.declaredProperties.Add(property);
 
-            lock (LockObj)
-            {
-                this.propertiesDictionary.Clear(null);
-            }
+            this.propertiesDictionary.Clear(null);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

* This pull request fixes issue #1807 

### Description

Removes the lock object (and usage of it) in EdmStructuredType for Microsoft.Data.Edm 5.x to bring it in line with the implementation in Microsoft.OData.Edm 6.x and up. See issue #1807 for more details.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

* Release of Microsoft.Data.Edm 5.8.5 with this fix
