### PR TITLE
Enable JSON metadata reader, writer in OData Core

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -78,8 +78,8 @@ namespace Microsoft.OData
         internal const string ODataException_GeneralError = "ODataException_GeneralError";
         internal const string ODataErrorException_GeneralError = "ODataErrorException_GeneralError";
         internal const string ODataUriParserException_GeneralError = "ODataUriParserException_GeneralError";
-        internal const string ODataUrlValidationError_SelectRequired = "ODataUrlValidationError_SelectRequired";
-        internal const string ODataUrlValidationError_InvalidRule = "ODataUrlValidationError_InvalidRule";
+        internal const string ODataUrlValidationError_SelectRequired  = "ODataUrlValidationError_SelectRequired ";
+        internal const string ODataUrlValidationError_InvalidRule  = "ODataUrlValidationError_InvalidRule ";
         internal const string ODataMessageWriter_WriterAlreadyUsed = "ODataMessageWriter_WriterAlreadyUsed";
         internal const string ODataMessageWriter_EntityReferenceLinksInRequestNotAllowed = "ODataMessageWriter_EntityReferenceLinksInRequestNotAllowed";
         internal const string ODataMessageWriter_ErrorPayloadInRequest = "ODataMessageWriter_ErrorPayloadInRequest";
@@ -400,6 +400,7 @@ namespace Microsoft.OData
         internal const string XmlReaderExtension_InvalidRootNode = "XmlReaderExtension_InvalidRootNode";
         internal const string ODataMetadataInputContext_ErrorReadingMetadata = "ODataMetadataInputContext_ErrorReadingMetadata";
         internal const string ODataMetadataOutputContext_ErrorWritingMetadata = "ODataMetadataOutputContext_ErrorWritingMetadata";
+        internal const string ODataMetadataOutputContext_NotSupportJsonMetadata = "ODataMetadataOutputContext_NotSupportJsonMetadata";
         internal const string ODataAtomDeserializer_RelativeUriUsedWithoutBaseUriSpecified = "ODataAtomDeserializer_RelativeUriUsedWithoutBaseUriSpecified";
         internal const string ODataAtomPropertyAndValueDeserializer_InvalidCollectionElement = "ODataAtomPropertyAndValueDeserializer_InvalidCollectionElement";
         internal const string ODataAtomPropertyAndValueDeserializer_NavigationPropertyInProperties = "ODataAtomPropertyAndValueDeserializer_NavigationPropertyInProperties";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -78,8 +78,8 @@ namespace Microsoft.OData
         internal const string ODataException_GeneralError = "ODataException_GeneralError";
         internal const string ODataErrorException_GeneralError = "ODataErrorException_GeneralError";
         internal const string ODataUriParserException_GeneralError = "ODataUriParserException_GeneralError";
-        internal const string ODataUrlValidationError_SelectRequired  = "ODataUrlValidationError_SelectRequired ";
-        internal const string ODataUrlValidationError_InvalidRule  = "ODataUrlValidationError_InvalidRule ";
+        internal const string ODataUrlValidationError_SelectRequired = "ODataUrlValidationError_SelectRequired";
+        internal const string ODataUrlValidationError_InvalidRule = "ODataUrlValidationError_InvalidRule";
         internal const string ODataMessageWriter_WriterAlreadyUsed = "ODataMessageWriter_WriterAlreadyUsed";
         internal const string ODataMessageWriter_EntityReferenceLinksInRequestNotAllowed = "ODataMessageWriter_EntityReferenceLinksInRequestNotAllowed";
         internal const string ODataMessageWriter_ErrorPayloadInRequest = "ODataMessageWriter_ErrorPayloadInRequest";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -82,4 +82,8 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -82,8 +82,4 @@
     </Compile>
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -439,10 +439,10 @@ WriterValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint=The value type 
 XmlReaderExtension_InvalidNodeInStringValue=An XML node of type '{0}' was found in a string value. An element with a string value can only contain Text, CDATA, SignificantWhitespace, Whitespace or Comment nodes.
 XmlReaderExtension_InvalidRootNode=An XML node of type '{0}' was found at the root level. The root level of an OData payload must contain a single XML element and no text nodes.
 
