### PR TITLE
Implement asynchronous support in ODataJsonLightOutputContext

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -66,6 +66,14 @@ namespace Microsoft.OData.JsonLight
         private PropertyCacheHandler propertyCacheHandler;
 
         /// <summary>
+        /// The concrete <see cref="JsonWriter"/> instance initialized when
+        /// creating either synchronous or asynchronous writer.
+        /// Used to guarantee that the synchronous and asynchronous writers share the same scope(s) specifically
+        /// because the synchronous writer is used to write spatial data in both synchronous and asynchronous scenarios.
+        /// </summary>
+        private JsonWriter concreteJsonWriter;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="messageInfo">The context information for the message.</param>
@@ -98,11 +106,15 @@ namespace Microsoft.OData.JsonLight
                 // COMPAT 2: JSON indentation - WCFDS indents only partially, it inserts newlines but doesn't actually insert spaces for indentation
                 // in here we allow the user to specify if true indentation should be used or if the limited functionality is enough.
                 this.jsonWriter = CreateJsonWriter(this.Container, this.textWriter, messageInfo.MediaType.HasIeee754CompatibleSetToTrue(), messageWriterSettings);
-                this.asynchronousJsonWriter = CreateAsynchronousJsonWriter(this.Container, this.textWriter, messageInfo.MediaType.HasIeee754CompatibleSetToTrue(), messageWriterSettings);
+                this.asynchronousJsonWriter = CreateAsynchronousJsonWriter(
+                    this.Container,
+                    this.textWriter,
+                    messageInfo.MediaType.HasIeee754CompatibleSetToTrue(),
+                    messageWriterSettings);
             }
             catch (Exception e)
             {
-                // Dispose the message stream if we failed to create the input context.
+                // Dispose the message stream if we failed to create the output context.
                 if (ExceptionUtils.IsCatchableExceptionType(e))
                 {
                     this.messageOutputStream.Dispose();
@@ -418,16 +430,14 @@ namespace Microsoft.OData.JsonLight
         /// <param name="property">The property to write</param>
         /// <returns>A task representing the asynchronous operation of writing the property.</returns>
         /// <remarks>It is the responsibility of this method to flush the output before the task finishes.</remarks>
-        public override Task WritePropertyAsync(ODataProperty property)
+        public override async Task WritePropertyAsync(ODataProperty property)
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
-                () =>
-                {
-                    this.WritePropertyImplementation(property);
-                    return this.FlushAsync();
-                });
+            await this.WritePropertyImplementationAsync(property)
+                .ConfigureAwait(false);
+            await this.FlushAsync()
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -457,16 +467,14 @@ namespace Microsoft.OData.JsonLight
         /// </param>
         /// <returns>A task representing the asynchronous operation of writing the error.</returns>
         /// <remarks>It is the responsibility of this method to flush the output before the task finishes.</remarks>
-        public override Task WriteErrorAsync(ODataError error, bool includeDebugInformation)
+        public override async Task WriteErrorAsync(ODataError error, bool includeDebugInformation)
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
-                () =>
-                {
-                    this.WriteErrorImplementation(error, includeDebugInformation);
-                    return this.FlushAsync();
-                });
+            await this.WriteErrorImplementationAsync(error, includeDebugInformation)
+                .ConfigureAwait(false);
+            await this.FlushAsync()
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -499,22 +507,20 @@ namespace Microsoft.OData.JsonLight
         /// </summary>
         /// <returns>Task which represents the pending flush operation.</returns>
         /// <remarks>The method should not throw directly if the flush operation itself fails, it should instead return a faulted task.</remarks>
-        public Task FlushAsync()
+        public async Task FlushAsync()
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
-                () =>
-                {
-                    // JsonWriter.Flush will call the underlying TextWriter.Flush.
-                    // The TextWriter.Flush (Which is in fact StreamWriter.Flush) will call the underlying Stream.Flush.
-                    // In the async case the underlying stream is the async buffered stream, which ignores Flush call.
-                    this.jsonWriter.Flush();
+            // JsonWriter.FlushAsync will call the underlying TextWriter.FlushAsync.
+            // The TextWriter.FlushAsync will call the underlying Stream.FlushAsync.
+            // The underlying stream is the async buffered stream, which ignores FlushAsync call.
+            await this.asynchronousJsonWriter.FlushAsync()
+                .ConfigureAwait(false);
 
-                    Debug.Assert(this.asynchronousOutputStream != null, "In async writing we must have the async buffered stream.");
-                    return this.asynchronousOutputStream.FlushAsync();
-                })
-                .FollowOnSuccessWithTask((asyncBufferedStreamFlushTask) => this.messageOutputStream.FlushAsync());
+            Debug.Assert(this.asynchronousOutputStream != null, "In async writing we must have the async buffered stream.");
+            await this.asynchronousOutputStream.FlushAsync()
+                .FollowOnSuccessWithTask(_ => this.messageOutputStream.FlushAsync())
+                .ConfigureAwait(false);
         }
 
          /// <summary>
@@ -622,16 +628,14 @@ namespace Microsoft.OData.JsonLight
         /// the in-stream error is written.
         /// It is the responsibility of this method to flush the output before the task finishes.
         /// </remarks>
-        internal override Task WriteInStreamErrorAsync(ODataError error, bool includeDebugInformation)
+        internal override async Task WriteInStreamErrorAsync(ODataError error, bool includeDebugInformation)
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
-                () =>
-                {
-                    this.WriteInStreamErrorImplementation(error, includeDebugInformation);
-                    return this.FlushAsync();
-                });
+            await this.WriteInStreamErrorImplementationAsync(error, includeDebugInformation)
+                .ConfigureAwait(false);
+            await this.FlushAsync()
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -682,16 +686,14 @@ namespace Microsoft.OData.JsonLight
         /// <param name="serviceDocument">The service document to write.</param>
         /// <returns>A task representing the asynchronous operation of writing the service document.</returns>
         /// <remarks>It is the responsibility of this method to flush the output before the task finishes.</remarks>
-        internal override Task WriteServiceDocumentAsync(ODataServiceDocument serviceDocument)
+        internal override async Task WriteServiceDocumentAsync(ODataServiceDocument serviceDocument)
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
-                () =>
-                {
-                    this.WriteServiceDocumentImplementation(serviceDocument);
-                    return this.FlushAsync();
-                });
+            await this.WriteServiceDocumentImplementationAsync(serviceDocument)
+                .ConfigureAwait(false);
+            await this.FlushAsync()
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -713,16 +715,14 @@ namespace Microsoft.OData.JsonLight
         /// <param name="links">The entity reference links to write as message payload.</param>
         /// <returns>A task representing the asynchronous writing of the entity reference links.</returns>
         /// <remarks>It is the responsibility of this method to flush the output before the task finishes.</remarks>
-        internal override Task WriteEntityReferenceLinksAsync(ODataEntityReferenceLinks links)
+        internal override async Task WriteEntityReferenceLinksAsync(ODataEntityReferenceLinks links)
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
-                () =>
-                {
-                    this.WriteEntityReferenceLinksImplementation(links);
-                    return this.FlushAsync();
-                });
+            await this.WriteEntityReferenceLinksImplementationAsync(links)
+                .ConfigureAwait(false);
+            await this.FlushAsync()
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -744,16 +744,14 @@ namespace Microsoft.OData.JsonLight
         /// <param name="link">The link result to write as message payload.</param>
         /// <returns>A running task representing the writing of the link.</returns>
         /// <remarks>It is the responsibility of this method to flush the output before the task finishes.</remarks>
-        internal override Task WriteEntityReferenceLinkAsync(ODataEntityReferenceLink link)
+        internal override async Task WriteEntityReferenceLinkAsync(ODataEntityReferenceLink link)
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperationReturningTask(
-                () =>
-                {
-                    this.WriteEntityReferenceLinkImplementation(link);
-                    return this.FlushAsync();
-                });
+            await this.WriteEntityReferenceLinkImplementationAsync(link)
+                .ConfigureAwait(false);
+            await this.FlushAsync()
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -813,47 +811,113 @@ namespace Microsoft.OData.JsonLight
             base.Dispose(disposing);
         }
 
