### PR TITLE
Support for $apply/aggregate

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ApplyQueryOptionExpression.cs
+++ b/src/Microsoft.OData.Client/ALinq/ApplyQueryOptionExpression.cs
@@ -35,7 +35,7 @@ namespace Microsoft.OData.Client
 		}
 
 		/// <summary>
-		/// Aggregations in the $apply expression
+		/// Gets the aggregations in the $apply expression
 		/// </summary>
 		internal List<Aggregation> Aggregations { get; private set; }
 

--- a/src/Microsoft.OData.Client/ALinq/ApplyQueryOptionExpression.cs
+++ b/src/Microsoft.OData.Client/ALinq/ApplyQueryOptionExpression.cs
@@ -6,130 +6,114 @@
 
 namespace Microsoft.OData.Client
 {
-	using System;
-	using System.Collections.Generic;
+    using System;
+    using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Linq;
     using System.Linq.Expressions;
-	using Microsoft.OData.UriParser.Aggregation;
+    using Microsoft.OData.UriParser.Aggregation;
 
-	/// <summary>
-	/// A resource specific expression representing an apply query option.
-	/// </summary>
-	internal class ApplyQueryOptionExpression : QueryOptionExpression
-	{
-		/// <summary>
-		/// The filter expressions that make the filter predicate
-		/// </summary>
-		private readonly List<Expression> filterExpressions;
+    /// <summary>
+    /// A resource specific expression representing an apply query option.
+    /// </summary>
+    internal class ApplyQueryOptionExpression : QueryOptionExpression
+    {
+        /// <summary>
+        /// The filter expressions that make the filter predicate
+        /// </summary>
+        private readonly List<Expression> filterExpressions;
 
-		/// <summary>
-		/// Creates an <see cref="ApplyQueryOptionExpression"/> expression.
-		/// </summary>
-		/// <param name="type">the return type of the expression.</param>
-		internal ApplyQueryOptionExpression(Type type)
-			: base(type)
-		{
-			this.Aggregations = new List<Aggregation>();
-			this.filterExpressions = new List<Expression>();
-		}
+        /// <summary>
+        /// Creates an <see cref="ApplyQueryOptionExpression"/> expression.
+        /// </summary>
+        /// <param name="type">the return type of the expression.</param>
+        internal ApplyQueryOptionExpression(Type type)
+            : base(type)
+        {
+            this.Aggregations = new List<Aggregation>();
+            this.filterExpressions = new List<Expression>();
+        }
 
-		/// <summary>
-		/// The <see cref="ExpressionType"/> of the <see cref="Expression"/>.
-		public override ExpressionType NodeType
-		{
-			get { return (ExpressionType)ResourceExpressionType.ApplyQueryOption; }
-		}
+        /// <summary>
+        /// The <see cref="ExpressionType"/> of the <see cref="Expression"/>.
+        /// </summary>
+        public override ExpressionType NodeType
+        {
+            get { return (ExpressionType)ResourceExpressionType.ApplyQueryOption; }
+        }
 
-		/// <summary>
-		/// Gets the aggregations in the $apply expression
-		/// </summary>
-		internal List<Aggregation> Aggregations { get; private set; }
+        /// <summary>
+        /// Gets the aggregations in the $apply expression
+        /// </summary>
+        internal List<Aggregation> Aggregations { get; private set; }
 
-		/// <summary>
-		/// Adds the conjuncts to the filter expressions
-		/// </summary>
-		internal void AddPredicateConjuncts(IEnumerable<Expression> predicates)
-		{
-			this.filterExpressions.AddRange(predicates);
-		}
+        /// <summary>
+        /// Adds the conjuncts to the filter expressions
+        /// </summary>
+        internal void AddPredicateConjuncts(IEnumerable<Expression> predicates)
+        {
+            this.filterExpressions.AddRange(predicates);
+        }
 
-		internal ReadOnlyCollection<Expression> PredicateConjuncts
-		{
-			get
-			{
-				return new ReadOnlyCollection<Expression>(this.filterExpressions);
-			}
-		}
+        internal ReadOnlyCollection<Expression> PredicateConjuncts
+        {
+            get
+            {
+                return new ReadOnlyCollection<Expression>(this.filterExpressions);
+            }
+        }
 
-		/// <summary>
-		/// Gets filter transformation predicate.
-		/// </summary>
-		/// <returns>A predicate with all conjuncts AND'd</returns>
-		internal Expression GetPredicate()
-		{
-			Expression combinedPredicate = null;
-			bool isFirst = true;
+        /// <summary>
+        /// Gets filter transformation predicate.
+        /// </summary>
+        /// <returns>A predicate with all conjuncts AND'd</returns>
+        internal Expression GetPredicate()
+        {
+            return this.filterExpressions.Aggregate((leftExpr, rightExpr) => Expression.And(leftExpr, rightExpr));
+        }
 
-			foreach (Expression expr in this.filterExpressions)
-			{
-				if (isFirst)
-				{
-					combinedPredicate = expr;
-					isFirst = false;
-				}
-				else
-				{
-					combinedPredicate = Expression.And(combinedPredicate, expr);
-				}
-			}
+        /// <summary>
+        /// Structure for an aggregation. Holds lambda expression plus enum indicating aggregation method
+        /// </summary>
+        internal struct Aggregation
+        {
+            /// <summary>
+            /// Lambda expression for aggregation selector.
+            /// </summary>
+            internal readonly Expression Expression;
 
-			return combinedPredicate;
-		}
+            /// <summary>
+            /// Enum indicating aggregation method.
+            /// </summary>
+            internal readonly AggregationMethod AggregationMethod;
 
-		/// <summary>
-		/// Structure for an aggregation. Holds lambda expression plus enum indicating aggregation method
-		/// </summary>
-		internal struct Aggregation
-		{
-			/// <summary>
-			/// Lambda expression for aggregation selector.
-			/// </summary>
-			internal readonly Expression Expression;
+            /// <summary>
+            /// Aggregation alias.
+            /// </summary>
+            internal readonly string AggregationAlias;
 
-			/// <summary>
-			/// Enum indicating aggregation method.
-			/// </summary>
-			internal readonly AggregationMethod AggregationMethod;
+            /// <summary>
+            /// Creates an aggregation.
+            /// </summary>
+            /// <param name="expr">Lambda expression for aggregation selector.</param>
+            /// <param name="aggregationMethod">Enum indicating aggregation method.</param>
+            internal Aggregation(Expression expr, AggregationMethod aggregationMethod)
+                : this(expr, aggregationMethod, string.Empty)
+            {
+            }
 
-			/// <summary>
-			/// Aggregation alias.
-			/// </summary>
-			internal readonly string AggregationAlias;
-
-			/// <summary>
-			/// Creates an aggregation.
-			/// </summary>
-			/// <param name="exp">Lambda expression for aggregation selector.</param>
-			/// <param name="aggregationMethod">Enum indicating aggregation method.</param>
-			internal Aggregation(Expression exp, AggregationMethod aggregationMethod)
-			{
-				this.Expression = exp;
-				this.AggregationMethod = aggregationMethod;
-				this.AggregationAlias = string.Empty;
-			}
-
-			/// <summary>
-			/// Creates an aggregation.
-			/// </summary>
-			/// <param name="exp">Lambda expression for aggregation selector.</param>
-			/// <param name="aggregationMethod">Enum indicating aggregation method.</param>
-			/// <param name="aggregationAlias">Aggregation alias.</param>
-			internal Aggregation(Expression exp, AggregationMethod aggregationMethod, string aggregationAlias)
-			{
-				this.Expression = exp;
-				this.AggregationMethod = aggregationMethod;
-				this.AggregationAlias = aggregationAlias;
-			}
-		}
-	}
+            /// <summary>
+            /// Creates an aggregation.
+            /// </summary>
+            /// <param name="expr">Lambda expression for aggregation selector.</param>
+            /// <param name="aggregationMethod">Enum indicating aggregation method.</param>
+            /// <param name="aggregationAlias">Aggregation alias.</param>
+            internal Aggregation(Expression expr, AggregationMethod aggregationMethod, string aggregationAlias)
+            {
+                this.Expression = expr;
+                this.AggregationMethod = aggregationMethod;
+                this.AggregationAlias = aggregationAlias;
+            }
+        }
+    }
 }

--- a/src/Microsoft.OData.Client/ALinq/ApplyQueryOptionExpression.cs
+++ b/src/Microsoft.OData.Client/ALinq/ApplyQueryOptionExpression.cs
@@ -1,0 +1,88 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ApplyQueryOptionExpression.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq.Expressions;
+	using Microsoft.OData.UriParser.Aggregation;
+
+	/// <summary>
+	/// A resource specific expression representing an apply query option.
+	/// </summary>
+	internal class ApplyQueryOptionExpression : QueryOptionExpression
+	{
+
+		/// <summary>
+		/// Creates an <see cref="ApplyQueryOptionExpression"/> expression.
+		/// </summary>
+		/// <param name="type">the return type of the expression.</param>
+		internal ApplyQueryOptionExpression(Type type)
+			: base(type)
+		{
+			this.Aggregations = new List<Aggregation>();
+		}
+
+		/// <summary>
+		/// The <see cref="ExpressionType"/> of the <see cref="Expression"/>.
+		public override ExpressionType NodeType
+		{
+			get { return (ExpressionType)ResourceExpressionType.ApplyQueryOption; }
+		}
+
+		/// <summary>
+		/// Aggregations in the $apply expression
+		/// </summary>
+		internal List<Aggregation> Aggregations { get; private set; }
+
+		/// <summary>
+		/// Structure for an aggregation. Holds lambda expression plus enum indicating aggregation method
+		/// </summary>
+		internal struct Aggregation
+		{
+			/// <summary>
+			/// Lambda expression for aggregation selector.
+			/// </summary>
+			internal readonly Expression Expression;
+
+			/// <summary>
+			/// Enum indicating aggregation method.
+			/// </summary>
+			internal readonly AggregationMethod AggregationMethod;
+
+			/// <summary>
+			/// Aggregation alias.
+			/// </summary>
+			internal readonly string AggregationAlias;
+
+			/// <summary>
+			/// Creates an aggregation.
+			/// </summary>
+			/// <param name="exp">Lambda expression for aggregation selector.</param>
+			/// <param name="aggregationMethod">Enum indicating aggregation method.</param>
+			internal Aggregation(Expression exp, AggregationMethod aggregationMethod)
+			{
+				this.Expression = exp;
+				this.AggregationMethod = aggregationMethod;
+				this.AggregationAlias = string.Empty;
+			}
+
+			/// <summary>
+			/// Creates an aggregation.
+			/// </summary>
+			/// <param name="exp">Lambda expression for aggregation selector.</param>
+			/// <param name="aggregationMethod">Enum indicating aggregation method.</param>
+			/// <param name="aggregationAlias">Aggregation alias.</param>
+			internal Aggregation(Expression exp, AggregationMethod aggregationMethod, string aggregationAlias)
+			{
+				this.Expression = exp;
+				this.AggregationMethod = aggregationMethod;
+				this.AggregationAlias = aggregationAlias;
+			}
+		}
+	}
+}

--- a/src/Microsoft.OData.Client/ALinq/DataServiceQueryProvider.cs
+++ b/src/Microsoft.OData.Client/ALinq/DataServiceQueryProvider.cs
@@ -11,9 +11,11 @@ namespace Microsoft.OData.Client
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.IO;
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
+    using System.Xml;
 
     #endregion Namespaces
 
@@ -109,11 +111,33 @@ namespace Microsoft.OData.Client
                         return query.AsEnumerable().First();
                     case SequenceMethod.FirstOrDefault:
                         return query.AsEnumerable().FirstOrDefault();
-#if !PORTABLELIB
                     case SequenceMethod.LongCount:
                     case SequenceMethod.Count:
-                        return (TElement)Convert.ChangeType(((DataServiceQuery<TElement>)query).GetQuerySetCount(this.Context), typeof(TElement), System.Globalization.CultureInfo.InvariantCulture.NumberFormat);
-#endif
+                        return ((DataServiceQuery<TElement>)query).GetValue(this.Context, ParseQuerySetCount<TElement>);
+                    case SequenceMethod.SumIntSelector:
+                    case SequenceMethod.SumDoubleSelector:
+                    case SequenceMethod.SumDecimalSelector:
+                    case SequenceMethod.SumLongSelector:
+                    case SequenceMethod.SumSingleSelector:
+                    case SequenceMethod.SumNullableIntSelector:
+                    case SequenceMethod.SumNullableDoubleSelector:
+                    case SequenceMethod.SumNullableDecimalSelector:
+                    case SequenceMethod.SumNullableLongSelector:
+                    case SequenceMethod.SumNullableSingleSelector:
+                    case SequenceMethod.AverageIntSelector:
+                    case SequenceMethod.AverageDoubleSelector:
+                    case SequenceMethod.AverageDecimalSelector:
+                    case SequenceMethod.AverageLongSelector:
+                    case SequenceMethod.AverageSingleSelector:
+                    case SequenceMethod.AverageNullableIntSelector:
+                    case SequenceMethod.AverageNullableDoubleSelector:
+                    case SequenceMethod.AverageNullableDecimalSelector:
+                    case SequenceMethod.AverageNullableLongSelector:
+                    case SequenceMethod.AverageNullableSingleSelector:
+                    case SequenceMethod.MinSelector: // Mapped to a generic expression - Min(IQueryable`1<T0>, Expression`1<Func`2<T0, T1>>)->T1
+                    case SequenceMethod.MaxSelector: // Mapped to a generic expression - Max(IQueryable`1<T0>, Expression`1<Func`2<T0, T1>>)->T1
+                    case SequenceMethod.CountDistinctSelector: // Mapped to a generic expression - CountDistinct(IQueryable`1<T0>, Expression`1<Func`2<T0, T1>>)->Int32
+                        return ((DataServiceQuery<TElement>)query).GetValue(this.Context, this.ParseAggregateSingletonResult<TElement>);
                     default:
                         throw Error.MethodNotSupported(mce);
                 }
