### PR TITLE
Implement asynchronous support in ODataWriteStream

### DIFF
--- a/src/Microsoft.OData.Core/ODataWriteStream.cs
+++ b/src/Microsoft.OData.Core/ODataWriteStream.cs
@@ -28,8 +28,8 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="stream">The underlying stream to write the message to.</param>
         /// <param name="listener">Listener interface to be notified of operation changes.</param>
-        internal ODataWriteStream(Stream stream, IODataStreamListener listener)
-            : base(listener)
+        internal ODataWriteStream(Stream stream, IODataStreamListener listener, bool synchronous = true)
+            : base(listener, synchronous)
         {
             Debug.Assert(stream != null, "stream != null");
             this.stream = stream;
@@ -152,5 +152,18 @@ namespace Microsoft.OData
 
             base.Dispose(disposing);
         }
+
+#if NETSTANDARD2_0
+        /// <summary>
+        /// Encapsulates the common asynchronous cleanup operations.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        protected override ValueTask DisposeAsyncCore()
+        {
+            this.stream = null;
+
+            return base.DisposeAsyncCore();
+        }
+#endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriteStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriteStreamTests.cs
@@ -1,0 +1,164 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataWriteStreamTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OData.Tests
+{
+    /// <summary>
+    /// Unit tests for <see cref="ODataWriteStream"/>.
+    /// </summary>
+    public class ODataWriteStreamTests
+    {
+        private MemoryStream stream;
+        private TextWriter writer;
+        private IODataStreamListener streamListener;
+
+        public ODataWriteStreamTests()
+        {
+            this.stream = new MemoryStream();
+            this.writer = new StreamWriter(this.stream);
+            this.streamListener = new MockODataStreamListener(this.writer);
+        }
+
+        [Theory]
+        [InlineData(true, "StreamDisposed")]
+        [InlineData(false, "StreamDisposedAsync")]
+        public void WriteStreamDisposeShouldInvokeStreamDisposed(bool synchronous, string expected)
+        {
+            // We care about the write stream being disposed
+            // We don't care about the stream passed to the write stream
+            using (var writeStream = new ODataWriteStream(
+                new MemoryStream(),
+                this.streamListener,
+                synchronous))
+            {
+            }
+
+            var result = ReadStreamContents();
+
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(true, "StreamDisposed")]
+        [InlineData(false, "StreamDisposedAsync")]
+        public void WriteStreamDisposeShouldBeIdempotent(bool synchronous, string expected)
+        {
+            var writeStream = new ODataWriteStream(
+                new MemoryStream(),
+                this.streamListener,
+                synchronous);
+
+            // 1st call to Dispose
+            writeStream.Dispose();
+            // 2nd call to Dispose
+            writeStream.Dispose();
+
+            var result = ReadStreamContents();
+
+            // StreamDisposed/StreamDisposeAsync was written only once
+            Assert.Equal(expected, result);
+        }
+
+#if NETCOREAPP3_1
+        [Fact]
+        public async Task WriteStreamDisposeShouldInvokeStreamDisposedAsync()
+        {
+            await using (var writeStream = new ODataWriteStream(
+                new MemoryStream(),
+                this.streamListener)) // `synchronous` argument becomes irrelevant
+            {
+            }
+
+            var result = await this.ReadStreamContentsAsync();
+
+            Assert.Equal("StreamDisposedAsync", result);
+        }
+
+        [Fact]
+        public async Task WriteStreamDisposeAsyncShouldBeIdempotent()
+        {
+            var writeStream = new ODataWriteStream(
+                new MemoryStream(),
+                this.streamListener);
+
+            // 1st call to DisposeAsync
+            await writeStream.DisposeAsync();
+            // 2nd call to DisposeAsync
+            await writeStream.DisposeAsync();
+
+            var result = await this.ReadStreamContentsAsync();
+
+            // StreamDisposeAsync was written only once
+            Assert.Equal("StreamDisposedAsync", result);
+        }
+
+#else
+        [Fact]
+        public async Task WriteStreamDisposeShouldInvokeStreamDisposedAsync()
+        {
+            using (var writeStream = new ODataWriteStream(
+                new MemoryStream(),
+                this.streamListener,
+                /*synchronous*/ false))
+            {
+            }
+
+            var result = await this.ReadStreamContentsAsync();
+
+            Assert.Equal("StreamDisposedAsync", result);
+        }
+#endif
+
+        private string ReadStreamContents()
+        {
+            this.stream.Position = 0;
+            return new StreamReader(this.stream).ReadToEnd();
+        }
+
+        private Task<string> ReadStreamContentsAsync()
+        {
+            this.stream.Position = 0;
+            return new StreamReader(this.stream).ReadToEndAsync();
+        }
+
+        private class MockODataStreamListener : IODataStreamListener
+        {
+            private TextWriter writer;
+
+            public MockODataStreamListener(TextWriter writer)
+            {
+                this.writer = writer;
+            }
+
+            public void StreamDisposed()
+            {
+                writer.Write("StreamDisposed");
+                writer.Flush();
+            }
+
+            public async Task StreamDisposedAsync()
+            {
+                await writer.WriteAsync("StreamDisposedAsync").ConfigureAwait(false);
+                await writer.FlushAsync().ConfigureAwait(false);
+            }
+
+            public void StreamRequested()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task StreamRequestedAsync()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request is in partial fulfilment of issue #2019.

### Description

Implement asynchronous support in `ODataWriteStream`
- Ensures that if `Dispose` method of `ODataWriteStream` is fired when writing asynchronously, `StreamDisposedAsync` method of `IODataStreamListener` instance is fired instead of the synchronous `StreamDisposed` method.
- Implements `IAsyncDisposable` interface in `ODataWriteStream` such that its possible to use `await using` for frameworks that implement NETSTANDARD2_0

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
