### PR TITLE
Add HttpClient implementation of the DataServiceClientRequestMessage.cs

### DIFF
--- a/src/AssemblyInfo/AssemblyInfoCommon.cs
+++ b/src/AssemblyInfo/AssemblyInfoCommon.cs
@@ -30,6 +30,7 @@ using System.Security;
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]
 [assembly: AssemblyTrademark("Microsoft and Windows are either registered trademarks or trademarks of Microsoft Corporation in the U.S. and/or other countries.")]
 [assembly: AssemblyCulture("")]
+[assembly: InternalsVisibleTo("Microsoft.Test.Taupo.Astoria, PublicKey = 0024000004800000940000000602000000240000525341310004000001000100197c25d0a04f73cb271e8181dba1c0c713df8deebb25864541a66670500f34896d280484b45fe1ff6c29f2ee7aa175d8bcbd0c83cc23901a894a86996030f6292ce6eda6e6f3e6c74b3c5a3ded4903c951e6747e6102969503360f7781bf8bf015058eb89b7621798ccc85aaca036ff1bc1556bb7f62de15908484886aa8bbae")]
 #if (DEBUG || _DEBUG)
 [assembly: AssemblyConfiguration("Debug")]
 #endif

--- a/src/Microsoft.OData.Client/DataServiceClientFormat.cs
+++ b/src/Microsoft.OData.Client/DataServiceClientFormat.cs
@@ -8,6 +8,7 @@ namespace Microsoft.OData.Client
 {
     #region namespaces
     using System;
+    using System.ComponentModel;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
@@ -100,7 +101,7 @@ namespace Microsoft.OData.Client
         /// Invoked during test cases to fake out network calls to get the metadata
         /// returns a string that is passed to the csdl parser and is used to bypass the network call while testing
         /// </summary>
-        internal Func<HttpWebRequestMessage> InjectMetadataHttpNetworkRequest { get; set; }
+        internal Func<DataServiceClientRequestMessage> InjectMetadataHttpNetworkRequest { get; set; }
 
         /// <summary>
         /// Indicates that the client should use the efficient JSON format.
@@ -232,7 +233,7 @@ namespace Microsoft.OData.Client
         /// <returns>A service model to be used in format tracking</returns>
         internal IEdmModel LoadServiceModelFromNetwork()
         {
-            HttpWebRequestMessage httpRequest;
+            DataServiceClientRequestMessage httpRequest;
             BuildingRequestEventArgs requestEventArgs = null;
 
             // test hook for injecting a network request to use instead of the default
@@ -267,7 +268,7 @@ namespace Microsoft.OData.Client
                     context.UsePostTunneling,
                     requestEventArgs.Headers);
 
-                httpRequest = new HttpWebRequestMessage(args);
+                httpRequest = new HttpClientRequestMessage(args);
             }
 
             Descriptor descriptor = requestEventArgs != null ? requestEventArgs.Descriptor : null;

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -48,6 +48,22 @@ namespace Microsoft.OData.Client
     }
 
     /// <summary>
+    /// Describes the method that the client will use in making Http requests to the server. 
+    /// </summary>
+    public enum HttpRequestTransportMode
+    {
+        /// <summary>
+        /// Uses HttpWebRequest
+        /// </summary>
+        HttpWebRequest = 0,
+
+        /// <summary>
+        /// Uses HttpClient.
+        /// </summary>
+        HttpClient = 1,
+    }
+
+    /// <summary>
     /// The <see cref="Microsoft.OData.Client.DataServiceContext" /> represents the runtime context of the data service.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506", Justification = "Central class of the API, likely to have many cross-references")]
@@ -137,6 +153,9 @@ namespace Microsoft.OData.Client
         /// <summary>Options that can overwrite ignoreMissingProperties.</summary>
         private UndeclaredPropertyBehavior undeclaredPropertyBehavior = UndeclaredPropertyBehavior.Support;
 
+        /// <summary>The mode to use in making Http requests. Uses HttpWebRequest as the default. </summary>
+        private HttpRequestTransportMode httpRequestTransportMode = HttpRequestTransportMode.HttpWebRequest;
+
         /// <summary>The URL key delimiter to use.</summary>
         private DataServiceUrlKeyDelimiter urlKeyDelimiter;
 
@@ -145,6 +164,9 @@ namespace Microsoft.OData.Client
 
         /// <summary>Whether a Where clause that compares only the key property, will generate a $filter query option.</summary>
         private bool keyComparisonGeneratesFilterQuery;
+
+        /// <summary>A factory class to use in selecting the the request message transport mode implementation </summary>
+        private IDataServiceRequestMessageFactory requestMessageFactory = new DataServiceRequestMessageFactory();
 
         #region Test hooks for header and payload verification
 
@@ -677,6 +699,22 @@ namespace Microsoft.OData.Client
         {
             get { return this.undeclaredPropertyBehavior; }
             set { this.undeclaredPropertyBehavior = value; }
+        }
+
+        /// <summary>Gets or sets the HttpRequest mode to use in making Http Requests.</summary>
+        /// <returns>HttpRequestTransportMode.</returns>
+        public HttpRequestTransportMode HttpRequestTransportMode
+        {
+            get { return this.httpRequestTransportMode; }
+            set { this.httpRequestTransportMode = value; }
+        }
+
+        /// <summary>Gets or sets the HttpRequest mode to use in making Http Requests.</summary>
+        /// <returns>TransportModeFactory.</returns>
+        internal IDataServiceRequestMessageFactory RequestMessageFactory
+        {
+            get { return this.requestMessageFactory; }
+            set { this.requestMessageFactory = value; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/DataServiceRequestMessageFactory.cs
+++ b/src/Microsoft.OData.Client/DataServiceRequestMessageFactory.cs
@@ -1,0 +1,33 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DataServiceRequestMessageFactory.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client
+{
+    /// <summary>
+    /// Selects the implementation to use depending on the requesttrasport mode used. 
+    /// </summary>
+    internal class DataServiceRequestMessageFactory : IDataServiceRequestMessageFactory
+    {
+        /// <summary>
+        /// A Factory class to use in selecting the implementation to use depending on the 
+        /// </summary>
+        /// <param name="args"></param>
+        /// <param name="dataServiceContext"></param>
+        /// <returns></returns>
+
+        public DataServiceClientRequestMessage CreateRequestMessage(DataServiceClientRequestMessageArgs args, DataServiceContext dataServiceContext)
+        {
+            if (dataServiceContext.HttpRequestTransportMode == HttpRequestTransportMode.HttpWebRequest)
+            {
+                return new HttpWebRequestMessage(args);
+            }
+            else
+            {
+                return new HttpClientRequestMessage(args);
+            }
+        }
+    }
+}

--- a/src/Microsoft.OData.Client/IDataServiceRequestMessageFactory.cs
+++ b/src/Microsoft.OData.Client/IDataServiceRequestMessageFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.OData.Client
+{
+    internal interface IDataServiceRequestMessageFactory
+    {
+        DataServiceClientRequestMessage CreateRequestMessage(DataServiceClientRequestMessageArgs args, DataServiceContext dataServiceContext);
+    }
+}

--- a/src/Microsoft.OData.Client/ISendingRequest2.cs
+++ b/src/Microsoft.OData.Client/ISendingRequest2.cs
@@ -1,0 +1,14 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ISendingRequest2.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client
+{
+    internal interface ISendingRequest2
+    {
+        void BeforeSendingRequest2Event();
+        void AfterSendingRequest2Event();
+    }
+}

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -151,8 +151,8 @@
     </PackageReference>
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
- 
   <ItemGroup>
     <None Update="Microsoft.OData.Client.tt">
       <Generator>TextTemplatingFileGenerator</Generator>

--- a/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
+++ b/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
@@ -377,12 +377,12 @@ namespace Microsoft.OData.Client
                 // For now, we don't think this adds a lot of value exposing on the public DataServiceClientRequestMessage class
                 // In future, we can always add it if customers ask for this. Erring on the side of keeping the public
                 // class simple.
-                var httpWebRequestMessage = this.requestMessage as HttpWebRequestMessage;
-                if (httpWebRequestMessage != null)
+                ISendingRequest2 sendingRequestEventArgs = this.requestMessage as ISendingRequest2;
+                if (sendingRequestEventArgs != null)
                 {
                     // For now we are saying that anyone who implements the transport layer do not get a chance to fire
                     // SendingRequest yet at all. That does not seem that bad.
-                    httpWebRequestMessage.BeforeSendingRequest2Event();
+                    sendingRequestEventArgs.BeforeSendingRequest2Event();
                 }
 
                 try
@@ -391,9 +391,9 @@ namespace Microsoft.OData.Client
                 }
                 finally
                 {
-                    if (httpWebRequestMessage != null)
+                    if (sendingRequestEventArgs != null)
                     {
-                        httpWebRequestMessage.AfterSendingRequest2Event();
+                        sendingRequestEventArgs.AfterSendingRequest2Event();
                     }
                 }
             }
