### PR TITLE
Add WriteMetadataAsync API to enable write CSDL async

### DIFF
--- a/src/Microsoft.OData.Core/Metadata/ODataMetadataWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Metadata/ODataMetadataWriterUtils.cs
@@ -32,6 +32,11 @@ namespace Microsoft.OData.Metadata
 
             XmlWriterSettings xmlWriterSettings = CreateXmlWriterSettings(messageWriterSettings, encoding);
 
+            if (stream is AsyncBufferedStream)
+            {
+                xmlWriterSettings.Async = true;
+            }
+
             XmlWriter writer = XmlWriter.Create(stream, xmlWriterSettings);
 
             return writer;

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -283,8 +283,6 @@ namespace Microsoft.OData
                 (context) => context.CreateODataDeltaResourceSetWriter(entitySet, resourceType));
         }
 
-
-
         /// <summary> Asynchronously creates an <see cref="Microsoft.OData.ODataWriter" /> to write a delta resource set. </summary>
         /// <returns>A running task for the created writer.</returns>
         public Task<ODataWriter> CreateODataDeltaResourceSetWriterAsync()
@@ -330,7 +328,6 @@ namespace Microsoft.OData
                 ODataPayloadKind.ResourceSet,
                 (context) => context.CreateODataDeltaWriter(entitySet, entityType));
         }
-
 
         /// <summary>
         /// Asynchronously creates an <see cref="ODataDeltaWriter" /> to write a delta response.
@@ -424,7 +421,6 @@ namespace Microsoft.OData
                 (context) => context.CreateODataUriParameterResourceWriter(navigationSource, resourceType));
         }
 
-
         /// <summary>
         /// Asynchronously creates an <see cref="ODataWriter" /> to write Uri operation parameter.
         /// </summary>
@@ -452,7 +448,6 @@ namespace Microsoft.OData
                 ODataPayloadKind.ResourceSet,
                 (context) => context.CreateODataUriParameterResourceSetWriter(entitySetBase, resourceType));
         }
-
 
         /// <summary>
         /// Asynchronously creates an <see cref="ODataWriter" /> to write Uri operation parameter.
@@ -488,7 +483,6 @@ namespace Microsoft.OData
                 (context) => context.CreateODataCollectionWriter(itemTypeReference));
         }
 
-
         /// <summary> Asynchronously creates an <see cref="Microsoft.OData.ODataCollectionWriter" /> to write a collection of primitive or complex values (as result of a service operation invocation). </summary>
         /// <returns>A running task for the created collection writer.</returns>
         public Task<ODataCollectionWriter> CreateODataCollectionWriterAsync()
@@ -519,7 +513,6 @@ namespace Microsoft.OData
                 (context) => context.CreateODataBatchWriter());
         }
 
-
         /// <summary> Asynchronously creates an <see cref="Microsoft.OData.ODataBatchWriter" /> to write a batch of requests or responses. </summary>
         /// <returns>A running task for the created batch writer.</returns>
         public Task<ODataBatchWriter> CreateODataBatchWriterAsync()
@@ -542,7 +535,6 @@ namespace Microsoft.OData
                 ODataPayloadKind.Parameter,
                 (context) => context.CreateODataParameterWriter(operation));
         }
-
 
         /// <summary>
         /// Asynchronously creates an <see cref="ODataParameterWriter" /> to write a parameter payload.
@@ -567,7 +559,6 @@ namespace Microsoft.OData
                 (context) => context.WriteServiceDocument(serviceDocument));
         }
 
-
         /// <summary> Asynchronously writes a service document with the specified <paramref name="serviceDocument" /> as the message payload. </summary>
         /// <returns>A task representing the asynchronous operation of writing the service document.</returns>
         /// <param name="serviceDocument">The service document to write.</param>
@@ -588,7 +579,6 @@ namespace Microsoft.OData
                 ODataPayloadKind.Property,
                 (context) => context.WriteProperty(property));
         }
