### PR TITLE
Support reading/writing OData V4 deleted entries with only key values

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
@@ -11,18 +11,14 @@ namespace Microsoft.OData.Evaluation
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
     using System.Text;
-    using Microsoft.OData.JsonLight;
-    using Microsoft.OData.Metadata;
-    using Microsoft.OData.UriParser;
     using Microsoft.OData.Edm;
     #endregion
 
     /// <summary>
     /// Implementation of OData entity metadata builder based on OData protocol conventions.
     /// </summary>
-    internal sealed class ODataConventionalEntityMetadataBuilder : ODataConventionalResourceMetadataBuilder
+    internal sealed class ODataConventionalEntityMetadataBuilder : ODataConventionalIdMetadataBuilder
     {
         /// <summary>The edit link.</summary>
         /// <remarks>This is lazily evaluated. It may be retrieved from the resource or computed.</remarks>
@@ -38,12 +34,6 @@ namespace Microsoft.OData.Evaluation
         /// <summary>true if the etag value has been computed, false otherwise.</summary>
         private bool etagComputed;
 
-        /// <summary>The computed ID of this entity instance.</summary>
-        /// <remarks>
-        /// This is always built from the key properties, and never comes from the resource.
-        /// </remarks>
-        private Uri computedId;
-
         /// <summary>The computed MediaResource for MLEs.</summary>
         private ODataStreamReferenceValue computedMediaResource;
 
@@ -58,9 +48,6 @@ namespace Microsoft.OData.Evaluation
         /// <summary>The missing operation generator for the current resource.</summary>
         private ODataMissingOperationGenerator missingOperationGenerator;
 
-        /// <summary>The computed key property name and value pairs of the resource.</summary>
-        private ICollection<KeyValuePair<string, object>> computedKeyProperties;
-
         /// <summary>
         /// Constructor
         /// </summary>
@@ -74,46 +61,11 @@ namespace Microsoft.OData.Evaluation
         }
 
         /// <summary>
-        /// Lazy evaluated computed entity Id. This is always a computed value and never comes from the resource.
-        /// </summary>
-        private Uri ComputedId
-        {
-            get
-            {
-                this.ComputeAndCacheId();
-                return this.computedId;
-            }
-        }
-
-        /// <summary>
         /// The missing operation generator for the current resource.
         /// </summary>
         private ODataMissingOperationGenerator MissingOperationGenerator
         {
             get { return this.missingOperationGenerator ?? (this.missingOperationGenerator = new ODataMissingOperationGenerator(this.ResourceMetadataContext, this.MetadataContext)); }
-        }
-
-        /// <summary>
-        /// The computed key property name and value pairs of the resource.
-        /// If a value is unsigned integer, it will be automatically converted to its underlying type.
-        /// </summary>
-        private ICollection<KeyValuePair<string, object>> ComputedKeyProperties
-        {
-            get
-            {
-                if (computedKeyProperties == null)
-                {
-                    computedKeyProperties = new List<KeyValuePair<string, object>>();
-
-                    foreach (var originalKeyProperty in this.ResourceMetadataContext.KeyProperties)
-                    {
-                        object newValue = this.MetadataContext.Model.ConvertToUnderlyingTypeIfUIntValue(originalKeyProperty.Value);
-                        computedKeyProperties.Add(new KeyValuePair<string, object>(originalKeyProperty.Key, newValue));
-                    }
-                }
-
-                return computedKeyProperties;
-            }
         }
 
         /// <summary>
@@ -203,22 +155,6 @@ namespace Microsoft.OData.Evaluation
                     return this.computedReadLink = this.GetEditLink();
                 }
             }
-        }
-
-        /// <summary>
-        /// Gets the ID of the entity.
-        /// </summary>
-        /// <returns>
-        /// The ID for the entity.
-        /// Or null if it is not possible to determine the ID.
-        /// </returns>
-        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "A method for consistency with the rest of the API.")]
-        internal override Uri GetId()
-        {
-            // If the Id were on the wire, use that wire value for the Id.
-            // If the resource was transient resource, return null for Id
-            // Otherwise compute it based on the key values.
-            return this.ResourceMetadataContext.Resource.HasNonComputedId ? this.ResourceMetadataContext.Resource.NonComputedId : (this.ResourceMetadataContext.Resource.IsTransient ? null : this.ComputedId);
         }
 
         /// <summary>
@@ -464,143 +400,6 @@ namespace Microsoft.OData.Evaluation
         }
 
         /// <summary>