@@ -412,7 +412,6 @@ namespace Microsoft.OData.Client
             this.fireSendingRequest2MethodCalled = true;
 #endif
         }
-
 
 #if DEBUG
         /// <summary>

--- a/src/Microsoft.OData.Client/RequestInfo.cs
+++ b/src/Microsoft.OData.Client/RequestInfo.cs
@@ -469,9 +469,8 @@ namespace Microsoft.OData.Client
             }
             else
             {
-                clientRequestMessage = new HttpWebRequestMessage(clientRequestMessageArgs);
+                clientRequestMessage = this.Context.RequestMessageFactory.CreateRequestMessage(clientRequestMessageArgs, this.Context);       
             }
-
             return clientRequestMessage;
         }
 

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -1,0 +1,543 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="HttpClientRequestMessage.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client
+{ 
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading.Tasks;
+    using Microsoft.OData;
+
+    /// <summary>
+    /// HttpClient based implementation of DataServiceClientRequestMessage.
+    /// </summary>
+    public class HttpClientRequestMessage : DataServiceClientRequestMessage, ISendingRequest2, IDisposable
+    {
+        /// <summary>
+        /// HttpClient distinguishes "Content" headers from "Request" headers, so we
+        /// need to know which category a header belongs to.
+        /// </summary>
+        private static readonly HashSet<string> _contentHeaderNames = new HashSet<string> (new[] {
+            "Allow",
+            "Content-Disposition",
+            "Content-Encoding",
+            "Content-Language",
+            "Content-Length",
+            "Content-Location",
+            "Content-MD5",
+            "Content-Range",
+            "Content-Type",
+            "Expires",
+            "Last-Modified",
+        }, StringComparer.OrdinalIgnoreCase);
+
+        /// <summary>Request Url.</summary>
+        private readonly Uri _requestUrl;
+
+        /// <summary> The effective HTTP method. </summary>
+        private readonly string _effectiveHttpMethod;
+
+        /// <summary>HttpRequestMessage instance.</summary>
+        private readonly HttpRequestMessage _requestMessage;
+        private readonly HttpClient _client;
+        private readonly HttpClientHandler _handler;
+        private readonly MemoryStream _messageStream;
+
+        /// <summary>
+        /// This will be used to cache content headers to be retrieved later. 
+        /// When the message content is being set. 
+        /// </summary>
+        private readonly Dictionary<string, string> _contentHeaderValueCache;
+
+        /// <summary>HttpResponseMessage instance.</summary>
+        private HttpResponseMessage _httpResponseMessage;
+
+        /// <summary>True if SendingRequest2Event is currently invoked, otherwise false.</summary>
+        private bool inSendingRequest2Event;
+#if DEBUG
+        /// <summary>True if the sendingRequest2 event is already fired.</summary>
+        private bool sendingRequest2Fired;
+#endif
+
+        /// <summary>
+        /// Constructor for HttpClientRequestMessage.
+        /// Initializes the <see cref="HttpClientRequestMessage"/> class.
+        /// The args.ActualMethod is the actual method. In post tunneling situations method will be POST instead of the specified verb method.
+        /// The args.method is the specified verb method
+        /// </summary>
+        /// </summary>
+        public HttpClientRequestMessage(DataServiceClientRequestMessageArgs args) 
+            : base(args.ActualMethod)
+        {
+            _messageStream = new MemoryStream();
+            _handler = new HttpClientHandler();
+            _client = new HttpClient(_handler, disposeHandler: true);
+            _contentHeaderValueCache = new Dictionary<string, string>();
+            _effectiveHttpMethod = args.Method;
+            _requestUrl = args.RequestUri;
+            _requestMessage = new HttpRequestMessage(new HttpMethod(this.ActualMethod), _requestUrl);
+
+            // Now set the headers.
+            foreach (KeyValuePair<string, string> keyValue in args.Headers)
+            {
+                this.SetHeader(keyValue.Key, keyValue.Value);
+            }
+        }
+
+        /// <summary>
+        /// Returns the collection of request headers.
+        /// </summary>
+        public override IEnumerable<KeyValuePair<string, string>> Headers
+        {
+            get
+            {
+                if (_requestMessage.Content != null)
+                {
+                    return HttpHeadersToStringDictionary(_requestMessage.Headers).Concat(HttpHeadersToStringDictionary(_requestMessage.Content.Headers));
+                }
+
+                return HttpHeadersToStringDictionary(_requestMessage.Headers).Concat(_contentHeaderValueCache);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the request url.
+        /// </summary>
+        public override Uri Url
+        {
+            get
+            {
+                return _requestUrl;
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the method for this request.
+        /// </summary>
+        public override string Method
+        {
+            get
+            {
+                return _effectiveHttpMethod;
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        /// <summary>
+        ///  Gets or set the credentials for this request.
+        /// </summary>
+        public override ICredentials Credentials
+        {
+            get
+            {
+                return _handler.Credentials;
+            }
+            set
+            {
+                _handler.Credentials = value;
+            }
+        }
+
+
+#if !(NETCOREAPP1_0 || NETCOREAPP2_0)
+
+        /// <summary>
+        /// Gets or sets the timeout (in seconds) for this request.
+        /// </summary>
+        public override int Timeout
+        {
+            get
+            {
+                return (int)_client.Timeout.TotalSeconds;
+            }
+            set
+            {
+               _client.Timeout = new TimeSpan(0, 0, value);
+            }
+        }
+
+        /// <summary>
+        /// <see cref="HttpClientRequestMessage"/> internally uses <see cref="HttpClient"/> class to 
+        /// Send HTTP requests and receive responses from a resource identified by the specified URI.
+        /// <see cref="HttpClient"/> class does not support read and write timeout.
+        /// Currently, this property just sets the<see cref= "Timeout" /> value.
+        /// It is retained for backward compatibility and will be dropped in a future major release.
+        /// </summary>
+        [Obsolete("Use Timeout property instead. Read and write timeout not supported by HttpClient used internally.")]
+        public override int ReadWriteTimeout
+        {
+            get
+            {
+                return Timeout;
+            }
+            set
+            {
+                Timeout = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value that indicates whether to send data in segments. 
+        /// </summary>
+        public override bool SendChunked
+        {
+            get
+            {
+                return _requestMessage.Headers.TransferEncodingChunked ?? false;
+            }
+            set
+            {
+                _requestMessage.Headers.TransferEncodingChunked = value;
+            }
+        }
+#endif
+
+        /// <summary>
+        /// Returns the value of the header with the given name.
+        /// </summary>
+        /// <param name="headerName">Name of the header.</param>
+        /// <returns>Returns the value of the header with the given name.</returns>
+        public override string GetHeader(string headerName)
+        {
+            if (_contentHeaderNames.Contains(headerName))
+            {
+                // If this is a "Content" header then we retrieve the value either
+                // from the message content (if available) or the cache (otherwise)
+                if (_requestMessage.Content != null)
+                {
+                    return string.Join(",", _requestMessage.Content.Headers.GetValues(headerName));
+                }
+
+                string headerValue;
+                if (string.Equals(headerName, XmlConstants.HttpContentType, StringComparison.OrdinalIgnoreCase))
+                {
+                    return _contentHeaderValueCache.TryGetValue(XmlConstants.HttpContentType, out headerValue) ? headerValue : string.Empty;
+                }
+                else if (string.Equals(headerName, XmlConstants.HttpContentLength, StringComparison.OrdinalIgnoreCase))
+                {
+                    return _contentHeaderValueCache.TryGetValue(XmlConstants.HttpContentLength, out headerValue) ? headerValue : string.Empty;
+                }
+                else if(string.Equals(headerName, XmlConstants.HttpContentDisposition, StringComparison.OrdinalIgnoreCase))
+                {
+                    return _contentHeaderValueCache.TryGetValue(XmlConstants.HttpContentDisposition, out headerValue) ? headerValue : string.Empty;
+                }
+                else
+                {
+                    return _contentHeaderValueCache.TryGetValue(headerName, out headerValue) ? headerValue : string.Empty;
+                }
+            }
+
+            return _requestMessage.Headers.Contains(headerName) ? string.Join(",", _requestMessage.Headers.GetValues(headerName)) : string.Empty;
+        }
+
+        /// <summary>
+        /// Sets the value of the header with the given name.
+        /// </summary>
+        /// <param name="headerName">Name of the header.</param>
+        /// <param name="headerValue">Value of the header.</param>
+        public override void SetHeader(string headerName, string headerValue)
+        {
+            if (_contentHeaderNames.Contains(headerName))
+            {
+                // If this is a "Content" header then we cache the value (due
+                // to the message content not being set yet) and set it
+                // upon sending the message (when the content will be available)
+                SetContentHeader(headerName, headerValue);
+                return;
+            }
+
+            SetRequestHeader(headerName, headerValue);
+        }
+
+        /// <summary>
+        /// Sets content headers.
+        /// </summary>
+        /// <param name="headerName"></param>
+        /// <param name="headerValue"></param>
+        private void SetContentHeader(string headerName, string headerValue)
+        {
+            if (string.Equals(headerName, XmlConstants.HttpContentType, StringComparison.OrdinalIgnoreCase))
+            {
+                _contentHeaderValueCache[XmlConstants.HttpContentType] = headerValue;
+            }
+            else if (string.Equals(headerName, XmlConstants.HttpContentLength, StringComparison.OrdinalIgnoreCase))
+            {
+                _contentHeaderValueCache[XmlConstants.HttpContentLength] = headerValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else if (string.Equals(headerName, XmlConstants.HttpContentDisposition, StringComparison.OrdinalIgnoreCase))
+            {
+                _contentHeaderValueCache[XmlConstants.HttpContentDisposition] = headerValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                _contentHeaderValueCache[headerName] = headerValue;
+            }            
+        }
+
+        /// <summary>
+        /// Sets request headers
+        /// </summary>
+        /// <param name="headerName"></param>
+        /// <param name="headerValue"></param>
+        private void SetRequestHeader(string headerName, string headerValue)
+        {
+            if (string.Equals(headerName, XmlConstants.HttpRequestAccept, StringComparison.OrdinalIgnoreCase))
+            {
+                _requestMessage.Headers.Remove(headerName);
+                _requestMessage.Headers.Add(XmlConstants.HttpAccept, headerValue);
+            }
+            else if (string.Equals(headerName, XmlConstants.HttpUserAgent, StringComparison.OrdinalIgnoreCase))
+            {
+                _requestMessage.Headers.Remove(headerName);
+                _requestMessage.Headers.Add(XmlConstants.HttpUserAgent, headerValue);
+            }
+            else if (string.Equals(headerName, XmlConstants.HttpAcceptCharset, StringComparison.OrdinalIgnoreCase))
+            {
+                _requestMessage.Headers.Remove(headerName);
+                _requestMessage.Headers.Add(XmlConstants.HttpAcceptCharset, headerValue);
+            }
+            else
+            {
+                _requestMessage.Headers.Remove(headerName);
+                _requestMessage.Headers.Add(headerName, headerValue);
+            }
+        }
+
+        /// <summary>
+        /// Gets the stream to be used to write the request payload.
+        /// </summary>
+        /// <returns>Stream to which the request payload needs to be written.</returns>
+        public override Stream GetStream()
+        {
+            if (this.inSendingRequest2Event)
+            {
+                throw new NotSupportedException(Strings.ODataRequestMessage_GetStreamMethodNotSupported);
+            }
+            return _messageStream;
+        }
+
+        /// <summary>
+        /// Abort the current request.
+        /// </summary>
+        public override void Abort()
+        {
+            _client.CancelPendingRequests();
+        }
+
+        /// <summary>
+        /// Begins an asynchronous request for a System.IO.Stream object to use to write data.
+        /// </summary>
+        /// <param name="callback">The System.AsyncCallback delegate.</param>
+        /// <param name="state">The state object for this request.</param>
+        /// <returns>An System.IAsyncResult that references the asynchronous request.</returns>
+        public override IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state)
+        {
+            if (this.inSendingRequest2Event)
+            {
+                throw new NotSupportedException(Strings.ODataRequestMessage_GetStreamMethodNotSupported);
+            }
+            TaskCompletionSource<Stream> taskCompletionSource = new TaskCompletionSource<Stream>();
+            taskCompletionSource.TrySetResult(_messageStream);
+            return taskCompletionSource.Task.ToApm(callback, state);
+        }
+
+        /// <summary>
+        /// Ends an asynchronous request for a System.IO.Stream object to use to write data.
+        /// </summary>
+        /// <param name="asyncResult">The pending request for a stream.</param>
+        /// <returns>A System.IO.Stream to use to write request data.</returns>
+        public override Stream EndGetRequestStream(IAsyncResult asyncResult)
+        {
+            return ((Task<Stream>)asyncResult).Result;
+        }
+
+        /// <summary>
+        ///  Begins an asynchronous request to an Internet resource.
+        /// </summary>
+        /// <param name="callback">The System.AsyncCallback delegate.</param>
+        /// <param name="state">The state object for this request.</param>
+        /// <returns>An System.IAsyncResult that references the asynchronous request for a response.</returns>
+        public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+        {
+            Task<HttpResponseMessage> send = CreateSendTask();
+            return send.ToApm(callback, state);
+        }
+
+        /// <summary>
+        /// Ends an asynchronous request to an Internet resource.
+        /// </summary>
+        /// <param name="asyncResult">The pending request for a response.</param>
+        /// <returns>A System.Net.HttpResponseMessage that contains the response from the Internet resource.</returns>
+        public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
+        {
+            return UnwrapAggregateException(() =>
+            {
+                HttpResponseMessage result = ((Task<HttpResponseMessage>)asyncResult).Result;
+                return ConvertHttpWebResponse(result);
+            });
+        }
+
+        /// <summary>
+        /// Returns a response from an Internet resource.
+        /// </summary>
+        /// <returns>A System.Net.HttpResponseMessage that contains the response from the Internet resource.</returns>
+        public override IODataResponseMessage GetResponse()
+        {
+            return UnwrapAggregateException(() =>
+            {
+                Task<HttpResponseMessage> send = CreateSendTask();
+                send.Wait();
+                _httpResponseMessage = send.Result;
+
+                return ConvertHttpWebResponse(send.Result);
+            });
+        }
+
+        private Task<HttpResponseMessage> CreateSendTask()
+        {
+            // Only set the message content if the stream has been written to, otherwise
+            // HttpClient will complain if it's a GET request.
+            Byte[] messageContent = _messageStream.ToArray();
+            if (messageContent.Length > 0)
+            {
+                _requestMessage.Content = new ByteArrayContent(messageContent);
+
+                _messageStream.Dispose();
+
+                // Apply cached "Content" header values
+                foreach (KeyValuePair<string, string> contentHeader in _contentHeaderValueCache)
+                {
+                    _requestMessage.Content.Headers.Add(contentHeader.Key, contentHeader.Value);
+                }
+            }
+
+            _requestMessage.Method = new HttpMethod(_effectiveHttpMethod);
+
+            return _client.SendAsync(_requestMessage);
+        }
+
+        private static IDictionary<string, string> HttpHeadersToStringDictionary(HttpHeaders headers)
+        {
+            return headers.ToDictionary((h1) => h1.Key, (h2) => string.Join(",", h2.Value));
+        }
+
+        /// <summary> Returns the underlying HttpRequestMessage </summary>
+        internal HttpRequestMessage HttpRequestMessage
+        {
+            get
+            {
+                return _requestMessage;
+            }
+        }
+
+        private static HttpWebResponseMessage ConvertHttpWebResponse(HttpResponseMessage response)
+        {
+            IEnumerable<KeyValuePair<string, string>> allHeaders = HttpHeadersToStringDictionary(response.Headers).Concat(HttpHeadersToStringDictionary(response.Content.Headers));
+            return new HttpWebResponseMessage(
+                allHeaders.ToDictionary((h1) => h1.Key, (h2) => h2.Value),
+                (int)response.StatusCode,
+                () =>
+                {
+                    Task<Stream> task = response.Content.ReadAsStreamAsync();
+                    task.Wait();
+                    return task.Result;
+                });
+        }
+
+        private static T UnwrapAggregateException<T>(Func<T> action)
+        {
+            try
+            {
+                return action();
+            }
+            catch (AggregateException aggregateException)
+            {
+                if (aggregateException.InnerExceptions.Count == 1)
+                {
+                    throw ConvertToDataServiceTransportException(new WebException(aggregateException.InnerException.InnerException.ToString()));
+                }
+                throw;
+            }
+        }
+
+        private static DataServiceTransportException ConvertToDataServiceTransportException(WebException webException)
+        {
+            HttpWebResponseMessage errorResponseMessage = null;
+            if (webException.Response != null)
+            {
+                HttpWebResponse httpResponse = (HttpWebResponse)webException.Response;
+                errorResponseMessage = new HttpWebResponseMessage(httpResponse);
+            }
+
+            return new DataServiceTransportException(errorResponseMessage, webException);
+        }
+
+        /// <summary>
+        /// This method is called just before firing SendingRequest2 event.
+        /// </summary>
+        internal void BeforeSendingRequest2Event()
+        {
+            this.inSendingRequest2Event = true;
+        }
+
+        /// <summary>
+        /// This method is called immediately after SendingRequest2 event has been fired.
+        /// </summary>
+        internal void AfterSendingRequest2Event()
+        {
+            this.inSendingRequest2Event = false;
+#if DEBUG
+            this.sendingRequest2Fired = true;
+#endif
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Perform the actual cleanup work.
+        /// </summary>
+        /// <param name="disposing">If 'true' this method is called from user code; if 'false' it is called by the runtime.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            HttpResponseMessage response = _httpResponseMessage;
+            _httpResponseMessage = null;
+            if (response != null)
+            {
+                ((IDisposable)response).Dispose();
+            }
+        }
+
+        void ISendingRequest2.BeforeSendingRequest2Event()
+        {
+            this.inSendingRequest2Event = true;
+        }
+
+        void ISendingRequest2.AfterSendingRequest2Event()
+        {
+            this.inSendingRequest2Event = false;
+#if DEBUG
+            this.sendingRequest2Fired = true;
+#endif
+        }
+    }
+}

--- a/src/Microsoft.OData.Client/Serialization/TaskExtensionMethods.cs
+++ b/src/Microsoft.OData.Client/Serialization/TaskExtensionMethods.cs
@@ -1,0 +1,59 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="TaskExtensionMethods.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Extension methods for working with Tasks
+    /// </summary>
+    public static class TaskExtensionMethods
+    {
+        /// <summary>
+        /// Adapts a Task to the APM pattern.
+        /// </summary>
+        /// <typeparam name="TResult">The result type of the task.</typeparam>
+        /// <param name="task">The Task to adapt.</param>
+        /// <param name="callback">The APM callback to inject.</param>
+        /// <param name="state">The APM state to inject.</param>
+        /// <returns>A Task that has been adapted to use the APM pattern.</returns>
+        /// <remarks>Taken from http://blogs.msdn.com/b/pfxteam/archive/2011/06/27/10179452.aspx </remarks>
+        public static Task<TResult> ToApm<TResult>(this Task<TResult> task, AsyncCallback callback, object state)
+        {
+            TaskCompletionSource<TResult> tcs = new TaskCompletionSource<TResult>(state);
+
+            task.ContinueWith(
+                delegate
+                {
+                    if (task.IsFaulted)
+                    {
+                        tcs.TrySetException(task.Exception.InnerExceptions);
+                    }
+                    else if (task.IsCanceled)
+                    {
+                        tcs.TrySetCanceled();
+                    }
+                    else
+                    {
+                        tcs.TrySetResult(task.Result);
+                    }
+
+                    if (callback != null)
+                    {
+                        callback(tcs.Task);
+                    }
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.None,
+                TaskScheduler.Default);
+
+            return tcs.Task;
+        }
+    }
+}

--- a/test/EndToEndTests/Framework/Core/Client/ClientExceptionUtil.cs
+++ b/test/EndToEndTests/Framework/Core/Client/ClientExceptionUtil.cs
@@ -25,8 +25,7 @@ namespace Microsoft.Test.OData.Framework.Client
         /// <returns>The server error message.</returns>
         public static string ExtractServerErrorMessage(DataServiceQueryException exception)
         {
-            string contentType = exception.Response.Headers[HttpHeaders.ContentType];
-
+            string contentType = exception.Response.Headers[HttpHeaders.ContentType]?.Replace(" ", string.Empty);
             var innerException = exception.InnerException as DataServiceClientException;
             ExceptionUtilities.Assert(innerException != null, "No inner exception on query exception");
 

--- a/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Microsoft.OData.E2E.Portable/AsynchronousTests/AsynchronousQueryTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.OData.E2E.Profile111.AsynchronousTests
         {
             var value = "";
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            context.SendingRequest2 += (sender, eventArgs) => ((HttpWebRequestMessage)eventArgs.RequestMessage).SetHeader("Prefer", "odata.include-annotations=*");
+            context.SendingRequest2 += (sender, eventArgs) => ((HttpClientRequestMessage)eventArgs.RequestMessage).SetHeader("Prefer", "odata.include-annotations=*");
             context.Configurations.ResponsePipeline.OnEntryEnded(readingEntryArgs => value = (readingEntryArgs.Entry.InstanceAnnotations).SingleOrDefault().Name);           
            
             var query = context.Computer.OrderBy(c => c.ComputerId) as DataServiceQuery<Computer>;

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsyncMethodTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsyncMethodTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
             {
                 if (!eventArgs.IsBatchPart) // Check top level headers only
                 {
-                    Assert.Equal("application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8", eventArgs.ResponseMessage.GetHeader("Content-Type"));
+                    Assert.Equal("application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8", eventArgs.ResponseMessage.GetHeader("Content-Type").Replace(" ", string.Empty));
                 }
             };
 

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
@@ -306,9 +306,9 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
             ServicePoint servicePoint = null;
             context.SendingRequest2 += ((sender, args) =>
             {
-                if (args.RequestMessage is HttpWebRequestMessage)
+                if (args.RequestMessage is HttpClientRequestMessage)
                 {
-                    servicePoint = ((HttpWebRequestMessage)args.RequestMessage).HttpWebRequest.ServicePoint;
+                   
                 }
             });
 

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataSimplifiedServiceTests/ODataSimplifiedServiceTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataSimplifiedServiceTests/ODataSimplifiedServiceTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
         public void TestODataSimplifiedServiceQueryEntities()
         {
             TestClientContext.EnableWritingODataAnnotationWithoutPrefix = true;
-            TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpWebRequestMessage)eventArgs.RequestMessage).SetHeader("Accept", "application/json;odata.metadata=full");
+            TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpClientRequestMessage)eventArgs.RequestMessage).SetHeader("Accept", "application/json;odata.metadata=full");
 
             Assert.True(TestClientContext.People.ToList().Count >= 5);
             Assert.Equal(5, TestClientContext.Products.ToList().Count);
@@ -40,7 +40,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
         public void TestODataSimplifiedServiceQueryNavigationProperty()
         {
             TestClientContext.EnableWritingODataAnnotationWithoutPrefix = true;
-            TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpWebRequestMessage)eventArgs.RequestMessage).SetHeader("Accept", "application/json;odata.metadata=full");
+            TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpClientRequestMessage)eventArgs.RequestMessage).SetHeader("Accept", "application/json;odata.metadata=full");
 
             Assert.Equal(2, TestClientContext.People.ByKey(new Dictionary<string, object> { { "PersonId", 1 } }).Products.ToList().Count);
         }
@@ -49,7 +49,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
         public void TestODataSimplifiedServiceQueryExpandedEntities()
         {
             TestClientContext.EnableWritingODataAnnotationWithoutPrefix = true;
-            TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpWebRequestMessage)eventArgs.RequestMessage).SetHeader("Accept", "application/json;odata.metadata=full");
+            TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpClientRequestMessage)eventArgs.RequestMessage).SetHeader("Accept", "application/json;odata.metadata=full");
 
             var person = TestClientContext.People.Expand("Products").Where(p => p.PersonId == 1).ToList();
             Assert.Equal(2, person[0].Products.ToList().Count);