-        private static IJsonWriter CreateJsonWriter(IServiceProvider container, TextWriter textWriter, bool isIeee754Compatible, ODataMessageWriterSettings writerSettings)
+        /// <summary>
+        /// Creates a new JSON writer of <see cref="IJsonWriter"/>.
+        /// </summary>
+        /// <param name="container">The dependency injection container to get related services.</param>
+        /// <param name="textWriter">The text writer to write to.</param>
+        /// <param name="isIeee754Compatible">true if the writer should write large integers as strings.</param>
+        /// <param name="writerSettings">Configuration settings for the OData writer.</param>
+        /// <returns>A JSON writer.</returns>
+        /// <remarks>Asynchronous support is not implemented in Microsoft.Spatial library.
+        /// To write spatial data, we rely on the synchronous PrimitiveConverter.Instance.WriteJsonLight(object, IJsonWriter) method.
+        /// When writing asynchronously we wrap this method in a Task. WriteJsonLight method takes an
+        /// IJsonWriter parameter while the asynchronous writer is declared as IJsonWriterAsync.
+        /// However, JsonWriter class implements both IJsonWriter and IJsonWriterAsync.
+        /// To guarantee that when the synchronous writer is called to write spatial data it shares
+        /// the same scope(s) as the asynchronous writer, we initialize them to the same concrete JsonWriter instance.
+        /// We only do this when the dependency injection container is uninitialized or
+        /// when the JSON writer factory is DefaultJsonWriterFactory - since both CreateJsonWriter and
+        /// CreateAsynchronousJsonWriter methods of that factory return an instance of JsonWriter.
+        /// Merging IJsonWriter and IJsonWriterAsync interface in a major release will simplify this.</remarks>
+        private IJsonWriter CreateJsonWriter(
+            IServiceProvider container,
+            TextWriter textWriter,
+            bool isIeee754Compatible,
+            ODataMessageWriterSettings writerSettings)
         {
             IJsonWriter jsonWriter;
             if (container == null)
             {
+                if (this.concreteJsonWriter != null)
+                {
+                    return this.concreteJsonWriter;
+                }
+
                 jsonWriter = new JsonWriter(textWriter, isIeee754Compatible);
             }
             else
             {
                 IJsonWriterFactory jsonWriterFactory = container.GetRequiredService<IJsonWriterFactory>();
+                if (jsonWriterFactory is DefaultJsonWriterFactory && this.concreteJsonWriter != null)
+                {
+                    return this.concreteJsonWriter;
+                }
+
                 jsonWriter = jsonWriterFactory.CreateJsonWriter(textWriter, isIeee754Compatible);
                 Debug.Assert(jsonWriter != null, "jsonWriter != null");
             }
 
-            JsonWriter writer = jsonWriter as JsonWriter;
-            if (writer != null && writerSettings.ArrayPool != null)
+            this.concreteJsonWriter = jsonWriter as JsonWriter;
+            if (this.concreteJsonWriter != null && writerSettings.ArrayPool != null)
             {
-                writer.ArrayPool = writerSettings.ArrayPool;
+                this.concreteJsonWriter.ArrayPool = writerSettings.ArrayPool;
             }
 
             return jsonWriter;
         }
 
-        private static IJsonWriterAsync CreateAsynchronousJsonWriter(IServiceProvider container, TextWriter textWriter, bool isIeee754Compatible, ODataMessageWriterSettings writerSettings)
+        /// <summary>
+        /// Creates a new JSON writer of <see cref="IJsonWriterAsync"/> with support for writing asynchronously.
+        /// </summary>
+        /// <param name="container">The dependency injection container to get related services.</param>
+        /// <param name="textWriter">The text writer to write to.</param>
+        /// <param name="isIeee754Compatible">true if the writer should write large integers as strings.</param>
+        /// <param name="writerSettings">Configuration settings for the OData writer.</param>
+        /// <returns>An asynchronous JSON writer.</returns>
+        /// <remarks>Asynchronous support is not implemented in Microsoft.Spatial library.
+        /// To write spatial data, we rely on the synchronous PrimitiveConverter.Instance.WriteJsonLight(object, IJsonWriter) method.
+        /// When writing asynchronously we wrap this method in a Task. WriteJsonLight method takes an
+        /// IJsonWriter parameter while the asynchronous writer is declared as IJsonWriterAsync.
+        /// However, JsonWriter class implements both IJsonWriter and IJsonWriterAsync.
+        /// To guarantee that when the synchronous writer is called to write spatial data it shares
+        /// the same scope(s) as the asynchronous writer, we initialize them to the same concrete JsonWriter instance.
+        /// We only do this when the dependency injection container is uninitialized or
+        /// when the JSON writer factory is DefaultJsonWriterFactory - since both CreateJsonWriter and
+        /// CreateAsynchronousJsonWriter methods of that factory return an instance of JsonWriter.
+        /// Merging IJsonWriter and IJsonWriterAsync interface in a major release will simplify this.</remarks>
+        private IJsonWriterAsync CreateAsynchronousJsonWriter(
+            IServiceProvider container,
+            TextWriter textWriter,
+            bool isIeee754Compatible,
+            ODataMessageWriterSettings writerSettings)
         {
             IJsonWriterAsync asynchronousJsonWriter;
             if (container == null)
             {
+                if (this.concreteJsonWriter != null)
+                {
+                    return this.concreteJsonWriter;
+                }
+
                 asynchronousJsonWriter = new JsonWriter(textWriter, isIeee754Compatible);
             }
             else
             {
                 IJsonWriterFactoryAsync asynchronousJsonWriterFactory = container.GetRequiredService<IJsonWriterFactoryAsync>();
+                if (asynchronousJsonWriterFactory is DefaultJsonWriterFactory && this.concreteJsonWriter != null)
+                {
+                    return this.concreteJsonWriter;
+                }
+
                 asynchronousJsonWriter = asynchronousJsonWriterFactory.CreateAsynchronousJsonWriter(textWriter, isIeee754Compatible);
                 Debug.Assert(asynchronousJsonWriter != null, "asynchronousJsonWriter != null");
             }
 
-            JsonWriter writer = asynchronousJsonWriter as JsonWriter;
-            if (writer != null && writerSettings.ArrayPool != null)
+            this.concreteJsonWriter = asynchronousJsonWriter as JsonWriter;
+            if (this.concreteJsonWriter != null && writerSettings.ArrayPool != null)
             {
-                writer.ArrayPool = writerSettings.ArrayPool;
+                this.concreteJsonWriter.ArrayPool = writerSettings.ArrayPool;
             }
 
             return asynchronousJsonWriter;
@@ -955,6 +1019,32 @@ namespace Microsoft.OData.JsonLight
         }
 
         /// <summary>
