### PR TITLE
Consistently use CharArrayPool in JsonWriter to cut cost of initializing char arrays

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -215,7 +215,7 @@ namespace Microsoft.OData.Json
 
             currentScope.ObjectCount++;
 
-            JsonValueUtils.WriteEscapedJsonString(this.writer, name, this.stringEscapeOption, this.wrappedBuffer);
+            JsonValueUtils.WriteEscapedJsonString(this.writer, name, this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool);
             this.writer.Write(JsonConstants.NameValueSeparator);
         }
 
@@ -280,7 +280,7 @@ namespace Microsoft.OData.Json
             if (isIeee754Compatible)
             {
                 JsonValueUtils.WriteValue(this.writer, value.ToString(CultureInfo.InvariantCulture),
-                    this.stringEscapeOption, this.wrappedBuffer);
+                    this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool);
             }
             else
             {
@@ -320,7 +320,7 @@ namespace Microsoft.OData.Json
             if (isIeee754Compatible)
             {
                 JsonValueUtils.WriteValue(this.writer, value.ToString(CultureInfo.InvariantCulture),
-                    this.stringEscapeOption, this.wrappedBuffer);
+                    this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool);
             }
             else
             {
@@ -395,7 +395,7 @@ namespace Microsoft.OData.Json
         public void WriteValue(string value)
         {
             this.WriteValueSeparator();
-            JsonValueUtils.WriteValue(this.writer, value, this.stringEscapeOption, this.wrappedBuffer);
+            JsonValueUtils.WriteValue(this.writer, value, this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
@@ -100,7 +100,7 @@ namespace Microsoft.OData.Json
 
             currentScope.ObjectCount++;
 
-            await this.writer.WriteEscapedJsonStringAsync(name, this.stringEscapeOption, this.wrappedBuffer)
+            await this.writer.WriteEscapedJsonStringAsync(name, this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool)
                 .ConfigureAwait(false);
             await this.writer.WriteAsync(JsonConstants.NameValueSeparator).ConfigureAwait(false);
         }
@@ -148,7 +148,7 @@ namespace Microsoft.OData.Json
             if (isIeee754Compatible)
             {
                 await this.writer.WriteValueAsync(value.ToString(CultureInfo.InvariantCulture),
-                    this.stringEscapeOption, this.wrappedBuffer).ConfigureAwait(false);
+                    this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool).ConfigureAwait(false);
             }
             else
             {
@@ -179,7 +179,7 @@ namespace Microsoft.OData.Json
             if (isIeee754Compatible)
             {
                 await this.writer.WriteValueAsync(value.ToString(CultureInfo.InvariantCulture),
-                    this.stringEscapeOption, this.wrappedBuffer).ConfigureAwait(false);
+                    this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool).ConfigureAwait(false);
             }
             else
             {
@@ -234,7 +234,7 @@ namespace Microsoft.OData.Json
         public async Task WriteValueAsync(string value)
         {
             await this.WriteValueSeparatorAsync().ConfigureAwait(false);
-            await this.writer.WriteValueAsync(value, this.stringEscapeOption, this.wrappedBuffer)
+            await this.writer.WriteValueAsync(value, this.stringEscapeOption, this.wrappedBuffer, this.ArrayPool)
                 .ConfigureAwait(false);
         }
 
@@ -242,7 +242,7 @@ namespace Microsoft.OData.Json
         public async Task WriteValueAsync(byte[] value)
         {
             await this.WriteValueSeparatorAsync().ConfigureAwait(false);
-            await this.writer.WriteValueAsync(value, this.wrappedBuffer, ArrayPool).ConfigureAwait(false);
+            await this.writer.WriteValueAsync(value, this.wrappedBuffer, this.ArrayPool).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -270,7 +270,7 @@ namespace Microsoft.OData.Json
             // ODL supports net45 and netstandard1.1 (in addition to .netstandard2.0)
             // This makes it complicated to implement IAsyncDisposable in ODataBinaryStreamWriter
             // TODO: Can the returned stream be safely used asynchronously?
-            this.binaryValueStream = new ODataBinaryStreamWriter(writer, this.wrappedBuffer, ArrayPool);
+            this.binaryValueStream = new ODataBinaryStreamWriter(writer, this.wrappedBuffer, this.ArrayPool);
             return this.binaryValueStream;
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockCharArrayPool.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockCharArrayPool.cs
@@ -1,0 +1,31 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="MockCharArrayPool.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using Microsoft.OData.Buffers;
+
+namespace Microsoft.OData.Tests.Json
+{
+    public class MockCharArrayPool : ICharArrayPool
+    {
+        public Action<int> RentVerifier;
+        public Action<char[]> ReturnVerifier;
+
+        public char[] Rent(int minSize)
+        {
+            var charArray = new char[minSize];
+            RentVerifier(minSize);
+            
+            return charArray;
+        }
+
+        public void Return(char[] array)
+        {
+            ReturnVerifier(array);
+            // Do nothing else
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2074.*

### Description

Consistently use `CharArrayPool` in `JsonWriter` to cut cost of initializing char arrays

**Notes:**
- `CharArrayPool` is already used in `JsonWriter` class. It was just not being passed along in some instances.
- There's no real value in passing the `CharArrayPool` parameter for the methods listed below because we only use it if the input has special characters. I decided to still pass the parameter just to keep things consistent and avoid confusion.
  - `WriteName(string)`/`WriteNameAsync(string)` - name _should_ not contain special chars
  - `WriteValue(long)`/`WriteValueAsync(long)` - - special chars not expected when the value is converted to string (IEEE 754 compatible)
  - `WriteValue(decimal)`/`WriteValueAsync(decimal)` - special chars not expected when the value is converted to string (IEEE 754 compatible)

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
