### PR TITLE
Implement asynchronous support in JsonWriter

### DIFF
--- a/src/Microsoft.OData.Core/Json/DefaultJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/DefaultJsonWriterFactory.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OData.Json
         /// <param name="textWriter">Writer to which text needs to be written.</param>
         /// <param name="isIeee754Compatible">True if it is IEEE754Compatible.</param>
         /// <returns>The JSON writer created.</returns>
-        public IJsonWriterAsync CreateAsyncJsonWriter(TextWriter textWriter, bool isIeee754Compatible)
+        public IJsonWriterAsync CreateAsynchronousJsonWriter(TextWriter textWriter, bool isIeee754Compatible)
         {
             return new JsonWriter(textWriter, isIeee754Compatible, this.stringEscapeOption);
         }

--- a/src/Microsoft.OData.Core/Json/DefaultJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/DefaultJsonWriterFactory.cs
@@ -13,7 +13,7 @@ namespace Microsoft.OData.Json
     /// Default JSON writer factory
     /// </summary>
     [CLSCompliant(false)]
-    public sealed class DefaultJsonWriterFactory : IJsonWriterFactory
+    public sealed class DefaultJsonWriterFactory : IJsonWriterFactory, IJsonWriterFactoryAsync
     {
         private ODataStringEscapeOption stringEscapeOption;
 
@@ -41,6 +41,17 @@ namespace Microsoft.OData.Json
         /// <param name="isIeee754Compatible">True if it is IEEE754Compatible.</param>
         /// <returns>The JSON writer created.</returns>
         public IJsonWriter CreateJsonWriter(TextWriter textWriter, bool isIeee754Compatible)
+        {
+            return new JsonWriter(textWriter, isIeee754Compatible, this.stringEscapeOption);
+        }
+
+        /// <summary>
+        /// Creates a new JSON writer of <see cref="IJsonWriter"/> with support for writing asynchronously.
+        /// </summary>
+        /// <param name="textWriter">Writer to which text needs to be written.</param>
+        /// <param name="isIeee754Compatible">True if it is IEEE754Compatible.</param>
+        /// <returns>The JSON writer created.</returns>
+        public IJsonWriterAsync CreateAsyncJsonWriter(TextWriter textWriter, bool isIeee754Compatible)
         {
             return new JsonWriter(textWriter, isIeee754Compatible, this.stringEscapeOption);
         }

--- a/src/Microsoft.OData.Core/Json/IJsonStreamWriterAsync.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonStreamWriterAsync.cs
@@ -1,0 +1,46 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="IJsonStreamWriterAsync.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Json
+{
+    using System;
+    using System.IO;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Interface for writing JSON including streaming binary values.
+    /// </summary>
+    [CLSCompliant(false)]
+    public interface IJsonStreamWriterAsync : IJsonWriterAsync
+    {
+        /// <summary>
+        /// Asynchronously starts the stream property value scope.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation. 
+        /// The value of the TResult parameter contains the stream to write the property value to.</returns>
+        Task<Stream> StartStreamValueScopeAsync();
+
+        /// <summary>
+        /// Asynchronously starts the TextWriter value scope.
+        /// </summary>
+        /// <param name="contentType">ContentType of the string being written.</param>
+        /// <returns>A task that represents the asynchronous operation. 
+        /// The value of the TResult parameter contains the textwriter to write the text property value to.</returns>
+        Task<TextWriter> StartTextWriterValueScopeAsync(string contentType);
+
+        /// <summary>
+        /// Asynchronously ends the current stream property value scope.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task EndStreamValueScopeAsync();
+
+        /// <summary>
+        /// Asynchronously ends the TextWriter value scope.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task EndTextWriterValueScopeAsync();
+    }
+}

--- a/src/Microsoft.OData.Core/Json/IJsonWriterAsync.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriterAsync.cs
@@ -1,0 +1,194 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="IJsonWriterAsync.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Json
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.OData.Edm;
+
+    /// <summary>
+    /// Interface for a class that can write arbitrary JSON asynchronously.
+    /// </summary>
+    [CLSCompliant(false)]
+    public interface IJsonWriterAsync
+    {
+        /// <summary>
+        /// Asynchronously starts the padding function scope.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task StartPaddingFunctionScopeAsync();
+
+        /// <summary>
+        /// Asynchronously ends the padding function scope.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task EndPaddingFunctionScopeAsync();
+
+        /// <summary>
+        /// Asynchronously starts the object scope.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task StartObjectScopeAsync();
+
+        /// <summary>
+        /// Asynchronously ends the current object scope.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task EndObjectScopeAsync();
+
+        /// <summary>
+        /// Asynchronously starts the array scope.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task StartArrayScopeAsync();
+
+        /// <summary>
+        /// Asynchronously ends the current array scope.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task EndArrayScopeAsync();
+
+        /// <summary>
+        /// Asynchronously writes the name for the object property.
+        /// </summary>
+        /// <param name="name">Name of the object property.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteNameAsync(string name);
+
+        /// <summary>
+        /// Asynchronously writes a function name for JSON padding.
+        /// </summary>
+        /// <param name="functionName">Name of the padding function to write.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WritePaddingFunctionNameAsync(string functionName);
+
+        /// <summary>
+        /// Asynchronously writes a boolean value.
+        /// </summary>
+        /// <param name="value">Boolean value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(bool value);
+
+        /// <summary>
+        /// Asynchronously writes an integer value.
+        /// </summary>
+        /// <param name="value">Integer value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(int value);
+
+        /// <summary>
+        /// Asynchronously writes a float value.
+        /// </summary>
+        /// <param name="value">Float value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(float value);
+
+        /// <summary>
+        /// Asynchronously writes a short value.
+        /// </summary>
+        /// <param name="value">Short value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(short value);
+
+        /// <summary>
+        /// Asynchronously writes a long value.
+        /// </summary>
+        /// <param name="value">Long value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(long value);
+
+        /// <summary>
+        /// Asynchronously writes a double value.
+        /// </summary>
+        /// <param name="value">Double value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(double value);
+
+        /// <summary>
+        /// Asynchronously writes a Guid value.
+        /// </summary>
+        /// <param name="value">Guid value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(Guid value);
+
+        /// <summary>
+        /// Asynchronously writes a decimal value
+        /// </summary>
+        /// <param name="value">Decimal value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(decimal value);
+
+        /// <summary>
+        /// Asynchronously writes a DateTimeOffset value
+        /// </summary>
+        /// <param name="value">DateTimeOffset value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(DateTimeOffset value);
+
+        /// <summary>
+        /// Asynchronously writes a TimeSpan value
+        /// </summary>
+        /// <param name="value">TimeSpan value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(TimeSpan value);
+
+        /// <summary>
+        /// Asynchronously writes a byte value.
+        /// </summary>
+        /// <param name="value">Byte value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(byte value);
+
+        /// <summary>
+        /// Asynchronously writes an sbyte value.
+        /// </summary>
+        /// <param name="value">SByte value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(sbyte value);
+
+        /// <summary>
+        /// Asynchronously writes a string value.
+        /// </summary>
+        /// <param name="value">String value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(string value);
+
+        /// <summary>
+        /// Asynchronously writes a byte array.
+        /// </summary>
+        /// <param name="value">Byte array to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(byte[] value);
+
+        /// <summary>
+        /// Asynchronously writes a Date value
+        /// </summary>
+        /// <param name="value">Date value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(Date value);
+
+        /// <summary>
+        /// Asynchronously writes a TimeOfDay value
+        /// </summary>
+        /// <param name="value">TimeOfDay value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(TimeOfDay value);
+
+        /// <summary>
+        /// Asynchronously writes a raw value.
+        /// </summary>
+        /// <param name="rawValue">Raw value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteRawValueAsync(string rawValue);
+
+        /// <summary>
+        /// Asynchronously clears all buffers for the current writer.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous flush operation.</returns>
+        Task FlushAsync();
+    }
+}

--- a/src/Microsoft.OData.Core/Json/IJsonWriterFactoryAsync.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriterFactoryAsync.cs
@@ -22,6 +22,6 @@ namespace Microsoft.OData.Json
         /// <param name="textWriter">Writer to which text needs to be written.</param>
         /// <param name="isIeee754Compatible">True if it is IEEE754Compatible.</param>
         /// <returns>The JSON writer created.</returns>
-        IJsonWriterAsync CreateAsyncJsonWriter(TextWriter textWriter, bool isIeee754Compatible);
+        IJsonWriterAsync CreateAsynchronousJsonWriter(TextWriter textWriter, bool isIeee754Compatible);
     }
 }

--- a/src/Microsoft.OData.Core/Json/IJsonWriterFactoryAsync.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriterFactoryAsync.cs
@@ -1,0 +1,27 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="IJsonWriterFactoryAsync.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.Json
+{
+    /// <summary>
+    /// Interface of the factory to create asynchronous JSON writers.
+    /// </summary>
+    [CLSCompliant(false)]
+    public interface IJsonWriterFactoryAsync
+    {
+        /// <summary>
+        /// Creates a new JSON writer of <see cref="IJsonWriterAsync"/> with support for writing asynchronously.
+        /// </summary>
+        /// <param name="textWriter">Writer to which text needs to be written.</param>
+        /// <param name="isIeee754Compatible">True if it is IEEE754Compatible.</param>
+        /// <returns>The JSON writer created.</returns>
+        IJsonWriterAsync CreateAsyncJsonWriter(TextWriter textWriter, bool isIeee754Compatible);
+    }
+}

