### PR TITLE
Support asynchronous invocation of IODataStreamListener.StreamDisposedAsync method from ODataNotificationStream class

### DIFF
--- a/src/Microsoft.OData.Core/ODataNotificationStream.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationStream.cs
@@ -6,26 +6,34 @@
 
 namespace Microsoft.OData
 {
+    using System;
     using System.Diagnostics;
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Wrapper to listen for dispose on a stream
+    /// Wrapper to listen for dispose on a <see cref="Stream"/>.
     /// </summary>
+#if NETSTANDARD2_0
+    internal sealed class ODataNotificationStream : Stream, IAsyncDisposable
+#else
     internal sealed class ODataNotificationStream : Stream
+#endif
     {
-        private readonly Stream stream;
+        private Stream stream;
         private IODataStreamListener listener;
+        private bool disposed = false;
+        private bool synchronous;
 
-        internal ODataNotificationStream(Stream underlyingStream, IODataStreamListener listener)
+        internal ODataNotificationStream(Stream underlyingStream, IODataStreamListener listener, bool synchronous = true)
         {
             Debug.Assert(underlyingStream != null, "Creating a notification stream for a null stream.");
             Debug.Assert(listener != null, "Creating a notification stream with a null listener.");
 
             this.stream = underlyingStream;
             this.listener = listener;
+            this.synchronous = synchronous;
         }
 
         /// <inheritdoc/>
@@ -163,7 +171,7 @@ namespace Microsoft.OData
             return this.stream.ToString();
         }
 
-        #region async methods
+#region async methods
 
 
         /// <inheritdoc/>
@@ -190,7 +198,7 @@ namespace Microsoft.OData
             return this.stream.WriteAsync(buffer, offset, count, cancellationToken);
         }
 
-        #endregion
+#endregion
 
         /// <summary>
         /// Disposes the object.
@@ -198,17 +206,45 @@ namespace Microsoft.OData
         /// <param name="disposing">True if called from Dispose; false if called from the finalizer.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing)
+            if (!this.disposed && disposing)
             {
-                if (this.listener != null)
+                // Tell the listener that the stream is being disposed.
+                if (synchronous)
                 {
-                    // Tell the listener that the stream is being disposed.
-                    this.listener.StreamDisposed();
-                    this.listener = null;
+                    this.listener?.StreamDisposed();
                 }
+                else
+                {
+                    this.listener?.StreamDisposedAsync().Wait();
+                }
+
+                this.listener = null;
+
+                this.stream?.Dispose();
+                this.stream = null;
             }
 
+            this.disposed = true;
             base.Dispose(disposing);
         }
+
+#if NETSTANDARD2_0
+        public async ValueTask DisposeAsync()
+        {
+            if (!this.disposed && this.listener != null)
+            {
+                await this.listener.StreamDisposedAsync()
+                    .ConfigureAwait(false);
+                this.stream?.Dispose();
+
+                this.listener = null;
+                this.stream = null;
+            }
+
+            // Dispose unmanaged resources
+            // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
+            this.Dispose(false);
+        }
+#endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
@@ -1,0 +1,161 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataNotificationStreamTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OData.Tests
+{
+    public class ODataNotificationStreamTests
+    {
+        private MemoryStream stream;
+        private TextWriter writer;
+        private IODataStreamListener streamListener;
+
+        public ODataNotificationStreamTests()
+        {
+            this.stream = new MemoryStream();
+            this.writer = new StreamWriter(this.stream);
+            this.streamListener = new MockODataStreamListener(this.writer);
+        }
+
+        [Theory]
+        [InlineData(true, "StreamDisposed")]
+        [InlineData(false, "StreamDisposedAsync")]
+        public void NotificationStreamDisposeShouldInvokeStreamDisposed(bool synchronous, string expected)
+        {
+            // We care about the notification stream being disposed
+            // We don't care about the stream passed to the notification stream
+            using (var notificationStream = new ODataNotificationStream(
+                new MemoryStream(),
+                this.streamListener,
+                synchronous))
+            {
+            }
+
+            var result = ReadStreamContents();
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(true, "StreamDisposed")]
+        [InlineData(false, "StreamDisposedAsync")]
+        public void NotificationStreamDisposeShouldBeIdempotent(bool synchronous, string expected)
+        {
+            var notificationStream = new ODataNotificationStream(
+                new MemoryStream(),
+                this.streamListener,
+                synchronous);
+
+            // 1st call to Dispose
+            notificationStream.Dispose();
+            // 2nd call to Dispose
+            notificationStream.Dispose();
+
+            var result = ReadStreamContents();
+
+            // StreamDisposed/StreamDisposeAsync was written only once
+            Assert.Equal(expected, result);
+        }
+
+#if NETCOREAPP3_1
+        [Fact]
+        public async Task NotificationStreamDisposeShouldInvokeStreamDisposedAsync()
+        {
+            await using (var notificationStream = new ODataNotificationStream(
+                new MemoryStream(),
+                this.streamListener)) // `synchronous` argument becomes irrelevant
+            {
+            }
+
+            var result = await this.ReadStreamContentsAsync();
+
+            Assert.Equal("StreamDisposedAsync", result);
+        }
+
+        [Fact]
+        public async Task NotificationStreamDisposeAsyncShouldBeIdempotent()
+        {
+            var notificationStream = new ODataNotificationStream(
+                new MemoryStream(),
+                this.streamListener);
+
+            // 1st call to DisposeAsync
+            await notificationStream.DisposeAsync();
+            // 2nd call to DisposeAsync
+            await notificationStream.DisposeAsync();
+
+            var result = await this.ReadStreamContentsAsync();
+
+            // StreamDisposeAsync was written only once
+            Assert.Equal("StreamDisposedAsync", result);
+        }
+
+#else
+        [Fact]
+        public async Task NotificationStreamDisposeShouldInvokeStreamDisposedAsync()
+        {
+            using (var notificationStream = new ODataNotificationStream(
+                new MemoryStream(),
+                this.streamListener,
+                /*synchronous*/ false))
+            {
+            }
+
+            var result = await this.ReadStreamContentsAsync();
+
+            Assert.Equal("StreamDisposedAsync", result);
+        }
+#endif
+
+        private string ReadStreamContents()
+        {
+            this.stream.Position = 0;
+            return new StreamReader(this.stream).ReadToEnd();
+        }
+
+        private Task<string> ReadStreamContentsAsync()
+        {
+            this.stream.Position = 0;
+            return new StreamReader(this.stream).ReadToEndAsync();
+        }
+
+        private class MockODataStreamListener : IODataStreamListener
+        {
+            private TextWriter writer;
+
+            public MockODataStreamListener(TextWriter writer)
+            {
+                this.writer = writer;
+            }
+
+            public void StreamDisposed()
+            {
+                writer.Write("StreamDisposed");
+                writer.Flush();
+            }
+
+            public async Task StreamDisposedAsync()
+            {
+                await writer.WriteAsync("StreamDisposedAsync").ConfigureAwait(false);
+                await writer.FlushAsync().ConfigureAwait(false);
+            }
+
+            public void StreamRequested()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task StreamRequestedAsync()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request is in partial fulfilment of issue #2019.

### Description

Support asynchronous invocation of **`IODataStreamListener.StreamDisposedAsync`** method from `Dispose`/`DisposeAsync` methods of **`ODataNotificationStream`** class.
- In .NET Core 3.1 or later, we're able to ride on asynchronous `DisposeAsync` method defined in `IAsyncDisposable` interface to avoid blocking.
- In platforms below .NET Core 3.1, we're forced to `.Wait()` on the asynchronous method.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
