### PR TITLE
Fix logic to validate URL segment by type

### DIFF
--- a/src/Microsoft.OData.Core/UrlValidation/Rules/DeprecationRules.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/Rules/DeprecationRules.cs
@@ -118,10 +118,6 @@ namespace Microsoft.OData.UriParser.Validation.Rules
             {
                 context.Messages.Add(CreateUrlValidationMessage(element.Name, message, version, date, removalDate));
             }
-            else if (IsDeprecated(context.Model, elementType, out message, out version, out date, out removalDate))
-            {
-                context.Messages.Add(CreateUrlValidationMessage(element.Name, message, version, date, removalDate));
-            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
@@ -271,7 +271,7 @@ namespace Microsoft.OData.UriParser.Validation.ValidationEngine
             IEdmCollectionType collectionType = segment.EdmType as IEdmCollectionType;
             if (collectionType != null)
             {
-                ValidateItem(collectionType.ElementType);
+                ValidateItem(collectionType.ElementType.Definition);
             }
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UrlValidation/DeprecationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UrlValidation/DeprecationTests.cs
@@ -25,6 +25,7 @@ namespace Microsoft.OData.Tests
         [Theory]
         [InlineData(@"company", "name", "state")]
         [InlineData(@"company/employees", "employees")]
+        [InlineData(@"company/employees(1)/vehicles", "employees", "vehicle")]
         [InlineData(@"competitors", "competitors", "name", "state")]
         [InlineData(@"company/address", "state")]
         [InlineData(@"company/address/state", "state")]
@@ -63,6 +64,9 @@ namespace Microsoft.OData.Tests
                 Assert.True(error.ExtendedProperties.TryGetValue("RemovalDate", out removalDate)); 
                 object version;
                 Assert.True(error.ExtendedProperties.TryGetValue("Version", out version));
+
+                string elementNameAsString = elementName as string;
+                elementName =elementNameAsString.Substring(elementNameAsString.LastIndexOf('.') + 1);
 
                 Assert.Contains(elementName as string, expectedErrors);
                 Assert.Equal(date as Date?, expectedDate);
@@ -168,6 +172,25 @@ namespace Microsoft.OData.Tests
         <Property Name = ""firstName"" Type=""Edm.String""/>
         <Property Name = ""lastName"" Type=""Edm.String""/>
         <Property Name = ""title"" Type=""Edm.String""/>
+        <NavigationProperty Name = ""vehicles"" Type=""Collection(Jetsons.Models.vehicle)"" ContainsTarget=""true""/>
+     </EntityType>
+      <EntityType Name = ""vehicle"" >
+        <Key>
+          <PropertyRef Name=""license""/>
+        </Key>
+        <Property Name = ""license"" Type=""Edm.String"" Nullable=""false""/>
+        <Property Name = ""model"" Type=""Edm.String""/>
+        <Annotation Term = ""Core.Revisions"" >
+            <Collection>
+                <Record>
+                <PropertyValue Property=""Date"" Date=""2020-03-30""/>
+                <PropertyValue Property=""RemovalDate"" Date=""2022-03-30""/>
+                <PropertyValue Property=""Version"" String=""2020-03-30""/>
+                <PropertyValue Property = ""Kind"" EnumMember=""RevisionKind/Deprecated""/>
+                <PropertyValue Property = ""Description"" String=""'vehicle' is deprecated and will be retired on 2022-03-30.""/>
+                </Record>
+            </Collection>
+        </Annotation>
       </EntityType>
       <Action Name = ""ResetDataSource"" />
       <EntityContainer Name=""Container"">
@@ -192,4 +215,3 @@ namespace Microsoft.OData.Tests
 </edmx:Edmx>";
     }
 }
-


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1890.*

### Description

When validating a segment, we also validate the type. However, if the type of the segment is a collection, we pass the typereference, rather than the type.

Because this resulted in not validating the type for a collection-valued navigation property in the path, the DeprecationRule had logic to explicitly validate the type of the segment being validated.

For navigation property segments, the validator validates both the navigation property and the navigation source, so the deprecation rule gets called twice (once for the navigation property and once for the navigation source).

Which is fine, except that the deprecation rule had explicit logic to also validate the type, which is the same for the navigation property and the navigation source, so the rule was called twice and two messages were logged.

The fix is to:
1) Fix handling within the ODataUriValidator to pass the EdmType, rather than the EdmTypeReference, in the case of a collection-valued segment.
2) Remove the logic from the deprecation rule to separately validate the type
3) Also removed a redundant check for used types. 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
