### PR TITLE
Support asynchronous invocation of IODataStreamListener.StreamDisposedAsync method from ODataNotificationWriter class

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -65,4 +65,16 @@
     <ProjectReference Include="..\Microsoft.OData.TestCommon\Microsoft.OData.TestCommon.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
@@ -1,0 +1,122 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataNotificationWriterTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OData.Tests
+{
+    public class ODataNotificationWriterTests
+    {
+        private MemoryStream stream;
+        private TextWriter writer;
+        private IODataStreamListener streamListener;
+
+        public ODataNotificationWriterTests()
+        {
+            this.stream = new MemoryStream();
+            this.writer = new StreamWriter(this.stream);
+            this.streamListener = new MockODataStreamListener(this.writer);
+        }
+
+        [Fact]
+        public void NotificationWriterDisposeShouldInvokeStreamDisposed()
+        {
+            // We care about the notification writer being disposed
+            // We don't care about the writer passed to the notification writer
+            using (var notificationWriter = new ODataNotificationWriter(
+                new StreamWriter(new MemoryStream()),
+                this.streamListener))
+            {
+
+            }
+
+            var result = ReadStreamContents();
+
+            Assert.Equal("StreamDisposed", result);
+        }
+
+#if NETCOREAPP3_1
+        [Fact]
+        public async Task NotificationWriterDisposeShouldInvokeStreamDisposedAsync()
+        {
+            await using (var notificationWriter = new ODataNotificationWriter(
+                new StreamWriter(new MemoryStream()),
+                this.streamListener)) // `synchronous` argument becomes irrelevant
+            {
+
+            }
+
+            var result = await this.ReadStreamContentsAsync();
+
+            Assert.Equal("StreamDisposedAsync", result);
+        }
+
+#else
+        [Fact]
+        public async Task NotificationWriterDisposeShouldInvokeStreamDisposedAsync()
+        {
+            using (var notificationWriter = new ODataNotificationWriter(
+                new StreamWriter(new MemoryStream()),
+                this.streamListener,
+                /*synchronous*/ false))
+            {
+
+            }
+
+            var result = await this.ReadStreamContentsAsync();
+
+            Assert.Equal("StreamDisposedAsync", result);
+        }
+#endif
+
+        private string ReadStreamContents()
+        {
+            this.stream.Position = 0;
+            return new StreamReader(this.stream).ReadToEnd();
+        }
+
+        private Task<string> ReadStreamContentsAsync()
+        {
+            this.stream.Position = 0;
+            return new StreamReader(this.stream).ReadToEndAsync();
+        }
+
+        private class MockODataStreamListener : IODataStreamListener
+        {
+            private TextWriter writer;
+
+            public MockODataStreamListener(TextWriter writer)
+            {
+                this.writer = writer;
+            }
+
+            public void StreamDisposed()
+            {
+                writer.Write("StreamDisposed");
+                writer.Flush();
+            }
+
+            public async Task StreamDisposedAsync()
+            {
+                await writer.WriteAsync("StreamDisposedAsync").ConfigureAwait(false);
+                await writer.FlushAsync().ConfigureAwait(false);
+            }
+
+            public void StreamRequested()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task StreamRequestedAsync()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request is in partial fulfilment of issue #2019.

### Description

Support asynchronous invocation of **`IODataStreamListener.StreamDisposedAsync`** method from `Dispose`/`DisposeAsync` methods of **`ODataNotificationWriter`** class.
- In .NET Core 3.1 or later, we're able to ride on asynchronous `DisposeAsync` method defined in `IAsyncDisposable` interface to avoid blocking.
- In platforms below .NET Core 3.1, we're forced to `.Wait()` on the asynchronous method.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
