### PR TITLE
Import vocabulary annotations declared in external referenced models

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
@@ -525,7 +525,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             CsdlSemanticsSchema schemaWrapper = new CsdlSemanticsSchema(this, schema);
             this.schemata.Add(schemaWrapper);
 
-            AddSchemaElements(schema, schemaWrapper);
+            AddSchemaElements(schemaWrapper);
 
             if (!string.IsNullOrEmpty(schema.Alias))
             {
@@ -566,7 +566,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
             if (shouldAddSchemaElements)
             {
-                AddSchemaElements(schema, schemaWrapper);
+                AddSchemaElements(schemaWrapper);
             }
 
             if (includeAnnotationsIndex.Count > 0)
@@ -708,7 +708,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             CsdlSemanticsSchema schemaWrapper,
             Dictionary<string, List<IEdmIncludeAnnotations>> includeAnnotationsIndex)
         {
-            if (includeAnnotationsIndex?.Count == 0)
+            if (includeAnnotationsIndex != null && includeAnnotationsIndex.Count == 0)
             {
                 return;
             }

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
@@ -115,9 +115,11 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             {
                 string schemaNamespace = schema.Namespace;
                 IEdmInclude edmInclude = referencedCsdlModel.ParentModelReferences.SelectMany(s => s.Includes).FirstOrDefault(s => s.Namespace == schemaNamespace);
-                if (edmInclude != null)
+                bool includeAnnotations = referencedCsdlModel.ParentModelReferences.SelectMany(s => s.IncludeAnnotations).Any();
+                if (edmInclude != null || includeAnnotations)
                 {
-                    this.AddSchema(schema, false /*addAnnotations*/);
+                    this.AddSchema(schema, includeAnnotations);
+                    //this.AddSchema(schema, false);
                 }
 
                 // TODO: REF add annotations
@@ -602,6 +604,11 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             {
                 this.SetEdmVersion(schema.Version);
             }
+        }
+
+        private void AddOutOfLineAnnotationsFromSchema(CsdlSchema schema)
+        {
+
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
@@ -613,8 +613,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
         private CsdlAnnotations FilterIncludedAnnotations(CsdlAnnotations csdlAnnotations, string target, IEnumerable<IEdmIncludeAnnotations> includeAnnotations)
         {
-            
-            if (includeAnnotations == null && !includeAnnotations.Any())
+            if (includeAnnotations == null || !includeAnnotations.Any())
             {
                 return csdlAnnotations;
             }
@@ -634,7 +633,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                 (this.ReplaceAlias(annotation.Term).StartsWith(include.TermNamespace, System.StringComparison.Ordinal))
                     && (string.IsNullOrEmpty(include.Qualifier) || annotation.Qualifier == include.Qualifier)
                     && (string.IsNullOrEmpty(include.TargetNamespace)
-                        ||target.StartsWith(include.TargetNamespace, System.StringComparison.Ordinal))
+                        || target.StartsWith(include.TargetNamespace, System.StringComparison.Ordinal))
             );
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
@@ -1219,7 +1220,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
         {
             string xml = "<?xml version=\"1.0\" encoding=\"utf-16\"?><edmx:Edmx Version=\"" + odataVersion + "\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\"><edmx:DataServices /></edmx:Edmx>";
 
-            var stringReader = new System.IO.StringReader(xml);
+            var stringReader = new StringReader(xml);
             var xmlReader = System.Xml.XmlReader.Create(stringReader);
 
             IEdmModel edmModel = null;
@@ -1319,12 +1320,12 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Func<Uri, XmlReader> getReferenceModelReader = uri =>
             {
                 string csdl = uri.OriginalString == "SimplePermissions.xml" ? permissionsCsdl : mainCsdl;
-                var stringReader = new System.IO.StringReader(permissionsCsdl);
+                var stringReader = new StringReader(csdl);
                 return XmlReader.Create(stringReader);
             };
 
 
-            var reader = XmlReader.Create(new System.IO.StringReader(mainCsdl));
+            var reader = XmlReader.Create(new StringReader(mainCsdl));
             IEdmModel model = CsdlReader.Parse(reader, getReferencedModelReaderFunc: getReferenceModelReader);
 
             var entitySet = model.FindDeclaredEntitySet("Products");
@@ -1441,12 +1442,12 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Func<Uri, XmlReader> getReferenceModelReader = uri =>
             {
                 string csdl = uri.OriginalString == "SimplePermissions.xml" ? permissionsCsdl : mainCsdl;
-                var stringReader = new System.IO.StringReader(permissionsCsdl);
+                var stringReader = new StringReader(csdl);
                 return XmlReader.Create(stringReader);
             };
 
 
-            var reader = XmlReader.Create(new System.IO.StringReader(mainCsdl));
+            var reader = XmlReader.Create(new StringReader(mainCsdl));
             IEdmModel model = CsdlReader.Parse(reader, getReferencedModelReaderFunc: getReferenceModelReader);
             
             var entitySet = model.FindDeclaredEntitySet("Products");
@@ -1466,6 +1467,87 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Assert.NotNull(productAnnotation);
         }
 
-        
+        [Fact]
+        public void ImportAnnotationsFromExternalNamespaceWithAlias()
+        {
+            string permissionsCsdl = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:Reference  Uri=""SimpleModel.xml"">
+    <edmx:Include Namespace=""Default""/>
+    <edmx:Include Namespace=""Example.Types"" Alias=""examples"" />
+  </edmx:Reference >
+  <edmx:DataServices>
+    <Schema Namespace=""Example.Permissions"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <Annotations Target=""examples.Product"">
+         <Annotation Term=""MyNS.SomeAnnotationPath"" AnnotationPath=""abc/efg"" />
+      </Annotations>
+      <Annotations Target=""Default.Container/Products"">
+        <Annotation Term=""MyNS.MyAnnotationPathTerm"" AnnotationPath=""abc/efg"" />
+        <Annotation Term=""Org.OData.Capabilities.V1.InsertRestrictions"">
+          <Record>
+            <PropertyValue Property=""Permissions"">
+              <Collection>
+                <Record>
+                  <PropertyValue Property=""SchemeName"" String=""Scheme"" />
+                  <PropertyValue Property=""Scopes"">
+                    <Collection>
+                      <Record>
+                        <PropertyValue Property=""Scope"" String=""Product.Create"" />
+                      </Record>
+                    </Collection>
+                  </PropertyValue>
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+      </Annotations>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>
+";
+            string mainCsdl = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:Reference  Uri=""SimplePermissions.xml"">
+    <edmx:IncludeAnnotations TermNamespace=""MyNS"" TargetNamespace=""Example.Types"" />
+  </edmx:Reference >
+  <edmx:DataServices>
+    <Schema Namespace=""Example.Types"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Product"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""Name"" Type=""Edm.String"" />
+        <Property Name=""Price"" Type=""Edm.Int32"" Nullable=""false"" />
+      </EntityType>
+    </Schema>
+    <Schema Namespace=""Default"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityContainer Name=""Container"">
+        <EntitySet Name=""Products"" EntityType=""Example.Types.Product"" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>
+";
+
+            Func<Uri, XmlReader> getReferenceModelReader = uri =>
+            {
+                string csdl = uri.OriginalString == "SimplePermissions.xml" ? permissionsCsdl : mainCsdl;
+                var stringReader = new StringReader(csdl);
+                return XmlReader.Create(stringReader);
+            };
+
+
+            var reader = XmlReader.Create(new StringReader(mainCsdl));
+            IEdmModel model = CsdlReader.Parse(reader, getReferencedModelReaderFunc: getReferenceModelReader);
+
+            var entity = model.FindDeclaredType("Example.Types.Product");
+            var entityAnnotations = model.FindVocabularyAnnotations(entity);
+            Assert.Single(entityAnnotations);
+
+            IEdmVocabularyAnnotation annotation = entityAnnotations.First(a => a.Term.Name == "SomeAnnotationPath");
+            Assert.NotNull(annotation);
+        }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -1243,6 +1243,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
   <edmx:DataServices>
     <Schema Namespace=""ODataAuthorizationDemo.Models"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
       <Annotations Target=""Default.Container/Products"">
+        <Annotation Term=""NotIncludedNS.MyAnnotationPathTerm"" AnnotationPath=""abc/efg"" />
         <Annotation Term=""Org.OData.Capabilities.V1.InsertRestrictions"">
           <Record>
             <PropertyValue Property=""Permissions"">
@@ -1253,6 +1254,24 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                     <Collection>
                       <Record>
                         <PropertyValue Property=""Scope"" String=""Product.Create"" />
+                      </Record>
+                    </Collection>
+                  </PropertyValue>
+                </Record>
+              </Collection>
+            </PropertyValue>
+          </Record>
+        </Annotation>
+        <Annotation Term=""Org.OData.Capabilities.V1.DeleteRestrictions"">
+          <Record>
+            <PropertyValue Property=""Permissions"">
+              <Collection>
+                <Record>
+                  <PropertyValue Property=""SchemeName"" String=""Scheme"" />
+                  <PropertyValue Property=""Scopes"">
+                    <Collection>
+                      <Record>
+                        <PropertyValue Property=""Scope"" String=""Product.Delete"" />
                       </Record>
                     </Collection>
                   </PropertyValue>
@@ -1304,7 +1323,24 @@ namespace Microsoft.OData.Edm.Tests.Csdl
 
             var entitySet = model.FindDeclaredEntitySet("Products");
             var annotations = model.FindVocabularyAnnotations(entitySet);
-            Assert.NotNull(annotations.First(a => a.Term.Name == "InsertRestrictions"));
+            Assert.Equal(2, annotations.Count());
+
+            // only imports annotations terms in the Org.OData.Capabilities.V1 namespace
+            IEdmVocabularyAnnotation insertRestrictions = annotations.First(a => a.Term.Name == "InsertRestrictions");
+            Assert.NotNull(insertRestrictions);
+            IEdmVocabularyAnnotation deleteRestrictions = annotations.First(a => a.Term.Name == "DeleteRestrictions");
+            Assert.NotNull(deleteRestrictions);
+
+            IEdmRecordExpression record = insertRestrictions.Value as IEdmRecordExpression;
+            Assert.NotNull(record);
+            var insertPermissions = record.FindProperty("Permissions").Value as IEdmCollectionExpression;
+            Assert.NotNull(insertPermissions);
+
+            var permission = insertPermissions.Elements.First() as IEdmRecordExpression;
+            Assert.NotNull(permission);
+            var scheme = permission.FindProperty("SchemeName");
+            Assert.NotNull(scheme);
+            Assert.Equal("Scheme", ((IEdmStringConstantExpression)scheme.Value).Value);
         }
 
         

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -1607,7 +1607,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       </EntityType>
     </Schema>
     <Schema Namespace=""Other.Types"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
