### PR TITLE
Added writer setting to add type annotations

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
@@ -28,6 +28,20 @@ namespace Microsoft.OData.JsonLight
         /// <param name="model">The edm model.</param>
         /// <param name="writingResponse">true if we are writing a response, false otherwise.</param>
         /// <returns>The JSON Light metadata level being written.</returns>
+        internal static JsonLightMetadataLevel Create(ODataMediaType mediaType, Uri metadataDocumentUri, IEdmModel model, bool writingResponse)
+        {
+            return Create(mediaType, metadataDocumentUri, /*alwaysAddTypeAnnotationsForDerivedTypes*/ false, model, writingResponse);
+        }
+
+        /// <summary>
+        /// Creates the appropriate metadata level based on the media type being written.
+        /// </summary>
+        /// <param name="mediaType">The full media type being written. This media type must have a type/subtype of "application/json".</param>
+        /// <param name="metadataDocumentUri">The metadata document uri from the writer settings.</param>
+        /// <param name="alwaysAddTypeAnnotationsForDerivedTypes">When set, type annotations will be added for derived types, even when the metadata level is set to "None".</param>
+        /// <param name="model">The edm model.</param>
+        /// <param name="writingResponse">true if we are writing a response, false otherwise.</param>
+        /// <returns>The JSON Light metadata level being written.</returns>
         internal static JsonLightMetadataLevel Create(ODataMediaType mediaType, Uri metadataDocumentUri, bool alwaysAddTypeAnnotationsForDerivedTypes, IEdmModel model, bool writingResponse)
         {
             Debug.Assert(mediaType != null, "mediaType != null");

--- a/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
@@ -24,10 +24,11 @@ namespace Microsoft.OData.JsonLight
         /// </summary>
         /// <param name="mediaType">The full media type being written. This media type must have a type/subtype of "application/json".</param>
         /// <param name="metadataDocumentUri">The metadata document uri from the writer settings.</param>
+        /// <param name="alwaysAddTypeAnnotationsForDerivedTypes">When set, type annotations will be added for derived types, even when the metadata level is set to "None".</param>
         /// <param name="model">The edm model.</param>
         /// <param name="writingResponse">true if we are writing a response, false otherwise.</param>
         /// <returns>The JSON Light metadata level being written.</returns>
-        internal static JsonLightMetadataLevel Create(ODataMediaType mediaType, Uri metadataDocumentUri, IEdmModel model, bool writingResponse)
+        internal static JsonLightMetadataLevel Create(ODataMediaType mediaType, Uri metadataDocumentUri, bool alwaysAddTypeAnnotationsForDerivedTypes, IEdmModel model, bool writingResponse)
         {
             Debug.Assert(mediaType != null, "mediaType != null");
 
@@ -57,7 +58,7 @@ namespace Microsoft.OData.JsonLight
 
                     if (string.Compare(parameter.Value, MimeConstants.MimeMetadataParameterValueNone, StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        return new JsonNoMetadataLevel();
+                        return new JsonNoMetadataLevel(alwaysAddTypeAnnotationsForDerivedTypes);
                     }
 
                     Debug.Assert(

--- a/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
@@ -24,7 +24,6 @@ namespace Microsoft.OData.JsonLight
         /// </summary>
         /// <param name="mediaType">The full media type being written. This media type must have a type/subtype of "application/json".</param>
         /// <param name="metadataDocumentUri">The metadata document uri from the writer settings.</param>
-        /// <param name="alwaysAddTypeAnnotationsForDerivedTypes">When set, type annotations will be added for derived types, even when the metadata level is set to "None".</param>
         /// <param name="model">The edm model.</param>
         /// <param name="writingResponse">true if we are writing a response, false otherwise.</param>
         /// <returns>The JSON Light metadata level being written.</returns>

--- a/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
@@ -26,6 +26,14 @@ namespace Microsoft.OData.JsonLight
         /// <summary>
         /// Constructs a new <see cref="JsonNoMetadataLevel"/>.
         /// </summary>
+        public JsonNoMetadataLevel()
+            : this(/*alwaysAddTypeAnnotationsForDerivedTypes*/ false)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="JsonNoMetadataLevel"/>.
+        /// </summary>
         /// <param name="alwaysAddTypeAnnotationsForDerivedTypes">When set, type annotations will be added for derived types, even when the metadata level is set to "None".</param>
         public JsonNoMetadataLevel(bool alwaysAddTypeAnnotationsForDerivedTypes)
         {

--- a/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
@@ -19,12 +19,33 @@ namespace Microsoft.OData.JsonLight
     internal sealed class JsonNoMetadataLevel : JsonLightMetadataLevel
     {
         /// <summary>
+        /// When set, type annotations will be added for derived types, even when the metadata level is set to "None".
+        /// </summary>
+        private readonly bool alwaysAddTypeAnnotationsForDerivedTypes;
+
+        /// <summary>
+        /// Constructs a new <see cref="JsonNoMetadataLevel"/>.
+        /// </summary>
+        /// <param name="alwaysAddTypeAnnotationsForDerivedTypes">When set, type annotations will be added for derived types, even when the metadata level is set to "None".</param>
+        public JsonNoMetadataLevel(bool alwaysAddTypeAnnotationsForDerivedTypes)
+        {
+            this.alwaysAddTypeAnnotationsForDerivedTypes = alwaysAddTypeAnnotationsForDerivedTypes;
+        }
+
+        /// <summary>
         /// Returns the oracle to use when determining the type name to write for entries and values.
         /// </summary>
         /// <returns>An oracle that can be queried to determine the type name to write.</returns>
         internal override JsonLightTypeNameOracle GetTypeNameOracle()
         {
-            return new JsonNoMetadataTypeNameOracle();
+            if (this.alwaysAddTypeAnnotationsForDerivedTypes)
+            {
+                return new JsonMinimalMetadataTypeNameOracle();
+            }
+            else
+            {
+                return new JsonNoMetadataTypeNameOracle();
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightInputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightInputContext.cs
@@ -112,7 +112,7 @@ namespace Microsoft.OData.JsonLight
             // don't know how to get MetadataDocumentUri uri here, messageReaderSettings do not have one
             // Uri metadataDocumentUri = messageReaderSettings..MetadataDocumentUri == null ? null : messageReaderSettings.MetadataDocumentUri.BaseUri;
             // the uri here is used here to create the FullMetadataLevel can pass null in
-            this.metadataLevel = JsonLightMetadataLevel.Create(messageInfo.MediaType, null, this.Model, this.ReadingResponse);
+            this.metadataLevel = JsonLightMetadataLevel.Create(messageInfo.MediaType, null, false, this.Model, this.ReadingResponse);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -109,7 +109,8 @@ namespace Microsoft.OData.JsonLight
             }
 
             Uri metadataDocumentUri = messageWriterSettings.MetadataDocumentUri;
-            this.metadataLevel = JsonLightMetadataLevel.Create(messageInfo.MediaType, metadataDocumentUri, this.Model, this.WritingResponse);
+            bool alwaysAddTypeAnnotationsForDerivedTypes = messageWriterSettings.AlwaysAddTypeAnnotationsForDerivedTypes;
+            this.metadataLevel = JsonLightMetadataLevel.Create(messageInfo.MediaType, metadataDocumentUri, alwaysAddTypeAnnotationsForDerivedTypes, this.Model, this.WritingResponse);
             this.propertyCacheHandler = new PropertyCacheHandler();
         }
 

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -78,6 +78,7 @@ namespace Microsoft.OData
             this.Validator = new WriterValidator(this);
             this.LibraryCompatibility = ODataLibraryCompatibility.Latest;
             this.MultipartNewLine = "\r\n";
+            this.AlwaysAddTypeAnnotationsForDerivedTypes = false;
         }
 
         /// <summary>
@@ -188,6 +189,11 @@ namespace Microsoft.OData
         /// A TextWriter uses OS specific newline but rfc2046 requires it to be CRLF.
         /// </summary>
         public string MultipartNewLine { get; set; }
+
+        /// <summary>
+        /// When set, type annotations will be added for derived types, even when the metadata level is set to "None".
+        /// </summary>
+        public bool AlwaysAddTypeAnnotationsForDerivedTypes { get; set; }
 
         /// <summary>
         /// Gets the validator corresponding to the validation settings.
@@ -432,6 +438,7 @@ namespace Microsoft.OData
             this.useFormat = other.useFormat;
             this.Version = other.Version;
             this.LibraryCompatibility = other.LibraryCompatibility;
+            this.AlwaysAddTypeAnnotationsForDerivedTypes = other.AlwaysAddTypeAnnotationsForDerivedTypes;
             this.MetadataSelector = other.MetadataSelector;
             this.IsIeee754Compatible = other.IsIeee754Compatible;
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonLightMetadataLevelTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonLightMetadataLevelTests.cs
@@ -29,48 +29,48 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ODataMinimalMetadataShouldCreateMinimalMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "minimal"));
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void ODataFullMetadataShouldCreateFullMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "full"));
-            Assert.IsType<JsonFullMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonFullMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void ODataNoMetadataShouldCreateNoMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "none"));
-            Assert.IsType<JsonNoMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonNoMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void NoODataParameterShouldCreateMinimalMetadataLevel()
         {
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void FooFullMetadataShouldCreateMinimalMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("foo", "full"));
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void FooNoMetadataShouldCreateMinimalMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("foo", "none"));
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void FooMinimalMetadataShouldCreateMinimalMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("foo", "minimal"));
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.parameterList.Add(new KeyValuePair<string, string>("foo", "something"));
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "full"));
-            Assert.IsType<JsonFullMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonFullMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
 
         [Fact]
