### PR TITLE
entity tracker equality comparer

### DIFF
--- a/src/Microsoft.OData.Client/EntityTracker.cs
+++ b/src/Microsoft.OData.Client/EntityTracker.cs
@@ -14,6 +14,7 @@ namespace Microsoft.OData.Client
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Microsoft.OData.Client.Metadata;
+    using System.Runtime.CompilerServices;
     #endregion Namespaces
 
     /// <summary>
@@ -26,28 +27,12 @@ namespace Microsoft.OData.Client
 
         #region Resource state management
 
-    #if PORTABLELIB && WINDOWSPHONE
         /// <summary>Set of tracked resources</summary>
-        private Dictionary<object, EntityDescriptor> entityDescriptors = new Dictionary<object, EntityDescriptor>(EqualityComparer<object>.Default);
-    #else
-        /// <summary>Set of tracked resources</summary>
-        private ConcurrentDictionary<object, EntityDescriptor> entityDescriptors = new ConcurrentDictionary<object, EntityDescriptor>(EqualityComparer<object>.Default);
-    #endif
-    #if PORTABLELIB && WINDOWSPHONE
-        /// <summary>Set of tracked resources by Identity</summary>
-        private Dictionary<Uri, EntityDescriptor> identityToDescriptor;
-    #else
+        private ConcurrentDictionary<object, EntityDescriptor> entityDescriptors = new ConcurrentDictionary<object, EntityDescriptor>(EntityEqualityComparer<object>.Instance);
         /// <summary>Set of tracked resources by Identity</summary>
         private ConcurrentDictionary<Uri, EntityDescriptor> identityToDescriptor;
-    #endif
-
-    #if PORTABLELIB && WINDOWSPHONE
-        /// <summary>Set of tracked bindings</summary>
-        private Dictionary<LinkDescriptor, LinkDescriptor> bindings;
-    #else
         /// <summary>Set of tracked bindings</summary>
         private ConcurrentDictionary<LinkDescriptor, LinkDescriptor> bindings;
-    #endif
 
         /// <summary>change order</summary>
         private uint nextChange;
@@ -575,5 +560,17 @@ namespace Microsoft.OData.Client
                 throw Error.InvalidOperation(Strings.Context_DifferentEntityAlreadyContained);
             }
         }