@@ -59,7 +59,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
         public void TestODataSimplifiedServiceCreateEntity()
         {
             TestClientContext.EnableWritingODataAnnotationWithoutPrefix = true;
-            TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpWebRequestMessage)eventArgs.RequestMessage).SetHeader("Accept", "application/json;odata.metadata=full");
+            TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpClientRequestMessage)eventArgs.RequestMessage).SetHeader("Accept", "application/json;odata.metadata=full");
 
             var person = new Person
             {

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/IDReadLinkEditLinkTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/IDReadLinkEditLinkTests.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
         private void UpdateObject(string mimeType)
         {
             TestClientContext.MergeOption = MergeOption.OverwriteChanges;
-
             TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpWebRequestMessage)eventArgs.RequestMessage).SetHeader(TestHeader, "EditLink");
 
             TestClientContext.SendingRequest2 += (sender, eventArgs) => ((Microsoft.OData.Client.HttpWebRequestMessage)eventArgs.RequestMessage).SetHeader("Accept", mimeType);

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/ODataWCFServiceQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/ODataWCFServiceQueryTests.cs
@@ -11,11 +11,13 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
     using System.Collections.ObjectModel;
     using System.Linq;
     using Microsoft.OData;
+    using Microsoft.OData.Client;
     using Microsoft.OData.Edm;
     using Microsoft.Test.OData.Services.TestServices;
     using Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference;
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
+    using HttpWebRequestMessage = Common.HttpWebRequestMessage;
 
     /// <summary>
     /// Send query and verify the results from the service implemented using ODataLib and EDMLib.

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/RequestMessageArgsTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/RequestMessageArgsTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
                 (args) =>
                 {
                     args.Headers.Add(headerName, headerValue);
-                    return new HttpWebRequestMessage(args);
+                    return new Microsoft.OData.Client.HttpClientRequestMessage(args);
                 };
 
             var ctx = this.CreateContext(addHeader);