@@ -151,6 +175,83 @@ namespace Microsoft.OData.Client
             Type lastSegmentType = re.Projection == null ? re.ResourceType : re.Projection.Selector.Parameters[0].Type;
             LambdaExpression selector = re.Projection == null ? null : re.Projection.Selector;
             return new QueryComponents(uri, version, lastSegmentType, selector, normalizerRewrites);
+        }
+
+        /// <summary>
+        /// Parses the result of a query set count request.
+        /// </summary>
+        /// <typeparam name="TElement">The return type.</typeparam>
+        /// <param name="queryResult">The query result.</param>
+        /// <returns></returns>
+        private static TElement ParseQuerySetCount<TElement>(QueryResult queryResult)
+        {
+            StreamReader reader = new StreamReader(queryResult.GetResponseStream());
+            long querySetCount = -1;
+
+            try
+            {
+                querySetCount = XmlConvert.ToInt64(reader.ReadToEnd());
+            }
+            finally
+            {
+                reader.Close();
+            }
+
+            return (TElement)Convert.ChangeType(querySetCount, typeof(TElement), System.Globalization.CultureInfo.InvariantCulture.NumberFormat);
+        }
+
+        /// <summary>
+        /// Parses the scalar result of an aggegrate request.
+        /// </summary>
+        /// <typeparam name="TElement">The return type.</typeparam>
+        /// <param name="queryResult">The query result.</param>
+        /// <returns></returns>
+        private TElement ParseAggregateSingletonResult<TElement>(QueryResult queryResult)
+        {
+            IDictionary<string, string> responseHeaders = new Dictionary<string, string>();
+            responseHeaders.Add(ODataConstants.ContentTypeHeader, "application/json");
+            HttpWebResponseMessage httpWebResponseMessage = new HttpWebResponseMessage(responseHeaders, (int)queryResult.StatusCode, queryResult.GetResponseStream);
+
+            ODataMessageReaderSettings messageReaderSettings = new ODataMessageReaderSettings
+            {
+                Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType
+            };
+
+            ODataResource entry = default(ODataResource);
+            using (var messageReader = new ODataMessageReader(httpWebResponseMessage, messageReaderSettings, this.Context.Format.ServiceModel))
+            {
+                var reader = messageReader.CreateODataResourceSetReader();
+                while (reader.Read())
+                {
+                    switch (reader.State)
+                    {
+                        case ODataReaderState.ResourceEnd:
+                            entry = reader.Item as ODataResource;
+                            if (entry != null && entry.Properties.Any())
+                            {
+                                ODataProperty aggregationProperty = entry.Properties.First();
+                                ODataUntypedValue untypedValue = aggregationProperty.Value as ODataUntypedValue;
+
+                                Type underlyingType = Nullable.GetUnderlyingType(typeof(TElement));
+                                if (underlyingType == null) // Not a nullable type
+                                {
+                                    underlyingType = typeof(TElement);
+                                }
+
+                                return (TElement)Convert.ChangeType(
+                                    untypedValue.RawValue,
+                                    underlyingType,
+                                    System.Globalization.CultureInfo.InvariantCulture.NumberFormat);
+                            }
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+
+            // Failed to retrieve the aggregate result for whatever reason
+            throw new DataServiceQueryException(Strings.DataServiceRequest_FailGetValue);
         }
     }
 }

--- a/src/Microsoft.OData.Client/ALinq/DataServiceQueryProvider.cs
+++ b/src/Microsoft.OData.Client/ALinq/DataServiceQueryProvider.cs
@@ -210,7 +210,8 @@ namespace Microsoft.OData.Client
         {
             IDictionary<string, string> responseHeaders = new Dictionary<string, string>();
             responseHeaders.Add(ODataConstants.ContentTypeHeader, "application/json");
-            HttpWebResponseMessage httpWebResponseMessage = new HttpWebResponseMessage(responseHeaders, (int)queryResult.StatusCode, queryResult.GetResponseStream);
+            HttpWebResponseMessage httpWebResponseMessage = new HttpWebResponseMessage(
+                responseHeaders, (int)queryResult.StatusCode, queryResult.GetResponseStream);
 
             ODataMessageReaderSettings messageReaderSettings = new ODataMessageReaderSettings
             {
@@ -218,9 +219,10 @@ namespace Microsoft.OData.Client
             };
 
             ODataResource entry = default(ODataResource);
-            using (var messageReader = new ODataMessageReader(httpWebResponseMessage, messageReaderSettings, this.Context.Format.ServiceModel))
+            using (ODataMessageReader messageReader = new ODataMessageReader(
+                httpWebResponseMessage, messageReaderSettings, this.Context.Format.ServiceModel))
             {
-                var reader = messageReader.CreateODataResourceSetReader();
+                ODataReader reader = messageReader.CreateODataResourceSetReader();
                 while (reader.Read())
                 {
                     switch (reader.State)

--- a/src/Microsoft.OData.Client/ALinq/QueryableResourceExpression.cs
+++ b/src/Microsoft.OData.Client/ALinq/QueryableResourceExpression.cs
@@ -196,6 +196,14 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
+        /// Apply query option for ResourceSet
+        /// </summary>
+        internal ApplyQueryOptionExpression Apply
+        {
+            get { return this.sequenceQueryOptions.OfType<ApplyQueryOptionExpression>().SingleOrDefault(); }
+        }
+
+        /// <summary>
         /// Gets sequence query options for ResourceSet
         /// </summary>
         internal IEnumerable<QueryOptionExpression> SequenceQueryOptions

--- a/src/Microsoft.OData.Client/ALinq/QueryableResourceExpression.cs
+++ b/src/Microsoft.OData.Client/ALinq/QueryableResourceExpression.cs
@@ -371,6 +371,56 @@ namespace Microsoft.OData.Client
             this.keyPredicateConjuncts.Clear();
         }
 
+        internal void AddApply(Expression aggregateExpr, OData.UriParser.Aggregation.AggregationMethod aggregationMethod)
+        {
+            if (this.OrderBy != null)
+            {
+                throw new NotSupportedException(Strings.ALinq_QueryOptionOutOfOrder("apply", "orderby"));
+            }
+            else if (this.Skip != null)
+            {
+                // $skip and $top may be used together with rollup. 
+                // However, support for rollup is currently not implemented in OData WebApi
+                // If $skip and/or $top appears before $apply, its currently ignored. 
+                // Makes sense to throw an exception to avoid giving a false impression.
+                throw new NotSupportedException(Strings.ALinq_QueryOptionOutOfOrder("apply", "skip"));
+            }
+            else if (this.Take != null)
+            {
+                throw new NotSupportedException(Strings.ALinq_QueryOptionOutOfOrder("apply", "top"));
+            }
+
+            if (this.Apply == null)
+            {
+                AddSequenceQueryOption(new ApplyQueryOptionExpression(this.Type));
+            }
+
+            if (this.Filter != null && this.Filter.PredicateConjuncts.Count > 0)
+            {
+                // The $apply query option is evaluated first, then other query options ($filter, $orderby, $select) are evaluated, 
+                // if applicable, on the result of $apply in their normal order.
+                // http://docs.oasis-open.org/odata/odata-data-aggregation-ext/v4.0/cs02/odata-data-aggregation-ext-v4.0-cs02.html#_Toc435016590
+                
+                // If a Where appears before an aggregation method (e.g. Average, Sum, etc) or GroupBy, 
+                // the conjuncts of the filter expression will be used to restrict the set of data to be aggregated. 
+                // They will not appear on the $filter query option. Instead, we use them to construct a filter transformation.
+                // E.g. /Sales?$apply=filter(Amount gt 1)/aggregate(Amount with average as AverageAmount)
+                
+                // If a Where appears after an aggregation method or GroupBy, the conjuncts should appear
+                // on a $filter query option after the $apply.
+                // E.g. /Sales?$apply=groupby((Product/Color),aggregate(Amount with average as AverageAmount))&$filter=Product/Color eq 'Brown'
+
+                // To separate the two sets of possible conjuncts, we store those that appear in the Where 
+                // before aggregate method in the Apply query option object.
+                // We also don't concern ourselves with whether there's a key predicate or not since a ByKey query is not applicable
+                this.Apply.AddPredicateConjuncts(this.Filter.PredicateConjuncts);
+                this.keyPredicateConjuncts.Clear();
+                this.RemoveFilterExpression();
+            }
+
+            this.Apply.Aggregations.Add(new ApplyQueryOptionExpression.Aggregation(aggregateExpr, aggregationMethod));
+        }
+
         /// <summary>
         /// Add query option to resource expression
         /// </summary>

--- a/src/Microsoft.OData.Client/ALinq/ReflectionUtil.cs
+++ b/src/Microsoft.OData.Client/ALinq/ReflectionUtil.cs
@@ -333,6 +333,8 @@ namespace Microsoft.OData.Client
             map.Add(@"Average(IEnumerable`1<Nullable`1<Double>>)->Nullable`1<Double>", SequenceMethod.AverageNullableDouble);
             map.Add(@"Average(IEnumerable`1<Decimal>)->Decimal", SequenceMethod.AverageDecimal);
             map.Add(@"Average(IEnumerable`1<Nullable`1<Decimal>>)->Nullable`1<Decimal>", SequenceMethod.AverageNullableDecimal);
+            map.Add(@"CountDistinct(IQueryable`1<T0>, Expression`1<Func`2<T0, T1>>)->Int32", SequenceMethod.CountDistinctSelector);
+            map.Add(@"CountDistinct(IEnumerable`1<T0>, Func`2<T0, T1>)->Int32", SequenceMethod.CountDistinctSelector);
 
             // by redirection through canonical method names, determine sequence enum value
             // for all know LINQ operators
@@ -543,7 +545,8 @@ namespace Microsoft.OData.Client
         internal static IEnumerable<MethodInfo> GetAllLinqOperators()
         {
             return typeof(Queryable).GetPublicStaticMethods().Concat(
-                typeof(Enumerable).GetPublicStaticMethods());
+                typeof(Enumerable).GetPublicStaticMethods()).Concat(
+                typeof(DataServiceExtensions).GetPublicStaticMethods());
         }
     }
 
@@ -727,6 +730,8 @@ namespace Microsoft.OData.Client
         AsEnumerable,
 
         ToList,
+
+        CountDistinctSelector,
 
         NotSupported,
     }

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -799,30 +799,36 @@ namespace Microsoft.OData.Client
             return input;
         }
 
-        private static Expression AnalyzeAggregation(MethodCallExpression methodCallExpr, AggregationMethod aggregationMethod)
+        /// <summary>
+        /// Analyzes an aggregation expression - Average, Sum, Min, Max and CountDistinct
+        /// </summary>
+        /// <param name="aggregationExpr">The aggregation expression.</param>
+        /// <param name="aggregationMethod">The aggregation method.</param>
+        /// <returns>The resource expression if successful; aggregation expression otherwise</returns>
+        private static Expression AnalyzeAggregation(MethodCallExpression aggregationExpr, AggregationMethod aggregationMethod)
         {
-            Debug.Assert(methodCallExpr != null, "methodCallExpr != null");
-            if (methodCallExpr.Arguments.Count != 2)
+            Debug.Assert(aggregationExpr != null, "methodCallExpr != null");
+            if (aggregationExpr.Arguments.Count != 2)
             {
-                return methodCallExpr;
+                return aggregationExpr;
             }
 
             QueryableResourceExpression resourceExpr;
             LambdaExpression lambdaExpr;
-            if (!TryGetResourceSetMethodArguments(methodCallExpr, out resourceExpr, out lambdaExpr))
+            if (!TryGetResourceSetMethodArguments(aggregationExpr, out resourceExpr, out lambdaExpr))
             {
                 // UNSUPPORTED: Expected LambdaExpression as second argument to sequence method
-                return methodCallExpr;
+                return aggregationExpr;
             }
 
-            ValidationRules.DisallowExpressionEndWithTypeAs(lambdaExpr.Body, methodCallExpr.Method.Name);
+            ValidationRules.DisallowExpressionEndWithTypeAs(lambdaExpr.Body, aggregationExpr.Method.Name);
             ValidationRules.ValidateAggregateExpression(lambdaExpr.Body);
 
             Expression selector;
             if (!TryBindToInput(resourceExpr, lambdaExpr, out selector))
             {
                 // UNSUPPORTED: Lambda should reference the resource expression
-                return methodCallExpr;
+                return aggregationExpr;
             }
 
             resourceExpr.AddApply(selector, aggregationMethod);

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -825,10 +825,7 @@ namespace Microsoft.OData.Client
                 return methodCallExpr;
             }
 
-            EnsureApplyInitialized(input);
-            Debug.Assert(input.Apply != null, "input.Apply != null");
-
-            input.Apply.Aggregations.Add(new ApplyQueryOptionExpression.Aggregation(selector, aggregationMethod));
+            input.AddApply(selector, aggregationMethod);
 
             return input;
         }
@@ -1617,20 +1614,6 @@ namespace Microsoft.OData.Client
             }
 
             return expression;
-        }
-
-        /// <summary>
-        /// Ensure apply query option for the resource set is initialized
-        /// </summary>
-        /// <param name="input">The resource expression</param>
-        private static void EnsureApplyInitialized(QueryableResourceExpression input)
-        {
-            Debug.Assert(input != null, "input != null");
-
-            if (input.Apply == null)
-            {
-                AddSequenceQueryOption(input, new ApplyQueryOptionExpression(input.Type));
-            }
         }
 
         /// <summary>Use this class to perform pattern-matching over expression trees.</summary>
@@ -2991,7 +2974,7 @@ namespace Microsoft.OData.Client
 
             /// <summary>
             /// Checks whether the specified <paramref name="expr"/> is a valid aggregate expression.
-            /// A valid aggregate expression must be translatable into a path to an aggregatable property.
+            /// An aggregate expression must evaluate to a single-valued property path to an aggregatable property.
             /// </summary>
             /// <param name="expr">The aggregate expression</param>
             internal static void ValidateAggregateExpression(Expression expr)

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -1517,7 +1517,7 @@ namespace Microsoft.OData.Client
                         case SequenceMethod.Count:
                             return AnalyzeCountMethod(mce);
                         case SequenceMethod.CountDistinctSelector:
