### PR TITLE
in operator not working with null Guid values

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -313,6 +313,7 @@ namespace Microsoft.OData.UriParser
                 {
                     items[i] = String.Format(CultureInfo.InvariantCulture, "'{0}'", items[i]);
                 }
+
             }
 
             return "[" + String.Join(",", items) + "]";

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -305,15 +305,10 @@ namespace Microsoft.OData.UriParser
 
             for (int i = 0; i < items.Length; i++)
             {
-                if (items[i] == "null")
-                {
-                    items[i] = items[i];
-                }
-                else if(items[i][0] != '\'' && items[i][0] != '"')
+                if (items[i] != "null" && items[i][0] != '\'' && items[i][0] != '"')
                 {
                     items[i] = String.Format(CultureInfo.InvariantCulture, "'{0}'", items[i]);
                 }
-
             }
 
             return "[" + String.Join(",", items) + "]";

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -305,7 +305,11 @@ namespace Microsoft.OData.UriParser
 
             for (int i = 0; i < items.Length; i++)
             {
-                if (items[i][0] != '\'' && items[i][0] != '"')
+                if (items[i] == "null")
+                {
+                    items[i] = items[i];
+                }
+                else if(items[i][0] != '\'' && items[i][0] != '"')
                 {
                     items[i] = String.Format(CultureInfo.InvariantCulture, "'{0}'", items[i]);
                 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2345,12 +2345,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void FilterWithInOperationWithGuidCollection()
         {
-            FilterClause filter = ParseFilter("MyGuid in (D01663CF-EB21-4A0E-88E0-361C10ACE7FD, 492CF54A-84C9-490C-A7A4-B5010FAD8104)",
+            FilterClause filter = ParseFilter("MyGuid in (D01663CF-EB21-4A0E-88E0-361C10ACE7FD, 492CF54A-84C9-490C-A7A4-B5010FAD8104, null)",
                 HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
 
             var inNode = Assert.IsType<InNode>(filter.Expression);
             Assert.Equal("MyGuid", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
-            Assert.Equal("(D01663CF-EB21-4A0E-88E0-361C10ACE7FD, 492CF54A-84C9-490C-A7A4-B5010FAD8104)",
+            Assert.Equal("(D01663CF-EB21-4A0E-88E0-361C10ACE7FD, 492CF54A-84C9-490C-A7A4-B5010FAD8104, null)",
                 Assert.IsType<CollectionConstantNode>(inNode.Right).LiteralText);
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1997 .*

### Description

*Briefly describe the changes of this pull request.*

For a sample model like the one shown below

```csharp
public class TestEntity
{
   public guid? NullableProperty { get; set; }
}
```
Running the following sample query throws an error. 
It is also been clear that a null GUID should not be equated to an empty GUID. 
```url
http://host/service/TestEntity?$filter=NullableProperty in (null)
```
Guid literals are converted to single-quoted form, so that they are  compatible with the Json reader used for deserialization.
``` 
Sample: [D01663CF-EB21-4A0E-88E0-361C10ACE7FD, 492CF54A-84C9-490C-A7A4-B5010FAD8104]
==>  ['D01663CF-EB21-4A0E-88E0-361C10ACE7FD', '492CF54A-84C9-490C-A7A4-B5010FAD8104']
```
This means that even null GUIDS will be converted to the single quoted form which will later lead to them being processed as null strings. ("null"). 
``` 
Sample: [null, null]
==>  ['null', 'null']
```
This fix ensures that null GUIDs are not converted to the single-quoted form and are processed as null values. 
``` 
Sample: [null] ==>  [null]
```
### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
