### PR TITLE
Retrieve the content type for stream property from vocabulary annotation by convention

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/IODataResourceMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/IODataResourceMetadataContext.cs
@@ -28,6 +28,11 @@ namespace Microsoft.OData.Evaluation
         IODataResourceTypeContext TypeContext { get; }
 
         /// <summary>
+        /// The actual structured type of the resource.
+        /// </summary>
+        IEdmStructuredType ActualResourceType { get; }
+
+        /// <summary>
         /// The actual structured type of the resource, i.e. ODataResource.TypeName.
         /// </summary>
         string ActualResourceTypeName { get; }

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
@@ -235,12 +235,15 @@ namespace Microsoft.OData.Evaluation
 
                 // from OData spec: Media entity types MAY specify a list of acceptable media types using an annotation with term Core.AcceptableMediaTypes
                 IEdmEntityType entityType = this.ResourceMetadataContext.ActualResourceType as IEdmEntityType;
-                var mediaTypes = this.MetadataContext.Model.GetVocabularyStringCollection(entityType, CoreVocabularyModel.AcceptableMediaTypesTerm);
-                if (mediaTypes.Count() == 1)
+                if (entityType != null)
                 {
-                    // Be noted: AcceptableMediaTypes might have more than one media type,
-                    // Convention (default) behavior only works if AcceptableMediaTypes is a collection of one.
-                    this.computedMediaResource.ContentType = mediaTypes.ElementAt(0);
+                    var mediaTypes = this.MetadataContext.Model.GetVocabularyStringCollection(entityType, CoreVocabularyModel.AcceptableMediaTypesTerm);
+                    if (mediaTypes.Count() == 1)
+                    {
+                        // Be noted: AcceptableMediaTypes might have more than one media type,
+                        // Convention (default) behavior only works if AcceptableMediaTypes is a collection of one.
+                        this.computedMediaResource.ContentType = mediaTypes.ElementAt(0);
+                    }
                 }
             }
 

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
@@ -11,6 +11,7 @@ namespace Microsoft.OData.Evaluation
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
     using System.Text;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Edm.Vocabularies.V1;
@@ -235,10 +236,11 @@ namespace Microsoft.OData.Evaluation
                 // from OData spec: Media entity types MAY specify a list of acceptable media types using an annotation with term Core.AcceptableMediaTypes
                 IEdmEntityType entityType = this.ResourceMetadataContext.ActualResourceType as IEdmEntityType;
                 var mediaTypes = this.MetadataContext.Model.GetVocabularyStringCollection(entityType, CoreVocabularyModel.AcceptableMediaTypesTerm);
-                if (mediaTypes != null)
+                if (mediaTypes.Count() == 1)
                 {
-                    // TODO: Make sure we use ',' to concatant the multiple media types or pick the first one?
-                    this.computedMediaResource.ContentType = string.Join(",", mediaTypes);
+                    // Be noted: AcceptableMediaTypes might have more than one media type,
+                    // Convention (default) behavior only works if AcceptableMediaTypes is a collection of one.
+                    this.computedMediaResource.ContentType = mediaTypes.ElementAt(0);
                 }
             }
 
@@ -440,10 +442,11 @@ namespace Microsoft.OData.Evaluation
                         // by default, let's retrieve the content type from vocabulary annotation
                         var edmProperty = projectedStreamProperties[missingStreamPropertyName];
                         var mediaTypes = this.MetadataContext.Model.GetVocabularyStringCollection(edmProperty, CoreVocabularyModel.AcceptableMediaTypesTerm);