-        <EntitType Name=""Person"">
+        <EntityType Name=""Person"">
           <Key>
             <PropertyRef Name=""Id"" />
           </Key>
@@ -1638,6 +1638,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             var container = model.FindEntityContainer("Default.Container");
             Assert.NotNull(container);
 
+            // this is not imported because the Other.Types namespace is not referenced by the permissionsCsdl model
             var personType = model.FindType("Other.Types.Person");
             Assert.Null(personType);
         }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -1242,6 +1242,12 @@ namespace Microsoft.OData.Edm.Tests.Csdl
   </edmx:Reference >
   <edmx:DataServices>
     <Schema Namespace=""Example.Permissions"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""BasicType"">
+        <Key>
+          <PropertyRef Name=""Id"" />
+        </Key>
+        <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+      </EntityType>
       <Annotations Target=""Default.Container/Products"">
         <Annotation Term=""NotIncludedNS.MyAnnotationPathTerm"" AnnotationPath=""abc/efg"" />
         <Annotation Term=""Org.OData.Capabilities.V1.InsertRestrictions"">
@@ -1341,6 +1347,11 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             var scheme = permission.FindProperty("SchemeName");
             Assert.NotNull(scheme);
             Assert.Equal("Scheme", ((IEdmStringConstantExpression)scheme.Value).Value);