-
 ODataMetadataInputContext_ErrorReadingMetadata=The metadata document could not be read from the message content.\r\n{0}
 
 ODataMetadataOutputContext_ErrorWritingMetadata=The metadata document could not be written as specified.\r\n{0}
+ODataMetadataOutputContext_NotSupportJsonMetadata=The JSON metadata is not supported at this platform. It's only supported at platform implementing .NETStardard 2.0.
 
 ODataAtomDeserializer_RelativeUriUsedWithoutBaseUriSpecified=A relative URI value '{0}' was specified in the payload, but no base URI for it was found. When the payload contains a relative URI, there must be an xml:base in the payload or else a base URI must specified in the reader settings.
 

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -75,8 +75,8 @@ ODataException_GeneralError=An error occurred while processing the OData message
 ODataErrorException_GeneralError=An error was read from the payload. See the 'Error' property for more details.
 ODataUriParserException_GeneralError=An error occurred while parsing part of the URI.
 
-ODataUrlValidationError_SelectRequired = '{0}' is missing a $select clause. All property paths, expands, and selects of complex types should include a $select statement.
-ODataUrlValidationError_InvalidRule = Exception thrown by invalid rule {0}. {1}
+ODataUrlValidationError_SelectRequired='{0}' is missing a $select clause. All property paths, expands, and selects of complex types should include a $select statement.
+ODataUrlValidationError_InvalidRule=Exception thrown by invalid rule {0}. {1}
 
 ODataMessageWriter_WriterAlreadyUsed=The ODataMessageWriter has already been used to write a message payload. An ODataMessageWriter can only be used once to write a payload for a given message.
 ODataMessageWriter_EntityReferenceLinksInRequestNotAllowed=Top-level entity reference link collection payloads are not allowed in requests.

--- a/src/Microsoft.OData.Core/ODataInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataInputContext.cs
@@ -476,6 +476,17 @@ namespace Microsoft.OData
         /// This method reads the metadata document from the input and returns
         /// an <see cref="IEdmModel"/> that represents the read metadata document.
         /// </summary>
+        /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
+        internal virtual IEdmModel ReadMetadataDocument()
+        {
+            throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.MetadataDocument);
+        }
+
+        /// <summary>
+        /// Read a metadata document.
+        /// This method reads the metadata document from the input and returns
+        /// an <see cref="IEdmModel"/> that represents the read metadata document.
+        /// </summary>
         /// <param name="getReferencedModelReaderFunc">The function to load referenced model xml. If null, will stop loading the referenced models. Normally it should throw no exception.</param>
         /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
         internal virtual IEdmModel ReadMetadataDocument(Func<Uri, XmlReader> getReferencedModelReaderFunc)

--- a/src/Microsoft.OData.Core/ODataInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataInputContext.cs
@@ -482,6 +482,20 @@ namespace Microsoft.OData
             throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.MetadataDocument);
         }
 
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Read a metadata document.
+        /// This method reads the metadata document from the input and returns
+        /// an <see cref="IEdmModel"/> that represents the read metadata document.
+        /// </summary>
+        /// <param name="jsonCsdlReaderSettings">The given reader settings.</param>
+        /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
+        internal virtual IEdmModel ReadMetadataDocument(Edm.Csdl.CsdlJsonReaderSettings jsonCsdlReaderSettings)
+        {
+            throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.MetadataDocument);
+        }
+#endif
+
         /// <summary>
         /// Read a metadata document.
         /// This method reads the metadata document from the input and returns

--- a/src/Microsoft.OData.Core/ODataInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataInputContext.cs
@@ -482,19 +482,17 @@ namespace Microsoft.OData
             throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.MetadataDocument);
         }
 
-#if NETSTANDARD2_0
         /// <summary>
         /// Read a metadata document.
         /// This method reads the metadata document from the input and returns
         /// an <see cref="IEdmModel"/> that represents the read metadata document.
         /// </summary>
