### PR TITLE
Modify IODataOutputInStreamErrorListener interface to support asynchronous notifications when an in-stream error is to be written

### DIFF
--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -419,6 +419,14 @@ namespace Microsoft.OData
         /// </remarks>
         public abstract void OnInStreamError();
 
+        /// <inheritdoc/>
+        public virtual Task OnInStreamErrorAsync()
+        {
+            // NOTE: ODataBatchWriter class is abstract and public. This method body is intended
+            // to prevent a breaking change in subclasses that provide the implementation.
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Flush the output.
         /// </summary>

--- a/src/Microsoft.OData.Core/IODataOutputInStreamErrorListener.cs
+++ b/src/Microsoft.OData.Core/IODataOutputInStreamErrorListener.cs
@@ -6,6 +6,10 @@
 
 namespace Microsoft.OData
 {
+    #region Namespaces
+    using System.Threading.Tasks;
+    #endregion Namespaces
+
     /// <summary>
     /// An interface that allows the implementations of the writers to get notified if an in-stream error is to be written.
     /// </summary>
@@ -19,5 +23,15 @@ namespace Microsoft.OData
         /// If the listener returns, the writer should not allow any more writing, since the in-stream error is the last thing in the payload.
         /// </remarks>
         void OnInStreamError();
+
+        /// <summary>
+        /// This method asynchronously notifies the listener, that an in-stream error is to be written.
+        /// </summary>
+        /// <remarks>
+        /// This listener can choose to fail, if the currently written payload doesn't support in-stream error at this position.
+        /// If the listener returns, the writer should not allow any more writing, since the in-stream error is the last thing in the payload.
+        /// </remarks>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task OnInStreamErrorAsync();
     }
 }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeltaWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeltaWriter.cs
@@ -287,6 +287,12 @@ namespace Microsoft.OData.JsonLight
             this.inStreamErrorListener.OnInStreamError();
         }
 
+        /// <inheritdoc/>
+        Task IODataOutputInStreamErrorListener.OnInStreamErrorAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         #endregion
     }
 }

--- a/src/Microsoft.OData.Core/ODataAsynchronousWriter.cs
+++ b/src/Microsoft.OData.Core/ODataAsynchronousWriter.cs
@@ -101,6 +101,12 @@ namespace Microsoft.OData
             throw new ODataException(Strings.ODataAsyncWriter_CannotWriteInStreamErrorForAsync);
         }
 
+        /// <inheritdoc/>
+        Task IODataOutputInStreamErrorListener.OnInStreamErrorAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Validates that the async writer is not disposed.
         /// </summary>

--- a/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
@@ -265,6 +265,12 @@ namespace Microsoft.OData
             this.EnterScope(CollectionWriterState.Error, this.scopes.Peek().Item);
         }
 
+        /// <inheritdoc/>
+        Task IODataOutputInStreamErrorListener.OnInStreamErrorAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Determines whether a given writer state is considered an error state.
         /// </summary>

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -306,6 +306,12 @@ namespace Microsoft.OData
             throw new ODataException(Strings.ODataParameterWriter_InStreamErrorNotSupported);
         }
 
+        /// <inheritdoc/>
+        Task IODataOutputInStreamErrorListener.OnInStreamErrorAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// Check if the object has been disposed; called from all public API methods. Throws an ObjectDisposedException if the object
         /// has already been disposed.

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -760,6 +760,12 @@ namespace Microsoft.OData
             this.EnterScope(WriterState.Error, this.CurrentScope.Item);
         }
 
+        /// <inheritdoc/>
+        Task IODataOutputInStreamErrorListener.OnInStreamErrorAsync()
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// This method is called when a stream is requested. It is a no-op.
         /// </summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request is in partial fulfilment of issue #2019.

### Description

Modify **`IODataOutputInStreamErrorListener`** interface to support asynchronous notifications when an in-stream error is to be written

#### Background
When an error occurs when writing a payload to the stream, a notification is sent to any subscribed listener to notify it that an in-stream error is to be written. The listener implements the `IODataOutputInStreamErrorListener` interface that contains a single synchronous method `OnInStreamError`. **This interface is `internal`**.
To support similar functionality in asynchronous scenarios, we need to modify the interface to support an asynchronous equivalent method - `OnInStreamErrorAsync`.

`ODataBatchWriter` is a `public abstract` class that implements the `IODataOutputInStreamErrorListener` interface. If `OnInStreamErrorAsync` method was implemented abstractly in the classes, subclasses of `ODataBatchWriter` that users of the library might have implemented would break. For that reason, the method has been implemented as a virtual method that just throws a `NotImplementedException` to prevent the breaking change.
As for other `internal` classes that implement the interface, an explicit implementation has been added. For now, it just throws a `NotImplementedException`. The actual implemententation will be provided when implementing asynchronous support in the following 6 sets of writer classes:
- `ODataWriterCore`/`ODataJsonLightWriter`
- `ODataParameterWriterCore`/`ODataJsonLightParameterWriter`
- `ODataCollectionWriterCore`/`ODataJsonLightCollectionWriter` (PR #2059)
- `ODataDeltaWriter`/`ODataJsonLightDeltaWriter`
- `ODataBatchWriter`/`ODataJsonLightBatchWriter`
- `ODataAsynchronousWriter`

Below is how that implementation looks like in **`ODataCollectionWriterCore`**. Notice the call to the asynchronous method `StartPayloadInStartStateAsync` that sets the stage for writing the error.
```csharp
async Task IODataOutputInStreamErrorListener.OnInStreamErrorAsync()
{
    this.VerifyNotDisposed();

    // We're in a completed state trying to write an error
    // We can't write error after the payload was finished as it might introduce another top-level element in XML
    if (this.State == CollectionWriterState.Completed)
    {
        throw new ODataException(Strings.ODataWriterCore_InvalidTransitionFromCompleted(this.State.ToString(), CollectionWriterState.Error.ToString()));
    }

    await this.StartPayloadInStartStateAsync()
        .ConfigureAwait(false);
    this.EnterScope(CollectionWriterState.Error, this.scopes.Peek().Item);
}
```
### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
