### PR TITLE
Enable serialize and deseriaze the property with Untyped type

### DIFF
--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -263,6 +263,9 @@ namespace Microsoft.OData.Edm
                 case EdmTypeKind.Path:
                     this.ProcessPathTypeReference(reference.AsPath());
                     break;
+                case EdmTypeKind.Untyped:
+                    this.ProcessUntypedTypeReference(reference as IEdmUntypedTypeReference);
+                    break;
                 default:
                     throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_TypeKind(reference.TypeKind().ToString()));
             }
@@ -516,6 +519,11 @@ namespace Microsoft.OData.Edm
         }
 
         protected virtual void ProcessPathTypeReference(IEdmPathTypeReference reference)
+        {
+            this.ProcessTypeReference(reference);
+        }
+
+        protected virtual void ProcessUntypedTypeReference(IEdmUntypedTypeReference reference)
         {
             this.ProcessTypeReference(reference);
         }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -1175,6 +1175,43 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Assert.Equal("123/456.t", ((IEdmPathExpression)annotation.Value).Path);
         }
 
+        [Fact]
+        public void ParsingUntypedPropertiesWorks()
+        {
+            string csdl =
+            "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+                "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+                  "<edmx:DataServices>" +
+                    "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                      "<ComplexType Name=\"Complex\">" +
+                        "<Property Name=\"Value\" Type=\"Edm.Untyped\" />" +
+                        "<Property Name=\"Data\" Type=\"Collection(Edm.Untyped)\" />" +
+                      "</ComplexType>" +
+                    "</Schema>" +
+                  "</edmx:DataServices>" +
+                "</edmx:Edmx>";
+
+            IEdmModel model;
+            IEnumerable<EdmError> errors;
+
+            bool result = CsdlReader.TryParse(XElement.Parse(csdl).CreateReader(), out model, out errors);
+            Assert.True(result);
+            Assert.NotNull(model);
+
+            IEdmComplexType complexType = model.SchemaElements.OfType<IEdmComplexType>().FirstOrDefault();
+            Assert.NotNull(complexType);
+
+            Assert.Equal(2, complexType.Properties().Count());
+
+            IEdmProperty valueProperty = complexType.Properties().FirstOrDefault(p => p.Name == "Value");
+            Assert.NotNull(valueProperty);
+            Assert.Equal("Edm.Untyped", valueProperty.Type.FullName());
+
+            IEdmProperty dataProperty = complexType.Properties().FirstOrDefault(p => p.Name == "Data");
+            Assert.NotNull(dataProperty);
+            Assert.Equal("Collection(Edm.Untyped)", dataProperty.Type.FullName());
+        }
+
         [Theory]
         [InlineData("4.0")]
         [InlineData("4.01")]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -2354,6 +2354,61 @@ namespace Microsoft.OData.Edm.Tests.Csdl
 }");
         }
 
+        [Fact]
+        public void CanWriteEdmModelWithUntypedProperty()
+        {
+            EdmModel model = new EdmModel();
+
+            var entityType = new EdmEntityType("NS", "Entity");
+            var key = entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String);
+            entityType.AddKeys(key);
+            entityType.AddStructuralProperty("Value", EdmCoreModel.Instance.GetUntyped());
+            entityType.AddStructuralProperty("Data", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetUntyped())));
+            model.AddElement(entityType);
+
+            // Act & Assert for XML
+            WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+                "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+                  "<edmx:DataServices>" +
+                    "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                      "<EntityType Name=\"Entity\">" +
+                        "<Key>" +
+                          "<PropertyRef Name=\"Id\" />" +
+                        "</Key>" +
+                        "<Property Name=\"Id\" Type=\"Edm.String\" />" +
+                        "<Property Name=\"Value\" Type=\"Edm.Untyped\" />" +
+                        "<Property Name=\"Data\" Type=\"Collection(Edm.Untyped)\" />" +
+                      "</EntityType>" +
+                    "</Schema>" +
+                  "</edmx:DataServices>" +
+                "</edmx:Edmx>");
+
+            // Act & Assert for JSON
+            WriteAndVerifyJson(model, @"{
+  ""$Version"": ""4.0"",
+  ""NS"": {
+    ""Entity"": {
+      ""$Kind"": ""EntityType"",
+      ""$Key"": [
+        ""Id""
+      ],
+      ""Id"": {
+        ""$Nullable"": true
+      },
+      ""Value"": {
+        ""$Type"": ""Edm.Untyped"",
+        ""$Nullable"": true
+      },
+      ""Data"": {
+        ""$Collection"": true,
+        ""$Type"": ""Edm.Untyped"",
+        ""$Nullable"": true
+      }
+    }
+  }
+}");
+        }
+
         [Theory]
         [InlineData("4.0")]
         [InlineData("4.01")]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue https://github.com/OData/odata.net/issues/1979.*

### Description

* Enable the CsdlWriter to write the model with Untyped property
* Add test cases to cover the write and read

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