-                            return AnalyzeCountDistinct(mce);
+                            return AnalyzeAggregation(mce, AggregationMethod.CountDistinct);
                         case SequenceMethod.SumIntSelector:
                         case SequenceMethod.SumDoubleSelector:
                         case SequenceMethod.SumDecimalSelector:
@@ -1595,40 +1595,6 @@ namespace Microsoft.OData.Client
             }
 
             return e;
-        }
-
-        private static Expression AnalyzeCountDistinct(MethodCallExpression methodCallExpr)
-        {
-            Debug.Assert(methodCallExpr != null, "methodCallExpr != null");
-            if (methodCallExpr.Arguments.Count != 2)
-            {
-                return methodCallExpr;
-            }
-
-            QueryableResourceExpression input;
-            LambdaExpression lambdaExpr;
-            if (!TryGetResourceSetMethodArguments(methodCallExpr, out input, out lambdaExpr))
-            {
-                // UNSUPPORTED: Expected LambdaExpression as second argument to sequence method
-                return methodCallExpr;
-            }
-
-            ValidationRules.DisallowExpressionEndWithTypeAs(lambdaExpr.Body, methodCallExpr.Method.Name);
-            ValidationRules.ValidateAggregateExpression(lambdaExpr.Body);
-
-            Expression selector;
-            if (!TryBindToInput(input, lambdaExpr, out selector))
-            {
-                // UNSUPPORTED: Lambda should reference the input, and only the input
-                return methodCallExpr;
-            }
-
-            EnsureApplyInitialized(input);
-            Debug.Assert(input.Apply != null, "input.Apply != null");
-
-            input.Apply.Aggregations.Add(new ApplyQueryOptionExpression.Aggregation(selector, AggregationMethod.CountDistinct));
-
-            return input;
         }
 
         /// <summary>Strips calls to .Cast() methods, returning the underlying expression.</summary>

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -2982,7 +2982,7 @@ namespace Microsoft.OData.Client
                 MemberExpression memberExpr = StripTo<MemberExpression>(expr);
 
                 // ResourceBinder's VisitMemberAccess override transforms member access expressions 
-                // involving properties of known primitive types into their method method equivalent
+                // involving properties of known primitive types into their method equivalent
                 // E.g. Length into get_Length()
                 // Disallow expressions of the form d1.Prop.get_PropertyName() - e.g. d1.Prop.get_Length()
                 // memberExpr will be null in such a scenario

--- a/src/Microsoft.OData.Client/ALinq/ResourceExpressionType.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceExpressionType.cs
@@ -41,5 +41,8 @@ namespace Microsoft.OData.Client
 
         /// <summary>Expand Query Option Expression</summary>
         ExpandQueryOption,
+
+        /// <summary>Apply Query Option Expression</summary>
+        ApplyQueryOption
     }
 }

--- a/src/Microsoft.OData.Client/ALinq/TypeSystem.cs
+++ b/src/Microsoft.OData.Client/ALinq/TypeSystem.cs
@@ -11,6 +11,7 @@ namespace Microsoft.OData.Client
     using System.Diagnostics;
     using System.Reflection;
     using Microsoft.OData.Edm;
+    using Microsoft.OData.UriParser.Aggregation;
     using Microsoft.Spatial;
 
     /// <summary>Utility functions for processing Expression trees</summary>
@@ -35,6 +36,9 @@ namespace Microsoft.OData.Client
         /// Entity       - null
         /// </summary>
         private static readonly Dictionary<Type, Type> ienumerableElementTypeCache = new Dictionary<Type, Type>(EqualityComparer<Type>.Default);
+
+        /// <summary> Aggregation method map to the URI equivalent</summary>
+        private static Dictionary<AggregationMethod, string> aggregationMethodMap = new Dictionary<AggregationMethod, string>(EqualityComparer<AggregationMethod>.Default);
 
         /// <summary> VB Assembly name</summary>
         private const string VisualBasicAssemblyName = "Microsoft.VisualBasic,";
@@ -223,6 +227,13 @@ namespace Microsoft.OData.Client
                 typeof(Date).GetProperty("Day", typeof(int)).GetGetMethod());
 
             Debug.Assert(propertiesAsMethodsMap.Count == 24, "propertiesAsMethodsMap.Count == 24");
+
+            aggregationMethodMap.Add(AggregationMethod.Sum, "sum");
+            aggregationMethodMap.Add(AggregationMethod.Average, "average");
+            aggregationMethodMap.Add(AggregationMethod.Min, "min");
+            aggregationMethodMap.Add(AggregationMethod.Max, "max");
+            aggregationMethodMap.Add(AggregationMethod.CountDistinct, "countdistinct");
+            aggregationMethodMap.Add(AggregationMethod.VirtualPropertyCount, "$count");
         }
 
         /// <summary>
@@ -306,6 +317,17 @@ namespace Microsoft.OData.Client
             }
 
             return resultType;
+        }
+
+        /// <summary>
+        /// See if aggregation method has URI equivalent
+        /// </summary>
+        /// <param name="aggregationMethod">The aggregation method.</param>
+        /// <param name="uriEquivalent">The URI equivalent.</param>
+        /// <returns>true if the aggregation method is mapped to its URI equivalent</returns>
+        internal static bool TryGetUriEquivalent(AggregationMethod aggregationMethod, out string uriEquivalent)
+        {
+            return aggregationMethodMap.TryGetValue(aggregationMethod, out uriEquivalent);
         }
 
         /// <summary>Finds whether a non-primitive implements IEnumerable and returns element type if it does.</summary>

--- a/src/Microsoft.OData.Client/ALinq/TypeSystem.cs
+++ b/src/Microsoft.OData.Client/ALinq/TypeSystem.cs
@@ -228,12 +228,12 @@ namespace Microsoft.OData.Client
 
             Debug.Assert(propertiesAsMethodsMap.Count == 24, "propertiesAsMethodsMap.Count == 24");
 
-            aggregationMethodMap.Add(AggregationMethod.Sum, "sum");
-            aggregationMethodMap.Add(AggregationMethod.Average, "average");
-            aggregationMethodMap.Add(AggregationMethod.Min, "min");
-            aggregationMethodMap.Add(AggregationMethod.Max, "max");
-            aggregationMethodMap.Add(AggregationMethod.CountDistinct, "countdistinct");
-            aggregationMethodMap.Add(AggregationMethod.VirtualPropertyCount, "$count");
+            aggregationMethodMap.Add(AggregationMethod.Sum, UriHelper.SUM);
+            aggregationMethodMap.Add(AggregationMethod.Average, UriHelper.AVERAGE);
+            aggregationMethodMap.Add(AggregationMethod.Min, UriHelper.MIN);
+            aggregationMethodMap.Add(AggregationMethod.Max, UriHelper.MAX);
+            aggregationMethodMap.Add(AggregationMethod.CountDistinct, UriHelper.COUNTDISTINCT);
+            aggregationMethodMap.Add(AggregationMethod.VirtualPropertyCount, UriHelper.VIRTUALPROPERTYCOUNT);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/ALinq/UriHelper.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriHelper.cs
@@ -83,6 +83,21 @@ namespace Microsoft.OData.Client
         /// <summary>The $format query option.</summary>
         internal const string OPTIONFORMAT = "format";
 
+        /// <summary>apply</summary>
+        internal const string OPTIONAPPLY = "apply";
+
+        /// <summary>groupby</summary>
+        internal const string GROUPBY = "groupby";
+
+        /// <summary>aggregate</summary>
+        internal const string AGGREGATE = "aggregate";
+
+        /// <summary>aggregate</summary>
+        internal const string WITH = "with";
+
+        /// <summary>aggregate</summary>
+        internal const string AS = "as";
+
         /// <summary>true</summary>
         internal const string COUNTTRUE = "true";
 

--- a/src/Microsoft.OData.Client/ALinq/UriHelper.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriHelper.cs
@@ -92,10 +92,10 @@ namespace Microsoft.OData.Client
         /// <summary>aggregate</summary>
         internal const string AGGREGATE = "aggregate";
 
-        /// <summary>aggregate</summary>
+        /// <summary>with</summary>
         internal const string WITH = "with";
 
-        /// <summary>aggregate</summary>
+        /// <summary>as</summary>
         internal const string AS = "as";
 
         /// <summary>true</summary>

--- a/src/Microsoft.OData.Client/ALinq/UriHelper.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriHelper.cs
@@ -173,6 +173,24 @@ namespace Microsoft.OData.Client
         /// <summary>The encoded { sign</summary>
         internal const string ENCODEDBRACESIGN = "%7B";
 
+        /// <summary>average</summary>
+        internal const string AVERAGE = "average";
+
+        /// <summary>sum</summary>
+        internal const string SUM = "sum";
+
+        /// <summary>min</summary>
+        internal const string MIN = "min";
+
+        /// <summary>max</summary>
+        internal const string MAX = "max";
+
+        /// <summary>countdistinct</summary>
+        internal const string COUNTDISTINCT = "countdistinct";
+
+        /// <summary>$count</summary>
+        internal const string VIRTUALPROPERTYCOUNT = "$count";
+
         /// <summary>Gets the type name to be used in the URI for the given <paramref name="type"/>.</summary>
         /// <param name="type">Type to get name for.</param>
         /// <param name="context">Data context used to generate type names for types.</param>

--- a/src/Microsoft.OData.Client/ALinq/UriWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriWriter.cs
@@ -445,8 +445,8 @@ namespace Microsoft.OData.Client
                 }
 
                 this.AppendCachedQueryOptionsToUriBuilder();
-                }
             }
+        }
 
         /// <summary>
         /// SkipQueryOptionExpression visit method.

--- a/src/Microsoft.OData.Client/ALinq/UriWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriWriter.cs
@@ -641,6 +641,7 @@ namespace Microsoft.OData.Client
                 {
                     aggregationAlias = aggregationMethod.ToString() + aggregationProperty.Replace('/', '_');
                 }
+
                 aggregateBuilder.Append(aggregationAlias);
 
                 if (++i == applyQueryOptionExpr.Aggregations.Count)
@@ -650,6 +651,7 @@ namespace Microsoft.OData.Client
 
                 aggregateBuilder.Append(UriHelper.COMMA);
             }
+
             aggregateBuilder.Append(UriHelper.RIGHTPAREN);
 
             // e.g. $apply=aggregate(Prop with sum as SumProp, Prop with average as AverageProp)

--- a/src/Microsoft.OData.Client/ALinq/UriWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriWriter.cs
@@ -588,10 +588,10 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// ApplyQueryOptionExpression visit method.
         /// </summary>
-        /// <param name="aqoExpr">ApplyQueryOptionExpression expression to visit</param>
-        internal void VisitQueryOptionExpression(ApplyQueryOptionExpression aqoExpr)
+        /// <param name="applyQueryOptionExpr">ApplyQueryOptionExpression expression to visit</param>
+        internal void VisitQueryOptionExpression(ApplyQueryOptionExpression applyQueryOptionExpr)
         {
-            if (aqoExpr.Aggregations.Count == 0)
+            if (applyQueryOptionExpr.Aggregations.Count == 0)
             {
                 return;
             }
@@ -600,11 +600,11 @@ namespace Microsoft.OData.Client
 
             aggregateBuilder.Append(UriHelper.AGGREGATE);
             aggregateBuilder.Append(UriHelper.LEFTPAREN);
-            int aggIdx = 0;
+            int i = 0;
 
             while (true)
             {
-                ApplyQueryOptionExpression.Aggregation aggregation = aqoExpr.Aggregations[aggIdx];
+                ApplyQueryOptionExpression.Aggregation aggregation = applyQueryOptionExpr.Aggregations[i];
                 AggregationMethod aggregationMethod = aggregation.AggregationMethod;
                 string aggregationAlias = aggregation.AggregationAlias;
 
@@ -643,7 +643,7 @@ namespace Microsoft.OData.Client
                 }
                 aggregateBuilder.Append(aggregationAlias);
 
-                if (++aggIdx == aqoExpr.Aggregations.Count)
+                if (++i == applyQueryOptionExpr.Aggregations.Count)
                 {
                     break;
                 }

--- a/src/Microsoft.OData.Client/ALinq/UriWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriWriter.cs
@@ -15,9 +15,9 @@ namespace Microsoft.OData.Client
     using System.Globalization;
     using System.Linq;
     using System.Linq.Expressions;
-    using System.Reflection;
     using System.Text;
     using Microsoft.OData.Client.Metadata;
+    using Microsoft.OData.UriParser.Aggregation;
 
     #endregion Namespaces
 
@@ -409,6 +409,9 @@ namespace Microsoft.OData.Client
                             case ResourceExpressionType.FilterQueryOption:
                                 this.VisitQueryOptionExpression((FilterQueryOptionExpression)e);
                                 break;
+                            case ResourceExpressionType.ApplyQueryOption:
+                                this.VisitQueryOptionExpression((ApplyQueryOptionExpression)e);
+                                break;
                             default:
                                 Debug.Assert(false, "Unexpected expression type " + ((int)et).ToString(CultureInfo.InvariantCulture));
                                 break;
@@ -439,7 +442,7 @@ namespace Microsoft.OData.Client
                 if (re.CustomQueryOptions.Count > 0)
                 {
                     this.VisitCustomQueryOptions(re.CustomQueryOptions);
-                    }
+                }
 
                 this.AppendCachedQueryOptionsToUriBuilder();
                 }
