### PR TITLE
HttpClientRequestMessage: Fix UnwrapAggregateException.

### DIFF
--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -470,7 +470,7 @@ namespace Microsoft.OData.Client
             {
                 if (aggregateException.InnerExceptions.Count == 1)
                 {
-                    throw ConvertToDataServiceTransportException(new WebException(aggregateException.InnerException.InnerException.ToString()));
+                    throw ConvertToDataServiceTransportException(new WebException(aggregateException.InnerException.ToString()));
                 }
                 throw;
             }

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.Serialization
+{
+    public class HttpClientRequestMessageTests
+    {
+        [Fact]
+        public void UnwrapAggregateException()
+        {
+            var msg = new HttpClientRequestMessage(new DataServiceClientRequestMessageArgs("GET", new Uri("http://localhost"), false, false, new Dictionary<string, string>()));
+            var task = new Task<HttpResponseMessage>(() => throw new Exception("single exception"));
+            task.RunSynchronously();
+
+            var exception = Assert.Throws<DataServiceTransportException>(() => msg.EndGetResponse(task));
+            Assert.StartsWith("System.Exception: single exception\r\n", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

UnwrapAggregateException of HttpClientRequestMessage can currently either re-throw incomplete exception informations (by skipping an exception layer) or cause a NPE.

UnwrapAggregateException tries to unwrap an exception two layers deep. This is wrong. I got here a NPE because the exception that was wrapped in the AggregateException had no InnerException. This PR fixes this simple mistake.

### Additional work necessary
none