-                        if (mediaTypes != null)
+                        if (mediaTypes.Count() == 1)
                         {
-                            // TODO: Make sure we use ',' to concatant the multiple media types or pick the first one?
-                            streamPropertyValue.ContentType = string.Join(",", mediaTypes);
+                            // Be noted: AcceptableMediaTypes might have more than one media type,
+                            // Convention (default) behavior only works if AcceptableMediaTypes is a collection of one.
+                            streamPropertyValue.ContentType = mediaTypes.ElementAt(0);
                         }
 
                         this.computedStreamProperties.Add(new ODataProperty { Name = missingStreamPropertyName, Value = streamPropertyValue });

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalResourceMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalResourceMetadataBuilder.cs
@@ -12,6 +12,7 @@ namespace Microsoft.OData.Evaluation
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using Microsoft.OData.Edm.Vocabularies.V1;
     using Microsoft.OData.JsonLight;
     #endregion
 
@@ -428,13 +429,23 @@ namespace Microsoft.OData.Evaluation
                 string propertyName = unprocessedStreamProperties.Current;
                 ODataStreamReferenceValue streamPropertyValue = new ODataStreamReferenceValue();
                 streamPropertyValue.SetMetadataBuilder(this, propertyName);
+
+                // by default, let's retrieve the content type from vocabulary annotation
+                var edmProperty = this.ResourceMetadataContext.SelectedStreamProperties[propertyName];
+                var mediaTypes = this.MetadataContext.Model.GetVocabularyStringCollection(edmProperty, CoreVocabularyModel.AcceptableMediaTypesTerm);
+                if (mediaTypes != null)
+                {
+                    // TODO: Make sure we use ',' to concatant the multiple media types or pick the first one?
+                    streamPropertyValue.ContentType = string.Join(",", mediaTypes);
+                }
+
                 return new ODataProperty { Name = propertyName, Value = streamPropertyValue };
             }
 
             return null;
         }
 
-        //// Stream content type and ETag can't be computed from conventions.
+        //// Stream content type and ETag can't be computed from conventions, but it can retrieve from the vocabulary annoation?
 
         /// <summary>
         /// Gets the navigation link URI for the specified navigation property.

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalResourceMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalResourceMetadataBuilder.cs
@@ -433,10 +433,11 @@ namespace Microsoft.OData.Evaluation
                 // by default, let's retrieve the content type from vocabulary annotation
                 var edmProperty = this.ResourceMetadataContext.SelectedStreamProperties[propertyName];
                 var mediaTypes = this.MetadataContext.Model.GetVocabularyStringCollection(edmProperty, CoreVocabularyModel.AcceptableMediaTypesTerm);
-                if (mediaTypes != null)
+                if (mediaTypes.Count() == 1)
                 {
-                    // TODO: Make sure we use ',' to concatant the multiple media types or pick the first one?
-                    streamPropertyValue.ContentType = string.Join(",", mediaTypes);
+                    // Be noted: AcceptableMediaTypes might have more than one media type,
+                    // Convention (default) behavior only works if AcceptableMediaTypes is a collection of one.
+                    streamPropertyValue.ContentType = mediaTypes.ElementAt(0);
                 }
 
                 return new ODataProperty { Name = propertyName, Value = streamPropertyValue };

--- a/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
@@ -90,6 +90,11 @@ namespace Microsoft.OData.Evaluation
         }
 
         /// <summary>
+        /// The actual structured type of the resource.
+        /// </summary>
+        public IEdmStructuredType ActualResourceType { get; set; }
+
+        /// <summary>
         /// The actual structured type of the resource, i.e. ODataResource.TypeName.
         /// </summary>
         public abstract string ActualResourceTypeName { get; }