+
+            // do not import other schema elements since there's
+            // no explicit <edmx:Include Namespace="Example.Permissions" /> declaration
+            var basicType = model.FindType("Example.Permissions.BasicType");
+            Assert.Null(basicType);
         }
 
         [Fact]
@@ -1437,12 +1448,13 @@ namespace Microsoft.OData.Edm.Tests.Csdl
 
             var reader = XmlReader.Create(new System.IO.StringReader(mainCsdl));
             IEdmModel model = CsdlReader.Parse(reader, getReferencedModelReaderFunc: getReferenceModelReader);
-
+            
             var entitySet = model.FindDeclaredEntitySet("Products");
             var entitySetAnnotations = model.FindVocabularyAnnotations(entitySet);
             Assert.Single(entitySetAnnotations);
 
-            // only imports annotation terms in the Org.OData.Capabilities.V1 namespace that match the qualifier Insert
+
+            // imports annotation terms in the Org.OData.Capabilities.V1 namespace that match the qualifier Insert
             IEdmVocabularyAnnotation insertRestrictions = entitySetAnnotations.FirstOrDefault(a => a.Term.Name == "InsertRestrictions");
             Assert.NotNull(insertRestrictions);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fix #1936 

### Description

Includes annotations referenced in the `edmx:IncludeAnnotations` tag of the `edmx:Reference` to be included when loading external referenced models.

