### PR TITLE
Fix reading untyped collections containing values with @type specified.

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -1783,6 +1783,7 @@ namespace Microsoft.OData.JsonLight
                 }
             }
 
+            expectedTypeReference = expectedTypeReference != null && expectedTypeReference.IsUntyped() ? null : expectedTypeReference;
             ODataTypeAnnotation typeAnnotation;
             EdmTypeKind targetTypeKind;
             IEdmTypeReference targetTypeReference = this.ReaderValidator.ResolvePayloadTypeNameAndComputeTargetType(
@@ -1907,7 +1908,7 @@ namespace Microsoft.OData.JsonLight
                 }
 
                 // If we have no expected type make sure the collection items are of the same kind and specify the same name.
-                if (collectionValidator != null)
+                if (collectionValidator != null && targetTypeKind != EdmTypeKind.None)
                 {
                     string payloadTypeNameFromResult = ODataJsonLightReaderUtils.GetPayloadTypeName(result);
                     Debug.Assert(expectedTypeReference == null, "If a collection validator is specified there must not be an expected value type reference.");

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
@@ -1320,6 +1320,7 @@ namespace Microsoft.OData.JsonLight
             Func<IEdmPrimitiveType, bool, string, IEdmProperty, bool> readAsStream = this.MessageReaderSettings.ReadAsStreamFunc;
 
             // is the property a stream or a stream collection,
+            // untyped collection,
             // or a binary or binary collection the client wants to read as a stream...
             if (
                 (primitiveType != null &&
@@ -1328,7 +1329,10 @@ namespace Microsoft.OData.JsonLight
                              && (property == null || !property.IsKey())  // don't stream key properties
                              && (primitiveType.IsBinary() || primitiveType.IsString() || isCollection))
                          && readAsStream(primitiveType, isCollection, propertyName, property))) ||
-                ((propertyType == null || propertyType.Definition.AsElementType().IsUntyped())
+                (propertyType != null &&
+                    isCollection &&
+                    propertyType.Definition.AsElementType().IsUntyped()) ||
+                (propertyType == null
                     && (isCollection || this.JsonReader.CanStream())
                     && readAsStream != null
                     && readAsStream(null, isCollection, propertyName, property)))

--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -1572,7 +1572,7 @@ namespace Microsoft.OData.Metadata
                     IEdmStructuredType untypedType = type as IEdmStructuredType;
                     if (untypedType != null)
                     {
-                        return new EdmUntypedStructuredTypeReference(untypedType);
+                        return new EdmUntypedStructuredTypeReference(untypedType, nullable);
                     }
 
                     return new EdmUntypedTypeReference((IEdmUntypedType)type);

--- a/src/Microsoft.OData.Core/ODataReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataReaderCore.cs
@@ -739,7 +739,7 @@ namespace Microsoft.OData
             ODataTypeAnnotation typeAnnotation;
             EdmTypeKind targetTypeKind;
             IEdmStructuredTypeReference targetResourceTypeReference =
-                (IEdmStructuredTypeReference)this.inputContext.MessageReaderSettings.Validator.ResolvePayloadTypeNameAndComputeTargetType(
+                this.inputContext.MessageReaderSettings.Validator.ResolvePayloadTypeNameAndComputeTargetType(
                     EdmTypeKind.None,
                     /*expectStructuredType*/ true,
                     /*defaultPrimitivePayloadType*/ null,
@@ -748,7 +748,7 @@ namespace Microsoft.OData
                     this.inputContext.Model,
                     () => EdmTypeKind.Entity,
                     out targetTypeKind,
-                    out typeAnnotation);
+                    out typeAnnotation) as IEdmStructuredTypeReference;
 
             IEdmStructuredType targetResourceType = null;
             ODataResourceBase resource = this.Item as ODataResourceBase;
@@ -765,6 +765,12 @@ namespace Microsoft.OData
             else if (resourceTypeNameFromPayload != null)
             {
                 resource.TypeName = resourceTypeNameFromPayload;
+            }
+            else if (this.CurrentResourceTypeReference.IsUntyped())
+            {
+                targetResourceTypeReference = this.CurrentResourceTypeReference.IsNullable ?
+                    EdmUntypedStructuredTypeReference.NullableTypeReference : 
+                    EdmUntypedStructuredTypeReference.NonNullableTypeReference;
             }
 
             // Set the current resource type since the type might be derived from the expected one.

