### PR TITLE
Expand TextWriterWrapper abstract class with equivalent async method

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonSharedUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonSharedUtils.cs
@@ -27,6 +27,16 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
+        /// Determines if the given float is serialized as a string in JSON.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <returns>true if the value should be written as a string, false if should be written as a JSON number.</returns>
+        internal static bool IsFloatValueSerializedAsString(float value)
+        {
+            return float.IsInfinity(value) || float.IsNaN(value);
+        }
+
+        /// <summary>
         /// Determines if the given primitive value is of a basic type where we can rely on just the JSON representation to convey type information.
         /// If so, we don't have to write the type name.
         /// </summary>

--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -742,13 +742,12 @@ namespace Microsoft.OData.Json
             Debug.Assert(value != null, "value != null");
             Debug.Assert(buffer != null, "buffer != null");
 
-            int length = bufferByteSize;
-            if (offsetIn + length > value.Length)
+            if (offsetIn + bufferByteSize > value.Length)
             {
-                length = value.Length - offsetIn;
+                bufferByteSize = value.Length - offsetIn;
             }
 
-            return Convert.ToBase64CharArray(value, offsetIn, length, buffer, 0);
+            return Convert.ToBase64CharArray(value, offsetIn, bufferByteSize, buffer, 0);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -1,0 +1,468 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="JsonValueUtils.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Json
+{
+    #region Namespaces
+    using System;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using Microsoft.OData.Buffers;
+    using Microsoft.OData.Edm;
+    #endregion Namespaces
+
+    /// <summary>
+    /// Provides helper method for converting data values to and from the OData JSON format.
+    /// </summary>
+    internal static partial class JsonValueUtils
+    {
+        /// <summary>
+        /// Write a char value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">The char value to write.</param>
+        /// <param name="stringEscapeOption">The ODataStringEscapeOption to use in escaping the string.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, char value, ODataStringEscapeOption stringEscapeOption)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            if (stringEscapeOption == ODataStringEscapeOption.EscapeNonAscii || value <= 0x7F)
+            {
+                string escapedString = SpecialCharToEscapedStringMap[value];
+                if (escapedString != null)
+                {
+                    await writer.WriteAsync(escapedString).ConfigureAwait(false);
+                    return;
+                }
+            }
+
+            await writer.WriteAsync(value).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a boolean value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">The boolean value to write.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, bool value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteAsync(FormatAsBooleanLiteral(value)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write an integer value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Integer value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, int value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a float value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Float value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, float value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            if (JsonSharedUtils.IsFloatValueSerializedAsString(value))
+            {
+                await writer.WriteQuotedAsync(value.ToString(ODataNumberFormatInfo)).ConfigureAwait(false);
+            }
+            else
+            {
+                // float.ToString() supports a max scale of six,
+                // whereas float.MinValue and float.MaxValue have 8 digits scale. Hence we need
+                // to use XmlConvert in all other cases, except infinity
+                await writer.WriteAsync(XmlConvert.ToString(value)).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Write a short value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Short value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, short value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a long value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Long value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, long value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a double value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Double value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, double value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            if (JsonSharedUtils.IsDoubleValueSerializedAsString(value))
+            {
+                await writer.WriteQuotedAsync(value.ToString(ODataNumberFormatInfo)).ConfigureAwait(false);
+            }
+            else
+            {
+                // double.ToString() supports a max scale of 14,
+                // whereas double.MinValue and double.MaxValue have 16 digits scale. Hence we need
+                // to use XmlConvert in all other cases, except infinity
+                string valueToWrite = XmlConvert.ToString(value);
+
+                await writer.WriteAsync(valueToWrite).ConfigureAwait(false);
+                if (valueToWrite.IndexOfAny(DoubleIndicatingCharacters) < 0)
+                {
+                    await writer.WriteAsync(".0").ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Write a Guid value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Guid value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, Guid value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteQuotedAsync(value.ToString()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a decimal value
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Decimal value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, decimal value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a DateTimeOffset value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">DateTimeOffset value to be written.</param>
+        /// <param name="dateTimeFormat">The format to write out the DateTime value in.</param>
+        [SuppressMessage("Microsoft.Globalization", "CA1303:Do not pass literals as localized parameters", MessageId = "Microsoft.OData.Json.JsonValueUtils.WriteQuotedAsync(System.IO.TextWriter,System.String)", Justification = "Constant defined by the JSON spec.")]
+        internal static async Task WriteValueAsync(this TextWriter writer, DateTimeOffset value, ODataJsonDateTimeFormat dateTimeFormat)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            switch (dateTimeFormat)
+            {
+                case ODataJsonDateTimeFormat.ISO8601DateTime:
+                    {
+                        // Uses the same format as DateTime but with offset:
+                        // jsonDateTime= quotation-mark
+                        //  YYYY-MM-DDThh:mm:ss.sTZD
+                        //  [("+" / "-") offset]
+                        //  quotation-mark
+                        //
+                        // offset = 4DIGIT
+                        string textValue = XmlConvert.ToString(value);
+                        await writer.WriteQuotedAsync(textValue).ConfigureAwait(false);
+                    }
+
+                    break;
+
+                case ODataJsonDateTimeFormat.ODataDateTime:
+                    {
+                        // Uses the same format as DateTime but with offset:
+                        // jsonDateTime= quotation-mark
+                        //  "\/Date("
+                        //  ticks
+                        //  [("+" / "-") offset]
+                        //  ")\/"
+                        //  quotation-mark
+                        //
+                        // ticks = *DIGIT
+                        // offset = 4DIGIT
+                        string textValue = FormatDateTimeAsJsonTicksString(value);
+                        await writer.WriteQuotedAsync(textValue).ConfigureAwait(false);
+                    }
+
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Write a TimeSpan value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">TimeSpan value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, TimeSpan value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteQuotedAsync(EdmValueWriter.DurationAsXml(value)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a TimeOfDay value
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">TimeOfDay value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, TimeOfDay value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteQuotedAsync(value.ToString()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a Date value
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Date value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, Date value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteQuotedAsync(value.ToString()).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a byte value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Byte value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, byte value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write an sbyte value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">SByte value to be written.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, sbyte value)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Write a string value.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">String value to be written.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
+        /// <param name="arrayPool">Array pool for renting a buffer.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, string value, ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool arrayPool = null)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            if (value == null)
+            {
+                await writer.WriteAsync(JsonConstants.JsonNullLiteral).ConfigureAwait(false);
+            }
+            else
+            {
+                await writer.WriteEscapedJsonStringAsync(value, stringEscapeOption, buffer, arrayPool).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Write a byte array.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Byte array to be written.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
+        /// <param name="arrayPool">Array pool for renting a buffer.</param>
+        internal static async Task WriteValueAsync(this TextWriter writer, byte[] value, Ref<char[]> buffer, ICharArrayPool arrayPool = null)
+        {
+            Debug.Assert(writer != null, "writer != null");
+
+            if (value == null)
+            {
+                await writer.WriteAsync(JsonConstants.JsonNullLiteral).ConfigureAwait(false);
+            }
+            else
+            {
+                await writer.WriteAsync(JsonConstants.QuoteCharacter).ConfigureAwait(false);
+                await writer.WriteBinaryStringAsync(value, buffer, arrayPool).ConfigureAwait(false);
+                await writer.WriteAsync(JsonConstants.QuoteCharacter).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Write a byte array.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="value">Byte array to be written.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
+        /// <param name="arrayPool">Array pool for renting a buffer.</param>
+        internal static async Task WriteBinaryStringAsync(this TextWriter writer, byte[] value, Ref<char[]> buffer, ICharArrayPool arrayPool)
+        {
+            Debug.Assert(writer != null, "writer != null");
+            Debug.Assert(value != null, "The value must not be null.");
+
+            buffer.Value = BufferUtils.InitializeBufferIfRequired(arrayPool, buffer.Value);
+            Debug.Assert(buffer.Value != null);
+
+            int bufferLength = buffer.Value.Length;
+
+            // Try to hold base64 string as much as possible in one converting.
+            int bufferByteSize = bufferLength * 3 / 4;
+
+            for (int offsetIn = 0; offsetIn < value.Length; offsetIn += bufferByteSize)
+            {
+                int count = WriteByteArrayToBuffer(value, offsetIn, buffer.Value, bufferByteSize);
+                await writer.WriteAsync(buffer.Value, 0, count).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Returns the string value with special characters escaped.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="inputString">Input string value.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
+        /// <param name="bufferPool">Array pool for renting a buffer.</param>
+        internal static async Task WriteEscapedJsonStringAsync(this TextWriter writer, string inputString,
+            ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool = null)
+        {
+            Debug.Assert(writer != null, "writer != null");
+            Debug.Assert(inputString != null, "The string value must not be null.");
+
+            await writer.WriteAsync(JsonConstants.QuoteCharacter).ConfigureAwait(false);
+            await writer.WriteEscapedJsonStringValueAsync(inputString, stringEscapeOption, buffer, bufferPool).ConfigureAwait(false);
+            await writer.WriteAsync(JsonConstants.QuoteCharacter).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Writes the string value with special characters escaped.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="inputString">Input string value.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
+        /// <param name="bufferPool">Array pool for renting a buffer.</param>
+        internal static async Task WriteEscapedJsonStringValueAsync(this TextWriter writer, string inputString,
+            ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool)
+        {
+            Debug.Assert(writer != null, "writer != null");
+            Debug.Assert(inputString != null, "The string value must not be null.");
+
+            int firstIndex;
+            if (!CheckIfStringHasSpecialChars(inputString, stringEscapeOption, out firstIndex))
+            {
+                await writer.WriteAsync(inputString).ConfigureAwait(false);
+            }
+            else
+            {
+                Debug.Assert(firstIndex < inputString.Length, "First index of the special character should be within the string");
+                buffer.Value = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer.Value);
+                int bufferLength = buffer.Value.Length;
+                int bufferIndex = 0;
+                int currentIndex = 0;
+
+                // Let's copy and flush strings up to the first index of the special char
+                while (currentIndex < firstIndex)
+                {
+                    int substrLength = firstIndex - currentIndex;
+
+                    Debug.Assert(substrLength > 0, "SubStrLength should be greater than 0 always");
+
+                    // If the first index of the special character is larger than the buffer length,
+                    // flush everything to the buffer first and reset the buffer to the next chunk.
+                    // Otherwise copy to the buffer and go on from there.
+                    if (substrLength >= bufferLength)
+                    {
+                        inputString.CopyTo(currentIndex, buffer.Value, 0, bufferLength);
+                        await writer.WriteAsync(buffer.Value, 0, bufferLength).ConfigureAwait(false);
+                        currentIndex += bufferLength;
+                    }
+                    else
+                    {
+                        WriteSubstringToBuffer(inputString, ref currentIndex, buffer.Value, ref bufferIndex, substrLength);
+                    }
+                }
+
+                // Write escaped string to buffer
+                WriteEscapedStringToBuffer(writer, inputString, ref currentIndex, buffer.Value, ref bufferIndex, stringEscapeOption);
+
+                // write any remaining chars to the writer
+                if (bufferIndex > 0)
+                {
+                    await writer.WriteAsync(buffer.Value, 0, bufferIndex).ConfigureAwait(false);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Escapes and writes a character array to a writer.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="inputArray">Character array to write.</param>
+        /// <param name="inputArrayOffset">How many characters to skip in the input array.</param>
+        /// <param name="inputArrayCount">How many characters to write from the input array.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
+        /// <param name="bufferPool">Character buffer pool.</param>
+        internal static async Task WriteEscapedCharArrayAsync(this TextWriter writer, char[] inputArray, int inputArrayOffset, int inputArrayCount, ODataStringEscapeOption stringEscapeOption, ICharArrayPool bufferPool)
+        {
+            int bufferIndex = 0;
+            char[] buffer = null;
+
+            buffer = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer);
+            
+            WriteEscapedCharArrayToBuffer(writer, inputArray, ref inputArrayOffset, inputArrayCount, buffer, ref bufferIndex, stringEscapeOption);
+
+            // write remaining bytes in buffer
+            if (bufferIndex > 0)
+            {
+                await writer.WriteAsync(buffer, 0, bufferIndex).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Write the string value with quotes.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="text">String value to be written.</param>
+        private static async Task WriteQuotedAsync(this TextWriter writer, string text)
+        {
+            await writer.WriteAsync(
+                JsonConstants.QuoteCharacter + text + JsonConstants.QuoteCharacter)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -461,7 +461,7 @@ namespace Microsoft.OData.Json
         private static async Task WriteQuotedAsync(this TextWriter writer, string text)
         {
             await writer.WriteAsync(
-                JsonConstants.QuoteCharacter + text + JsonConstants.QuoteCharacter)
+                string.Concat(JsonConstants.QuoteCharacter, text, JsonConstants.QuoteCharacter))
                 .ConfigureAwait(false);
         }
     }

--- a/src/Microsoft.OData.Core/Json/NonIndentedTextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/NonIndentedTextWriter.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 using System.IO;
+using System.Threading.Tasks;
 
 namespace Microsoft.OData.Json
 {
@@ -33,6 +34,16 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
+        /// Writes the given string value to the underlying writer asynchronously.
+        /// </summary>
+        /// <param name="s">String value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        public override async Task WriteAsync(string s)
+        {
+            await this.writer.WriteAsync(s).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Writes the given char value to the underlying writer.
         /// </summary>
         /// <param name="value">Char value to be written.</param>
@@ -42,10 +53,30 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
+        /// Writes the given char value to the underlying writer asynchronously.
+        /// </summary>
+        /// <param name="value">Char value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        public override async Task WriteAsync(char value)
+        {
+            await this.writer.WriteAsync(value).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Writes a new line.
         /// </summary>
         public override void WriteLine()
         {
+        }
+
+        /// <summary>
+        /// Writes a new line asynchronously.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait has no effect on already completed task.")]
+        public override async Task WriteLineAsync()
+        {
+            await TaskUtils.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OData.Core/Json/TextWriterWrapper.cs
+++ b/src/Microsoft.OData.Core/Json/TextWriterWrapper.cs
@@ -11,6 +11,7 @@ namespace Microsoft.OData.Json
     using System.Diagnostics;
     using System.IO;
     using System.Text;
+    using System.Threading.Tasks;
     #endregion Namespaces
 
     /// <summary>
@@ -74,6 +75,33 @@ namespace Microsoft.OData.Json
         public override void Flush()
         {
             this.writer.Flush();
+        }
+
+
+        /// <summary>
+        /// Increases the level of indentation applied to the output asynchronously.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait has no effect on already completed task.")]
+        public virtual async Task IncreaseIndentationAsync()
+        {
+            await TaskUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Decreases the level of indentation applied to the output asynchronously.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait has no effect on already completed task.")]
+        public virtual async Task DecreaseIndentationAsync()
+        {
+            await TaskUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Clears the buffer of the current writer asynchronously.
+        /// </summary>
+        public override async Task FlushAsync()
+        {
+            await this.writer.FlushAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/RefOfT.cs
+++ b/src/Microsoft.OData.Core/RefOfT.cs
@@ -1,0 +1,36 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="RefOfT.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData
+{
+    /// <summary>
+    /// Asynchronous methods do not support ref and out parameters.
+    /// This class provides a workaround to enable passing around
+    /// of the value in an object.
+    /// </summary>
+    /// <typeparam name="T">The type of object wrapped in the object.</typeparam>
+    internal sealed class Ref<T>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ref{T}"/> class.
+        /// </summary>
+        public Ref() : this(default(T)) {}
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Ref{T}"/> class with value to be wrapped.
+        /// </summary>
+        /// <param name="value">The value to be wrapped.</param>
+        public Ref(T value)
+        {
+            this.Value = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the value wrapped in the object.
+        /// </summary>
+        public T Value { get; set; }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsAsyncTests.cs
@@ -1,0 +1,326 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="JsonValueUtilsAsyncTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.OData.Json;
+using Xunit;
+
+namespace Microsoft.OData.Tests.Json
+{
+    public class JsonValueUtilsAsyncTests
+    {
+        private MemoryStream stream;
+        private NonIndentedTextWriter writer;
+        private Ref<char[]> buffer;
+        private IDictionary<string, string> escapedCharMap;
+        private IDictionary<string, string> controlCharsMap;
+
+        public JsonValueUtilsAsyncTests()
+        {
+            controlCharsMap = new Dictionary<string, string>
+            {
+                {string.Format("{0}",(char)0),string.Format(CultureInfo.InvariantCulture, "\\u{0:x4}", 0)},
+                {"\r\n","\\r\\n"},
+                {"\r","\\r"},
+                {"\t","\\t"},
+                {"\"","\\\""},
+                {"\\","\\\\"},
+                {"\n","\\n"},
+                {"\b","\\b"},
+                {"\f","\\f"},
+            };
+
+            escapedCharMap = new Dictionary<string, string>
+            {
+                {string.Format("{0}",(char)0x80), string.Format(CultureInfo.InvariantCulture, "\\u{0:x4}", 0x80)},
+                {"и",  "\\u0438"}
+            };
+
+            foreach (var item in controlCharsMap)
+            {
+                escapedCharMap.Add(item);
+            }
+
+            // Ran before each test
+            this.Reset();
+        }
+
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        public async Task WriteEmptyStringShouldWork(ODataStringEscapeOption stringEscapeOption)
+        {
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Empty, stringEscapeOption, this.buffer);
+            Assert.Equal("\"\"", this.StreamToString());
+        }
+
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        public async Task WriteNonSpecialCharactersShouldWork(ODataStringEscapeOption stringEscapeOption)
+        {
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "abcdefg123", stringEscapeOption, this.buffer);
+            Assert.Equal("\"abcdefg123\"", this.StreamToString());
+        }
+
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        public async Task WriteLowSpecialCharactersShouldWorkForEscapeOption(ODataStringEscapeOption stringEscapeOption)
+        {
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_\n\r\b", stringEscapeOption, this.buffer);
+            Assert.Equal("\"cA_\\n\\r\\b\"", this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteHighSpecialCharactersShouldWorkForEscapeNonAsciiOption()
+        {
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeNonAscii, this.buffer);
+            Assert.Equal("\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\"", this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteHighSpecialCharactersShouldWorkForEscapeOnlyControlsOption()
+        {
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeOnlyControls, this.buffer);
+            Assert.Equal("\"cA_Россия\"", this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteSpecialCharactersShouldWork()
+        {
+            foreach (string specialChar in this.escapedCharMap.Keys)
+            {
+                this.Reset();
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
+                Assert.Equal(string.Format("\"{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Fact]
+        public async Task WriteSpecialCharactersAtStartOfStringShouldWork()
+        {
+            foreach (string specialChar in this.escapedCharMap.Keys)
+            {
+                this.Reset();
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}MiddleEnd", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
+                Assert.Equal(string.Format("\"{0}MiddleEnd\"", this.escapedCharMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Fact]
+        public async Task WriteSpecialCharactersAtMiddleOfStringShouldWork()
+        {
+            foreach (string specialChar in this.escapedCharMap.Keys)
+            {
+                this.Reset();
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("Start{0}End", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
+                Assert.Equal(string.Format("\"Start{0}End\"", this.escapedCharMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Fact]
+        public async Task WriteSpecialCharactersAtEndOfStringShouldWork()
+        {
+            foreach (string specialChar in this.escapedCharMap.Keys)
+            {
+                this.Reset();
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("StartMiddle{0}", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
+                Assert.Equal(string.Format("\"StartMiddle{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Fact]
+        public async Task WriteMultipleSpecialCharactersShouldWork()
+        {
+            foreach (string specialChar in this.escapedCharMap.Keys)
+            {
+                this.Reset();
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}Start{0}Middle{0}End", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
+                Assert.Equal(string.Format("\"{0}Start{0}Middle{0}End\"", this.escapedCharMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Fact]
+        public async Task WriteSpecialCharactersAtStartOfBufferLengthShouldWork()
+        {
+            foreach (string specialChar in this.escapedCharMap.Keys)
+            {
+                this.Reset();
+                Ref<char[]> charBuffer = new Ref<char[]>(new char[10]);
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("StartMiddle{0}End", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, charBuffer);
+                Assert.Equal(string.Format("\"StartMiddle{0}End\"", this.escapedCharMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Fact]
+        public async Task WriteMultipleSpecialCharactersAtEndOfBufferLengthShouldWork()
+        {
+            foreach (string specialChar in this.escapedCharMap.Keys)
+            {
+                this.Reset();
+                Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("Start{0}Middle{0}End{0}", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, charBuffer);
+                Assert.Equal(string.Format("\"Start{0}Middle{0}End{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Fact]
+        public async Task WriteSpecialCharactersAtEndOfBufferLengthShouldWork()
+        {
+            foreach (string specialChar in this.escapedCharMap.Keys)
+            {
+                this.Reset();
+                Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("Start{0}", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, charBuffer);
+                Assert.Equal(string.Format("\"Start{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        public async Task WriteControllCharactersWithStringEscapeOptionShouldWork(ODataStringEscapeOption escapeOption)
+        {
+            foreach (string specialChar in this.controlCharsMap.Keys)
+            {
+                this.Reset();
+                Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("S{0}M{0}E{0}", specialChar),
+                    escapeOption, charBuffer);
+                Assert.Equal(string.Format("\"S{0}M{0}E{0}\"", this.controlCharsMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        public async Task WriteStringWithNoSpecialCharShouldLeaveBufferUntouched(ODataStringEscapeOption stringEscapeOption)
+        {
+            this.Reset();
+            Ref<char[]> charBuffer = new Ref<char[]>(null);
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "StartMiddleEnd", stringEscapeOption, charBuffer);
+            Assert.Equal("\"StartMiddleEnd\"", this.StreamToString());
+            Assert.Null(charBuffer.Value);
+        }
+
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        public async Task WriteStringShouldIgnoreExistingContentsOfTheBuffer(ODataStringEscapeOption stringEscapeOption)
+        {
+            Ref<char[]> charBuffer = new Ref<char[]>(new char[128]);
+            for (int index = 0; index < 128; index++)
+            {
+                charBuffer.Value[index] = (char)index;
+            }
+
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "StartVeryVeryLongMiddleEnd", stringEscapeOption, charBuffer);
+            Assert.Equal("\"StartVeryVeryLongMiddleEnd\"", this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteByteShouldWork()
+        {
+            var byteArray = new byte[] { 1, 2, 3 };
+            await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
+            Assert.Equal("\"AQID\"", this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteLongBytesShouldWork()
+        {
+            // Arrange
+            byte[] byteArray = new byte[1000];
+            for (int i = 0; i < byteArray.Length; i++)
+            {
+                byteArray[i] = (byte)(i % 255);
+            }
+
+            // Act, Get Base64 string from OData library
+            await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
+            string convertedBase64String = this.StreamToString();
+
+            // Get Base64 string directly calling the converter.
+            string actualBase64String = JsonConstants.QuoteCharacter + Convert.ToBase64String(byteArray) + JsonConstants.QuoteCharacter;
+
+            // Assert
+            Assert.Equal(convertedBase64String, actualBase64String);
+            Assert.Equal("\"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6uvs7e7v8PHy8/T19vf4+fr7/P3+AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+P0BBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWltcXV5fYGFiY2RlZmdoaWprbG1ub3BxcnN0dXZ3eHl6e3x9fn+AgYKDhIWGh4iJiouMjY6PkJGSk5SVlpeYmZqbnJ2en6ChoqOkpaanqKmqq6ytrq+wsbKztLW2t7i5uru8vb6/wMHCw8TFxsfIycrLzM3Oz9DR0tPU1dbX2Nna29zd3t/g4eLj5OXm5+jp6g==\"", convertedBase64String);
+        }
+
+        [Fact]
+        public async Task WriteBytesLengthSameAsBufferSizeShouldWork()
+        {
+            // Arrange
+
+            // Initialize the buffer
+            int bufferLength = 40;
+            this.buffer = new Ref<char[]>(new char[bufferLength]);
+            int byteSize = bufferLength * 3 / 4;
+
+            // Make the output Base64 string length same as the buffer size.
+            byte[] byteArray = new byte[byteSize];
+            for (int i = 0; i < byteArray.Length; i++)
+            {
+                byteArray[i] = (byte)(i % 255);
+            }
+
+            // Act, Get Base64 string from OData library
+            await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
+            string convertedBase64String = this.StreamToString();
+
+            // Get Base64 string directly calling the converter.
+            string actualBase64String = JsonConstants.QuoteCharacter + Convert.ToBase64String(byteArray) + JsonConstants.QuoteCharacter;
+
+            // Assert
+            Assert.Equal(convertedBase64String, actualBase64String);
+            Assert.Equal("\"AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwd\"", convertedBase64String);
+        }
+
+        [Fact]
+        public async Task WriteEmptyByteShouldWork()
+        {
+            var byteArray = new byte[] { };
+            await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
+            Assert.Equal("\"\"", this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteNullByteShouldWork()
+        {
+            await JsonValueUtils.WriteValueAsync(this.writer, (byte[])null, this.buffer);
+            Assert.Equal("null", this.StreamToString());
+        }
+
+        private void Reset()
+        {
+            this.buffer = new Ref<char[]>();
+            this.stream = new MemoryStream();
+            StreamWriter innerWriter = new StreamWriter(this.stream);
+            innerWriter.AutoFlush = true;
+            this.writer = new NonIndentedTextWriter(innerWriter);
+        }
+
+        private string StreamToString()
+        {
+            this.stream.Position = 0;
+            return (new StreamReader(this.stream)).ReadToEnd();
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/NonIndentedTextWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/NonIndentedTextWriterAsyncTests.cs
@@ -1,0 +1,109 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="NonIndentedTextWriterAsyncTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.OData.Json;
+using Xunit;
+
+namespace Microsoft.OData.Tests.Json
+{
+    public class NonIndentedTextWriterAsyncTests
+    {
+        private MemoryStream stream;
+        private TextWriterWrapper writer;
+        private Ref<char[]> buffer;
+        private Dictionary<string, string> escapedCharMap;
+
+        public NonIndentedTextWriterAsyncTests()
+        {
+            escapedCharMap = new Dictionary<string, string>()
+            {
+                {"\r\n", "\\r\\n"},
+                {"\r", "\\r"},
+                {"\t", "\\t"},
+                {"\"", "\\\""},
+                {"\\", "\\\\"},
+                {"\n", "\\n"},
+                {"\b", "\\b"},
+                {"\f", "\\f"},
+                {string.Format("{0}", (char)0), string.Format(CultureInfo.InvariantCulture, "\\u{0:x4}", 0)},
+                {string.Format("{0}", (char)0x80), string.Format(CultureInfo.InvariantCulture, "\\u{0:x4}", 0x80)},
+            };
+
+            Reset();
+        }
+
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        public async Task WriteEmptyStringShouldWork(ODataStringEscapeOption stringEscapeOption)
+        {
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Empty, stringEscapeOption, this.buffer);
+            Assert.Equal("\"\"", this.StreamToString());
+        }
+
+        [Theory]
+        [InlineData(ODataStringEscapeOption.EscapeOnlyControls)]
+        [InlineData(ODataStringEscapeOption.EscapeNonAscii)]
+        public async Task WriteNonSpecialCharactersShouldWork(ODataStringEscapeOption stringEscapeOption)
+        {
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "abcdefg123", stringEscapeOption, this.buffer);
+            Assert.Equal("\"abcdefg123\"", this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteSpecialCharactersShouldWork()
+        {
+            foreach (string specialChar in this.escapedCharMap.Keys)
+            {
+                this.Reset();
+                await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}", specialChar),
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
+                Assert.Equal(string.Format("\"{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
+            }
+        }
+
+        [Fact]
+        public async Task WriteHighSpecialCharactersShouldWorkForEscapeNonAsciiOption()
+        {
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeNonAscii, this.buffer);
+            Assert.Equal("\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\"", this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteHighSpecialCharactersShouldWorkForEscapeOnlyControlsOption()
+        {
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeOnlyControls, this.buffer);
+            Assert.Equal("\"cA_Россия\"", this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteByteShouldWork()
+        {
+            var byteArray = new byte[] { 1, 2, 3 };
+            await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
+            Assert.Equal("\"AQID\"", this.StreamToString());
+        }
+
+        private void Reset()
+        {
+            this.buffer = new Ref<char[]>();
+            this.stream = new MemoryStream();
+            StreamWriter innerWriter = new StreamWriter(this.stream);
+            innerWriter.AutoFlush = true;
+            this.writer = new NonIndentedTextWriter(innerWriter);
+        }
+
+        private string StreamToString()
+        {
+            this.stream.Position = 0;
+            return (new StreamReader(this.stream)).ReadToEnd();
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request is a partial fulfilment of issue #2019*

### Description

Expand `TextWriterWrapper` internal abstract class with equivalent async method and provide the implementation in the derived `NonIndentedTextWriter` internal class and `JsonValueUtils` internal static class

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