-
 
         /// <summary> Asynchronously writes an <see cref="Microsoft.OData.ODataProperty" /> as the message payload. </summary>
         /// <returns>A task representing the asynchronous operation of writing the property.</returns>
@@ -625,7 +615,6 @@ namespace Microsoft.OData
             this.outputContext.WriteInStreamError(error, includeDebugInformation);
         }
 
-
         /// <summary> Asynchronously writes an <see cref="Microsoft.OData.ODataError" /> as the message payload. </summary>
         /// <returns>A task representing the asynchronous operation of writing the error.</returns>
         /// <param name="error">The error to write.</param>
@@ -660,7 +649,6 @@ namespace Microsoft.OData
                 (context) => context.WriteEntityReferenceLinks(links));
         }
 
-
         /// <summary> Asynchronously writes the result of a $ref query as the message payload. </summary>
         /// <returns>A task representing the asynchronous writing of the entity reference links.</returns>
         /// <param name="links">The entity reference links to write as message payload.</param>
@@ -681,7 +669,6 @@ namespace Microsoft.OData
                 ODataPayloadKind.EntityReferenceLink,
                 (context) => context.WriteEntityReferenceLink(link));
         }
-
 
         /// <summary> Asynchronously writes a singleton result of a $ref query as the message payload. </summary>
         /// <returns>A running task representing the writing of the link.</returns>
@@ -704,7 +691,6 @@ namespace Microsoft.OData
                 (context) => context.WriteValue(value));
         }
 
-
         /// <summary> Asynchronously writes a single value as the message body. </summary>
         /// <returns>A running task representing the writing of the value.</returns>
         /// <param name="value">The value to write.</param>
@@ -723,6 +709,18 @@ namespace Microsoft.OData
             this.WriteToOutput(
                 ODataPayloadKind.MetadataDocument,
                 (context) => context.WriteMetadataDocument());
+        }
+
+        /// <summary>
+        /// Asynchronously writes a metadata document as the message payload.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation of writing the metadata document.</returns>
+        public Task WriteMetadataDocumentAsync()
+        {
+            this.VerifyCanWriteMetadataDocument();
+            return this.WriteToOutputAsync(
+                ODataPayloadKind.MetadataDocument,
+                (context) => context.WriteMetadataDocumentAsync());
         }
 
         /// <summary><see cref="System.IDisposable.Dispose()" /> implementation to cleanup unmanaged resources of the writer. </summary>

--- a/src/Microsoft.OData.Core/ODataMetadataFormat.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataFormat.cs
@@ -67,10 +67,8 @@ namespace Microsoft.OData
             {
                 return new ODataMetadataJsonInputContext(messageInfo, messageReaderSettings);
             }
-            else
-            {
-                return new ODataMetadataInputContext(messageInfo, messageReaderSettings);
-            }
+
+            return new ODataMetadataInputContext(messageInfo, messageReaderSettings);
 #else
             if (isJson)
             {
@@ -101,10 +99,8 @@ namespace Microsoft.OData
             {
                 return new ODataMetadataJsonOutputContext(messageInfo, messageWriterSettings);
             }
-            else
-            {
-                return new ODataMetadataOutputContext(messageInfo, messageWriterSettings);
-            }
+
+            return new ODataMetadataOutputContext(messageInfo, messageWriterSettings);
 #else
             if (isJson)
             {
@@ -168,10 +164,8 @@ namespace Microsoft.OData
             {
                 return Task.FromResult<ODataOutputContext>(new ODataMetadataJsonOutputContext(messageInfo, messageWriterSettings));
             }
-            else
-            {
-                return Task.FromResult<ODataOutputContext>(new ODataMetadataOutputContext(messageInfo, messageWriterSettings));
-            }
+
+            return Task.FromResult<ODataOutputContext>(new ODataMetadataOutputContext(messageInfo, messageWriterSettings));
 #else
             if (isJson)
             {

--- a/src/Microsoft.OData.Core/ODataMetadataFormat.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataFormat.cs
@@ -161,7 +161,25 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentNotNull(messageInfo, "messageInfo");
             ExceptionUtils.CheckArgumentNotNull(messageWriterSettings, "messageWriterSettings");
 
-            throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataMetadataFormat_CreateOutputContextAsync));
+            bool isJson = IsJsonMetadata(messageInfo.MediaType);
+
+#if NETSTANDARD2_0
+            if (isJson)
+            {
+                return Task.FromResult<ODataOutputContext>(new ODataMetadataJsonOutputContext(messageInfo, messageWriterSettings));
+            }
+            else
+            {
+                return Task.FromResult<ODataOutputContext>(new ODataMetadataOutputContext(messageInfo, messageWriterSettings));
+            }
+#else
+            if (isJson)
+            {
+                throw new ODataException(Strings.ODataMetadataOutputContext_NotSupportJsonMetadata);
+            }
+
+            return Task.FromResult<ODataOutputContext>(new ODataMetadataOutputContext(messageInfo, messageWriterSettings));
+#endif
         }
 
         private static bool IsJsonMetadata(ODataMediaType contentType)