@@ -583,13 +586,84 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
+        /// ApplyQueryOptionExpression visit method.
+        /// </summary>
+        /// <param name="aqoExpr">ApplyQueryOptionExpression expression to visit</param>
+        internal void VisitQueryOptionExpression(ApplyQueryOptionExpression aqoExpr)
+        {
+            if (aqoExpr.Aggregations.Count == 0)
+            {
+                return;
+            }
+
+            StringBuilder aggregateBuilder = new StringBuilder();
+
+            aggregateBuilder.Append(UriHelper.AGGREGATE);
+            aggregateBuilder.Append(UriHelper.LEFTPAREN);
+            int aggIdx = 0;
+
+            while (true)
+            {
+                ApplyQueryOptionExpression.Aggregation aggregation = aqoExpr.Aggregations[aggIdx];
+                AggregationMethod aggregationMethod = aggregation.AggregationMethod;
+                string aggregationAlias = aggregation.AggregationAlias;
+
+                string aggregationUriEquivalent;
+                if (!TypeSystem.TryGetUriEquivalent(aggregationMethod, out aggregationUriEquivalent))
+                {
+                    // This would happen if an aggregation method was added to the enum with no
+                    // relevant update to map it to the URI equivalent 
+                    throw new NotSupportedException(Strings.ALinq_AggregationMethodNotSupported(aggregationMethod.ToString()));
+                }
+
+                string aggregationProperty = string.Empty;
+
+                // E.g. Amount with sum as SumAmount (For $count aggregation: $count as Count)
+                if (aggregationMethod != AggregationMethod.VirtualPropertyCount)
+                {
+                    aggregationProperty = this.ExpressionToString(aggregation.Expression, /*inPath*/ false);
+
+                    aggregateBuilder.Append(aggregationProperty);
+                    aggregateBuilder.Append(UriHelper.SPACE);
+                    aggregateBuilder.Append(UriHelper.WITH);
+                    aggregateBuilder.Append(UriHelper.SPACE);
+                }
+
+                aggregateBuilder.Append(aggregationUriEquivalent);
+                aggregateBuilder.Append(UriHelper.SPACE);
+                aggregateBuilder.Append(UriHelper.AS);
+                aggregateBuilder.Append(UriHelper.SPACE);
+                // MUST define an alias for the resulting aggregate value
+                // Concatenate aggregation method with aggregation property to generate a simple identifier/alias
+                // OASIS Standard: The alias MUST NOT collide with names of declared properties, custom aggregates, or other aliases in that type
+                // TODO: Strategy to avoid name collision - Append a Guid?
+                if (string.IsNullOrEmpty(aggregationAlias))
+                {
+                    aggregationAlias = aggregationMethod.ToString() + aggregationProperty.Replace('/', '_');
+                }
+                aggregateBuilder.Append(aggregationAlias);
+
+                if (++aggIdx == aqoExpr.Aggregations.Count)
+                {
+                    break;
+                }
+
+                aggregateBuilder.Append(UriHelper.COMMA);
+            }
+            aggregateBuilder.Append(UriHelper.RIGHTPAREN);
+
+            // e.g. $apply=aggregate(Prop with sum as SumProp, Prop with average as AverageProp)
+            this.AddAsCachedQueryOption(UriHelper.DOLLARSIGN + UriHelper.OPTIONAPPLY, aggregateBuilder.ToString());
+        }
+
+        /// <summary>
         /// Caches query option to be grouped
         /// </summary>
         /// <param name="optionKey">The key.</param>
         /// <param name="optionValue">The value</param>
         private void AddAsCachedQueryOption(string optionKey, string optionValue)
         {
-            List<string> tmp = null;
+            List<string> tmp;
             if (!this.cachedQueryOptions.TryGetValue(optionKey, out tmp))
             {
                 tmp = new List<string>();

--- a/src/Microsoft.OData.Client/ALinq/UriWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/UriWriter.cs
@@ -620,7 +620,7 @@ namespace Microsoft.OData.Client
                 return string.Empty;
             }
 
-            return "filter(" + this.ExpressionToString(applyQueryOptionExpr.GetPredicate(), /*inPath*/ false) + ")"; ;
+            return "filter(" + this.ExpressionToString(applyQueryOptionExpr.GetPredicate(), /*inPath*/ false) + ")";
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/DataServiceExtensions.cs
+++ b/src/Microsoft.OData.Client/DataServiceExtensions.cs
@@ -42,7 +42,8 @@ namespace Microsoft.OData.Client
             else
             {
                 // Provide a default implementation...
-                // To handle scenarios like: new List<int> { 1, 2, 1 }.AsQueryable().CountDistinct(d => d)
+                // In the event that a developer who adds a reference to the library invokes CountDistinct() as follows:
+                // - new List<int> { 1, 2, 1 }.AsQueryable().CountDistinct(d => d)
 
                 // Method: Select<TSource,TResult>(IQueryable<TSource>, Expression<Func<TSource,TResult>>)
                 MethodInfo selectMethod = GetSelectMethod();
@@ -81,9 +82,10 @@ namespace Microsoft.OData.Client
         public static int CountDistinct<TSource, TTarget>(this IEnumerable<TSource> source, Func<TSource, TTarget> selector)
         {
             // Provide a default implementation...
-            // To handle scenarios like: new List<int> { 1, 2, 1 }.CountDistinct(d => d)
+            // In the event that a developer who adds a reference to the library invokes CountDistinct() as follows:
+            // - new List<int> { 1, 2, 1 }.CountDistinct(d => d)
 
-            // Extract method: Select<TSource,TResult>(IEnumerable<TSource>, Func<TSource,TResult>)
+            // Method: Select<TSource,TResult>(IEnumerable<TSource>, Func<TSource,TResult>)
             MethodInfo selectMethod = typeof(Enumerable).GetMethods(BindingFlags.Static | BindingFlags.Public)
                 .Where(d1 => d1.Name.Equals("Select", StringComparison.Ordinal))
                 .Select(d2 => new { Method = d2, Parameters = d2.GetParameters() })
@@ -129,9 +131,9 @@ namespace Microsoft.OData.Client
                 .Select(d6 => d6.Method).Single();
         }
 
-        private static MethodInfo GetDistinctMethod(Type targetType, Type sourceType)
+        private static MethodInfo GetDistinctMethod(Type declaringType, Type sourceType)
         {
-            return targetType.GetMethods(BindingFlags.Static | BindingFlags.Public)
+            return declaringType.GetMethods(BindingFlags.Static | BindingFlags.Public)
                 .Where(d1 => d1.Name.Equals("Distinct", StringComparison.Ordinal))
                 .Select(d2 => new { Method = d2, Parameters = d2.GetParameters() })
                 .Where(d3 => d3.Parameters.Length.Equals(1)
@@ -140,9 +142,9 @@ namespace Microsoft.OData.Client
                 .Select(d6 => d6.Method).Single();
         }
 
-        private static MethodInfo GetCountMethod(Type targetType, Type sourceType)
+        private static MethodInfo GetCountMethod(Type declaringType, Type sourceType)
         {
-            return targetType.GetMethods(BindingFlags.Static | BindingFlags.Public)
+            return declaringType.GetMethods(BindingFlags.Static | BindingFlags.Public)
                 .Where(d1 => d1.Name.Equals("Count", StringComparison.Ordinal))
                 .Select(d2 => new { Method = d2, Parameters = d2.GetParameters() })
                 .Where(d3 => d3.Parameters.Length.Equals(1)

--- a/src/Microsoft.OData.Client/DataServiceExtensions.cs
+++ b/src/Microsoft.OData.Client/DataServiceExtensions.cs
@@ -18,20 +18,29 @@ namespace Microsoft.OData.Client
 
     public static class DataServiceExtensions
     {
+        /// <summary>
+        /// The single MethodInfo instance of Enumerable.Distinct
+        /// </summary>
         private readonly static SimpleLazy<MethodInfo> EnumerableSelectMethod = new SimpleLazy<MethodInfo>(() =>
         {
             return GetEnumerableSelectMethod();
-        });
+        }, /*isThreadSafe*/ true);
 
+        /// <summary>
+        /// The single MethodInfo instance of Enumerable.Distinct
+        /// </summary>
         private readonly static SimpleLazy<MethodInfo> EnumerableDistinctMethod = new SimpleLazy<MethodInfo>(() =>
         {
             return GetDistinctMethod(typeof(Enumerable), typeof(IEnumerable<>));
-        });
+        }, /*isThreadSafe*/ true);
 
+        /// <summary>
+        /// The single MethodInfo instance of Enumerable.Count
+        /// </summary>
         private readonly static SimpleLazy<MethodInfo> EnumerableCountMethod = new SimpleLazy<MethodInfo>(() =>
         {
             return GetCountMethod(typeof(Enumerable), typeof(IEnumerable<>));
-        });
+        }, /*isThreadSafe*/ true);
 
         /// <summary>
         /// Returns the distinct count of elements in a sequence after applying the projection function to each element.

--- a/src/Microsoft.OData.Client/DataServiceExtensions.cs
+++ b/src/Microsoft.OData.Client/DataServiceExtensions.cs
@@ -1,0 +1,154 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DataServiceExtensions.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client
+{
+    #region Namespaces
+
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    #endregion Namespaces
+
+    public static class DataServiceExtensions
+    {
+        /// <summary>
+        /// Returns the distinct count of elements in a sequence after applying the projection function to each element.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/></typeparam>
+        /// <typeparam name="TTarget">The type returned by the projection function represented in <paramref name="selector"/>.</typeparam>
+        /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
+        /// <param name="selector">A projection function to apply to each element.</param>
+        /// <returns>Distinct count of elements in a sequence after applying the projection function to each element.</returns>
+        public static int CountDistinct<TSource, TTarget>(this IQueryable<TSource> source, Expression<Func<TSource, TTarget>> selector)
+        {
+            MethodCallExpression countMethodExpr;
+
+            if (source.Provider.GetType().Equals(typeof(DataServiceQueryProvider)))
+            {
+                var currentMethod = (MethodInfo)MethodBase.GetCurrentMethod();
+                MethodInfo methodInfo = currentMethod.MakeGenericMethod(typeof(TSource), typeof(TTarget));
+
+                countMethodExpr = Expression.Call(null,
+                    methodInfo,
+                    new Expression[] { source.Expression, selector });
+            }
+            else
+            {
+                // Provide a default implementation...
+                // To handle scenarios like: new List<int> { 1, 2, 1 }.AsQueryable().CountDistinct(d => d)
+
+                // Method: Select<TSource,TResult>(IQueryable<TSource>, Expression<Func<TSource,TResult>>)
+                MethodInfo selectMethod = GetSelectMethod();
+                // Method: Distinct<TSource>(IQueryable<TSource>)
+                MethodInfo distinctMethod = GetDistinctMethod(typeof(Queryable), typeof(IQueryable<>));
+                // Method: Count<TSource>(IQueryable<TSource>)
+                MethodInfo countMethod = GetCountMethod(typeof(Queryable), typeof(IQueryable<>));
+
+                // Select(d => d.Prop)
+                MethodCallExpression selectMethodExpr = Expression.Call(null,
+                    selectMethod.MakeGenericMethod(new Type[] { source.ElementType, selector.Body.Type }),
+                    new[] { source.Expression, Expression.Quote(selector) });
+
+                // Select(d => d.Prop).Distinct()
+                MethodCallExpression distinctMethodExpr = Expression.Call(null,
+                    distinctMethod.MakeGenericMethod(new Type[] { selector.Body.Type }),
+                    new[] { selectMethodExpr });
+
+                // Select(d => d.Prop).Distinct().Count()
+                countMethodExpr = Expression.Call(null,
+                    countMethod.MakeGenericMethod(new Type[] { selector.Body.Type }),
+                    new[] { distinctMethodExpr });
+            }
+
+            return source.Provider.Execute<int>(countMethodExpr);
+        }
+
+        /// <summary>
+        /// Returns the distinct count of elements in a sequence after applying the projection function to each element.
+        /// </summary>
+        /// <typeparam name="TSource">The type of the elements of <paramref name="source"/></typeparam>
+        /// <typeparam name="TTarget">The type returned by the projection function represented in <paramref name="selector"/>.</typeparam>
+        /// <param name="source">A sequence of values of type <typeparamref name="TSource"/>.</param>
+        /// <param name="selector">A projection function to apply to each element.</param>
+        /// <returns>Distinct count of elements in a sequence after applying the projection function to each element.</returns>
+        public static int CountDistinct<TSource, TTarget>(this IEnumerable<TSource> source, Func<TSource, TTarget> selector)
+        {
+            // Provide a default implementation...
+            // To handle scenarios like: new List<int> { 1, 2, 1 }.CountDistinct(d => d)
+
+            // Extract method: Select<TSource,TResult>(IEnumerable<TSource>, Func<TSource,TResult>)
+            MethodInfo selectMethod = typeof(Enumerable).GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .Where(d1 => d1.Name.Equals("Select", StringComparison.Ordinal))
+                .Select(d2 => new { Method = d2, Parameters = d2.GetParameters() })
+                .Where(d3 => d3.Parameters.Length.Equals(2)
+                    && d3.Parameters[0].ParameterType.IsGenericType
+                    && d3.Parameters[0].ParameterType.GetGenericTypeDefinition().Equals(typeof(IEnumerable<>))
+                    && d3.Parameters[1].ParameterType.IsGenericType
+                    && d3.Parameters[1].ParameterType.GetGenericTypeDefinition().Equals(typeof(Func<,>)))
+                .Select(d6 => d6.Method).Single();
+
+            IEnumerable<TTarget> transientResult;
+
+            transientResult = (IEnumerable<TTarget>)selectMethod.MakeGenericMethod(
+                typeof(TSource), typeof(TTarget)).Invoke(null, new object[] { source, selector });
+
+            // Method: Distinct<TSource>(IEnumerable<TSource>)
+            MethodInfo distinctMethod = GetDistinctMethod(typeof(Enumerable), typeof(IEnumerable<>));
+
+            transientResult = (IEnumerable<TTarget>)distinctMethod.MakeGenericMethod(
+                typeof(TTarget)).Invoke(null, new object[] { transientResult });
+
+            // Method: Count<TSource>(IEnumerable<TSource>)
+            MethodInfo countMethod = GetCountMethod(typeof(Enumerable), typeof(IEnumerable<>));
+
+            return (int)countMethod.MakeGenericMethod(
+                typeof(TTarget)).Invoke(null, new object[] { transientResult });
+        }
+
+        private static MethodInfo GetSelectMethod()
+        {
+            return typeof(Queryable).GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .Where(d1 => d1.Name.Equals("Select", StringComparison.Ordinal))
+                .Select(d2 => new { Method = d2, Parameters = d2.GetParameters() })
+                .Where(d3 => d3.Parameters.Length.Equals(2)
+                    && d3.Parameters[0].ParameterType.IsGenericType
+                    && d3.Parameters[0].ParameterType.GetGenericTypeDefinition().Equals(typeof(IQueryable<>))
+                    && d3.Parameters[1].ParameterType.IsGenericType
+                    && d3.Parameters[1].ParameterType.GetGenericTypeDefinition().Equals(typeof(Expression<>)))
+                .Select(d4 => new { d4.Method, SelectorArguments = d4.Parameters[1].ParameterType.GetGenericArguments() })
+                .Where(d5 => d5.SelectorArguments.Length.Equals(1)
+                    && d5.SelectorArguments[0].IsGenericType
+                    && d5.SelectorArguments[0].GetGenericTypeDefinition().Equals(typeof(Func<,>)))
+                .Select(d6 => d6.Method).Single();
+        }
+
+        private static MethodInfo GetDistinctMethod(Type targetType, Type sourceType)
+        {
+            return targetType.GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .Where(d1 => d1.Name.Equals("Distinct", StringComparison.Ordinal))
+                .Select(d2 => new { Method = d2, Parameters = d2.GetParameters() })
+                .Where(d3 => d3.Parameters.Length.Equals(1)
+                    && d3.Parameters[0].ParameterType.IsGenericType
+                    && d3.Parameters[0].ParameterType.GetGenericTypeDefinition().Equals(sourceType))
+                .Select(d6 => d6.Method).Single();
+        }
+
+        private static MethodInfo GetCountMethod(Type targetType, Type sourceType)
+        {
+            return targetType.GetMethods(BindingFlags.Static | BindingFlags.Public)
+                .Where(d1 => d1.Name.Equals("Count", StringComparison.Ordinal))
+                .Select(d2 => new { Method = d2, Parameters = d2.GetParameters() })
+                .Where(d3 => d3.Parameters.Length.Equals(1)
+                    && d3.Parameters[0].ParameterType.IsGenericType
+                    && d3.Parameters[0].ParameterType.GetGenericTypeDefinition().Equals(sourceType))
+                .Select(d6 => d6.Method).Single();
+        }
+    }
+}

