### PR TITLE
Fix null dynamic property materialization

### DIFF
--- a/src/Microsoft.OData.Client/Materialization/StructuralValueMaterializationPolicy.cs
+++ b/src/Microsoft.OData.Client/Materialization/StructuralValueMaterializationPolicy.cs
@@ -334,9 +334,11 @@ namespace Microsoft.OData.Client.Materialization
             // Stop if owning type is not an open type
             // Or container property is not found
             // Or key with matching name already exists in the dictionary
+            // Or value is null - based on the spec, a missing dynamic property is defined to be the same as a dynamic property with value null
             if (!ClientTypeUtil.IsInstanceOfOpenType(instance, this.MaterializerContext.Model)
                 || !ClientTypeUtil.TryGetContainerProperty(instance, out containerProperty) 
-                || containerProperty.ContainsKey(property.Name))
+                || containerProperty.ContainsKey(property.Name)
+                || property.Value == null)
             {
                 return;
             }
@@ -355,6 +357,11 @@ namespace Microsoft.OData.Client.Materialization
             if (untypedVal != null)
             {
                 value = CommonUtil.ParseJsonToPrimitiveValue(untypedVal.RawValue);
+                if (value == null)
+                {
+                    return;
+                }
+
                 containerProperty.Add(property.Name, value);
                 return;
             }

--- a/src/Microsoft.OData.Client/Serialization/ODataPropertyConverter.cs
+++ b/src/Microsoft.OData.Client/Serialization/ODataPropertyConverter.cs
@@ -95,6 +95,13 @@ namespace Microsoft.OData.Client
                 {
                     string dynamicPropertyName = kvPair.Key;
                     object dynamicPropertyValue = kvPair.Value;
+
+                    // Based on the spec, a missing dynamic property is defined to be the same as a dynamic property with value null
+                    if (dynamicPropertyValue == null)
+                    {
+                        continue;
+                    }
+
                     Type dynamicPropertyType = dynamicPropertyValue.GetType();
                     Type dynamicPropertyItemType = !(dynamicPropertyValue is ICollection) ? dynamicPropertyType : dynamicPropertyType.GetGenericArguments().Single();
 
@@ -237,6 +244,13 @@ namespace Microsoft.OData.Client
                 {
                     string dynamicPropertyName = kvPair.Key;
                     object dynamicPropertyValue = kvPair.Value;
+
+                    // Based on the spec, a missing dynamic property is defined to be the same as a dynamic property with value null
+                    if (dynamicPropertyValue == null)
+                    {
+                        continue;
+                    }
+
                     Type dynamicPropertyType = dynamicPropertyValue.GetType();
                     bool isCollection = dynamicPropertyValue is ICollection;
                     Type dynamicPropertyItemType = !isCollection ? dynamicPropertyType : dynamicPropertyType.GetGenericArguments().Single();
@@ -730,9 +744,10 @@ namespace Microsoft.OData.Client
                 odataValue = CreateODataPrimitiveValue(clientType, value);
                 
                 PrimitiveType primitiveType;
-                PrimitiveType.TryGetPrimitiveType(value.GetType(), out primitiveType);
-                
-                if (shouldWriteClientType && !JsonSharedUtils.ValueTypeMatchesJsonType((ODataPrimitiveValue)odataValue, primitiveType.PrimitiveKind))
+                if (value != null 
+                    && PrimitiveType.TryGetPrimitiveType(value.GetType(), out primitiveType)
+                    && shouldWriteClientType
+                    && !JsonSharedUtils.ValueTypeMatchesJsonType((ODataPrimitiveValue)odataValue, primitiveType.PrimitiveKind))
                 {
                     odataValue.TypeAnnotation = new ODataTypeAnnotation(primitiveType.EdmTypeName);
                 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1943.*

### Description

If an OData service returns an open entity type when a dynamic property is returned with a value of null, attempt to materialize that value into the dynamic properties container property results into an error. This pull request fixes that.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
