### PR TITLE
Enable Base term for IEdmTerm

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
@@ -68,6 +68,7 @@ namespace Microsoft.OData.Edm.Csdl
         internal const string Attribute_DateTimeOffset = "DateTimeOffset";
         internal const string Attribute_Decimal = "Decimal";
         internal const string Attribute_DefaultValue = "DefaultValue";
+        internal const string Attribute_BaseTerm = "BaseTerm";
         internal const string Attribute_ElementType = "ElementType";
         internal const string Attribute_Extends = "Extends";
         internal const string Attribute_EntityType = "EntityType";

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlTerm.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlTerm.cs
@@ -14,11 +14,13 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         private readonly CsdlTypeReference type;
         private readonly string appliesTo;
         private readonly string defaultValue;
+        private readonly string baseTermName;
 
-        public CsdlTerm(string name, CsdlTypeReference type, string appliesTo, string defaultValue, CsdlLocation location)
+        public CsdlTerm(string name, CsdlTypeReference type, string baseTermName, string appliesTo, string defaultValue, CsdlLocation location)
             : base(name, location)
         {
             this.type = type;
+            this.baseTermName = baseTermName;
             this.appliesTo = appliesTo;
             this.defaultValue = defaultValue;
         }
@@ -26,6 +28,11 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         public CsdlTypeReference Type
         {
             get { return this.type; }
+        }
+
+        public string BaseTermName
+        {
+            get { return this.baseTermName; }
         }
 
         public string AppliesTo

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
@@ -509,8 +509,9 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             string name = Required(CsdlConstants.Attribute_Name);
             string appliesTo = Optional(CsdlConstants.Attribute_AppliesTo);
             string defaultValue = Optional(CsdlConstants.Attribute_DefaultValue);
+            string baseTerm = Optional(CsdlConstants.Attribute_BaseTerm);
 
-            return new CsdlTerm(name, type, appliesTo, defaultValue, element.Location);
+            return new CsdlTerm(name, type, baseTerm, appliesTo, defaultValue, element.Location);
         }
 
         private CsdlAnnotations OnAnnotationsElement(XmlElementInfo element, XmlElementValueCollection childValues)

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/SchemaJsonParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/SchemaJsonParser.cs
@@ -1084,6 +1084,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
 
             IList<string> appliesTo = null;
             string defaultValue = null;
+            string baseTerm = null;
             IList<CsdlAnnotation> termAnnotations = new List<CsdlAnnotation>();
             element.ParseAsObject(context, (propertyName, propertyValue) =>
             {
@@ -1103,8 +1104,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
 
                     case "$BaseTerm":
                         // The value of $BaseTerm is the qualified name of the base term.
-                        // Skip it because it's not supported
-                        context.ReportError(EdmErrorCode.UnexpectedElement, Strings.CsdlJsonParser_UnexpectedJsonMember(context.Path, element.ValueKind));
+                        baseTerm = propertyValue.ParseAsString(context);
                         break;
 
                     case "$DefaultValue":
@@ -1126,7 +1126,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             });
 
             string appliesToStr = appliesTo != null ? string.Join(" ", appliesTo) : null;
-            CsdlTerm termType = new CsdlTerm(name, typeReference, appliesToStr, defaultValue, context.Location());
+            CsdlTerm termType = new CsdlTerm(name, typeReference, baseTerm, appliesToStr, defaultValue, context.Location());
             termAnnotations.ForEach(a => termType.AddAnnotation(a));
 
             return termType;

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedVocabularyTerm.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/BadElements/UnresolvedVocabularyTerm.cs
@@ -51,6 +51,11 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             get { return this.type; }
         }
 
+        public IEdmTerm BaseTerm
+        {
+            get { return null; }
+        }
+
         public string AppliesTo
         {
             get { return this.appliesTo; }

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
@@ -79,7 +79,8 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             }
 
             // A term MAY specialize another term in scope by specifying it as its base term.
-            // The value of $BaseTerm is the qualified name of the base term. So far, it's not supported.
+            // The value of $BaseTerm is the qualified name of the base term.
+            this.jsonWriter.WriteOptionalProperty("$BaseTerm", term.BaseTerm, this.SerializationName);
 
             // It MAY contain the members $AppliesTo.
             // The value of $AppliesTo is an array whose items are strings containing symbolic values from a table

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
@@ -67,6 +67,8 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                 this.WriteRequiredAttribute(CsdlConstants.Attribute_Type, term.Type, this.TypeReferenceAsXml);
             }
 
