### PR TITLE
Modify IODataStreamListener interface to support asynchronous notifications when the content stream of an operation has been disposed

### DIFF
--- a/src/Microsoft.OData.Core/Batch/ODataBatchReader.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchReader.cs
@@ -232,6 +232,16 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// This method is called asynchronously to notify that the content stream of a batch operation has been disposed.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task IODataStreamListener.StreamDisposedAsync()
+        {
+            this.operationState = OperationState.StreamDisposed;
+            return TaskUtils.CompletedTask;
+        }
+
+        /// <summary>
         /// Sets the 'Exception' state and then throws an ODataException with the specified error message.
         /// </summary>
         /// <param name="errorMessage">The error message for the exception.</param>

--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -411,6 +411,17 @@ namespace Microsoft.OData
         public abstract void StreamDisposed();
 
         /// <summary>
+        /// This method is called asynchronously to notify that the content stream of a batch operation has been disposed.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        public virtual Task StreamDisposedAsync()
+        {
+            // NOTE: ODataBatchWriter class is abstract and public. This method body is intended
+            // to prevent a breaking change in subclasses that provide the implementation.
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// This method notifies the listener, that an in-stream error is to be written.
         /// </summary>
         /// <remarks>

--- a/src/Microsoft.OData.Core/IODataStreamListener.cs
+++ b/src/Microsoft.OData.Core/IODataStreamListener.cs
@@ -35,5 +35,11 @@ namespace Microsoft.OData
         /// This method notifies the implementer of this interface that the content stream of a batch operation has been disposed.
         /// </summary>
         void StreamDisposed();
+
+        /// <summary>
+        /// Asynchronously notifies the implementer of this interface that the content stream of an operation has been disposed.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task StreamDisposedAsync();
     }
 }

--- a/src/Microsoft.OData.Core/ODataReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataReaderCore.cs
@@ -473,6 +473,15 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// This method is called asynchronously when a stream is disposed.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task IODataStreamListener.StreamDisposedAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Seek scope in the stack which is type of <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">The type of scope to seek.</typeparam>

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -804,6 +804,15 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// This method is called asynchronously when a stream is disposed
+        /// </summary>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        Task IODataStreamListener.StreamDisposedAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Get instance of the parent resource scope
         /// </summary>
         /// <returns>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request is in partial fulfilment of issue #2019.

### Description

Modify **`IODataStreamListener`** interface to support asynchronous notifications when the content stream of an operation has been disposed.

#### Background
**`IODataStreamListener`** interface allows the creators of a stream to listen for status changes of the operation stream. The `StreamDisposed` method notified the implementer of this interface that the content stream of the operation has been disposed. To support similar functionality in asynchronous scenarios, we need to modify the interface to support an equivalent method - `OnStreamDisposedAsync`.

The actual implemented will be provided when implementing asynchronous support in the following 3 classes that implement the interface:
- `ODataWriterCore`
- `ODataBatchWriter`
- `ODataReaderCore`
- `ODataBatchReader`

A stubbed implementation has been provided in each of the classes to prevent a breaking change.
Here's how the actual implementation would look like in `ODataWriterCore`.
```csharp
async Task IODataStreamListener.StreamDisposedAsync()
{
    Debug.Assert(this.State == WriterState.Stream || this.State == WriterState.String, "Stream was disposed when not in WriterState.Stream state.");

    // Complete writing the stream
    if (this.State == WriterState.Stream)
    {
        await this.EndBinaryStreamAsync().ConfigureAwait(false);
    }
    else if (this.State == WriterState.String)
    {
        await this.EndTextWriterAsync().ConfigureAwait(false);
    }

    await this.LeaveScopeAsync().ConfigureAwait(false);
}
```

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
