### PR TITLE
Fix issue with async reader for Parsing the Context Uri

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -303,7 +303,7 @@ namespace Microsoft.OData.JsonLight
                             contextUriAnnotationValue,
                             payloadKind,
                             this.MessageReaderSettings.ClientCustomTypeResolver,
-                            this.JsonLightInputContext.ReadingResponse);
+                            this.JsonLightInputContext.ReadingResponse || payloadKind == ODataPayloadKind.Delta);
                     }
 
 #if DEBUG

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -1162,7 +1162,7 @@ namespace Microsoft.OData.JsonLight
                     UriUtils.UriToString(nestedInfo.ContextUrl),
                     payloadKind,
                     this.jsonLightResourceDeserializer.MessageReaderSettings.ClientCustomTypeResolver,
-                    this.jsonLightResourceDeserializer.JsonLightInputContext.ReadingResponse).Path;
+                    this.jsonLightResourceDeserializer.JsonLightInputContext.ReadingResponse || this.ReadingDelta).Path;
 
                 return new ODataUri() { Path = odataPath };
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues
Fix issue with async reader for Parsing the Context Uri - Its there good in sync but not in async

*This pull request fixes issue #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
