### PR TITLE
no error message when reading an incorrect structure of a collection …

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -2060,6 +2060,13 @@ namespace Microsoft.OData.JsonLight
                     this.ReadResourceSetEnd();
                     break;
                 case JsonNodeType.PrimitiveValue:
+                    if (resourceType?.TypeKind == EdmTypeKind.Entity && !resourceType.IsOpen())
+                    {
+                        throw new ODataException(
+                        ODataErrorStrings.ODataJsonReader_CannotReadResourcesOfResourceSet(
+                            this.jsonLightResourceDeserializer.JsonReader.NodeType));
+                    }
+
                     // Is this a stream, or a binary or string value with a collection that the client wants to read as a stream
                     if (!TryReadPrimitiveAsStream(resourceType))
                     {

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/FeedReaderJsonLightTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/FeedReaderJsonLightTests.cs
@@ -179,9 +179,10 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                         .JsonRepresentation("{" +
                             "\"" + JsonLightConstants.ODataPropertyAnnotationSeparator + JsonLightConstants.ODataContextAnnotationName + "\":\"http://odata.org/test/$metadata#TestModel.DefaultContainer.Cities\"," +
                             "\"" + JsonLightConstants.ODataValuePropertyName + "\":[ 1 ]" +
-                            "}"),
+                            "}")
+                        .ExpectedEntityType(cityType, citiesEntitySet),               
                     PayloadEdmModel = model,
-                    ExpectedResultPayloadElement = (ReaderTestConfiguration t) => { return PayloadBuilder.EntitySet().Append(new PrimitiveValue("Edm.Int32", 1)); },
+                    ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonReader_CannotReadResourcesOfResourceSet","PrimitiveValue"),
                 },
                 new PayloadReaderTestDescriptor(this.Settings)
                 {


### PR DESCRIPTION
…of entities

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2071 .*

### Description
If we have such a model: 
```
    public class ProductFamily
    {
        public int Id { get; set; }

        public string Name { get; set; }

        public string Description { get; set; }

        public virtual Supplier Supplier { get; set; }

        public virtual ICollection<Product> Products { get; set; } = new List<Product>();
    }
```
Then a HTTP POST request to create a `ProductFamily` that demonstrates the bug has this POST Body:
```
{
  "Id": 9,
  "Products": ["Hello"]
}
```
The above request body creates a ProductFamily successfully instead of returning a BadRequest

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