+    }
+
+    /// <summary>
+    /// An object instance equality comparer
+    /// </summary>
+    /// <typeparam name="TObject"></typeparam>
+    internal class EntityEqualityComparer<TObject> : EqualityComparer<TObject> where TObject : class
+    {
+        public static EntityEqualityComparer<TObject> Instance = new EntityEqualityComparer<TObject>();
+        private EntityEqualityComparer() { }
+        public override bool Equals(TObject x, TObject y) => ReferenceEquals(x, y);
+        public override int GetHashCode(TObject obj) => RuntimeHelpers.GetHashCode(obj);
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/ClientEntityTrackerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/ClientEntityTrackerTests.cs
@@ -1,0 +1,374 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ClientEntityTrackerTests.cs" company="Microsoft">
+// Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.Tests.Tracking
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using Microsoft.OData.Edm.Csdl;
+    using Xunit;
+
+    public class ClientEntityTrackerTests
+    {
+        private Container DefaultTrackingContext;
+
+        #region TestEdmx
+        private const string Edmx = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+        <edmx:DataServices>
+            <Schema Namespace=""Microsoft.OData.Client.Tests.Tracking"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+                <EntityType Name=""ExampleObject"">
+                    <Key>
+                        <PropertyRef Name=""Id""/>
+                    </Key>
+                    <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false""/>
+                    <Property Name=""Name"" Type=""Edm.String""/>
+                </EntityType>
+                <EntityType Name=""ExampleObjectA"">
+                    <Key>
+                        <PropertyRef Name=""Id""/>
+                    </Key>
+                    <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false""/>
+                    <Property Name=""Name"" Type=""Edm.String""/>
+                </EntityType>
+                <EntityType Name=""ExampleObjectB"">
+                    <Key>
+                        <PropertyRef Name=""Id""/>
+                    </Key>
+                    <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false""/>
+                    <Property Name=""Name"" Type=""Edm.String""/>
+                </EntityType>
+                <EntityType Name=""ExampleObjectC"">
+                    <Key>
+                        <PropertyRef Name=""Id""/>
+                    </Key>
+                    <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false""/>
+                    <Property Name=""Name"" Type=""Edm.String""/>
+                </EntityType>
+                <EntityType Name=""ExampleObjectD"">
+                    <Key>
+                        <PropertyRef Name=""Id""/>
+                    </Key>
+                    <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false""/>
+                    <Property Name=""Name"" Type=""Edm.String""/>
+                </EntityType>
+                <EntityType Name=""ExampleObjectE"">
+                    <Key>
+                        <PropertyRef Name=""Id""/>
+                    </Key>
+                    <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false""/>
+                    <Property Name=""Name"" Type=""Edm.String""/>
+                </EntityType>
+            </Schema>
+            <Schema Namespace=""Default"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+                <EntityContainer Name=""Container"">
+                    <EntitySet Name=""ExampleObject"" EntityType=""Microsoft.OData.Client.Tests.Tracking.ExampleObject""/>
+                    <EntitySet Name=""ExampleObjectA"" EntityType=""Microsoft.OData.Client.Tests.Tracking.ExampleObjectA""/>
+                    <EntitySet Name=""ExampleObjectB"" EntityType=""Microsoft.OData.Client.Tests.Tracking.ExampleObjectB""/>
+                    <EntitySet Name=""ExampleObjectC"" EntityType=""Microsoft.OData.Client.Tests.Tracking.ExampleObjectC""/>
+                    <EntitySet Name=""ExampleObjectD"" EntityType=""Microsoft.OData.Client.Tests.Tracking.ExampleObjectD""/>
+                    <EntitySet Name=""ExampleObjectE"" EntityType=""Microsoft.OData.Client.Tests.Tracking.ExampleObjectE""/>
+                </EntityContainer>
+            </Schema>
+        </edmx:DataServices>
+        </edmx:Edmx>";
+        #endregion
+
+        #region responses
+        private const string Response = @"{
+            ""@odata.context"":""http://localhost:8000/$metadata#ExampleObject/$entity"",
+            ""Id"":1,
+            ""Name"":""Example1""}";
+
+        private const string ResponseA = @"{
+            ""@odata.context"":""http://localhost:8000/$metadata#ExampleObjectA/$entity"",
+            ""Id"":1,
+            ""Name"":""Example1""}";
+
+        private const string ResponseB = @"{
+            ""@odata.context"":""http://localhost:8000/$metadata#ExampleObjectB/$entity"",
+            ""Id"":1,
+            ""Name"":""Example1""}";
+
+        private const string ResponseC = @"{
+            ""@odata.context"":""http://localhost:8000/$metadata#ExampleObjectC/$entity"",
+            ""Id"":1,
+            ""Name"":""Example1""}";
+
+        private const string ResponseD = @"{
+            ""@odata.context"":""http://localhost:8000/$metadata#ExampleObjectD/$entity"",
+            ""Id"":1,
+            ""Name"":""Example1""}";
+
+        private const string ResponseE = @"{
+            ""@odata.context"":""http://localhost:8000/$metadata#ExampleObjectE/$entity"",
+            ""Id"":1,
+            ""Name"":""Example1""}";
+        #endregion
+
+        public ClientEntityTrackerTests()
+        {
+            var uri = new Uri("http://localhost:8000");
+            DefaultTrackingContext = new Container(uri);
+        }
+
+        [Fact]
+        public async Task SavingObject_ThatOverridesEqualsAndGetHashCodeMethods_SavesSuccessfully()
+        {
+            SetupContextWithRequestPipelineForSaving(
+             new DataServiceContext[] { DefaultTrackingContext },Response,"http://localhost:8000/ExampleObjects(1)");
+            var exampleObject = new ExampleObject
+            {
+                Id = 0,
+                Name = "Example1"
+            };
+
+            DefaultTrackingContext.AddObject("ExampleObjects", exampleObject);
+            Assert.NotNull(DefaultTrackingContext.GetEntityDescriptor(exampleObject));
+            await SaveContextChangesAsync(new DataServiceContext[] { DefaultTrackingContext });
+
+        }
+
+        [Fact]
+        public async Task SavingExampleObject_ThatOverridesEqualsAndGetHashCodeMethods_SavesSuccessfully()
+        {
+            SetupContextWithRequestPipelineForSaving(
+             new DataServiceContext[] { DefaultTrackingContext }, ResponseC, "http://localhost:8000/ExampleObjectCs(1)");
+            var exampleObject = new ExampleObjectC
+            {
+                Id = 0,
+                Name = "Example1"
+            };
+
+            DefaultTrackingContext.AddObject("ExampleObjectCs", exampleObject);
+            Assert.NotNull(DefaultTrackingContext.GetEntityDescriptor(exampleObject));
+            await SaveContextChangesAsync(new DataServiceContext[] { DefaultTrackingContext });
+
+        }
+
+        [Fact]
+        public async Task SavingObject_ThatImplementsIEqualityComparerInterface_SavesSuccessfully()
+        {
+            SetupContextWithRequestPipelineForSaving(
+             new DataServiceContext[] { DefaultTrackingContext }, ResponseA, "http://localhost:8000/ExampleObjectAs(1)");
+            var exampleObject = new ExampleObjectA
+            {
+                Id = 0,
+                Name = "Example1"
+            };
+
+            DefaultTrackingContext.AddObject("ExampleObjectAs", exampleObject);
+            Assert.NotNull(DefaultTrackingContext.GetEntityDescriptor(exampleObject));
+            await SaveContextChangesAsync(new DataServiceContext[] { DefaultTrackingContext });
+
+        }
+
+        [Fact]
+        public async Task SavingExampleObject_ThatImplementsIEqualityComparerInterface_SavesSuccessfully()
+        {
+            SetupContextWithRequestPipelineForSaving(
+             new DataServiceContext[] { DefaultTrackingContext }, ResponseD, "http://localhost:8000/ExampleObjectDs(1)");
+            var exampleObject = new ExampleObjectD
+            {
+                Id = 0,
+                Name = "Example1"
+            };
+
+            DefaultTrackingContext.AddObject("ExampleObjectDs", exampleObject);
+            Assert.NotNull(DefaultTrackingContext.GetEntityDescriptor(exampleObject));
+            await SaveContextChangesAsync(new DataServiceContext[] { DefaultTrackingContext });
+        }
+
+        [Fact]
+        public async Task SavingObject_ThatDoesNotImplementOrOverrideEqualityComparer_SavesSuccessfully()
+        {
+            SetupContextWithRequestPipelineForSaving(
+            new DataServiceContext[] { DefaultTrackingContext }, ResponseB, "http://localhost:8000/ExampleObjectBs(1)");
+            var exampleObject = new ExampleObjectB
+            {
+                Id = 0,
+                Name = "Example1"
+            };
+
+            DefaultTrackingContext.AddObject("ExampleObjectBs", exampleObject);
+            Assert.NotNull(DefaultTrackingContext.GetEntityDescriptor(exampleObject));
+            await SaveContextChangesAsync(new DataServiceContext[] { DefaultTrackingContext });
+
+        }
+
+        [Fact]
+        public async Task SavingExampleObject_ThatDoesNotImplementOrOverrideEqualityComparer_SavesSuccessfully()
+        {
+            SetupContextWithRequestPipelineForSaving(
+            new DataServiceContext[] { DefaultTrackingContext }, ResponseE, "http://localhost:8000/ExampleObjectEs(1)");
+            var exampleObject = new ExampleObjectE
+            {
+                Id = 0,
+                Name = "Example1"
+            };
+
+            DefaultTrackingContext.AddObject("ExampleObjectEs", exampleObject);
+            Assert.NotNull(DefaultTrackingContext.GetEntityDescriptor(exampleObject));
+            await SaveContextChangesAsync(new DataServiceContext[] { DefaultTrackingContext });
+
+        }
+
+        private async Task SaveContextChangesAsync(DataServiceContext[] dataServiceContexts)
+        {
+            foreach (var dataServiceContext in dataServiceContexts)
+            {
+                await dataServiceContext.SaveChangesAsync();
+            }
+        }
+
+        private void SetupContextWithRequestPipelineForSaving(DataServiceContext[] dataServiceContexts, string response, string location)
+        {
+            foreach (var context in dataServiceContexts)
+            {
+                context.Configurations.RequestPipeline.OnMessageCreating =
+                    (args) => new CustomizedRequestMessage(
+                        args,
+                        response,
+                        new Dictionary<string, string>()
+                        {
+                            {"Content-Type", "application/json;charset=utf-8"},
+                            { "Location", location },
+                        });
+            }
+        }
+
+        class Container : DataServiceContext
+        {
+            public Container(global::System.Uri serviceRoot) :
+                base(serviceRoot, ODataProtocolVersion.V4)
+            {
+                this.Format.LoadServiceModel = () => CsdlReader.Parse(XmlReader.Create(new StringReader(Edmx)));
+                this.Format.UseJson();
+                this.ExampleObjects = base.CreateQuery<ExampleObject>("ExampleObjects");
+                this.ExampleObjectAs = base.CreateQuery<ExampleObjectA>("ExampleObjectAs");
+                this.ExampleObjectBs = base.CreateQuery<ExampleObjectB>("ExampleObjectBs");
+                this.ExampleObjectCs = base.CreateQuery<ExampleObjectC>("ExampleObjectCs");
+                this.ExampleObjectDs = base.CreateQuery<ExampleObjectD>("ExampleObjectDs");
+                this.ExampleObjectEs = base.CreateQuery<ExampleObjectE>("ExampleObjectEs");
+            }
+            public DataServiceQuery<ExampleObject> ExampleObjects { get; private set; }
+            public DataServiceQuery<ExampleObjectA> ExampleObjectAs { get; private set; }
+            public DataServiceQuery<ExampleObjectB> ExampleObjectBs { get; private set; }
+            public DataServiceQuery<ExampleObjectC> ExampleObjectCs { get; private set; }
+            public DataServiceQuery<ExampleObjectD> ExampleObjectDs { get; private set; }
+            public DataServiceQuery<ExampleObjectE> ExampleObjectEs { get; private set; }
+        }
+    }
+    [Key("Id")]
+    public class ExampleObject : BaseEntityType
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public bool Equals(ExampleObject other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            return other.Id == Id;
+        }
+        public override bool Equals(object obj)
+        {
+            var other = obj as ExampleObject;
+
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+
+            return other.Id == Id;
+        }
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+    }
+
+    [Key("Id")]
+    public class ExampleObjectA : BaseEntityType, IEqualityComparer<ExampleObjectA>
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public bool Equals(ExampleObjectA x, ExampleObjectA y)
+        {
+            return x.Id == y.Id;
+        }
+
+        public int GetHashCode(ExampleObjectA obj)
+        {
+            return obj.Id.GetHashCode();
+        }
+    }
+
+    [Key("Id")]
+    public class ExampleObjectB : BaseEntityType
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    [Key("Id")]
+    public class ExampleObjectC 
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public bool Equals(ExampleObjectC other)
+        {
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            return other.Id == Id;
+        }
+        public override bool Equals(object obj)
+        {
+            var other = obj as ExampleObjectC;
+
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+
+            return other.Id == Id;
+        }
+        public override int GetHashCode()
+        {
+            return Id.GetHashCode();
+        }
+    }
+
+    [Key("Id")]
+    public class ExampleObjectD : IEqualityComparer<ExampleObjectD>
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+
+        public bool Equals(ExampleObjectD x, ExampleObjectD y)
+        {
+            return x.Id == y.Id;
+        }
+
+        public int GetHashCode(ExampleObjectD obj)
+        {
+            return obj.Id.GetHashCode();
+        }
+    }
+
+    [Key("Id")]
+    public class ExampleObjectE
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #1531 *.
Having such a POCO class when working with <code> OData Client </code> leads to errors when you try to perform save or update operations. 
```csharp
public class ExampleObject
    {
        [Key]
        public int Id { get; set; }
        public string Name { get; set; }
        public bool Equals(ExampleObject other)
        {
            if (ReferenceEquals(other, null))
            {
                return false;
            }

            return other.Id == Id;
        }
        public override bool Equals(object obj)
        {
            var other = obj as ExampleObject;

            if (ReferenceEquals(other, null))
            {
                return false;
            }

            return other.Id == Id;
        }
        public override int GetHashCode()
        {
            return Id.GetHashCode();
        }
    }

```
The reason for the exceptions is because the <code> EntityTracker </code> uses the default EqualityComparer. 

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