+        /// Asynchronously writes an in-stream error.
+        /// </summary>
+        /// <param name="error">The error to write.</param>
+        /// <param name="includeDebugInformation">
+        /// A flag indicating whether debug information (e.g., the inner error from the <paramref name="error"/>) should
+        /// be included in the payload. This should only be used in debug scenarios.
+        /// </param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WriteInStreamErrorImplementationAsync(ODataError error, bool includeDebugInformation)
+        {
+            if (this.outputInStreamErrorListener != null)
+            {
+                await this.outputInStreamErrorListener.OnInStreamErrorAsync()
+                    .ConfigureAwait(false);
+            }
+
+            JsonLightInstanceAnnotationWriter instanceAnnotationWriter = new JsonLightInstanceAnnotationWriter(new ODataJsonLightValueSerializer(this), this.TypeNameOracle);
+            await ODataJsonWriterUtils.WriteErrorAsync(
+                this.AsynchronousJsonWriter,
+                instanceAnnotationWriter.WriteInstanceAnnotationsForErrorAsync,
+                error,
+                includeDebugInformation,
+                this.MessageWriterSettings.MessageQuotas.MaxNestingDepth).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Writes an <see cref="ODataProperty"/> as message payload.
         /// </summary>
         /// <param name="property">The property to write.</param>
@@ -962,6 +1052,18 @@ namespace Microsoft.OData.JsonLight
         {
             ODataJsonLightPropertySerializer jsonLightPropertySerializer = new ODataJsonLightPropertySerializer(this, /*initContextUriBuilder*/ true);
             jsonLightPropertySerializer.WriteTopLevelProperty(property);
+        }
+
+        /// <summary>
+        /// Asynchronously writes an <see cref="ODataProperty"/> as message payload.
+        /// </summary>
+        /// <param name="property">The property to write.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WritePropertyImplementationAsync(ODataProperty property)
+        {
+            ODataJsonLightPropertySerializer jsonLightPropertySerializer = new ODataJsonLightPropertySerializer(this, /*initContextUriBuilder*/ true);
+            await jsonLightPropertySerializer.WriteTopLevelPropertyAsync(property)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -973,6 +1075,19 @@ namespace Microsoft.OData.JsonLight
         {
             ODataJsonLightServiceDocumentSerializer jsonLightServiceDocumentSerializer = new ODataJsonLightServiceDocumentSerializer(this);
             jsonLightServiceDocumentSerializer.WriteServiceDocument(serviceDocument);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a service document with the specified <paramref name="serviceDocument"/>
+        /// as message payload.
+        /// </summary>
+        /// <param name="serviceDocument">The service document to write.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WriteServiceDocumentImplementationAsync(ODataServiceDocument serviceDocument)
+        {
+            ODataJsonLightServiceDocumentSerializer jsonLightServiceDocumentSerializer = new ODataJsonLightServiceDocumentSerializer(this);
+            await jsonLightServiceDocumentSerializer.WriteServiceDocumentAsync(serviceDocument)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -990,6 +1105,22 @@ namespace Microsoft.OData.JsonLight
         }
 
         /// <summary>
+        /// Asynchronously writes an <see cref="ODataError"/> as the message payload.
+        /// </summary>
+        /// <param name="error">The error to write.</param>
+        /// <param name="includeDebugInformation">
+        /// A flag indicating whether debug information (e.g., the inner error from the <paramref name="error"/>) should
+        /// be included in the payload. This should only be used in debug scenarios.
+        /// </param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WriteErrorImplementationAsync(ODataError error, bool includeDebugInformation)
+        {
+            ODataJsonLightSerializer jsonLightSerializer = new ODataJsonLightSerializer(this, false);
+            await jsonLightSerializer.WriteTopLevelErrorAsync(error, includeDebugInformation)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Writes the result of a $ref query as the message payload.
         /// </summary>
         /// <param name="links">The entity reference links to write as message payload.</param>
@@ -1000,6 +1131,18 @@ namespace Microsoft.OData.JsonLight
         }
 
         /// <summary>
+        /// Asynchronously writes the result of a $ref query as the message payload.
+        /// </summary>
+        /// <param name="links">The entity reference links to write as message payload.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WriteEntityReferenceLinksImplementationAsync(ODataEntityReferenceLinks links)
+        {
+            ODataJsonLightEntityReferenceLinkSerializer jsonLightEntityReferenceLinkSerializer = new ODataJsonLightEntityReferenceLinkSerializer(this);
+            await jsonLightEntityReferenceLinkSerializer.WriteEntityReferenceLinksAsync(links)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Writes a singleton result of a $ref query as the message payload.
         /// </summary>
         /// <param name="link">The entity reference link to write as message payload.</param>
@@ -1007,6 +1150,18 @@ namespace Microsoft.OData.JsonLight
         {
             ODataJsonLightEntityReferenceLinkSerializer jsonLightEntityReferenceLinkSerializer = new ODataJsonLightEntityReferenceLinkSerializer(this);
             jsonLightEntityReferenceLinkSerializer.WriteEntityReferenceLink(link);
+        }
+
+        /// <summary>
+        /// Asynchronously writes a singleton result of a $ref query as the message payload.
+        /// </summary>
+        /// <param name="link">The entity reference link to write as message payload.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task WriteEntityReferenceLinkImplementationAsync(ODataEntityReferenceLink link)
+        {
+            ODataJsonLightEntityReferenceLinkSerializer jsonLightEntityReferenceLinkSerializer = new ODataJsonLightEntityReferenceLinkSerializer(this);
+            await jsonLightEntityReferenceLinkSerializer.WriteEntityReferenceLinkAsync(link)
+                .ConfigureAwait(false);
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightCollectionWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightCollectionWriterTests.cs
@@ -165,7 +165,7 @@ namespace Microsoft.OData.Tests.JsonLight
             {
                 SerializationInfo = new ODataCollectionStartSerializationInfo
                 {
-                    CollectionTypeName = "Collection(Product)"
+                    CollectionTypeName = "Collection(NS.Product)"
                 }
             };
 
@@ -180,7 +180,7 @@ namespace Microsoft.OData.Tests.JsonLight
                 model,
                 itemTypeReference);
 
-            Assert.Equal("{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(Product)\"," +
+            Assert.Equal("{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(NS.Product)\"," +
                 "\"value\":[", result);
         }
 
@@ -213,7 +213,7 @@ namespace Microsoft.OData.Tests.JsonLight
                 model,
                 itemTypeReference);
 
-            Assert.Equal("{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(Product)\"," +
+            Assert.Equal("{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(NS.Product)\"," +
                 "\"value\":[{\"Id\":1,\"Name\":\"Pencil\"}", result);
         }
 
@@ -313,7 +313,7 @@ namespace Microsoft.OData.Tests.JsonLight
                 model,
                 itemTypeReference);
 
-            Assert.Equal("{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(Product)\"," +
+            Assert.Equal("{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(NS.Product)\"," +
                 "\"value\":[{\"Id\":1,\"Name\":\"Pencil\"},{\"Id\":2,\"Name\":\"Paper\"}]}", result);
         }
 
@@ -437,7 +437,7 @@ namespace Microsoft.OData.Tests.JsonLight
             {
                 SerializationInfo = new ODataCollectionStartSerializationInfo
                 {
-                    CollectionTypeName = "Collection(Product)"
+                    CollectionTypeName = "Collection(NS.Product)"
                 }
             };
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightOutputContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightOutputContextTests.cs
@@ -5,11 +5,16 @@
 //---------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Json;
 using Microsoft.OData.JsonLight;
+using Microsoft.Spatial;
+using Microsoft.Test.OData.DependencyInjection;
 using Xunit;
 using ODataErrorStrings = Microsoft.OData.Strings;
 
@@ -17,6 +22,36 @@ namespace Microsoft.OData.Tests.JsonLight
 {
     public class ODataJsonLightOutputContextTests
     {
+        private const string ServiceUri = "http://tempuri.org";
+        private EdmModel model;
+        private MemoryStream stream;
+        private ODataMessageWriterSettings messageWriterSettings;
+
+        private EdmEntityType orderEntityType;
+        private EdmEntityType customerEntityType;
+        private EdmEntitySet orderEntitySet;
+        private EdmEntitySet customerEntitySet;
+
+        private ODataError nullReferenceError;
+
+        public ODataJsonLightOutputContextTests()
+        {
+            InitializeEdmModel();
+            this.stream = new MemoryStream();
+            this.messageWriterSettings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
+            this.messageWriterSettings.SetServiceDocumentUri(new Uri(ServiceUri));
+            this.messageWriterSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            this.nullReferenceError = new ODataError
+            {
+                ErrorCode = "NRE",
+                Message = "Object reference not set to an instance of an object",
+                InstanceAnnotations = new List<ODataInstanceAnnotation>
+                {
+                    new ODataInstanceAnnotation("Is.Error", new ODataPrimitiveValue(true))
+                }
+            };
+        }
+
         #region WriteProperty
         [Fact]
         public void ShouldBeAbleToWritePropertyRequestWithoutModel()
@@ -46,36 +81,6 @@ namespace Microsoft.OData.Tests.JsonLight
             Action test = () => WriteAndValidate(outputContext => outputContext.WriteProperty(property), "", writingResponse: true);
             test.Throws<ODataException>(ODataErrorStrings.ODataMessageWriter_CannotWriteTopLevelNull);
         }
-
-        //[Fact]
-        //public void ShouldBeAbleToWritePropertyRequestWithoutModelAsync()
-        //{
-        //    ODataProperty property = new ODataProperty { Name = "Prop", Value = Guid.Empty };
-        //    WriteAndValidate(outputContext => outputContext.WritePropertyAsync(property).Wait(), "{\"@odata.context\":\"http://odata.org/test/$metadata#Edm.Guid\",\"@odata.type\":\"#Guid\",\"value\":\"00000000-0000-0000-0000-000000000000\"}", writingResponse: false, synchronous: false);
-        //}
-
-        //[Fact]
-        //public void ShouldBeAbleToWritePropertyResponseWithoutModelAsync()
-        //{
-        //    ODataProperty property = new ODataProperty { Name = "Prop", Value = Guid.Empty };
-        //    WriteAndValidate(outputContext => outputContext.WritePropertyAsync(property).Wait(), "{\"@odata.context\":\"http://odata.org/test/$metadata#Edm.Guid\",\"@odata.type\":\"#Guid\",\"value\":\"00000000-0000-0000-0000-000000000000\"}", writingResponse: false, synchronous: false);
-        //}
-
-        //[Fact]
-        //public void ShouldBeAbleToWrite6xNullPropertyResponseWithoutModelAsync()
-        //{
-        //    ODataProperty property = new ODataProperty { Name = "Prop", Value = null };
-        //    WriteAndValidate(outputContext => outputContext.WritePropertyAsync(property).Wait(), "{\"@odata.context\":\"http://odata.org/test/$metadata#Edm.Null\",\"@odata.null\":true}", writingResponse: false, synchronous: false, use6x: true);
-        //}
-
-        //[Fact]
-        //public void ThrowsOnWriteNullPropertyResponseWithoutModelAsync()
-        //{
-        //    ODataProperty property = new ODataProperty { Name = "Prop", Value = null };
-        //    Action test = () => WriteAndValidate(outputContext => outputContext.WritePropertyAsync(property).Wait(), "", writingResponse: false, synchronous: false);
-        //    AggregateException exception = Assert.Throws<AggregateException>(test);
-        //    Assert.Equal(ODataErrorStrings.ODataMessageWriter_CannotWriteTopLevelNull, exception.InnerException.Message);
-        //}
 
         [Fact]
         public void ShouldBeAbleToWriteInstanceAnnotationsInRequest()
@@ -123,18 +128,6 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             WriteAndValidate(outputContext => outputContext.CreateODataResourceSetWriter(entitySet: null, resourceType: null), "", writingResponse: true);
         }
-
-        //[Fact]
-        //public void ShouldBeAbleToCreateResourceSetWriterAsyncForRequestWithoutModelAndWithoutSet()
-        //{
-        //    WriteAndValidate(outputContext => Assert.NotNull(outputContext.CreateODataResourceSetWriterAsync(entitySet: null, resourceType: null).Result), "", writingResponse: false, synchronous: false);
-        //}
-
-        //[Fact]
-        //public void ShouldBeAbleToCreateResourceSetWriterAsyncForResponseWithoutModelAndWithoutSet()
-        //{
-        //    WriteAndValidate(outputContext => Assert.NotNull(outputContext.CreateODataResourceSetWriterAsync(entitySet: null, resourceType: null).Result), "", writingResponse: true, synchronous: false);
-        //}
         #endregion CreateResourceSetWriter
 
         #region CreateResourceWriter
@@ -149,18 +142,6 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             WriteAndValidate(outputContext => outputContext.CreateODataResourceWriter(navigationSource: null, resourceType: null), "", writingResponse: true);
         }
-
-        //[Fact]
-        //public void ShouldBeAbleToCreateResourceWriterAsyncForRequestWithoutModelAndWithoutSet()
-        //{
-        //    WriteAndValidate(outputContext => Assert.NotNull(outputContext.CreateODataResourceWriterAsync(navigationSource: null, resourceType: null).Result), "", writingResponse: false, synchronous: false);
-        //}
-
-        //[Fact]
-        //public void ShouldBeAbleToCreateResourceWriterAsyncForResponseWithoutModelAndWithoutSet()
-        //{
-        //    WriteAndValidate(outputContext => Assert.NotNull(outputContext.CreateODataResourceWriterAsync(navigationSource: null, resourceType: null).Result), "", writingResponse: true, synchronous: false);
-        //}
         #endregion CreateResourceWriter
 
         #region CreateCollectionWriter
@@ -175,18 +156,6 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             WriteAndValidate(outputContext => outputContext.CreateODataCollectionWriter(itemTypeReference: null), "", writingResponse: true);
         }
