### PR TITLE
ConvertFromUriLiteral can't work for short data type

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -240,6 +240,7 @@ namespace Microsoft.OData
         internal const string ExpressionLexer_ExpectedLiteralToken = "ExpressionLexer_ExpectedLiteralToken";
         internal const string ODataUriUtils_ConvertToUriLiteralUnsupportedType = "ODataUriUtils_ConvertToUriLiteralUnsupportedType";
         internal const string ODataUriUtils_ConvertFromUriLiteralTypeRefWithoutModel = "ODataUriUtils_ConvertFromUriLiteralTypeRefWithoutModel";
+        internal const string ODataUriUtils_ConvertFromUriLiteralOverflowNumber = "ODataUriUtils_ConvertFromUriLiteralOverflowNumber";
         internal const string ODataUriUtils_ConvertFromUriLiteralTypeVerificationFailure = "ODataUriUtils_ConvertFromUriLiteralTypeVerificationFailure";
         internal const string ODataUriUtils_ConvertFromUriLiteralNullTypeVerificationFailure = "ODataUriUtils_ConvertFromUriLiteralNullTypeVerificationFailure";
         internal const string ODataUriUtils_ConvertFromUriLiteralNullOnNonNullableType = "ODataUriUtils_ConvertFromUriLiteralNullOnNonNullableType";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -82,4 +82,8 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
 </Project>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -82,8 +82,4 @@
     </Compile>
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-  </ItemGroup>
-
 </Project>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -261,7 +261,7 @@ ExpressionLexer_ExpectedLiteralToken=Expected literal type token but found token
 
 ODataUriUtils_ConvertToUriLiteralUnsupportedType=The type '{0}' is not supported when converting to a URI literal.
 ODataUriUtils_ConvertFromUriLiteralTypeRefWithoutModel=An IEdmTypeReference must be provided with a matching IEdmModel. No model was provided.
-ODataUriUtils_ConvertFromUriLiteralOverflowNumber=The overflow exception caught for expected type '{0}'.'{1}'.
+ODataUriUtils_ConvertFromUriLiteralOverflowNumber=The overflow exception caught for expected type '{0}'. '{1}'.
 ODataUriUtils_ConvertFromUriLiteralTypeVerificationFailure=Type verification failed. Expected type '{0}' but received the value '{1}'.
 ODataUriUtils_ConvertFromUriLiteralNullTypeVerificationFailure=Type verification failed. Expected type '{0}' but received non-matching null value with associated type '{1}'.
 ODataUriUtils_ConvertFromUriLiteralNullOnNonNullableType=Type verification failed. Expected non-nullable type '{0}' but received a null value.

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -261,6 +261,7 @@ ExpressionLexer_ExpectedLiteralToken=Expected literal type token but found token
 
 ODataUriUtils_ConvertToUriLiteralUnsupportedType=The type '{0}' is not supported when converting to a URI literal.
 ODataUriUtils_ConvertFromUriLiteralTypeRefWithoutModel=An IEdmTypeReference must be provided with a matching IEdmModel. No model was provided.
+ODataUriUtils_ConvertFromUriLiteralOverflowNumber=The overflow exception caught for expected type '{0}'.'{1}'.
 ODataUriUtils_ConvertFromUriLiteralTypeVerificationFailure=Type verification failed. Expected type '{0}' but received the value '{1}'.
 ODataUriUtils_ConvertFromUriLiteralNullTypeVerificationFailure=Type verification failed. Expected type '{0}' but received non-matching null value with associated type '{1}'.
 ODataUriUtils_ConvertFromUriLiteralNullOnNonNullableType=Type verification failed. Expected non-nullable type '{0}' but received a null value.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -2054,6 +2054,14 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The overflow exception caught for expected type '{0}'.'{1}'."
+        /// </summary>
+        internal static string ODataUriUtils_ConvertFromUriLiteralOverflowNumber(object p0, object p1)
+        {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataUriUtils_ConvertFromUriLiteralOverflowNumber, p0, p1);
+        }
+
+        /// <summary>
         /// A string like "Type verification failed. Expected type '{0}' but received the value '{1}'."
         /// </summary>
         internal static string ODataUriUtils_ConvertFromUriLiteralTypeVerificationFailure(object p0, object p1)
@@ -6208,17 +6216,6 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "The UriValidator used to validate an ODataUri must use the same Model as the ODataUriParser."
-        /// </summary>
-        internal static string UriValidator_ValidatorMustUseSameModelAsParser
-        {
-            get
-            {
-                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriValidator_ValidatorMustUseSameModelAsParser);
-            }
-        }
-
-        /// <summary>
         /// A string like "The URI '{0}' must be an absolute URI."
         /// </summary>
         internal static string UriParser_UriMustBeAbsolute(object p0)