--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -314,7 +314,12 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="arrayPool">Array pool for renting a buffer.</param>
-        internal static void WriteValue(TextWriter writer, string value, ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool arrayPool = null)
+        internal static void WriteValue(
+            TextWriter writer,
+            string value,
+            ODataStringEscapeOption stringEscapeOption,
+            Ref<char[]> buffer,
+            ICharArrayPool arrayPool = null)
         {
             Debug.Assert(writer != null, "writer != null");
 
@@ -386,8 +391,12 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data</param>
         /// <param name="bufferPool">Array pool for renting a buffer.</param>
-        internal static void WriteEscapedJsonString(TextWriter writer, string inputString,
-            ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool = null)
+        internal static void WriteEscapedJsonString(
+            TextWriter writer,
+            string inputString,
+            ODataStringEscapeOption stringEscapeOption,
+            Ref<char[]> buffer,
+            ICharArrayPool bufferPool = null)
         {
             Debug.Assert(writer != null, "writer != null");
             Debug.Assert(inputString != null, "The string value must not be null.");
@@ -405,8 +414,12 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="bufferPool">Array pool for renting a buffer.</param>
-        internal static void WriteEscapedJsonStringValue(TextWriter writer, string inputString,
-            ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool)
+        internal static void WriteEscapedJsonStringValue(
+            TextWriter writer,
+            string inputString,
+            ODataStringEscapeOption stringEscapeOption,
+            Ref<char[]> buffer,
+            ICharArrayPool bufferPool)
         {
             Debug.Assert(writer != null, "writer != null");
             Debug.Assert(inputString != null, "The string value must not be null.");
@@ -469,7 +482,13 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="bufferPool">Character buffer pool.</param>
-        internal static void WriteEscapedCharArray(TextWriter writer, char[] inputArray, int inputArrayOffset, int inputArrayCount, ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool)
+        internal static void WriteEscapedCharArray(
+            TextWriter writer,
+            char[] inputArray,
+            int inputArrayOffset,
+            int inputArrayCount,
+            ODataStringEscapeOption stringEscapeOption,
+            Ref<char[]> buffer, ICharArrayPool bufferPool)
         {
             int bufferIndex = 0;
             buffer.Value = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer.Value);
@@ -781,7 +800,13 @@ namespace Microsoft.OData.Json
         /// IMPORTANT: After all characters have been written,
         /// caller is responsible for writing the final buffer contents to the writer.
         /// </remarks>
-        private static void WriteEscapedStringToBuffer(TextWriter writer, string inputString, ref int currentIndex, char[] buffer, ref int bufferIndex, ODataStringEscapeOption stringEscapeOption)
+        private static void WriteEscapedStringToBuffer(
+            TextWriter writer,
+            string inputString,
+            ref int currentIndex,
+            char[] buffer,
+            ref int bufferIndex,
+            ODataStringEscapeOption stringEscapeOption)
         {
             Debug.Assert(inputString != null, "inputString != null");
             Debug.Assert(buffer != null, "buffer != null");
@@ -806,7 +831,14 @@ namespace Microsoft.OData.Json
         /// IMPORTANT: After all characters have been written,
         /// caller is responsible for writing the final buffer contents to the writer.
         /// </remarks>
-        private static void WriteEscapedCharArrayToBuffer(TextWriter writer, char[] inputArray, ref int inputArrayOffset, int inputArrayCount, char[] buffer, ref int bufferIndex, ODataStringEscapeOption stringEscapeOption)
+        private static void WriteEscapedCharArrayToBuffer(
+            TextWriter writer,
+            char[] inputArray,
+            ref int inputArrayOffset,
+            int inputArrayCount,
+            char[] buffer,
+            ref int bufferIndex,
+            ODataStringEscapeOption stringEscapeOption)
         {
             Debug.Assert(inputArray != null, "inputArray != null");
             Debug.Assert(buffer != null, "buffer != null");

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -285,7 +285,12 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="arrayPool">Array pool for renting a buffer.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, string value, ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool arrayPool = null)
+        internal static async Task WriteValueAsync(
+            this TextWriter writer,
+            string value,
+            ODataStringEscapeOption stringEscapeOption,
+            Ref<char[]> buffer,
+            ICharArrayPool arrayPool = null)
         {
             Debug.Assert(writer != null, "writer != null");
 
@@ -357,8 +362,12 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="bufferPool">Array pool for renting a buffer.</param>
-        internal static async Task WriteEscapedJsonStringAsync(this TextWriter writer, string inputString,
-            ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool = null)
+        internal static async Task WriteEscapedJsonStringAsync(
+            this TextWriter writer,
+            string inputString,
+            ODataStringEscapeOption stringEscapeOption,
+            Ref<char[]> buffer,
+            ICharArrayPool bufferPool = null)
         {
             Debug.Assert(writer != null, "writer != null");
             Debug.Assert(inputString != null, "The string value must not be null.");
@@ -376,8 +385,12 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="bufferPool">Array pool for renting a buffer.</param>
-        internal static async Task WriteEscapedJsonStringValueAsync(this TextWriter writer, string inputString,
-            ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool)
+        internal static async Task WriteEscapedJsonStringValueAsync(
+            this TextWriter writer,
+            string inputString,
+            ODataStringEscapeOption stringEscapeOption,
+            Ref<char[]> buffer,
+            ICharArrayPool bufferPool)
         {
             Debug.Assert(writer != null, "writer != null");
             Debug.Assert(inputString != null, "The string value must not be null.");
@@ -438,8 +451,14 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="bufferPool">Character buffer pool.</param>
-        internal static async Task WriteEscapedCharArrayAsync(this TextWriter writer, char[] inputArray, int inputArrayOffset, 
-            int inputArrayCount, ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool)
+        internal static async Task WriteEscapedCharArrayAsync(
+            this TextWriter writer,
+            char[] inputArray,
+            int inputArrayOffset, 
+            int inputArrayCount,
+            ODataStringEscapeOption stringEscapeOption,
+            Ref<char[]> buffer,
+            ICharArrayPool bufferPool)
         {
             int bufferIndex = 0;
             buffer.Value = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer.Value);

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -436,20 +436,20 @@ namespace Microsoft.OData.Json
         /// <param name="inputArrayOffset">How many characters to skip in the input array.</param>
         /// <param name="inputArrayCount">How many characters to write from the input array.</param>
         /// <param name="stringEscapeOption">The string escape option.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="bufferPool">Character buffer pool.</param>
-        internal static async Task WriteEscapedCharArrayAsync(this TextWriter writer, char[] inputArray, int inputArrayOffset, int inputArrayCount, ODataStringEscapeOption stringEscapeOption, ICharArrayPool bufferPool)
+        internal static async Task WriteEscapedCharArrayAsync(this TextWriter writer, char[] inputArray, int inputArrayOffset, 
+            int inputArrayCount,ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool)
         {
             int bufferIndex = 0;
-            char[] buffer = null;
-
-            buffer = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer);
+            buffer.Value = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer.Value);
             
-            WriteEscapedCharArrayToBuffer(writer, inputArray, ref inputArrayOffset, inputArrayCount, buffer, ref bufferIndex, stringEscapeOption);
+            WriteEscapedCharArrayToBuffer(writer, inputArray, ref inputArrayOffset, inputArrayCount, buffer.Value, ref bufferIndex, stringEscapeOption);
 
             // write remaining bytes in buffer
             if (bufferIndex > 0)
             {
-                await writer.WriteAsync(buffer, 0, bufferIndex).ConfigureAwait(false);
+                await writer.WriteAsync(buffer.Value, 0, bufferIndex).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -439,7 +439,7 @@ namespace Microsoft.OData.Json
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="bufferPool">Character buffer pool.</param>
         internal static async Task WriteEscapedCharArrayAsync(this TextWriter writer, char[] inputArray, int inputArrayOffset, 
-            int inputArrayCount,ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool)
+            int inputArrayCount, ODataStringEscapeOption stringEscapeOption, Ref<char[]> buffer, ICharArrayPool bufferPool)
         {
             int bufferIndex = 0;
             buffer.Value = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer.Value);

--- a/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
@@ -1,0 +1,367 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="JsonWriterAsync.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Json
+{
+    #region Namespaces
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using System.IO;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.OData.Buffers;
+    using Microsoft.OData.Edm;
+    #endregion Namespaces
+
+    /// <summary>
+    /// Writer for the JSON format. http://www.json.org
+    /// </summary>
+    internal sealed partial class JsonWriter
+    {
+        /// <inheritdoc/>
+        public async Task StartPaddingFunctionScopeAsync()
+        {
+            Debug.Assert(this.scopes.Count == 0, "Padding scope can only be the outer most scope.");
+            await this.StartScopeAsync(ScopeType.Padding).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task EndPaddingFunctionScopeAsync()
+        {
+            Debug.Assert(this.scopes.Count > 0, "No scope to end.");
+
+            await this.writer.WriteLineAsync().ConfigureAwait(false);
+            await this.writer.DecreaseIndentationAsync().ConfigureAwait(false);
+            Scope scope = this.scopes.Pop();
+
+            Debug.Assert(scope.Type == ScopeType.Padding, "Ending scope does not match.");
+
+            await this.writer.WriteAsync(scope.EndString).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task StartObjectScopeAsync()
+        {
+            await this.StartScopeAsync(ScopeType.Object).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task EndObjectScopeAsync()
+        {
+            Debug.Assert(this.scopes.Count > 0, "No scope to end.");
+
+            await this.writer.WriteLineAsync().ConfigureAwait(false);
+            await this.writer.DecreaseIndentationAsync().ConfigureAwait(false);
+            Scope scope = this.scopes.Pop();
+
+            Debug.Assert(scope.Type == ScopeType.Object, "Ending scope does not match.");
+
+            await this.writer.WriteAsync(scope.EndString).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task StartArrayScopeAsync()
+        {
+            await this.StartScopeAsync(ScopeType.Array).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task EndArrayScopeAsync()
+        {
+            Debug.Assert(this.scopes.Count > 0, "No scope to end.");
+
+            await this.writer.WriteLineAsync().ConfigureAwait(false);
+            await this.writer.DecreaseIndentationAsync().ConfigureAwait(false);
+            Scope scope = this.scopes.Pop();
+
+            Debug.Assert(scope.Type == ScopeType.Array, "Ending scope does not match.");
+
+            await this.writer.WriteAsync(scope.EndString).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteNameAsync(string name)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(name), "The name must be specified.");
+            Debug.Assert(this.scopes.Count > 0, "There must be an active scope for name to be written.");
+            Debug.Assert(this.scopes.Peek().Type == ScopeType.Object, "The active scope must be an object scope for name to be written.");
+
+            Scope currentScope = this.scopes.Peek();
+            if (currentScope.ObjectCount != 0)
+            {
+                await this.writer.WriteAsync(JsonConstants.ObjectMemberSeparator).ConfigureAwait(false);
+            }
+
+            currentScope.ObjectCount++;
+
+            await this.writer.WriteEscapedJsonStringAsync(name, this.stringEscapeOption, this.wrappedBuffer)
+                .ConfigureAwait(false);
+            await this.writer.WriteAsync(JsonConstants.NameValueSeparator).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WritePaddingFunctionNameAsync(string functionName)
+        {
+            await this.writer.WriteAsync(functionName).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(bool value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(int value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(float value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(short value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(long value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+
+            // if it is IEEE754Compatible, write numbers with quotes; otherwise, write numbers directly.
+            if (isIeee754Compatible)
+            {
+                await this.writer.WriteValueAsync(value.ToString(CultureInfo.InvariantCulture),
+                    this.stringEscapeOption, this.wrappedBuffer).ConfigureAwait(false);
+            }
+            else
+            {
+                await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(double value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(Guid value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(decimal value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+
+            // if it is not IEEE754Compatible, write numbers directly without quotes;
+            if (isIeee754Compatible)
+            {
+                await this.writer.WriteValueAsync(value.ToString(CultureInfo.InvariantCulture),
+                    this.stringEscapeOption, this.wrappedBuffer).ConfigureAwait(false);
+            }
+            else
+            {
+                await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(DateTimeOffset value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value, ODataJsonDateTimeFormat.ISO8601DateTime)
+                .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(TimeSpan value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(TimeOfDay value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(Date value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(byte value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(sbyte value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(string value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value, this.stringEscapeOption, this.wrappedBuffer)
+                .ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteValueAsync(byte[] value)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value, this.wrappedBuffer, ArrayPool).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task WriteRawValueAsync(string rawValue)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteAsync(rawValue).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task FlushAsync()
+        {
+            await this.writer.FlushAsync().ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task<Stream> StartStreamValueScopeAsync()
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            await this.writer.WriteAsync(JsonConstants.QuoteCharacter).ConfigureAwait(false);
+            await this.writer.FlushAsync().ConfigureAwait(false);
+            // IMPORTANT: The Dispose method of the returned stream does the following:
+            // - Writes trailing bytes to the writer synchronously
+            // - Flushes the buffer of the writer synchronously
+            // ODL supports net45 and netstandard1.1 (in addition to .netstandard2.0)
+            // This makes it complicated to implement IAsyncDisposable in ODataBinaryStreamWriter
+            // TODO: Can the returned stream be safely used asynchronously?
+            this.binaryValueStream = new ODataBinaryStreamWriter(writer, this.wrappedBuffer, ArrayPool);
+            return this.binaryValueStream;
+        }
+
+        /// <inheritdoc/>
+        public async Task EndStreamValueScopeAsync()
+        {
+            await this.binaryValueStream.FlushAsync().ConfigureAwait(false);
+            this.binaryValueStream.Dispose();
+            this.binaryValueStream = null;
+            await this.writer.FlushAsync().ConfigureAwait(false);
+            await this.writer.WriteAsync(JsonConstants.QuoteCharacter).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        public async Task<TextWriter> StartTextWriterValueScopeAsync(string contentType)
+        {
+            await this.WriteValueSeparatorAsync().ConfigureAwait(false);
+            this.currentContentType = contentType;
+            if (!IsWritingJson)
+            {
+                await this.writer.WriteAsync(JsonConstants.QuoteCharacter)
+                    .ConfigureAwait(false);
+                await this.writer.FlushAsync().ConfigureAwait(false);
+                return new ODataJsonTextWriter(writer, this.wrappedBuffer, this.ArrayPool);
+            }
+
+            await this.writer.FlushAsync().ConfigureAwait(false);
+
+            return this.writer;
+        }
+
+        /// <inheritdoc/>
+        public async Task EndTextWriterValueScopeAsync()
+        {
+            if (!IsWritingJson)
+            {
+                await this.writer.WriteAsync(JsonConstants.QuoteCharacter)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously writes a separator of a value if it's needed for the next value to be written.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WriteValueSeparatorAsync()
+        {
+            if (this.scopes.Count == 0)
+            {
+                return;
+            }
+
+            Scope currentScope = this.scopes.Peek();
+            if (currentScope.Type == ScopeType.Array)
+            {
+                if (currentScope.ObjectCount != 0)
+                {
+                    await this.writer.WriteAsync(JsonConstants.ArrayElementSeparator)
+                        .ConfigureAwait(false);
+                }
+
+                currentScope.ObjectCount++;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously starts the scope given the scope type.
+        /// </summary>
+        /// <param name="type">The scope type to start.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task StartScopeAsync(ScopeType type)
+        {
+            if (this.scopes.Count != 0 && this.scopes.Peek().Type != ScopeType.Padding)
+            {
+                Scope currentScope = this.scopes.Peek();
+                if ((currentScope.Type == ScopeType.Array) &&
+                    (currentScope.ObjectCount != 0))
+                {
+                    await this.writer.WriteAsync(JsonConstants.ArrayElementSeparator)
+                        .ConfigureAwait(false);
+                }
+
+                currentScope.ObjectCount++;
+            }
+
+            Scope scope = new Scope(type);
+            this.scopes.Push(scope);
+
+            await this.writer.WriteAsync(scope.StartString).ConfigureAwait(false);
+            await this.writer.IncreaseIndentationAsync().ConfigureAwait(false);
+            await this.writer.WriteLineAsync().ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/Json/JsonWriterAsyncExtensions.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterAsyncExtensions.cs
@@ -1,0 +1,281 @@
+//---------------------------------------------------------------------
+// <copyright file="JsonWriterAsyncExtensions.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Json
+{
+    #region Namespaces
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading.Tasks;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Metadata;
+    using ODataErrorStrings = Microsoft.OData.Strings;
+    #endregion Namespaces
+
+    /// <summary>
+    /// Extension methods for the asynchronous JSON writer.
+    /// </summary>
+    internal static class JsonWriterAsyncExtensions
+    {
+        /// <summary>
+        /// Asynchronously writes the json object value to the <paramref name="jsonWriter"/>.
+        /// </summary>
+        /// <param name="jsonWriter">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="jsonObjectValue">Writes the given json object value to the underlying json writer.</param>
+        /// <param name="injectPropertyAction">Called when the top-level object is started to possibly inject first property into the object.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        internal static async Task WriteJsonObjectValueAsync(
+            this IJsonWriterAsync jsonWriter,
+            IDictionary<string, object> jsonObjectValue,
+            Func<IJsonWriterAsync, Task> injectPropertyAction)
+        {
+            Debug.Assert(jsonWriter != null, "jsonWriter != null");
+            Debug.Assert(jsonObjectValue != null, "jsonObjectValue != null");
+
+            await jsonWriter.StartObjectScopeAsync().ConfigureAwait(false);
+
+            if (injectPropertyAction != null)
+            {
+                await injectPropertyAction(jsonWriter).ConfigureAwait(false);
+            }
+
+            foreach (KeyValuePair<string, object> property in jsonObjectValue)
+            {
+                await jsonWriter.WriteNameAsync(property.Key).ConfigureAwait(false);
+                await jsonWriter.WriteJsonValueAsync(property.Value).ConfigureAwait(false);
+            }
+
+            await jsonWriter.EndObjectScopeAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a primitive value.
+        /// </summary>
+        /// <param name="jsonWriter">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="value">The value to write.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        internal static async Task WritePrimitiveValueAsync(this IJsonWriterAsync jsonWriter, object value)
+        {
+            if (value is bool)
+            {
+                await jsonWriter.WriteValueAsync((bool)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is byte)
+            {
+                await jsonWriter.WriteValueAsync((byte)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is decimal)
+            {
+                await jsonWriter.WriteValueAsync((decimal)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is double)
+            {
+                await jsonWriter.WriteValueAsync((double)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is Int16)
+            {
+                await jsonWriter.WriteValueAsync((Int16)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is Int32)
+            {
+                await jsonWriter.WriteValueAsync((Int32)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is Int64)
+            {
+                await jsonWriter.WriteValueAsync((Int64)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is sbyte)
+            {
+                await jsonWriter.WriteValueAsync((sbyte)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is Single)
+            {
+                await jsonWriter.WriteValueAsync((Single)value).ConfigureAwait(false);
+                return;
+            }
+
+            var str = value as string;
+            if (str != null)
+            {
+                await jsonWriter.WriteValueAsync(str).ConfigureAwait(false);
+                return;
+            }
+
+            byte[] valueAsByteArray = value as byte[];
+            if (valueAsByteArray != null)
+            {
+                await jsonWriter.WriteValueAsync(valueAsByteArray).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is DateTimeOffset)
+            {
+                await jsonWriter.WriteValueAsync((DateTimeOffset)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is Guid)
+            {
+                await jsonWriter.WriteValueAsync((Guid)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is TimeSpan)
+            {
+                await jsonWriter.WriteValueAsync((TimeSpan)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is Date)
+            {
+                await jsonWriter.WriteValueAsync((Date)value).ConfigureAwait(false);
+                return;
+            }
+
+            if (value is TimeOfDay)
+            {
+                await jsonWriter.WriteValueAsync((TimeOfDay)value).ConfigureAwait(false);
+                return;
+            }
+
+            throw new ODataException(ODataErrorStrings.ODataJsonWriter_UnsupportedValueType(value.GetType().FullName));
+        }
+
+        /// <summary>
+        /// Asynchronously writes the ODataValue (primitive, collection or resource value) to the underlying json writer.
+        /// </summary>
+        /// <param name="jsonWriter">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="odataValue">value to write.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        internal static async Task WriteODataValueAsync(this IJsonWriterAsync jsonWriter, ODataValue odataValue)
+        {
+            if (odataValue == null || odataValue is ODataNullValue)
+            {
+                await jsonWriter.WriteValueAsync((string)null).ConfigureAwait(false);
+                return;
+            }
+
+            object objectValue = odataValue.FromODataValue();
+            if (EdmLibraryExtensions.IsPrimitiveType(objectValue.GetType()))
+            {
+                await jsonWriter.WritePrimitiveValueAsync(objectValue).ConfigureAwait(false);
+                return;
+            }
+
+            ODataResourceValue resourceValue = odataValue as ODataResourceValue;
+            if (resourceValue != null)
+            {
+                await jsonWriter.StartObjectScopeAsync().ConfigureAwait(false);
+
+                foreach (ODataProperty property in resourceValue.Properties)
+                {
+                    await jsonWriter.WriteNameAsync(property.Name).ConfigureAwait(false);
+                    await jsonWriter.WriteODataValueAsync(property.ODataValue).ConfigureAwait(false);
+                }
+
+                await jsonWriter.EndObjectScopeAsync().ConfigureAwait(false);
+                return;
+            }
+
+            ODataCollectionValue collectionValue = odataValue as ODataCollectionValue;
+            if (collectionValue != null)
+            {
+                await jsonWriter.StartArrayScopeAsync().ConfigureAwait(false);
+
+                foreach (object item in collectionValue.Items)
+                {
+                    // Will not be able to accurately serialize complex objects unless they are ODataValues.
+                    ODataValue collectionItem = item as ODataValue;
+                    if (item != null)
+                    {
+                        await jsonWriter.WriteODataValueAsync(collectionItem).ConfigureAwait(false);
+                    }
+                    else
+                    {
+                        throw new ODataException(ODataErrorStrings.ODataJsonWriter_UnsupportedValueInCollection);
+                    }
+                }
+
+                await jsonWriter.EndArrayScopeAsync().ConfigureAwait(false);
+
+                return;
+            }
+
+            throw new ODataException(
+                ODataErrorStrings.ODataJsonWriter_UnsupportedValueType(odataValue.GetType().FullName));
+        }
+
+        /// <summary>
+        /// Asynchronously writes the json array value.
+        /// </summary>
+        /// <param name="jsonWriter">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="arrayValue">Writes the json array value to the underlying json writer.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private static async Task WriteJsonArrayValueAsync(this IJsonWriterAsync jsonWriter, IEnumerable arrayValue)
+        {
+            Debug.Assert(arrayValue != null, "arrayValue != null");
+
+            await jsonWriter.StartArrayScopeAsync().ConfigureAwait(false);
+
+            foreach (object element in arrayValue)
+            {
+                await jsonWriter.WriteJsonValueAsync(element).ConfigureAwait(false);
+            }
+
+            await jsonWriter.EndArrayScopeAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the json value (primitive, IDictionary or IEnumerable) to the underlying json writer.
+        /// </summary>
+        /// <param name="jsonWriter">The <see cref="JsonWriter"/> to write to.</param>
+        /// <param name="propertyValue">value to write.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private static async Task WriteJsonValueAsync(this IJsonWriterAsync jsonWriter, object propertyValue)
+        {
+            if (propertyValue == null)
+            {
+                await jsonWriter.WriteValueAsync((string)null).ConfigureAwait(false);
+            }
+            else if (EdmLibraryExtensions.IsPrimitiveType(propertyValue.GetType()))
+            {
+                await jsonWriter.WritePrimitiveValueAsync(propertyValue).ConfigureAwait(false);
+            }
+            else
+            {
+                IDictionary<string, object> objectValue = propertyValue as IDictionary<string, object>;
+                if (objectValue != null)
+                {
+                    await jsonWriter.WriteJsonObjectValueAsync(objectValue, null /*typeName */).ConfigureAwait(false);
+                }
+                else
+                {
+                    IEnumerable arrayValue = propertyValue as IEnumerable;
+                    Debug.Assert(arrayValue != null, "arrayValue != null");
+                    await jsonWriter.WriteJsonArrayValueAsync(arrayValue).ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/Json/JsonWriterAsyncExtensions.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterAsyncExtensions.cs
@@ -27,21 +27,21 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="jsonWriter">The <see cref="JsonWriter"/> to write to.</param>
         /// <param name="jsonObjectValue">Writes the given json object value to the underlying json writer.</param>
-        /// <param name="injectPropertyAction">Called when the top-level object is started to possibly inject first property into the object.</param>
+        /// <param name="injectPropertyDelegate">Called when the top-level object is started to possibly inject first property into the object.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         internal static async Task WriteJsonObjectValueAsync(
             this IJsonWriterAsync jsonWriter,
             IDictionary<string, object> jsonObjectValue,
-            Func<IJsonWriterAsync, Task> injectPropertyAction)
+            Func<IJsonWriterAsync, Task> injectPropertyDelegate)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
             Debug.Assert(jsonObjectValue != null, "jsonObjectValue != null");
 
             await jsonWriter.StartObjectScopeAsync().ConfigureAwait(false);
 
-            if (injectPropertyAction != null)
+            if (injectPropertyDelegate != null)
             {
-                await injectPropertyAction(jsonWriter).ConfigureAwait(false);
+                await injectPropertyDelegate(jsonWriter).ConfigureAwait(false);
             }
 
             foreach (KeyValuePair<string, object> property in jsonObjectValue)

--- a/src/Microsoft.OData.Core/Json/ODataJsonTextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonTextWriter.cs
@@ -7,8 +7,8 @@
 namespace Microsoft.OData
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
-    using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.OData.Buffers;
@@ -30,9 +30,9 @@ namespace Microsoft.OData
         private readonly ODataStringEscapeOption escapeOption = ODataStringEscapeOption.EscapeOnlyControls;
 
         /// <summary>
-        /// The buffer to help when converting binary values.
+        /// The wrapped buffer to help when converting binary values.
         /// </summary>
-        private char[] streamingBuffer;
+        private Ref<char[]> wrappedBuffer;
 
         /// <summary>
         /// Get/sets the character buffer pool for streaming.
@@ -45,13 +45,13 @@ namespace Microsoft.OData
         /// <param name="textWriter">The underlying TextWriter used when writing JSON</param>
         /// <param name="buffer">Buffer used when converting binary values.</param>
         /// <param name="bufferPool">Buffer pool used for renting a buffer.</param>
-        internal ODataJsonTextWriter(TextWriter textWriter, ref char[] buffer, ICharArrayPool bufferPool)
+        internal ODataJsonTextWriter(TextWriter textWriter, Ref<char[]> wrappedBuffer, ICharArrayPool bufferPool)
             : base(System.Globalization.CultureInfo.InvariantCulture)
         {
             ExceptionUtils.CheckArgumentNotNull(textWriter, "textWriter");
 
             this.textWriter = textWriter;
-            this.streamingBuffer = buffer;
+            this.wrappedBuffer = wrappedBuffer;
             this.bufferPool = bufferPool;
         }
 
@@ -299,53 +299,49 @@ namespace Microsoft.OData
         }
 
         /// <inheritdoc/>
-        public override Task WriteAsync(char value)
+        public override async Task WriteAsync(char value)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-                this.Write(value));
+            await this.WriteEscapedCharValueAsync(value).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public override Task WriteAsync(char[] buffer, int index, int count)
+        public override async Task WriteAsync(char[] buffer, int index, int count)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-                this.Write(buffer, index, count));
+            await this.WriteEscapedCharArrayAsync(buffer, index, count).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public override Task WriteAsync(string value)
+        public override async Task WriteAsync(string value)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-                this.Write(value));
+            await this.WriteEscapedStringValueAsync(value).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public override Task WriteLineAsync()
+        public override async Task WriteLineAsync()
         {
-            return this.textWriter.WriteLineAsync();
+            await this.textWriter.WriteLineAsync().ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public override Task WriteLineAsync(char value)
+        public override async Task WriteLineAsync(char value)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-                this.WriteLine(value));
+            await this.WriteAsync(value).ConfigureAwait(false);
+            await this.textWriter.WriteLineAsync().ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public override Task WriteLineAsync(char[] buffer, int index, int count)
+        public override async Task WriteLineAsync(char[] buffer, int index, int count)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-                this.WriteLine(buffer, index, count));
+            await this.WriteAsync(buffer, index, count).ConfigureAwait(false);
+            await this.textWriter.WriteLineAsync().ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
-        public override Task WriteLineAsync(string value)
+        public override async Task WriteLineAsync(string value)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-                this.WriteLine(value));
+            await this.WriteAsync(value).ConfigureAwait(false);
+            await this.textWriter.WriteLineAsync().ConfigureAwait(false);
         }
-
 
         #endregion
 
@@ -360,20 +356,82 @@ namespace Microsoft.OData
         }
 
         #region private methods
+
+        /// <summary>
+        /// Writes a char value escaped where necessary.
+        /// </summary>
+        /// <param name="value">Char value to be written.</param>
         private void WriteEscapedCharValue(char value)
         {
             JsonValueUtils.WriteValue(this.textWriter, value, escapeOption);
         }
 
+        /// <summary>
+        /// Writes a string value with special characters escaped.
+        /// </summary>
+        /// <param name="value">String value to be written.</param>
         private void WriteEscapedStringValue(string value)
         {
-            JsonValueUtils.WriteEscapedJsonStringValue(this.textWriter, value, escapeOption, ref streamingBuffer, this.bufferPool);
+            Debug.Assert(this.wrappedBuffer != null, "wrappedBuffer != null");
+
+            JsonValueUtils.WriteEscapedJsonStringValue(this.textWriter, value, escapeOption, wrappedBuffer, this.bufferPool);
         }
 
+        /// <summary>
+        /// Escapes and writes a character array.
+        /// </summary>
+        /// <param name="value">Character array to be written.</param>
+        /// <param name="offset">Number of characters to skip in the character array.</param>
+        /// <param name="count">Number of characters to write from the character array.</param>
         private void WriteEscapedCharArray(char[] value, int offset, int count)
         {
-            JsonValueUtils.WriteEscapedCharArray(this.textWriter, value, offset, count, escapeOption, ref streamingBuffer, this.bufferPool);
+            Debug.Assert(this.wrappedBuffer != null, "wrappedBuffer != null");
+
+            JsonValueUtils.WriteEscapedCharArray(this.textWriter, value, offset, count, escapeOption, wrappedBuffer, this.bufferPool);
         }
+
         #endregion
+
+        #region Private async methods
+
+        /// <summary>
+        /// Asynchronously writes a char value escaped where necessary.
+        /// </summary>
+        /// <param name="value">Char value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WriteEscapedCharValueAsync(char value)
+        {
+            await this.textWriter.WriteValueAsync(value, escapeOption).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a string value with special characters escaped.
+        /// </summary>
+        /// <param name="value">String value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WriteEscapedStringValueAsync(string value)
+        {
+            Debug.Assert(this.wrappedBuffer != null, "wrappedBuffer != null");
+
+            await this.textWriter.WriteEscapedJsonStringValueAsync(
+                value, escapeOption, this.wrappedBuffer, this.bufferPool).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously escapes and writes a character array.
+        /// </summary>
+        /// <param name="value">Character array to be written.</param>
+        /// <param name="offset">Number of characters to skip in the character array.</param>
+        /// <param name="count">Number of characters to write from the character array.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WriteEscapedCharArrayAsync(char[] value, int offset, int count)
+        {
+            Debug.Assert(this.wrappedBuffer != null, "wrappedBuffer != null");
+
+            await this.textWriter.WriteEscapedCharArrayAsync(
+                value, offset, count, escapeOption, this.wrappedBuffer, this.bufferPool).ConfigureAwait(false);
+        }
+
+        #endregion Private async methods
     }
 }

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
@@ -30,9 +30,13 @@ namespace Microsoft.OData.Json
         /// <param name="includeDebugInformation">A flag indicating whether error details should be written (in debug mode only) or not.</param>
         /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
         /// <param name="writingJsonLight">true if we're writing JSON lite, false if we're writing verbose JSON.</param>
-        internal static void WriteError(IJsonWriter jsonWriter,
-            Action<IEnumerable<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate, ODataError error,
-            bool includeDebugInformation, int maxInnerErrorDepth, bool writingJsonLight)
+        internal static void WriteError(
+            IJsonWriter jsonWriter,
+            Action<IEnumerable<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate,
+            ODataError error,
+            bool includeDebugInformation,
+            int maxInnerErrorDepth,
+            bool writingJsonLight)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
             Debug.Assert(error != null, "error != null");
@@ -134,11 +138,16 @@ namespace Microsoft.OData.Json
         /// <param name="writeInstanceAnnotationsDelegate">Action to write the instance annotations.</param>
         /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
         /// <param name="writingJsonLight">true if we're writing JSON lite, false if we're writing verbose JSON.</param>
-        private static void WriteError(IJsonWriter jsonWriter, string code, string message, string target,
+        private static void WriteError(
+            IJsonWriter jsonWriter,
+            string code,
+            string message,
+            string target,
             IEnumerable<ODataErrorDetail> details,
             ODataInnerError innerError,
             IEnumerable<ODataInstanceAnnotation> instanceAnnotations,
-            Action<IEnumerable<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate, int maxInnerErrorDepth,
+            Action<IEnumerable<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate,
+            int maxInnerErrorDepth,
             bool writingJsonLight)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
@@ -201,7 +210,9 @@ namespace Microsoft.OData.Json
             jsonWriter.EndObjectScope();
         }
 
-        private static void WriteErrorDetails(IJsonWriter jsonWriter, IEnumerable<ODataErrorDetail> details,
+        private static void WriteErrorDetails(
+            IJsonWriter jsonWriter,
+            IEnumerable<ODataErrorDetail> details,
             string odataErrorDetailsName)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
@@ -248,7 +259,12 @@ namespace Microsoft.OData.Json
         /// <param name="innerErrorPropertyName">The property name for the inner error property.</param>
         /// <param name="recursionDepth">The number of times this method has been called recursively.</param>
         /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
-        private static void WriteInnerError(IJsonWriter jsonWriter, ODataInnerError innerError, string innerErrorPropertyName, int recursionDepth, int maxInnerErrorDepth)
+        private static void WriteInnerError(
+            IJsonWriter jsonWriter,
+            ODataInnerError innerError,
+            string innerErrorPropertyName,
+            int recursionDepth,
+            int maxInnerErrorDepth)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
             Debug.Assert(innerErrorPropertyName != null, "innerErrorPropertyName != null");

--- a/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
+++ b/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
@@ -147,7 +147,7 @@ namespace Microsoft.OData
 
             PrepareByteArray(bytes, offset, count, out byteArray);
 
-            JsonValueUtils.WriteBinaryString(this.Writer, byteArray, wrappedBuffer, this.bufferPool);
+            JsonValueUtils.WriteBinaryString(this.Writer, byteArray, this.wrappedBuffer, this.bufferPool);
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
+++ b/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
@@ -20,23 +20,26 @@ namespace Microsoft.OData
     /// </summary>
     internal sealed class ODataBinaryStreamWriter : Stream
     {
+        /// <summary>Desired minimum bytes per write operation.</summary>
+        private const int MinBytesPerWriteEvent = 3;
+
         /// <summary>The writer to write to the underlying stream.</summary>
         private readonly TextWriter Writer;
 
         /// <summary>Trailing bytes from a previous write to be prepended to the next write.</summary>
-        private Byte[] trailingBytes = new Byte[0];
+        private byte[] trailingBytes = new byte[0];
 
         /// <summary>
-        /// The buffer to help with streaming responses.
+        /// The wrapped buffer to help with streaming responses.
         /// </summary>
-        private char[] streamingBuffer;
+        private Ref<char[]> wrappedBuffer;
 
         /// <summary>
         /// Get/sets the character buffer pool for streaming.
         /// </summary>
         private ICharArrayPool bufferPool;
 
-        /// <summary> An empty byte[].</summary>
+        /// <summary>An empty byte[].</summary>
         private static byte[] emptyByteArray = new byte[0];
 
         /// <summary>
@@ -56,10 +59,10 @@ namespace Microsoft.OData
         /// <param name="writer">A Textwriter for writing to the stream.</param>
         /// <param name="streamingBuffer">A temporary buffer to use when converting binary values.</param>
         /// <param name="bufferPool">Array pool for renting a buffer.</param>
-        public ODataBinaryStreamWriter(TextWriter writer, ref char[] streamingBuffer, ICharArrayPool bufferPool)
+        public ODataBinaryStreamWriter(TextWriter writer, Ref<char[]> wrappedBuffer, ICharArrayPool bufferPool)
         {
             this.Writer = writer;
-            this.streamingBuffer = streamingBuffer;
+            this.wrappedBuffer = wrappedBuffer;
             this.bufferPool = bufferPool;
         }
 
@@ -131,37 +134,40 @@ namespace Microsoft.OData
         /// <param name="count">The number of bytes to write.</param>
         public override void Write(byte[] bytes, int offset, int count)
         {
-            byte[] prefixByteString = emptyByteArray;
-            int trailingByteLength = trailingBytes.Length;
-            int numberOfBytesToPrefix = trailingByteLength > 0 ? 3 - trailingByteLength : 0;
+            Debug.Assert(this.wrappedBuffer != null, "this.wrappedBuffer != null");
 
             // if we have less than 3 bytes, store the bytes and continue
-            if (count + trailingByteLength < 3)
+            if (count + trailingBytes.Length < MinBytesPerWriteEvent)
             {
-                trailingBytes = trailingBytes.Concat(bytes.Skip(offset).Take(count)).ToArray();
+                this.trailingBytes = this.trailingBytes.Concat(bytes.Skip(offset).Take(count)).ToArray();
                 return;
             }
 
-            // if we have bytes left over from the previous write, prepend them
-            if (trailingByteLength > 0)
-            {
-                // convert the trailing bytes plus the first 3-trailingByteLength bytes of the new byte[]
-                prefixByteString = trailingBytes.Concat(bytes.Skip(offset).Take(numberOfBytesToPrefix)).ToArray();
-            }
+            byte[] byteArray;
 
-            // compute if there will be trailing bytes from this write
-            int remainingBytes = (count - numberOfBytesToPrefix) % 3;
-            trailingBytes = bytes.Skip(offset + count - remainingBytes).Take(remainingBytes).ToArray();
+            PrepareByteArray(bytes, offset, count, out byteArray);
 
-            JsonValueUtils.WriteBinaryString(this.Writer, prefixByteString.Concat(bytes.Skip(offset + numberOfBytesToPrefix).Take(count - numberOfBytesToPrefix - remainingBytes)).ToArray(), ref streamingBuffer, this.bufferPool);
+            JsonValueUtils.WriteBinaryString(this.Writer, byteArray, wrappedBuffer, this.bufferPool);
         }
 
-    
         /// <inheritdoc />
-        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task WriteAsync(byte[] bytes, int offset, int count, CancellationToken cancellationToken)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-                this.Write(buffer, offset, count));
+            Debug.Assert(this.wrappedBuffer != null, "this.wrappedBuffer != null");
+
+            // if we have less than 3 bytes, store the bytes and continue
+            if (count + trailingBytes.Length < MinBytesPerWriteEvent)
+            {
+                this.trailingBytes = this.trailingBytes.Concat(bytes.Skip(offset).Take(count)).ToArray();
+                return;
+            }
+
+            byte[] byteArray;
+
+            PrepareByteArray(bytes, offset, count, out byteArray);
+
+            await JsonValueUtils.WriteBinaryStringAsync(this.Writer, 
+                byteArray, this.wrappedBuffer, this.bufferPool).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -201,7 +207,13 @@ namespace Microsoft.OData
         /// </summary>
         public override void Flush()
         {
-            Writer.Flush();
+            this.Writer.Flush();
+        }
+
+        /// <inheritdoc/>
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            await this.Writer.FlushAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -219,6 +231,36 @@ namespace Microsoft.OData
 
             this.Writer.Flush();
             base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Prepares bytes to be written for the particular write event
+        /// </summary>
+        /// <param name="bytes">The bytes to write to the stream.</param>
+        /// <param name="offset">The offset in the buffer to start from.</param>
+        /// <param name="count">The number of bytes targeted in this write event.</param>
+        /// <param name="byteArray">The bytes to be written in this write event.</param>
+        private void PrepareByteArray(byte[] bytes, int offset, int count, out byte[] byteArray)
+        {
+            int trailingBytesLength = this.trailingBytes.Length;
+            byte[] prefixByteString = emptyByteArray;
+            int numberOfBytesToPrefix = trailingBytesLength > 0 ? MinBytesPerWriteEvent - trailingBytesLength : 0;
+
+            // if we have bytes left over from the previous write, prepend them
+            if (trailingBytesLength > 0)
+            {
+                // convert the trailing bytes plus the first 3-trailingByteLength bytes of the new byte[]
+                prefixByteString = trailingBytes.Concat(bytes.Skip(offset).Take(numberOfBytesToPrefix)).ToArray();
+            }
+
+            // compute if there will be trailing bytes from this write
+            int remainingBytes = (count - numberOfBytesToPrefix) % MinBytesPerWriteEvent;
+            trailingBytes = bytes.Skip(offset + count - remainingBytes).Take(remainingBytes).ToArray();
+
+            // TODO: Too much LINQ? Investigate a more performant way of achieving this
+            byteArray = prefixByteString.Concat(bytes
+                .Skip(offset + numberOfBytesToPrefix)
+                .Take(count - numberOfBytesToPrefix - remainingBytes)).ToArray();
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData.Tests.Json
     {
         private MemoryStream stream;
         private NonIndentedTextWriter writer;
-        private char[] buffer;
+        private Ref<char[]> buffer;
         private IDictionary<string, string> escapedCharMap;
         private IDictionary<string, string> controlCharsMap;
 
@@ -54,7 +54,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteEmptyStringShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, string.Empty, stringEscapeOption, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, string.Empty, stringEscapeOption, this.buffer);
             Assert.Equal("\"\"", this.StreamToString());
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteNonSpecialCharactersShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "abcdefg123", stringEscapeOption, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "abcdefg123", stringEscapeOption, this.buffer);
             Assert.Equal("\"abcdefg123\"", this.StreamToString());
         }
 
@@ -74,7 +74,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteLowSpecialCharactersShouldWorkForEscapeOption(ODataStringEscapeOption stringEscapeOption)
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_\n\r\b", stringEscapeOption, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_\n\r\b", stringEscapeOption, this.buffer);
             Assert.Equal("\"cA_\\n\\r\\b\"", this.StreamToString());
         }
 
@@ -82,7 +82,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteHighSpecialCharactersShouldWorkForEscapeNonAsciiOption()
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeNonAscii, this.buffer);
             Assert.Equal("\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\"", this.StreamToString());
         }
 
@@ -90,7 +90,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteHighSpecialCharactersShouldWorkForEscapeOnlyControlsOption()
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeOnlyControls, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeOnlyControls, this.buffer);
             Assert.Equal("\"cA_Россия\"", this.StreamToString());
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 this.TestInit();
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("{0}", specialChar),
-                    ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
                 Assert.Equal(string.Format("\"{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
             }
         }
@@ -113,7 +113,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 this.TestInit();
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("{0}MiddleEnd", specialChar),
-                    ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
                 Assert.Equal(string.Format("\"{0}MiddleEnd\"", this.escapedCharMap[specialChar]), this.StreamToString());
             }
         }
@@ -125,7 +125,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 this.TestInit();
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("Start{0}End", specialChar),
-                    ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
                 Assert.Equal(string.Format("\"Start{0}End\"", this.escapedCharMap[specialChar]), this.StreamToString());
             }
         }
@@ -137,7 +137,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 this.TestInit();
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("StartMiddle{0}", specialChar),
-                    ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
                 Assert.Equal(string.Format("\"StartMiddle{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
             }
         }
@@ -149,7 +149,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 this.TestInit();
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("{0}Start{0}Middle{0}End", specialChar),
-                    ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
                 Assert.Equal(string.Format("\"{0}Start{0}Middle{0}End\"", this.escapedCharMap[specialChar]), this.StreamToString());
             }
         }
@@ -160,9 +160,9 @@ namespace Microsoft.OData.Tests.Json
             foreach (string specialChar in this.escapedCharMap.Keys)
             {
                 this.TestInit();
-                char[] charBuffer = new char[10];
+                Ref<char[]> charBuffer = new Ref<char[]>(new char[10]);
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("StartMiddle{0}End", specialChar),
-                    ODataStringEscapeOption.EscapeNonAscii, ref charBuffer);
+                    ODataStringEscapeOption.EscapeNonAscii, charBuffer);
                 Assert.Equal(string.Format("\"StartMiddle{0}End\"", this.escapedCharMap[specialChar]), this.StreamToString());
             }
         }
@@ -173,9 +173,9 @@ namespace Microsoft.OData.Tests.Json
             foreach (string specialChar in this.escapedCharMap.Keys)
             {
                 this.TestInit();
-                char[] charBuffer = new char[6];
+                Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("Start{0}Middle{0}End{0}", specialChar),
-                    ODataStringEscapeOption.EscapeNonAscii, ref charBuffer);
+                    ODataStringEscapeOption.EscapeNonAscii, charBuffer);
                 Assert.Equal(string.Format("\"Start{0}Middle{0}End{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
             }
         }
@@ -186,9 +186,9 @@ namespace Microsoft.OData.Tests.Json
             foreach (string specialChar in this.escapedCharMap.Keys)
             {
                 this.TestInit();
-                char[] charBuffer = new char[6];
+                Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("Start{0}", specialChar),
-                    ODataStringEscapeOption.EscapeNonAscii, ref charBuffer);
+                    ODataStringEscapeOption.EscapeNonAscii, charBuffer);
                 Assert.Equal(string.Format("\"Start{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
             }
         }
@@ -201,9 +201,9 @@ namespace Microsoft.OData.Tests.Json
             foreach (string specialChar in this.controlCharsMap.Keys)
             {
                 this.TestInit();
-                char[] charBuffer = new char[6];
+                Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("S{0}M{0}E{0}", specialChar),
-                    escapeOption, ref charBuffer);
+                    escapeOption, charBuffer);
                 Assert.Equal(string.Format("\"S{0}M{0}E{0}\"", this.controlCharsMap[specialChar]), this.StreamToString());
             }
         }
@@ -214,10 +214,10 @@ namespace Microsoft.OData.Tests.Json
         public void WriteStringWithNoSpecialCharShouldLeaveBufferUntouched(ODataStringEscapeOption stringEscapeOption)
         {
             this.TestInit();
-            char[] charBuffer = null;
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "StartMiddleEnd", stringEscapeOption, ref charBuffer);
+            Ref<char[]> charBuffer = new Ref<char[]>(null);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "StartMiddleEnd", stringEscapeOption, charBuffer);
             Assert.Equal("\"StartMiddleEnd\"", this.StreamToString());
-            Assert.Null(charBuffer);
+            Assert.Null(charBuffer.Value);
         }
 
         [Theory]
@@ -226,13 +226,13 @@ namespace Microsoft.OData.Tests.Json
         public void WriteStringShouldIgnoreExistingContentsOfTheBuffer(ODataStringEscapeOption stringEscapeOption)
         {
             this.TestInit();
-            char[] charBuffer = new char[128];
+            Ref<char[]> charBuffer = new Ref<char[]>(new char[128]);
             for (int index = 0; index < 128; index++)
             {
-                charBuffer[index] = (char)index;
+                charBuffer.Value[index] = (char)index;
             }
 
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "StartVeryVeryLongMiddleEnd", stringEscapeOption, ref charBuffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "StartVeryVeryLongMiddleEnd", stringEscapeOption, charBuffer);
             Assert.Equal("\"StartVeryVeryLongMiddleEnd\"", this.StreamToString());
         }
 
@@ -241,7 +241,7 @@ namespace Microsoft.OData.Tests.Json
         {
             this.TestInit();
             var byteArray = new byte[] { 1, 2, 3 };
-            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
+            JsonValueUtils.WriteValue(this.writer, byteArray, this.buffer);
             Assert.Equal("\"AQID\"", this.StreamToString());
         }
 
@@ -257,7 +257,7 @@ namespace Microsoft.OData.Tests.Json
             }
 
             // Act, Get Base64 string from OData library
-            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
+            JsonValueUtils.WriteValue(this.writer, byteArray, this.buffer);
             string convertedBase64String = this.StreamToString();
 
             // Get Base64 string directly calling the converter.
@@ -276,7 +276,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Initialize the buffer
             int bufferLength = 40;
-            this.buffer = new char[bufferLength];
+            this.buffer = new Ref<char[]>(new char[bufferLength]);
             int byteSize = bufferLength * 3 / 4;
 
             // Make the output Base64 string length same as the buffer size.
@@ -287,7 +287,7 @@ namespace Microsoft.OData.Tests.Json
             }
 
             // Act, Get Base64 string from OData library
-            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
+            JsonValueUtils.WriteValue(this.writer, byteArray, this.buffer);
             string convertedBase64String = this.StreamToString();
 
             // Get Base64 string directly calling the converter.
@@ -303,7 +303,7 @@ namespace Microsoft.OData.Tests.Json
         {
             this.TestInit();
             var byteArray = new byte[] { };
-            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
+            JsonValueUtils.WriteValue(this.writer, byteArray, this.buffer);
             Assert.Equal("\"\"", this.StreamToString());
         }
 
@@ -311,7 +311,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteNullByteShouldWork()
         {
             this.TestInit();
-            JsonValueUtils.WriteValue(this.writer, (byte[])null, ref this.buffer);
+            JsonValueUtils.WriteValue(this.writer, (byte[])null, this.buffer);
             Assert.Equal("null", this.StreamToString());
         }
 
@@ -321,6 +321,7 @@ namespace Microsoft.OData.Tests.Json
             StreamWriter innerWriter = new StreamWriter(this.stream);
             innerWriter.AutoFlush = true;
             this.writer = new NonIndentedTextWriter(innerWriter);
+            this.buffer = new Ref<char[]>();
         }
 
         private string StreamToString()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
@@ -1,0 +1,363 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="JsonWriterAsyncTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Text;
+using Microsoft.OData.Json;
+using Microsoft.OData.Edm;
+using Xunit;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+
+namespace Microsoft.OData.Tests.Json
+{
+    /// <summary>
+    /// Unit tests for the JsonWriter class.
+    /// </summary>
+    public class JsonWriterAsyncTests
+    {
+        private StringBuilder builder;
+        private IJsonWriterAsync writer;
+
+        public JsonWriterAsyncTests()
+        {
+            this.builder = new StringBuilder();
+            this.writer = new JsonWriter(new StringWriter(builder), isIeee754Compatible: true);
+        }
+
+        [Fact]
+        public async Task StartPaddingFunctionScopeAsyncWritesParenthesis()
+        {
+            await this.writer.StartPaddingFunctionScopeAsync();
+            Assert.Equal("(", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task EndPaddingFunctionScopeAsyncWritesParenthesis()
+        {
+            await this.writer.StartPaddingFunctionScopeAsync();
+            await this.writer.EndPaddingFunctionScopeAsync();
+            Assert.Equal("()", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WritePaddingFunctionNameAsyncWritesName()
+        {
+            await this.writer.WritePaddingFunctionNameAsync("example");
+            Assert.Equal("example", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task StartObjectScopeAsyncWritesCurlyBraces()
+        {
+            await this.writer.StartObjectScopeAsync();
+            Assert.Equal("{", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task EndObjectScopeAsyncCurlyBraces()
+        {
+            await this.writer.StartObjectScopeAsync();
+            await this.writer.EndObjectScopeAsync();
+            Assert.Equal("{}", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task StartArrayScopeAsyncWritesSquareBrackets()
+        {
+            await this.writer.StartArrayScopeAsync();
+            Assert.Equal("[", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task EndArrayScopeAsyncSquareBrackets()
+        {
+            await this.writer.StartArrayScopeAsync();
+            await this.writer.EndArrayScopeAsync();
+            Assert.Equal("[]", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteArrayElementSeparatorAsync()
+        {
+            await this.writer.StartArrayScopeAsync();
+            await this.writer.StartObjectScopeAsync();
+            await this.writer.EndObjectScopeAsync();
+            await this.writer.StartObjectScopeAsync();
+            Assert.Equal("[{},{", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteNameAsyncWritesName()
+        {
+            await this.writer.StartObjectScopeAsync();
+            await this.writer.WriteNameAsync("Name");
+            Assert.Equal("{\"Name\":", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteNameAsyncWritesNameWithObjectMemberSeparator()
+        {
+            await this.writer.StartObjectScopeAsync();
+            await this.writer.WriteNameAsync("Name");
+            await this.writer.WritePrimitiveValueAsync("Sue");
+            await this.writer.WriteNameAsync("Age");
+            Assert.Equal("{\"Name\":\"Sue\",\"Age\":", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteRawValueAsyncWritesValue()
+        {
+            await this.writer.WriteRawValueAsync("Raw\tValue");
+            await this.writer.FlushAsync();
+            Assert.Equal("Raw\tValue", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task TestStartTextWriterValueScopeAsync()
+        {
+            var stringBuilder = new StringBuilder();
+            var jsonWriter = new JsonWriter(new StringWriter(stringBuilder), isIeee754Compatible: true);
+            var jsonTextWriter = await jsonWriter.StartTextWriterValueScopeAsync(MimeConstants.MimeTextPlain);
+            await jsonTextWriter.WriteLineAsync("Быстрая коричневая лиса прыгает через ленивую собаку");
+            await jsonWriter.EndTextWriterValueScopeAsync();
+
+            Assert.Equal("\"Быстрая коричневая лиса прыгает через ленивую собаку\"", stringBuilder.ToString());
+        }
+
+        #region JsonWriter Extension Methods
+
+        [Fact]
+        public async Task WriteJsonObjectValueAsyncWritesJsonObject()
+        {
+            var properties = new Dictionary<string, object>
+            {
+                { "Name", "Sue" },
+                { "Attributes",
+                    new Dictionary<string, object>
+                    {
+                        { "Height", 1.77 },
+                        { "Weight", 80.7 }
+                    } 
+                }
+            };
+            await this.writer.WriteJsonObjectValueAsync(properties, null);
+            Assert.Equal("{\"Name\":\"Sue\",\"Attributes\":{\"Height\":1.77,\"Weight\":80.7}}", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteJsonObjectValueAsyncCallsInjectedPropertyAction()
+        {
+            var properties = new Dictionary<string, object> { { "Name", "Sue" } };
+            Func<IJsonWriterAsync, Task> injectPropertyAction = async (IJsonWriterAsync actionWriter) =>
+            {
+                await actionWriter.WriteNameAsync("Id");
+                await actionWriter.WriteValueAsync(7);
+            };
+            await this.writer.WriteJsonObjectValueAsync(properties, injectPropertyAction);
+            Assert.Equal("{\"Id\":7,\"Name\":\"Sue\"}", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteJsonObjectValueAsyncWritesPrimitiveCollection()
+        {
+            var properties = new Dictionary<string, object>
+            {
+                { "Names", new string[] { "Sue", "Joe", null } }
+            };
+            await this.writer.WriteJsonObjectValueAsync(properties, null);
+            Assert.Equal("{\"Names\":[\"Sue\",\"Joe\",null]}", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteODataValueAsyncWritesODataValue()
+        {
+            var value = new ODataPrimitiveValue(3.14);
+            await this.writer.WriteODataValueAsync(value);
+            Assert.Equal("3.14", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteODataValueAsyncWritesNullValue()
+        {
+            var value = new ODataNullValue();
+            await this.writer.WriteODataValueAsync(value);
+            Assert.Equal("null", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteODataValueAsyncWritesODataResourceValue()
+        {
+            var resourceValue = new ODataResourceValue
+            {
+                Properties = new List<ODataProperty>
+                { 
+                    new ODataProperty { Name = "Name", Value = "Sue" },
+                    new ODataProperty { Name = "Age", Value = 19 }
+                }
+            };
+            await this.writer.WriteODataValueAsync(resourceValue);
+            Assert.Equal("{\"Name\":\"Sue\",\"Age\":19}", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteODataValueAsyncWritesODataCollectionValue()
+        {
+            var collectionValue = new ODataCollectionValue
+            {
+                Items = new List<ODataResourceValue>
+                {
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Sue" },
+                            new ODataProperty { Name = "Age", Value = 19 }
+                        }
+                    },
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Joe" },
+                            new ODataProperty { Name = "Age", Value = 23 }
+                        }
+                    }
+                }
+            };
+            await this.writer.WriteODataValueAsync(collectionValue);
+            Assert.Equal("[{\"Name\":\"Sue\",\"Age\":19},{\"Name\":\"Joe\",\"Age\":23}]", this.builder.ToString());
+        }
+
+        #endregion JsonWriter Extension Methods
+
+        #region WritePrimitiveValue
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncBoolean()
+        {
+            await this.VerifyWritePrimitiveValueAsync(false, "false");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncByte()
+        {
+            await this.VerifyWritePrimitiveValueAsync((byte)4, "4");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncDecimalWithIeee754CompatibleTrue()
+        {
+            await this.VerifyWriterPrimitiveValueWithIeee754CompatibleAsync(42.2m, "\"42.2\"", isIeee754Compatible: true);
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncDecimalWithIeee754CompatibleFalse()
+        {
+            await this.VerifyWriterPrimitiveValueWithIeee754CompatibleAsync(42.2m, "42.2", isIeee754Compatible: false);
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncDouble()
+        {
+            await this.VerifyWritePrimitiveValueAsync(42.2d, "42.2");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncInt16()
+        {
+            await this.VerifyWritePrimitiveValueAsync((short)876, "876");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncInt32()
+        {
+            await this.VerifyWritePrimitiveValueAsync((int)876, "876");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncInt64WithIeee754CompatibleTrue()
+        {
+            await this.VerifyWriterPrimitiveValueWithIeee754CompatibleAsync((long)876, "\"876\"", isIeee754Compatible: true);
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncInt64WithIeee754CompatibleFalse()
+        {
+            await this.VerifyWriterPrimitiveValueWithIeee754CompatibleAsync((long)876, "876", isIeee754Compatible: false);
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncSByte()
+        {
+            await this.VerifyWritePrimitiveValueAsync((sbyte)4, "4");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncSingle()
+        {
+            await this.VerifyWritePrimitiveValueAsync((Single)876, "876");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncString()
+        {
+            await this.VerifyWritePrimitiveValueAsync("string", "\"string\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncByteArray()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new byte[] { 0 }, "\"" + Convert.ToBase64String(new byte[] { 0 }) + "\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncDateTimeOffset()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new DateTimeOffset(1, 2, 3, 4, 5, 6, 7, new TimeSpan(1, 2, 0)), "\"0001-02-03T04:05:06.007+01:02\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncGuid()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new Guid("00000012-0000-0000-0000-012345678900"), "\"00000012-0000-0000-0000-012345678900\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncTimeSpan()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new TimeSpan(1, 2, 3, 4, 5), "\"P1DT2H3M4.005S\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncDate()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new Date(2014, 12, 31), "\"2014-12-31\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncTimeOfDay()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new TimeOfDay(12, 30, 5, 10), "\"12:30:05.0100000\"");
+        }
+
+        private async Task VerifyWritePrimitiveValueAsync<T>(T parameter, string expected)
+        {
+            await this.writer.WritePrimitiveValueAsync(parameter);
+            Assert.Equal(expected, this.builder.ToString());
+        }
+
+        private async Task VerifyWriterPrimitiveValueWithIeee754CompatibleAsync<T>(T parameter, string expected, bool isIeee754Compatible)
+        {
+            this.writer = new JsonWriter(new StringWriter(builder), isIeee754Compatible);
+            await this.writer.WritePrimitiveValueAsync(parameter);
+            Assert.Equal(expected, this.builder.ToString());
+        }
+
+        #endregion
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
@@ -153,12 +153,12 @@ namespace Microsoft.OData.Tests.Json
         public async Task WriteJsonObjectValueAsyncCallsInjectedPropertyAction()
         {
             var properties = new Dictionary<string, object> { { "Name", "Sue" } };
-            Func<IJsonWriterAsync, Task> injectPropertyAction = async (IJsonWriterAsync actionWriter) =>
+            Func<IJsonWriterAsync, Task> injectPropertyDelegate = async (IJsonWriterAsync actionWriter) =>
             {
                 await actionWriter.WriteNameAsync("Id");
                 await actionWriter.WriteValueAsync(7);
             };
-            await this.writer.WriteJsonObjectValueAsync(properties, injectPropertyAction);
+            await this.writer.WriteJsonObjectValueAsync(properties, injectPropertyDelegate);
             Assert.Equal("{\"Id\":7,\"Name\":\"Sue\"}", this.builder.ToString());
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/NonIndentedTextWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/NonIndentedTextWriterTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.Tests.Json
     {
         private MemoryStream stream;
         private TextWriterWrapper writer;
-        private char[] buffer;
+        private Ref<char[]> buffer;
         private Dictionary<string, string> escapedCharMap = new Dictionary<string, string>()
         {
             {"\r\n", "\\r\\n"}, 
@@ -37,7 +37,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteEmptyStringShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, string.Empty, stringEscapeOption, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, string.Empty, stringEscapeOption, this.buffer);
             Assert.Equal("\"\"", this.StreamToString());
         }
 
@@ -47,7 +47,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteNonSpecialCharactersShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "abcdefg123", stringEscapeOption, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "abcdefg123", stringEscapeOption, this.buffer);
             Assert.Equal("\"abcdefg123\"", this.StreamToString());
         }
 
@@ -58,7 +58,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 this.TestInit();
                 JsonValueUtils.WriteEscapedJsonString(this.writer, string.Format("{0}", specialChar),
-                    ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
+                    ODataStringEscapeOption.EscapeNonAscii, this.buffer);
                 Assert.Equal(string.Format("\"{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
             }
         }
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteHighSpecialCharactersShouldWorkForEscapeNonAsciiOption()
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeNonAscii, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeNonAscii, this.buffer);
             Assert.Equal("\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\"", this.StreamToString());
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.OData.Tests.Json
         public void WriteHighSpecialCharactersShouldWorkForEscapeOnlyControlsOption()
         {
             this.TestInit();
-            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeOnlyControls, ref this.buffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeOnlyControls, this.buffer);
             Assert.Equal("\"cA_Россия\"", this.StreamToString());
         }
 
@@ -84,7 +84,7 @@ namespace Microsoft.OData.Tests.Json
         {
             this.TestInit();
             var byteArray = new byte[] { 1, 2, 3 };
-            JsonValueUtils.WriteValue(this.writer, byteArray, ref this.buffer);
+            JsonValueUtils.WriteValue(this.writer, byteArray, this.buffer);
             Assert.Equal("\"AQID\"", this.StreamToString());
         }
 
@@ -94,6 +94,7 @@ namespace Microsoft.OData.Tests.Json
             StreamWriter innerWriter = new StreamWriter(this.stream);
             innerWriter.AutoFlush = true;
             this.writer = new NonIndentedTextWriter(innerWriter);
+            this.buffer = new Ref<char[]>();
         }
 
         private string StreamToString()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonTextWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonTextWriterAsyncTests.cs
@@ -1,0 +1,82 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataJsonTextWriterAsyncTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OData.Tests.Json
+{
+    /// <summary>
+    /// Asynchronous unit tests for the ODataJsonTextWriter class.
+    /// </summary>
+    public class ODataJsonTextWriterAsyncTests
+    {
+        private StringBuilder builder;
+        private Ref<char[]> buffer;
+        private ODataJsonTextWriter writer;
+
+        public ODataJsonTextWriterAsyncTests()
+        {
+            this.builder = new StringBuilder();
+            this.buffer = new Ref<char[]>();
+            this.writer = new ODataJsonTextWriter(new StringWriter(this.builder), this.buffer, null);
+        }
+
+        [Fact]
+        public async Task WriteAsyncChar()
+        {
+            await this.writer.WriteAsync('\\');
+            Assert.Equal("\\\\", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteAsyncCharSubarray()
+        {
+            char[] array = new char[] { 'C', ':', '\\', 'W', 'i', 'n', 'd', 'o', 'w', 's' };
+            await this.writer.WriteAsync(array);
+            Assert.Equal("C:\\\\Windows", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteAsyncString()
+        {
+            await this.writer.WriteAsync("C:\\Windows");
+            Assert.Equal("C:\\\\Windows", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteLineAsyncChar()
+        {
+            await this.writer.WriteLineAsync('\\');
+            Assert.Equal("\\\\\r\n", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteLineAsyncCharSubarray()
+        {
+            char[] array = new char[] { 'C', ':', '\\', 'W', 'i', 'n', 'd', 'o', 'w', 's' };
+            await this.writer.WriteLineAsync(array);
+            Assert.Equal("C:\\\\Windows\r\n", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteLineAsyncString()
+        {
+            await this.writer.WriteLineAsync("C:\\Windows");
+            Assert.Equal("C:\\\\Windows\r\n", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task TestWriteLineAsync()
+        {
+            await this.writer.WriteLineAsync();
+            await this.writer.FlushAsync();
+            Assert.Equal("\r\n", this.builder.ToString());
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataBinaryStreamWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataBinaryStreamWriterTests.cs
@@ -1,0 +1,59 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataBinaryStreamWriterTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OData.Tests.JsonLight
+{
+    /// <summary>
+    /// Unit tests for the ODataBinaryStreamWriter class.
+    /// </summary>
+    public class ODataBinaryStreamWriterTests
+    {
+        private StringBuilder builder;
+        private Ref<char[]> buffer;
+        private ODataBinaryStreamWriter writer;
+
+        public ODataBinaryStreamWriterTests()
+        {
+            this.builder = new StringBuilder();
+            this.buffer = new Ref<char[]>();
+            this.writer = new ODataBinaryStreamWriter(new StringWriter(this.builder), this.buffer, null);
+        }
+
+        [Fact]
+        public void WriteByteArray()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 };
+
+            this.writer.Write(bytes, 0, 4);
+            this.writer.Write(bytes, 4, 4);
+            this.writer.Write(bytes, 8, 2);
+            // Calling Dispose should cause the trailing bytes to be written
+            this.writer.Dispose();
+
+            Assert.Equal("AQIDBAUGBwgJAA==", this.builder.ToString());
+        }
+
+        [Fact]
+        public async Task WriteAsyncByteArray()
+        {
+            var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 };
+
+            await this.writer.WriteAsync(bytes, 0, 4, CancellationToken.None);
+            await this.writer.WriteAsync(bytes, 4, 4, CancellationToken.None);
+            await this.writer.WriteAsync(bytes, 8, 2, CancellationToken.None);
+            // Calling Dispose should cause the trailing bytes to be written
+            this.writer.Dispose();
+
+            Assert.Equal("AQIDBAUGBwgJAA==", this.builder.ToString());
+        }
+    }
+}

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Json/JsonValueUtilsTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Json/JsonValueUtilsTests.cs
@@ -9,13 +9,13 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Json
     using System;
     using System.IO;
     using System.Text;
-
+    using Microsoft.OData;
+    using Microsoft.OData.Buffers;
+    using Microsoft.OData.Json;
     using Microsoft.Test.OData.Utils.CombinatorialEngine;
     using Microsoft.Test.Taupo.Execution;
     using Microsoft.Test.Taupo.OData.Common;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using Microsoft.OData.Json;
-    using Microsoft.OData.Buffers;
 
     /// <summary>
     /// Tests for the ODataJsonConvert class
@@ -286,7 +286,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Json
             public static void WriteValue(TextWriter writer, TimeSpan value) { ReflectionUtils.InvokeMethod(classType, "WriteValue", writer, value); }
             public static void WriteValue(TextWriter writer, byte value) { ReflectionUtils.InvokeMethod(classType, "WriteValue", writer, value); }
             public static void WriteValue(TextWriter writer, sbyte value) { ReflectionUtils.InvokeMethod(classType, "WriteValue", writer, value); }
-            public static void WriteValue(TextWriter writer, string value) { char[] buffer = null; ReflectionUtils.InvokeMethod(classType, "WriteValue", new Type[] { typeof(TextWriter), typeof(string), typeof(ODataStringEscapeOption), typeof(char[]).MakeByRefType(), typeof(ICharArrayPool) }, writer, value, ODataStringEscapeOption.EscapeNonAscii, buffer, null); }
+            public static void WriteValue(TextWriter writer, string value) { Ref<char[]> buffer = new Ref<char[]>(); ReflectionUtils.InvokeMethod(classType, "WriteValue", new Type[] { typeof(TextWriter), typeof(string), typeof(ODataStringEscapeOption), typeof(Ref<char[]>), typeof(ICharArrayPool) }, writer, value, ODataStringEscapeOption.EscapeNonAscii, buffer, null); }
         }
 #endif
     }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request is a partial fulfilment of issue #2019.*

### Description

Implement asynchronous support in JsonWriter
- Added `IJsonWriterAsync` interface.
- Added `IJsonStreamWriterAsync` interface.
- Added `IJsonWriterFactoryAsync` interface.
- Implemented `IJsonStreamWriterAsync` asynchronous methods in `JsonWriter` class.
- Implemented `IJsonWriterFactoryAsync` methods in `DefaultJsonWriterFactory` class.
- Implemented asynchronous methods in `ODataJsonTextWriter` class.
- Implemented asynchronous methods in `ODataBinaryStreamWriter` class.
- Added test for `JsonWriter`, `ODataJsonTextWriter` and `ODataBinaryStreamWriter` classes asynchronous methods.
- Passing around a `char` array reference in the synchronous workflow to support use of char array pool and a `char` array wrapped in an object in the asynchronous workflow started degenerating into a code smell so I opted for one that works across both workflows.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
