### PR TITLE
Add a * (STAR) in the OData context URL when expanding an entity

### DIFF
--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -420,7 +420,7 @@ namespace Microsoft.OData
         /// <returns>The generated expand string.</returns>
         private static string ProcessSubExpand(string expandNode, string subExpand)
         {
-            return expandNode + ODataConstants.ContextUriProjectionStart + subExpand + ODataConstants.ContextUriProjectionEnd;
+            return expandNode + ODataConstants.ContextUriProjectionStart + (subExpand ?? "*") + ODataConstants.ContextUriProjectionEnd;
         }
 
         /// <summary>Create combined result string using selected items list and expand items list.</summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/NavigationPropertyOnComplexTests.cs
@@ -418,9 +418,9 @@ namespace Microsoft.OData.Tests
 
             string expected = version == ODataVersion.V4 ?
                 //OData V4.0
-                "{\"@odata.context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2())\",\"value\":[{\"@odata.id\":\"People('abc')\",\"@odata.editLink\":\"People('abc')\",\"UserName\":\"abc\",\"Address\":{\"Road\":\"Zixing\",\"WorkAddress\":{\"@odata.type\":\"#DefaultNs.WorkAddress\",\"Road\":\"Ziyue\",\"City2@odata.associationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2/$ref\",\"City2@odata.navigationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2\",\"City2\":{\"@odata.id\":\"City(222)\",\"@odata.editLink\":\"City(222)\",\"ZipCode\":222}}}}]}" :
+                "{\"@odata.context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2(*))\",\"value\":[{\"@odata.id\":\"People('abc')\",\"@odata.editLink\":\"People('abc')\",\"UserName\":\"abc\",\"Address\":{\"Road\":\"Zixing\",\"WorkAddress\":{\"@odata.type\":\"#DefaultNs.WorkAddress\",\"Road\":\"Ziyue\",\"City2@odata.associationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2/$ref\",\"City2@odata.navigationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2\",\"City2\":{\"@odata.id\":\"City(222)\",\"@odata.editLink\":\"City(222)\",\"ZipCode\":222}}}}]}" :
                 //OData V4.01
-                "{\"@context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2())\",\"value\":[{\"@id\":\"People('abc')\",\"@editLink\":\"People('abc')\",\"UserName\":\"abc\",\"Address\":{\"Road\":\"Zixing\",\"WorkAddress\":{\"@type\":\"#DefaultNs.WorkAddress\",\"Road\":\"Ziyue\",\"City2@associationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2/$ref\",\"City2@navigationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2\",\"City2\":{\"@id\":\"City(222)\",\"@editLink\":\"City(222)\",\"ZipCode\":222}}}}]}";
+                "{\"@context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2(*))\",\"value\":[{\"@id\":\"People('abc')\",\"@editLink\":\"People('abc')\",\"UserName\":\"abc\",\"Address\":{\"Road\":\"Zixing\",\"WorkAddress\":{\"@type\":\"#DefaultNs.WorkAddress\",\"Road\":\"Ziyue\",\"City2@associationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2/$ref\",\"City2@navigationLink\":\"http://host/People('abc')/Address/WorkAddress/DefaultNs.WorkAddress/City2\",\"City2\":{\"@id\":\"City(222)\",\"@editLink\":\"City(222)\",\"ZipCode\":222}}}}]}";
 
             Assert.Equal(actual, expected);
 
@@ -478,7 +478,7 @@ namespace Microsoft.OData.Tests
 
             string expected = version == ODataVersion.V4 ?
                 //OData V4.01
-                "{\"@odata.context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2())\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2(*))\"," +
                     "\"value\":[" +
                     "{" +
                         "\"UserName\":\"abc\"," +
@@ -494,7 +494,7 @@ namespace Microsoft.OData.Tests
                         "}" +
                     "}]}" :
                 //OData V4.01
-                "{\"@context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2())\"," +
+                "{\"@context\":\"http://host/$metadata#People(UserName,Address/WorkAddress/DefaultNs.WorkAddress/City2(*))\"," +
                     "\"value\":[" +
                     "{" +
                         "\"UserName\":\"abc\"," +
@@ -527,7 +527,7 @@ namespace Microsoft.OData.Tests
         }
 
         private const string v4MinimalMetadataPayload =
-                                               "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav())/$entity\"," +
+                                               "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav(*))/$entity\"," +
                                                        "\"ID\":\"abc\"," +
                                                         "\"Complex\":{" +
                                                         "\"Prop1\":123," +