--- a/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceQueryOfT.cs
@@ -268,7 +268,6 @@ namespace Microsoft.OData.Client
             return nextTask;
         }
 
-#if !PORTABLELIB // Synchronous methods not available
         /// <summary>Executes the query and returns the results as a collection that implements IEnumerable.</summary>
         /// <returns>An <see cref="System.Collections.Generic.IEnumerable{T}" /> in which TElement represents the type of the query results.</returns>
         /// <exception cref="Microsoft.OData.Client.DataServiceQueryException">When the data service returns an HTTP 404: Resource Not Found error.</exception>
@@ -294,7 +293,6 @@ namespace Microsoft.OData.Client
             QueryOperationResponse<TElement> response = this.Execute<TElement>(this.Context, this.Translate());
             return this.GetRestPages(response);
         }
-#endif
 
         /// <summary>Expands a query to include entities from a related entity set in the query response.</summary>
         /// <returns>A new query that includes the requested $expand query option appended to the URI of the supplied query.</returns>
@@ -386,17 +384,10 @@ namespace Microsoft.OData.Client
 
         /// <summary>Executes the query and returns the results as a collection.</summary>
         /// <returns>A typed enumerator over the results in which TElement represents the type of the query results.</returns>
-#if !PORTABLELIB // Synchronous methods not available
         public virtual IEnumerator<TElement> GetEnumerator()
         {
             return this.Execute().GetEnumerator();
         }
-#else
-        public IEnumerator<TElement> GetEnumerator()
-        {
-            throw Error.NotSupported(Strings.DataServiceQuery_EnumerationNotSupported);
-        }
-#endif
 
         /// <summary>Represents the URI of the query to the data service.</summary>
         /// <returns>A URI as string that represents the query to the data service for this <see cref="Microsoft.OData.Client.DataServiceQuery{TElement}" /> instance.</returns>
@@ -414,13 +405,9 @@ namespace Microsoft.OData.Client
 
         /// <summary>Executes the query and returns the results as a collection.</summary>
         /// <returns>An enumerator over the query results.</returns>
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        IEnumerator System.Collections.IEnumerable.GetEnumerator()
         {
-#if !PORTABLELIB // Synchronous methods not available
             return this.GetEnumerator();
-#else
-            throw Error.NotSupported();
-#endif
         }
 
         /// <summary>
@@ -433,7 +420,6 @@ namespace Microsoft.OData.Client
             return this.Translate();
         }
 
-#if !PORTABLELIB
         /// Synchronous methods not available
         /// <summary>
         /// Returns an IEnumerable from an Internet resource.
@@ -443,7 +429,6 @@ namespace Microsoft.OData.Client
         {
             return this.Execute();
         }
-#endif
 
         /// <summary>
         /// Begins an asynchronous request to an Internet resource.
@@ -507,7 +492,6 @@ namespace Microsoft.OData.Client
             }
         }
 
-#if !PORTABLELIB
         /// Synchronous methods not available
         /// <summary>
         /// Returns an IEnumerable from an Internet resource.
@@ -533,7 +517,6 @@ namespace Microsoft.OData.Client
                 continuation = (response as QueryOperationResponse<TElement>).GetContinuation();
             }
         }
-#endif
 
         /// <summary>
         /// Ordered DataServiceQuery which implements IOrderedQueryable.

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.Common.txt
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.Common.txt
@@ -208,7 +208,9 @@ ALinq_AnyAllNotSupportedInOrderBy=The method '{0}' is not supported by the 'orde
 ALinq_FormatQueryOptionNotSupported=The '$format' query option is not supported. Use the DataServiceContext.Format property to set the desired format.
 ALinq_IllegalSystemQueryOption=Found the following illegal system token while building a projection or expansion path: '{0}'
 ALinq_IllegalPathStructure=Found a projection as a non-leaf segment in an expand path. Please rephrase your query. The projected property was : '{0}'
-ALinq_TypeTokenWithNoTrailingNavProp=Found an illegal type token '{0}' without a trailing navigation property. 
+ALinq_TypeTokenWithNoTrailingNavProp=Found an illegal type token '{0}' without a trailing navigation property.
+ALinq_AggregationMethodNotSupported=The aggregation method '{0}' is not supported.
+ALinq_InvalidAggregateExpression=The expression '{0}' is not a valid aggregate expression. The aggregate expression must evaluate to a single-valued property path to an aggregatable property.
 
 DSKAttribute_MustSpecifyAtleastOnePropertyName=DataServiceKey attribute must specify at least one property name.
 

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.Desktop.txt
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.Desktop.txt
@@ -9,6 +9,7 @@
 ; Error Messages
 
 DataServiceRequest_FailGetCount=Failed to get the count value from the server.
+DataServiceRequest_FailGetValue=Failed to get the value from the server.
 
 Context_ExecuteExpectedVoidResponse=Execute overload for void service operations and actions received a non-void response from the server.
 ;END

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.cs
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.cs
@@ -207,6 +207,8 @@ namespace Microsoft.OData.Client
         internal const string ALinq_IllegalSystemQueryOption = "ALinq_IllegalSystemQueryOption";
         internal const string ALinq_IllegalPathStructure = "ALinq_IllegalPathStructure";
         internal const string ALinq_TypeTokenWithNoTrailingNavProp = "ALinq_TypeTokenWithNoTrailingNavProp";
+        internal const string ALinq_AggregationMethodNotSupported = "ALinq_AggregationMethodNotSupported";
+        internal const string ALinq_InvalidAggregateExpression = "ALinq_InvalidAggregateExpression";
         internal const string DSKAttribute_MustSpecifyAtleastOnePropertyName = "DSKAttribute_MustSpecifyAtleastOnePropertyName";
         internal const string DataServiceCollection_LoadRequiresTargetCollectionObserved = "DataServiceCollection_LoadRequiresTargetCollectionObserved";
         internal const string DataServiceCollection_CannotStopTrackingChildCollection = "DataServiceCollection_CannotStopTrackingChildCollection";
@@ -270,6 +272,7 @@ namespace Microsoft.OData.Client
         internal const string ValueParser_InvalidDuration = "ValueParser_InvalidDuration";
         internal const string PlatformHelper_DateTimeOffsetMustContainTimeZone = "PlatformHelper_DateTimeOffsetMustContainTimeZone";
         internal const string DataServiceRequest_FailGetCount = "DataServiceRequest_FailGetCount";
+        internal const string DataServiceRequest_FailGetValue = "DataServiceRequest_FailGetValue";
         internal const string Context_ExecuteExpectedVoidResponse = "Context_ExecuteExpectedVoidResponse";
 
         static TextRes loader = null;

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.txt
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.txt
@@ -206,7 +206,9 @@ ALinq_AnyAllNotSupportedInOrderBy=The method '{0}' is not supported by the 'orde
 ALinq_FormatQueryOptionNotSupported=The '$format' query option is not supported. Use the DataServiceContext.Format property to set the desired format.
 ALinq_IllegalSystemQueryOption=Found the following illegal system token while building a projection or expansion path: '{0}'
 ALinq_IllegalPathStructure=Found a projection as a non-leaf segment in an expand path. Please rephrase your query. The projected property was : '{0}'
-ALinq_TypeTokenWithNoTrailingNavProp=Found an illegal type token '{0}' without a trailing navigation property. 
+ALinq_TypeTokenWithNoTrailingNavProp=Found an illegal type token '{0}' without a trailing navigation property.
+ALinq_AggregationMethodNotSupported=The aggregation method '{0}' is not supported.
+ALinq_InvalidAggregateExpression=The expression '{0}' is not a valid aggregate expression. The aggregate expression must evaluate to a single-valued property path to an aggregatable property.
 
 DSKAttribute_MustSpecifyAtleastOnePropertyName=DataServiceKey attribute must specify at least one property name.
 
@@ -299,6 +301,7 @@ PlatformHelper_DateTimeOffsetMustContainTimeZone=The time zone information is mi
 ; Error Messages
 
 DataServiceRequest_FailGetCount=Failed to get the count value from the server.
+DataServiceRequest_FailGetValue=Failed to get the value from the server.
 
 Context_ExecuteExpectedVoidResponse=Execute overload for void service operations and actions received a non-void response from the server.
 ;END

--- a/src/Microsoft.OData.Client/Parameterized.Microsoft.OData.Client.cs
+++ b/src/Microsoft.OData.Client/Parameterized.Microsoft.OData.Client.cs
@@ -1805,6 +1805,22 @@ namespace Microsoft.OData.Client {
         }
 
         /// <summary>
+        /// A string like "The aggregation method '{0}' is not supported."
+        /// </summary>
+        internal static string ALinq_AggregationMethodNotSupported(object p0)
+        {
+            return Microsoft.OData.Client.TextRes.GetString(Microsoft.OData.Client.TextRes.ALinq_AggregationMethodNotSupported, p0);
+        }
+
+        /// <summary>
+        /// A string like "The expression '{0}' is not a valid aggregate expression. The aggregate expression must evaluate to a single-valued property path to an aggregatable property."
+        /// </summary>
+        internal static string ALinq_InvalidAggregateExpression(object p0)
+        {
+            return Microsoft.OData.Client.TextRes.GetString(Microsoft.OData.Client.TextRes.ALinq_InvalidAggregateExpression, p0);
+        }
+
+        /// <summary>
         /// A string like "DataServiceKey attribute must specify at least one property name."
         /// </summary>
         internal static string DSKAttribute_MustSpecifyAtleastOnePropertyName
@@ -2359,6 +2375,17 @@ namespace Microsoft.OData.Client {
             get
             {
                 return Microsoft.OData.Client.TextRes.GetString(Microsoft.OData.Client.TextRes.DataServiceRequest_FailGetCount);
+            }
+        }
+
+        /// <summary>
+        /// A string like "Failed to get the value from the server."
+        /// </summary>
+        internal static string DataServiceRequest_FailGetValue
+        {
+            get
+            {
+                return Microsoft.OData.Client.TextRes.GetString(Microsoft.OData.Client.TextRes.DataServiceRequest_FailGetValue);
             }
         }
 

--- a/src/Microsoft.OData.Client/XmlConstants.cs
+++ b/src/Microsoft.OData.Client/XmlConstants.cs
@@ -320,6 +320,22 @@ namespace Microsoft.OData.Service
 
         #endregion URI constants.
 
