### PR TITLE
Issues #2016, #1447: In-operator precedence

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -980,7 +980,7 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
-        /// Parses the has, and in operators.
+        /// Parses the has and in operators.
         /// </summary>
         /// <returns>The lexical token representing the expression.</returns>
         private QueryToken ParseInHas()

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -823,7 +823,7 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
-        /// Parses the eq, ne, lt, gt, le, ge, has, and in operators.
+        /// Parses the eq, ne, lt, gt, le, and ge operators.
         /// </summary>
         /// <returns>The lexical token representing the expression.</returns>
         private QueryToken ParseComparison()
@@ -832,52 +832,39 @@ namespace Microsoft.OData.UriParser
             QueryToken left = this.ParseAdditive();
             while (true)
             {
-                if (this.TokenIdentifierIs(ExpressionConstants.KeywordIn))
+                BinaryOperatorKind binaryOperatorKind;
+                if (this.TokenIdentifierIs(ExpressionConstants.KeywordEqual))
                 {
-                    this.lexer.NextToken();
-                    QueryToken right = this.ParseAdditive();
-                    left = new InToken(left, right);
+                    binaryOperatorKind = BinaryOperatorKind.Equal;
+                }
+                else if (this.TokenIdentifierIs(ExpressionConstants.KeywordNotEqual))
+                {
+                    binaryOperatorKind = BinaryOperatorKind.NotEqual;
+                }
+                else if (this.TokenIdentifierIs(ExpressionConstants.KeywordGreaterThan))
+                {
+                    binaryOperatorKind = BinaryOperatorKind.GreaterThan;
+                }
+                else if (this.TokenIdentifierIs(ExpressionConstants.KeywordGreaterThanOrEqual))
+                {
+                    binaryOperatorKind = BinaryOperatorKind.GreaterThanOrEqual;
+                }
+                else if (this.TokenIdentifierIs(ExpressionConstants.KeywordLessThan))
+                {
+                    binaryOperatorKind = BinaryOperatorKind.LessThan;
+                }
+                else if (this.TokenIdentifierIs(ExpressionConstants.KeywordLessThanOrEqual))
+                {
+                    binaryOperatorKind = BinaryOperatorKind.LessThanOrEqual;
                 }
                 else
                 {
-                    BinaryOperatorKind binaryOperatorKind;
-                    if (this.TokenIdentifierIs(ExpressionConstants.KeywordEqual))
-                    {
-                        binaryOperatorKind = BinaryOperatorKind.Equal;
-                    }
-                    else if (this.TokenIdentifierIs(ExpressionConstants.KeywordNotEqual))
-                    {
-                        binaryOperatorKind = BinaryOperatorKind.NotEqual;
-                    }
-                    else if (this.TokenIdentifierIs(ExpressionConstants.KeywordGreaterThan))
-                    {
-                        binaryOperatorKind = BinaryOperatorKind.GreaterThan;
-                    }
-                    else if (this.TokenIdentifierIs(ExpressionConstants.KeywordGreaterThanOrEqual))
-                    {
-                        binaryOperatorKind = BinaryOperatorKind.GreaterThanOrEqual;
-                    }
-                    else if (this.TokenIdentifierIs(ExpressionConstants.KeywordLessThan))
-                    {
-                        binaryOperatorKind = BinaryOperatorKind.LessThan;
-                    }
-                    else if (this.TokenIdentifierIs(ExpressionConstants.KeywordLessThanOrEqual))
-                    {
-                        binaryOperatorKind = BinaryOperatorKind.LessThanOrEqual;
-                    }
-                    else if (this.TokenIdentifierIs(ExpressionConstants.KeywordHas))
-                    {
-                        binaryOperatorKind = BinaryOperatorKind.Has;
-                    }
-                    else
-                    {
-                        break;
-                    }
-
-                    this.lexer.NextToken();
-                    QueryToken right = this.ParseAdditive();
-                    left = new BinaryOperatorToken(binaryOperatorKind, left, right);
+                    break;
                 }
+
+                this.lexer.NextToken();
+                QueryToken right = this.ParseAdditive();
+                left = new BinaryOperatorToken(binaryOperatorKind, left, right);
             }
 
             this.RecurseLeave();
@@ -969,7 +956,7 @@ namespace Microsoft.OData.UriParser
                     numberLiteral.Position = operatorToken.Position;
                     this.lexer.CurrentToken = numberLiteral;
                     this.RecurseLeave();