+            this.WriteOptionalAttribute(CsdlConstants.Attribute_BaseTerm, term.BaseTerm, this.SerializationName);
+
             this.WriteOptionalAttribute(CsdlConstants.Attribute_DefaultValue, term.DefaultValue, EdmValueWriter.StringAsXml);
             this.WriteOptionalAttribute(CsdlConstants.Attribute_AppliesTo, term.AppliesTo, EdmValueWriter.StringAsXml);
         }

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelSchemaSeparationSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelSchemaSeparationSerializationVisitor.cs
@@ -164,6 +164,15 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             }
         }
 
+        protected override void ProcessTerm(IEdmTerm element)
+        {
+            base.ProcessTerm(element);
+            if (element.BaseTerm != null)
+            {
+                this.CheckSchemaElementReference(element.BaseTerm);
+            }
+        }
+
         protected override void ProcessEnumType(IEdmEnumType element)
         {
             base.ProcessEnumType(element);

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
@@ -304,6 +304,7 @@ namespace Microsoft.OData.Edm
         internal const string Bad_CyclicComplex = "Bad_CyclicComplex";
         internal const string Bad_CyclicEntityContainer = "Bad_CyclicEntityContainer";
         internal const string Bad_UnresolvedNavigationPropertyPath = "Bad_UnresolvedNavigationPropertyPath";
+        internal const string Bad_CyclicTerm = "Bad_CyclicTerm";
         internal const string RuleSet_DuplicateRulesExistInRuleSet = "RuleSet_DuplicateRulesExistInRuleSet";
         internal const string EdmToClr_UnsupportedType = "EdmToClr_UnsupportedType";
         internal const string EdmToClr_StructuredValueMappedToNonClass = "EdmToClr_StructuredValueMappedToNonClass";

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -307,6 +307,7 @@ Bad_CyclicEntity=The entity '{0}' is invalid because its base type is cyclic.
 Bad_CyclicComplex=The complex type '{0}' is invalid because its base type is cyclic.
 Bad_CyclicEntityContainer=The entity container '{0}' is invalid because its extends hierarchy is cyclic.
 Bad_UnresolvedNavigationPropertyPath=A navigation property could not be found for the path '{0}' starting from the type '{1}'.
+Bad_CyclicTerm=The term '{0}' is invalid because its base type is cyclic.
 
 ; Error messages for validation rulesets
 RuleSet_DuplicateRulesExistInRuleSet=The same rule cannot be in the same rule set twice.

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -1583,7 +1583,7 @@ namespace Microsoft.OData.Edm {
         /// A string like "Unknown Edm version '{0}'."
         /// </summary>
         internal static string Serializer_UnknownEdmVersion(object p0)
-		{
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.Serializer_UnknownEdmVersion, p0);
         }
 
@@ -1591,7 +1591,7 @@ namespace Microsoft.OData.Edm {
         /// A string like "Unknown Edmx version '{0}'."
         /// </summary>
         internal static string Serializer_UnknownEdmxVersion(object p0)
-		{
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.Serializer_UnknownEdmxVersion, p0);
         }
 
@@ -1955,77 +1955,88 @@ namespace Microsoft.OData.Edm {
         /// <summary>
         /// A string like "An unexpected '{0}' value kind was found when parsing the JSON path '{1}'. A '{2}' value kind was expected."
         /// </summary>
-        internal static string CsdlJsonParser_UnexpectedJsonValueKind(object p0, object p1, object p2) {
+        internal static string CsdlJsonParser_UnexpectedJsonValueKind(object p0, object p1, object p2)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_UnexpectedJsonValueKind, p0, p1, p2);
         }
 
         /// <summary>
         /// A string like "A member '{0}' is missing when parsing the JSON path '{1}'."
         /// </summary>
-        internal static string CsdlJsonParser_MissingMemberInObject(object p0, object p1) {
+        internal static string CsdlJsonParser_MissingMemberInObject(object p0, object p1)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_MissingMemberInObject, p0, p1);
         }
 
         /// <summary>
         /// A string like "A member '{0}' with value type '{1}' is unexpected."
         /// </summary>
-        internal static string CsdlJsonParser_UnexpectedJsonMember(object p0, object p1) {
+        internal static string CsdlJsonParser_UnexpectedJsonMember(object p0, object p1)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_UnexpectedJsonMember, p0, p1);
         }
 
         /// <summary>
         /// A string like "Cannot read the value '{0}' at JSON path '{1}' as '{2}' numeric value."
         /// </summary>