-        /// <param name="jsonCsdlReaderSettings">The given reader settings.</param>
+        /// <param name="csdlReaderSettings">The given CSDL reader settings.</param>
         /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
-        internal virtual IEdmModel ReadMetadataDocument(Edm.Csdl.CsdlJsonReaderSettings jsonCsdlReaderSettings)
+        internal virtual IEdmModel ReadMetadataDocument(Edm.Csdl.CsdlReaderSettingsBase csdlReaderSettings)
         {
             throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.MetadataDocument);
         }
-#endif
 
         /// <summary>
         /// Read a metadata document.

--- a/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
+++ b/src/Microsoft.OData.Core/ODataMediaTypeResolver.cs
@@ -59,7 +59,11 @@ namespace Microsoft.OData
             },
             {
                 ODataPayloadKind.MetadataDocument,
-                new[] { new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeXmlSubType), ODataFormat.Metadata) }
+                new[]
+                {
+                    new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeXmlSubType), ODataFormat.Metadata),
+                    new ODataMediaTypeFormat(new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType), ODataFormat.Metadata)
+                }
             },
             {
                 ODataPayloadKind.Asynchronous,

--- a/src/Microsoft.OData.Core/ODataMessageReader.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReader.cs
@@ -856,13 +856,13 @@ namespace Microsoft.OData
                 supportedPayloadKinds);
         }
 
-        /// <summary>Reads the message body as metadata document.</summary>
+        /// <summary>Reads the message body as metadata document. It can read JSON/XML CSDL based on the content type.</summary>
         /// <returns>Returns <see cref="Microsoft.OData.Edm.IEdmModel" />.</returns>
         public IEdmModel ReadMetadataDocument()
         {
             this.VerifyCanReadMetadataDocument();
             return this.ReadFromInput(
-                (context) => context.ReadMetadataDocument(null),
+                (context) => context.ReadMetadataDocument(),
                 ODataPayloadKind.MetadataDocument);
         }
 

--- a/src/Microsoft.OData.Core/ODataMessageReader.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReader.cs
@@ -866,20 +866,19 @@ namespace Microsoft.OData
                 ODataPayloadKind.MetadataDocument);
         }
 
-#if NETSTANDARD2_0
         /// <summary>
-        /// Reads the message body as metadata document. It can read JSON CSDL based on the content type using the given settings.
+        /// Reads the message body as metadata document. It can read CSDL based on the content type using the given settings.
+        /// Be NOTED: If the setting is not related to the metadata format, it will be ignored.
         /// </summary>
-        /// <param name="jsonCsdlReaderSettings">The given reader settings.</param>
+        /// <param name="csdlReaderSettings">The given CSDL reader settings.</param>
         /// <returns>Returns <see cref="IEdmModel" />.</returns>
-        public IEdmModel ReadMetadataDocument(Edm.Csdl.CsdlJsonReaderSettings jsonCsdlReaderSettings)
+        public IEdmModel ReadMetadataDocument(Edm.Csdl.CsdlReaderSettingsBase csdlReaderSettings)
         {
             this.VerifyCanReadMetadataDocument();
             return this.ReadFromInput(
-                (context) => context.ReadMetadataDocument(jsonCsdlReaderSettings),
+                (context) => context.ReadMetadataDocument(csdlReaderSettings),
                 ODataPayloadKind.MetadataDocument);
         }
-#endif
 
         /// <summary>Reads the message body as metadata document.</summary>
         /// <param name="getReferencedModelReaderFunc">The function to load referenced model xml. If null, will stop loading the referenced models. Normally it should throw no exception.</param>

