### PR TITLE
add parameter to control if Nullable gets written always

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
@@ -384,10 +384,18 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         /// 7.2.1 Nullable, A Boolean value specifying whether a value is required for the property.
         /// </summary>
         /// <param name="reference">The Edm type reference.</param>
-        internal override void WriteNullableAttribute(IEdmTypeReference reference)
+        /// <param name="alwaysWrite">Specifies if the attribute is always written or not if the value is the default value.
+        internal override void WriteNullableAttribute(IEdmTypeReference reference, bool alwaysWrite)
         {
             // The value of $Nullable is one of the Boolean literals true or false. Absence of the member means false.
-            this.jsonWriter.WriteOptionalProperty("$Nullable", reference.IsNullable, defaultValue: false);
+            if(alwaysWrite)
+            {
+                this.jsonWriter.WriteRequiredProperty("$Nullable", reference.IsNullable);
+            }
+            else
+            {
+                this.jsonWriter.WriteOptionalProperty("$Nullable", reference.IsNullable, defaultValue: false);
+            }
         }
 
         internal override void WriteTypeDefinitionAttributes(IEdmTypeDefinitionReference reference)

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaWriter.cs
@@ -105,7 +105,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             // Nothing here
         }
 
-        internal abstract void WriteNullableAttribute(IEdmTypeReference reference);
+        internal abstract void WriteNullableAttribute(IEdmTypeReference reference, bool alwaysWrite);
 
         internal abstract void WriteTypeDefinitionAttributes(IEdmTypeDefinitionReference reference);
 

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
@@ -223,9 +223,16 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.xmlWriter.WriteEndElement();
         }
 
-        internal override void WriteNullableAttribute(IEdmTypeReference reference)
+        internal override void WriteNullableAttribute(IEdmTypeReference reference, bool alwaysWrite)
         {
-            this.WriteOptionalAttribute(CsdlConstants.Attribute_Nullable, reference.IsNullable, CsdlConstants.Default_Nullable, EdmValueWriter.BooleanAsXml);
+            if (alwaysWrite)
+            {
+                this.WriteRequiredAttribute(CsdlConstants.Attribute_Nullable, reference.IsNullable, EdmValueWriter.BooleanAsXml);
+            }
+            else
+            {
+                this.WriteOptionalAttribute(CsdlConstants.Attribute_Nullable, reference.IsNullable, CsdlConstants.Default_Nullable, EdmValueWriter.BooleanAsXml);
+            }
         }
 
         internal override void WriteTypeDefinitionAttributes(IEdmTypeDefinitionReference reference)

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
@@ -668,12 +668,12 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                     if (element.TypeKind() == EdmTypeKind.Collection)
                     {
                         IEdmCollectionTypeReference collectionElement = element.AsCollection();
-                        this.schemaWriter.WriteNullableAttribute(collectionElement.CollectionDefinition().ElementType);
+                        this.schemaWriter.WriteNullableAttribute(collectionElement.CollectionDefinition().ElementType, true);
                         VisitTypeReference(collectionElement.CollectionDefinition().ElementType);
                     }
                     else
                     {
-                        this.schemaWriter.WriteNullableAttribute(element);
+                        this.schemaWriter.WriteNullableAttribute(element, false);
                         VisitTypeReference(element);
                     }
                 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2028 

### Description

Added parameter to WriteNullableAttribute to indicate if the property should be written always or depending on the default value.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
