### PR TITLE
Fix/2005 translate path select item

### DIFF
--- a/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.OData
                     selectClause += this.Translate((PathSelectItem)selectItem);
                 }
 
-                if (selectItem.GetType() == typeof(ExpandedNavigationSelectItem))
+                else if (selectItem.GetType() == typeof(ExpandedNavigationSelectItem))
                 {
                     if (string.IsNullOrEmpty(expandClause))
                     {
@@ -56,7 +56,7 @@ namespace Microsoft.OData
                     expandClause += this.Translate((ExpandedNavigationSelectItem)selectItem);
                 }
 
-                if (selectItem.GetType() == typeof(ExpandedReferenceSelectItem))
+                else if (selectItem.GetType() == typeof(ExpandedReferenceSelectItem))
                 {
                     if (string.IsNullOrEmpty(expandClause))
                     {

--- a/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
@@ -37,7 +37,7 @@ namespace Microsoft.OData
 
             foreach (SelectItem selectItem in selectExpandClause.SelectedItems)
             {
-                if(selectItem.GetType() == typeof(PathSelectItem))
+                if (selectItem.GetType() == typeof(PathSelectItem))
                 {
                     selectClause += this.Translate((PathSelectItem)selectItem);
                 }
@@ -46,7 +46,7 @@ namespace Microsoft.OData
                 {
                     if (string.IsNullOrEmpty(expandClause))
                     {
-                        expandClause = firstFlag ? expandClause : string.Concat("$expand", ExpressionConstants.SymbolEqual);
+                        expandClause = firstFlag ? expandClause : string.Concat(ExpressionConstants.QueryOptionExpand, ExpressionConstants.SymbolEqual);
                     }
                     else
                     {
@@ -60,18 +60,18 @@ namespace Microsoft.OData
                 {
                     if (string.IsNullOrEmpty(expandClause))
                     {
-                        expandClause = firstFlag ? expandClause : string.Concat("$expand", ExpressionConstants.SymbolEqual);
+                        expandClause = firstFlag ? expandClause : string.Concat(ExpressionConstants.QueryOptionExpand, ExpressionConstants.SymbolEqual);
                     }
                     else
                     {
                         expandClause += ExpressionConstants.SymbolComma;
                     }
 
-                    expandClause += this.Translate((ExpandedReferenceSelectItem)selectItem) + "/$ref";
+                    expandClause += this.Translate((ExpandedReferenceSelectItem)selectItem) + ODataConstants.UriSegmentSeparator + ODataConstants.EntityReferenceSegmentName;
                 }
             }
 
-            selectClause = string.IsNullOrEmpty(selectClause) ? null : string.Concat("$select", ExpressionConstants.SymbolEqual, firstFlag ? Uri.EscapeDataString(selectClause) : selectClause);
+            selectClause = string.IsNullOrEmpty(selectClause) ? null : string.Concat(ExpressionConstants.QueryOptionSelect, ExpressionConstants.SymbolEqual, firstFlag ? Uri.EscapeDataString(selectClause) : selectClause);
 
             if (string.IsNullOrEmpty(expandClause))
             {
@@ -81,7 +81,7 @@ namespace Microsoft.OData
             {
                 if (firstFlag)
                 {
-                    return string.IsNullOrEmpty(selectClause) ? string.Concat("$expand=", Uri.EscapeDataString(expandClause)) : string.Concat(selectClause, "&$expand=", Uri.EscapeDataString(expandClause));
+                    return string.IsNullOrEmpty(selectClause) ? string.Concat(ExpressionConstants.QueryOptionExpand, ExpressionConstants.SymbolEqual, Uri.EscapeDataString(expandClause)) : string.Concat(selectClause, ExpressionConstants.SymbolQueryConcatenate, ExpressionConstants.QueryOptionExpand, ExpressionConstants.SymbolEqual, Uri.EscapeDataString(expandClause));
                 }
                 else
                 {

--- a/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
@@ -110,7 +110,6 @@ namespace Microsoft.OData
         public override string Translate(PathSelectItem item)
         {
             NodeToStringBuilder nodeToStringBuilder = new NodeToStringBuilder();
-            string currentExpandClause = string.Empty;
             string res = string.Empty;
             if (item.FilterOption != null)
             {
@@ -166,7 +165,7 @@ namespace Microsoft.OData
                 res += nodeToStringBuilder.TranslateComputeClause(item.ComputeOption);
             }
 
-            return string.Concat(currentExpandClause, string.IsNullOrEmpty(res) ? null : string.Concat(ExpressionConstants.SymbolOpenParen, res, ExpressionConstants.SymbolClosedParen));
+            return string.IsNullOrEmpty(res) ? null : string.Concat(ExpressionConstants.SymbolOpenParen, res, ExpressionConstants.SymbolClosedParen);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
@@ -37,9 +37,9 @@ namespace Microsoft.OData
 
             foreach (SelectItem selectItem in selectExpandClause.SelectedItems)
             {
-                if (selectItem.GetType() == typeof(PathSelectItem))
+                if (selectItem is PathSelectItem pathSelectItem)
                 {
-                    selectClause += this.Translate((PathSelectItem)selectItem);
+                    selectClause += this.Translate(pathSelectItem);
                 }
 
                 else if (selectItem.GetType() == typeof(ExpandedNavigationSelectItem))

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
@@ -717,6 +717,22 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
 
         [Fact]
+        public void SelectWithMultipleOptionsInPrimitiveCollectionShouldWork()
+        {
+            Uri queryUri = new Uri("People?$select=RelatedSSNs($count=true;$filter=endswith($this,'xyz');$orderby=$this;$top=10;$skip=5)", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("RelatedSSNs($filter=endswith($this,'xyz');$orderby=$this;$top=10;$skip=5;$count=true)"), actualUri.OriginalString);
+        }
+
+        [Fact]
+        public void SelectWithMultipleOptionsInComplexCollectionShouldWork()
+        {
+            Uri queryUri = new Uri("People?$select=PreviousAddresses($count=true;$filter=endswith($this/City,'xyz');$orderby=$this/City;$top=10;$skip=5)", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("PreviousAddresses($filter=endswith($this/City,'xyz');$orderby=$this/City;$top=10;$skip=5;$count=true)"), actualUri.OriginalString);
+        }
+
+        [Fact]
         public void ExpandWithNestedQueryOptionsShouldWork()
         {
             var ervFilter = new ResourceRangeVariable(ExpressionConstants.It, HardCodedTestModel.GetDogTypeReference(), HardCodedTestModel.GetDogsSet());

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
@@ -701,6 +701,22 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
 
         [Fact]
+        public void SelectWithDollarThisInFilterClauseShouldWork()
+        {
+            Uri queryUri = new Uri("People?$select=RelatedSSNs($filter=endswith($this,'xyz'))", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("RelatedSSNs($filter=endswith($this,'xyz'))"), actualUri.OriginalString);
+        }
+
+        [Fact]
+        public void SelectWithDollarThisSlashPropertyInFilterClauseShouldWork()
+        {
+            Uri queryUri = new Uri("People?$select=PreviousAddresses($filter=endswith($this/Street,'xyz'))", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("PreviousAddresses($filter=endswith($this/Street,'xyz'))"), actualUri.OriginalString);
+        }
+
+        [Fact]
         public void ExpandWithNestedQueryOptionsShouldWork()
         {
             var ervFilter = new ResourceRangeVariable(ExpressionConstants.It, HardCodedTestModel.GetDogTypeReference(), HardCodedTestModel.GetDogsSet());

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
@@ -701,7 +701,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
 
         [Fact]
-        public void SelectWithDollarThisInFilterClauseShouldWork()
+        public void SelectWithDollarThisInNestedDollarFilterClauseShouldWork()
         {
             Uri queryUri = new Uri("People?$select=RelatedSSNs($filter=endswith($this,'xyz'))", UriKind.Relative);
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
@@ -732,6 +732,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("PreviousAddresses($filter=endswith($this/City,'xyz');$orderby=$this/City;$top=10;$skip=5;$count=true)"), actualUri.OriginalString);
         }
 
+        //MyDog($select=Color;$expand=MyPeople($expand=MyPaintings($filter=ID eq $it/ID)))
+        [Fact]
+        public void SelectWithinMultipleNestedExpandsShouldWork()
+        {
+            Uri queryUri = new Uri("People?$expand=MyDog($select=Color;$expand=MyPeople($select=PreviousAddresses($count=true;$filter=endswith($this/City,'xyz');$orderby=$this/City;$top=10;$skip=5)))", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString("MyDog($select=Color;$expand=MyPeople($select=PreviousAddresses($filter=endswith($this/City,'xyz');$orderby=$this/City;$top=10;$skip=5;$count=true)))"), actualUri.OriginalString);
+        }
         [Fact]
         public void ExpandWithNestedQueryOptionsShouldWork()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
@@ -693,6 +693,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
         }
 
         [Fact]
+        public void SelectWithDollarThisInOrderByClauseShouldWork()
+        {
+            Uri queryUri = new Uri("People?$select=RelatedSSNs($orderby=$this)", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("RelatedSSNs($orderby=$this)"), actualUri.OriginalString);
+        }
+
+        [Fact]
         public void ExpandWithNestedQueryOptionsShouldWork()
         {
             var ervFilter = new ResourceRangeVariable(ExpressionConstants.It, HardCodedTestModel.GetDogTypeReference(), HardCodedTestModel.GetDogsSet());


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2005 .*

### Description
In `SelectExpandBinder` we create either of the 4 Select Items.

`WildcardSelectItem` e.g People?$select=*
`ExpandedNavigationSelectItem` e.g People?$expand=Trips($count=true)
`ExpandedReferenceSelectItem` e.g People?$expand=Trips/$ref
`PathSelectItem` e.g People?$select=RelatedSSNs($orderby=$this)

When you call `BuildUri` as shown below:
```csharp
ODataUri odataUri = odataUriParser.ParseUri();
Uri uri = odataUri.BuildUri(urlKeyDelimiter);
```
The `TranslateSelectExpandClause` method in `SelectExpandToStringBuilder` only handles `ExpandedNavigationSelectItem` and `ExpandedReferenceSelectItem`. https://github.com/OData/odata.net/blob/e5458e4e6bbae09dc9546fe13f49611f9d1795ec/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs#L30

`WildcardSelectItem` and `PathSelectItem` are ignored. This PR fixes the `PathSelectItem` translation.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