-
-        //[Fact]
-        //public void ShouldBeAbleToCreateCollectionWriterAsyncForRequestWithoutModelAndWithoutItemType()
-        //{
-        //    WriteAndValidate(outputContext => Assert.NotNull(outputContext.CreateODataCollectionWriterAsync(itemTypeReference: null).Result), "", writingResponse: false, synchronous: false);
-        //}
-
-        //[Fact]
-        //public void ShouldBeAbleToCreateCollectionWriterAsyncForResponseWithoutModelAndWithoutItemType()
-        //{
-        //    WriteAndValidate(outputContext => Assert.NotNull(outputContext.CreateODataCollectionWriterAsync(itemTypeReference: null).Result), "", writingResponse: true, synchronous: false);
-        //}
         #endregion CreateCollectionWriter
 
         #region CreateParameterWriter
@@ -201,18 +170,6 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             WriteAndValidate(outputContext => outputContext.CreateODataParameterWriter(operation: null), "", writingResponse: true);
         }
-
-        //[Fact]
-        //public void ShouldBeAbleToCreateParameterWriterAsyncForRequestWithoutModelAndWithoutFunction()
-        //{
-        //    WriteAndValidate(outputContext => Assert.NotNull(outputContext.CreateODataParameterWriterAsync(operation: null).Result), "", writingResponse: false, synchronous: false);
-        //}
-
-        //[Fact]
-        //public void ShouldBeAbleToCreateParameterWriterAsyncForResponseWithoutModelAndWithoutFunction()
-        //{
-        //    WriteAndValidate(outputContext => Assert.NotNull(outputContext.CreateODataParameterWriterAsync(operation: null).Result), "", writingResponse: true, synchronous: false);
-        //}
         #endregion CreateParameterWriter
 
         #region WriteServiceDocument
@@ -223,18 +180,9 @@ namespace Microsoft.OData.Tests.JsonLight
             serviceDocument.EntitySets = new ODataEntitySetInfo[] {new ODataEntitySetInfo {Name = "Customers", Url = new Uri("http://host/Customers")}};
             WriteAndValidate(outputContext => outputContext.WriteServiceDocument(serviceDocument), "{\"@odata.context\":\"http://odata.org/test/$metadata\",\"value\":[{\"name\":\"Customers\",\"kind\":\"EntitySet\",\"url\":\"http://host/Customers\"}]}");
         }