This makes the vocabulary annotations imported from referenced models available through:
```c#
IEnumerable<IEdmVocabularyAnnotation> annotations = model.FindVocabularyAnnotations(element);
```
or
```c#
IEnumerable<IEdmVocabularyAnnotation> annotations = element.VocabularyAnnotations(model);
```

**Note**, these external vocabulary annotations will not appear in `model.FindDeclaredVocabularyAnnotations(element)`  or `model.VocabularyAnnotations` since they only return the annotations declared directly in the current model.

This PR attempts to restrict the imported annotations based on the `TermNamespace`, `TargetNamespace` and `Qualifier` 
as specified in the specification: http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_IncludedAnnotations

Assuming the main model has the following reference:
```xml
<edmx:Reference  Uri=""SimplePermissions.xml"">
    <edmx:IncludeAnnotations  TermNamespace=""Org.OData.Capabilities.V1"" Qualifier=""Insert""/>
    <edmx:IncludeAnnotations  TermNamespace=""OtherIncludedNS"" TargetNamespace=""Example.Types""/>
</edmx:Reference>
```

then this feature will import vocabulary annotations from the `SimplePermissions.xml` csdl which meet either of the following criteria:
- The annotation's term is in the namespace `Org.OData.Capabilities.V1` namespace and it has the qualifier `Insert`
- The annotation's term is in the namespace `OtherIncludedNS` and it's target element is in the namespace `Example.Types`

Other vocabulary annotations in the referenced csdl will be skipped.

**Note**: This restriction only applies to "out of line" annotations, i.e. annotations with are declared inside of a top-level `<Annotations>` element rather than being declared directly inside ("in-line") the target element.


**Note**: If the reference only has `edmx:IncludeAnnotations` declarations, but not `edmx:Include` declaration (http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_IncludedSchema), then this feature will only vocabulary annotations from the referenced models and exclude other schema elements like entity types, operations, etc.


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
