### PR TITLE
Add CoreVocabularyModel.RevisionsTerm

### DIFF
--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyModel.cs
@@ -56,6 +56,12 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
         public static readonly IEdmTerm ResourcePathTerm = VocabularyModelProvider.CoreModel.FindDeclaredTerm(CoreVocabularyConstants.ResourcePath);
 
         /// <summary>
+        /// The Revisions term.
+        /// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "EdmTerm is immutable")]
+        public static readonly IEdmTerm RevisionsTerm = VocabularyModelProvider.CoreModel.FindDeclaredTerm(CoreVocabularyConstants.Revisions);
+
+        /// <summary>
         /// The DereferenceableIDs term.
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "EdmTerm is immutable")]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
@@ -525,5 +525,14 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             IEdmTypeDefinition typeDefinition = (IEdmTypeDefinition)declaredType;
             Assert.Equal(underlyingTypeName, typeDefinition.UnderlyingType.FullName());
         }
+
+        [Fact]
+        public void TestRevisionsTerm()
+        {
+            var revisionsTerm = CoreVocabularyModel.RevisionsTerm;
+            Assert.NotNull(revisionsTerm);
+            Assert.Equal("Org.OData.Core.V1.Revisions", revisionsTerm.FullName());
+            Assert.Equal("Collection(Org.OData.Core.V1.RevisionType)", revisionsTerm.Type.FullName());
+        }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1951.*

### Description

*Adds CoreVocabularyModel.RevisonsTerm to make it easy and efficient (since the lookup only happens once) for applications to reference the RevisionsTerm in the Core Vocabulary.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
