### PR TITLE
Add System.Runtime.CompilerServices.Unsafe and System.Text.Encodings.web dependency for OData.Edm

### DIFF
--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Nightly.Release.nuspec
@@ -16,6 +16,8 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" />
+        <dependency id="System.Text.Encodings.Web" version="4.6.0" />
         <dependency id="System.Text.Json" version="4.6.0" />
       </group>
     </dependencies>

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
@@ -17,6 +17,8 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" />
+        <dependency id="System.Text.Encodings.Web" version="4.6.0" />
         <dependency id="System.Text.Json" version="4.6.0" />
       </group>
     </dependencies>


### PR DESCRIPTION
See detail at: https://github.com/dotnet/aspnetcore/issues/31725

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

### Description

v2.1.27 nuget package pins a number of libraries to 4.6.0 not inclusive. This breaks downstream dependencies when combined with the OData libraries.

It's better to add "System.Runtime.CompilerServices.Unsafe and System.Text.Encodings.web" dependency to unblock customer to use latest .net core 2.1.27

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
