### PR TITLE
Fix issue #1883, MultipartMixed grows cache indefinitely

### DIFF
--- a/src/Microsoft.OData.Core/MediaTypeUtils.cs
+++ b/src/Microsoft.OData.Core/MediaTypeUtils.cs
@@ -414,6 +414,15 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Internal method for testing membership of the cache
+        /// </summary>
+        /// <returns>The ContentTypes in the cache in the MediaInfoCache</returns>
+        internal static IEnumerable<string> GetCacheKeys()
+        {
+            return MatchInfoCache.GetKeys();
+        }
+
+        /// <summary>
         /// Parses the specified content type header into a media type instance.
         /// </summary>
         /// <param name="contentTypeHeader">The content type header to parse.</param>
@@ -924,7 +933,7 @@ namespace Microsoft.OData
             /// <summary>
             /// Name of content type.
             /// </summary>
-            private string ContentTypeName { get; set; }
+            internal string ContentTypeName { get; set; }
 
             /// <summary>
             /// Returns a value indicating whether this instance is equal to a specified object.
@@ -1038,6 +1047,15 @@ namespace Microsoft.OData
                     this.dict.Clear();
                     this.dict.TryAdd(key, value);
                 }
+            }
+
+            /// <summary>
+            /// Internal method for validating expected elements in the cache
+            /// </summary>
+            /// <returns>ContentType of items in the cache</returns>
+            internal IEnumerable<string> GetKeys()
+            {
+                return this.dict.Keys.Select(k => k.ContentTypeName);
             }
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/MediaTypeUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/MediaTypeUtilsTests.cs
@@ -434,6 +434,20 @@ namespace Microsoft.OData.Tests
             Action target = () => MediaTypeUtils.AlterContentTypeForJsonPadding(original);
             target.Throws<ODataException>(Strings.ODataMessageWriter_JsonPaddingOnInvalidContentType("tricky/application/json"));
         }
+
+        [Fact]
+        public void MultipartBoundariesShouldNotGrowCache()
+        {
+            for (int i = 1; i < 100; i++)
+            {
+                ODataMediaType mediaType;
+                Encoding encoding;
+                ODataPayloadKind payloadKind;
+                MediaTypeUtils.GetFormatFromContentType(string.Format("multipart/mixed;boundary={0}", Guid.NewGuid()), new ODataPayloadKind[] { ODataPayloadKind.Batch }, ODataMediaTypeResolver.GetMediaTypeResolver(null), out mediaType, out encoding, out payloadKind);
+            }
+
+            Assert.True(MediaTypeUtils.GetCacheKeys().Count(k => k.StartsWith("multipart/mixed")) == 1, "Multiple multipart/mixed keys in cache");
+        }
     }
 
     internal class TestMediaTypeWithFormat


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes issue #1883

### Description

The process of matching a formatter to a media type can be expensive, so we cache the results of a lookup in our MediaTypeCache.  Unfortunately, since the key for this cache is the content type, each new content type is a separate entry in the cache.

The multipart/mixed mime type, used for batch, has a required boundary parameter, expressed as part of the media type in the content-type header, which may be set to any random value.

Some clients have fixed values for these, but it's not uncommon to use a guid.

Because a guid makes each content-type unique, the cache size grows unbounded.

The boundary isn't needed to look up the formatter, so can safely be removed from the cache lookup key.

Also fixed apparent misunderstanding in the code of the size parameter passed to the concurrent dictionary constructor. It is not a max size, but an initial size for the cache.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
