### PR TITLE
Skip string allocation for keys of PropertyCache

### DIFF
--- a/src/Microsoft.OData.Core/PropertyCache.cs
+++ b/src/Microsoft.OData.Core/PropertyCache.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.OData.Edm;
 
-
 namespace Microsoft.OData
 {
     /// <summary>

--- a/src/Microsoft.OData.Core/PropertyCache.cs
+++ b/src/Microsoft.OData.Core/PropertyCache.cs
@@ -4,8 +4,10 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
 using System.Collections.Generic;
 using Microsoft.OData.Edm;
+
 
 namespace Microsoft.OData
 {
@@ -14,15 +16,68 @@ namespace Microsoft.OData
     /// </summary>
     internal class PropertyCache
     {
-        private readonly Dictionary<string, PropertySerializationInfo> propertyInfoDictionary = new Dictionary<string, PropertySerializationInfo>();
+        private readonly Dictionary<PropertyKey, PropertySerializationInfo> propertyInfoDictionary = new Dictionary<PropertyKey, PropertySerializationInfo>();
 
-        public PropertySerializationInfo GetProperty(IEdmModel model, string name, string uniqueName, IEdmStructuredType owningType)
+        private struct PropertyKey : IEquatable<PropertyKey>
+        {
+            public PropertyKey(int depth, string name, string fullTypeName)
+            {
+                this.Depth = depth;
+                this.Name = name;
+                this.FullTypeName = fullTypeName;
+            }
+
+            public int Depth { get; private set; }
+
+            public string Name { get; private set; }
+         
+            public string FullTypeName { get; private set; }
+
+            public static bool operator ==(PropertyKey lhs, PropertyKey rhs)
+            {
+                return lhs.Equals(rhs);
+            }
+
+            public static bool operator !=(PropertyKey lhs, PropertyKey rhs)
+            {
+                return !lhs.Equals(rhs);
+            }
+
+            public override int GetHashCode()
+            {
+                return this.Depth.GetHashCode() ^
+                       this.Name.GetHashCode() ^
+                       (this.FullTypeName?.GetHashCode() ?? 0);
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (obj is PropertyKey propertyKey)
+                {
+                    return this.Equals(propertyKey);
+                }
+
+                return false;
+            }
+
+            public bool Equals(PropertyKey other)
+            {
+                return
+                    this.Depth == other.Depth &&
+                    this.Name == other.Name &&
+                    this.FullTypeName == other.FullTypeName;
+            }
+        }
+
+        public PropertySerializationInfo GetProperty(IEdmModel model, int depth, string name, IEdmStructuredType owningType)
         {
             PropertySerializationInfo propertyInfo;
-            if (!propertyInfoDictionary.TryGetValue(uniqueName, out propertyInfo))
+
+            PropertyKey propertyKey = new PropertyKey(depth, name, owningType?.FullTypeName());
+            if (!propertyInfoDictionary.TryGetValue(propertyKey, out propertyInfo))
             {
                 propertyInfo = new PropertySerializationInfo(model, name, owningType);
-                propertyInfoDictionary[uniqueName] = propertyInfo;
+                propertyInfoDictionary[propertyKey] = propertyInfo;
             }
 
             return propertyInfo;

--- a/src/Microsoft.OData.Core/PropertyCacheHandler.cs
+++ b/src/Microsoft.OData.Core/PropertyCacheHandler.cs
@@ -6,7 +6,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using Microsoft.OData.Edm;
 
 namespace Microsoft.OData
@@ -18,8 +17,6 @@ namespace Microsoft.OData
     /// </summary>
     internal class PropertyCacheHandler
     {
-        private const string PropertyTypeDelimiter = "-";
-
         private readonly Stack<PropertyCache> cacheStack = new Stack<PropertyCache>();
 
         private readonly Stack<int> scopeLevelStack = new Stack<int>();
@@ -38,14 +35,7 @@ namespace Microsoft.OData
 
             Debug.Assert(depth >= 1, "'depth' should always be greater than or equal to 1");
 
-            // In production, depthStr == 1 in most cases. So we optimize string allocation for this case.
-            string depthStr = depth == 1 ? string.Empty : depth.ToString(CultureInfo.InvariantCulture);
-
-            string uniqueName = owningType != null
-                ? string.Concat(owningType.FullTypeName(), PropertyCacheHandler.PropertyTypeDelimiter, depthStr, name)
-                : string.Concat(depthStr, name);
-
-            return this.currentPropertyCache.GetProperty(model, name, uniqueName, owningType);
+            return this.currentPropertyCache.GetProperty(model, depth, name, owningType);
         }
 
         public void SetCurrentResourceScopeLevel(int level)


### PR DESCRIPTION
### Issues

2.5% of all allocations in AGS come from concatenating strings to compose keys used to lookup the PropertyCache. This also represents 13.5% of all string allocations for AGS, and it is the second largest hotspot when it comes to allocations according to CPR.

This code is present in the hot path while writing the OData response payload back to the client.

![image](https://user-images.githubusercontent.com/24846248/127418478-7479a65b-c45a-46a8-ab5a-5e5cb82d89e3.png)

### Description

Changing the type of the key from string to a struct that is composed by the relevant properties: depth, name, fullTypeName. Thus avoiding the string allocation to compose the key. Furthermore, struct is a value type and therefore it is only stored in the stack and does not require any heap allocation overhead.

### Checklist (Uncheck if it is not completed)

- [X] *Tests already cover this logic*
- [X] *Build and test with one-click build and test script passed*