-        /// Computes and sets the field for the computed Id.
-        /// </summary>
-        private void ComputeAndCacheId()
-        {
-            if (this.computedId != null)
-            {
-                return;
-            }
-
-            Uri uri;
-            switch (this.ResourceMetadataContext.TypeContext.NavigationSourceKind)
-            {
-                case EdmNavigationSourceKind.Singleton:
-                    uri = this.ComputeIdForSingleton();
-                    break;
-                case EdmNavigationSourceKind.ContainedEntitySet:
-                    uri = this.ComputeIdForContainment();
-                    break;
-                case EdmNavigationSourceKind.UnknownEntitySet:
-                    throw new ODataException(Strings.ODataMetadataBuilder_UnknownEntitySet(this.ResourceMetadataContext.TypeContext.NavigationSourceName));
-                default:
-                    uri = this.ComputeId();
-                    break;
-            }
-
-            this.computedId = uri;
-        }
-
-        /// <summary>
-        /// Compute id for neither singleton, nor containment scenario.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Uri"/> of @odata.id.
-        /// </returns>
-        private Uri ComputeId()
-        {
-            Uri uri = this.UriBuilder.BuildBaseUri();
-            uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);
-            uri = this.UriBuilder.BuildEntityInstanceUri(uri, this.ComputedKeyProperties, this.ResourceMetadataContext.ActualResourceTypeName);
-            return uri;
-        }
-
-        /// <summary>
-        /// Compute id for containment scenario.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Uri"/> of @odata.id.
-        /// </returns>
-        private Uri ComputeIdForContainment()
-        {
-            Uri uri;
-
-            if (!TryComputeIdFromParent(out uri))
-            {
-                // Compute ID from context URL rather than from parent.
-                uri = this.UriBuilder.BuildBaseUri();
-                ODataUri odataUri = this.ODataUri ?? this.MetadataContext.ODataUri;
-
-                if (odataUri == null || odataUri.Path == null || odataUri.Path.Count == 0)
-                {
-                    throw new ODataException(Strings.ODataMetadataBuilder_MissingParentIdOrContextUrl);
-                }
-
-                uri = this.GetContainingEntitySetUri(uri, odataUri);
-            }
-
-            // A path segment for the containment navigation property
-            uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);
-
-            if (this.ResourceMetadataContext.TypeContext.IsFromCollection)
-            {
-                uri = this.UriBuilder.BuildEntityInstanceUri(
-                    uri,
-                    this.ComputedKeyProperties,
-                    this.ResourceMetadataContext.ActualResourceTypeName);
-            }
-
-            return uri;
-        }
-
-        private bool TryComputeIdFromParent(out Uri uri)
-        {
-            try
-            {
-                ODataConventionalResourceMetadataBuilder parent = this.ParentMetadataBuilder as ODataConventionalResourceMetadataBuilder;
-                if (parent != null && parent != this)
-                {
-                    // Get the parent canonical url
-                    uri = parent.GetCanonicalUrl();
-
-                    if (uri != null)
-                    {
-                        // And append cast (if needed).
-                        // A cast segment if the navigation property is defined on a type derived from the type expected.
-                        IODataResourceTypeContext typeContext = parent.ResourceMetadataContext.TypeContext;
-
-                        if (parent.ResourceMetadataContext.ActualResourceTypeName != typeContext.ExpectedResourceTypeName)
-                        {
-                            // Do not append type cast if we know that the navigation property is in base type, not in derived type.
-                            ODataResourceTypeContext.ODataResourceTypeContextWithModel typeContextWithModel =
-                                typeContext as ODataResourceTypeContext.ODataResourceTypeContextWithModel;
-                            if (typeContextWithModel == null ||
-                                typeContextWithModel.ExpectedResourceType.FindProperty(
-                                    this.ResourceMetadataContext.TypeContext.NavigationSourceName) == null)
-                            {
-                                uri = new Uri(UriUtils.EnsureTaillingSlash(uri),
-                                    parent.ResourceMetadataContext.ActualResourceTypeName);
-                            }
-                        }
-
-                        return true;
-                    }
-                }
-            }
-            catch (ODataException)
-            {
-            }
-
-            uri = null;
-            return false;
-        }
-
-        /// <summary>
-        /// Compute id for singleton scenario.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="Uri"/> of @odata.id.
-        /// </returns>
-        private Uri ComputeIdForSingleton()
-        {
-            // Do not append key for singleton.
-            Uri uri = this.UriBuilder.BuildBaseUri();
-            uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);
-            return uri;
-        }
-
-        /// <summary>
         /// Computes all projected or missing stream properties.
         /// </summary>
         /// <param name="nonComputedProperties">Non-computed properties from the entity.</param>
@@ -633,61 +432,6 @@ namespace Microsoft.OData.Evaluation
             }
 
             return this.computedStreamProperties;