@@ -143,10 +148,16 @@ namespace Microsoft.OData.Evaluation
         {
             if (serializationInfo != null)
             {
-                return new ODataResourceMetadataContextWithoutModel(resource, typeContext, serializationInfo, requiresId);
+                return new ODataResourceMetadataContextWithoutModel(resource, typeContext, serializationInfo, requiresId)
+                {
+                    ActualResourceType = actualResourceType
+                };
             }
 
-            return new ODataResourceMetadataContextWithModel(resource, typeContext, actualResourceType, metadataContext, selectedProperties, metadataSelector, requiresId);
+            return new ODataResourceMetadataContextWithModel(resource, typeContext, actualResourceType, metadataContext, selectedProperties, metadataSelector, requiresId)
+            {
+                ActualResourceType = actualResourceType
+            };
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Vocabularies/VocabularyAnnotationExtensions.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/VocabularyAnnotationExtensions.cs
@@ -1,0 +1,44 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="VocabularyAnnotationExtensions.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.OData.Edm.Vocabularies.V1
+{
+    /// <summary>
+    /// Extension methods for the vocabulary annotations.
+    /// </summary>
+    public static class VocabularyAnnotationExtensions
+    {
+        /// <summary>
+        /// Gets the collection of string for a target annotatable.
+        /// </summary>
+        /// <param name="model">The model referenced to.</param>
+        /// <param name="target">The target annotatable to find annotation.</param>
+        /// <param name="term">The target annotatable to find annotation.</param>
+        /// <returns>Null or a collection string of qualified type name.</returns>
+        public static IEnumerable<string> GetVocabularyStringCollection(this IEdmModel model, IEdmVocabularyAnnotatable target, IEdmTerm term)
+        {
+            if (model == null || target == null || term == null)
+            {
+                return null;
+            }
+
+            IEdmVocabularyAnnotation annotation = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(target, term).FirstOrDefault();
+            if (annotation != null)
+            {
+                IEdmCollectionExpression collectionExpression = annotation.Value as IEdmCollectionExpression;
+                if (collectionExpression != null && collectionExpression.Elements != null)
+                {
+                    return collectionExpression.Elements.OfType<IEdmStringConstantExpression>().Select(e => e.Value);
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Vocabularies/VocabularyAnnotationExtensions.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/VocabularyAnnotationExtensions.cs
@@ -23,10 +23,9 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
         /// <returns>Null or a collection string of qualified type name.</returns>
         public static IEnumerable<string> GetVocabularyStringCollection(this IEdmModel model, IEdmVocabularyAnnotatable target, IEdmTerm term)
         {
-            if (model == null || target == null || term == null)
-            {
-                return null;
-            }
+            EdmUtil.CheckArgumentNull(model, "model");
+            EdmUtil.CheckArgumentNull(target, "target");
+            EdmUtil.CheckArgumentNull(target, "term");
 
             IEdmVocabularyAnnotation annotation = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(target, term).FirstOrDefault();
             if (annotation != null)
@@ -38,7 +37,7 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
                 }
             }
 
-            return null;
+            return Enumerable.Empty<string>();
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataConventionalEntityMetadataBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataConventionalEntityMetadataBuilderTests.cs
@@ -1181,6 +1181,8 @@ namespace Microsoft.OData.Tests.Evaluation
         public IDictionary<string, IEdmStructuralProperty> SelectedStreamProperties { get; set; }
 
         public IEnumerable<IEdmOperation> SelectedBindableOperations { get; set; }
+
+        public IEdmStructuredType ActualResourceType { get; set; }
     }
 
     internal class TestFeedAndEntryTypeContext : IODataResourceTypeContext


### PR DESCRIPTION
…ion by default

<!-- markdownlint-disable MD002 MD041 -->

### Issues

OData spec says:

6.4 Media Entity Type
An entity type that does not specify a base type MAY specify that it is a media entity type. Media entities are entities that represent a media stream, such as a photo. Use a media entity if the out-of-band stream is the main topic of interest and the media entity is just additional structured information attached to the stream. Use a normal entity with one or more properties of type Edm.Stream if the structured data of the entity is the main topic of interest and the stream data is just additional information attached to the structured data. For more information on media entities see [OData‑Protocol].

An entity type derived from a media entity type MUST indicate that it is also a media entity type.

**Media entity types MAY specify a list of acceptable media types using an annotation with term Core.AcceptableMediaTypes, see [OData‑VocCore].**


and

**Stream properties MAY specify a list of acceptable media types using an annotation with term Core.AcceptableMediaTypes, see [OData-VocCore].**

This PR is indented to retrieve the media types from the vocabulary annotation.

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
