### PR TITLE
Group by on a date(System.DateTime) results in an exception

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonWriterExtensions.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterExtensions.cs
@@ -153,6 +153,13 @@ namespace Microsoft.OData.Json
                 return;
             }
 
+            if (value is DateTime)
+            {
+                Date dt = (DateTime)value;
+                jsonWriter.WriteValue((Date)dt);
+                return;
+            }
+            
             throw new ODataException(ODataErrorStrings.ODataJsonWriter_UnsupportedValueType(value.GetType().FullName));
         }
 

--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -601,6 +601,11 @@ namespace Microsoft.OData.Metadata
                 return true;
             }
 
+            if (clrType == typeof(DateTime))
+            {
+                return PrimitiveTypeReferenceMap.ContainsKey(typeof(Date));
+            }
+
             return PrimitiveTypeReferenceMap.ContainsKey(clrType) || typeof(ISpatial).IsAssignableFrom(clrType);
         }
 
@@ -1469,6 +1474,12 @@ namespace Microsoft.OData.Metadata
             IEdmPrimitiveTypeReference primitiveTypeReference;
             if (PrimitiveTypeReferenceMap.TryGetValue(clrType, out primitiveTypeReference))
             {
+                return primitiveTypeReference;
+            }
+
+            if (clrType == typeof(DateTime))
+            { 
+                primitiveTypeReference = ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Date), false);
                 return primitiveTypeReference;
             }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -137,6 +137,12 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void WriteUnSupportedPrimitiveValueDateTime()
+        {
+            this.VerifyWritePrimitiveValue(new DateTime(2020, 5, 1), "\"2020-05-01\"");
+        }
+
+        [Fact]
         public void WritePrimitiveValueGuid()
         {
             this.VerifyWritePrimitiveValue(new Guid("00000012-0000-0000-0000-012345678900"), "\"00000012-0000-0000-0000-012345678900\"");


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1874 *

### Description

OData doesn't include DateTime as a primitive type.  If a user defines a model as 
<pre>
public class Customer
{
    public int Id { get; set; }
    public DateTime Birthday { get; set; }
}
</pre>

then uses the <code> AsDate()</code> method to translate the DateTime field to <code> Edm.Date</code> as explained here https://docs.microsoft.com/en-us/odata/webapi/date-timeofday-with-entity-framework,<code> Microsoft.OData.Core</code> throws an exception that the primitive type (System.DateTime) is unsupported. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