-        }
-
-        /// <summary>
-        /// Gets resource path from service root, and request Uri.
-        /// </summary>
-        /// <param name="baseUri">The service root Uri.</param>
-        /// <param name="odataUri">The request Uri.</param>
-        /// <returns>The resource path.</returns>
-        private Uri GetContainingEntitySetUri(Uri baseUri, ODataUri odataUri)
-        {
-            ODataPath path = odataUri.Path;
-            List<ODataPathSegment> segments = path.ToList();
-            int lastIndex = segments.Count - 1;
-            ODataPathSegment lastSegment = segments[lastIndex];
-            while (!(lastSegment is NavigationPropertySegment) && !(lastSegment is OperationSegment))
-            {
-                lastSegment = segments[--lastIndex];
-            }
-
-            while (lastSegment is TypeSegment)
-            {
-                ODataPathSegment previousSegment = segments[lastIndex - 1];
-                IEdmStructuredType owningType = previousSegment.TargetEdmType as IEdmStructuredType;
-                if (owningType != null && owningType.FindProperty(lastSegment.Identifier) != null)
-                {
-                    lastSegment = segments[--lastIndex];
-                }
-                else
-                {
-                    break;
-                }
-            }
-
-            // trim all the un-needed segments 
-            segments = segments.GetRange(0, lastIndex);
-
-            // append each segment to base uri
-            Uri uri = baseUri;
-            foreach (ODataPathSegment segment in segments)
-            {
-                var keySegment = segment as KeySegment;
-                if (keySegment == null)
-                {
-                    uri = this.UriBuilder.BuildEntitySetUri(uri, segment.Identifier);
-                }
-                else
-                {
-                    uri = this.UriBuilder.BuildEntityInstanceUri(
-                        uri,
-                        keySegment.Keys.ToList(),
-                        keySegment.EdmType.FullTypeName());
-                }
-            }
-
-            return uri;
         }
     }
 }

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
@@ -1,0 +1,288 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataConventionalIdMetadataBuilder.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Evaluation
+{
+    #region Namespaces
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using Microsoft.OData.Metadata;
+    using Microsoft.OData.UriParser;
+    using Microsoft.OData.Edm;
+    #endregion
+
+    /// <summary>
+    /// Implementation of OData metadata builder that generates ids based on OData protocol conventions.
+    /// </summary>
+    internal class ODataConventionalIdMetadataBuilder : ODataConventionalResourceMetadataBuilder
+    {
+
+        /// <summary>The computed ID of this entity instance.</summary>
+        /// <remarks>
+        /// This is always built from the key properties, and never comes from the resource.
+        /// </remarks>
+        private Uri computedId;
+
+        /// <summary>The computed key property name and value pairs of the resource.</summary>
+        private ICollection<KeyValuePair<string, object>> computedKeyProperties;
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="resourceMetadataContext">The context to answer basic metadata questions about the resource.</param>
+        /// <param name="metadataContext">The metadata context.</param>
+        /// <param name="uriBuilder">The uri builder to use.</param>
+        internal ODataConventionalIdMetadataBuilder(IODataResourceMetadataContext resourceMetadataContext, IODataMetadataContext metadataContext, ODataUriBuilder uriBuilder)
+            : base(resourceMetadataContext, metadataContext, uriBuilder)
+        {
+        }
+
+        /// <summary>
+        /// Lazy evaluated computed entity Id. This is always a computed value and never comes from the resource.
+        /// </summary>
+        protected Uri ComputedId
+        {
+            get
+            {
+                this.ComputeAndCacheId();
+                return this.computedId;
+            }
+        }
+        
+        /// <summary>
+        /// The computed key property name and value pairs of the resource.
+        /// If a value is unsigned integer, it will be automatically converted to its underlying type.
+        /// </summary>
+        private ICollection<KeyValuePair<string, object>> ComputedKeyProperties
+        {
+            get
+            {
+                if (computedKeyProperties == null)
+                {
+                    computedKeyProperties = new List<KeyValuePair<string, object>>();
+
+                    foreach (var originalKeyProperty in this.ResourceMetadataContext.KeyProperties)
+                    {
+                        object newValue = this.MetadataContext.Model.ConvertToUnderlyingTypeIfUIntValue(originalKeyProperty.Value);
+                        computedKeyProperties.Add(new KeyValuePair<string, object>(originalKeyProperty.Key, newValue));
+                    }
+                }
+
+                return computedKeyProperties;
+            }
+        }
+
+        /// <summary>
+        /// Gets the ID of the entity.
+        /// </summary>
+        /// <returns>
+        /// The ID for the entity.
+        /// Or null if it is not possible to determine the ID.
+        /// </returns>
+        [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "A method for consistency with the rest of the API.")]
+        internal override Uri GetId()
+        {
+            // If the Id were on the wire, use that wire value for the Id.
+            // If the resource was transient resource, return null for Id
+            // Otherwise compute it based on the key values.
+            return this.ResourceMetadataContext.Resource.HasNonComputedId ? this.ResourceMetadataContext.Resource.NonComputedId : (this.ResourceMetadataContext.Resource.IsTransient ? null : this.ComputedId);
+        }
+
+        /// <summary>
+        /// Computes and sets the field for the computed Id.
+        /// </summary>
+        private void ComputeAndCacheId()
+        {
+            if (this.computedId != null)
+            {
+                return;
+            }
+
+            Uri uri;
+            switch (this.ResourceMetadataContext.TypeContext.NavigationSourceKind)
+            {
+                case EdmNavigationSourceKind.Singleton:
+                    uri = this.ComputeIdForSingleton();
+                    break;
+                case EdmNavigationSourceKind.ContainedEntitySet:
+                    uri = this.ComputeIdForContainment();
+                    break;
+                case EdmNavigationSourceKind.UnknownEntitySet:
+                    throw new ODataException(Strings.ODataMetadataBuilder_UnknownEntitySet(this.ResourceMetadataContext.TypeContext.NavigationSourceName));
+                default:
+                    uri = this.ComputeId();
+                    break;
+            }
+
+            this.computedId = uri;
+        }
+
+        /// <summary>
+        /// Compute id for neither singleton, nor containment scenario.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Uri"/> of @odata.id.
+        /// </returns>
+        private Uri ComputeId()
+        {
+            Uri uri = this.UriBuilder.BuildBaseUri();
+            uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);
+            uri = this.UriBuilder.BuildEntityInstanceUri(uri, this.ComputedKeyProperties, this.ResourceMetadataContext.ActualResourceTypeName);
+            return uri;
+        }
+
+        /// <summary>
+        /// Compute id for containment scenario.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Uri"/> of @odata.id.
+        /// </returns>
+        private Uri ComputeIdForContainment()
+        {
+            Uri uri;
+
+            if (!TryComputeIdFromParent(out uri))
+            {
+                // Compute ID from context URL rather than from parent.
+                uri = this.UriBuilder.BuildBaseUri();
+                ODataUri odataUri = this.ODataUri ?? this.MetadataContext.ODataUri;
+
+                if (odataUri == null || odataUri.Path == null || odataUri.Path.Count == 0)
+                {
+                    throw new ODataException(Strings.ODataMetadataBuilder_MissingParentIdOrContextUrl);
+                }
+
+                uri = this.GetContainingEntitySetUri(uri, odataUri);
+            }
+
+            // A path segment for the containment navigation property
+            uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);
+
+            if (this.ResourceMetadataContext.TypeContext.IsFromCollection)
+            {
+                uri = this.UriBuilder.BuildEntityInstanceUri(
+                    uri,
+                    this.ComputedKeyProperties,
+                    this.ResourceMetadataContext.ActualResourceTypeName);
+            }
+
+            return uri;
+        }
+
+        private bool TryComputeIdFromParent(out Uri uri)
+        {
+            try
+            {
+                ODataConventionalResourceMetadataBuilder parent = this.ParentMetadataBuilder as ODataConventionalResourceMetadataBuilder;
+                if (parent != null && parent != this)
+                {
+                    // Get the parent canonical url
+                    uri = parent.GetCanonicalUrl();
+
+                    if (uri != null)
+                    {
+                        // And append cast (if needed).
+                        // A cast segment if the navigation property is defined on a type derived from the type expected.
+                        IODataResourceTypeContext typeContext = parent.ResourceMetadataContext.TypeContext;
+
+                        if (parent.ResourceMetadataContext.ActualResourceTypeName != typeContext.ExpectedResourceTypeName)
+                        {
+                            // Do not append type cast if we know that the navigation property is in base type, not in derived type.
+                            ODataResourceTypeContext.ODataResourceTypeContextWithModel typeContextWithModel =
+                                typeContext as ODataResourceTypeContext.ODataResourceTypeContextWithModel;
+                            if (typeContextWithModel == null ||
+                                typeContextWithModel.ExpectedResourceType.FindProperty(
+                                    this.ResourceMetadataContext.TypeContext.NavigationSourceName) == null)
+                            {
+                                uri = new Uri(UriUtils.EnsureTaillingSlash(uri),
+                                    parent.ResourceMetadataContext.ActualResourceTypeName);
+                            }
+                        }
+
+                        return true;
+                    }
+                }
+            }
+            catch (ODataException)
+            {
+            }
+
+            uri = null;
+            return false;
+        }
+
+        /// <summary>
+        /// Compute id for singleton scenario.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="Uri"/> of @odata.id.
+        /// </returns>
+        private Uri ComputeIdForSingleton()
+        {
+            // Do not append key for singleton.
+            Uri uri = this.UriBuilder.BuildBaseUri();
+            uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);
+            return uri;
+        }
+
+        /// <summary>
+        /// Gets resource path from service root, and request Uri.
+        /// </summary>
+        /// <param name="baseUri">The service root Uri.</param>
+        /// <param name="odataUri">The request Uri.</param>
+        /// <returns>The resource path.</returns>
+        private Uri GetContainingEntitySetUri(Uri baseUri, ODataUri odataUri)
+        {
+            ODataPath path = odataUri.Path;
+            List<ODataPathSegment> segments = path.ToList();
+            int lastIndex = segments.Count - 1;
+            ODataPathSegment lastSegment = segments[lastIndex];
+            while (!(lastSegment is NavigationPropertySegment) && !(lastSegment is OperationSegment))
+            {
+                lastSegment = segments[--lastIndex];
+            }
+
+            while (lastSegment is TypeSegment)
+            {
+                ODataPathSegment previousSegment = segments[lastIndex - 1];
+                IEdmStructuredType owningType = previousSegment.TargetEdmType as IEdmStructuredType;
+                if (owningType != null && owningType.FindProperty(lastSegment.Identifier) != null)
+                {
+                    lastSegment = segments[--lastIndex];
+                }
+                else
+                {
+                    break;
+                }
+            }
+
+            // trim all the un-needed segments 
+            segments = segments.GetRange(0, lastIndex);
+
+            // append each segment to base uri
+            Uri uri = baseUri;
+            foreach (ODataPathSegment segment in segments)
+            {
+                var keySegment = segment as KeySegment;
+                if (keySegment == null)
+                {
+                    uri = this.UriBuilder.BuildEntitySetUri(uri, segment.Identifier);
+                }
+                else
+                {
+                    uri = this.UriBuilder.BuildEntityInstanceUri(
+                        uri,
+                        keySegment.Keys.ToList(),
+                        keySegment.EdmType.FullTypeName());
+                }
+            }
+
+            return uri;
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
@@ -18,10 +18,10 @@ namespace Microsoft.OData.Evaluation
 
     /// <summary>
     /// Implementation of OData metadata builder that generates ids based on OData protocol conventions.
+    /// This specifically does NOT generate navigation links/stream properties as it is used for deltas.
     /// </summary>
     internal class ODataConventionalIdMetadataBuilder : ODataConventionalResourceMetadataBuilder
     {
-
         /// <summary>The computed ID of this entity instance.</summary>
         /// <remarks>
         /// This is always built from the key properties, and never comes from the resource.
@@ -43,6 +43,15 @@ namespace Microsoft.OData.Evaluation
         }
 
         /// <summary>
+        /// Gets canonical url of current resource.
+        /// </summary>
+        /// <returns>The canonical url of current resource.</returns>
+        public override Uri GetCanonicalUrl()
+        {
+            return this.GetId();
+        }
+
+        /// <summary>
         /// Lazy evaluated computed entity Id. This is always a computed value and never comes from the resource.
         /// </summary>
         protected Uri ComputedId
@@ -53,7 +62,7 @@ namespace Microsoft.OData.Evaluation
                 return this.computedId;
             }
         }
