### PR TITLE
Add ComputedDefaultValue to CoreVocabularyModel

### DIFF
--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
@@ -341,6 +341,7 @@
   <Term Name="ComputedDefaultValue" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Property">
     <Annotation Term="Core.Description" String="A value for this property can be provided by the client on insert and update. If no value is provided on insert, a non-static default value is generated" />
   </Term>
+  
   <Term Name="IsURL" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Property Term">
     <Annotation Term="Core.Description" String="Properties and terms annotated with this term MUST contain a valid URL" />
     <Annotation Term="Core.RequiresType" String="Edm.String" />

--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyConstants.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyConstants.cs
@@ -44,6 +44,9 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
         /// <summary>Org.OData.Core.V1.Computed</summary>
         public const string Computed = "Org.OData.Core.V1.Computed";
 
+        /// <summary>Org.OData.Core.V1.Computed</summary>
+        public const string ComputedDefaultValue = "Org.OData.Core.V1.ComputedDefaultValue";
+
         /// <summary>Org.OData.Core.V1.IsURL</summary>
         public const string IsURL = "Org.OData.Core.V1.IsURL";
 

--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyConstants.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyConstants.cs
@@ -44,7 +44,7 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
         /// <summary>Org.OData.Core.V1.Computed</summary>
         public const string Computed = "Org.OData.Core.V1.Computed";
 
-        /// <summary>Org.OData.Core.V1.Computed</summary>
+        /// <summary>Org.OData.Core.V1.ComputedDefaultValue</summary>
         public const string ComputedDefaultValue = "Org.OData.Core.V1.ComputedDefaultValue";
 
         /// <summary>Org.OData.Core.V1.IsURL</summary>

--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyModel.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularyModel.cs
@@ -86,6 +86,12 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
         public static readonly IEdmTerm ComputedTerm = VocabularyModelProvider.CoreModel.FindDeclaredTerm(CoreVocabularyConstants.Computed);
 
         /// <summary>
+        /// The ComputedDefaultValue term.
+        /// </summary>
+        [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "EdmTerm is immutable")]
+        public static readonly IEdmTerm ComputedDefaultValueTerm = VocabularyModelProvider.CoreModel.FindDeclaredTerm(CoreVocabularyConstants.ComputedDefaultValue);
+
+        /// <summary>
         /// The Optional Parameter term.
         /// </summary>
         [SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "EdmTerm is immutable")]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

ComputedDefaultValue is missing from to CoreVocabularyModel

### Description

Changed corresponding XML, .cs and constants fule. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