@@ -540,7 +540,7 @@ namespace Microsoft.OData.Tests
                                                     "}" +
                                                 "}";
         private const string v4FullMetadataPayload =
-                                         "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav())/$entity\"," +
+                                         "{\"@odata.context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav(*))/$entity\"," +
                                              "\"@odata.id\":\"Entities('abc')\"," +
                                              "\"@odata.editLink\":\"Entities('abc')\"," +
                                              "\"ID\":\"abc\"," +
@@ -563,7 +563,7 @@ namespace Microsoft.OData.Tests
                                              "}" +
                                              "}";
         private const string v401MinimalMetadataPayload =
-                                               "{\"@context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav())/$entity\"," +
+                                               "{\"@context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav(*))/$entity\"," +
                                                     "\"ID\":\"abc\"," +
                                                     "\"Complex\":{" +
                                                         "\"Prop1\":123," +
@@ -576,7 +576,7 @@ namespace Microsoft.OData.Tests
                                                     "}" +
                                                 "}";
         private const string v401FullMetadataPayload =
-                                        "{\"@context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav())/$entity\"," +
+                                        "{\"@context\":\"http://host/$metadata#Entities(ID,Complex/CollectionOfNav(*))/$entity\"," +
                                              "\"@id\":\"Entities('abc')\"," +
                                              "\"@editLink\":\"Entities('abc')\"," +
                                              "\"ID\":\"abc\"," +
@@ -767,7 +767,7 @@ namespace Microsoft.OData.Tests
 
             string expectedPayload = version == ODataVersion.V4 ?
                 // OData version 4.0
-                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(ZipCode,Region()))\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(ZipCode,Region(*)))\"," +
                 "\"@odata.type\":\"#DefaultNs.WorkAddress\"," +
                 "\"Road\":\"Ziyue\"," +
                 "\"City2\":{" +
@@ -778,7 +778,7 @@ namespace Microsoft.OData.Tests
                     "}" +
                 "}" :
                // OData version 4.01
-               "{\"@context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(ZipCode,Region()))\"," +
+               "{\"@context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(ZipCode,Region(*)))\"," +
                 "\"@type\":\"#DefaultNs.WorkAddress\"," +
                 "\"Road\":\"Ziyue\"," +
                 "\"City2\":{" +
@@ -833,7 +833,7 @@ namespace Microsoft.OData.Tests
 
             string expectedPayload = version == ODataVersion.V4 ?
                 // OData V4 Version
-                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(Region()))\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(Region(*)))\"," +
                 "\"@odata.type\":\"#DefaultNs.WorkAddress\"," +
                 "\"Road\":\"Ziyue\"," +
                 "\"City2\":{" +
@@ -847,7 +847,7 @@ namespace Microsoft.OData.Tests
                         "\"@odata.editLink\":\"Regions('China')\"," +
                         "\"Name\":\"China\"}}}" :
                 // OData Version 4.01
-                "{\"@context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(Region()))\"," +
+                "{\"@context\":\"http://host/$metadata#People('abc')/Address/WorkAddress(DefaultNs.WorkAddress/City2(Region(*)))\"," +
                     "\"@type\":\"#DefaultNs.WorkAddress\"," +
                     "\"Road\":\"Ziyue\"," +
                     "\"City2\":{" +
@@ -911,7 +911,7 @@ namespace Microsoft.OData.Tests
 
             string expectedPayload = version == ODataVersion.V4 ?
                 // OData version 4.0
-                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address(WorkAddress/DefaultNs.WorkAddress/City2(ZipCode,Region()))\"," +
+                "{\"@odata.context\":\"http://host/$metadata#People('abc')/Address(WorkAddress/DefaultNs.WorkAddress/City2(ZipCode,Region(*)))\"," +
                 "\"Road\":\"Zixing\"," +
                 "\"WorkAddress\":{" +
                     "\"@odata.type\":\"#DefaultNs.WorkAddress\"," +
@@ -925,7 +925,7 @@ namespace Microsoft.OData.Tests
                     "}" +
                 "}" :
                 // OData version 4.01
-                "{\"@context\":\"http://host/$metadata#People('abc')/Address(WorkAddress/DefaultNs.WorkAddress/City2(ZipCode,Region()))\"," +
+                "{\"@context\":\"http://host/$metadata#People('abc')/Address(WorkAddress/DefaultNs.WorkAddress/City2(ZipCode,Region(*)))\"," +
                 "\"Road\":\"Zixing\"," +
                 "\"WorkAddress\":{" +
                     "\"@type\":\"#DefaultNs.WorkAddress\"," +

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -281,9 +281,9 @@ namespace Microsoft.OData.Tests
 
         [Theory]
         // expand without select, $expand=A