-        
+
         /// <summary>
         /// The computed key property name and value pairs of the resource.
         /// If a value is unsigned integer, it will be automatically converted to its underlying type.
@@ -91,6 +100,19 @@ namespace Microsoft.OData.Evaluation
             // If the resource was transient resource, return null for Id
             // Otherwise compute it based on the key values.
             return this.ResourceMetadataContext.Resource.HasNonComputedId ? this.ResourceMetadataContext.Resource.NonComputedId : (this.ResourceMetadataContext.Resource.IsTransient ? null : this.ComputedId);
+        }
+
+        /// <summary>
+        /// Get the id that need to be written into wire
+        /// </summary>
+        /// <param name="id">The id return to the caller</param>
+        /// <returns>
+        /// If writer should write odata.id property into wire
+        /// </returns>
+        internal override bool TryGetIdForSerialization(out Uri id)
+        {
+            id = this.ResourceMetadataContext.Resource.IsTransient ? null : this.GetId();
+            return true;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
@@ -152,10 +152,15 @@ namespace Microsoft.OData.Evaluation
         /// </returns>
         private Uri ComputeId()
         {
-            Uri uri = this.UriBuilder.BuildBaseUri();
-            uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);
-            uri = this.UriBuilder.BuildEntityInstanceUri(uri, this.ComputedKeyProperties, this.ResourceMetadataContext.ActualResourceTypeName);
-            return uri;
+            if (this.ResourceMetadataContext.KeyProperties.Any())
+            {
+                Uri uri = this.UriBuilder.BuildBaseUri();
+                uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);
+                uri = this.UriBuilder.BuildEntityInstanceUri(uri, this.ComputedKeyProperties, this.ResourceMetadataContext.ActualResourceTypeName);
+                return uri;
+            }
+
+            return null;
         }
 
         /// <summary>
