### PR TITLE
Fix NullReferenceException thrown during materialization of lower-camel-cased payload

### DIFF
--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -328,7 +328,7 @@ namespace Microsoft.OData.Client
                 {
                     hierarchy.Insert(0, type);
                 }
-                while ((type = c.PlatformHelper.GetBaseType(type)) != null);
+                while ((type = c.PlatformHelper.GetBaseType(type)) != null && type != typeof(object));
             }
 
             return hierarchy.ToArray();
@@ -413,7 +413,7 @@ namespace Microsoft.OData.Client
             }
 
             if (cachedEdmType == null)
-            {
+            { 
                 Type collectionType;
                 bool isOpen = false;
                 IEdmSchemaElement edmSchemaElement = null;

--- a/src/Microsoft.OData.Client/Common.cs
+++ b/src/Microsoft.OData.Client/Common.cs
@@ -187,6 +187,18 @@ namespace Microsoft.OData.Service
         internal static string GetModelTypeName(Type type)
         {
             Debug.Assert(type != null, "type != null");
+
+            string typeName;
+            OriginalNameAttribute originalNameAttribute = (OriginalNameAttribute)type.GetCustomAttributes(typeof(OriginalNameAttribute), false).SingleOrDefault();
+            if (originalNameAttribute != null)
+            {
+                typeName = originalNameAttribute.OriginalName;
+            }
+            else
+            {
+                typeName = type.Name;
+            }
+
 #if ODATA_CLIENT
             if (type.IsGenericType())
 #else
@@ -194,7 +206,7 @@ namespace Microsoft.OData.Service
 #endif
             {
                 Type[] genericArguments = type.GetGenericArguments();
-                StringBuilder builder = new StringBuilder(type.Name.Length * 2 * (1 + genericArguments.Length));
+                StringBuilder builder = new StringBuilder(typeName.Length * 2 * (1 + genericArguments.Length));
                 if (type.IsNested)
                 {
                     Debug.Assert(type.DeclaringType != null, "type.DeclaringType != null");
@@ -202,7 +214,7 @@ namespace Microsoft.OData.Service
                     builder.Append('_');
                 }
 
-                builder.Append(type.Name);
+                builder.Append(typeName);
                 builder.Append('[');
                 for (int i = 0; i < genericArguments.Length; i++)
                 {
@@ -234,11 +246,11 @@ namespace Microsoft.OData.Service
             else if (type.IsNested)
             {
                 Debug.Assert(type.DeclaringType != null, "type.DeclaringType != null");
-                return GetModelTypeName(type.DeclaringType) + "_" + type.Name;
+                return GetModelTypeName(type.DeclaringType) + "_" + typeName;
             }
             else
             {
-                return type.Name;
+                return typeName;
             }
         }
 

--- a/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
+++ b/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
@@ -683,5 +683,61 @@ namespace Microsoft.OData.Client.Metadata
 
             return false;
         }
+
+        /// <summary>
+        /// Tries to resolve a type with specified name from the loaded assemblies.
+        /// </summary>
+        /// <param name="typeName">Name of the type to resolve.</param>
+        /// <param name="fullNamespace">Namespace of the type.</param>
+        /// <param name="languageDependentNamespace">Namespace that the resolved type is expected to be.
+        /// Usually same as <paramref name="fullNamespace"/> but can be different
+        /// where namespace for client types does not match namespace in service types.</param>
+        /// <param name="matchedType">The resolved type.</param>
+        /// <returns>true if type was successfully resolved; otherwise false.</returns>
+        internal static bool TryResolveType(string typeName, string fullNamespace, string languageDependentNamespace, out Type matchedType)
+        {
+            Debug.Assert(typeName != null, "typeName != null");
+
+            matchedType = null;
+            int namespaceLength = fullNamespace?.Length ?? 0;
+            string serverDefinedName = typeName.Substring(namespaceLength + 1);
+
+            // Searching only loaded assemblies, not referenced assemblies
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                matchedType = assembly.GetType(string.Concat(languageDependentNamespace, typeName.Substring(namespaceLength)), false);
+                if (matchedType != null)
+                {
+                    return true;
+                }
+
+                IEnumerable<Type> types = null;
+
+                try
+                {
+                    types = assembly.GetTypes();
+                }
+                catch (ReflectionTypeLoadException)
+                {
+                    // Ignore
+                }
+
+                if (types != null)
+                {
+                    foreach (Type type in types)
+                    {
+                        OriginalNameAttribute originalNameAttribute = (OriginalNameAttribute)type.GetCustomAttributes(typeof(OriginalNameAttribute), true).SingleOrDefault();
+                        if (string.Equals(originalNameAttribute?.OriginalName, serverDefinedName, StringComparison.Ordinal)
+                            && type.Namespace.Equals(languageDependentNamespace, StringComparison.Ordinal))
+                        {
+                            matchedType = type;
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Microsoft.OData.Client/TypeResolver.cs
+++ b/src/Microsoft.OData.Client/TypeResolver.cs
@@ -422,7 +422,7 @@ namespace Microsoft.OData.Client
         private Type ResolveTypeFromName(string wireName, Type expectedType)
         {
             Debug.Assert(!String.IsNullOrEmpty(wireName), "!String.IsNullOrEmpty(wireName)");
-            Debug.Assert(expectedType != null, "userType != null");
+            Debug.Assert(expectedType != null, "expectedType != null");
 
             // If there is a mismatch between the wireName and expected type (For e.g. wireName is Edm.Int32 and expectedType is a complex type)
             // we will return Edm.Int32 from this method and ODatalib fails stating the type kind do not match.

--- a/src/Microsoft.OData.Client/Util.cs
+++ b/src/Microsoft.OData.Client/Util.cs
@@ -112,6 +112,7 @@ namespace Microsoft.OData.Client
         /// <param name="parameterName">name of the argument</param>
         /// <exception cref="System.ArgumentNullException">if value is null</exception>
         /// <returns>value</returns>
+        [DebuggerStepThrough]
         internal static T CheckArgumentNull<T>([ValidatedNotNull] T value, string parameterName) where T : class
         {
             if (value == null)
@@ -129,6 +130,7 @@ namespace Microsoft.OData.Client
         /// <param name="parameterName">parameterName of public function</param>
         /// <exception cref="System.ArgumentNullException">if value is null</exception>
         /// <exception cref="System.ArgumentException">if value is empty</exception>
+        [DebuggerStepThrough]
         internal static void CheckArgumentNullAndEmpty([ValidatedNotNull] string value, string parameterName)
         {
             CheckArgumentNull(value, parameterName);
@@ -141,6 +143,7 @@ namespace Microsoft.OData.Client
         /// <param name="value">value to check</param>
         /// <param name="parameterName">parameterName of public function</param>
         /// <exception cref="System.ArgumentException">if value is empty</exception>
+        [DebuggerStepThrough]
         internal static void CheckArgumentNotEmpty(string value, string parameterName)
         {
             if (value != null && value.Length == 0)
@@ -157,6 +160,7 @@ namespace Microsoft.OData.Client
         /// <param name="parameterName">parameterName of public function</param>
         /// <exception cref="System.ArgumentNullException">if value is null</exception>
         /// <exception cref="System.ArgumentException">if value is empty or contains null elements</exception>
+        [DebuggerStepThrough]
         internal static void CheckArgumentNotEmpty<T>(T[] value, string parameterName) where T : class
         {
             CheckArgumentNull(value, parameterName);

--- a/src/Microsoft.OData.Client/WebUtil.cs
+++ b/src/Microsoft.OData.Client/WebUtil.cs
@@ -201,6 +201,7 @@ namespace Microsoft.OData.Client
         /// <param name="value">argument whose value needs to be checked</param>
         /// <param name="parameterName">name of the argument</param>
         /// <returns>returns the argument back</returns>
+        [DebuggerStepThrough]
         internal static T CheckArgumentNull<T>([ValidatedNotNull] T value, string parameterName) where T : class
         {
             if (value == null)

--- a/src/Microsoft.OData.Edm/EdmUtil.cs
+++ b/src/Microsoft.OData.Edm/EdmUtil.cs
@@ -492,6 +492,7 @@ namespace Microsoft.OData.Edm
             return null;
         }
 
+        [DebuggerStepThrough]
         internal static T CheckArgumentNull<T>([ValidatedNotNull]T value, string parameterName) where T : class
         {
             if (value == null)

--- a/src/Microsoft.Spatial/Util.cs
+++ b/src/Microsoft.Spatial/Util.cs
@@ -7,6 +7,7 @@
 namespace Microsoft.Spatial
 {
     using System;
+    using System.Diagnostics;
 
     /// <summary>
     /// Util class
@@ -27,6 +28,7 @@ namespace Microsoft.Spatial
         /// </summary>
         /// <param name="arg">The input argument</param>
         /// <param name="errorMessage">The error to throw</param>
+        [DebuggerStepThrough]
         internal static void CheckArgumentNull([ValidatedNotNull] object arg, string errorMessage)
         {
             if (arg == null)

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextNoTrackingStreamsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextNoTrackingStreamsTests.cs
@@ -401,7 +401,6 @@ namespace Microsoft.OData.Client.Tests.Tracking
             : base(args)
         {
         }
-        
 
         public CustomizedRequestMessage(DataServiceClientRequestMessageArgs args, string response, Dictionary<string, string> headers)
             : base(args)
@@ -431,7 +430,7 @@ namespace Microsoft.OData.Client.Tests.Tracking
 
         public override Stream EndGetRequestStream(IAsyncResult asyncResult)
         {
-           return GetStream();
+            return GetStream();
         }
 
         public override IODataResponseMessage GetResponse()

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Microsoft.OData.Client.TDDUnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Microsoft.OData.Client.TDDUnitTests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Tests\Materialization\EntryMaterializationPolicyForComplexResourceTests.cs" />
     <Compile Include="Tests\Materialization\CollectionValueMaterializationPolicyTests.cs" />
     <Compile Include="Tests\Materialization\EntryValueMaterializationPolicyUnitTests.cs" />
+    <Compile Include="Tests\Materialization\CamelCasedTypeMaterializationTests.cs" />
     <Compile Include="Tests\Materialization\ODataMaterializerTests.cs" />
     <Compile Include="Tests\Materialization\ODataMaterializerTestsProxy.cs" />
     <Compile Include="Tests\Materialization\PrimitiveValueMaterializationPolicyTests.cs" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/CamelCasedTypeMaterializationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/CamelCasedTypeMaterializationTests.cs
@@ -1,0 +1,219 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CamelCasedTypeMaterializationTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.TDDUnitTests.Tests.Materialization
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Xml;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Edm.Csdl;
+    using NS.Models;
+    using Xunit;
+
+    public partial class CamelCasedTypeMaterializationTests
+    {
+        #region Edmx Constants
+        private const string CamelCasedEdmx = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""NS.Models"">
+      <EntityType Name=""shape"" OpenType=""true"">
+        <Key>
+          <PropertyRef Name=""id"" />
+        </Key>
+        <Property Name=""id"" Type=""Edm.Int32"" Nullable=""false"" />
+        <Property Name=""area"" Type=""Edm.Double"" Nullable=""false"" />
+      </EntityType>
+      <EntityType Name=""rectangle"" BaseType=""NS.Models.shape"" OpenType=""true"">
+		<Property Name=""length"" Type=""Edm.Double"" Nullable=""false"" />
+        <Property Name=""width"" Type=""Edm.Double"" Nullable=""false"" />
+        <Property Name=""attributes"" Type=""Collection(Edm.String)"" Nullable=""false"" />
+      </EntityType>
+      <EntityContainer Name=""Container"">
+        <EntitySet Name=""shapes"" EntityType=""NS.Models.shape"" />
+        <EntitySet Name=""rectangles"" EntityType=""NS.Models.rectangle"" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+        #endregion Edmx Constants
+
+        private const string ServiceUri = "http://tempuri.org/";
+        private ClientEdmModel clientModel;
+        private DataServiceContext dataServiceContext;
+
+        public CamelCasedTypeMaterializationTests()
+        {
+            this.InitializeEdmModel();
+        }
+
+        [Fact]
+        public void MaterializationForEntityBoundToBaseEntityTypeCollection()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#shapes/$entity\"," +
+                "\"@odata.type\":\"#NS.Models.Rectangle\"," + // Note: Rectangle as opposed to rectangle
+                "\"id\":1," +
+                "\"area\":28," +
+                "\"length\":7," +
+                "\"width\":4," +
+                "\"attributes\":[]}";
+
+            ConfigureOnMessageCreating(payload);
+            var query = dataServiceContext.CreateQuery<Rectangle>("shapes");
+
+            var rectangle = query.Execute().FirstOrDefault();
+
+            Assert.NotNull(rectangle);
+            Assert.Equal(7D, rectangle.Length);
+            Assert.Equal(4D, rectangle.Width);
+            Assert.Equal(28D, rectangle.Area);
+            Assert.Empty(rectangle.Attributes);
+        }
+
+        [Fact]
+        public void MaterializationForEntityBoundToEntityTypeCollection()
+        {
+            // No "@odata.type" property
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#rectangles/$entity\"," +
+                "\"id\":1," +
+                "\"area\":28," +
+                "\"length\":7," +
+                "\"width\":4," +
+                "\"attributes\":[]}";
+
+            ConfigureOnMessageCreating(payload);
+            var query = dataServiceContext.CreateQuery<Rectangle>("rectangles");
+
+            var rectangle = query.Execute().FirstOrDefault();
+
+            Assert.NotNull(rectangle);
+            Assert.Equal(7D, rectangle.Length);
+            Assert.Equal(4D, rectangle.Width);
+            Assert.Equal(28D, rectangle.Area);
+            Assert.Empty(rectangle.Attributes);
+        }
+
+        [Fact]
+        public void MaterializationForEntitySetBoundToBaseEntityTypeCollection()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#shapes\"," +
+                "\"value\":[{" +
+                "\"@odata.type\":\"#NS.Models.Rectangle\"," +
+                "\"id\":1," +
+                "\"area\":28," +
+                "\"length\":7," +
+                "\"width\":4," +
+                "\"attributes\":[]" +
+                "}]}";
+
+            ConfigureOnMessageCreating(payload);
+            var query = dataServiceContext.CreateQuery<Rectangle>("shapes");
+
+            var rectangles = query.Execute().ToArray();
+
+            Assert.NotNull(rectangles);
+            Assert.Single(rectangles);
+            Assert.Equal(7D, rectangles[0].Length);
+            Assert.Equal(4D, rectangles[0].Width);
+            Assert.Equal(28D, rectangles[0].Area);
+            Assert.Empty(rectangles[0].Attributes);
+        }
+
+        private void ConfigureOnMessageCreating(string payload)
+        {
+            dataServiceContext.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                var contentTypeHeader = "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8";
+                var odataVersionHeader = "4.0";
+
+                return new CustomizedHttpWebRequestMessage(args,
+                    payload,
+                    new Dictionary<string, string>
+                    {
+                        {"Content-Type", contentTypeHeader},
+                        {"OData-Version", odataVersionHeader},
+                    });
+            };
+        }
+
+        private void InitializeEdmModel()
+        {
+            this.clientModel = new ClientEdmModel(ODataProtocolVersion.V4);
+            this.dataServiceContext = new DataServiceContext(new Uri(ServiceUri), ODataProtocolVersion.V4, this.clientModel);
+            this.dataServiceContext.UndeclaredPropertyBehavior = UndeclaredPropertyBehavior.Support;
+            this.dataServiceContext.ResolveType = (typeName) =>
+            {
+                return this.dataServiceContext.DefaultResolveType(typeName, "NS.Models", "NS.Models");
+            };
+
+            this.dataServiceContext.ResolveName = (clientType) =>
+            {
+                var originalNameAttribute = (OriginalNameAttribute)Enumerable.SingleOrDefault(Utility.GetCustomAttributes(clientType, typeof(OriginalNameAttribute), true));
+                if (clientType.Namespace.Equals("NS.Models", global::System.StringComparison.Ordinal))
+                {
+                    if (originalNameAttribute != null)
+                    {
+                        return string.Concat("NS.Models.", originalNameAttribute.OriginalName);
+                    }
+
+                    return string.Concat("NS.Models.", clientType.Name);
+                }
+
+                if (originalNameAttribute != null)
+                {
+                    return clientType.Namespace + "." + originalNameAttribute.OriginalName;
+                }
+
+                return clientType.FullName;
+            };
+
+            using (var reader = XmlReader.Create(new StringReader(CamelCasedEdmx)))
+            {
+                if (CsdlReader.TryParse(reader, out IEdmModel serviceModel, out _))
+                {
+                    this.dataServiceContext.Format.UseJson(serviceModel);
+                }
+            }
+        }
+    }
+}
+
+namespace NS.Models
+{
+    using System.Collections.ObjectModel;
+    using Microsoft.OData.Client;
+
+    [Key("id")]
+    [EntitySet("shapes")]
+    [OriginalName("shape")]
+    public class Shape
+    {
+        [OriginalName("id")]
+        public int Id { get; set; }
+        [OriginalName("area")]
+        public double Area { get; set; }
+    }
+
+    [Key("id")]
+    [OriginalName("rectangle")]
+    public class Rectangle : Shape
+    {
+        public Rectangle()
+        {
+            Attributes = new ObservableCollection<string>();
+        }
+
+        [OriginalName("length")]
+        public double Length { get; set; }
+        [OriginalName("width")]
+        public double Width { get; set; }
+        [OriginalName("attributes")]
+        public ObservableCollection<string> Attributes { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2119.*

### Description

When an OData service metadata and payload is camel-cased and an entity bound to base entity type collection is returned, the value for `@odata.type` property is not in the expected form leading to a `NullReferenceException` during materialization.

Consider the following service metadata for a contrived sample service comprising of two open entity types `Rectangle` and `Shape` where `Rectangle` derives from `Shape`.
```xml
<?xml version="1.0" encoding="utf-8"?>
<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
  <edmx:DataServices>
    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="NS.Models">
      <EntityType Name="shape" OpenType="true">
        <Key>
          <PropertyRef Name="id" />
        </Key>
        <Property Name="id" Type="Edm.Int32" Nullable="false" />
        <Property Name="area" Type="Edm.Double" Nullable="false" />
      </EntityType>
      <EntityType Name="rectangle" BaseType="NS.Models.shape" OpenType="true">
		<Property Name="length" Type="Edm.Double" Nullable="false" />
        <Property Name="width" Type="Edm.Double" Nullable="false" />
        <Property Name="attributes" Type="Collection(Edm.String)" Nullable="false" />
      </EntityType>
      <EntityContainer Name="Container">
        <EntitySet Name="shapes" EntityType="NS.Models.shape" />
        <EntitySet Name="rectangles" EntityType="NS.Models.rectangle" />
      </EntityContainer>
    </Schema>
  </edmx:DataServices>
</edmx:Edmx>
```
In the `EdmModelBase` class, we maintain a dictionary mapping the fully qualified name of each structured type to the corresponding schema type. Given the above service metadata, we'll store the `Rectangle` entity type under the key "NS.Models.rectangle".
However, if one queries for the `Rectangle` entity against the base entity type collection "shapes", the following payload is returned:
```json
{
  "@odata.context": "http://tempuri.org/$metadata#shapes/$entity",
  "@odata.type": "#NS.Models.Rectangle",
  "id": 1,
  "area": 28,
  "length": 7,
  "width": 4,
  "attributes": []
}
```
In the above payload, the value for `@odata.type` property is written as "#NS.Models.Rectangle" rather than "#NS.Models.rectangle".
For this reason, the search for the entity type in the schema types dictionary by key **is unsuccessful**. This throws off the materialization logic and a `NullReferenceException` is thrown when trying to materialize the primitive collection property.

**Note:**
The alternative option considered was to apply a fix in ODL such that the lower-camel-case option was applied when writing `@odata.type` property but that carries a bigger risk since payloads for all workloads on AGS would suddenly change.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