-                    return this.ParsePrimary();
+                    return this.ParseInHas();
                 }
 
                 QueryToken operand = this.ParseUnary();
@@ -989,7 +976,40 @@ namespace Microsoft.OData.UriParser
             }
 
             this.RecurseLeave();
-            return this.ParsePrimary();
+            return this.ParseInHas();
+        }
+
+        /// <summary>
+        /// Parses the has, and in operators.
+        /// </summary>
+        /// <returns>The lexical token representing the expression.</returns>
+        private QueryToken ParseInHas()
+        {
+            this.RecurseEnter();
+            QueryToken left = this.ParsePrimary();
+            while (true)
+            {
+                if (this.TokenIdentifierIs(ExpressionConstants.KeywordIn))
+                {
+                    this.lexer.NextToken();
+                    QueryToken right = this.ParsePrimary();
+                    left = new InToken(left, right);
+                    this.RecurseLeave();
+                }
+                else if (this.TokenIdentifierIs(ExpressionConstants.KeywordHas))
+                {
+                    this.lexer.NextToken();
+                    QueryToken right = this.ParsePrimary();
+                    left = new BinaryOperatorToken(BinaryOperatorKind.Has, left, right);
+                } 
+                else
+                {
+                    break;
+                }
+            }
+
+            this.RecurseLeave();
+            return left;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -994,7 +994,6 @@ namespace Microsoft.OData.UriParser
                     this.lexer.NextToken();
                     QueryToken right = this.ParsePrimary();
                     left = new InToken(left, right);
-                    this.RecurseLeave();
                 }
                 else if (this.TokenIdentifierIs(ExpressionConstants.KeywordHas))
                 {

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/DataServiceQueryProviderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/DataServiceQueryProviderTests.cs
@@ -107,6 +107,22 @@ namespace Microsoft.OData.Client.Tests
         }
 
         [Fact]
+        public void TranslatesEnumerableNotContainsToNotInOperator()
+        {
+            // Arrange
+            var sut = new DataServiceQueryProvider(dsc);
+            var productNames = new[] { "Milk", "Cheese", "Donut" };
+            var products = dsc.CreateQuery<Product>("Products")
+                .Where(product => !productNames.Contains(product.Name));
+
+            // Act
+            var queryComponents = sut.Translate(products.Expression);
+
+            // Assert
+            Assert.Equal(@"http://root/Products?$filter=not Name in ('Milk','Cheese','Donut')", queryComponents.Uri.ToString());
+        }
+
+        [Fact]
         public void EnumerableContainsOnCollectionValuedPropertiesWithConstantIsNotSupported()
         {
             // Arrange

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/SelectExpandParserTests.cs
@@ -674,7 +674,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             ExpandToken expandTree;
             ODataUriParserConfiguration configuration = new ODataUriParserConfiguration(EdmCoreModel.Instance)
             {
-                Settings = { PathLimit = 2, FilterLimit = 7, OrderByLimit = 7, SearchLimit = 7, SelectExpandLimit = 5 }
+                Settings = { PathLimit = 2, FilterLimit = 8, OrderByLimit = 8, SearchLimit = 7, SelectExpandLimit = 5 }
             };
 
             SelectExpandSyntacticParser.Parse(select, expand, null , configuration, out expandTree, out selectTree);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2016.
This pull request fixes #1447.

### Description

This PR lowers the parsing of the `in` and `has` operators to just before the other "primary" operators per [the precedence table listed in the OData 4.01 spec](https://docs.oasis-open.org/odata/odata/v4.01/os/part2-url-conventions/odata-v4.01-os-part2-url-conventions.html#_Toc31361036).

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

~_NOTE:_ I'm having issues building the E2E project locally and will keep this as a Draft PR until I work that out.~

### Additional work necessary

There is an open issue with this fix in that it introduces a new recursion depth to the code. This could be considered a breaking change for services which use OData.Net with queries that work today but tomorrow will not because they exist right _at_ the recursion limit.

I see two paths forward:
1. Leave this PR as-is and make a possible breaking change note explaining the new recursion depth.
2. Make this PR "pay-for-play" and only charge for recursion depths if an `in` or `has` operator is present.

Option 2 is not what the existing code does, which took me somewhat by surprise. I was unaware that the recursion limits for filters et al were based on the parsing logic rather than the depth of the resultant AST. I experimented with changing the usage of recursion limits to be based on the AST, but that has the side effect of allowing some seriously large parser call stacks when the AST ends up being rather simple.
