### PR TITLE
Translate ExpandedCountSelectItem in BuildUri

### DIFF
--- a/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
@@ -311,13 +311,13 @@ namespace Microsoft.OData
             string res = string.Empty;
             if (item.FilterOption != null)
             {
-                res += "$filter=" + nodeToStringBuilder.TranslateFilterClause(item.FilterOption);
+                res += ExpressionConstants.QueryOptionFilter + ExpressionConstants.SymbolEqual + nodeToStringBuilder.TranslateFilterClause(item.FilterOption);
             }
 
             if (item.SearchOption != null)
             {
                 res += string.IsNullOrEmpty(res) ? null : ";";
-                res += "$search=" + nodeToStringBuilder.TranslateSearchClause(item.SearchOption);
+                res += ExpressionConstants.QueryOptionSearch + ExpressionConstants.SymbolEqual + nodeToStringBuilder.TranslateSearchClause(item.SearchOption);
             }
 
             return string.Concat(currentExpandClause, ODataConstants.UriSegmentSeparator, UriQueryConstants.CountSegment, string.IsNullOrEmpty(res) ? null : string.Concat(ExpressionConstants.SymbolOpenParen, res, ExpressionConstants.SymbolClosedParen));

--- a/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
+++ b/src/Microsoft.OData.Core/Uri/SelectExpandClauseToStringBuilder.cs
@@ -317,9 +317,7 @@ namespace Microsoft.OData
             if (item.SearchOption != null)
             {
                 res += string.IsNullOrEmpty(res) ? null : ";";
-                res += "$search";
-                res += ExpressionConstants.SymbolEqual;
-                res += nodeToStringBuilder.TranslateSearchClause(item.SearchOption);
+                res += "$search=" + nodeToStringBuilder.TranslateSearchClause(item.SearchOption);
             }
 
             return string.Concat(currentExpandClause, ODataConstants.UriSegmentSeparator, UriQueryConstants.CountSegment, string.IsNullOrEmpty(res) ? null : string.Concat(ExpressionConstants.SymbolOpenParen, res, ExpressionConstants.SymbolClosedParen));

--- a/src/Microsoft.OData.Core/UriParser/Visitors/SelectItemTranslator.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/SelectItemTranslator.cs
@@ -63,5 +63,15 @@ namespace Microsoft.OData.UriParser
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Translate an ExpandedCountSelectItem
+        /// </summary>
+        /// <param name="item">the item to Translate</param>
+        /// <returns>Defined by the implementer</returns>
+        public virtual T Translate(ExpandedCountSelectItem item)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
@@ -732,7 +732,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.Equal("http://gobbledygook/People?$select=" + Uri.EscapeDataString("PreviousAddresses($filter=endswith($this/City,'xyz');$orderby=$this/City;$top=10;$skip=5;$count=true)"), actualUri.OriginalString);
         }
 
-        //MyDog($select=Color;$expand=MyPeople($expand=MyPaintings($filter=ID eq $it/ID)))
         [Fact]
         public void SelectWithinMultipleNestedExpandsShouldWork()
         {
@@ -740,6 +739,31 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
             Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString("MyDog($select=Color;$expand=MyPeople($select=PreviousAddresses($filter=endswith($this/City,'xyz');$orderby=$this/City;$top=10;$skip=5;$count=true)))"), actualUri.OriginalString);
         }
+
+        [Fact]
+        public void ExpandWithCountSegmentWithFilterQueryOptionShouldWork()
+        {
+            Uri queryUri = new Uri("People?$expand=MyFriendsDogs/$count($filter=Color eq 'Brown')", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString("MyFriendsDogs/$count($filter=Color eq 'Brown')"), actualUri.OriginalString);
+        }
+
+        [Fact]
+        public void ExpandWithCountSegmentWithSearchQueryOptionShouldWork()
+        {
+            Uri queryUri = new Uri("People?$expand=MyFriendsDogs/$count($search=blue)", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString("MyFriendsDogs/$count($search=blue)"), actualUri.OriginalString);
+        }
+
+        [Fact]
+        public void ExpandWithCountSegmentWithBothFilterAndSearchQueryOptionsShouldWork()
+        {
+            Uri queryUri = new Uri("People?$expand=MyFriendsDogs/$count($filter=Color eq 'Brown';$search=blue)", UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString("MyFriendsDogs/$count($filter=Color eq 'Brown';$search=blue)"), actualUri.OriginalString);
+        }
+
         [Fact]
         public void ExpandWithNestedQueryOptionsShouldWork()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2084 .*

### Description

When you call `ODataUriParser.ParseUri()`, we create an `ODataUri`.

`BuildUri` extension method creates a `Uri` from an `ODataUri`. The result Uri's query options are URL encoded.

```csharp
ODataUriParser odataUriParser = new ODataUriParser(EdmModel, ServiceRoot, queryUri);
odataUriParser.UrlKeyDelimiter = urlKeyDelimiter;
ODataUri odataUri = odataUriParser.ParseUri();

Uri uri = odataUri.BuildUri(urlKeyDelimiter);
```

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
