### PR TITLE
Fix escape function binding type constraint

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -1763,7 +1763,7 @@ namespace Microsoft.OData.UriParser
 
             if (previous != null)
             {
-                bindingType = previous.TargetEdmType;
+                bindingType = previous.EdmType;
             }
 
             if (bindingType == null || model == null)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Currently the binding type constraint for escape functions comes from `TargetEdmType`, but when the escape function is rooted on a contained navigation the chosen type ends up being the collection instead of the entity.

### Description

Consider the following request (where `items` is a contained navigation from `oneDrive.drive` to `Collection(oneDrive.item)`):
`/drive/items/32:/path`

The expectation is that, if `oneDrive.getByPath` is bound to `oneDrive.item`, the escape function mechanism will translate the path to:
`/drive/items/32/oneDrive.getByPath(path='path')`

However, the current logic is trying to find a function bound to `Collection(oneDrive.item)` and so the escape logic is not translating at all. The fix is to use `EdmType` which appears to be the expected value for all scenarios.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