-        internal static string CsdlJsonParser_CannotReadValueAsType(object p0, object p1, object p2) {
+        internal static string CsdlJsonParser_CannotReadValueAsType(object p0, object p1, object p2)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_CannotReadValueAsType, p0, p1, p2);
         }
 
         /// <summary>
         /// A string like "A schema '{0}' object MUST contain the member '$Kind' with a string value of '{1}'."
         /// </summary>
-        internal static string CsdlJsonParser_MissingKindMember(object p0, object p1) {
+        internal static string CsdlJsonParser_MissingKindMember(object p0, object p1)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_MissingKindMember, p0, p1);
         }
 
         /// <summary>
         /// A string like "A property '{0}' is missing when parsing the JSON path '{1}'."
         /// </summary>
-        internal static string CsdlJsonParser_MissingRequiredPropertyInObject(object p0, object p1) {
+        internal static string CsdlJsonParser_MissingRequiredPropertyInObject(object p0, object p1)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_MissingRequiredPropertyInObject, p0, p1);
         }
 
         /// <summary>
         /// A string like "Found an unknown value kind '{0}' when parsing the JSON path '{1}'."
         /// </summary>
-        internal static string CsdlJsonParser_UnknownJsonElementValueKind(object p0, object p1) {
+        internal static string CsdlJsonParser_UnknownJsonElementValueKind(object p0, object p1)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_UnknownJsonElementValueKind, p0, p1);
         }
 
         /// <summary>
         /// A string like "Cannot parse a JSON number '{0}' when parsing the JSON path '{1}'."
         /// </summary>
-        internal static string CsdlJsonParser_InvalidJsonNumberType(object p0, object p1) {
+        internal static string CsdlJsonParser_InvalidJsonNumberType(object p0, object p1)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_InvalidJsonNumberType, p0, p1);
         }
 
         /// <summary>
         /// A string like "A member at JSON path '{0}' is not supported."
         /// </summary>
-        internal static string CsdlJsonParser_UnsupportedJsonMember(object p0) {
+        internal static string CsdlJsonParser_UnsupportedJsonMember(object p0)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_UnsupportedJsonMember, p0);
         }
 
         /// <summary>
         /// A string like "The version specified at '{0}' is not valid. It should be a string containing either '4.0' or '4.01'."
         /// </summary>
-        internal static string CsdlJsonParser_InvalidCsdlVersion(object p0) {
+        internal static string CsdlJsonParser_InvalidCsdlVersion(object p0)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_InvalidCsdlVersion, p0);
         }
 
         /// <summary>
         /// A string like "The schema object at '{0}' cannot have more than one entity container."
         /// </summary>
-        internal static string CsdlJsonParser_SchemaCannotHaveMoreThanOneEntityContainer(object p0) {
+        internal static string CsdlJsonParser_SchemaCannotHaveMoreThanOneEntityContainer(object p0)
+        {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.CsdlJsonParser_SchemaCannotHaveMoreThanOneEntityContainer, p0);
         }
 
@@ -2420,6 +2431,14 @@ namespace Microsoft.OData.Edm {
         internal static string Bad_UnresolvedNavigationPropertyPath(object p0, object p1)
         {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.Bad_UnresolvedNavigationPropertyPath, p0, p1);
+        }
+
+        /// <summary>
+        /// A string like "The term '{0}' is invalid because its base type is cyclic."
+        /// </summary>
+        internal static string Bad_CyclicTerm(object p0)
+        {
+            return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.Bad_CyclicTerm, p0);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/AmbiguousTermBinding.cs
+++ b/src/Microsoft.OData.Edm/Schema/AmbiguousTermBinding.cs
@@ -55,6 +55,11 @@ namespace Microsoft.OData.Edm
             get { return this.type.GetValue(this, ComputeTypeFunc, null); }
         }
 