-        [InlineData("TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts()")]
+        [InlineData("TestModel.CapitolCity/Districts", "TestModel.CapitolCity/Districts(*)")]
         // expands without select, $expand=A,B
-        [InlineData("TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", "TestModel.CapitolCity/CapitolDistrict(),TestModel.CapitolCity/Districts()")]
+        [InlineData("TestModel.CapitolCity/CapitolDistrict,TestModel.CapitolCity/Districts", "TestModel.CapitolCity/CapitolDistrict(*),TestModel.CapitolCity/Districts(*)")]
         // expand with nested select, $expand=A($select=B)
         [InlineData("TestModel.CapitolCity/Districts($select=Name)", "TestModel.CapitolCity/Districts(Name)")]
 
@@ -297,13 +297,13 @@ namespace Microsoft.OData.Tests
 
         [Theory]
         // $select=A&$expand=B
-        [InlineData( "Name", "Districts", "Name,Districts()")]
+        [InlineData( "Name", "Districts", "Name,Districts(*)")]
         // $select=A&$expand=A
-        [InlineData( "Districts", "Districts", "Districts,Districts()")]
+        [InlineData( "Districts", "Districts", "Districts,Districts(*)")]
         // $select=A,B,C&$expand=A
-        [InlineData( "Name,Districts,Size", "Districts", "Name,Districts,Size,Districts()")]
+        [InlineData( "Name,Districts,Size", "Districts", "Name,Districts,Size,Districts(*)")]
         // $select=A&$expand=A,B
-        [InlineData( "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(),TestModel.CapitolCity/CapitolDistrict()")]
+        [InlineData( "Districts", "Districts,TestModel.CapitolCity/CapitolDistrict", "Districts,Districts(*),TestModel.CapitolCity/CapitolDistrict(*)")]
         // $select=A,B&$expand=B($select=C)
         [InlineData( "Name,Districts", "Districts($select=Name)", "Name,Districts,Districts(Name)")]
         public void FeedContextUriWithSelectAndExpandString(string selectClause, string expandClause, string expectedClause)
@@ -341,7 +341,7 @@ namespace Microsoft.OData.Tests
         {
             // Without inner $select, $expand=A($expand=B($expand=C))
             string expandClause = "Districts($expand=City($expand=Districts))";
-            string expectedClause = "Districts(City(Districts()))";
+            string expectedClause = "Districts(City(Districts(*)))";
             string urlString = this.CreateEntryContextUri(null, expandClause, version).OriginalString;
             Assert.Equal(urlString, BuildExpectedContextUri("#Cities", true, expectedClause));
 
@@ -368,7 +368,7 @@ namespace Microsoft.OData.Tests
         {
             const string selectClause = "Size,Name";
             const string expandClause = "Districts($select=Zip,City;$expand=City($expand=Districts;$select=Name))";
-            const string expectedClause = "Size,Name,Districts(Zip,City,City(Name,Districts()))";
+            const string expectedClause = "Size,Name,Districts(Zip,City,City(Name,Districts(*)))";
             Assert.Equal(this.CreateFeedContextUri(selectClause, expandClause, null, null, version).OriginalString, BuildExpectedContextUri("#Cities", false, expectedClause));
         }
         #endregion context uri with $select and $expand

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/ContextUrlWriterReaderTests.cs
@@ -739,7 +739,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
         [Fact]
         public void CollectionOfExpandedEntities()
         {
-            string contextString = "\"{0}$metadata#Employees(AssociatedCompany())\"";
+            string contextString = "\"{0}$metadata#Employees(AssociatedCompany(*))\"";
             foreach (ODataVersion version in Versions)
             {
                 foreach (ODataFormat mimeType in mimeTypes)
@@ -806,7 +806,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                     feed.Id = new Uri("urn:test");
                     writer.WriteStart(feed);
                     writer.WriteEnd();
-                }, string.Format("\"{0}$metadata#Employees(AssociatedCompany())\"", TestBaseUri), out payload, out contentType);
+                }, string.Format("\"{0}$metadata#Employees(AssociatedCompany(*))\"", TestBaseUri), out payload, out contentType);
 
                 this.ReadPayload(payload, contentType, model, omReader =>
                 {
@@ -909,7 +909,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                     writer.WriteStart(entry);
                     writer.WriteEnd();
                 },
-                string.Format("\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany())/$entity\"", TestBaseUri),
+                string.Format("\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany(*))/$entity\"", TestBaseUri),
                 out payload, out contentType);
 
                 this.ReadPayload(payload, contentType, model, omReader =>
@@ -928,7 +928,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
         [InlineData(ODataVersion.V401)]
         public void ExpandedMultiSegmentEntity(ODataVersion version)
         {
-            string contextString = "\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany())/$entity\"";
+            string contextString = "\"{0}$metadata#Employees(AssociatedCompany,AssociatedCompany(*))/$entity\"";
             ODataResource entry = new ODataResource()
             {
                 TypeName = TestNameSpace + ".Employee",

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/FullPayloadValidateTests.cs
@@ -315,7 +315,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedCollectionNavProp,ContainedCollectionNavProp()))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedCollectionNavProp,ContainedCollectionNavProp(*)))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -355,7 +355,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp(ContainedNavProp,ContainedNavProp()))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp(ContainedNavProp,ContainedNavProp(*)))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -390,7 +390,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp()))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp(*)))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -425,7 +425,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp,ExpandedCollectionNavProp(ContainedNavProp,ContainedNavProp()))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ExpandedCollectionNavProp,ExpandedCollectionNavProp(ContainedNavProp,ContainedNavProp(*)))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ExpandedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ExpandedCollectionNavProp\":" +
@@ -461,7 +461,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
             string expectedPayload = "{" +
