### PR TITLE
Elide async and await in pass-through asynchronous methods

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -76,22 +76,20 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">Float value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, float value)
+        internal static Task WriteValueAsync(this TextWriter writer, float value)
         {
             Debug.Assert(writer != null, "writer != null");
 
             if (JsonSharedUtils.IsFloatValueSerializedAsString(value))
             {
-                await writer.WriteQuotedAsync(value.ToString(ODataNumberFormatInfo))
-                    .ConfigureAwait(false);
+                return writer.WriteQuotedAsync(value.ToString(ODataNumberFormatInfo));
             }
             else
             {
                 // float.ToString() supports a max scale of six,
                 // whereas float.MinValue and float.MaxValue have 8 digits scale. Hence we need
                 // to use XmlConvert in all other cases, except infinity
-                await writer.WriteAsync(XmlConvert.ToString(value))
-                    .ConfigureAwait(false);
+                return writer.WriteAsync(XmlConvert.ToString(value));
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -52,11 +52,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">The boolean value to write.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, bool value)
+        internal static Task WriteValueAsync(this TextWriter writer, bool value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteAsync(FormatAsBooleanLiteral(value)).ConfigureAwait(false);
+            return writer.WriteAsync(FormatAsBooleanLiteral(value));
         }
 
         /// <summary>
@@ -64,11 +64,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">Integer value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, int value)
+        internal static Task WriteValueAsync(this TextWriter writer, int value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+            return writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -82,14 +82,16 @@ namespace Microsoft.OData.Json
 
             if (JsonSharedUtils.IsFloatValueSerializedAsString(value))
             {
-                await writer.WriteQuotedAsync(value.ToString(ODataNumberFormatInfo)).ConfigureAwait(false);
+                await writer.WriteQuotedAsync(value.ToString(ODataNumberFormatInfo))
+                    .ConfigureAwait(false);
             }
             else
             {
                 // float.ToString() supports a max scale of six,
                 // whereas float.MinValue and float.MaxValue have 8 digits scale. Hence we need
                 // to use XmlConvert in all other cases, except infinity
-                await writer.WriteAsync(XmlConvert.ToString(value)).ConfigureAwait(false);
+                await writer.WriteAsync(XmlConvert.ToString(value))
+                    .ConfigureAwait(false);
             }
         }
 
@@ -98,11 +100,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">Short value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, short value)
+        internal static Task WriteValueAsync(this TextWriter writer, short value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+            return writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -110,11 +112,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">Long value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, long value)
+        internal static Task WriteValueAsync(this TextWriter writer, long value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+            return writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -150,11 +152,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">Guid value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, Guid value)
+        internal static Task WriteValueAsync(this TextWriter writer, Guid value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteQuotedAsync(value.ToString()).ConfigureAwait(false);
+            return writer.WriteQuotedAsync(value.ToString());
         }
 
         /// <summary>
@@ -162,11 +164,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">Decimal value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, decimal value)
+        internal static Task WriteValueAsync(this TextWriter writer, decimal value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+            return writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -222,11 +224,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">TimeSpan value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, TimeSpan value)
+        internal static Task WriteValueAsync(this TextWriter writer, TimeSpan value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteQuotedAsync(EdmValueWriter.DurationAsXml(value)).ConfigureAwait(false);
+            return writer.WriteQuotedAsync(EdmValueWriter.DurationAsXml(value));
         }
 
         /// <summary>
@@ -234,11 +236,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">TimeOfDay value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, TimeOfDay value)
+        internal static Task WriteValueAsync(this TextWriter writer, TimeOfDay value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteQuotedAsync(value.ToString()).ConfigureAwait(false);
+            return writer.WriteQuotedAsync(value.ToString());
         }
 
         /// <summary>
@@ -246,11 +248,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">Date value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, Date value)
+        internal static Task WriteValueAsync(this TextWriter writer, Date value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteQuotedAsync(value.ToString()).ConfigureAwait(false);
+            return writer.WriteQuotedAsync(value.ToString());
         }
 
         /// <summary>
@@ -258,11 +260,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">Byte value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, byte value)
+        internal static Task WriteValueAsync(this TextWriter writer, byte value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+            return writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -270,11 +272,11 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="value">SByte value to be written.</param>
-        internal static async Task WriteValueAsync(this TextWriter writer, sbyte value)
+        internal static Task WriteValueAsync(this TextWriter writer, sbyte value)
         {
             Debug.Assert(writer != null, "writer != null");
 
-            await writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture)).ConfigureAwait(false);
+            return writer.WriteAsync(value.ToString(CultureInfo.InvariantCulture));
         }
 
         /// <summary>
@@ -285,7 +287,7 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="arrayPool">Array pool for renting a buffer.</param>
-        internal static async Task WriteValueAsync(
+        internal static Task WriteValueAsync(
             this TextWriter writer,
             string value,
             ODataStringEscapeOption stringEscapeOption,
@@ -296,11 +298,11 @@ namespace Microsoft.OData.Json
 
             if (value == null)
             {
-                await writer.WriteAsync(JsonConstants.JsonNullLiteral).ConfigureAwait(false);
+                return writer.WriteAsync(JsonConstants.JsonNullLiteral);
             }
             else
             {
-                await writer.WriteEscapedJsonStringAsync(value, stringEscapeOption, buffer, arrayPool).ConfigureAwait(false);
+                return writer.WriteEscapedJsonStringAsync(value, stringEscapeOption, buffer, arrayPool);
             }
         }
 
@@ -477,11 +479,10 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>
         /// <param name="text">String value to be written.</param>
-        private static async Task WriteQuotedAsync(this TextWriter writer, string text)
+        private static Task WriteQuotedAsync(this TextWriter writer, string text)
         {
-            await writer.WriteAsync(
-                string.Concat(JsonConstants.QuoteCharacter, text, JsonConstants.QuoteCharacter))
-                .ConfigureAwait(false);
+            return writer.WriteAsync(
+                string.Concat(JsonConstants.QuoteCharacter, text, JsonConstants.QuoteCharacter));
         }
     }
 }

--- a/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
@@ -25,10 +25,10 @@ namespace Microsoft.OData.Json
     internal sealed partial class JsonWriter
     {
         /// <inheritdoc/>
-        public async Task StartPaddingFunctionScopeAsync()
+        public Task StartPaddingFunctionScopeAsync()
         {
             Debug.Assert(this.scopes.Count == 0, "Padding scope can only be the outer most scope.");
-            await this.StartScopeAsync(ScopeType.Padding).ConfigureAwait(false);
+            return this.StartScopeAsync(ScopeType.Padding);
         }
 
         /// <inheritdoc/>
@@ -46,9 +46,9 @@ namespace Microsoft.OData.Json
         }
 
         /// <inheritdoc/>
-        public async Task StartObjectScopeAsync()
+        public Task StartObjectScopeAsync()
         {
-            await this.StartScopeAsync(ScopeType.Object).ConfigureAwait(false);
+            return this.StartScopeAsync(ScopeType.Object);
         }
 
         /// <inheritdoc/>
@@ -66,9 +66,9 @@ namespace Microsoft.OData.Json
         }
 
         /// <inheritdoc/>
-        public async Task StartArrayScopeAsync()
+        public Task StartArrayScopeAsync()
         {
-            await this.StartScopeAsync(ScopeType.Array).ConfigureAwait(false);
+            return this.StartScopeAsync(ScopeType.Array);
         }
 
         /// <inheritdoc/>
@@ -106,9 +106,9 @@ namespace Microsoft.OData.Json
         }
 
         /// <inheritdoc/>
-        public async Task WritePaddingFunctionNameAsync(string functionName)
+        public Task WritePaddingFunctionNameAsync(string functionName)
         {
-            await this.writer.WriteAsync(functionName).ConfigureAwait(false);
+            return this.writer.WriteAsync(functionName);
         }
 
         /// <inheritdoc/>
@@ -253,9 +253,9 @@ namespace Microsoft.OData.Json
         }
 
         /// <inheritdoc/>
