### PR TITLE
Revert "Apply same backslash escaping to string literal within "IN" clause as Equals"

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -283,10 +283,6 @@ namespace Microsoft.OData.UriParser
                     sb.Append('\\');
                     sb.Append('"');
                 }
-                else if (next == '\\')
-                {
-                    sb.Append("\\\\");
-                }
                 else
                 {
                     sb.Append(next);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2085,31 +2085,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
             Assert.Equal("('a\\b\\\\bc', 'd\\ff''\\t','xy/z''')", collectionNode.LiteralText);
             Assert.Equal(3, collectionNode.Collection.Count);
-            collectionNode.Collection.ElementAt(0).ShouldBeConstantQueryNode("a\\b\\\\bc");
-            collectionNode.Collection.ElementAt(1).ShouldBeConstantQueryNode("d\\ff'\\t");
+            collectionNode.Collection.ElementAt(0).ShouldBeConstantQueryNode("a\b\\bc");
+            collectionNode.Collection.ElementAt(1).ShouldBeConstantQueryNode("d\ff'\t");
             collectionNode.Collection.ElementAt(2).ShouldBeConstantQueryNode("xy/z'");
-        }
-
-
-        [Theory]
-        [InlineData(@"'a\b\\bc'")]
-        [InlineData(@"'a''b''''bc'")]
-        [InlineData(@"'a,b,bc'")]
-        public void FilterWithInOperationShouldMatchEquals_SlashesInSingleQuotedStringLiterals(string constantString)
-        {
-            FilterClause inFilter = ParseFilter(String.Format(@"SSN in ({0})", constantString), HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
-            FilterClause eqFilter = ParseFilter(String.Format(@"SSN eq {0}", constantString), HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
-
-            var inNode = Assert.IsType<InNode>(inFilter.Expression);
-            Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
-            CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal(1, collectionNode.Collection.Count);
-
-            var eqNode = Assert.IsType<BinaryOperatorNode>(eqFilter.Expression);
-            Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(eqNode.Left).Property.Name);
-            ConstantNode constantNode = Assert.IsType<ConstantNode>(eqNode.Right);
-
-            Assert.Equal(collectionNode.Collection.ElementAt(0).Value, constantNode.Value);
         }
 
         [Theory]


### PR DESCRIPTION
Reverts OData/odata.net#1916

Merged too early; missing 2 commits.