+        #region OData constants
+
+        /// <summary>The context URL for a collection, entity, primitive value, or service document.</summary>
+        internal const string ODataContext = "@odata.context";
+
+        /// <summary>The ID of th entity.</summary>
+        internal const string ODataID = "@odata.id";
+
+        /// <summary>The total count of a collection of entities or collection of entity references, if requested.</summary>
+        internal const string ODataCount = "@odata.count";
+
+        /// <summary>the type of the containing object or targeted property if the type of the object or targeted property cannot be heuristically determined.</summary>
+        internal const string ODataType = "@odata.type";
+
+        #endregion OData constants
+
         #region WCF constants.
 
         /// <summary>"Binary" - WCF element name for binary content in XML-wrapping streams.</summary>

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/CountDistinctTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/CountDistinctTests.cs
@@ -1,0 +1,50 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CountDistinctTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.ALinq
+{
+    public class CountDistinctTests
+    {
+        [Fact]
+        public void CountDistinct_Enumerable()
+        {
+            // Arrange/Act/Assert
+            Assert.Equal(6, new[] { 0, 1, 1, 2, 3, 5, 8 }.CountDistinct(d1 => d1));
+        }
+
+        [Fact]
+        public void CountDistinct_Queryable()
+        {
+            // Arrange/Act/Assert
+            Assert.Equal(6, new[] { 0, 1, 1, 2, 3, 5, 8 }.AsQueryable().CountDistinct(d1 => d1));
+        }
+
+        [Fact]
+        public void CountDistinct_EnumerableSourceIsNull()
+        {
+            // Arrange
+            List<int> source = null;
+
+            // Act/Assert
+            Assert.Throws<ArgumentNullException>(() => source.CountDistinct(d => d));
+        }
+
+        [Fact]
+        public void CountDistinct_QueryableSourceIsNull()
+        {
+            // Arrange
+            IQueryable<int> source = null;
+
+            // Act/Assert
+            Assert.Throws<ArgumentNullException>(() => source.CountDistinct(d => d));
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/DollarApplyAggregateTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/DollarApplyAggregateTests.cs
@@ -1,0 +1,365 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DollarApplyAggregateTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq.Expressions;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.ALinq
+{
+    public class DollarApplyAggregateTests : DollarApplyTestsBase
+    {
+        public DollarApplyAggregateTests() : base()
+        {
+        }
+
+        // Generates aggregation test data for 40 scenarios involving Average, Sum, Mix, Max
+        public static IEnumerable<object[]> AggregationTestData()
+        {
+            var testData = new List<object[]>();
+
+            foreach (var aggregationMethodName in new[] { "Sum", "Average", "Min", "Max" })
+            {
+                foreach (var type in new[] { "Int", "Double", "Decimal", "Long", "Single" })
+                {
+                    var propertyName = $"{type}Prop";  // e.g. IntProp
+                    var nullablePropertyName = $"Nullable{propertyName}"; // e.g. NullableIntProp
+
+                    testData.Add(new object[] { propertyName, aggregationMethodName });
+                    testData.Add(new object[] { nullablePropertyName, aggregationMethodName });
+                    // e.g.
+                    // { "Average", "IntProp" }
+                    // { "Average", "NullableIntProp" }
+                }
+            }
+
+            foreach (var item in testData)
+                yield return item;
+        }
+
+        [Theory]
+        [MemberData(nameof(AggregationTestData))]
+        public void Aggregation_ExpressionTranslatedToExpectedUri(string propertyName, string aggregationMethodName)
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            var propertyInfo = queryable.ElementType.GetProperty(propertyName);
+
+            // Get the aggregation method
+            var aggregationMethod = GetAggregationMethod(aggregationMethodName, propertyInfo.PropertyType);
+
+            // Build method call expression dynamically, e.g. Queryable.Average(d1 => d1.Prop)
+            var methodCallExpr = BuildMethodCallExpression(queryable, aggregationMethod, propertyInfo);
+
+            // Act
+            // Call factory method for creating DataServiceOrderedQuery based on expression
+            var query = new DataServiceQueryProvider(dsContext).CreateQuery(methodCallExpr);
+
+            // Assert
+            // E.g. http://tempuri.org/Sales?apply=aggregate(Prop with average as AverageProp)
+            var expectedAggregateUri = $"{serviceUri}/{numbersEntitySetName}?$apply=" + string.Format(
+                aggregateTransformationTemplate, string.Format(
+                    aggregateExpressionTemplate,
+                    propertyName,
+                    aggregationMethodName.ToLower(),
+                    $"{aggregationMethodName}{propertyName}"));
+
+            Assert.Equal(expectedAggregateUri, query.ToString());
+        }
+
+        [Theory]
+        [MemberData(nameof(AggregationTestData))]
+        public void Aggregation_ReturnsExpectedResult(string propertyName, string aggregationMethodName)
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+            var propertyInfo = queryable.ElementType.GetProperty(propertyName);
+
+            // Get the aggregation method
+            var aggregationMethod = GetAggregationMethod(aggregationMethodName, propertyInfo.PropertyType);
+            var returnType = GetMethodReturnType(aggregationMethod, propertyInfo.PropertyType);
+
+            // Build expression dynamically, e.g. [Queryable].Average(d1 => d1.Prop)
+            var methodCallExpr = BuildMethodCallExpression(queryable, aggregationMethod, propertyInfo);
+
+            // Mock aggregated response
+            var aggregationAlias = $"{aggregationMethodName}{propertyName}"; // E.g. AverageProp
+            var randomAggregateResult = GenerateRandomAggregateValue(aggregationMethodName, returnType);
+
+            InterceptRequestAndMockResponse(aggregationAlias, randomAggregateResult);
+
+            var queryProvider = new DataServiceQueryProvider(dsContext);
+            // Get Execute method defined in DataServiceQueryProvider class
+            var executeMethod = GetExecuteMethod();
+
+            // Act
+            var result = executeMethod.MakeGenericMethod(returnType).Invoke(queryProvider, new object[] { methodCallExpr });
+
+            // Assert
+            Assert.Equal(result, randomAggregateResult);
+        }
+
+        [Theory]
+        [InlineData("Average")]
+        [InlineData("Sum")]
+        [InlineData("Min")]
+        [InlineData("Max")]
+        public void Aggregation_TargetingNavProperty_ExpressionTranslatedToExpectedUri(string aggregationMethodName)
+        {
+            var queryable = this.dsContext.CreateQuery<Sale>(salesEntitySetName);
+            var navPropertyName = "Product";
+            var propertyName = "TaxRate";
+
+            // Build selector expression, e.g. d1 => d1.NavProp.Prop
+            var parameterExpr = Expression.Parameter(queryable.ElementType, "d1");
+            var selectorExpr = Expression.Lambda(
+                Expression.MakeMemberAccess(
+                    Expression.MakeMemberAccess(parameterExpr, typeof(Sale).GetProperty(navPropertyName)),
+                    typeof(Product).GetProperty(propertyName)),
+                parameterExpr);
+
+            var propertyType = ((MemberExpression)selectorExpr.Body).Type;
+            // Get the aggregation method
+            var aggregationMethod = GetAggregationMethod(aggregationMethodName, propertyType);
+
+            // Build expression dynamically, e.g. [Queryable].Average(d1 => d1.NavProp.Prop)
+            var methodCallExpr = BuildMethodCallExpression(queryable, aggregationMethod, selectorExpr);
+
+            // Act
+            // Call factory method for creating DataServiceOrderedQuery based on expression
+            var query = new DataServiceQueryProvider(dsContext).CreateQuery(methodCallExpr);
+
+            // Assert
+            // E.g. http://tempuri.org/Sales?apply=aggregate(NavProp/Prop with average as AverageNavProp_Prop)
+            var expectedAggregateUri = $"{serviceUri}/{salesEntitySetName}?$apply=" + string.Format(
+                aggregateTransformationTemplate, string.Format(
+                    aggregateExpressionTemplate,
+                    $"{navPropertyName}/{propertyName}",
+                    aggregationMethodName.ToLower(),
+                    $"{aggregationMethodName}{navPropertyName}_{propertyName}"));
+
+            Assert.Equal(expectedAggregateUri, query.ToString());
+        }
+
+        [Theory]
+        [InlineData("Average")]
+        [InlineData("Sum")]
+        [InlineData("Min")]
+        [InlineData("Max")]
+        public void Aggregation_TargetingNavProperty_ReturnsExpectedResult(string aggregationMethodName)
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Sale>(salesEntitySetName);
+            var navPropertyName = "Product";
+            var propertyName = "TaxRate";
+
+            // Build selector expression, e.g. d1 => d1.NavProp.Prop
+            var parameterExpr = Expression.Parameter(queryable.ElementType, "d1");
+            var selectorExpr = Expression.Lambda(
+                Expression.MakeMemberAccess(
+                    Expression.MakeMemberAccess(parameterExpr, typeof(Sale).GetProperty(navPropertyName)),
+                    typeof(Product).GetProperty(propertyName)),
+                parameterExpr);
+
+            var propertyType = ((MemberExpression)selectorExpr.Body).Type;
+            // Get the aggregation method
+            var aggregationMethod = GetAggregationMethod(aggregationMethodName, propertyType);
+            var returnType = GetMethodReturnType(aggregationMethod, propertyType);
+
+            // Build expression dynamically, e.g. [Queryable].Average(d1 => d1.NavProp.Prop)
+            var methodCallExpr = BuildMethodCallExpression(queryable, aggregationMethod, selectorExpr);
+
+            // Mock aggregated response
+            var aggregationAlias = $"{aggregationMethodName}{navPropertyName}_{propertyName}"; // E.g. AverageNavProp_Prop
+            var randomAggregateResult = GenerateRandomAggregateValue(aggregationMethodName, returnType);
+
+            InterceptRequestAndMockResponse(aggregationAlias, randomAggregateResult);
+
+            var queryProvider = new DataServiceQueryProvider(dsContext);
+            // Get Execute method defined in DataServiceQueryProvider class
+            var executeMethod = GetExecuteMethod();
+
+            // Act
+            var result = executeMethod.MakeGenericMethod(returnType).Invoke(queryProvider, new object[] { methodCallExpr });
+
+            // Assert
+            Assert.Equal(result, randomAggregateResult);
+        }
+
+        [Fact]
+        public void CountDistinct_ExpressionTranslatedToExpectedUri()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+
+            var countDistinctMethod = GetCountDistinctMethod();
+
+            var propertyInfo = queryable.ElementType.GetProperty("RowParity");
+            var parameterExpr = Expression.Parameter(queryable.ElementType, "d1");
+            var selectorExpr = Expression.Lambda(Expression.MakeMemberAccess(parameterExpr, propertyInfo), parameterExpr);
+
+            var methodCallExpr = Expression.Call(
+                null,
+                countDistinctMethod.MakeGenericMethod(new Type[] { queryable.ElementType, propertyInfo.PropertyType }),
+                new[] { queryable.Expression, Expression.Quote(selectorExpr) });
+
+            // Act
+            // Call factory method for creating DataServiceOrderedQuery based on expression
+            var query = new DataServiceQueryProvider(dsContext).CreateQuery(methodCallExpr);
+
+            // Assert
+            var expectedAggregateUri = $"{serviceUri}/{numbersEntitySetName}?$apply=aggregate(RowParity with countdistinct as CountDistinctRowParity)";
+            Assert.Equal(expectedAggregateUri, query.ToString());
+        }
+
+        [Fact]
+        public void CountDistinct_ReturnsExpectedResult()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Number>(numbersEntitySetName);
+
+            MockCountDistinct();
+
+            // Act
+            int countDistinct = queryable.CountDistinct(d1 => d1.RowParity);
+
+            // Assert
+            Assert.Equal(3, countDistinct);
+        }
+
+        [Fact]
+        public void CountDistinct_TargetingNavProperty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Sale>(salesEntitySetName);
+
+            MockCountDistinct_TargetingNavProperty();
+
+            // Act
+            int countDistinct = queryable.CountDistinct(d1 => d1.Customer.Country);
+
+            // Assert
+            Assert.Equal(2, countDistinct);
+        }
+
+        [Theory]
+        [InlineData("Average")]
+        [InlineData("Sum")]
+        [InlineData("Min")]
+        [InlineData("Max")]
+        public void Aggregation_NotSupportedException_ThrownForNonAggregatableProperty(string aggregationMethodName)
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Sale>(salesEntitySetName);
+
+            // Build selector expression, e.g. d1 => d1.Prop.Length
+            var parameterExpr = Expression.Parameter(queryable.ElementType, "d1");
+            var selectorExpr = Expression.Lambda(
+                Expression.MakeMemberAccess(
+                    Expression.MakeMemberAccess(parameterExpr, typeof(Sale).GetProperty("ProductId")),
+                    typeof(string).GetProperty("Length")),
+                parameterExpr);
+
+            var propertyType = ((MemberExpression)selectorExpr.Body).Type;
+            // Get the aggregation method
+            var aggregationMethod = GetAggregationMethod(aggregationMethodName, propertyType);
+            var returnType = GetMethodReturnType(aggregationMethod, propertyType);
+
+            // Build method call expression dynamically, e.g. Queryable.Average(d1 => d1.Prop.Length)
+            var methodCallExpr = BuildMethodCallExpression(queryable, aggregationMethod, selectorExpr);
+
+            var queryProvider = new DataServiceQueryProvider(dsContext);
+            // Get Execute method defined in DataServiceQueryProvider class
+            var executeMethod = GetExecuteMethod();
+
+            // Act & Assert
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                executeMethod.MakeGenericMethod(returnType).Invoke(queryProvider, new object[] { methodCallExpr }));
+            Assert.True(ex.InnerException is NotSupportedException);
+        }
+
+        [Theory]
+        [InlineData("Average")]
+        [InlineData("Sum")]
+        [InlineData("Min")]
+        [InlineData("Max")]
+        public void Aggregation_NotSupportedException_ThrownForMemberAccessOnCollectionProperty(string aggregationMethodName)
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Product>(productsEntitySetName);
+
+            // Build selector expression, e.g. d1 => d1.CollectionProp.Member
+            var parameterExpr = Expression.Parameter(queryable.ElementType, "d1");
+            var selectorExpr = Expression.Lambda(
+                Expression.MakeMemberAccess(
+                    Expression.MakeMemberAccess(parameterExpr, typeof(Product).GetProperty("Sales")),
+                    typeof(Collection<Sale>).GetProperty("Count")),
+                parameterExpr);
+
+            var propertyType = ((MemberExpression)selectorExpr.Body).Type;
+            // Get the aggregation method
+            var aggregationMethod = GetAggregationMethod(aggregationMethodName, propertyType);
+            var returnType = GetMethodReturnType(aggregationMethod, propertyType);
+
+            // Build method call expression dynamically, e.g. Queryable.Average(d1 => d1.CollectionProp.Member)
+            var methodCallExpr = BuildMethodCallExpression(queryable, aggregationMethod, selectorExpr);
+
+            var queryProvider = new DataServiceQueryProvider(dsContext);
+            // Get Execute method defined in DataServiceQueryProvider class
+            var executeMethod = GetExecuteMethod();
+
+            // Act & Assert
+            var ex = Assert.Throws<TargetInvocationException>(() =>
+                executeMethod.MakeGenericMethod(returnType).Invoke(queryProvider, new object[] { methodCallExpr }));
+            Assert.True(ex.InnerException is NotSupportedException);
+        }
+
+        [Fact]
+        public void CountDistinct_NotSupportedException_ThrownForNonKnownPrimitiveProperty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Sale>(salesEntitySetName);
+
+            // Act & Assert
+            Assert.Throws<NotSupportedException>(() => queryable.CountDistinct(d => d.Product));
+        }
+
+        [Fact]
+        public void CountDistinct_NotSupportedException_ThrownForCollectionProperty()
+        {
+            // Arrange
+            var queryable = this.dsContext.CreateQuery<Product>(productsEntitySetName);
+
+            // Act & Assert
+            Assert.Throws<NotSupportedException>(() => queryable.CountDistinct(d => d.Sales));
+        }
+
+        #region Mock Aggregation Responses
+
+        private void MockCountDistinct()
+        {
+            string mockResponse = string.Format("{{\"@odata.context\":\"{0}/$metadata#Numbers(" +
+                "CountDistinctRowParity)\"," +
+                "\"value\":[{{\"@odata.id\":null,\"CountDistinctRowParity\":3}}]}}", serviceUri);
+
+            InterceptRequestAndMockResponse(mockResponse);
+        }
+
+        private void MockCountDistinct_TargetingNavProperty()
+        {
+            string mockResponse = string.Format("{{\"@odata.context\":\"{0}/$metadata#Numbers(" +
+                "CountDistinctCustomerCountry)\"," +
+                "\"value\":[{{\"@odata.id\":null,\"CountDistinctCustomerCountry\":2}}]}}", serviceUri);
+
+            InterceptRequestAndMockResponse(mockResponse);
+        }
+
+        #endregion Mock Aggregation Responses
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/DollarApplyTestsBase.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/DollarApplyTestsBase.cs
@@ -1,0 +1,361 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DollarApplyTestsBase.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Text;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.OData.Client.Tests.ALinq
+{
+    /// <summary>
+    /// Base class for $apply tests
+    /// </summary>
+    public class DollarApplyTestsBase
+    {
+        private Random rand = new Random();
+
+        protected readonly DataServiceContext dsContext;
+        protected const string serviceUri = "http://tempuri.org";
+        protected const string numbersEntitySetName = "Numbers";
+        protected const string salesEntitySetName = "Sales";
+        protected const string productsEntitySetName = "Products";
+        protected static string aggregateExpressionTemplate = "{0} with {1} as {2}";
+        protected static string aggregateTransformationTemplate = "aggregate({0})";
+
+        public DollarApplyTestsBase()
+        {
+            EdmModel model = BuildEdmModel();
+
+            dsContext = new DataServiceContext(new Uri(serviceUri));
+            dsContext.Format.UseJson(model);
+        }
+
+        #region Helper Methods
+
+        private static EdmModel BuildEdmModel()
+        {
+            var model = new EdmModel();
+
+            var numberEntity = new EdmEntityType("NS", "Number");
+            numberEntity.AddKeys(numberEntity.AddStructuralProperty("RowId", EdmCoreModel.Instance.GetInt32(false)));
+            numberEntity.AddStructuralProperty("RowParity", EdmCoreModel.Instance.GetString(false));
+            numberEntity.AddStructuralProperty("RowCategory", EdmCoreModel.Instance.GetString(false));
+            numberEntity.AddStructuralProperty("IntProp", EdmCoreModel.Instance.GetInt32(false));
+            numberEntity.AddStructuralProperty("NullableIntProp", EdmCoreModel.Instance.GetInt32(true));
+            numberEntity.AddStructuralProperty("DoubleProp", EdmCoreModel.Instance.GetDouble(false));
+            numberEntity.AddStructuralProperty("NullableDoubleProp", EdmCoreModel.Instance.GetDouble(true));
+            numberEntity.AddStructuralProperty("DecimalProp", EdmCoreModel.Instance.GetDecimal(false));
+            numberEntity.AddStructuralProperty("NullableDecimalProp", EdmCoreModel.Instance.GetDecimal(true));
+            numberEntity.AddStructuralProperty("LongProp", EdmCoreModel.Instance.GetInt64(false));
+            numberEntity.AddStructuralProperty("NullableLongProp", EdmCoreModel.Instance.GetInt64(true));
+            numberEntity.AddStructuralProperty("SingleProp", EdmCoreModel.Instance.GetSingle(false));
+            numberEntity.AddStructuralProperty("NullableSingleProp", EdmCoreModel.Instance.GetSingle(true));
+
+            var saleEntity = new EdmEntityType("NS", "Sale");
+            saleEntity.AddKeys(saleEntity.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            saleEntity.AddStructuralProperty("CustomerId", EdmCoreModel.Instance.GetString(false));
+            saleEntity.AddStructuralProperty("Date", EdmCoreModel.Instance.GetString(false));
+            saleEntity.AddStructuralProperty("ProductId", EdmCoreModel.Instance.GetString(false));
+            saleEntity.AddStructuralProperty("CurrencyCode", EdmCoreModel.Instance.GetString(false));
+            saleEntity.AddStructuralProperty("Amount", EdmCoreModel.Instance.GetDecimal(false));
+
+            var productEntity = new EdmEntityType("NS", "Product");
+            productEntity.AddKeys(productEntity.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            productEntity.AddStructuralProperty("CategoryId", EdmCoreModel.Instance.GetString(false));
+            productEntity.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(false));
+            productEntity.AddStructuralProperty("Color", EdmCoreModel.Instance.GetString(false));
+            productEntity.AddStructuralProperty("TaxRate", EdmCoreModel.Instance.GetDecimal(false));
+
+            var customerEntity = new EdmEntityType("NS", "Customer");
+            customerEntity.AddKeys(customerEntity.AddStructuralProperty("Id", EdmCoreModel.Instance.GetString(false)));
+            customerEntity.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(false));
+            customerEntity.AddStructuralProperty("Country", EdmCoreModel.Instance.GetString(false));
+
+            var categoryEntity = new EdmEntityType("NS", "Category");
+            categoryEntity.AddKeys(categoryEntity.AddStructuralProperty("Id", EdmCoreModel.Instance.GetString(false)));
+            categoryEntity.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(false));
+
+            var currencyEntity = new EdmEntityType("NS", "Currency");
+            currencyEntity.AddKeys(currencyEntity.AddStructuralProperty("Code", EdmCoreModel.Instance.GetString(false)));
+            currencyEntity.AddStructuralProperty("Name", EdmCoreModel.Instance.GetString(false));
+
+            // Associations
+            saleEntity.AddBidirectionalNavigation(
+                new EdmNavigationPropertyInfo { Name = "Customer", Target = customerEntity, TargetMultiplicity = EdmMultiplicity.One },
+                new EdmNavigationPropertyInfo { Name = "Sales", Target = saleEntity, TargetMultiplicity = EdmMultiplicity.Many });
+            saleEntity.AddBidirectionalNavigation(
+                new EdmNavigationPropertyInfo { Name = "Product", Target = productEntity, TargetMultiplicity = EdmMultiplicity.One },
+                new EdmNavigationPropertyInfo { Name = "Sales", Target = saleEntity, TargetMultiplicity = EdmMultiplicity.Many });
+            saleEntity.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo { Name = "Currency", Target = currencyEntity, TargetMultiplicity = EdmMultiplicity.One });
+
+            productEntity.AddBidirectionalNavigation(
+                new EdmNavigationPropertyInfo { Name = "Category", Target = categoryEntity, TargetMultiplicity = EdmMultiplicity.One },
+                new EdmNavigationPropertyInfo { Name = "Products", Target = productEntity, TargetMultiplicity = EdmMultiplicity.Many });
+
+            var entityContainer = new EdmEntityContainer("NS", "Container");
+
+            model.AddElement(numberEntity);
+            model.AddElement(saleEntity);
+            model.AddElement(productEntity);
+            model.AddElement(customerEntity);
+            model.AddElement(categoryEntity);
+            model.AddElement(currencyEntity);
+            model.AddElement(entityContainer);
+
+            entityContainer.AddEntitySet(numbersEntitySetName, numberEntity);
+            entityContainer.AddEntitySet(salesEntitySetName, saleEntity);
+            entityContainer.AddEntitySet(productsEntitySetName, productEntity);
+
+            return model;
+        }
+
+        /// <summary>
+        /// Uses reflection to find the relevant aggregation method
+        /// </summary>
+        protected static MethodInfo GetAggregationMethod(string aggregationMethodName, Type genericArgumentType)
+        {
+            return typeof(Queryable).GetMethods(BindingFlags.Static | BindingFlags.Public)
+                            .Where(d1 => d1.Name.Equals(aggregationMethodName))
+                            .Select(d2 => new { Method = d2, Parameters = d2.GetParameters() })
+                            .Where(d3 => d3.Parameters.Length.Equals(2)
+                                && d3.Parameters[0].ParameterType.IsGenericType
+                                && d3.Parameters[0].ParameterType.GetGenericTypeDefinition().Equals(typeof(IQueryable<>))
+                                && d3.Parameters[1].ParameterType.IsGenericType
+                                && d3.Parameters[1].ParameterType.GetGenericTypeDefinition().Equals(typeof(Expression<>)))
+                            .Select(d4 => new { d4.Method, Arguments = d4.Parameters[1].ParameterType.GetGenericArguments() })
+                            .Where(d5 => d5.Arguments.Length > 0
+                                && d5.Arguments[0].IsGenericType
+                                && d5.Arguments[0].GetGenericTypeDefinition().Equals(typeof(Func<,>)))
+                            .Select(d6 => new { d6.Method, Arguments = d6.Arguments[0].GetGenericArguments() })
+                            .Where(d7 => d7.Arguments.Length > 1
+                                && d7.Arguments[0].IsGenericParameter
+                                && new[] { "Min", "Max" }.Contains(d7.Method.Name) ? true : d7.Arguments[1].Equals(genericArgumentType))
+                            .Select(d8 => d8.Method)
+                            .FirstOrDefault();
+        }
+
+        /// <summary>
+        /// Uses reflection to find the CountDistinct method
+        /// </summary>
+        protected static MethodInfo GetCountDistinctMethod()
+        {
+            return typeof(DataServiceExtensions).GetMethods(BindingFlags.Static | BindingFlags.Public)
+                    .Where(d1 => d1.Name.Equals("CountDistinct", StringComparison.Ordinal))
+                    .Select(d2 => new { Method = d2, Parameters = d2.GetParameters() })
+                    .Where(d3 => d3.Parameters.Length.Equals(2)
+                        && d3.Parameters[0].ParameterType.IsGenericType
+                        && d3.Parameters[0].ParameterType.GetGenericTypeDefinition().Equals(typeof(IQueryable<>))
+                        && d3.Parameters[1].ParameterType.IsGenericType
+                        && d3.Parameters[1].ParameterType.GetGenericTypeDefinition().Equals(typeof(Expression<>)))
+                    .Select(d4 => new { d4.Method, SelectorArguments = d4.Parameters[1].ParameterType.GetGenericArguments() })
+                    .Where(d5 => d5.SelectorArguments.Length.Equals(1)
+                        && d5.SelectorArguments[0].IsGenericType
+                        && d5.SelectorArguments[0].GetGenericTypeDefinition().Equals(typeof(Func<,>)))
+                    .Select(d6 => d6.Method).Single();
+        }
+
+        /// <summary>
+        /// Builds a method call expression dynamically.
+        /// </summary>
+        protected static MethodCallExpression BuildMethodCallExpression<T>(DataServiceQuery<T> queryable, MethodInfo methodInfo, PropertyInfo propertyInfo)
+        {
+            ParameterExpression parameterExpr = Expression.Parameter(queryable.ElementType, "d1");
+            LambdaExpression selectorExpr = Expression.Lambda(Expression.MakeMemberAccess(parameterExpr, propertyInfo), parameterExpr);
+
+            return BuildMethodCallExpression(queryable, methodInfo, selectorExpr);
+        }
+
+        /// <summary>
+        /// Builds a method call expression dynamically.
+        /// </summary>
+        protected static MethodCallExpression BuildMethodCallExpression<T>(DataServiceQuery<T> queryable, MethodInfo methodInfo, LambdaExpression selectorExpr)
+        {
+            Type propertyType = ((MemberExpression)selectorExpr.Body).Type;
+
+            List<Type> genericArguments = new List<Type>();
+            genericArguments.Add(queryable.ElementType);
+            if (methodInfo.GetGenericArguments().Length > 1)
+            {
+                genericArguments.Add(propertyType);
+            }
+
+            return Expression.Call(
+                null,
+                methodInfo.MakeGenericMethod(genericArguments.ToArray()),
+                new[] { queryable.Expression, Expression.Quote(selectorExpr) });
+        }
+
+        /// <summary>
+        /// Uses reflection to find the Execute method defined in DataServiceQueryProvider class
+        /// </summary>
+        protected static MethodInfo GetExecuteMethod()
+        {
+            return typeof(DataServiceQueryProvider).GetMethods()
+                .Where(d => d.Name.Equals("Execute")
+                    && d.IsGenericMethodDefinition
+                    && d.GetParameters().Length == 1
+                    && d.GetParameters()[0].ParameterType.Equals(typeof(Expression))
+                    && d.IsPublic
+                    && !d.IsStatic
+                ).FirstOrDefault();
+        }
+
+        protected static Type GetMethodReturnType(MethodInfo methodInfo, Type genericArgumentType)
+        {
+            Type returnType = genericArgumentType;
+            if ((genericArgumentType.Equals(typeof(int)) || genericArgumentType.Equals(typeof(long)))
+                && methodInfo.Name.Equals("Average", StringComparison.OrdinalIgnoreCase))
+            {
+                returnType = methodInfo.ReturnType;
+            }
+
+            return returnType;
+        }
+
+        /// <summary>
+        /// Generates a random and valid aggregated value based on the aggregation method
+        /// </summary>
+        protected object GenerateRandomAggregateValue(string aggregationMethodName, Type returnType)
+        {
+            int lowerBound = 100;
+            int upperBound = 1000;
+            object aggregationValue;
+
+            switch (aggregationMethodName.ToLowerInvariant())
+            {
+                case "average":
+                    // A decimal value should suffice as average for all types
+                    aggregationValue = Math.Round((double)upperBound * rand.NextDouble(), 2);
+                    break;
+                case "min":
+                case "max":
+                case "sum":
+                    if (returnType.Equals(typeof(int)) || returnType.Equals(typeof(long)))
+                        aggregationValue = rand.Next(lowerBound, upperBound);
+                    else
+                        aggregationValue = Math.Round(upperBound * rand.NextDouble(), 2);
+                    break;
+                default:
+                    aggregationValue = rand.Next(lowerBound, upperBound);
+                    break;
+            }
+
+            // Get underlying type if type is nullable - to use in Convert.ChangeType
+            Type underlyingType = Nullable.GetUnderlyingType(returnType);
+            if (underlyingType == null) // Not a nullable type
+            {
+                underlyingType = returnType;
+            }
+
+            return Convert.ChangeType(aggregationValue, underlyingType, CultureInfo.InvariantCulture.NumberFormat);
+        }
+
+        protected void InterceptRequestAndMockResponse(string aggregateAlias, object aggregateValue)
+        {
+            var mockResponse = string.Format(
+                    "{{\"@odata.context\":\"{0}/$metadata#{1}({2})\",\"value\":[{{\"@odata.id\":null,\"{2}\":{3}}}]}}",
+                    serviceUri,
+                    numbersEntitySetName,
+                    aggregateAlias,
+                    aggregateValue);
+
+            InterceptRequestAndMockResponse(mockResponse);
+        }
+
+        protected void InterceptRequestAndMockResponse(string mockResponse)
+        {
+            dsContext.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                var contentTypeHeader = "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8";
+                var odataVersionHeader = "4.0";
+
+                return new TestHttpWebRequestMessage(args,
+                    new Dictionary<string, string>
+                    {
+                        {"Content-Type", contentTypeHeader},
+                        {"OData-Version", odataVersionHeader},
+                    },
+                    () => new MemoryStream(Encoding.UTF8.GetBytes(mockResponse)));
+            };
+        }
+
+        #endregion
+
+        #region Types
+
+        public class Number
+        {
+            public int RowId { get; set; }
+            public string RowParity { get; set; }
+            public string RowCategory { get; set; }
+            public int IntProp { get; set; }
+            public int? NullableIntProp { get; set; }
+            public double DoubleProp { get; set; }
+            public double? NullableDoubleProp { get; set; }
+            public decimal DecimalProp { get; set; }
+            public decimal? NullableDecimalProp { get; set; }
+            public long LongProp { get; set; }
+            public long? NullableLongProp { get; set; }
+            public float SingleProp { get; set; }
+            public float? NullableSingleProp { get; set; }
+        }
+
+        public class Sale
+        {
+            public int Id { get; set; }
+            public string CustomerId { get; set; }
+            public Customer Customer { get; set; }
+            public string Date { get; set; }
+            public string ProductId { get; set; }
+            public Product Product { get; set; }
+            public string CurrencyCode { get; set; }
+            public Currency Currency { get; set; }
+            public decimal Amount { get; set; }
+        }
+
+        public class Product
+        {
+            public string Id { get; set; }
+            public string CategoryId { get; set; }
+            public Category Category { get; set; }
+            public string Name { get; set; }
+            public string Color { get; set; }
+            public decimal TaxRate { get; set; }
+            public Collection<Sale> Sales { get; set; }
+        }
+
+        public class Customer
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public string Country { get; set; }
+            public Collection<Sale> Sales { get; set; }
+        }
+
+        public class Category
+        {
+            public string Id { get; set; }
+            public string Name { get; set; }
+            public Collection<Product> Products { get; set; }
+        }
+
+        public class Currency
+        {
+            public string Code { get; set; }
+            public string Name { get; set; }
+        }
+
+        #endregion
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/TestHttpWebRequestMessage.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/TestHttpWebRequestMessage.cs
@@ -1,0 +1,60 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="TestHttpWebRequestMessage.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.Client.Tests
+{
+    public class TestHttpWebRequestMessage : HttpWebRequestMessage
+{
+	private readonly Func<Stream> getResponseStream;
+	private readonly int statusCode;
+	private readonly IDictionary<string, string> headers;
+
+	public TestHttpWebRequestMessage(DataServiceClientRequestMessageArgs args)
+		: this(args, new Dictionary<string, string>(), 200, () => new MemoryStream(Encoding.UTF8.GetBytes("")))
+	{
+	}
+
+	public TestHttpWebRequestMessage(DataServiceClientRequestMessageArgs args, IDictionary<string, string> headers, Func<Stream> getResponseStream)
+		: this(args, headers, 200, getResponseStream)
+    {
+    }
+
+	public TestHttpWebRequestMessage(DataServiceClientRequestMessageArgs args, IDictionary<string, string> headers, int statusCode, Func<Stream> getResponseStream)
+		: base(args)
+	{
+		this.headers = headers;
+		this.statusCode = statusCode;
+		this.getResponseStream = getResponseStream;
+	}
+
+#if (NETCOREAPP1_0 || NETCOREAPP2_0)
+	public IODataResponseMessage GetResponse()
+#else
+	public override IODataResponseMessage GetResponse()
+#endif
+	{
+		return new HttpWebResponseMessage(this.headers, this.statusCode, this.getResponseStream);
+	}
+
+	public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+	{
+		// APM is deprecated in .NET Core and Task.CompletedTask is not available in NET45
+		callback.Invoke(Task.FromResult(0));
+		return Task.FromResult(0);
+	}
+
+	public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
+	{
+		return GetResponse();
+	}
+}
+}

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/TestHttpWebRequestMessage.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/TestHttpWebRequestMessage.cs
@@ -13,44 +13,44 @@ using System.Threading.Tasks;
 namespace Microsoft.OData.Client.Tests
 {
     public class TestHttpWebRequestMessage : HttpWebRequestMessage
-{
-	private readonly Func<Stream> getResponseStream;
-	private readonly int statusCode;
-	private readonly IDictionary<string, string> headers;
-
-	public TestHttpWebRequestMessage(DataServiceClientRequestMessageArgs args)
-		: this(args, new Dictionary<string, string>(), 200, () => new MemoryStream(Encoding.UTF8.GetBytes("")))
-	{
-	}
-
-	public TestHttpWebRequestMessage(DataServiceClientRequestMessageArgs args, IDictionary<string, string> headers, Func<Stream> getResponseStream)
-		: this(args, headers, 200, getResponseStream)
     {
+        private readonly Func<Stream> getResponseStream;
+        private readonly int statusCode;
+        private readonly IDictionary<string, string> headers;
+
+        public TestHttpWebRequestMessage(DataServiceClientRequestMessageArgs args)
+            : this(args, new Dictionary<string, string>(), 200, () => new MemoryStream(Encoding.UTF8.GetBytes("")))
+        {
+        }
+
+        public TestHttpWebRequestMessage(DataServiceClientRequestMessageArgs args, IDictionary<string, string> headers, Func<Stream> getResponseStream)
+            : this(args, headers, 200, getResponseStream)
+        {
+        }
+
+        public TestHttpWebRequestMessage(DataServiceClientRequestMessageArgs args, IDictionary<string, string> headers, int statusCode, Func<Stream> getResponseStream)
+            : base(args)
+        {
+            this.headers = headers;
+            this.statusCode = statusCode;
+            this.getResponseStream = getResponseStream;
+        }
+
+        public override IODataResponseMessage GetResponse()
+        {
+            return new HttpWebResponseMessage(this.headers, this.statusCode, this.getResponseStream);
+        }
+
+        public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+        {
+            // APM is deprecated in .NET Core and Task.CompletedTask is not available in NET45
+            callback.Invoke(Task.FromResult(0));
+            return Task.FromResult(0);
+        }
+
+        public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
+        {
+            return GetResponse();
+        }
     }
-
-	public TestHttpWebRequestMessage(DataServiceClientRequestMessageArgs args, IDictionary<string, string> headers, int statusCode, Func<Stream> getResponseStream)
-		: base(args)
-	{
-		this.headers = headers;
-		this.statusCode = statusCode;
-		this.getResponseStream = getResponseStream;
-	}
-
-	public override IODataResponseMessage GetResponse()
-	{
-		return new HttpWebResponseMessage(this.headers, this.statusCode, this.getResponseStream);
-	}
-
-	public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
-	{
-		// APM is deprecated in .NET Core and Task.CompletedTask is not available in NET45
-		callback.Invoke(Task.FromResult(0));
-		return Task.FromResult(0);
-	}
-
-	public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
-	{
-		return GetResponse();
-	}
-}
 }

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/TestHttpWebRequestMessage.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/TestHttpWebRequestMessage.cs
@@ -36,11 +36,7 @@ namespace Microsoft.OData.Client.Tests
 		this.getResponseStream = getResponseStream;
 	}
 
