### PR TITLE
Support empty collection with IN operator

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -91,10 +91,6 @@ namespace Microsoft.OData.UriParser
                 {
                     Debug.Assert(bracketLiteralText[bracketLiteralText.Length - 1] == ')',
                         "Collection with opening '(' should have corresponding ')'");
-                    if (bracketLiteralText.Replace(" ", String.Empty) == "()")
-                    {
-                        throw new ODataException(ODataErrorStrings.MetadataBinder_RightOperandNotCollectionValue);
-                    }
 
                     StringBuilder replacedText = new StringBuilder(bracketLiteralText);
                     replacedText[0] = '[';
@@ -313,12 +309,17 @@ namespace Microsoft.OData.UriParser
 
         private static string NormalizeGuidCollectionItems(string bracketLiteralText)
         {
-            string[] items = bracketLiteralText.Substring(1, bracketLiteralText.Length - 2).Split(',')
+            string normalizedText = bracketLiteralText.Substring(1, bracketLiteralText.Length - 2).Trim();
+            if (normalizedText.Length == 0)
+            {
+                return "[]";
+            }
+            string[] items = normalizedText.Split(',')
                 .Select(s => s.Trim()).ToArray();
 
             for (int i = 0; i < items.Length; i++)
             {
-                if (items[i] != "null" && items[i][0] != '\'' && items[i][0] != '"')
+                if (items[i] != NullLiteral && items[i][0] != '\'' && items[i][0] != '"')
                 {
                     items[i] = String.Format(CultureInfo.InvariantCulture, "'{0}'", items[i]);
                 }
@@ -329,7 +330,12 @@ namespace Microsoft.OData.UriParser
 
         private static string NormalizeDateTimeCollectionItems(string bracketLiteralText)
         {
-            string[] items = bracketLiteralText.Substring(1, bracketLiteralText.Length - 2).Split(',')
+            string normalizedText = bracketLiteralText.Substring(1, bracketLiteralText.Length - 2).Trim();
+            if (normalizedText.Length == 0)
+            {
+                return "[]";
+            }
+            string[] items = normalizedText.Split(',')
                 .Select(s => s.Trim()).ToArray();
 
             for (int i = 0; i < items.Length; i++)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2363,10 +2363,16 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [InlineData("ID in (  )")]
         [InlineData("SSN in (  )")]     // Edm.String
         [InlineData("MyGuid in (  )")]  // Edm.Guid
+        [InlineData("Birthdate in (  )")]  // Edm.DateTimeOffset
+        [InlineData("MyDate in (  )")]  // Edm.Date
         public void FilterWithInOperationWithEmptyCollection(string filterClause)
         {
-            Action parse = () => ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
-            parse.Throws<ODataException>(ODataErrorStrings.MetadataBinder_RightOperandNotCollectionValue);
+            FilterClause filter = ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            var inNode = Assert.IsType<InNode>(filter.Expression);
+
+            CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
+            Assert.Equal(0, collectionNode.Collection.Count);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #2141 .*

### Description

* Doesn't throw exception
* Quickly exits normalization when it detects an empty collection

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
