### PR TITLE
key attribute with one property throws exception

### DIFF
--- a/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
+++ b/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
@@ -489,14 +489,17 @@ namespace Microsoft.OData.Client.Metadata
                 }
             }
 
-            if (newKeyKind == KeyKind.AttributedKey && keyProperties.Count != dataServiceKeyAttribute?.KeyNames.Count)
+            if (dataServiceKeyAttribute != null)
             {
-                var m = (from string a in dataServiceKeyAttribute.KeyNames
-                         where (from b in properties
-                                where b.Name == a
-                                select b).FirstOrDefault() == null
-                         select a).First<string>();
-                throw c.Error.InvalidOperation(c.Strings.ClientType_MissingProperty(typeName, m));
+                if (newKeyKind == KeyKind.AttributedKey && keyProperties.Count != dataServiceKeyAttribute?.KeyNames.Count)
+                {
+                    var m = (from string a in dataServiceKeyAttribute.KeyNames
+                             where (from b in properties
+                                    where b.Name == a
+                                    select b).FirstOrDefault() == null
+                             select a).First<string>();
+                    throw c.Error.InvalidOperation(c.Strings.ClientType_MissingProperty(typeName, m));
+                }
             }
 
             return keyProperties.Count > 0 ? keyProperties.ToArray() : (isEntity ? ClientTypeUtil.EmptyPropertyInfoArray : null);

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.OData.Client.Tests.Metadata
     /// </summary>
     public class ClientTypeUtilTests
     {
-#if !PORTABLELIB
         [Fact]
         public void IFTypeProperty_HasKeyAttribute_TypeIsEntity()
         {
@@ -38,6 +37,19 @@ namespace Microsoft.OData.Client.Tests.Metadata
             Assert.False(actualResult);
         }
 
+        [Fact]
+        public void IFTypeProperty_HasKeyAttributeAndOneProperty_TypeIsEntityAndDoesNotThrowException()
+        {
+            //Arrange
+            Type car = typeof(Car);
+
+            //Act
+            bool actualResult = ClientTypeUtil.TypeOrElementTypeIsEntity(car);
+
+            //Assert
+            Assert.True(actualResult);
+        }
+
         public class Person
         {
             [System.ComponentModel.DataAnnotations.Key]
@@ -50,6 +62,12 @@ namespace Microsoft.OData.Client.Tests.Metadata
             public int SId { get; set; }
             public string Name { get; set; }
         }
-#endif
+
+        public class Car
+        {
+            [System.ComponentModel.DataAnnotations.Key]
+            public int NonStandardId { get; set; }
+        }
+
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*
If I have such a  POCO class with only one property when working with <code> Microsoft.OData.Client </code> 
![image](https://user-images.githubusercontent.com/25525526/101479049-a0a9e880-3962-11eb-928c-a65204141d74.png)

An exception will always be thrown because this condition will always be true  as the <code> Microsoft.OData.Client.KeyAttribute </code> is null. 

<code> if (newKeyKind == KeyKind.AttributedKey && keyProperties.Count != dataServiceKeyAttribute?.KeyNames.Count) </code> 

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