--- a/src/Microsoft.OData.Core/ODataMetadataJsonOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataJsonOutputContext.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Threading.Tasks;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Validation;
 
@@ -28,6 +29,9 @@ namespace Microsoft.OData
         /// <summary>The jsonWriter to write to.</summary>
         private Utf8JsonWriter jsonWriter;
 
+        /// <summary>The asynchronous output stream if we're writing asynchronously.</summary>
+        private AsyncBufferedStream asynchronousOutputStream;
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -39,12 +43,23 @@ namespace Microsoft.OData
             : base(ODataFormat.Metadata, messageInfo, messageWriterSettings)
         {
             Debug.Assert(messageInfo.MessageStream != null, "messageInfo.MessageStream != null");
-            Debug.Assert(!messageInfo.IsAsync, "Metadata output context is only supported in synchronous operations.");
 
             try
             {
                 this.messageOutputStream = messageInfo.MessageStream;
-                this.jsonWriter = CreateJsonWriter(this.messageOutputStream, messageWriterSettings);
+
+                Stream outputStream;
+                if (this.Synchronous)
+                {
+                    outputStream = this.messageOutputStream;
+                }
+                else
+                {
+                    this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
+                    outputStream = this.asynchronousOutputStream;
+                }
+
+                this.jsonWriter = CreateJsonWriter(outputStream, messageWriterSettings);
             }
             catch (Exception e)
             {
@@ -56,6 +71,34 @@ namespace Microsoft.OData
 
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Asynchronously flush the underlying stream.
+        /// </summary>
+        /// <returns></returns>
+        internal Task FlushAsync()
+        {
+            this.AssertAsynchronous();
+
+            return this.jsonWriter.FlushAsync();
+        }
+
+        /// <summary>
+        /// Asynchronously writes a metadata document as message payload.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation of writing the metadata document.</returns>
+        /// <remarks>It is the responsibility of this method to flush the output before the task finishes.</remarks>
+        internal override Task WriteMetadataDocumentAsync()
+        {
+            this.AssertAsynchronous();
+
+            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
+                () =>
+                {
+                    this.WriteMetadataDocumentImplementation();
+                    return this.FlushAsync();
+                });
         }
 
         /// <summary>
@@ -88,7 +131,6 @@ namespace Microsoft.OData
             this.AssertSynchronous();
 
             // What error should we write here?
-
             this.Flush();
         }
 
@@ -100,25 +142,7 @@ namespace Microsoft.OData
         {
             this.AssertSynchronous();
 
-            IEnumerable<EdmError> errors;
-
-            CsdlJsonWriterSettings writerSettings = new CsdlJsonWriterSettings
-            {
-                IsIeee754Compatible = MessageWriterSettings.IsIeee754Compatible
-            };
-
-            if (!CsdlWriter.TryWriteCsdl(this.Model, this.jsonWriter, writerSettings, out errors))
-            {
-                Debug.Assert(errors != null, "errors != null");
-
-                StringBuilder builder = new StringBuilder();
-                foreach (EdmError error in errors)
-                {
-                    builder.AppendLine(error.ToString());
-                }
-
-                throw new ODataException(Strings.ODataMetadataOutputContext_ErrorWritingMetadata(builder.ToString()));
-            }
+            this.WriteMetadataDocumentImplementation();
 
             this.Flush();
         }