@@ -187,10 +192,17 @@ namespace Microsoft.OData.Evaluation
 
             if (this.ResourceMetadataContext.TypeContext.IsFromCollection)
             {
-                uri = this.UriBuilder.BuildEntityInstanceUri(
-                    uri,
-                    this.ComputedKeyProperties,
-                    this.ResourceMetadataContext.ActualResourceTypeName);
+                if (this.ResourceMetadataContext.KeyProperties.Any())
+                {
+                    uri = this.UriBuilder.BuildEntityInstanceUri(
+                        uri,
+                        this.ComputedKeyProperties,
+                        this.ResourceMetadataContext.ActualResourceTypeName);
+                }
+                else
+                {
+                    uri = null;
+                }
             }
 
             return uri;

--- a/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
@@ -238,7 +238,7 @@ namespace Microsoft.OData.Evaluation
             if (resourceState.MetadataBuilder == null)
             {
                 ODataResourceBase resource = resourceState.Resource;
-                if (this.isResponse && !isDelta)
+                if (this.isResponse || (isDelta && this.metadataDocumentUri != null))
                 {
                     ODataTypeAnnotation typeAnnotation = resource.TypeAnnotation;
 
@@ -276,7 +276,9 @@ namespace Microsoft.OData.Evaluation
 
                     if (structuredType.IsODataEntityTypeKind())
                     {
-                        resourceState.MetadataBuilder = new ODataConventionalEntityMetadataBuilder(resourceMetadataContext, this, uriBuilder);
+                        resourceState.MetadataBuilder = isDelta ?
+                            new ODataConventionalIdMetadataBuilder(resourceMetadataContext, this, uriBuilder) :
+                            new ODataConventionalEntityMetadataBuilder(resourceMetadataContext, this, uriBuilder);
                     }
                     else
                     {

--- a/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
@@ -282,7 +282,9 @@ namespace Microsoft.OData.Evaluation
                     }
                     else
                     {
-                        resourceState.MetadataBuilder = new ODataConventionalResourceMetadataBuilder(resourceMetadataContext, this, uriBuilder);
+                        resourceState.MetadataBuilder = isDelta ?
+                            resourceState.MetadataBuilder = new NoOpResourceMetadataBuilder(resource) :
+                            new ODataConventionalResourceMetadataBuilder(resourceMetadataContext, this, uriBuilder);
                     }
                 }
                 else

--- a/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
@@ -269,7 +269,17 @@ namespace Microsoft.OData.Evaluation
                         ODataResourceTypeContext.Create( /*serializationInfo*/
                             null, navigationSource, navigationSourceElementType, resourceState.ResourceTypeFromMetadata ?? resourceState.ResourceType,
                             /*throwIfMissingTypeInfo*/ true);
-                    IODataResourceMetadataContext resourceMetadataContext = ODataResourceMetadataContext.Create(resource, typeContext, /*serializationInfo*/null, structuredType, this, resourceState.SelectedProperties, null);
+
+                    IODataResourceMetadataContext resourceMetadataContext = ODataResourceMetadataContext.Create(
+                        resource,
+                        typeContext,
+                        /*serializationInfo*/null,
+                        structuredType,
+                        this,
+                        resourceState.SelectedProperties,
+                        null,
+                        /*requiresId*/ (this.isResponse || !isDelta || resource is ODataDeletedResource) // id is required except for non-deleted resource in delta request
+                        );
 
                     ODataConventionalUriBuilder uriBuilder = new ODataConventionalUriBuilder(this.ServiceBaseUri,
                         useKeyAsSegment ? ODataUrlKeyDelimiter.Slash : ODataUrlKeyDelimiter.Parentheses);

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -1091,7 +1091,7 @@ namespace Microsoft.OData.JsonLight
                     ODataConventionalResourceMetadataBuilder conventionalResourceMetadataBuilder =
                         builder as ODataConventionalResourceMetadataBuilder;
 
-                    // If it's ODataConventionalResourceMetadataBuilder, then it means we need to build nested relation ship for it in containment case
+                    // If it's ODataConventionalResourceMetadataBuilder, then it means we need to build nested relationship for it in containment case
                     if (conventionalResourceMetadataBuilder != null)
                     {
                         if (parentNestInfo != null)

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -2477,7 +2477,10 @@ namespace Microsoft.OData.JsonLight
                 }
             }
 