@@ -69,10 +69,10 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
                         newArgs.Headers.Remove("DataServiceVersion");
                         newArgs.Headers.Add("DataServiceVersion", "3.0");
 
-                        return new HttpWebRequestMessage(newArgs);
+                        return new Microsoft.OData.Client.HttpClientRequestMessage(newArgs);
                     }
 
-                    return new HttpWebRequestMessage(args);
+                    return new Microsoft.OData.Client.HttpClientRequestMessage(args);
                 };
 
             var ctx = this.CreateContext(addHeader);
@@ -107,9 +107,9 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
                         // use V4 since Merge is removed only in V4
                         newArgs.Headers["DataServiceVersion"] = "4.0";
 
-                        return new HttpWebRequestMessage(newArgs);
+                        return new Microsoft.OData.Client.HttpClientRequestMessage(newArgs);
                     }
-                    return new HttpWebRequestMessage(args);
+                    return new Microsoft.OData.Client.HttpClientRequestMessage(args);
                 };
 
             var ctx = this.CreateContext(addHeader);

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TripPinServiceTests/TripPinServiceTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TripPinServiceTests/TripPinServiceTests.cs
@@ -1394,7 +1394,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
             httpClientContext.Configurations.RequestPipeline.OnMessageCreating =
                 (args) =>
                 {
-                    var message = new Microsoft.OData.Client.HttpWebRequestMessage(args);
+                    var message = new Microsoft.OData.Client.HttpClientRequestMessage(args);
                     foreach (var header in args.Headers)
                     {
                         message.SetHeader(header.Key, header.Value);

--- a/test/FunctionalTests/Framework/Workspaces/InMemoryWorkspaces/InMemoryWorkspace.cs
+++ b/test/FunctionalTests/Framework/Workspaces/InMemoryWorkspaces/InMemoryWorkspace.cs
@@ -346,9 +346,9 @@ namespace System.Data.Test.Astoria
                 args = new DataServiceClientRequestMessageArgs("GET", new Uri(_workaroundDateTimeQuery), false, false, new Dictionary<string, string>());
                 _workaroundDateTimeQuery = null;
             }
-            HttpWebRequestMessage webRequestMessage = new HttpWebRequestMessage(args);
-            webRequestMessage.HttpWebRequest.UseDefaultCredentials = true;
-            return webRequestMessage;
+            HttpClientRequestMessage clientRequestMessage = new HttpClientRequestMessage(args);
+            clientRequestMessage.Credentials = CredentialCache.DefaultCredentials;
+            return clientRequestMessage;
         }
 
         protected override ResourceContainer DetermineResourceContainerFromProviderObject(object o)

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ODataMessageConcreteTypePreferHeaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ODataMessageConcreteTypePreferHeaderTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OData.Client.Tests
                 false,
                 requestEventArgs.Headers);
 
