### PR TITLE
Implement asynchronous support in ODataAsynchronousWriter

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataAsynchronousWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataAsynchronousWriterTests.cs
@@ -5,7 +5,9 @@
 //---------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.OData.Edm;
 using Xunit;
 
@@ -23,6 +25,15 @@ namespace Microsoft.OData.Tests
         private EdmEntityType testType;
         private EdmSingleton singleton;
 
+        private ODataMessageWriterSettings settings;
+
+        public ODataAsynchronousWriterTests()
+        {
+            this.settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
+            this.responseStream = new MemoryStream();
+            InitializeEdmModel();
+        }
+
         [Fact]
         public void WriteCompletedAsyncResponse()
         {
@@ -39,7 +50,7 @@ namespace Microsoft.OData.Tests
             using (var innerMessageWriter = new ODataMessageWriter(innerMessage, settings, this.userModel))
             {
                 var entryWriter = innerMessageWriter.CreateODataResourceWriter(singleton, testType);
-                var entry = new ODataResource() {TypeName = "NS.Test", Properties = new[] {new ODataProperty() {Name = "Id", Value = 1}}};
+                var entry = new ODataResource() { TypeName = "NS.Test", Properties = new[] { new ODataProperty() { Name = "Id", Value = 1 } } };
                 entryWriter.WriteStart(entry);
                 entryWriter.WriteEnd();
             }
@@ -59,7 +70,82 @@ namespace Microsoft.OData.Tests
             test.Throws<ODataException>(Strings.ODataAsyncWriter_CannotCreateResponseMoreThanOnce);
         }
 
+        [Fact]
+        public async Task WriteResponseMessageAsync()
+        {
+            var result = await SetupAsynchronousWriterAndRunTestAsync(
+                async (asynchronousWriter) =>
+                {
+                    var responseMessage = await asynchronousWriter.CreateResponseMessageAsync();
+                    responseMessage.StatusCode = 200;
+                    responseMessage.SetHeader(ODataConstants.ContentTypeHeader, MimeConstants.MimeApplicationJson);
+
+                    var writerSettings = new ODataMessageWriterSettings
+                    {
+                        Version = ODataVersion.V4,
+                        EnableMessageStreamDisposal = false
+                    };
+
+                    writerSettings.SetServiceDocumentUri(new Uri(ServiceDocumentUri));
+
+                    using (var messageWriter = new ODataMessageWriter(responseMessage, writerSettings, this.userModel))
+                    {
+                        var jsonLightWriter = await messageWriter.CreateODataResourceWriterAsync(this.singleton, this.testType);
+                        var testResponse = new ODataResource
+                        {
+                            TypeName = "NS.Test",
+                            Properties = new List<ODataProperty>
+                            {
+                                new ODataProperty { Name = "Id", Value = 1 }
+                            }
+                        };
+
+                        await jsonLightWriter.WriteStartAsync(testResponse);
+                        await jsonLightWriter.WriteEndAsync();
+                    }
+                });
+
+            var expected = @"HTTP/1.1 200 OK
+Content-Type: application/json
+OData-Version: 4.0
+
+{""@odata.context"":""http://host/service/$metadata#MySingleton"",""Id"":1}";
+
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public async Task CreateResponseMessageAsync_ThrowsExceptionForMultipleInvocations()
+        {
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupAsynchronousWriterAndRunTestAsync(
+                    async (asynchronousWriter) =>
+                    {
+                        await asynchronousWriter.CreateResponseMessageAsync();
+                        await asynchronousWriter.CreateResponseMessageAsync();
+                    }));
+
+            Assert.Equal(Strings.ODataAsyncWriter_CannotCreateResponseMoreThanOnce, exception.Message);
+        }
+
+        [Fact]
+        public async Task OnInStreamErrorAsync_ThrowsException()
+        {
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupAsynchronousWriterAndRunTestAsync(
+                    (asynchronousWriter) => ((IODataOutputInStreamErrorListener)asynchronousWriter).OnInStreamErrorAsync()));
+
+            Assert.Equal(Strings.ODataAsyncWriter_CannotWriteInStreamErrorForAsync, exception.Message);
+        }
+
         private ODataAsynchronousWriter TestInit()
+        {
+            responseMessage = new InMemoryMessage { Stream = responseStream };
+            messageWriter = new ODataMessageWriter(responseMessage);
+            return messageWriter.CreateODataAsynchronousWriter();
+        }
+
+        private void InitializeEdmModel()
         {
             this.userModel = new EdmModel();
 
@@ -72,11 +158,6 @@ namespace Microsoft.OData.Tests
 
             this.singleton = new EdmSingleton(defaultContainer, "MySingleton", this.testType);
             defaultContainer.AddElement(this.singleton);
-
-            responseStream = new MemoryStream();
-            responseMessage = new InMemoryMessage { Stream = responseStream };
-            messageWriter = new ODataMessageWriter(responseMessage);
-            return messageWriter.CreateODataAsynchronousWriter();
         }
 
         private string TestFinish()
@@ -84,6 +165,30 @@ namespace Microsoft.OData.Tests
             responseStream.Seek(0, SeekOrigin.Begin);
             var streamReader = new StreamReader(responseStream);
             return streamReader.ReadToEnd();
+        }
+
+        private async Task<string> SetupAsynchronousWriterAndRunTestAsync(Func<ODataAsynchronousWriter, Task> func)
+        {
+            var messageInfo = new ODataMessageInfo
+            {
+                MessageStream = this.responseStream,
+                MediaType = new ODataMediaType(MimeConstants.MimeTextType, MimeConstants.MimePlainSubType),
+                Encoding = MediaTypeUtils.EncodingUtf8NoPreamble,
+                IsResponse = true,
+                IsAsync = true,
+                Model = EdmCoreModel.Instance
+            };
+
+            var rawOutputContext = new ODataRawOutputContext(ODataFormat.RawValue, messageInfo, this.settings);
+            var asynchronousWriter = new ODataAsynchronousWriter(rawOutputContext);
+
+            await func(asynchronousWriter);
+
+            await asynchronousWriter.FlushAsync();
+            await this.responseStream.FlushAsync();
+
+            this.responseStream.Position = 0;
+            return await new StreamReader(this.responseStream).ReadToEndAsync();
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request is in partial fulfilment of issue #2019.

### Description

Implement asynchronous support in **`ODataAsynchronousWriter`**.

#### About the constructors...
Firstly, they are all private.
Secondly, I introduced 2 new constructors.
The first new constructor doesn't take a delegate parameter to write the envelop for the inner message. I made the change such that its called from `CreateMessageForReading` method that was previously passing a `null` for `writeEnvelope` `Action` delegate parameter.
The other new constructor takes a `Func` delegate of `ODataAsynchronousResponseMessage` and `Task`. It is applied in asynchronous scenarios such that its possible to `await`. The constructor is called from `CreateMessageForWritingAsync` method.
Finally I cleaned everything up such that the 2 constructors that accept 6 parameters call the constructor that accepts 5 parameters and only initialize the additional parameter in their body.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