@@ -6307,6 +6304,17 @@ namespace Microsoft.OData {
         internal static string UriParserMetadata_MultipleMatchingParametersFound(object p0)
         {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriParserMetadata_MultipleMatchingParametersFound, p0);
+        }
+
+        /// <summary>
+        /// A string like "The UrlValidator used to validate an ODataUri must use the same Model as the ODataUriParser."
+        /// </summary>
+        internal static string UriValidator_ValidatorMustUseSameModelAsParser
+        {
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriValidator_ValidatorMustUseSameModelAsParser);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -2054,7 +2054,7 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "The overflow exception caught for expected type '{0}'.'{1}'."
+        /// A string like "The overflow exception caught for expected type '{0}'. '{1}'."
         /// </summary>
         internal static string ODataUriUtils_ConvertFromUriLiteralOverflowNumber(object p0, object p1)
         {

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -405,6 +405,12 @@ namespace Microsoft.OData
             {
                 switch (targetPrimitiveKind)
                 {
+                    case EdmPrimitiveTypeKind.Byte: // Int32 -> byte
+                        return ConvertToTargetType(targetEdmType, () => Convert.ToByte((Int32)primitiveValue));
+                    case EdmPrimitiveTypeKind.SByte: // Int32 -> sbyte
+                        return ConvertToTargetType(targetEdmType, () => Convert.ToSByte((Int32)primitiveValue));
+                    case EdmPrimitiveTypeKind.Int16: // Int32 -> short
+                        return ConvertToTargetType(targetEdmType, () => Convert.ToInt16((Int32)primitiveValue));
                     case EdmPrimitiveTypeKind.Int32:
                         return primitiveValue;
                     case EdmPrimitiveTypeKind.Int64:
@@ -652,6 +658,18 @@ namespace Microsoft.OData
 
                     return rawResult;
                 }
+            }
+        }
+
+        private static object ConvertToTargetType(IEdmPrimitiveType targetEdmType, Func<object> converter)
+        {
+            try
+            {
+                return converter();
+            }
+            catch (OverflowException ex)
+            {
+                throw new ODataException(ODataErrorStrings.ODataUriUtils_ConvertFromUriLiteralOverflowNumber(targetEdmType.FullName(), ex.Message));
             }
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
@@ -14,6 +14,35 @@ namespace Microsoft.OData.Tests.Query
 {
     public class ODataUriUtilsTests
     {
+        [Theory]
+        [InlineData(EdmPrimitiveTypeKind.SByte, (sbyte)2)]
+        [InlineData(EdmPrimitiveTypeKind.Byte, (byte)2)]
+        [InlineData(EdmPrimitiveTypeKind.Int16, (short)2)]
+        [InlineData(EdmPrimitiveTypeKind.Int32, (int)2)]
+        [InlineData(EdmPrimitiveTypeKind.Int64, (long)2)]
+        public void TestIntegerConvertFromUriLiteral(EdmPrimitiveTypeKind kind, object expected)
+        {
+            Type expectedType = expected.GetType();
+            var numberType = EdmCoreModel.Instance.GetPrimitive(kind, true);
+
+            object primitiveValue = ODataUriUtils.ConvertFromUriLiteral("2", ODataVersion.V4, EdmCoreModel.Instance, numberType);
+
+            Assert.IsType(expectedType, primitiveValue);
+            Assert.Equal(expected, primitiveValue);
+        }
+
+        [Theory]
+        [InlineData("42767")]
+        [InlineData("-42767")]
+        public void TestIntegerConvertFromUriLiteralThrowOverflow(string value)
+        {
+            var numberType = EdmCoreModel.Instance.GetInt16(true);
+
+            Action test = () => ODataUriUtils.ConvertFromUriLiteral(value, ODataVersion.V4, EdmCoreModel.Instance, numberType);
+
+            test.Throws<ODataException>(Strings.ODataUriUtils_ConvertFromUriLiteralOverflowNumber("Edm.Int16", "Value was either too large or too small for an Int16."));
+        }
+
         [Fact]
         public void TestDecimalConvertToUriLiteral()
         {
@@ -26,7 +55,6 @@ namespace Microsoft.OData.Tests.Query
             decimalString = ODataUriUtils.ConvertToUriLiteral(112M, ODataVersion.V4);
             Assert.Equal("112", decimalString);
         }
-
 
         [Theory]
         [InlineData("79228162514264337593543950335")]
@@ -41,7 +69,6 @@ namespace Microsoft.OData.Tests.Query
             Assert.True(dec is decimal);
 #endif
         }
-
 
         [Fact]
         public void TestLongConvertToUriLiteral()


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #262 *

### Description

* For example:  `ConvertFromUriLiteral("2", V4, model, Edm.Int16)`  throws exception.

This PR makes it working.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