-#if (NETCOREAPP1_0 || NETCOREAPP2_0)
-	public IODataResponseMessage GetResponse()
-#else
 	public override IODataResponseMessage GetResponse()
-#endif
 	{
 		return new HttpWebResponseMessage(this.headers, this.statusCode, this.getResponseStream);
 	}

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -7738,6 +7738,21 @@ public abstract class Microsoft.OData.Client.OperationResponse {
 	int StatusCode  { public get; }
 }
 
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.OData.Client.DataServiceExtensions {
+	[
+	ExtensionAttribute(),
+	]
+	public static int CountDistinct (IEnumerable`1 source, Func`2 selector)
+
+	[
+	ExtensionAttribute(),
+	]
+	public static int CountDistinct (IQueryable`1 source, Expression`1 selector)
+}
+
 public sealed class Microsoft.OData.Client.Utility {
 	public static System.Collections.Generic.IEnumerable`1[[System.Object]] GetCustomAttributes (System.Type type, System.Type attributeType, bool inherit)
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -7742,6 +7742,21 @@ public abstract class Microsoft.OData.Client.OperationResponse {
     int StatusCode  { public get; }
 }
 
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.OData.Client.DataServiceExtensions {
+    [
+    ExtensionAttribute(),
+    ]
+    public static int CountDistinct (IEnumerable`1 source, Func`2 selector)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static int CountDistinct (IQueryable`1 source, Expression`1 selector)
+}
+
 public sealed class Microsoft.OData.Client.Utility {
     public static System.Collections.Generic.IEnumerable`1[[System.Object]] GetCustomAttributes (System.Type type, System.Type attributeType, bool inherit)
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -7774,6 +7774,21 @@ public abstract class Microsoft.OData.Client.OperationResponse {
     int StatusCode  { public get; }
 }
 
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.OData.Client.DataServiceExtensions {
+    [
+    ExtensionAttribute(),
+    ]
+    public static int CountDistinct (IEnumerable`1 source, Func`2 selector)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static int CountDistinct (IQueryable`1 source, Expression`1 selector)
+}
+
 public sealed class Microsoft.OData.Client.Utility {
     public static System.Collections.Generic.IEnumerable`1[[System.Object]] GetCustomAttributes (System.Type type, System.Type attributeType, bool inherit)
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request is 1 of 3 from splitting [this](https://github.com/OData/odata.net/pull/1810) huge pull request to make it easier to review.*

### Description

The simple aggregations below are covered. The scope of this PR is aggregations that return a single scalar result.

```csharp
    // EntitySet?$apply=aggregate(Prop with average as AverageProp)
    EntitySet.Average(d1 => d1.Prop)

    // EntitySet?$apply=aggregate(Prop with sum as SumProp)
    EntitySet.Sum(d1 => d1.Prop)

    // EntitySet?$apply=aggregate(Prop with min as MinProp)
    EntitySet.Min(d1 => d1.Prop)

    // EntitySet?$apply=aggregate(Prop with max as MaxProp)
    EntitySet.Max(d1 => d1.Prop)

    // EntitySet?$apply=aggregate(Prop with countdistinct as CountDistinctProp)
    EntitySet.CountDistinct(d1 => d1.Prop)

    // EntitySet?$apply=aggregate(NavProp/Prop with average as AverageNavPro_Prop)
    EntitySet.Average(d1 => d1.NavProp.Prop)

    // EntitySet?$apply=aggregate(NavProp/Prop with sum as SumNavPro_Prop)
    EntitySet.Sum(d1 => d1.NavProp.Prop)

    // EntitySet?$apply=aggregate(NavProp/Prop with min as MinNavPro_Prop)
    EntitySet.Min(d1 => d1.NavProp.Prop)

    // EntitySet?$apply=aggregate(NavProp/Prop with max as MaxNavPro_Prop)
    EntitySet.Max(d1 => d1.NavProp.Prop)

    // EntitySet?$apply=aggregate(NavProp/Prop with countdistinct as CountDistinctNavPro_Prop)
    EntitySet.CountDistinct(d1 => d1.NavProp.Prop)

    // NOTE: We support nested navigation properties in the aggregate expression, i.e. d1 => d1.NavProp.NestedNavProp.Prop
    // E.g.
    // EntitySet?$apply=aggregate(NavProp/NestedNavProp/Prop with average as AverageNavProp_NestedNavProp_Prop)
    EntitySet.Average(d1 => d1.NavProp.NestedNavProp.Prop)
```
The [filter transformation](http://docs.oasis-open.org/odata/odata-data-aggregation-ext/v4.0/cs02/odata-data-aggregation-ext-v4.0-cs02.html#_Toc435016585) used together with aggregation is also covered. A filter transformation is used (_not $filter_) to restrict the set of data to be aggregated.
```csharp
    // EntitySet?$apply=filter(Amount gt 1)/aggregate(Prop with average as AverageProp)
    EntitySet.Where(d0 => d0.Amount > 1).Average(d1 => d1.Prop)
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