--- a/src/Microsoft.OData.Core/ReaderValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ReaderValidationUtils.cs
@@ -465,7 +465,7 @@ namespace Microsoft.OData
                 payloadTypeKind == EdmTypeKind.TypeDefinition || payloadTypeKind == EdmTypeKind.Untyped,
                 "The payload type kind must be one of None, Primitive, Enum, Untyped, Complex, Entity, Collection or TypeDefinition.");
             Debug.Assert(
-                expectedTypeReference == null || expectedTypeReference.TypeKind() == expectedTypeKind,
+                expectedTypeReference == null || expectedTypeReference.TypeKind() == EdmTypeKind.Untyped || expectedTypeReference.TypeKind() == expectedTypeKind,
                 "The expected type kind must match the expected type reference if that is available.");
             Debug.Assert(
                 payloadType == null || payloadType.TypeKind == payloadTypeKind,
@@ -823,7 +823,10 @@ namespace Microsoft.OData
                     {
                         // The payload type must be assignable to the expected type.
                         IEdmTypeReference payloadTypeReference = payloadType.ToTypeReference(/*nullable*/ true);
-                        ValidationUtils.ValidateEntityTypeIsAssignable((IEdmEntityTypeReference)expectedTypeReference, (IEdmEntityTypeReference)payloadTypeReference);
+                        if (!expectedTypeReference.IsUntyped())
+                        {
+                            ValidationUtils.ValidateEntityTypeIsAssignable((IEdmEntityTypeReference)expectedTypeReference, (IEdmEntityTypeReference)payloadTypeReference);
+                        }
 
                         // Use the payload type
                         return payloadTypeReference;
@@ -1003,7 +1006,7 @@ namespace Microsoft.OData
             }
 
             EdmTypeKind targetTypeKind;
-            if (expectedTypeKind != EdmTypeKind.None)
+            if (expectedTypeKind != EdmTypeKind.None && expectedTypeKind != EdmTypeKind.Untyped)
             {
                 // If we have an expected type, use that.
                 targetTypeKind = expectedTypeKind;

--- a/src/Microsoft.OData.Core/ValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ValidationUtils.cs
@@ -400,7 +400,7 @@ namespace Microsoft.OData
                 return;
             }
 
-            if (expectedTypeKind != actualTypeKind)
+            if (expectedTypeKind != EdmTypeKind.Untyped && expectedTypeKind != actualTypeKind)
             {
                 if (typeName == null)
                 {

--- a/src/Microsoft.OData.Edm/Schema/EdmUntypedStructuredType.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmUntypedStructuredType.cs
@@ -18,6 +18,11 @@ namespace Microsoft.OData.Edm
         private readonly string fullName;
 
         /// <summary>
+        /// The core Edm.Untyped singleton.
+        /// </summary>
+        public static readonly EdmUntypedStructuredType Instance = new EdmUntypedStructuredType();
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="EdmStructuredType"/> class.
         /// </summary>
         /// <param name="namespaceName">The namespace this type belongs to.</param>

--- a/src/Microsoft.OData.Edm/Schema/EdmUntypedStructuredTypeReference.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmUntypedStructuredTypeReference.cs
@@ -14,11 +14,31 @@ namespace Microsoft.OData.Edm
     public class EdmUntypedStructuredTypeReference : EdmTypeReference, IEdmUntypedTypeReference, IEdmStructuredTypeReference
     {
         /// <summary>
+        /// Returns a static instance of a nullable untyped structured type reference.
+        /// </summary>
+        public static readonly IEdmStructuredTypeReference NullableTypeReference = new EdmUntypedStructuredTypeReference(EdmUntypedStructuredType.Instance, true);
+
+        /// <summary>
+        /// Returns a static instance of a non-nullable untyped structured type reference.
+        /// </summary>
+        public static readonly IEdmStructuredTypeReference NonNullableTypeReference = new EdmUntypedStructuredTypeReference(EdmUntypedStructuredType.Instance, false);
+
+        /// <summary>
         /// Constructor
         /// </summary>
         /// <param name="definition">IEdmStructuredType definition.</param>
         public EdmUntypedStructuredTypeReference(IEdmStructuredType definition)
-            : base(definition, true)
+            : this(definition, true)
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="definition">IEdmStructuredType definition.</param>
+        /// <param name="isNullable">Denotes whether the type can be nullable.</param>
+        public EdmUntypedStructuredTypeReference(IEdmStructuredType definition, bool isNullable)
+            : base(definition, isNullable)
         {
         }
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

*When ODL reads an untyped value (for example, in a collection of untyped) that has a type specified, it fails because it doesn't understand that untyped can be cast to any type.  This PR adds support for specifying the type for an untyped value.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