-
-        //[Fact]
-        //public void ShouldWriteServiceDocumentAsyncWithoutModel()
-        //{
-        //    ODataServiceDocument serviceDocument = new ODataServiceDocument();
-        //    serviceDocument.EntitySets = new ODataEntitySetInfo[] { new ODataEntitySetInfo { Name = "Customers", Url = new Uri("http://host/Customers") } };
-        //    WriteAndValidate(outputContext => outputContext.WriteServiceDocumentAsync(serviceDocument).Wait(), "{\"@odata.context\":\"http://odata.org/test/$metadata\",\"value\":[{\"name\":\"Customers\",\"kind\":\"EntitySet\",\"url\":\"http://host/Customers\"}]}", writingResponse: true, synchronous: false);
-        //}
         #endregion WriteServiceDocument
 
         #region WriteEntityReferenceLink
-        #region sync
         [Fact]
         public void ShouldWriteContextUriForEntityReferenceLinkRequest()
         {
@@ -242,21 +190,9 @@ namespace Microsoft.OData.Tests.JsonLight
             WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLink(referenceLink), "{\"@odata.context\":\"http://odata.org/test/$metadata#$ref\",\"@odata.id\":\"http://host/Customers(1)\"}", writingResponse: false);
             WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLink(referenceLink), "{\"@odata.context\":\"http://odata.org/test/$metadata#$ref\",\"@odata.id\":\"http://host/Customers(1)\"}", writingResponse: true);
         }
-        #endregion sync
-
-        #region async
-        //[Fact]
-        //public void AsyncShouldWriteContextUriForEntityReferenceLinkRequest()
-        //{
-        //    ODataEntityReferenceLink referenceLink = new ODataEntityReferenceLink { Url = new Uri("http://host/Customers(1)") };
-        //    WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLinkAsync(referenceLink).Wait(), "{\"@odata.context\":\"http://odata.org/test/$metadata#$ref\",\"@odata.id\":\"http://host/Customers(1)\"}", writingResponse: false, synchronous: false);
-        //    WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLinkAsync(referenceLink).Wait(), "{\"@odata.context\":\"http://odata.org/test/$metadata#$ref\",\"@odata.id\":\"http://host/Customers(1)\"}", writingResponse: true, synchronous: false);
-        //}
-        #endregion async
         #endregion WriteEntityReferenceLink
 
         #region WriteEntityReferenceLinks
-        #region sync
         [Fact]
         public void ShouldWriteContextUriForEntityReferenceLinksRequest()
         {
@@ -300,49 +236,6 @@ namespace Microsoft.OData.Tests.JsonLight
                 "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection($ref)\",\"@odata.count\":1,\"@odata.nextLink\":\"http://odata.org/nextpage\",\"value\":[{\"@odata.id\":\"http://host/Orders(1)\"}]}",
                 writingResponse: true);
         }
-        #endregion sync
-
-        #region async
-        //[Fact]
-        //public void AsyncShouldWriteContextUriForEntityReferenceLinksRequest()
-        //{
-        //    ODataEntityReferenceLink referenceLink = new ODataEntityReferenceLink { Url = new Uri("http://host/Orders(1)") };
-        //    ODataEntityReferenceLinks referenceLinks = new ODataEntityReferenceLinks { Links = new[] { referenceLink } };
-        //    WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLinksAsync(referenceLinks).Wait(), "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection($ref)\",\"value\":[{\"@odata.id\":\"http://host/Orders(1)\"}]}", writingResponse: false, synchronous: false);
-        //    WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLinksAsync(referenceLinks).Wait(), "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection($ref)\",\"value\":[{\"@odata.id\":\"http://host/Orders(1)\"}]}", writingResponse: true, synchronous: false);
-        //}
-
-        //[Fact]
-        //public void AsyncWriteNextLinkAnnotationForEntityReferenceLinksRequest()
-        //{
-        //    ODataEntityReferenceLink referenceLink = new ODataEntityReferenceLink { Url = new Uri("http://host/Orders(1)") };
-        //    ODataEntityReferenceLinks referenceLinks = new ODataEntityReferenceLinks
-        //    {
-        //        Links = new[] { referenceLink },
-        //        NextPageLink = new Uri("http://odata.org/nextpage")
-        //    };
-        //    WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLinksAsync(referenceLinks).Wait(),
-        //        "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection($ref)\",\"@odata.nextLink\":\"http://odata.org/nextpage\",\"value\":[{\"@odata.id\":\"http://host/Orders(1)\"}]}", writingResponse: false, synchronous: false);
-        //    WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLinksAsync(referenceLinks).Wait(),
-        //        "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection($ref)\",\"@odata.nextLink\":\"http://odata.org/nextpage\",\"value\":[{\"@odata.id\":\"http://host/Orders(1)\"}]}", writingResponse: true, synchronous: false);
-        //}
-
-        //[Fact]
-        //public void AsyncShouldWriteCountAnnotationForEntityReferenceLinksRequest()
-        //{
-        //    ODataEntityReferenceLink referenceLink = new ODataEntityReferenceLink { Url = new Uri("http://host/Orders(1)") };
-        //    ODataEntityReferenceLinks referenceLinks = new ODataEntityReferenceLinks
-        //    {
-        //        Links = new[] { referenceLink },
-        //        Count = 1,
-        //        NextPageLink = new Uri("http://odata.org/nextpage")
-        //    };
-        //    WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLinksAsync(referenceLinks).Wait(),
-        //        "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection($ref)\",\"@odata.count\":1,\"@odata.nextLink\":\"http://odata.org/nextpage\",\"value\":[{\"@odata.id\":\"http://host/Orders(1)\"}]}", writingResponse: false, synchronous: false);
-        //    WriteAndValidate(outputContext => outputContext.WriteEntityReferenceLinksAsync(referenceLinks).Wait(),
-        //        "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection($ref)\",\"@odata.count\":1,\"@odata.nextLink\":\"http://odata.org/nextpage\",\"value\":[{\"@odata.id\":\"http://host/Orders(1)\"}]}", writingResponse: true, synchronous: false);
-        //}
-        #endregion async
         #endregion WriteEntityReferenceLinks
 
         #region WriteODataPrefix
@@ -366,6 +259,497 @@ namespace Microsoft.OData.Tests.JsonLight
         }
 
         #endregion
