### PR TITLE
Inconsistencies when query options are applied to edm function results

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -834,6 +834,7 @@ namespace Microsoft.OData
         internal const string JsonReaderExtensions_UnexpectedInstanceAnnotationName = "JsonReaderExtensions_UnexpectedInstanceAnnotationName";
         internal const string BufferUtils_InvalidBufferOrSize = "BufferUtils_InvalidBufferOrSize";
         internal const string ServiceProviderExtensions_NoServiceRegistered = "ServiceProviderExtensions_NoServiceRegistered";
+        internal const string NavigationSource_ShouldBeDefinedASAnEntitySet = "NavigationSource_ShouldBeDefinedASAnEntitySet";
 
         static TextRes loader = null;
         ResourceManager resources;

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -788,6 +788,7 @@ ExpandItemBinder_PropertyIsNotANavigationPropertyOrComplexProperty=Property '{0}
 ExpandItemBinder_TypeSegmentNotFollowedByPath=Found a path within a select or expand query option that isn't ended by a non-type segment.
 ExpandItemBinder_PathTooDeep=Trying to parse a type segment path that is too long.
 ExpandItemBinder_TraversingMultipleNavPropsInTheSamePath=Found a path traversing multiple navigation properties. Please rephrase the query such that each expand path contains only type segments and navigation properties.
+NavigationSource_ShouldBeDefinedASAnEntitySet=The navigation source should be set as an entity set.
 ExpandItemBinder_LevelsNotAllowedOnIncompatibleRelatedType=The $level option on navigation property '{0}' is not allowed, because the related entity type '{1}' could not be cast to source entity type '{2}'.
 ExpandItemBinder_InvaidSegmentInExpand=Segment '{0}' is not valid in expand path. Before navigation property, only type segment or entity or complex property can exist.
 

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -5936,6 +5936,17 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The navigation source should be set as an entity set."
+        /// </summary>
+        internal static string NavigationSource_ShouldBeDefinedASAnEntitySet
+        {
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.NavigationSource_ShouldBeDefinedASAnEntitySet);
+            }
+        }
+
+        /// <summary>
         /// A string like "The $level option on navigation property '{0}' is not allowed, because the related entity type '{1}' could not be cast to source entity type '{2}'."
         /// </summary>
         internal static string ExpandItemBinder_LevelsNotAllowedOnIncompatibleRelatedType(object p0, object p1, object p2)

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -371,6 +371,10 @@ namespace Microsoft.OData.UriParser
                 IEdmPathExpression bindingPath;
                 targetNavigationSource = this.NavigationSource.FindNavigationTarget(currentNavProp, BindingPathHelper.MatchBindingPath, parsedPath, out bindingPath);
             }
+            else 
+            {
+                throw new ODataException(ODataErrorStrings.NavigationSource_ShouldBeDefinedASAnEntitySet);
+            }
 
             NavigationPropertySegment navSegment = new NavigationPropertySegment(currentNavProp, targetNavigationSource);
             pathSoFar.Add(navSegment);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

For an Edm function that returns a collection of entities, either of the following two configurations are required to support query options ($filter, $select, $orderby, $expand, etc) against the function results:

1. Explicitly surface the entity set that the returned entities belong to by adding the entity set to the entity container. E.g.:
```
<Function Name="KeyProjects" IsBound="true">
<Parameter Name="bindingParameter" Type="Collection(NS.Models.Project)"/>
<ReturnType Type="Collection(NS.Models.Project)"/>
</Function>
<EntityContainer Name="Container">
<EntitySet Name="Projects" EntityType="NS.Models.Project">
</EntitySet>
</EntityContainer>
```

2. Explicitly set the entity set path property of the Edm function. By setting the entity set path, you're specifying which entity set the returned entities should come from. Where the entity set path is set to the binding parameter, this signifies that the returned entities come from the same entity set as the bound entity. This information makes it possible to build urls by convention
```
<Function Name="KeyMilestones" IsBound="true" EntitySetPath="bindingParameter">
<Parameter Name="bindingParameter" Type="Collection(NS.Models.Project)"/>
<ReturnType Type="Collection(NS.Models.Project)"/>
</Function>
<EntityContainer Name="Container">
<EntitySet Name="Projects" EntityType="NS.Models.Project">
</EntitySet>
</EntityContainer>
```
From the Edm model builder, the first option is exercised by calling ActionConfiguration.ReturnsCollectionFromEntitySet method while the second option is exercised by calling ActionConfiguration.ReturnsCollectionViaEntitySetPath method

When neither of the above configurations are set, it would appear that we handle any query options applied to the returned entities inconsistently.
Consider the following Edm function:
```
<Function Name="KeyMilestones" IsBound="true">
<Parameter Name="bindingParameter" Type="Collection(NS.Models.Project)"/>
<ReturnType Type="Collection(NS.Models.Milestone)"/>
</Function>
<EntityContainer Name="Container">
<EntitySet Name="Projects" EntityType="NS.Models.Project">
</EntitySet>
</EntityContainer>
```
Note that the returned entities are of entity type Milestone. The EntitySetPath property of the Edm function is not set and the entity set that Milestone entity belongs to is not surfaced on the entity container.
FYI: When using the Edm model build you'd usually end up with the above Edm function definition if you use ActionConfiguration.ReturnsCollection method. Based on the docs, this method is actually intended for use with collection of either primitive or complex types - not entity types. However, it doesn't error when used with entity types.

When you apply various query options to the function results, the following inconsistent behaviours are observed:
Queries applied at top level
http://ServiceRoot/Projects/KeyMilestones?$select=Name - Works
http://ServiceRoot/Projects/KeyMilestones?$orderby=Name - Works
http://ServiceRoot/Projects/KeyMilestones?$top=1 - Works
http://ServiceRoot/Projects/KeyMilestones?$orderby=Name desc&$top=1 - Works
http://ServiceRoot/Projects/KeyMilestones?$orderby=Name desc&$skip=1&$top=1 - Works
http://ServiceRoot/Projects/KeyMilestones?$filter=Name eq 'Excavation' - Works
http://ServiceRoot/Projects/KeyMilestones?$expand=Tasks - Does not work... no exception is thrown
Queries applied at nested/expanded level
http://ServiceRoot/Projects/KeyMilestones?$expand=Tasks($select=Description) - Does not work... no exception thrown
http://ServiceRoot/Projects/KeyMilestones?$expand=Tasks($orderby=Description) - Does not work... ArgumentNullException thrown
http://ServiceRoot/Projects/KeyMilestones?$expand=Tasks($top=1) - Does not work... no exception thrown
http://ServiceRoot/Projects/KeyMilestones?$expand=Tasks($orderby=Name desc&$top=1) - Does not work... ArgumentNullException thrown
http://ServiceRoot/Projects/KeyMilestones?$expand=Tasks($orderby=Name desc&$skip=1&$top=1) - Does not work... ArgumentNullException thrown
http://ServiceRoot/Projects/KeyMilestones?$expand=Tasks($filter=contains(Description, 'Install')) - Does not work... ArgumentNullException thrown

The inconsistencies had misled ODL library users to believe that query options will work just okay against an Edm function that returns a collection of entities but doesn't have the required configurations as described above.

There are two issues here:
An ArgumentNullException is internal to ODL in this case and should not be surfaced to the libraries that use ODL. An ODataException should be thrown if necessary.
For those other scenarios where no exception is thrown but the correct behaviour /outcome is not achieved, an impression is created that the request was processed successfully. We end up hiding an underlying issue with the Edm function definition.
These two issues need to be addressed to achieve consistent and predictable behaviour


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
