### PR TITLE
ODataNotificationWriter and ODataNotificationStream wrapper classes should not dispose the passed TextWriter and Stream respectively

### DIFF
--- a/src/Microsoft.OData.Core/ODataNotificationStream.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationStream.cs
@@ -219,8 +219,7 @@ namespace Microsoft.OData
                 }
 
                 this.listener = null;
-
-                this.stream?.Dispose();
+                // NOTE: Do not dispose the stream since this instance does not own it.
                 this.stream = null;
             }
 
@@ -235,9 +234,9 @@ namespace Microsoft.OData
             {
                 await this.listener.StreamDisposedAsync()
                     .ConfigureAwait(false);
-                this.stream?.Dispose();
 
                 this.listener = null;
+                // NOTE: Do not dispose the stream since this instance does not own it.
                 this.stream = null;
             }
 

--- a/src/Microsoft.OData.Core/ODataNotificationWriter.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationWriter.cs
@@ -340,8 +340,7 @@ namespace Microsoft.OData
                 }
 
                 this.listener = null;
-
-                this.textWriter?.Dispose();
+                // NOTE: Do not dispose the text writer since this instance does not own it.
                 this.textWriter = null;
             }
 
@@ -356,9 +355,9 @@ namespace Microsoft.OData
             {
                 await this.listener.StreamDisposedAsync()
                     .ConfigureAwait(false);
-                this.textWriter?.Dispose();
 
                 this.listener = null;
+                // NOTE: Do not dispose the text writer since this instance does not own it.
                 this.textWriter = null;
             }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.Tests
             // We care about the notification stream being disposed
             // We don't care about the stream passed to the notification stream
             using (var notificationStream = new ODataNotificationStream(
-                new MemoryStream(),
+                this.stream,
                 this.streamListener,
                 synchronous))
             {
@@ -49,7 +49,7 @@ namespace Microsoft.OData.Tests
         public void NotificationStreamDisposeShouldBeIdempotent(bool synchronous, string expected)
         {
             var notificationStream = new ODataNotificationStream(
-                new MemoryStream(),
+                this.stream,
                 this.streamListener,
                 synchronous);
 
@@ -69,7 +69,7 @@ namespace Microsoft.OData.Tests
         public async Task NotificationStreamDisposeShouldInvokeStreamDisposedAsync()
         {
             await using (var notificationStream = new ODataNotificationStream(
-                new MemoryStream(),
+                this.stream,
                 this.streamListener)) // `synchronous` argument becomes irrelevant
             {
             }
@@ -83,7 +83,7 @@ namespace Microsoft.OData.Tests
         public async Task NotificationStreamDisposeAsyncShouldBeIdempotent()
         {
             var notificationStream = new ODataNotificationStream(
-                new MemoryStream(),
+                this.stream,
                 this.streamListener);
 
             // 1st call to DisposeAsync
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Tests
         public async Task NotificationStreamDisposeShouldInvokeStreamDisposedAsync()
         {
             using (var notificationStream = new ODataNotificationStream(
-                new MemoryStream(),
+                this.stream,
                 this.streamListener,
                 /*synchronous*/ false))
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.Tests
             // We care about the notification writer being disposed
             // We don't care about the writer passed to the notification writer
             using (var notificationWriter = new ODataNotificationWriter(
-                new StreamWriter(new MemoryStream()),
+                this.writer,
                 this.streamListener,
                 synchronous))
             {
@@ -49,7 +49,7 @@ namespace Microsoft.OData.Tests
         public void NotificationWriterDisposeShouldBeIdempotent(bool synchronous, string expected)
         {
             var notificationWriter = new ODataNotificationWriter(
-                new StreamWriter(new MemoryStream()),
+                this.writer,
                 this.streamListener,
                 synchronous);
 
@@ -69,7 +69,7 @@ namespace Microsoft.OData.Tests
         public async Task NotificationWriterDisposeShouldInvokeStreamDisposedAsync()
         {
             await using (var notificationWriter = new ODataNotificationWriter(
-                new StreamWriter(new MemoryStream()),
+                this.writer,
                 this.streamListener)) // `synchronous` argument becomes irrelevant since we'll directly call DisposeAsync
             {
             }
@@ -83,7 +83,7 @@ namespace Microsoft.OData.Tests
         public async Task NotificationWriterDisposeAsyncShouldBeIdempotent()
         {
             var notificationWriter = new ODataNotificationWriter(
-                new StreamWriter(new MemoryStream()),
+                this.writer,
                 this.streamListener);
 
             // 1st call to DisposeAsync
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Tests
         public async Task NotificationWriterDisposeShouldInvokeStreamDisposedAsync()
         {
             using (var notificationWriter = new ODataNotificationWriter(
-                new StreamWriter(new MemoryStream()),
+                this.writer,
                 this.streamListener,
                 /*synchronous*/ false))
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

`ODataNotificationWriter` and `ODataNotificationStream` wrapper classes should not dispose the passed `TextWriter` and `Stream` respectively.

Reference to merged PRs [2079](https://github.com/OData/odata.net/pull/2079) and [2080](https://github.com/OData/odata.net/pull/2080) implementing support for asynchronous invocation of `IODataStreamListener.StreamDisposedAsync` from `ODataNotificationWriter` and `ODataNotificationStream` wrapper classes, a line was added such that the passed `TextWriter` and `Stream` respectively are disposed when the `Dispose` method is called.
This can cause a problem if the owner of `TextWriter` or `Stream` chose to use it after - _though that does not happen currently_. This pull request addresses that loop hole, leaving the owner to do the disposing.

**NOTE:** Confirmation of the fix is in the change made to the tests where the test class is able to read from the stream even after the `ODataNotificationWriter` or `ODataNotificationStream` instance is disposed.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