@@ -87,13 +87,13 @@ namespace Microsoft.OData.Tests.JsonLight
             // We could also throw in this case, but this should have already been validated.
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "none"));
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "full"));
-            Assert.IsType<JsonNoMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonNoMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void MediaTypeWithNullParameterListShouldCreateMinimalMetadataLevel()
         {
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(new ODataMediaType("application", "json"), MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(new ODataMediaType("application", "json"), MetadataDocumentUri, Model, /*writingResponse*/ true));
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonLightMetadataLevelTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonLightMetadataLevelTests.cs
@@ -29,48 +29,48 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ODataMinimalMetadataShouldCreateMinimalMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "minimal"));
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void ODataFullMetadataShouldCreateFullMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "full"));
-            Assert.IsType<JsonFullMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonFullMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void ODataNoMetadataShouldCreateNoMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "none"));
-            Assert.IsType<JsonNoMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonNoMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void NoODataParameterShouldCreateMinimalMetadataLevel()
         {
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void FooFullMetadataShouldCreateMinimalMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("foo", "full"));
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void FooNoMetadataShouldCreateMinimalMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("foo", "none"));
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void FooMinimalMetadataShouldCreateMinimalMetadataLevel()
         {
             this.parameterList.Add(new KeyValuePair<string, string>("foo", "minimal"));
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.parameterList.Add(new KeyValuePair<string, string>("foo", "something"));
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "full"));
-            Assert.IsType<JsonFullMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonFullMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
 
         [Fact]