-            this.jsonLightResourceDeserializer.ValidateMediaEntity(resourceState);
+            if (!this.ReadingDelta)
+            {
+                this.jsonLightResourceDeserializer.ValidateMediaEntity(resourceState);
+            }
 
             // In non-delta responses, ensure that all projected properties get created.
             // Also ignore cases where the resource is 'null' which happens for expanded null entries.

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -44,7 +44,7 @@ ODataJsonLightDeltaWriter_WriteStartExpandedResourceSetCalledInInvalidState=Writ
 ODataWriterCore_WriteEndCalledInInvalidState=ODataWriter.WriteEnd was called in an invalid state ('{0}'); WriteEnd is only supported in states 'Resource', 'ResourceSet', 'NavigationLink', and 'NavigationLinkWithContent'.
 ODataWriterCore_StreamNotDisposed=ODataWriter.Write or ODataWriter.WriteEnd was called while streaming a value. Stream or TextWriter must be disposed before calling additional methods on ODataWriter.
 
-ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties=No Id or key properties were found. A resource in a delta response requires an ID or key properties be specified.
+ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties=No Id or key properties were found. A resource in a delta payload requires an ID or key properties be specified.
 ODataWriterCore_QueryCountInRequest=The ODataResourceSet.Count must be null for request payloads. Query counts are only supported in responses.
 ODataWriterCore_QueryNextLinkInRequest=The NextPageLink must be null for request payloads. Next page links are only supported in responses.
 ODataWriterCore_QueryDeltaLinkInRequest=The DeltaLink must be null for request payloads. Delta links are only supported in responses.

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -2057,7 +2057,7 @@ namespace Microsoft.OData
                 IEdmEntityType entityType = resourceType as IEdmEntityType;
                 if (resource.Id == null &&
                     entityType != null &&
-                    (resource is ODataDeletedResource || this.outputContext.MessageWriterSettings.Version > ODataVersion.V4) &&
+                    (this.outputContext.WritingResponse || resource is ODataDeletedResource) &&
                     !HasKeyProperties(entityType, resource.Properties))
                 {
                     throw new ODataException(Strings.ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties);

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -283,7 +283,7 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "No Id or key properties were found. A resource in a delta response requires an ID or key properties be specified."
+        /// A string like "No Id or key properties were found. A resource in a delta payload requires an ID or key properties be specified."
         /// </summary>
         internal static string ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties
         {

--- a/src/Microsoft.OData.Edm/Csdl/EdmEnumValueParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/EdmEnumValueParser.cs
@@ -162,7 +162,7 @@ namespace Microsoft.OData.Edm.Csdl
                 // in symbolic value
                 // "@self.HasPattern": "Red,Striped"
                 var enumValues = value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                if (enumValues.Count() > 1 && (!enumType.IsFlags || !EdmEnumValueParser.IsEnumIntegerType(enumType)))
+                if (enumValues.Length > 1 && (!enumType.IsFlags || !EdmEnumValueParser.IsEnumIntegerType(enumType)))
                 {
                     return false;
                 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaWriterTests.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using System.Text;
 using Microsoft.OData.JsonLight;
 using Microsoft.OData.UriParser;
@@ -371,6 +370,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
             ODataResource orderEntry = new ODataResource()
             {
+                Id = new Uri("Orders(1)", UriKind.Relative),
                 SerializationInfo = new ODataResourceSerializationInfo
                 {
                     NavigationSourceEntityTypeName = "MyNS.Order",
@@ -389,6 +389,7 @@ namespace Microsoft.OData.Tests.JsonLight
             {
                 Properties = new List<ODataProperty>
                 {
+
                     new ODataProperty { Name = "City", Value = "Shanghai" },
                 }
             };
@@ -413,7 +414,7 @@ namespace Microsoft.OData.Tests.JsonLight
             writer.WriteEnd();
             writer.Flush();
 
-            Assert.Equal("{\"@odata.context\":\"http://host/service/$metadata#Products(ContactName,Orders(ShippingAddress))/$delta\",\"value\":[{\"@odata.context\":\"http://host/service/$metadata#Orders/$entity\",\"ShippingAddress\":{\"City\":\"Shanghai\"}}]}", this.TestPayload());
+            Assert.Equal("{\"@odata.context\":\"http://host/service/$metadata#Products(ContactName,Orders(ShippingAddress))/$delta\",\"value\":[{\"@odata.context\":\"http://host/service/$metadata#Orders/$entity\",\"@odata.id\":\"Orders(1)\",\"ShippingAddress\":{\"City\":\"Shanghai\"}}]}", this.TestPayload());
         }
 
         [InlineData(/*isResponse*/true)]
@@ -565,6 +566,100 @@ namespace Microsoft.OData.Tests.JsonLight
             writer.Flush();
 
             Assert.Equal("{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@odata.context\":\"http://host/service/$metadata#Products/$entity\",\"@odata.type\":\"#MyNS.PhysicalProduct\",\"Id\":1,\"Name\":\"car\",\"Material\":\"gold\"}]}", this.TestPayload());
+        }
+
+        [InlineData(/*isResponse*/true, /*keyAsSegment*/false)]
+        [InlineData(/*isResponse*/false, /*keyAsSegment*/false)]
+        [InlineData(/*isResponse*/true, /*keyAsSegment*/true)]
+        [InlineData(/*isResponse*/false, /*keyAsSegment*/true)]
+        [Theory]
+        public void Write40DeletedEntryWithKeyValues(bool isResponse, bool keyAsSegment)
+        {
+            ODataDeletedResource deletedCustomerWithContent = new ODataDeletedResource()
+            {
+                Properties = new ODataProperty[]
+                {
+                    new ODataProperty() {Name="Id", Value = 1},
+                    new ODataProperty() {Name="ContactName", Value="Samantha Stones" }
+                },
+                Reason = DeltaDeletedEntryReason.Changed
+            };
+
+            string payload = WriteDeletedResource(deletedCustomerWithContent, isResponse, keyAsSegment, ODataVersion.V4);
+
+            string id = keyAsSegment ? "http://host/service/Customers/1" : "http://host/service/Customers(1)";
+            Assert.Equal(payload, isResponse ?
+                "{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"@odata.count\":5,\"@odata.deltaLink\":\"Customers?$expand=Orders&$deltatoken=8015\",\"value\":[{\"@odata.context\":\"http://host/service/$metadata#Customers/$deletedEntity\",\"id\":\"" + id + "\",\"reason\":\"changed\"}]}" :
+                "{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@odata.context\":\"http://host/service/$metadata#Customers/$deletedEntity\",\"id\":\"" + id + "\",\"reason\":\"changed\"}]}"
+                );
+        }
+
+        [InlineData(/*isResponse*/true, /*keyAsSegment*/false)]
+        [InlineData(/*isResponse*/false, /*keyAsSegment*/false)]
+        [InlineData(/*isResponse*/true, /*keyAsSegment*/true)]
+        [InlineData(/*isResponse*/false, /*keyAsSegment*/true)]
+        [Theory]
+        public void Write40DeletedEntryWithKeyValuesMatchesId(bool isResponse, bool keyAsSegment)
+        {
+            ODataDeletedResource deletedCustomerWithKeys = new ODataDeletedResource()
+            {
+                Properties = new ODataProperty[]
+                {
+                    new ODataProperty() {Name="Id", Value = 1},
+                    new ODataProperty() {Name="ContactName", Value="Samantha Stones" }
+                },
+                Reason = DeltaDeletedEntryReason.Changed
+            };
+
+            string id = keyAsSegment ? "http://host/service/Customers/1" : "http://host/service/Customers(1)";
+            ODataDeletedResource deletedCustomerWithId = new ODataDeletedResource(new Uri(id, UriKind.Absolute), DeltaDeletedEntryReason.Changed);
+
+            string deletedCustomerWithKeysPayload = WriteDeletedResource(deletedCustomerWithKeys, isResponse, keyAsSegment, ODataVersion.V4);
+            string deletedCustomerWithIdPayload = WriteDeletedResource(deletedCustomerWithId, isResponse, keyAsSegment, ODataVersion.V4);
+
+            Assert.Equal(deletedCustomerWithIdPayload, deletedCustomerWithKeysPayload);
+        }
+
+        [InlineData(/*isResponse*/true)]
+        [InlineData(/*isResponse*/false)]
+        [Theory]
+        public void Write40DeletedEntryWithKeyAndIdUsesId(bool isResponse)
+        {
+            ODataDeletedResource deletedCustomerWithId = new ODataDeletedResource(new Uri("Customers(2)", UriKind.Relative), DeltaDeletedEntryReason.Changed)
+            {
+                Properties = new ODataProperty[]
+                {
+                    new ODataProperty() {Name="Id", Value = 1},
+                    new ODataProperty() {Name="ContactName", Value="Samantha Stones" }
+                },
+                Reason = DeltaDeletedEntryReason.Changed
+            };
+
+            string deletedCustomerWithKeysPayload = WriteDeletedResource(deletedCustomerWithId, isResponse, /*keyAsSegment*/false, ODataVersion.V4);
+
+            Assert.Equal(deletedCustomerWithKeysPayload, isResponse ?
+                "{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"@odata.count\":5,\"@odata.deltaLink\":\"Customers?$expand=Orders&$deltatoken=8015\",\"value\":[{\"@odata.context\":\"http://host/service/$metadata#Customers/$deletedEntity\",\"id\":\"Customers(2)\",\"reason\":\"changed\"}]}" :
+                "{\"@odata.context\":\"http://host/service/$metadata#Customers/$delta\",\"value\":[{\"@odata.context\":\"http://host/service/$metadata#Customers/$deletedEntity\",\"id\":\"Customers(2)\",\"reason\":\"changed\"}]}"
+                );
+        }
+
+        private string WriteDeletedResource(ODataDeletedResource deletedResource, bool isResponse, bool keyAsSegment, ODataVersion version)
+        {
+            MemoryStream stream = new MemoryStream();
+            ODataJsonLightOutputContext outputContext = CreateJsonLightOutputContext(stream, this.GetModel(), false, null, version, isResponse);
+            outputContext.ODataSimplifiedOptions.EnableWritingKeyAsSegment = keyAsSegment;
+
+            ODataJsonLightWriter writer = new ODataJsonLightWriter(outputContext, this.GetCustomers(), this.GetCustomerType(), true, false, true);
+            writer.WriteStart(isResponse ? feed : requestFeed);
+            writer.WriteStart(deletedResource);
+            writer.WriteEnd(); // customer
+            writer.WriteEnd(); // delta resource set
+            writer.Flush();
+
+            stream.Seek(0, SeekOrigin.Begin);
+            string result = new StreamReader(stream).ReadToEnd();
+            stream.Dispose();
+            return result;
         }
 
         #region Expanded Feeds
@@ -1382,7 +1477,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [InlineData(/*isResponse*/true)]
         [InlineData(/*isResponse*/false)]
         [Theory]
-        public void WriteResourceInDeltaSetWithoutKeyOrIdShouldFail(bool isResponse)
+        public void WriteResourceInDeltaSetResponseWithoutKeyOrIdShouldFail(bool isResponse)
         {
             this.TestInit(this.GetModel());
 
@@ -1393,7 +1488,14 @@ namespace Microsoft.OData.Tests.JsonLight
                 writer.WriteStart(new ODataResource());
             };
 
-            writeAction.Throws<ODataException>(Strings.ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties);
+            if (isResponse)
+            {
+                writeAction.Throws<ODataException>(Strings.ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties);
+            }
+            else
+            {
+                writeAction.DoesNotThrow();
+            }
         }
 
         [InlineData(/*isResponse*/true)]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaWriterTests.cs
@@ -389,7 +389,6 @@ namespace Microsoft.OData.Tests.JsonLight
             {
                 Properties = new List<ODataProperty>
                 {
-
                     new ODataProperty { Name = "City", Value = "Shanghai" },
                 }
             };

--- a/test/FunctionalTests/Taupo/Source/Taupo.Astoria/OData/ODataPayloadElementComparer.cs
+++ b/test/FunctionalTests/Taupo/Source/Taupo.Astoria/OData/ODataPayloadElementComparer.cs
@@ -386,7 +386,7 @@ namespace Microsoft.Test.Taupo.Astoria.OData
                     {
                         this.Assert.IsNotNull(observed.Id, "Conventional template evaluation should compute the Id.");
                     }
-                    else
+                    else if (expected.Id != null)
                     {
                         this.Assert.AreEqual(expected.Id, observed.Id, "ID did not match expectation");
                     }


### PR DESCRIPTION
… supplying key properties.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1910.*

### Description

If an id is not supplied when writing an OData V4.0 Deleted entry, uses key values instead if provided

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