--- a/src/Microsoft.OData.Core/ODataMessageReader.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReader.cs
@@ -866,6 +866,21 @@ namespace Microsoft.OData
                 ODataPayloadKind.MetadataDocument);
         }
 
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Reads the message body as metadata document. It can read JSON CSDL based on the content type using the given settings.
+        /// </summary>
+        /// <param name="jsonCsdlReaderSettings">The given reader settings.</param>
+        /// <returns>Returns <see cref="IEdmModel" />.</returns>
+        public IEdmModel ReadMetadataDocument(Edm.Csdl.CsdlJsonReaderSettings jsonCsdlReaderSettings)
+        {
+            this.VerifyCanReadMetadataDocument();
+            return this.ReadFromInput(
+                (context) => context.ReadMetadataDocument(jsonCsdlReaderSettings),
+                ODataPayloadKind.MetadataDocument);
+        }
+#endif
+
         /// <summary>Reads the message body as metadata document.</summary>
         /// <param name="getReferencedModelReaderFunc">The function to load referenced model xml. If null, will stop loading the referenced models. Normally it should throw no exception.</param>
         /// <returns>Returns <see cref="Microsoft.OData.Edm.IEdmModel" />.</returns>

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -9,6 +9,7 @@ namespace Microsoft.OData
     using System;
     using Microsoft.OData.Buffers;
     using Microsoft.OData.Edm;
+    using Microsoft.OData.Edm.Csdl;
 
     /// <summary>
     /// Configuration settings for OData message readers.
@@ -203,6 +204,12 @@ namespace Microsoft.OData
         /// </summary>
         public Func<string, bool> ShouldIncludeAnnotation { get; set; }
 
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Gets/sets the JSON-CSDL reader settings.
+        /// </summary>
+        public CsdlJsonReaderSettings JsonCsdlReaderSettings { get; set; }
+#endif
         /// <summary>
         /// Gets the bound validator.
         /// </summary>

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -204,12 +204,6 @@ namespace Microsoft.OData
         /// </summary>
         public Func<string, bool> ShouldIncludeAnnotation { get; set; }
 
-#if NETSTANDARD2_0
-        /// <summary>
-        /// Gets/sets the JSON-CSDL reader settings.
-        /// </summary>
-        public CsdlJsonReaderSettings JsonCsdlReaderSettings { get; set; }
-#endif
         /// <summary>
         /// Gets the bound validator.
         /// </summary>

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -9,7 +9,6 @@ namespace Microsoft.OData
     using System;
     using Microsoft.OData.Buffers;
     using Microsoft.OData.Edm;
-    using Microsoft.OData.Edm.Csdl;
 
     /// <summary>
     /// Configuration settings for OData message readers.

--- a/src/Microsoft.OData.Core/ODataMetadataFormat.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataFormat.cs
@@ -60,7 +60,25 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentNotNull(messageInfo, "messageInfo");
             ExceptionUtils.CheckArgumentNotNull(messageReaderSettings, "messageReaderSettings");
 
+            bool isJson = IsJsonMetadata(messageInfo.MediaType);
+
+#if NETSTANDARD2_0
+            if (isJson)
+            {
+                return new ODataMetadataJsonInputContext(messageInfo, messageReaderSettings);
+            }
+            else
+            {
+                return new ODataMetadataInputContext(messageInfo, messageReaderSettings);
+            }
+#else
+            if (isJson)
+            {
+                throw new ODataException(Strings.ODataMetadataOutputContext_NotSupportJsonMetadata);
+            }
+
             return new ODataMetadataInputContext(messageInfo, messageReaderSettings);
+#endif
         }
 
         /// <summary>
@@ -76,7 +94,25 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentNotNull(messageInfo, "messageInfo");
             ExceptionUtils.CheckArgumentNotNull(messageWriterSettings, "messageWriterSettings");
 
+            bool isJson = IsJsonMetadata(messageInfo.MediaType);
+
+#if NETSTANDARD2_0
+            if (isJson)
+            {
+                return new ODataMetadataJsonOutputContext(messageInfo, messageWriterSettings);
+            }
+            else
+            {
+                return new ODataMetadataOutputContext(messageInfo, messageWriterSettings);
+            }
+#else
+            if (isJson)
+            {
+                throw new ODataException(Strings.ODataMetadataOutputContext_NotSupportJsonMetadata);
+            }
+
             return new ODataMetadataOutputContext(messageInfo, messageWriterSettings);
+#endif
         }
 
         /// <summary>
@@ -126,6 +162,23 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentNotNull(messageWriterSettings, "messageWriterSettings");
 
             throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataMetadataFormat_CreateOutputContextAsync));