-        public async Task FlushAsync()
+        public Task FlushAsync()
         {
-            await this.writer.FlushAsync().ConfigureAwait(false);
+            return this.writer.FlushAsync();
         }
 
         /// <inheritdoc/>
@@ -303,13 +303,14 @@ namespace Microsoft.OData.Json
         }
 
         /// <inheritdoc/>
-        public async Task EndTextWriterValueScopeAsync()
+        public Task EndTextWriterValueScopeAsync()
         {
             if (!IsWritingJson)
             {
-                await this.writer.WriteAsync(JsonConstants.QuoteCharacter)
-                    .ConfigureAwait(false);
+                return this.writer.WriteAsync(JsonConstants.QuoteCharacter);
             }
+
+            return TaskUtils.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/NonIndentedTextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/NonIndentedTextWriter.cs
@@ -38,9 +38,9 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="s">String value to be written.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        public override async Task WriteAsync(string s)
+        public override Task WriteAsync(string s)
         {
-            await this.writer.WriteAsync(s).ConfigureAwait(false);
+            return this.writer.WriteAsync(s);
         }
 
         /// <summary>
@@ -57,9 +57,9 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="value">Char value to be written.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        public override async Task WriteAsync(char value)
+        public override Task WriteAsync(char value)
         {
-            await this.writer.WriteAsync(value).ConfigureAwait(false);
+            return this.writer.WriteAsync(value);
         }
 
         /// <summary>
@@ -73,10 +73,9 @@ namespace Microsoft.OData.Json
         /// Writes a new line asynchronously.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait has no effect on already completed task.")]
-        public override async Task WriteLineAsync()
+        public override Task WriteLineAsync()
         {
-            await TaskUtils.CompletedTask;
+            return TaskUtils.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OData.Core/Json/ODataJsonTextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonTextWriter.cs
@@ -299,27 +299,27 @@ namespace Microsoft.OData
         }
 
         /// <inheritdoc/>
-        public override async Task WriteAsync(char value)
+        public override Task WriteAsync(char value)
         {
-            await this.WriteEscapedCharValueAsync(value).ConfigureAwait(false);
+            return this.WriteEscapedCharValueAsync(value);
         }
 
         /// <inheritdoc/>
-        public override async Task WriteAsync(char[] buffer, int index, int count)
+        public override Task WriteAsync(char[] buffer, int index, int count)
         {
-            await this.WriteEscapedCharArrayAsync(buffer, index, count).ConfigureAwait(false);
+            return this.WriteEscapedCharArrayAsync(buffer, index, count);
         }
 
         /// <inheritdoc/>
-        public override async Task WriteAsync(string value)
+        public override Task WriteAsync(string value)
         {
-            await this.WriteEscapedStringValueAsync(value).ConfigureAwait(false);
+            return this.WriteEscapedStringValueAsync(value);
         }
 
         /// <inheritdoc/>
-        public override async Task WriteLineAsync()
+        public override Task WriteLineAsync()
         {
-            await this.textWriter.WriteLineAsync().ConfigureAwait(false);
+            return this.textWriter.WriteLineAsync();
         }
 
         /// <inheritdoc/>
@@ -399,9 +399,9 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="value">Char value to be written.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteEscapedCharValueAsync(char value)
+        private Task WriteEscapedCharValueAsync(char value)
         {
-            await this.textWriter.WriteValueAsync(value, escapeOption).ConfigureAwait(false);
+            return this.textWriter.WriteValueAsync(value, escapeOption);
         }
 
         /// <summary>
@@ -409,12 +409,12 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="value">String value to be written.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteEscapedStringValueAsync(string value)
+        private Task WriteEscapedStringValueAsync(string value)
         {
             Debug.Assert(this.wrappedBuffer != null, "wrappedBuffer != null");
 
-            await this.textWriter.WriteEscapedJsonStringValueAsync(
-                value, escapeOption, this.wrappedBuffer, this.bufferPool).ConfigureAwait(false);
+            return this.textWriter.WriteEscapedJsonStringValueAsync(
+                value, escapeOption, this.wrappedBuffer, this.bufferPool);
         }
 
         /// <summary>
@@ -424,12 +424,12 @@ namespace Microsoft.OData
         /// <param name="offset">Number of characters to skip in the character array.</param>
         /// <param name="count">Number of characters to write from the character array.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteEscapedCharArrayAsync(char[] value, int offset, int count)
+        private Task WriteEscapedCharArrayAsync(char[] value, int offset, int count)
         {
             Debug.Assert(this.wrappedBuffer != null, "wrappedBuffer != null");
 
-            await this.textWriter.WriteEscapedCharArrayAsync(
-                value, offset, count, escapeOption, this.wrappedBuffer, this.bufferPool).ConfigureAwait(false);
+            return this.textWriter.WriteEscapedCharArrayAsync(
+                value, offset, count, escapeOption, this.wrappedBuffer, this.bufferPool);
         }
 
         #endregion Private async methods

--- a/src/Microsoft.OData.Core/Json/TextWriterWrapper.cs
+++ b/src/Microsoft.OData.Core/Json/TextWriterWrapper.cs
@@ -81,27 +81,25 @@ namespace Microsoft.OData.Json
         /// <summary>
         /// Increases the level of indentation applied to the output asynchronously.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait has no effect on already completed task.")]
-        public virtual async Task IncreaseIndentationAsync()
+        public virtual Task IncreaseIndentationAsync()
         {
-            await TaskUtils.CompletedTask;
+            return TaskUtils.CompletedTask;
         }
 
         /// <summary>
         /// Decreases the level of indentation applied to the output asynchronously.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2007:Consider calling ConfigureAwait on the awaited task", Justification = "ConfigureAwait has no effect on already completed task.")]
-        public virtual async Task DecreaseIndentationAsync()
+        public virtual Task DecreaseIndentationAsync()
         {
-            await TaskUtils.CompletedTask;
+            return TaskUtils.CompletedTask;
         }
 
         /// <summary>
         /// Clears the buffer of the current writer asynchronously.
         /// </summary>
-        public override async Task FlushAsync()
+        public override Task FlushAsync()
         {
-            await this.writer.FlushAsync().ConfigureAwait(false);
+            return this.writer.FlushAsync();
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
+++ b/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
@@ -211,9 +211,9 @@ namespace Microsoft.OData
         }
 
         /// <inheritdoc/>
-        public override async Task FlushAsync(CancellationToken cancellationToken)
+        public override Task FlushAsync(CancellationToken cancellationToken)
         {
-            await this.Writer.FlushAsync().ConfigureAwait(false);
+            return this.Writer.FlushAsync();
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2019.*

### Description

Elide async and await in pass-through asynchronous methods

Affects:
- **`TextWriterWrapper`** abstract class
- **`NonIndentedTextWriter`** internal class
- **`JsonWriter`** internal class
- **`JsonValueUtils`** internal static class
- **`ODataJsonTextWriter`** internal class
- **`ODataBinaryStreamWriter`** internal class

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