-                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ExpandedNavProp,ExpandedNavProp()))/$entity\"," +
+                                        "\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedCollectionNavProp,ContainedCollectionNavProp(ExpandedNavProp,ExpandedNavProp(*)))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -498,7 +498,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
             const string expectedPayload = "{\"" +
-                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp()))\"," +
+                                                "@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(*)))\"," +
                                                 "\"value\":[" +
                                                     "{" +
                                                          "\"ID\":101,\"Name\":\"Alice\"," +
@@ -537,7 +537,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp($select=Namespace.DerivedType/ContainedNavProp;$expand=Namespace.DerivedType/ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, DerivedType, selectClause, expandClause, "EntitySet/Namespace.DerivedType");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp,ContainedNavProp(Namespace.DerivedType/ContainedNavProp,Namespace.DerivedType/ContainedNavProp()))\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet/Namespace.DerivedType(ContainedNavProp,ContainedNavProp(Namespace.DerivedType/ContainedNavProp,Namespace.DerivedType/ContainedNavProp(*)))\"," +
                                             "\"value\":[" +
                                                 "{" +
                                                     "\"ID\":101,\"Name\":\"Alice\"," +
@@ -572,7 +572,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "Namespace.DerivedType/ContainedCollectionNavProp($select=ContainedNavProp;$expand=ContainedNavProp)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp()))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(Namespace.DerivedType/ContainedCollectionNavProp,Namespace.DerivedType/ContainedCollectionNavProp(ContainedNavProp,ContainedNavProp(*)))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":" +
@@ -657,7 +657,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ExpandedNavProp,ContainedCollectionNavProp($select=ID),ContainedNavProp($select=ID,Name)";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet(101)");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ID,Name,ExpandedNavProp(),ContainedCollectionNavProp(ID),ContainedNavProp(ID,Name))/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ID,Name,ExpandedNavProp(*),ContainedCollectionNavProp(ID),ContainedNavProp(ID,Name))/$entity\"," +
                                             "\"ID\":101,\"Name\":\"Alice\"," +
                                             "\"ExpandedNavProp\":{\"ID\":102,\"Name\":\"Bob\"}," +
                                             "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
@@ -951,7 +951,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
             const string expandClause = "ContainedNavProp";
             string result = this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=minimal", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause, "EntitySet");
 
-            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp())/$entity\"," +
+            string expectedPayload = "{\"@odata.context\":\"http://example.org/odata.svc/$metadata#EntitySet(ContainedNavProp,ContainedNavProp(*))/$entity\"," +
                                         "\"ID\":101,\"Name\":\"Alice\"," +
                                         "\"ContainedCollectionNavProp@odata.navigationLink\":\"http://example.org/odata.svc/navigation\"," +
                                         "\"ContainedCollectionNavProp\":[{\"ID\":102,\"Name\":\"Bob\"}]" +


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue https://github.com/OData/WebApi/issues/2088 and #2081*

### Description

*This change adds the STAR character (*) to the OData context URL when an entity is expanded and no selectors are specified. The way I (and apparently the team behind the Excel and PowerBI OData connector) read the OData spec suggests this character is required. As a result, it is not possible to use Excel or PowerBI to expand any data from an odata.net backed API. Test cases adjusted to match the change.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*