+
+        #region Async Tests
+
+        [Fact]
+        public async Task WriteResourceSetAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    var resourceSetWriter = await jsonLightOutputContext.CreateODataResourceSetWriterAsync(this.orderEntitySet, this.orderEntityType);
+                    var resourceSet = CreateOrderResourceSet();
+
+                    await resourceSetWriter.WriteStartAsync(resourceSet);
+                    await resourceSetWriter.WriteEndAsync();
+                });
+
+            Assert.Equal("{\"@odata.context\":\"http://tempuri.org/$metadata#Orders\",\"value\":[]}", result);
+        }
+
+        [Fact]
+        public async Task WriteResourceAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    var resourceWriter = await jsonLightOutputContext.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
+                    var resource = CreateOrderResource();
+
+                    await resourceWriter.WriteStartAsync(resource);
+                    await resourceWriter.WriteEndAsync();
+                });
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Orders/$entity\",\"Id\":1,\"Amount\":13}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteCollectionAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    var collectionWriter = await jsonLightOutputContext.CreateODataCollectionWriterAsync(EdmCoreModel.Instance.GetString(false));
+                    var collectionStart = new ODataCollectionStart
+                    {
+                        SerializationInfo = new ODataCollectionStartSerializationInfo
+                        {
+                            CollectionTypeName = "Collection(Edm.String)"
+                        }
+                    };
+
+                    await collectionWriter.WriteStartAsync(collectionStart);
+                    await collectionWriter.WriteItemAsync("Violet");
+                    await collectionWriter.WriteItemAsync("Indigo");
+                    await collectionWriter.WriteItemAsync("Blue");
+                    await collectionWriter.WriteEndAsync();
+                });
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Collection(Edm.String)\",\"value\":[\"Violet\",\"Indigo\",\"Blue\"]}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteParameterAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    var rateCustomerAction = new EdmAction("NS", "RateCustomer", EdmCoreModel.Instance.GetInt32(false));
+                    rateCustomerAction.AddParameter("customerId", EdmCoreModel.Instance.GetInt32(false));
+                    
+                    var parameterWriter = await jsonLightOutputContext.CreateODataParameterWriterAsync(rateCustomerAction);
+
+                    await parameterWriter.WriteStartAsync();
+                    await parameterWriter.WriteValueAsync("customerId", 1);
+                    await parameterWriter.WriteEndAsync();
+                },
+                /*writingResponse*/ false);
+
+            Assert.Equal("{\"customerId\":1}", result);
+        }
+
+        [Fact]
+        public async Task WriteResourceSetUriParameterAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    var resourceSetUriParameterWriter = await jsonLightOutputContext.CreateODataUriParameterResourceSetWriterAsync(
+                        this.orderEntitySet, this.orderEntityType);
+                    var orderResourceSet = CreateOrderResourceSet();
+                    var orderResource = CreateOrderResource();
+
+                    await resourceSetUriParameterWriter.WriteStartAsync(orderResourceSet);
+                    await resourceSetUriParameterWriter.WriteStartAsync(orderResource);
+                    await resourceSetUriParameterWriter.WriteEndAsync();
+                    await resourceSetUriParameterWriter.WriteEndAsync();
+                },
+                /*writingResponse*/ false);
+
+            Assert.Equal("[{\"Id\":1,\"Amount\":13}]", result);
+        }
+
+        [Fact]
+        public async Task WriteResourceUriParameterAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    var resourceUriParameterWriter = await jsonLightOutputContext.CreateODataUriParameterResourceWriterAsync(
+                        this.orderEntitySet, this.orderEntityType);
+                    var orderResource = CreateOrderResource();
+
+                    await resourceUriParameterWriter.WriteStartAsync(orderResource);
+                    await resourceUriParameterWriter.WriteEndAsync();
+                },
+                /*writingResponse*/ false);
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Orders/$entity\",\"Id\":1,\"Amount\":13}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteDeltaResourceSetAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    var deltaResourceSetWriter = await jsonLightOutputContext.CreateODataDeltaResourceSetWriterAsync(this.orderEntitySet, this.orderEntityType);
+                    var deltaResourceSet = CreateOrderDeltaResourceSet();
+
+                    await deltaResourceSetWriter.WriteStartAsync(deltaResourceSet);
+                    await deltaResourceSetWriter.WriteEndAsync();
+                });
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Orders/$delta\"," +
+                "\"@odata.deltaLink\":\"http://tempuri.org/Orders/deltaLink\",\"value\":[]}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteDeltaResourceAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    var deltaResourceWriter = await jsonLightOutputContext.CreateODataDeltaWriterAsync(this.orderEntitySet, this.orderEntityType);
+                    var orderDeltaResourceSet = CreateOrderDeltaResourceSet();
+                    var deltaResource = CreateOrderResource();
+
+                    await deltaResourceWriter.WriteStartAsync(orderDeltaResourceSet);
+                    await deltaResourceWriter.WriteStartAsync(deltaResource);
+                    await deltaResourceWriter.WriteEndAsync();
+                    await deltaResourceWriter.WriteEndAsync();
+                });
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Orders/$delta\"," +
+                "\"@odata.deltaLink\":\"http://tempuri.org/Orders/deltaLink\"," +
+                "\"value\":[{\"Id\":1,\"Amount\":13}]}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteBatchAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    var batchWriter = await jsonLightOutputContext.CreateODataBatchWriterAsync();
+
+                    await batchWriter.WriteStartBatchAsync();
+                    var operationRequestMessage = await batchWriter.CreateOperationRequestMessageAsync(
+                        "POST", new Uri($"{ServiceUri}/Orders"), "1");
+
+                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
+                    {
+                        var resourceWriter = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
+                        var orderResource = CreateOrderResource();
+
+                        await resourceWriter.WriteStartAsync(orderResource);
+                        await resourceWriter.WriteEndAsync();
+                    }
+
+                    await batchWriter.WriteEndBatchAsync();
+                },
+                /*writingResponse*/ false);
+
+            Assert.Equal(
+                "{\"requests\":[{" +
+                "\"id\":\"1\"," +
+                "\"method\":\"POST\"," +
+                "\"url\":\"http://tempuri.org/Orders\"," +
+                "\"headers\":{\"odata-version\":\"4.0\",\"content-type\":\"application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8\"}, " +
+                "\"body\" :{\"Id\":1,\"Amount\":13}}]}",
+                result);
+        }
+
+        [Fact]
+        public async Task WritePropertyAsync()
+        {
+            var property = new ODataProperty
+            {
+                Name = "Prop",
+                Value = 13,
+                InstanceAnnotations = new List<ODataInstanceAnnotation>
+                {
+                    new ODataInstanceAnnotation("Is.LuckyNumber", new ODataPrimitiveValue(true))
+                }
+            };
+
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                (jsonLightOutputContext) => jsonLightOutputContext.WritePropertyAsync(property));
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Edm.Int32\",\"@Is.LuckyNumber\":true,\"value\":13}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteSpatialPropertyAsync()
+        {
+            var geographyValue = GeographyFactory.Point(32.0, -100.0).Build();
+
+            var geographyProperty = new ODataProperty
+            {
+                Name = "GeographyProperty",
+                Value = new ODataPrimitiveValue(geographyValue)
+            };
+
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                (jsonLightOutputContext) => jsonLightOutputContext.WritePropertyAsync(geographyProperty));
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Edm.GeographyPoint\"," +
+                "\"value\":{\"type\":\"Point\",\"coordinates\":[-100.0,32.0],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteSpatialCollectionPropertyAsync()
+        {
+            var geographyCollection = new object[]
+            {
+                GeographyFactory.Collection().Point(-19.99, -12.0).Build(),
+                GeographyFactory.LineString(33.1, -110.0).LineTo(35.97, -110).Build(),
+                GeographyFactory.MultiLineString().LineString(10.2, 11.2).LineTo(11.9, 11.6).LineString(16.2, 17.2).LineTo(18.9, 19.6).Build(),
+                GeographyFactory.MultiPoint().Point(10.2, 11.2).Point(11.9, 11.6).Build(),
+                GeographyFactory.MultiPolygon().Polygon().Ring(10.2, 11.2).LineTo(11.9, 11.6).LineTo(11.45, 87.75).Ring(16.2, 17.2).LineTo(18.9, 19.6).LineTo(11.45, 87.75).Build(),
+                GeographyFactory.Point(33.1, -110.0).Build(),
+                GeographyFactory.Polygon().Ring(33.1, -110.0).LineTo(35.97, -110.15).LineTo(11.45, 87.75).Ring(35.97, -110).LineTo(36.97, -110.15).LineTo(45.23, 23.18).Build(),
+                GeographyFactory.Point(32.0, -100.0).Build()
+            };
+
+            var geographyCollectionProperty = new ODataProperty
+            {
+                Name = "GeographyCollectionProperty",
+                Value = new ODataCollectionValue
+                {
+                    TypeName = "Collection(Edm.Geography)",
+                    Items = geographyCollection
+                }
+            };
+
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                (jsonLightOutputContext) => jsonLightOutputContext.WritePropertyAsync(geographyCollectionProperty));
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Collection(Edm.Geography)\"," +
+                "\"value\":[" +
+                "{\"type\":\"GeometryCollection\",\"geometries\":[{\"type\":\"Point\",\"coordinates\":[-12.0,-19.99]}],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}," +
+                "{\"type\":\"LineString\",\"coordinates\":[[-110.0,33.1],[-110.0,35.97]],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}," +
+                "{\"type\":\"MultiLineString\",\"coordinates\":[[[11.2,10.2],[11.6,11.9]],[[17.2,16.2],[19.6,18.9]]],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}," +
+                "{\"type\":\"MultiPoint\",\"coordinates\":[[11.2,10.2],[11.6,11.9]],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}," +
+                "{\"type\":\"MultiPolygon\",\"coordinates\":[[[[11.2,10.2],[11.6,11.9],[87.75,11.45],[11.2,10.2]],[[17.2,16.2],[19.6,18.9],[87.75,11.45],[17.2,16.2]]]],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}," +
+                "{\"type\":\"Point\",\"coordinates\":[-110.0,33.1],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}," +
+                "{\"type\":\"Polygon\",\"coordinates\":[[[-110.0,33.1],[-110.15,35.97],[87.75,11.45],[-110.0,33.1]],[[-110.0,35.97],[-110.15,36.97],[23.18,45.23],[-110.0,35.97]]],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}," +
+                "{\"type\":\"Point\",\"coordinates\":[-100.0,32.0],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}" +
+                "]}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteSpatialCollectionPropertyForInjectedJsonWriterFactoryAsync()
+        {
+            var messageInfo = CreateMessageInfo(this.model, /*synchronous*/ true, /*writingResponse*/ true);
+            messageInfo.Container = ContainerBuilderHelper.BuildContainer(builder =>
+            {
+                builder.AddService<IJsonWriterFactory>(ServiceLifetime.Singleton, _ => new DefaultJsonWriterFactory());
+                builder.AddService<IJsonWriterFactoryAsync>(ServiceLifetime.Singleton, _ => new DefaultJsonWriterFactory());
+            });
+
+            var jsonLightOutputContext = new ODataJsonLightOutputContext(messageInfo, this.messageWriterSettings);
+            var geographyCollection = new object[]
+            {
+                GeographyFactory.Point(33.1, -110.0).Build(),
+                GeographyFactory.LineString(33.1, -110.0).LineTo(35.97, -110).Build(),
+                GeographyFactory.MultiPoint().Point(10.2, 11.2).Point(11.9, 11.6).Build()
+            };
+
+            var geographyCollectionProperty = new ODataProperty
+            {
+                Name = "GeographyCollectionProperty",
+                Value = new ODataCollectionValue
+                {
+                    TypeName = "Collection(Edm.Geography)",
+                    Items = geographyCollection
+                }
+            };
+
+            await jsonLightOutputContext.WritePropertyAsync(geographyCollectionProperty);
+            await jsonLightOutputContext.FlushAsync();
+
+            this.stream.Position = 0;
+            var result = await new StreamReader(this.stream).ReadToEndAsync();
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Collection(Edm.Geography)\"," +
+                "\"value\":[" +
+                "{\"type\":\"Point\",\"coordinates\":[-110.0,33.1],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}," +
+                "{\"type\":\"LineString\",\"coordinates\":[[-110.0,33.1],[-110.0,35.97]],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}," +
+                "{\"type\":\"MultiPoint\",\"coordinates\":[[11.2,10.2],[11.6,11.9]],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}" +
+                "]}",
+                result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WriteEntityReferenceLinkAsync(bool writingResponse)
+        {
+            var entityReferenceLink = new ODataEntityReferenceLink
+            {
+                Url = new Uri($"{ServiceUri}/Customers(1)")
+            };
+
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                (jsonLightOutputContext) => jsonLightOutputContext.WriteEntityReferenceLinkAsync(entityReferenceLink),
+                writingResponse);
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#$ref\",\"@odata.id\":\"http://tempuri.org/Customers(1)\"}",
+                result);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task WriteEntityReferenceLinksAsync(bool writingResponse)
+        {
+            var entityReferenceLinks = new ODataEntityReferenceLinks
+            {
+                Links = new List<ODataEntityReferenceLink>
+                {
+                    new ODataEntityReferenceLink { Url = new Uri($"{ServiceUri}/Orders(1)") },
+                    new ODataEntityReferenceLink { Url = new Uri($"{ServiceUri}/Orders(2)") }
+                }
+            };
+
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                (jsonLightOutputContext) => jsonLightOutputContext.WriteEntityReferenceLinksAsync(entityReferenceLinks),
+                writingResponse);
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Collection($ref)\"," +
+                "\"value\":[{\"@odata.id\":\"http://tempuri.org/Orders(1)\"},{\"@odata.id\":\"http://tempuri.org/Orders(2)\"}]}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteServiceDocumentAsync()
+        {
+            var serviceDocument = new ODataServiceDocument
+            {
+                EntitySets = new List<ODataEntitySetInfo>
+                {
+                    new ODataEntitySetInfo { Name = "Orders", Title = "Orders", Url = new Uri($"{ServiceUri}/Orders") },
+                    new ODataEntitySetInfo { Name = "Customers", Title = "Customers", Url = new Uri($"{ServiceUri}/Customers") }
+                }
+            };
+
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                (jsonLightOutputContext) => jsonLightOutputContext.WriteServiceDocumentAsync(serviceDocument));
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata\"," +
+                "\"value\":[" +
+                "{\"name\":\"Orders\",\"kind\":\"EntitySet\",\"url\":\"http://tempuri.org/Orders\"}," +
+                "{\"name\":\"Customers\",\"kind\":\"EntitySet\",\"url\":\"http://tempuri.org/Customers\"}]}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteErrorAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                (jsonLightOutputContext) => jsonLightOutputContext.WriteErrorAsync(this.nullReferenceError, /*includeDebugInformation*/ false));
+
+            Assert.Equal(
+                "{\"error\":{\"code\":\"NRE\",\"message\":\"Object reference not set to an instance of an object\",\"@Is.Error\":true}}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteInStreamErrorWhenWritingResourceSetAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    // This should cause in-stream error listener to be initialized with an ODataJsonLightWriter instance
+                    await jsonLightOutputContext.CreateODataResourceSetWriterAsync(this.orderEntitySet, this.orderEntityType);
+
+                    await jsonLightOutputContext.WriteInStreamErrorAsync(this.nullReferenceError, /*includeDebugInformation*/ false);
+                });
+
+            Assert.Equal(
+                "{\"error\":{\"code\":\"NRE\",\"message\":\"Object reference not set to an instance of an object\",\"@Is.Error\":true}}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteInStreamErrorWhenWritingDeltaAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    // This should cause in-stream error listener to be initialized an ODataJsonLightDeltaWriter instance
+                    await jsonLightOutputContext.CreateODataDeltaWriterAsync(this.orderEntitySet, this.orderEntityType);
+
+                    await jsonLightOutputContext.WriteInStreamErrorAsync(this.nullReferenceError, /*includeDebugInformation*/ false);
+                });
+
+            Assert.Equal(
+                "{\"error\":{\"code\":\"NRE\",\"message\":\"Object reference not set to an instance of an object\",\"@Is.Error\":true}}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteInStreamErrorWhenWritingCollectionAsync()
+        {
+            var result = await SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    // This should cause in-stream error listener to be initialized an ODataJsonLightCollectionWriter instance
+                    await jsonLightOutputContext.CreateODataCollectionWriterAsync(new EdmEntityTypeReference(this.orderEntityType, true));
+
+                    await jsonLightOutputContext.WriteInStreamErrorAsync(this.nullReferenceError, /*includeDebugInformation*/ false);
+                });
+
+            Assert.Equal(
+                "{\"error\":{\"code\":\"NRE\",\"message\":\"Object reference not set to an instance of an object\",\"@Is.Error\":true}}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteInStreamError_ThrowsExceptionIfInvokedWhenWritingParamaterAsync()
+        {
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    // This should cause in-stream error listener to be initialized an ODataJsonLightParameterWriter instance
+                    await jsonLightOutputContext.CreateODataParameterWriterAsync(/*operation*/ null);
+
+                    await jsonLightOutputContext.WriteInStreamErrorAsync(this.nullReferenceError, /*includeDebugInformation*/ false);
+                }));
+
+            Assert.Equal(Strings.ODataParameterWriter_InStreamErrorNotSupported, exception.Message);
+        }
+
+        [Fact]
+        public async Task WriteInStreamError_ThrowsExceptionIfInvokedWhenWritingBatchAsync()
+        {
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightOutputContextAndRunTestAsync(
+                async (jsonLightOutputContext) =>
+                {
+                    // This should cause in-stream error listener to be initialized with an ODataJsonLightBatchWriter instance
+                    await jsonLightOutputContext.CreateODataBatchWriterAsync();
+
+                    await jsonLightOutputContext.WriteInStreamErrorAsync(this.nullReferenceError, /*includeDebugInformation*/ false);
+                }));
+
+            Assert.Equal(Strings.ODataBatchWriter_CannotWriteInStreamErrorForBatch, exception.Message);
+        }
+
+        #endregion Async Tests
 
         private static void WriteAndValidate(
             Action<ODataJsonLightOutputContext> test,
@@ -414,6 +798,140 @@ namespace Microsoft.OData.Tests.JsonLight
             }
 
             return new ODataJsonLightOutputContext(messageInfo, settings);