@@ -156,18 +180,54 @@ namespace Microsoft.OData
             {
                 if (this.jsonWriter != null)
                 {
-                    this.jsonWriter.Flush();
-                    this.jsonWriter.Dispose();
+                    if (this.asynchronousOutputStream != null)
+                    {
+                        this.asynchronousOutputStream.FlushSync();
+                        this.asynchronousOutputStream.Dispose();
+
+                        this.jsonWriter.FlushAsync();
+                        this.jsonWriter.DisposeAsync();
+                    }
+                    else
+                    {
+                        this.jsonWriter.Flush();
+                        this.jsonWriter.Dispose();
+                    }
+
                     this.messageOutputStream.Dispose();
                 }
             }
             finally
             {
                 this.messageOutputStream = null;
+                this.asynchronousOutputStream = null;
                 this.jsonWriter = null;
             }
 
             base.Dispose(disposing);
+        }
+
+        private void WriteMetadataDocumentImplementation()
+        {
+            IEnumerable<EdmError> errors;
+
+            CsdlJsonWriterSettings writerSettings = new CsdlJsonWriterSettings
+            {
+                IsIeee754Compatible = MessageWriterSettings.IsIeee754Compatible
+            };
+
+            if (!CsdlWriter.TryWriteCsdl(this.Model, this.jsonWriter, writerSettings, out errors))
+            {
+                Debug.Assert(errors != null, "errors != null");
+
+                StringBuilder builder = new StringBuilder();
+                foreach (EdmError error in errors)
+                {
+                    builder.AppendLine(error.ToString());
+                }
+
+                throw new ODataException(Strings.ODataMetadataOutputContext_ErrorWritingMetadata(builder.ToString()));
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataMetadataJsonOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataJsonOutputContext.cs
@@ -182,11 +182,7 @@ namespace Microsoft.OData
                 {
                     if (this.asynchronousOutputStream != null)
                     {
-                        this.asynchronousOutputStream.FlushAsync();
-                        this.asynchronousOutputStream.Dispose();
-
-                        this.jsonWriter.FlushAsync();
-                        this.jsonWriter.DisposeAsync();
+                        DisposeOutputStreamAsync().Wait();
                     }
                     else
                     {
@@ -228,6 +224,15 @@ namespace Microsoft.OData
 
                 throw new ODataException(Strings.ODataMetadataOutputContext_ErrorWritingMetadata(builder.ToString()));
             }
+        }
+
+        private async Task DisposeOutputStreamAsync()
+        {
+            await this.asynchronousOutputStream.FlushAsync().ConfigureAwait(false);
+            this.asynchronousOutputStream.Dispose();
+
+            await this.jsonWriter.FlushAsync().ConfigureAwait(false);
+            await this.jsonWriter.DisposeAsync().ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataMetadataJsonOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataJsonOutputContext.cs
@@ -182,7 +182,7 @@ namespace Microsoft.OData
                 {
                     if (this.asynchronousOutputStream != null)
                     {
-                        this.asynchronousOutputStream.FlushSync();
+                        this.asynchronousOutputStream.FlushAsync();
                         this.asynchronousOutputStream.Dispose();
 
                         this.jsonWriter.FlushAsync();

--- a/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
@@ -182,8 +182,8 @@ namespace Microsoft.OData
                     // In the async case the underlying stream is the async buffered stream, so we have to flush that explicitly.
                     if (this.asynchronousOutputStream != null)
                     {
-                        this.xmlWriter.FlushAsync();
-                        this.asynchronousOutputStream.FlushAsync();
+                        this.xmlWriter.FlushAsync().Wait();
+                        this.asynchronousOutputStream.FlushAsync().Wait();
                         this.asynchronousOutputStream.Dispose();
                     }
                     else

--- a/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using System.Xml;
 using Microsoft.OData.Metadata;
 using Microsoft.OData.Edm.Csdl;
@@ -27,6 +28,9 @@ namespace Microsoft.OData
         /// <summary>The XmlWriter to write to.</summary>
         private XmlWriter xmlWriter;
 
+        /// <summary>The asynchronous output stream if we're writing asynchronously.</summary>
+        private AsyncBufferedStream asynchronousOutputStream;
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -38,12 +42,23 @@ namespace Microsoft.OData
             : base(ODataFormat.Metadata, messageInfo, messageWriterSettings)
         {
             Debug.Assert(messageInfo.MessageStream != null, "messageInfo.MessageStream != null");
-            Debug.Assert(!messageInfo.IsAsync, "Metadata output context is only supported in synchronous operations.");
 
             try
             {
                 this.messageOutputStream = messageInfo.MessageStream;
-                this.xmlWriter = ODataMetadataWriterUtils.CreateXmlWriter(this.messageOutputStream, messageWriterSettings, messageInfo.Encoding);
+
+                Stream outputStream;
+                if (this.Synchronous)
+                {
+                    outputStream = this.messageOutputStream;
+                }
+                else
+                {
+                    this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
+                    outputStream = this.asynchronousOutputStream;
+                }
+
+                this.xmlWriter = ODataMetadataWriterUtils.CreateXmlWriter(outputStream, messageWriterSettings, messageInfo.Encoding);
             }
             catch (Exception e)
             {
@@ -55,6 +70,55 @@ namespace Microsoft.OData
 
                 throw;
             }
+        }
+
+        /// <summary>
+        /// Asynchronously flush the underlying stream.
+        /// </summary>
+        /// <returns></returns>
+        internal Task FlushAsync()
+        {
+            this.AssertAsynchronous();
+
+            return this.xmlWriter.FlushAsync();
+        }
+
+        /// <summary>
+        /// Writes an <see cref="ODataError"/> into the message payload.
+        /// </summary>
+        /// <param name="error">The error to write.</param>
+        /// <param name="includeDebugInformation">
+        /// A flag indicating whether debug information (e.g., the inner error from the <paramref name="error"/>) should
+        /// be included in the payload. This should only be used in debug scenarios.
+        /// </param>
+        /// <returns>Task which represents the pending write operation.</returns>
+        internal override Task WriteInStreamErrorAsync(ODataError error, bool includeDebugInformation)
+        {
+            this.AssertAsynchronous();
+
+            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
+                () =>
+                {
+                    ODataMetadataWriterUtils.WriteError(this.xmlWriter, error, includeDebugInformation, this.MessageWriterSettings.MessageQuotas.MaxNestingDepth);
+                    return this.FlushAsync();
+                });
+        }
+
+        /// <summary>
+        /// Asynchronously writes a metadata document as message payload.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation of writing the metadata document.</returns>
+        /// <remarks>It is the responsibility of this method to flush the output before the task finishes.</remarks>
+        internal override Task WriteMetadataDocumentAsync()
+        {
+            this.AssertAsynchronous();
+
+            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
+                () =>
+                {
+                    this.WriteMetadataDocumentImplementation();
+                    return this.FlushAsync();
+                });
         }
 
         /// <summary>
@@ -100,19 +164,7 @@ namespace Microsoft.OData
         {
             this.AssertSynchronous();
 
-            IEnumerable<EdmError> errors;
-            if (!CsdlWriter.TryWriteCsdl(this.Model, this.xmlWriter, CsdlTarget.OData, out errors))
-            {
-                Debug.Assert(errors != null, "errors != null");
-
-                StringBuilder builder = new StringBuilder();
-                foreach (EdmError error in errors)
-                {
-                    builder.AppendLine(error.ToString());
-                }
-
-                throw new ODataException(Strings.ODataMetadataOutputContext_ErrorWritingMetadata(builder.ToString()));
-            }
+            this.WriteMetadataDocumentImplementation();
 
             this.Flush();
         }
@@ -127,8 +179,18 @@ namespace Microsoft.OData
             {
                 if (this.xmlWriter != null)
                 {
-                    // XmlWriter.Flush will call the underlying Stream.Flush.
-                    this.xmlWriter.Flush();
+                    // In the async case the underlying stream is the async buffered stream, so we have to flush that explicitly.
+                    if (this.asynchronousOutputStream != null)
+                    {
+                        this.xmlWriter.FlushAsync();
+                        this.asynchronousOutputStream.FlushSync();
+                        this.asynchronousOutputStream.Dispose();
+                    }
+                    else
+                    {
+                        // XmlWriter.Flush will call the underlying Stream.Flush.
+                        this.xmlWriter.Flush();
+                    }
 
                     // XmlWriter.Dispose calls XmlWriter.Close which writes missing end elements.
                     // Thus we can't dispose the XmlWriter since that might end up writing more data into the stream right here
@@ -143,10 +205,28 @@ namespace Microsoft.OData
             finally
             {
                 this.messageOutputStream = null;
+                this.asynchronousOutputStream = null;
                 this.xmlWriter = null;
             }
 
             base.Dispose(disposing);
+        }
+
+        private void WriteMetadataDocumentImplementation()
+        {
+            IEnumerable<EdmError> errors;
+            if (!CsdlWriter.TryWriteCsdl(this.Model, this.xmlWriter, CsdlTarget.OData, out errors))
+            {
+                Debug.Assert(errors != null, "errors != null");
+
+                StringBuilder builder = new StringBuilder();
+                foreach (EdmError error in errors)
+                {
+                    builder.AppendLine(error.ToString());
+                }
+
+                throw new ODataException(Strings.ODataMetadataOutputContext_ErrorWritingMetadata(builder.ToString()));
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
@@ -183,7 +183,7 @@ namespace Microsoft.OData
                     if (this.asynchronousOutputStream != null)
                     {
                         this.xmlWriter.FlushAsync();
-                        this.asynchronousOutputStream.FlushSync();
+                        this.asynchronousOutputStream.FlushAsync();
                         this.asynchronousOutputStream.Dispose();
                     }
                     else

--- a/src/Microsoft.OData.Core/ODataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataOutputContext.cs
@@ -645,6 +645,16 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Asynchronously writes a metadata document as message payload.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation of writing the metadata document.</returns>
+        /// <remarks>It is the responsibility of this method to flush the output before the task finishes.</remarks>
+        internal virtual Task WriteMetadataDocumentAsync()
+        {
+            throw this.CreatePayloadKindNotSupportedException(ODataPayloadKind.MetadataDocument);
+        }
+
+        /// <summary>
         /// Asserts that the input context was created for synchronous operation.
         /// </summary>
         [Conditional("DEBUG")]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/InMemoryMessage.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/InMemoryMessage.cs
@@ -7,10 +7,12 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Microsoft.OData.Tests
 {
     public class InMemoryMessage : IODataRequestMessage, IODataResponseMessage, IContainerProvider, IDisposable
+        , IODataRequestMessageAsync, IODataResponseMessageAsync
     {
         private readonly Dictionary<string, string> headers;
 
@@ -51,6 +53,13 @@ namespace Microsoft.OData.Tests
         }
 
         public Action DisposeAction { get; set; }
+
+        public Task<Stream> GetStreamAsync()
+        {
+            TaskCompletionSource<Stream> taskCompletionSource = new TaskCompletionSource<Stream>();
+            taskCompletionSource.SetResult(this.Stream);
+            return taskCompletionSource.Task;
+        }
 
         void IDisposable.Dispose()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #https://github.com/OData/odata.net/issues/1889.*

### Description

* Add `WriteMetadataDocumentAsync` public API.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