+        public IEdmTerm BaseTerm
+        {
+            get { return null; }
+        }
+
         public string AppliesTo
         {
             get { return this.appliesTo; }

--- a/src/Microsoft.OData.Edm/Schema/CyclicTerm.cs
+++ b/src/Microsoft.OData.Edm/Schema/CyclicTerm.cs
@@ -1,0 +1,22 @@
+//---------------------------------------------------------------------
+// <copyright file="CyclicTerm.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Represents an EDM term that cannot be determined due to a cyclic reference.
+    /// </summary>
+    internal class CyclicTerm : BadTerm
+    {
+        public CyclicTerm(string qualifiedName, EdmLocation location)
+            : base(qualifiedName, new EdmError[] { new EdmError(location, EdmErrorCode.BadCyclicTerm, Edm.Strings.Bad_CyclicTerm(qualifiedName)) })
+        {
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
+++ b/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
@@ -1384,6 +1384,11 @@ namespace Microsoft.OData.Edm.Validation
         AnnotationApplyToNotAllowedAnnotatable = 400,
 
         /// <summary>
+        /// This ter, type is part of a cycle.
+        /// </summary>
+        BadCyclicTerm,
+
+        /// <summary>
         /// Invalid $Key value.
         /// </summary>
         InvalidKeyValue,

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/BadTerm.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/BadTerm.cs
@@ -1,0 +1,70 @@
+//---------------------------------------------------------------------
+// <copyright file="BadTerm.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.OData.Edm.Validation;
+
+namespace Microsoft.OData.Edm.Vocabularies
+{
+    /// <summary>
+    /// Represents a semantically invalid EDM Term.
+    /// </summary>
+    internal class BadTerm : BadElement, IEdmTerm
+    {
+        private readonly string namespaceName;
+        private readonly string name;
+        private readonly string fullName;
+        private readonly IEdmTypeReference type;
+
+        public BadTerm(string qualifiedName, IEnumerable<EdmError> errors)
+            : base(errors)
+        {
+            qualifiedName = qualifiedName ?? string.Empty;
+            EdmUtil.TryGetNamespaceNameFromQualifiedName(qualifiedName, out this.namespaceName, out this.name, out this.fullName);
+            type = new BadTypeReference(new BadType(errors), true);
+        }
+
+        public string Name
+        {
+            get { return this.name; }
+        }
+
+        public string Namespace
+        {
+            get { return this.namespaceName; }
+        }
+
+        public string FullName
+        {
+            get { return this.fullName; }
+        }
+
+        public IEdmTypeReference Type
+        {
+            get { return this.type; }
+        }
+
+        public string AppliesTo
+        {
+            get { return null; }
+        }
+
+        public string DefaultValue
+        {
+            get { return null; }
+        }
+
+        public IEdmTerm BaseTerm
+        {
+            get { return null; }
+        }
+
+        public EdmSchemaElementKind SchemaElementKind
+        {
+            get { return EdmSchemaElementKind.Term; }
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmTerm.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmTerm.cs
@@ -16,6 +16,7 @@ namespace Microsoft.OData.Edm.Vocabularies
         private readonly IEdmTypeReference type;
         private readonly string appliesTo;
         private readonly string defaultValue;
+        private readonly IEdmTerm baseTerm;
 
         /// <summary>
         /// Initializes a new instance of <see cref="EdmTerm"/> class.
@@ -49,7 +50,19 @@ namespace Microsoft.OData.Edm.Vocabularies
         /// <param name="name">Name of the term.</param>
         /// <param name="type">Type of the term.</param>
         public EdmTerm(string namespaceName, string name, IEdmTypeReference type)
-            : this(namespaceName, name, type, null)
+            : this(namespaceName, name, type, baseTerm: null, appliesTo: null, defaultValue: null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmTerm"/> class.
+        /// </summary>
+        /// <param name="namespaceName">Namespace of the term.</param>
+        /// <param name="name">Name of the term.</param>
+        /// <param name="type">Type of the term.</param>
+        /// <param name="baseTerm">Base term of the term.</param>
+        public EdmTerm(string namespaceName, string name, IEdmTypeReference type, IEdmTerm baseTerm)
+            : this(namespaceName, name, type, baseTerm, appliesTo: null, defaultValue: null)
         {
         }
 
@@ -74,6 +87,20 @@ namespace Microsoft.OData.Edm.Vocabularies
         /// <param name="appliesTo">AppliesTo of the term.</param>
         /// <param name="defaultValue">DefaultValue of the term.</param>
         public EdmTerm(string namespaceName, string name, IEdmTypeReference type, string appliesTo, string defaultValue)
+            : this(namespaceName, name, type, baseTerm: null, appliesTo: appliesTo, defaultValue: defaultValue)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmTerm"/> class.
+        /// </summary>
+        /// <param name="namespaceName">Namespace of the term.</param>
+        /// <param name="name">Name of the term.</param>
+        /// <param name="type">Type of the term.</param>
+        /// <param name="baseTerm">Base term of the term.</param>
+        /// <param name="appliesTo">AppliesTo of the term.</param>
+        /// <param name="defaultValue">DefaultValue of the term.</param>
+        public EdmTerm(string namespaceName, string name, IEdmTypeReference type, IEdmTerm baseTerm, string appliesTo, string defaultValue)
             : base(name)
         {
             EdmUtil.CheckArgumentNull(namespaceName, "namespaceName");
@@ -81,6 +108,7 @@ namespace Microsoft.OData.Edm.Vocabularies
 
             this.namespaceName = namespaceName;
             this.type = type;
+            this.baseTerm = baseTerm;
             this.appliesTo = appliesTo;
             this.defaultValue = defaultValue;
             this.fullName = EdmUtil.GetFullNameForSchemaElement(this.namespaceName, this.Name);
@@ -124,6 +152,14 @@ namespace Microsoft.OData.Edm.Vocabularies
         public string DefaultValue
         {
             get { return this.defaultValue; }
+        }
+
+        /// <summary>
+        /// Gets the base term of this term.
+        /// </summary>
+        public IEdmTerm BaseTerm
+        {
+            get { return this.baseTerm; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/IEdmTerm.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/IEdmTerm.cs
@@ -25,5 +25,10 @@ namespace Microsoft.OData.Edm.Vocabularies
         /// Gets the DefaultValue of this term.
         /// </summary>
         string DefaultValue { get; }
+
+        /// <summary>
+        /// Gets the base term of this term.
+        /// </summary>
+        IEdmTerm BaseTerm { get; }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Parsing/SchemaJsonParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Parsing/SchemaJsonParserTests.cs
@@ -286,13 +286,15 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Parsing
         #endregion
 
         #region Term
+
         [Fact]
-        public void ParseCsdlTermWithMembersWorksAsExpected()
+        public void ParseCsdlTermWithBaseTermAndMembersWorksAsExpected()
         {
             string json =  @"""ConformanceLevel"": {
   ""$Kind"": ""Term"",
   ""$Type"": ""Capabilities.ConformanceLevelType"",
   ""$Nullable"": true,
+  ""$BaseTerm"": ""NS.BaseTerm"",
   ""$AppliesTo"": [
     ""EntityContainer""
   ],
@@ -307,6 +309,8 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Parsing
             Assert.Equal("EntityContainer", term.AppliesTo);
             Assert.Null(term.DefaultValue);
             Assert.True(term.HasVocabularyAnnotations);
+
+            Assert.Equal("NS.BaseTerm", term.BaseTermName);
 
             CsdlNamedTypeReference namedType = Assert.IsType<CsdlNamedTypeReference>(term.Type);
             Assert.Equal("Capabilities.ConformanceLevelType", namedType.FullName);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
@@ -816,6 +816,34 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
         }
 
         [Fact]
+        public void VerifyTermWithBaseTermWrittenCorrectly()
+        {
+            // Arrange
+            IEdmPrimitiveTypeReference stringType = EdmCoreModel.Instance.GetString(true);
+            EdmTerm baseTerm = new EdmTerm("NS", "BaseTerm", stringType);
+            EdmTerm term = new EdmTerm("NS", "MyAnnotation", stringType, baseTerm, "Function,Action,EntitySet", null);
+
+            // Act & Assert for XML
+            VisitAndVerifyXml(v => v.VisitSchemaElement(term),
+                @"<Term Name=""MyAnnotation"" Type=""Edm.String"" BaseTerm=""NS.BaseTerm"" AppliesTo=""Function,Action,EntitySet"" />");
+
+            // Act & Assert for JSON
+            VisitAndVerifyJson(v => v.VisitSchemaElement(term), @"{
+  ""MyAnnotation"": {
+    ""$Kind"": ""Term"",
+    ""$Type"": ""Edm.String"",
+    ""$BaseTerm: ""NS.BaseTerm"",
+    ""$AppliesTo"": [
+      ""Function"",
+      ""Action"",
+      ""EntitySet""
+    ],
+    ""$Nullable"": true
+  }
+}");
+        }
+
+        [Fact]
         public void VerifyTermWithAnnotationsWrittenCorrectly()
         {
             // Arrange


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1955. & #1816*

### Description

*14.1.1 Specialized Term

A term MAY specialize another term in scope by specifying it as its base type.

When applying a term with a base term, the base term MUST also be applied with the same qualifier, and so on until a term without a base term is reached.

Attribute BaseTerm

The value of BaseTerm is the qualified name of the base term.

This PR is to enable the base term.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