+        }
+
+        private async Task<string> SetupJsonLightOutputContextAndRunTestAsync(
+            Func<ODataJsonLightOutputContext, Task> func,
+            bool writingResponse = true)
+        {
+            var messageInfo = CreateMessageInfo(this.model, /*synchronous*/ true, writingResponse);
+            var jsonLightOutputContext = new ODataJsonLightOutputContext(messageInfo, this.messageWriterSettings);
+
+            await func(jsonLightOutputContext);
+
+            this.stream.Position = 0;
+            return await new StreamReader(this.stream).ReadToEndAsync();
+        }
+
+        private ODataMessageInfo CreateMessageInfo(IEdmModel model, bool asynchronous = true, bool writingResponse = true)
+        {
+            return new ODataMessageInfo
+            {
+                MessageStream = this.stream,
+                MediaType = new ODataMediaType("application", "json",
+                new[]
+                {
+                    new KeyValuePair<string, string>("odata.metadata", "minimal"),
+                    new KeyValuePair<string, string>("odata.streaming", "true"),
+                    new KeyValuePair<string, string>("IEEE754Compatible", "false"),
+                    new KeyValuePair<string, string>("charset", "utf-8")
+                }),
+                Encoding = Encoding.UTF8,
+                IsResponse = writingResponse,
+                IsAsync = asynchronous,
+                Model = model
+            };
+        }
+
+        private void InitializeEdmModel()
+        {
+            this.model = new EdmModel();
+
+            this.orderEntityType = new EdmEntityType("NS", "Order", /*baseType*/ null, /*isAbstract*/ false, /*isOpen*/ true);
+            this.customerEntityType = new EdmEntityType("NS", "Customer");
+
+            var orderIdProperty = this.orderEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32);
+            this.orderEntityType.AddKeys(orderIdProperty);
+            this.orderEntityType.AddStructuralProperty("Amount", EdmPrimitiveTypeKind.Decimal);
+            var customerNavProperty = this.orderEntityType.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Customer",
+                    Target = this.customerEntityType,
+                    TargetMultiplicity = EdmMultiplicity.ZeroOrOne
+                });
+            this.model.AddElement(this.orderEntityType);
+
+            var customerIdProperty = this.customerEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32);
+            this.customerEntityType.AddKeys(customerIdProperty);
+            this.customerEntityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            var ordersNavProperty = this.customerEntityType.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Orders",
+                    Target = this.orderEntityType,
+                    TargetMultiplicity = EdmMultiplicity.Many
+                });
+            this.model.AddElement(this.customerEntityType);
+
+            var entityContainer = new EdmEntityContainer("NS", "Container");
+            this.model.AddElement(entityContainer);
+
+            this.orderEntitySet = entityContainer.AddEntitySet("Orders", this.orderEntityType);
+            this.customerEntitySet = entityContainer.AddEntitySet("Customers", this.customerEntityType);
+
+            this.orderEntitySet.AddNavigationTarget(customerNavProperty, this.customerEntitySet);
+            this.customerEntitySet.AddNavigationTarget(ordersNavProperty, this.orderEntitySet);
+        }
+
+        #region Helper Methods
+
+        private static ODataResourceSet CreateOrderResourceSet()
+        {
+            return new ODataResourceSet
+            {
+                TypeName = "Collection(NS.Order)",
+                SerializationInfo = new ODataResourceSerializationInfo
+                {
+                    NavigationSourceName = "Orders",
+                    ExpectedTypeName = "NS.Order",
+                    NavigationSourceEntityTypeName = "NS.Order",
+                    NavigationSourceKind = EdmNavigationSourceKind.EntitySet
+                }
+            };
+        }
+
+        private static ODataDeltaResourceSet CreateOrderDeltaResourceSet()
+        {
+            return new ODataDeltaResourceSet
+            {
+                TypeName = "Collection(NS.Order)",
+                DeltaLink = new Uri($"{ServiceUri}/Orders/deltaLink"),
+                SerializationInfo = new ODataResourceSerializationInfo
+                {
+                    NavigationSourceName = "Orders",
+                    ExpectedTypeName = "NS.Order",
+                    NavigationSourceEntityTypeName = "NS.Order",
+                    NavigationSourceKind = EdmNavigationSourceKind.EntitySet
+                }
+            };
+        }
+
+        private static ODataResource CreateOrderResource()
+        {
+            return new ODataResource
+            {
+                TypeName = "NS.Order",
+                Properties = new List<ODataProperty>
+                {
+                    new ODataProperty
+                    {
+                        Name = "Id",
+                        Value = 1,
+                        SerializationInfo = new ODataPropertySerializationInfo { PropertyKind = ODataPropertyKind.Key }
+                    },
+                    new ODataProperty { Name = "Amount", Value = 13M }
+                },
+                SerializationInfo = new ODataResourceSerializationInfo
+                {
+                    NavigationSourceName = "Orders",
+                    ExpectedTypeName = "NS.Order",
+                    NavigationSourceEntityTypeName = "NS.Order",
+                    NavigationSourceKind = EdmNavigationSourceKind.EntitySet
+                }
+            };
+
+            #endregion Helper Methods
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request is in partial fulfilment of issue #2019.

### Description

Implement asynchronous support in **`ODataJsonLightOutputContext`**.

##### About `CreateJsonWriter` and `CreateAsynchronousJsonWriter` methods
**What:**
Asynchronous support is not implemented in `Microsoft.Spatial` library. To write spatial data, we rely on the synchronous `PrimitiveConverter.Instance.WriteJsonLight(object, IJsonWriter)` method. When writing asynchronously we wrap this method in a task. The `WriteJsonLight` method takes an `IJsonWriter` parameter while the asynchronous writer is declared as `IJsonWriterAsync`. Luckily, `JsonWriter` sealed internal class implements both `IJsonWriter` and `IJsonWriterAsync`. To guarantee that when the synchronous writer is called to write spatial data it shares the same scope(s) as the asynchronous writer, we initialize them to the same concrete `JsonWriter` instance. We only do this when the dependency injection container is uninitialized or when the JSON writer factory is `DefaultJsonWriterFactory` - since both `CreateJsonWriter` and `CreateAsynchronousJsonWriter` methods of that factory return an instance of `JsonWriter`.

**Why:**
Consider a scenario where we need to write a Geography collection property into the payload. The array start and end (`[` and `]`) will get written using the asynchronous writer. But the elements of the array - which are of Geography types (e.g. `GeographyPoint`) - are written using the synchronous writer. If the two writers don't share scope, the synchronous writer won't know about the array scope and therefore won't write the array element separator.

Merging `IJsonWriter` and `IJsonWriterAsync` interface in the next major release will simplify this.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