+        }
+
+        private static bool IsJsonMetadata(ODataMediaType contentType)
+        {
+            // by default, it's XML metadata
+            if (contentType == null)
+            {
+                return false;
+            }
+
+            if (HttpUtils.CompareMediaTypeNames(MimeConstants.MimeApplicationType, contentType.Type) &&
+                HttpUtils.CompareMediaTypeNames(MimeConstants.MimeJsonSubType, contentType.SubType))
+            {
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataMetadataInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataInputContext.cs
@@ -68,6 +68,17 @@ namespace Microsoft.OData
         /// This method reads the metadata document from the input and returns
         /// an <see cref="IEdmModel"/> that represents the read metadata document.
         /// </summary>
+        /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
+        internal override IEdmModel ReadMetadataDocument()
+        {
+            return this.ReadMetadataDocument(null);
+        }
+
+        /// <summary>
+        /// Read a metadata document.
+        /// This method reads the metadata document from the input and returns
+        /// an <see cref="IEdmModel"/> that represents the read metadata document.
+        /// </summary>
         /// <param name="getReferencedModelReaderFunc">The function to load referenced model xml. If null, will stop loading the referenced models. Normally it should throw no exception.</param>
         /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
         internal override IEdmModel ReadMetadataDocument(Func<Uri, XmlReader> getReferencedModelReaderFunc)

--- a/src/Microsoft.OData.Core/ODataMetadataInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataInputContext.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using System.Xml;
 using Microsoft.OData.Metadata;
@@ -61,6 +62,43 @@ namespace Microsoft.OData
 
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Read a metadata document.
+        /// This method reads the metadata document from the input and returns
+        /// an <see cref="IEdmModel"/> that represents the read metadata document.
+        /// </summary>
+        /// <param name="csdlReaderSettings">The given CSDL reader settings.</param>
+        /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
+        internal override IEdmModel ReadMetadataDocument(CsdlReaderSettingsBase csdlReaderSettings)
+        {
+            // Be noted: If the input setting is not XML CSDL setting, let's use the default setting.
+            CsdlReaderSettings settings = csdlReaderSettings as CsdlReaderSettings;
+            if (settings == null)
+            {
+                settings = new CsdlReaderSettings();
+            }
+
+            // Use the setting to reader XML JSON
+            IEdmModel model;
+            IEnumerable<EdmError> errors;
+            if (!CsdlReader.TryParse(this.xmlReader, Enumerable.Empty<IEdmModel>(), settings, out model, out errors))
+            {
+                Debug.Assert(errors != null, "errors != null");
+
+                StringBuilder builder = new StringBuilder();
+                foreach (EdmError error in errors)
+                {
+                    builder.AppendLine(error.ToString());
+                }
+
+                throw new ODataException(Strings.ODataMetadataInputContext_ErrorReadingMetadata(builder.ToString()));
+            }
+
+            Debug.Assert(model != null, "model != null");
+
+            return model;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataMetadataInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataInputContext.cs
@@ -71,7 +71,7 @@ namespace Microsoft.OData
         /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
         internal override IEdmModel ReadMetadataDocument()
         {
-            return this.ReadMetadataDocument(null);
+            return this.ReadMetadataDocument(getReferencedModelReaderFunc: null);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataMetadataJsonInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataJsonInputContext.cs
@@ -1,0 +1,99 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataMetadataJsonInputContext.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETSTANDARD2_0
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+
+namespace Microsoft.OData
+{
+    /// <summary>
+    /// Implementation of the OData input for JSON metadata documents.
+    /// </summary>
+    internal sealed class ODataMetadataJsonInputContext : ODataInputContext
+    {
+        /// <summary>The stream to read from.</summary>
+        private Stream messageStream;
+
+        /// <summary>Constructor.</summary>
+        /// <param name="messageInfo">The context information for the message.</param>
+        /// <param name="messageReaderSettings">Configuration settings of the OData reader.</param>
+        public ODataMetadataJsonInputContext(
+            ODataMessageInfo messageInfo,
+            ODataMessageReaderSettings messageReaderSettings)
+            : base(ODataFormat.Metadata, messageInfo, messageReaderSettings)
+        {
+            Debug.Assert(messageInfo.MessageStream != null, "messageInfo.MessageStream != null");
+            messageStream = messageInfo.MessageStream;
+        }
+
+        /// <summary>
+        /// Read a metadata document.
+        /// This method reads the metadata document from the input and returns
+        /// an <see cref="IEdmModel"/> that represents the read metadata document.
+        /// </summary>
+        /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
+        internal override IEdmModel ReadMetadataDocument()
+        {
+            // We can't use stream.Read(Span<byte> buffer), this method is introduced since .NET Core 2.1. :(
+            byte[] bytes = this.messageStream.ReadAllBytes();
+
+            ReadOnlySpan<byte> jsonReadOnlySpan = new ReadOnlySpan<byte>(bytes);
+
+            Utf8JsonReader jsonReader = new Utf8JsonReader(jsonReadOnlySpan);
+
+            CsdlJsonReaderSettings setting = MessageReaderSettings.JsonCsdlReaderSettings ?? new CsdlJsonReaderSettings();
+
+            IEdmModel model;
+            IEnumerable<EdmError> errors;
+            if (!CsdlReader.TryParse(ref jsonReader, setting, out model, out errors))
+            {
+                Debug.Assert(errors != null, "errors != null");
+
+                StringBuilder builder = new StringBuilder();
+                foreach (EdmError error in errors)
+                {
+                    builder.AppendLine(error.ToString());
+                }
+
+                throw new ODataException(Strings.ODataMetadataInputContext_ErrorReadingMetadata(builder.ToString()));
+            }
+
+            Debug.Assert(model != null, "model != null");
+
+            return model;
+        }
+
+        /// <summary>
+        /// Perform the actual cleanup work.
+        /// </summary>
+        /// <param name="disposing">If 'true' this method is called from user code; if 'false' it is called by the runtime.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                try
+                {
+                    this.messageStream.Dispose();
+                }
+                finally
+                {
+                    this.messageStream = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}
+#endif

--- a/src/Microsoft.OData.Core/ODataMetadataJsonInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataJsonInputContext.cs
@@ -45,6 +45,18 @@ namespace Microsoft.OData
         /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
         internal override IEdmModel ReadMetadataDocument()
         {
+            return ReadMetadataDocument(jsonCsdlReaderSettings: null);
+        }
+
+        /// <summary>
+        /// Read a metadata document.
+        /// This method reads the metadata document from the input and returns
+        /// an <see cref="IEdmModel"/> that represents the read metadata document.
+        /// </summary>
+        /// <param name="jsonCsdlReaderSettings">The given reader settings.</param>
+        /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
+        internal override IEdmModel ReadMetadataDocument(CsdlJsonReaderSettings jsonCsdlReaderSettings)
+        {
             // We can't use stream.Read(Span<byte> buffer), this method is introduced since .NET Core 2.1. :(
             byte[] bytes = this.messageStream.ReadAllBytes();
 
@@ -52,7 +64,7 @@ namespace Microsoft.OData
 
             Utf8JsonReader jsonReader = new Utf8JsonReader(jsonReadOnlySpan);
 
-            CsdlJsonReaderSettings setting = MessageReaderSettings.JsonCsdlReaderSettings ?? new CsdlJsonReaderSettings();
+            CsdlJsonReaderSettings setting = jsonCsdlReaderSettings ?? new CsdlJsonReaderSettings();
 
             IEdmModel model;
             IEnumerable<EdmError> errors;

--- a/src/Microsoft.OData.Core/ODataMetadataJsonInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataJsonInputContext.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OData
         /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
         internal override IEdmModel ReadMetadataDocument()
         {
-            return ReadMetadataDocument(jsonCsdlReaderSettings: null);
+            return ReadMetadataDocument(csdlReaderSettings: null);
         }
 
         /// <summary>
@@ -53,18 +53,20 @@ namespace Microsoft.OData
         /// This method reads the metadata document from the input and returns
         /// an <see cref="IEdmModel"/> that represents the read metadata document.
         /// </summary>
-        /// <param name="jsonCsdlReaderSettings">The given reader settings.</param>
+        /// <param name="csdlReaderSettings">The given CSDL reader settings.</param>
         /// <returns>An <see cref="IEdmModel"/> representing the read metadata document.</returns>
-        internal override IEdmModel ReadMetadataDocument(CsdlJsonReaderSettings jsonCsdlReaderSettings)
+        internal override IEdmModel ReadMetadataDocument(CsdlReaderSettingsBase csdlReaderSettings)
         {
+            // Be noted: If the input setting is not JSON CSDL setting, let's use the default setting.
+            CsdlJsonReaderSettings settings = csdlReaderSettings as CsdlJsonReaderSettings;
+            CsdlJsonReaderSettings setting = settings ?? CsdlJsonReaderSettings.Default;
+
             // We can't use stream.Read(Span<byte> buffer), this method is introduced since .NET Core 2.1. :(
             byte[] bytes = this.messageStream.ReadAllBytes();
 
             ReadOnlySpan<byte> jsonReadOnlySpan = new ReadOnlySpan<byte>(bytes);
 
             Utf8JsonReader jsonReader = new Utf8JsonReader(jsonReadOnlySpan);
-
-            CsdlJsonReaderSettings setting = jsonCsdlReaderSettings ?? new CsdlJsonReaderSettings();
 
             IEdmModel model;
             IEnumerable<EdmError> errors;

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -548,19 +548,19 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like " '{0}' is missing a $select clause. All property paths, expands, and selects of complex types should include a $select statement."
+        /// A string like "'{0}' is missing a $select clause. All property paths, expands, and selects of complex types should include a $select statement."
         /// </summary>
-        internal static string ODataUrlValidationError_SelectRequired (object p0)
+        internal static string ODataUrlValidationError_SelectRequired(object p0)
         {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataUrlValidationError_SelectRequired , p0);
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataUrlValidationError_SelectRequired, p0);
         }
 
         /// <summary>
-        /// A string like " Exception thrown by invalid rule {0}. {1}"
+        /// A string like "Exception thrown by invalid rule {0}. {1}"
         /// </summary>
-        internal static string ODataUrlValidationError_InvalidRule (object p0, object p1)
+        internal static string ODataUrlValidationError_InvalidRule(object p0, object p1)
         {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataUrlValidationError_InvalidRule , p0, p1);
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataUrlValidationError_InvalidRule, p0, p1);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -548,19 +548,19 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "{0} is missing a $select clause. All property paths, expands, and selects of complex types must include a SELECT statement."
+        /// A string like " '{0}' is missing a $select clause. All property paths, expands, and selects of complex types should include a $select statement."
         /// </summary>
-        internal static string ODataUrlValidationError_SelectRequired(object p0)
+        internal static string ODataUrlValidationError_SelectRequired (object p0)
         {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataUrlValidationError_SelectRequired, p0);
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataUrlValidationError_SelectRequired , p0);
         }
 
         /// <summary>
-        /// A string like "Exception thrown by invalid rule {0}. {1}."
+        /// A string like " Exception thrown by invalid rule {0}. {1}"
         /// </summary>
-        internal static string ODataUrlValidationError_InvalidRule(object p0, object p1)
+        internal static string ODataUrlValidationError_InvalidRule (object p0, object p1)
         {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataUrlValidationError_InvalidRule, p0, p1);
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataUrlValidationError_InvalidRule , p0, p1);
         }
 
         /// <summary>
@@ -2150,7 +2150,8 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "A null value was found for a collection of type '{0}[Nullable=True]. Collection-valued properties with Nullable=True can contain null values, but collection-valued properties cannot themselves be null."
         /// </summary>
-        internal static string ReaderValidationUtils_NullValueForNullableType(object p0) {
+        internal static string ReaderValidationUtils_NullValueForNullableType(object p0)
+        {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ReaderValidationUtils_NullValueForNullableType, p0);
         }
 
@@ -2165,7 +2166,8 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "A null value was found for the property named '{0}', which has the expected type '{1}[Nullable=True]'. The expected type '{1}[Nullable=True]' cannot be null but it can have null values."
         /// </summary>
-        internal static string ReaderValidationUtils_NullNamedValueForNullableType(object p0, object p1) {
+        internal static string ReaderValidationUtils_NullNamedValueForNullableType(object p0, object p1)
+        {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ReaderValidationUtils_NullNamedValueForNullableType, p0, p1);
         }
 
@@ -3491,6 +3493,17 @@ namespace Microsoft.OData {
         internal static string ODataMetadataOutputContext_ErrorWritingMetadata(object p0)
         {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataMetadataOutputContext_ErrorWritingMetadata, p0);
+        }
+
+        /// <summary>
+        /// A string like "The JSON metadata is not supported at this platform. It's only supported at platform implementing .NETStardard 2.0."
+        /// </summary>
+        internal static string ODataMetadataOutputContext_NotSupportJsonMetadata
+        {
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataMetadataOutputContext_NotSupportJsonMetadata);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/StreamExtensions.cs
+++ b/src/Microsoft.OData.Core/StreamExtensions.cs
@@ -6,13 +6,28 @@
 
 namespace Microsoft.OData
 {
-    using System;
+    using System.Diagnostics;
     using System.IO;
 
     /// <summary>
-    /// Extension methods to Stream for .NET35.
+    /// Extension methods to Stream
     /// </summary>
     internal static class StreamExtensions
     {
+        public static byte[] ReadAllBytes(this Stream instream)
+        {
+            Debug.Assert(instream != null, "instream != null");
+
+            if (instream is MemoryStream)
+            {
+                return ((MemoryStream)instream).ToArray();
+            }
+
+            using (var memoryStream = new MemoryStream())
+            {
+                instream.CopyTo(memoryStream);
+                return memoryStream.ToArray();
+            }
+        }
     }
 }

--- a/src/Microsoft.OData.Edm/Csdl/CsdlJsonReaderSettings.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlJsonReaderSettings.cs
@@ -12,9 +12,9 @@ namespace Microsoft.OData.Edm.Csdl
     /// <summary>
     /// Settings used when parsing CSDL-JSON document.
     /// </summary>
-    public class CsdlJsonReaderSettings
+    public class CsdlJsonReaderSettings : CsdlReaderSettingsBase
     {
-        internal static CsdlJsonReaderSettings Default = new CsdlJsonReaderSettings();
+        public static CsdlJsonReaderSettings Default = new CsdlJsonReaderSettings();
 
         /// <summary>
         /// Initializes a new instance of <see cref="CsdlJsonReaderSettings"/> class.

--- a/src/Microsoft.OData.Edm/Csdl/CsdlReaderSettings.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReaderSettings.cs
@@ -10,9 +10,17 @@ namespace Microsoft.OData.Edm.Csdl
     using System.Xml;
 
     /// <summary>
+    /// The base setting for CSDL reader
+    /// </summary>
+    public abstract class CsdlReaderSettingsBase
+    {
+        // Empty now
+    }
+
+    /// <summary>
     /// Settings used when parsing CSDL document.
     /// </summary>
-    public sealed class CsdlReaderSettings
+    public sealed class CsdlReaderSettings : CsdlReaderSettingsBase
     {
         /// <summary>
         /// Default constructor.

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMediaTypeResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMediaTypeResolverTests.cs
@@ -56,6 +56,7 @@ namespace Microsoft.OData.Tests
             new ODataMediaTypeFormat[]
             {
                 new ODataMediaTypeFormat ( new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeXmlSubType), ODataFormat.Metadata),
+                new ODataMediaTypeFormat ( new ODataMediaType(MimeConstants.MimeApplicationType, MimeConstants.MimeJsonSubType), ODataFormat.Metadata),
             },
             // error
             JsonMediaTypes,


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1911*

### Description

OData.Edm lib supports to read/write JSON metadata.

This PR is to enable read/write JSON metadata in OData.Core lib.

So, if a request like:

*  `~/odata/$metadata `  => return XML CSDL
* `~/odata/$metadata?$format=application/json`  => return JSON CSDL

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
