### PR TITLE
Cache annotation full qualified name in FindDeclaredVocabularyAnnotations

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsElement.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsElement.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using Microsoft.OData.Edm.Csdl.Parsing.Ast;
 using Microsoft.OData.Edm.Validation;
@@ -95,7 +96,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         /// <returns>The cached annotation full qualified name.</returns>
         public string GetAnnotationFullQualifiedName(IEdmVocabularyAnnotatable element)
         {
-            System.Diagnostics.Debug.Assert(object.ReferenceEquals(this as IEdmVocabularyAnnotatable, element));
+            Debug.Assert(object.ReferenceEquals(this as IEdmVocabularyAnnotatable, element));
             this.annotationFullName = this.annotationFullName ?? EdmUtil.FullyQualifiedName(element);
             return this.annotationFullName;
         }

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsElement.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsElement.cs
@@ -26,6 +26,8 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
         private static readonly IEnumerable<IEdmVocabularyAnnotation> emptyVocabularyAnnotations = Enumerable.Empty<IEdmVocabularyAnnotation>();
 
+        private string annotationFullName = null;
+
         protected CsdlSemanticsElement(CsdlElement element)
         {
             if (element != null)
@@ -84,6 +86,18 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
                 return this.directValueAnnotationsCache.GetValue(this, ComputeDirectValueAnnotationsFunc, null);
             }
+        }
+
+        /// <summary>
+        /// Gets the cached annotation full qualified name.
+        /// </summary>
+        /// <param name="element">This element as <see cref="IEdmVocabularyAnnotatable"/>.</param>
+        /// <returns>The cached annotation full qualified name.</returns>
+        public string GetAnnotationFullQualifiedName(IEdmVocabularyAnnotatable element)
+        {
+            System.Diagnostics.Debug.Assert(object.ReferenceEquals(this as IEdmVocabularyAnnotatable, element));
+            this.annotationFullName = this.annotationFullName ?? EdmUtil.FullyQualifiedName(element);
+            return this.annotationFullName;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
@@ -320,7 +320,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             if (this.outOfLineAnnotations.Count > 0)
             {
                 List<CsdlSemanticsAnnotations> elementAnnotations;
-                string fullName = semanticsElement.GetAnnotationFullQualifiedName(element);
+                string fullName = semanticsElement?.GetAnnotationFullQualifiedName(element);
 
                 if (fullName != null && this.outOfLineAnnotations.TryGetValue(fullName, out elementAnnotations))
                 {

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
@@ -303,6 +303,10 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                 {
                     return semanticsReference.InlineVocabularyAnnotations;
                 }
+                else
+                {
+                    return Enumerable.Empty<IEdmVocabularyAnnotation>();
+                }
             }
 
             CsdlSemanticsInclude semanticsInclude = element as CsdlSemanticsInclude;
@@ -311,6 +315,10 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                 if (semanticsInclude.Model == this)
                 {
                     return semanticsInclude.InlineVocabularyAnnotations;
+                }
+                else
+                {
+                    return Enumerable.Empty<IEdmVocabularyAnnotation>();
                 }
             }
 

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
@@ -303,10 +303,6 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                 {
                     return semanticsReference.InlineVocabularyAnnotations;
                 }
-                else
-                {
-                    Enumerable.Empty<IEdmVocabularyAnnotation>();
-                }
             }
 
             CsdlSemanticsInclude semanticsInclude = element as CsdlSemanticsInclude;
@@ -316,33 +312,32 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                 {
                     return semanticsInclude.InlineVocabularyAnnotations;
                 }
-                else
-                {
-                    Enumerable.Empty<IEdmVocabularyAnnotation>();
-                }
             }
 
             CsdlSemanticsElement semanticsElement = element as CsdlSemanticsElement;
             IEnumerable<IEdmVocabularyAnnotation> inlineAnnotations = semanticsElement != null && semanticsElement.Model == this ? semanticsElement.InlineVocabularyAnnotations : Enumerable.Empty<IEdmVocabularyAnnotation>();
 
-            List<CsdlSemanticsAnnotations> elementAnnotations;
-            string fullName = EdmUtil.FullyQualifiedName(element);
-
-            if (fullName != null && this.outOfLineAnnotations.TryGetValue(fullName, out elementAnnotations))
+            if (this.outOfLineAnnotations.Count > 0)
             {
-                List<IEdmVocabularyAnnotation> result = new List<IEdmVocabularyAnnotation>();
+                List<CsdlSemanticsAnnotations> elementAnnotations;
+                string fullName = semanticsElement.GetAnnotationFullQualifiedName(element);
 
-                foreach (CsdlSemanticsAnnotations annotations in elementAnnotations)
+                if (fullName != null && this.outOfLineAnnotations.TryGetValue(fullName, out elementAnnotations))
                 {
-                    foreach (CsdlAnnotation annotation in annotations.Annotations.Annotations)
-                    {
-                        IEdmVocabularyAnnotation vocabAnnotation = this.WrapVocabularyAnnotation(annotation, annotations.Context, null, annotations, annotations.Annotations.Qualifier);
-                        vocabAnnotation.SetSerializationLocation(this, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
-                        result.Add(vocabAnnotation);
-                    }
-                }
+                    List<IEdmVocabularyAnnotation> result = new List<IEdmVocabularyAnnotation>();
 
-                return inlineAnnotations.Concat(result);
+                    foreach (CsdlSemanticsAnnotations annotations in elementAnnotations)
+                    {
+                        foreach (CsdlAnnotation annotation in annotations.Annotations.Annotations)
+                        {
+                            IEdmVocabularyAnnotation vocabAnnotation = this.WrapVocabularyAnnotation(annotation, annotations.Context, null, annotations, annotations.Annotations.Qualifier);
+                            vocabAnnotation.SetSerializationLocation(this, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+                            result.Add(vocabAnnotation);
+                        }
+                    }
+
+                    return inlineAnnotations.Concat(result);
+                }
             }
 
             return inlineAnnotations;

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsModel.cs
@@ -320,7 +320,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             if (this.outOfLineAnnotations.Count > 0)
             {
                 List<CsdlSemanticsAnnotations> elementAnnotations;
-                string fullName = semanticsElement?.GetAnnotationFullQualifiedName(element);
+                string fullName = semanticsElement != null ? semanticsElement.GetAnnotationFullQualifiedName(element) : EdmUtil.FullyQualifiedName(element);
 
                 if (fullName != null && this.outOfLineAnnotations.TryGetValue(fullName, out elementAnnotations))
                 {


### PR DESCRIPTION
### Issues

3% of all allocations in AGS, come from this method, allocating string for full qualified name. This also represents 16% of all string allocations for AGS.

### Description

This fix attempts to reduce string allocations by caching the annotation full qualified name in CsdlSemanticsElement the first time it is evaluated.

![image](https://user-images.githubusercontent.com/24846248/125890863-5beddda3-ab44-4267-ab11-c93ec8eab265.png)

### Checklist (Uncheck if it is not completed)

- [X ] *Test cases already covering this code path*
- [ ] *Build and test with one-click build and test script passed*