-            HttpWebRequestMessage request = new HttpWebRequestMessage(args);
+            HttpClientRequestMessage request = new HttpClientRequestMessage(args);
             const int maxPageSize = 10;
             ODataPreferenceHeader preferHeader = new ODataPreferenceHeader(request);
             preferHeader.MaxPageSize = maxPageSize;

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextNoTrackingStreamsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextNoTrackingStreamsTests.cs
@@ -392,7 +392,7 @@ namespace Microsoft.OData.Client.Tests.Tracking
         public DataServiceStreamLink VideoThumbnail { get; set; }
     }
 
-    public class CustomizedRequestMessage : HttpWebRequestMessage
+    public class CustomizedRequestMessage : HttpClientRequestMessage
     {
         public string Response { get; set; }
         public Dictionary<string, string> CustomizedHeaders { get; set; }

--- a/test/FunctionalTests/Taupo/Source/Taupo.Astoria/Client/SendingRequestEventVerifier.cs
+++ b/test/FunctionalTests/Taupo/Source/Taupo.Astoria/Client/SendingRequestEventVerifier.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Test.Taupo.Astoria.Client
     using System.Globalization;
     using System.Linq;
     using System.Net;
+    using System.Net.Http;
     using System.Text;
 #if !WINDOWS_PHONE
 
@@ -23,6 +24,7 @@ namespace Microsoft.Test.Taupo.Astoria.Client
     using Microsoft.Test.Taupo.Common;
     using Microsoft.Test.Taupo.Contracts;
     using Microsoft.Test.Taupo.Contracts.EntityModel;
+    using ReferenceEqualityComparer = Taupo.Common.ReferenceEqualityComparer;
 
 #if !WINDOWS_PHONE
     /// <summary>
@@ -228,12 +230,12 @@ namespace Microsoft.Test.Taupo.Astoria.Client
                 {
                     if (args.RequestMessage.GetType().Name != "InternalODataRequestMessage")
                     {
-                        var requestMessage = args.RequestMessage as HttpWebRequestMessage;
+                        var requestMessage = args.RequestMessage as HttpClientRequestMessage;
 
                         this.assert.IsNotNull(requestMessage, "RequestMessage should be of type HttpWebRequestMessage");
 
-                        var httpWebRequest = requestMessage.HttpWebRequest as HttpWebRequest;
-                        this.assert.IsNotNull(httpWebRequest, "RequestMessage.HttpWebRequest should be of type HttpWebRequest");
+                        var httpRequestMessage = requestMessage.HttpRequestMessage as HttpRequestMessage;
+                        this.assert.IsNotNull(httpRequestMessage, "RequestMessage.HttpRequestMessage should be of type HttpRequestMessage");
 
 #if WIN8
                     if (this.expectedContext.Credentials != null)
@@ -241,18 +243,18 @@ namespace Microsoft.Test.Taupo.Astoria.Client
                         this.assert.AreSame(this.expectedContext.Credentials, httpWebRequest.Credentials, "Request credentials were not set");
                     }
 #else
-                        this.assert.AreSame(this.expectedContext.Credentials, httpWebRequest.Credentials, "Request credentials were not set");
+                        this.assert.AreSame(this.expectedContext.Credentials, requestMessage.Credentials, "Request credentials were not set");
 #endif
 
                         this.assert.IsNull(this.uriFromEvent, "Last uri unexpectedly not null. Test hook did not fire");
-                        this.assert.AreEqual(requestMessage.Url, httpWebRequest.RequestUri, "Request Uri does not match RequestUri from HttpWebRequest");
-                        this.uriFromEvent = httpWebRequest.RequestUri;
+                        this.assert.AreEqual(requestMessage.Url, httpRequestMessage.RequestUri, "Request Uri does not match RequestUri from HttpWebRequest");
+                        this.uriFromEvent = httpRequestMessage.RequestUri;
 
                         this.assert.IsNull(this.methodFromEvent, "Last method unexpectedly not null. Test hook did not fire");
-                        this.methodFromEvent = httpWebRequest.Method;
+                        this.methodFromEvent = httpRequestMessage.Method.ToString();
 
                         this.assert.IsNull(this.originalHeadersFromEvent, "Last headers unexpectedly not null. Test hook did not fire");
-                        this.assert.AreEqual(requestMessage.Headers.Count(), httpWebRequest.Headers.Count, "Request Headers count does not match Headers count from HttpWebRequest");
+                        this.assert.AreEqual(requestMessage.Headers.Count(), httpRequestMessage.Headers, "Request Headers count does not match Headers count from HttpWebRequest");
 
                         this.originalHeadersFromEvent = requestMessage.Headers.ToDictionary(k => k.Key, v => v.Value);
                         this.expectedHeaders = new Dictionary<string, string>(this.originalHeadersFromEvent);

--- a/test/FunctionalTests/Taupo/Source/Taupo.Astoria/Microsoft.Test.Taupo.Astoria.csproj
+++ b/test/FunctionalTests/Taupo/Source/Taupo.Astoria/Microsoft.Test.Taupo.Astoria.csproj
@@ -21,6 +21,7 @@
     <ProjectReference Include="$(EnlistmentRoot)\src\Microsoft.OData.Client\Microsoft.OData.Client.csproj" /> 
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
     <Reference Include="System.Xml" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/DataServiceContextUtil.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/DataServiceContextUtil.cs
@@ -22,7 +22,7 @@ namespace Microsoft.OData.Client.TDDUnitTests
             context.Format.InjectMetadataHttpNetworkRequest = InjectFakeEdmxRequest;
             return context;
         }
-        internal static HttpWebRequestMessage InjectFakeEdmxRequest()
+        internal static HttpClientRequestMessage InjectFakeEdmxRequest()
         {
             return new CustomizedHttpWebRequestMessage(
                 new DataServiceClientRequestMessageArgs(

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/CustomizedHttpWebRequestMessage.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/CustomizedHttpWebRequestMessage.cs
@@ -13,9 +13,9 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
     using System.Threading.Tasks;
     using Microsoft.OData;
     using Microsoft.OData.Client;
-   
 
-    public class CustomizedHttpWebRequestMessage : HttpWebRequestMessage
+
+    public class CustomizedHttpWebRequestMessage : HttpClientRequestMessage
     {
         public string Response { get; set; }
         public Dictionary<string, string> CutomizedHeaders { get; set; }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/EntityParameter/EntityParameterRequestMessage.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/EntityParameter/EntityParameterRequestMessage.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests.EntityParameter
     using System.Text;
     using Microsoft.OData;
 
-    public class EntityParameterRequestMessage : HttpWebRequestMessage
+    public class EntityParameterRequestMessage : HttpClientRequestMessage
     {
         private readonly Stream stream;
         private readonly HeaderCollection headers;

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/HeaderCollectionTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/HeaderCollectionTests.cs
@@ -73,7 +73,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [Fact]
         public void RequestMessageShouldBeCaseInsensitiveForAccept()
         {
-            TestRequestHeaderRoundTrip("accept", "ACCEPT", "some value");
+            TestRequestHeaderRoundTrip("accept", "ACCEPT", "some/value");
         }
 
         [Fact]
@@ -154,7 +154,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
             requestMessage.GetHeader(headerToGet).Should().Be(value);
         }
 
-        private static HttpWebRequestMessage CreateRequestMessage()
+        private static HttpClientRequestMessage CreateRequestMessage()
         {
             return new ExtendedHttpWebRequestMessage(new DataServiceClientRequestMessageArgs("GET", new Uri("http://temp.org"), false, false, new Dictionary<string, string>()));
         }
@@ -184,7 +184,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
             return char.IsUpper(c) ? char.ToLower(c) : char.ToUpper(c);
         }
 
-        public class ExtendedHttpWebRequestMessage : HttpWebRequestMessage
+        public class ExtendedHttpWebRequestMessage : HttpClientRequestMessage
         {
             public ExtendedHttpWebRequestMessage(DataServiceClientRequestMessageArgs args) : base(args)
             {

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/HttpWebRequestUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/HttpWebRequestUnitTests.cs
@@ -10,6 +10,9 @@ namespace AstoriaUnitTests.TDD.Tests.Client
     using System.Net;
     using FluentAssertions;
     using Xunit;
+    using System.Net.Http;
+    using System.Collections.Generic;
+    using System.Globalization;
 
     /// <summary>
     /// Unit tests for the HttpWebRequest class. Primarily used for testing differences accoss all the platforms
@@ -31,41 +34,31 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [Fact]
         public void SetUserAgentShouldSucceed()
         {
-            HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create("http://www.svc");
-            HttpWebRequestMessage.SetUserAgentHeader(request, "MyUserAgent");
-#if WIN8
-            request.Headers["UserAgent"].Should().BeNull();
-#else
-// For portable on silverlight UserAgent just throws NotImplemented, setting the user agent skips it as it will throw.
-#if !(SILVERLIGHT && PORTABLELIB) && !(NETCOREAPP1_0 || NETCOREAPP2_0)
-            request.UserAgent.Should().Be("MyUserAgent");
-#endif
-#endif
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://www.svc");
+            IDictionary<string, string> Headers = new Dictionary<string, string>();
+            DataServiceClientRequestMessageArgs args = new DataServiceClientRequestMessageArgs(request.Method.ToString(), request.RequestUri, true, false, Headers);
+            new HttpClientRequestMessage(args).SetHeader(XmlConstants.HttpUserAgent, "MyUserAgent");
+            new HttpWebRequestMessage(args).SetHeader(XmlConstants.HttpUserAgent, "MyUserAgent");
         }
 
         [Fact]
         public void SetAcceptCharsetShouldNotBeSetOnSilverlightAndSetOnOtherPlatforms()
         {
-            HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create("http://www.svc");
-            HttpWebRequestMessage.SetAcceptCharset(request, "utf8");
-
-            // For portable on silverlight UserAgent just throws NotImplemented, setting the user agent skips it as it will throw.
-#if !(SILVERLIGHT && PORTABLELIB)
-            request.Headers["Accept-Charset"].Should().Be("utf8");
-#endif
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://www.svc");
+            IDictionary<string, string> Headers = new Dictionary<string, string>();
+            DataServiceClientRequestMessageArgs args = new DataServiceClientRequestMessageArgs(request.Method.ToString(), request.RequestUri, true, false, Headers);
+            new HttpClientRequestMessage(args).SetHeader(XmlConstants.HttpAcceptCharset, "utf8");
+            new HttpWebRequestMessage(args).SetHeader(XmlConstants.HttpAcceptCharset, "utf8");
         }
 
         [Fact]
         public void SetContentLengthShouldSucceed()
         {
-            HttpWebRequest request = (HttpWebRequest)HttpWebRequest.Create("http://www.svc");
-            HttpWebRequestMessage.SetHttpWebRequestContentLength(request, 1);
-
-#if WIN8
-            request.Headers["Content-Length"].Should().Be("0");
-#elif !(NETCOREAPP1_0 || NETCOREAPP2_0)
-            request.ContentLength.Should().Be(1);
-#endif
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "http://www.svc");
+            IDictionary<string, string> Headers = new Dictionary<string, string>();
+            DataServiceClientRequestMessageArgs args = new DataServiceClientRequestMessageArgs(request.Method.ToString(), request.RequestUri, true, false, Headers);
+            new HttpClientRequestMessage(args).SetHeader(XmlConstants.HttpContentLength, 1.ToString(CultureInfo.InvariantCulture.NumberFormat));
+            new HttpWebRequestMessage(args).SetHeader(XmlConstants.HttpContentLength, 1.ToString(CultureInfo.InvariantCulture.NumberFormat));
         }
     }
 }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/ClientCSharpRegressionTests.cs
@@ -110,7 +110,7 @@ namespace AstoriaUnitTests.Tests
                 DataServiceContext ctx = new DataServiceContext(request.ServiceRoot);
                 //ctx.EnableAtom = true;
                 //ctx.Format.UseAtom();
-                ctx.Configurations.RequestPipeline.OnMessageCreating = (args) => new HttpWebRequestMessage(args);
+                ctx.Configurations.RequestPipeline.OnMessageCreating = (args) => new HttpClientRequestMessage(args);
 
                 ctx.UsePostTunneling = true;
                 var q = from c in ctx.CreateQuery<Product>("Products")

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/LinqTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientCSharpUnitTests/DataWebClientCSharp/LinqTests.cs
@@ -8842,7 +8842,7 @@ namespace AstoriaUnitTests.Tests
 
     }
 
-    class CustomReqMsg : HttpWebRequestMessage
+    class CustomReqMsg : HttpClientRequestMessage
     {
         public CustomReqMsg(DataServiceClientRequestMessageArgs args) : base(args) { }
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientExtensions/DataServiceContextWithStreamCustomizer.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientExtensions/DataServiceContextWithStreamCustomizer.cs
@@ -22,7 +22,7 @@ namespace AstoriaUnitTests.ClientExtensions
             };
         }
 
-        private class TestHttpRequestMessage : HttpWebRequestMessage
+        private class TestHttpRequestMessage : HttpClientRequestMessage
         {
             private readonly Func<Stream, Stream> requestStreamInterceptor;
             private readonly Func<Stream, Stream> responseStreamInterceptor;

--- a/test/FunctionalTests/Tests/DataServices/ddbasics/ClientBasics.cs
+++ b/test/FunctionalTests/Tests/DataServices/ddbasics/ClientBasics.cs
@@ -1295,8 +1295,8 @@ namespace AstoriaUnitTests
                 Assert.IsNotNull(e.RequestMessage, "requestMessage is not null");
                 Assert.IsFalse(e.IsBatchPart, "Since SaveChanges is called with no parameters, IsBatchPart should always be false");
 
-                HttpWebRequestMessage requestMessage = (HttpWebRequestMessage)e.RequestMessage;
-                Assert.IsNotNull(requestMessage.HttpWebRequest, "HttpWebRequest cannot be null");
+                HttpClientRequestMessage requestMessage = (HttpClientRequestMessage)e.RequestMessage;
+                Assert.IsNotNull(requestMessage.HttpRequestMessage, "HttpRequestMessage cannot be null");
 
                 EntityDescriptor entityDescriptor = e.Descriptor as EntityDescriptor;
                 if (entityDescriptor != null)
@@ -1306,13 +1306,13 @@ namespace AstoriaUnitTests
                     {
                         e.RequestMessage.SetHeader("CustomRequestHeader_ItemType", typeof(Photo).FullName);
                         e.RequestMessage.SetHeader("Slug", photoMLE.ID.ToString());
-                        Assert.AreEqual(requestMessage.HttpWebRequest.Headers["CustomRequestHeader_ItemType"], typeof(Photo).FullName, "HttpWebRequest should have CustomRequestHeader_ItemType");
-                        Assert.AreEqual(requestMessage.HttpWebRequest.Headers["Slug"], photoMLE.ID.ToString(), "HttpWebRequest should have Slug header");
+                        Assert.AreEqual(requestMessage.HttpRequestMessage.Headers.GetValues("CustomRequestHeader_ItemType"), typeof(Photo).FullName, "HttpWebRequest should have CustomRequestHeader_ItemType");
+                        Assert.AreEqual(requestMessage.HttpRequestMessage.Headers.GetValues("Slug"), photoMLE.ID.ToString(), "HttpWebRequest should have Slug header");
                     }
                     else if (entityDescriptor.Entity is Item)
                     {
                         e.RequestMessage.SetHeader("CustomRequestHeader_ItemType", typeof(Item).FullName);
-                        Assert.AreEqual(requestMessage.HttpWebRequest.Headers["CustomRequestHeader_ItemType"], typeof(Item).FullName, "HttpWebRequest should have CustomRequestHeader_ItemType");
+                        Assert.AreEqual(requestMessage.HttpRequestMessage.Headers.GetValues("CustomRequestHeader_ItemType"), typeof(Item).FullName, "HttpWebRequest should have CustomRequestHeader_ItemType");
                     }
                 }
 
@@ -2737,8 +2737,8 @@ namespace AstoriaUnitTests
                         ctx.SendingRequest2 += new EventHandler<SendingRequest2EventArgs>((sender, e) =>
                         {
                             Assert.AreEqual(e.RequestMessage.Method, "GET", "Method must be GET");
-                            Assert.IsTrue(e.RequestMessage != null && e.RequestMessage is HttpWebRequestMessage, "RequestMessage must be ODataRequestMessage");
-                            Assert.IsNotNull(((HttpWebRequestMessage)e.RequestMessage).HttpWebRequest != null, "HttpWebRequest should not be null");
+                            Assert.IsTrue(e.RequestMessage != null && e.RequestMessage is HttpClientRequestMessage, "RequestMessage must be ODataRequestMessage");
+                            Assert.IsNotNull(((HttpClientRequestMessage)e.RequestMessage).HttpRequestMessage != null, "HttpWebRequest should not be null");
                             Assert.IsFalse(e.IsBatchPart, "Since SaveChanges is called with no parameters, IsBatchPart should always be false");
 
                             Assert.AreEqual(testCase.QueryString, baseUri.MakeRelativeUri(e.RequestMessage.Url).OriginalString);

--- a/test/FunctionalTests/Tests/DataServices/ddbasics/Microsoft.Test.Data.Services.DDBasics.csproj
+++ b/test/FunctionalTests/Tests/DataServices/ddbasics/Microsoft.Test.Data.Services.DDBasics.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0" Version="10.0.30320" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   
   <ItemGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1784 .*

### Description

*Briefly describe the changes of this pull request.*
<code>Microsoft.OData.Client</code> currently uses <code>HttpWebRequest</code> for http calls. Most modern Clients like blazor are unable to work with <code>Microsoft.OData.Client</code> because of this.

To avoid breaking most clients who might be using the public <code>HttpWebRequest</code> property in the <code> HttpwebRequestMessage </code> class, we've added an enum option called <code> HttpRequestTransportMode </code>  in the <code> DataServiceContext </code> class that will allow users to select between HttpWebRequest and HttpClient in processing HttpRequests and HttpResponses. 

The use of <code> HttpWebRequest </code> will be the default. So, if you want to use <code> HttpClient </code> with <code> Microsoft.OData.Client </code> then you will be required to do the following: 

<pre> 
DefaultContainer context = new DefaultContainer(new Uri("https://localhost:44307/odata/"));
context.HttpRequestTransportMode = HttpRequestTransportMode.HttpClientRequestMessage; 
</pre> 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