@@ -87,13 +87,13 @@ namespace Microsoft.OData.Tests.JsonLight
             // We could also throw in this case, but this should have already been validated.
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "none"));
             this.parameterList.Add(new KeyValuePair<string, string>("odata.metadata", "full"));
-            Assert.IsType<JsonNoMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonNoMetadataLevel>(JsonLightMetadataLevel.Create(this.applicationJsonMediaType, MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
 
         [Fact]
         public void MediaTypeWithNullParameterListShouldCreateMinimalMetadataLevel()
         {
-            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(new ODataMediaType("application", "json"), MetadataDocumentUri, Model, /*writingResponse*/ true));
+            Assert.IsType<JsonMinimalMetadataLevel>(JsonLightMetadataLevel.Create(new ODataMediaType("application", "json"), MetadataDocumentUri, /* alwaysAddTypeAnnotationsForDerivedTypes */ false, Model, /*writingResponse*/ true));
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonNoMetadataLevelTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonNoMetadataLevelTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OData.Tests.JsonLight
 {
     public class JsonNoMetadataLevelTests
     {
-        private readonly JsonNoMetadataLevel testSubject = new JsonNoMetadataLevel();
+        private readonly JsonNoMetadataLevel testSubject = new JsonNoMetadataLevel(/* alwaysAddTypeAnnotationsForDerivedTypes */ false);
 
         [Fact]
         public void NoMetadataLevelShouldReturnNoMetadataTypeOracleWhenKnobIsSet()
@@ -21,6 +21,13 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.IsType<JsonNoMetadataTypeNameOracle>(testSubject.GetTypeNameOracle());
         }
 
+        [Fact]
+        public void NoMetadataLevelShouldReturnMinimalMetadataTypeOracleWhenKnobIsSet()
+        {
+            JsonNoMetadataLevel testSubjectWithTypeAnnotations = new JsonNoMetadataLevel(/* alwaysAddTypeAnnotationsForDerivedTypes */ true);
+            Assert.IsType<JsonMinimalMetadataTypeNameOracle>(testSubject.GetTypeNameOracle());
+        }
+        
         [Fact]
         public void NoMetadataLevelShouldReturnNullMetadataBuilder()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonNoMetadataLevelTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonNoMetadataLevelTests.cs
@@ -15,17 +15,13 @@ namespace Microsoft.OData.Tests.JsonLight
     {
         private readonly JsonNoMetadataLevel testSubject = new JsonNoMetadataLevel(/* alwaysAddTypeAnnotationsForDerivedTypes */ false);
 
-        [Fact]
-        public void NoMetadataLevelShouldReturnNoMetadataTypeOracleWhenKnobIsSet()
+        [Theory]
+        [InlineData(false, typeof(JsonNoMetadataTypeNameOracle))]
+        [InlineData(true, typeof(JsonMinimalMetadataTypeNameOracle))]
+        public void NoMetadataLevelShouldReturnExpectedMetadataTypeOracleWhenKnobIsSet(bool alwaysAddTypeAnnotationsForDerivedTypes, Type expectedType)
         {
-            Assert.IsType<JsonNoMetadataTypeNameOracle>(testSubject.GetTypeNameOracle());
-        }
-
-        [Fact]
-        public void NoMetadataLevelShouldReturnMinimalMetadataTypeOracleWhenKnobIsSet()
-        {
-            JsonNoMetadataLevel testSubjectWithTypeAnnotations = new JsonNoMetadataLevel(/*alwaysAddTypeAnnotationsForDerivedTypes*/ true);
-            Assert.IsType<JsonMinimalMetadataTypeNameOracle>(testSubjectWithTypeAnnotations.GetTypeNameOracle());
+            JsonNoMetadataLevel testSubjectWithTypeAnnotations = new JsonNoMetadataLevel(alwaysAddTypeAnnotationsForDerivedTypes);
+            Assert.IsType(expectedType, testSubjectWithTypeAnnotations.GetTypeNameOracle());
         }
         
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonNoMetadataLevelTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/JsonNoMetadataLevelTests.cs
@@ -24,8 +24,8 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void NoMetadataLevelShouldReturnMinimalMetadataTypeOracleWhenKnobIsSet()
         {
-            JsonNoMetadataLevel testSubjectWithTypeAnnotations = new JsonNoMetadataLevel(/* alwaysAddTypeAnnotationsForDerivedTypes */ true);
-            Assert.IsType<JsonMinimalMetadataTypeNameOracle>(testSubject.GetTypeNameOracle());
+            JsonNoMetadataLevel testSubjectWithTypeAnnotations = new JsonNoMetadataLevel(/*alwaysAddTypeAnnotationsForDerivedTypes*/ true);
+            Assert.IsType<JsonMinimalMetadataTypeNameOracle>(testSubjectWithTypeAnnotations.GetTypeNameOracle());
         }
         
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/WriterTypeNameEndToEndTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/WriterTypeNameEndToEndTests.cs
@@ -13,8 +13,8 @@ using Xunit;
 namespace Microsoft.OData.Tests.ScenarioTests.Writer
 {
     /// <summary>
-    /// These tests baseline the end-to-end behavior of when type names are written on the wire, 
-    /// based on the format and metadata level along with whether the AutoComputePayloadMetadata 
+    /// These tests baseline the end-to-end behavior of when type names are written on the wire,
+    /// based on the format and metadata level along with whether the AlwaysAddTypeAnnotationsForDerivedTypes 
     /// flag is set on the message writer settings. These tests are not meant to be exhaustive, but
     /// should catch major end-to-end problems. The unit tests for the individual components are more extensive.
     /// </summary>
@@ -100,9 +100,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer
         }
 
         [Fact]
-        public void TypeNameShouldBeWrittenCorrectlyInMinimalMetadataWhenKnobIsOff()
+        public void TypeNameShouldBeWrittenCorrectlyInMinimalMetadataWhenAlwaysAddTypeAnnotationsForDerivedTypesIsOff()
         {
             this.settings.SetContentType(jsonLightMinimalMetadata, null);
+            this.settings.AlwaysAddTypeAnnotationsForDerivedTypes = false;
+
             Assert.DoesNotContain("DeclaredInt16@odata.type", this.writerOutput.Value);
             Assert.Contains("UndeclaredDecimal@odata.type\":\"#Decimal\"", this.writerOutput.Value);
             Assert.Contains("DerivedPrimitive@odata.type\":\"#GeographyPoint\"", this.writerOutput.Value);
@@ -110,9 +112,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer
         }
 
         [Fact]
-        public void TypeNameShouldBeWrittenCorrectlyInFullMetadataWhenKnobIsOff()
+        public void TypeNameShouldBeWrittenCorrectlyInFullMetadataWhenAlwaysAddTypeAnnotationsForDerivedTypesIsOff()
         {
             this.settings.SetContentType(jsonLightFullMetadata, null);
+            this.settings.AlwaysAddTypeAnnotationsForDerivedTypes = false;
 
             Assert.Contains("DeclaredInt16@odata.type", this.writerOutput.Value);
             Assert.Contains("UndeclaredDecimal@odata.type\":\"#Decimal\"", this.writerOutput.Value);
@@ -121,9 +124,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer
         }
 
         [Fact]
-        public void TypeNameShouldBeWrittenCorrectlyInNoMetadataWhenKnobIsOff()
+        public void TypeNameShouldBeWrittenCorrectlyInNoMetadataWhenAlwaysAddTypeAnnotationsForDerivedTypesIsOff()
         {
             this.settings.SetContentType(jsonLightNoMetadata, null);
+            this.settings.AlwaysAddTypeAnnotationsForDerivedTypes = false;
 
             Assert.DoesNotContain("DeclaredInt16@odata.type", this.writerOutput.Value);
             Assert.DoesNotContain("UndeclaredDecimal@odata.type\":\"#Decimal\"", this.writerOutput.Value);
@@ -132,9 +136,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer
         }
 
         [Fact]
-        public void TypeNameShouldBeWrittenCorrectlyInMinimalMetadataWhenKnobIsSet()
+        public void TypeNameShouldBeWrittenCorrectlyInMinimalMetadataWhenAlwaysAddTypeAnnotationsForDerivedTypesIsSet()
         {
             this.settings.SetContentType(jsonLightMinimalMetadata, null);
+            this.settings.AlwaysAddTypeAnnotationsForDerivedTypes = true;
 
             Assert.DoesNotContain("DeclaredInt16@odata.type", this.writerOutput.Value);
             Assert.Contains("UndeclaredDecimal@odata.type\":\"#Decimal\"", this.writerOutput.Value);
@@ -143,37 +148,52 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer
         }
 
         [Fact]
-        public void TypeNameShouldBeWrittenCorrectlyInNoMetadataWhenKnobIsSet()
+        public void TypeNameShouldBeWrittenCorrectlyInNoMetadataWhenAlwaysAddTypeAnnotationsForDerivedTypesIsSet()
         {
             this.settings.SetContentType(jsonLightNoMetadata, null);
+            this.settings.AlwaysAddTypeAnnotationsForDerivedTypes = true;
 
             Assert.DoesNotContain("DeclaredInt16@odata.type", this.writerOutput.Value);
-            Assert.DoesNotContain("UndeclaredDecimal@odata.type", this.writerOutput.Value);
-            Assert.DoesNotContain("DerivedPrimitive@odata.type", this.writerOutput.Value);
-            Assert.DoesNotContain("PropertyWithSTNA@odata.type\":\"#TypeNameFromSTNA\"", this.writerOutput.Value);
+            Assert.Contains("UndeclaredDecimal@odata.type\":\"#Decimal\"", this.writerOutput.Value);
+            Assert.Contains("DerivedPrimitive@odata.type\":\"#GeographyPoint\"", this.writerOutput.Value);
+            Assert.Contains("PropertyWithSTNA@odata.type\":\"#TypeNameFromSTNA\"", this.writerOutput.Value);
         }
 
         [Fact]
-        public void TypeNameShouldBeWrittenCorrectlyInNoMetadataWhenKnobIsSetWithJsonP()
+        public void TypeNameShouldBeWrittenCorrectlyInNoMetadataWhenAlwaysAddTypeAnnotationsForDerivedTypesIsSetWithJsonP()
         {
             this.settings.SetContentType(jsonLightNoMetadata, null);
             this.settings.JsonPCallback = "callback";
+            this.settings.AlwaysAddTypeAnnotationsForDerivedTypes = true;
 
             Assert.DoesNotContain("DeclaredInt16@odata.type", this.writerOutput.Value);
-            Assert.DoesNotContain("UndeclaredDecimal@odata.type", this.writerOutput.Value);
-            Assert.DoesNotContain("DerivedPrimitive@odata.type", this.writerOutput.Value);
-            Assert.DoesNotContain("PropertyWithSTNA@odata.type\":\"#TypeNameFromSTNA\"", this.writerOutput.Value);
+            Assert.Contains("UndeclaredDecimal@odata.type\":\"#Decimal\"", this.writerOutput.Value);
+            Assert.Contains("DerivedPrimitive@odata.type\":\"#GeographyPoint\"", this.writerOutput.Value);
+            Assert.Contains("PropertyWithSTNA@odata.type\":\"#TypeNameFromSTNA\"", this.writerOutput.Value);
         }
 
         [Fact]
-        public void TypeNameShouldBeWrittenCorrectlyInFullMetadataWhenKnobIsSet()
+        public void TypeNameShouldBeWrittenCorrectlyInFullMetadataWhenAlwaysAddTypeAnnotationsForDerivedTypesIsSet()
         {
             this.settings.SetContentType(jsonLightFullMetadata, null);
+            this.settings.AlwaysAddTypeAnnotationsForDerivedTypes = true;
 
             Assert.Contains("DeclaredInt16@odata.type", this.writerOutput.Value);
             Assert.Contains("UndeclaredDecimal@odata.type\":\"#Decimal\"", this.writerOutput.Value);
             Assert.Contains("DerivedPrimitive@odata.type\":\"#GeographyPoint\"", this.writerOutput.Value);
             Assert.Contains("PropertyWithSTNA@odata.type\":\"#TypeNameFromSTNA\"", this.writerOutput.Value);
         }
+
+        //[Fact]
+        //public void TypeNameShouldBeWrittenCorrectlyInNoMetadataWhenAlwaysAddTypeAnnotationsForDerivedTypesIsSet()
+        //{
+        //    this.settings.SetContentType(jsonLightNoMetadata, null);
+        //    this.settings.AlwaysAddTypeAnnotationsForDerivedTypes = true;
+
+        //    Assert.DoesNotContain("DeclaredInt16@odata.type", this.writerOutput.Value);
+        //    Assert.Contains("UndeclaredDecimal@odata.type\":\"#Decimal\"", this.writerOutput.Value);
+        //    Assert.Contains("DerivedPrimitive@odata.type\":\"#GeographyPoint\"", this.writerOutput.Value);
+        //    Assert.Contains("PropertyWithSTNA@odata.type\":\"#TypeNameFromSTNA\"", this.writerOutput.Value);
+        //}
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/WriterTypeNameEndToEndTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/WriterTypeNameEndToEndTests.cs
@@ -183,17 +183,5 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer
             Assert.Contains("DerivedPrimitive@odata.type\":\"#GeographyPoint\"", this.writerOutput.Value);
             Assert.Contains("PropertyWithSTNA@odata.type\":\"#TypeNameFromSTNA\"", this.writerOutput.Value);
         }
-
-        //[Fact]
-        //public void TypeNameShouldBeWrittenCorrectlyInNoMetadataWhenAlwaysAddTypeAnnotationsForDerivedTypesIsSet()
-        //{
-        //    this.settings.SetContentType(jsonLightNoMetadata, null);
-        //    this.settings.AlwaysAddTypeAnnotationsForDerivedTypes = true;
-
-        //    Assert.DoesNotContain("DeclaredInt16@odata.type", this.writerOutput.Value);
-        //    Assert.Contains("UndeclaredDecimal@odata.type\":\"#Decimal\"", this.writerOutput.Value);
-        //    Assert.Contains("DerivedPrimitive@odata.type\":\"#GeographyPoint\"", this.writerOutput.Value);
-        //    Assert.Contains("PropertyWithSTNA@odata.type\":\"#TypeNameFromSTNA\"", this.writerOutput.Value);
-        //}
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1945.*

### Description

* Added 'AlwaysAddTypeAnnotationsForDerivedTypes' to ODataMessageWriterSettings

* Chagned JsonNoMetadataLevel to use 'JsonMinimalMetadataTypeNameOracle' when 'AlwaysAddTypeAnnotationsForDerivedTypes' is setting

* Updated unit tests

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
