### PR TITLE
Skip lambda allocation in FindTransientAnnotation

### DIFF
--- a/src/Microsoft.OData.Edm/GlobalSuppressions.cs
+++ b/src/Microsoft.OData.Edm/GlobalSuppressions.cs
@@ -99,7 +99,6 @@
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Scope = "type", Target = "Microsoft.OData.Edm.VersioningList`1")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Scope = "type", Target = "Microsoft.OData.Edm.VersioningList`1+ArrayVersioningList")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Scope = "type", Target = "Microsoft.OData.Edm.VersioningList`1+EmptyVersioningList")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix", Scope = "type", Target = "Microsoft.OData.Edm.VersioningList`1+LinkedVersioningList")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Scope = "type", Target = "Microsoft.OData.Edm.VersioningDictionary`2")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Scope = "type", Target = "Microsoft.OData.Edm.VersioningDictionary`2+EmptyVersioningDictionary")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1711:IdentifiersShouldNotHaveIncorrectSuffix", Scope = "type", Target = "Microsoft.OData.Edm.VersioningDictionary`2+HashTreeDictionary")]

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
@@ -26,7 +26,7 @@ namespace Microsoft.OData.Edm.Vocabularies
         /// <summary>
         /// Keeps track of transient annotations on elements.
         /// </summary>
-        private VersioningDictionary<IEdmElement, object> annotationsDictionary;
+        private VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>> annotationsDictionary;
 
         /// <summary>
         /// Used for locking during updates to the annotations dictionary;
@@ -48,7 +48,7 @@ namespace Microsoft.OData.Edm.Vocabularies
         /// </summary>
         public EdmDirectValueAnnotationsManager()
         {
-            this.annotationsDictionary = VersioningDictionary<IEdmElement, object>.Create(this.CompareElements);
+            this.annotationsDictionary = VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>>.Create(this.CompareElements);
         }
 
         /// <summary>
@@ -59,10 +59,10 @@ namespace Microsoft.OData.Edm.Vocabularies
         public IEnumerable<IEdmDirectValueAnnotation> GetDirectValueAnnotations(IEdmElement element)
         {
             // Fetch the annotations dictionary once and only once, because this.annotationsDictionary might get updated by another thread.
-            VersioningDictionary<IEdmElement, object> annotationsDictionary = this.annotationsDictionary;
+            VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>> annotationsDictionary = this.annotationsDictionary;
 
             IEnumerable<IEdmDirectValueAnnotation> immutableAnnotations = this.GetAttachedAnnotations(element);
-            object transientAnnotations = GetTransientAnnotations(element, annotationsDictionary);
+            VersioningList<IEdmDirectValueAnnotation> transientAnnotations = GetTransientAnnotations(element, annotationsDictionary);
 
             if (immutableAnnotations != null)
             {
@@ -94,7 +94,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             {
                 // Use a local variable to store any interim changes to the annotations dictionary, and perform one atomic update
                 // to the field. Otherwise, other threads could see a dictionary in an interim state.
-                VersioningDictionary<IEdmElement, object> annotationsDictionary = this.annotationsDictionary;
+                VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>> annotationsDictionary = this.annotationsDictionary;
                 this.SetAnnotationValue(element, namespaceName, localName, value, ref annotationsDictionary);
 
                 this.annotationsDictionary = annotationsDictionary;
@@ -111,7 +111,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             {
                 // Use a local variable to store any interim changes to the annotations dictionary, and perform one atomic update
                 // to the field. Otherwise, other threads could see a dictionary in an interim state.
-                VersioningDictionary<IEdmElement, object> annotationsDictionary = this.annotationsDictionary;
+                VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>> annotationsDictionary = this.annotationsDictionary;
 
                 foreach (IEdmDirectValueAnnotationBinding annotation in annotations)
                 {
@@ -132,7 +132,7 @@ namespace Microsoft.OData.Edm.Vocabularies
         public object GetAnnotationValue(IEdmElement element, string namespaceName, string localName)
         {
             // Fetch the annotations dictionary once and only once, because this.annotationsDictionary might get updated by another thread.
-            VersioningDictionary<IEdmElement, object> annotationsDictionary = this.annotationsDictionary;
+            VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>> annotationsDictionary = this.annotationsDictionary;
 
             return this.GetAnnotationValue(element, namespaceName, localName, annotationsDictionary);
         }
@@ -145,7 +145,7 @@ namespace Microsoft.OData.Edm.Vocabularies
         public object[] GetAnnotationValues(IEnumerable<IEdmDirectValueAnnotationBinding> annotations)
         {
             // Fetch the annotations dictionary once and only once, because this.annotationsDictionary might get updated by another thread.
-            VersioningDictionary<IEdmElement, object> annotationsDictionary = this.annotationsDictionary;
+            VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>> annotationsDictionary = this.annotationsDictionary;
 
             object[] values = new object[annotations.Count()];
 
@@ -168,7 +168,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             return null;
         }
 
-        private static void SetAnnotation(IEnumerable<IEdmDirectValueAnnotation> immutableAnnotations, ref object transientAnnotations, string namespaceName, string localName, object value)
+        private static void SetAnnotation(IEnumerable<IEdmDirectValueAnnotation> immutableAnnotations, ref VersioningList<IEdmDirectValueAnnotation> transientAnnotations, string namespaceName, string localName, object value)
         {
             bool needTombstone = false;
             if (immutableAnnotations != null)
@@ -201,26 +201,11 @@ namespace Microsoft.OData.Edm.Vocabularies
 
             if (transientAnnotations == null)
             {
-                transientAnnotations = newAnnotation;
+                transientAnnotations = VersioningList<IEdmDirectValueAnnotation>.Create().Add(newAnnotation);
                 return;
             }
 
-            IEdmDirectValueAnnotation singleAnnotation = transientAnnotations as IEdmDirectValueAnnotation;
-            if (singleAnnotation != null)
-            {
-                if (singleAnnotation.NamespaceUri == namespaceName && singleAnnotation.Name == localName)
-                {
-                    transientAnnotations = newAnnotation;
-                }
-                else
-                {
-                    transientAnnotations = VersioningList<IEdmDirectValueAnnotation>.Create().Add(singleAnnotation).Add(newAnnotation);
-                }
-
-                return;
-            }
-
-            VersioningList<IEdmDirectValueAnnotation> annotationsList = (VersioningList<IEdmDirectValueAnnotation>)transientAnnotations;
+            VersioningList<IEdmDirectValueAnnotation> annotationsList = transientAnnotations;
             for (int index = 0; index < annotationsList.Count; index++)
             {
                 IEdmDirectValueAnnotation existingAnnotation = annotationsList[index];
@@ -234,28 +219,17 @@ namespace Microsoft.OData.Edm.Vocabularies
             transientAnnotations = annotationsList.Add(newAnnotation);
         }
 
-        private static IEdmDirectValueAnnotation FindTransientAnnotation(object transientAnnotations, string namespaceName, string localName)
+        private static IEdmDirectValueAnnotation FindTransientAnnotation(VersioningList<IEdmDirectValueAnnotation> transientAnnotations, string namespaceName, string localName)
         {
             if (transientAnnotations != null)
             {
-                IEdmDirectValueAnnotation singleAnnotation = transientAnnotations as IEdmDirectValueAnnotation;
-                if (singleAnnotation != null)
+                VersioningList<IEdmDirectValueAnnotation> annotationsList = transientAnnotations;
+                for (int index = 0; index < annotationsList.Count; index++)
                 {
-                    if (singleAnnotation.NamespaceUri == namespaceName && singleAnnotation.Name == localName)
+                    IEdmDirectValueAnnotation existingAnnotation = annotationsList[index];
+                    if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
                     {
-                        return singleAnnotation;
-                    }
-                }
-                else
-                {
-                    VersioningList<IEdmDirectValueAnnotation> annotationsList = (VersioningList<IEdmDirectValueAnnotation>)transientAnnotations;
-
-                    foreach (IEdmDirectValueAnnotation existingAnnotation in annotationsList)
-                    {
-                        if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
-                        {
-                            return existingAnnotation;
-                        }
+                        return existingAnnotation;
                     }
                 }
             }
@@ -263,65 +237,34 @@ namespace Microsoft.OData.Edm.Vocabularies
             return null;
         }
 
-        private static void RemoveTransientAnnotation(ref object transientAnnotations, string namespaceName, string localName)
+        private static void RemoveTransientAnnotation(ref VersioningList<IEdmDirectValueAnnotation> transientAnnotations, string namespaceName, string localName)
         {
             if (transientAnnotations != null)
             {
-                IEdmDirectValueAnnotation singleAnnotation = transientAnnotations as IEdmDirectValueAnnotation;
-                if (singleAnnotation != null)
+                VersioningList<IEdmDirectValueAnnotation> annotationsList = transientAnnotations;
+                for (int index = 0; index < annotationsList.Count; index++)
                 {
-                    if (singleAnnotation.NamespaceUri == namespaceName && singleAnnotation.Name == localName)
+                    IEdmDirectValueAnnotation existingAnnotation = annotationsList[index];
+                    if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
                     {
-                        transientAnnotations = null;
+                        transientAnnotations = annotationsList.RemoveAt(index);
                         return;
-                    }
-                }
-                else
-                {
-                    VersioningList<IEdmDirectValueAnnotation> annotationsList = (VersioningList<IEdmDirectValueAnnotation>)transientAnnotations;
-                    for (int index = 0; index < annotationsList.Count; index++)
-                    {
-                        IEdmDirectValueAnnotation existingAnnotation = annotationsList[index];
-                        if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
-                        {
-                            annotationsList = annotationsList.RemoveAt(index);
-                            if (annotationsList.Count == 1)
-                            {
-                                transientAnnotations = annotationsList[0];
-                            }
-                            else
-                            {
-                                transientAnnotations = annotationsList;
-                            }
-
-                            return;
-                        }
                     }
                 }
             }
         }
 
-        private static IEnumerable<IEdmDirectValueAnnotation> TransientAnnotations(object transientAnnotations)
+        private static IEnumerable<IEdmDirectValueAnnotation> TransientAnnotations(VersioningList<IEdmDirectValueAnnotation> transientAnnotations)
         {
             if (transientAnnotations == null)
             {
                 yield break;
             }
 
-            IEdmDirectValueAnnotation singleAnnotation = transientAnnotations as IEdmDirectValueAnnotation;
-            if (singleAnnotation != null)
+            VersioningList<IEdmDirectValueAnnotation> annotationsList = transientAnnotations;
+            for (int index = 0; index < annotationsList.Count; index++)
             {
-                if (singleAnnotation.Value != null)
-                {
-                    yield return singleAnnotation;
-                }
-
-                yield break;
-            }
-
-            VersioningList<IEdmDirectValueAnnotation> annotationsList = (VersioningList<IEdmDirectValueAnnotation>)transientAnnotations;
-            foreach (IEdmDirectValueAnnotation existingAnnotation in annotationsList)
-            {
+                IEdmDirectValueAnnotation existingAnnotation = annotationsList[index];
                 if (existingAnnotation.Value != null)
                 {
                     yield return existingAnnotation;
@@ -329,7 +272,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             }
         }
 
-        private static bool IsDead(string namespaceName, string localName, object transientAnnotations)
+        private static bool IsDead(string namespaceName, string localName, VersioningList<IEdmDirectValueAnnotation> transientAnnotations)
         {
             return FindTransientAnnotation(transientAnnotations, namespaceName, localName) != null;
         }
@@ -341,17 +284,17 @@ namespace Microsoft.OData.Edm.Vocabularies
         /// <param name="annotationsDictionary">The dictionary for looking up the element's annotations.</param>
         /// <returns>The transient annotations for the element, in a form managed by the annotations manager.</returns>
         /// <remarks>This method is static to guarantee that the annotations dictionary is not fetched more than once per lookup operation.</remarks>
-        private static object GetTransientAnnotations(IEdmElement element, VersioningDictionary<IEdmElement, object> annotationsDictionary)
+        private static VersioningList<IEdmDirectValueAnnotation> GetTransientAnnotations(IEdmElement element, VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>> annotationsDictionary)
         {
-            object transientAnnotations;
+            VersioningList<IEdmDirectValueAnnotation> transientAnnotations;
             annotationsDictionary.TryGetValue(element, out transientAnnotations);
             return transientAnnotations;
         }
 
-        private void SetAnnotationValue(IEdmElement element, string namespaceName, string localName, object value, ref VersioningDictionary<IEdmElement, object> annotationsDictionary)
+        private void SetAnnotationValue(IEdmElement element, string namespaceName, string localName, object value, ref VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>> annotationsDictionary)
         {
-            object transientAnnotations = GetTransientAnnotations(element, annotationsDictionary);
-            object transientAnnotationsBeforeSet = transientAnnotations;
+            VersioningList<IEdmDirectValueAnnotation> transientAnnotations = GetTransientAnnotations(element, annotationsDictionary);
+            VersioningList<IEdmDirectValueAnnotation> transientAnnotationsBeforeSet = transientAnnotations;
             SetAnnotation(this.GetAttachedAnnotations(element), ref transientAnnotations, namespaceName, localName, value);
 
             // There is at least one case (removing an annotation that was not present to begin with) where the transient annotations are not changed,
@@ -362,7 +305,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             }
         }
 
-        private object GetAnnotationValue(IEdmElement element, string namespaceName, string localName, VersioningDictionary<IEdmElement, object> annotationsDictionary)
+        private object GetAnnotationValue(IEdmElement element, string namespaceName, string localName, VersioningDictionary<IEdmElement, VersioningList<IEdmDirectValueAnnotation>> annotationsDictionary)
         {
             IEdmDirectValueAnnotation annotation = FindTransientAnnotation(GetTransientAnnotations(element, annotationsDictionary), namespaceName, localName);
             if (annotation != null)

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
@@ -173,9 +173,13 @@ namespace Microsoft.OData.Edm.Vocabularies
             bool needTombstone = false;
             if (immutableAnnotations != null)
             {
-                if (immutableAnnotations.Any(existingAnnotation => existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName))
+                foreach (var existingAnnotation in immutableAnnotations)
                 {
-                    needTombstone = true;
+                    if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
+                    {
+                        needTombstone = true;
+                        break;
+                    }
                 }
             }
 
@@ -245,8 +249,14 @@ namespace Microsoft.OData.Edm.Vocabularies
                 else
                 {
                     VersioningList<IEdmDirectValueAnnotation> annotationsList = (VersioningList<IEdmDirectValueAnnotation>)transientAnnotations;
-                    return annotationsList.FirstOrDefault(
-                        existingAnnotation => existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName);
+
+                    foreach (IEdmDirectValueAnnotation existingAnnotation in annotationsList)
+                    {
+                        if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
+                        {
+                            return existingAnnotation;
+                        }
+                    }
                 }
             }
 
@@ -277,7 +287,7 @@ namespace Microsoft.OData.Edm.Vocabularies
                             annotationsList = annotationsList.RemoveAt(index);
                             if (annotationsList.Count == 1)
                             {
-                                transientAnnotations = annotationsList.Single();
+                                transientAnnotations = annotationsList[0];
                             }
                             else
                             {

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
@@ -205,28 +205,29 @@ namespace Microsoft.OData.Edm.Vocabularies
                 return;
             }
 
-            VersioningList<IEdmDirectValueAnnotation> annotationsList = transientAnnotations;
-            for (int index = 0; index < annotationsList.Count; index++)
+            for (int index = 0; index < transientAnnotations.Count; index++)
             {
-                IEdmDirectValueAnnotation existingAnnotation = annotationsList[index];
+                IEdmDirectValueAnnotation existingAnnotation = transientAnnotations[index];
                 if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
                 {
-                    annotationsList = annotationsList.RemoveAt(index);
+                    transientAnnotations = transientAnnotations.RemoveAt(index);
                     break;
                 }
             }
 
-            transientAnnotations = annotationsList.Add(newAnnotation);
+            transientAnnotations = transientAnnotations.Add(newAnnotation);
         }
 
         private static IEdmDirectValueAnnotation FindTransientAnnotation(VersioningList<IEdmDirectValueAnnotation> transientAnnotations, string namespaceName, string localName)
         {
             if (transientAnnotations != null)
             {
-                VersioningList<IEdmDirectValueAnnotation> annotationsList = transientAnnotations;
-                for (int index = 0; index < annotationsList.Count; index++)
+                // This method runs very hot in AGS, it is important to optimize it as much as possible.
+                // 1. Doing indexed 'for' loop to avoid allocation of VersioningList enumerator.
+                // 2. VersioningList random access is O(1) because it uses ArrayVersioningList.
+                for (int index = 0; index < transientAnnotations.Count; index++)
                 {
-                    IEdmDirectValueAnnotation existingAnnotation = annotationsList[index];
+                    IEdmDirectValueAnnotation existingAnnotation = transientAnnotations[index];
                     if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
                     {
                         return existingAnnotation;
@@ -241,13 +242,12 @@ namespace Microsoft.OData.Edm.Vocabularies
         {
             if (transientAnnotations != null)
             {
-                VersioningList<IEdmDirectValueAnnotation> annotationsList = transientAnnotations;
-                for (int index = 0; index < annotationsList.Count; index++)
+                for (int index = 0; index < transientAnnotations.Count; index++)
                 {
-                    IEdmDirectValueAnnotation existingAnnotation = annotationsList[index];
+                    IEdmDirectValueAnnotation existingAnnotation = transientAnnotations[index];
                     if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
                     {
-                        transientAnnotations = annotationsList.RemoveAt(index);
+                        transientAnnotations = transientAnnotations.RemoveAt(index);
                         return;
                     }
                 }
@@ -261,10 +261,9 @@ namespace Microsoft.OData.Edm.Vocabularies
                 yield break;
             }
 
-            VersioningList<IEdmDirectValueAnnotation> annotationsList = transientAnnotations;
-            for (int index = 0; index < annotationsList.Count; index++)
+            for (int index = 0; index < transientAnnotations.Count; index++)
             {
-                IEdmDirectValueAnnotation existingAnnotation = annotationsList[index];
+                IEdmDirectValueAnnotation existingAnnotation = transientAnnotations[index];
                 if (existingAnnotation.Value != null)
                 {
                     yield return existingAnnotation;

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
@@ -222,7 +222,7 @@ namespace Microsoft.OData.Edm.Vocabularies
         {
             if (transientAnnotations != null)
             {
-                // This method runs very hot in AGS, it is important to optimize it as much as possible.
+                // This method runs very hot in schemas where direct value annotations are used.
                 // 1. Doing indexed 'for' loop to avoid allocation of VersioningList enumerator.
                 // 2. VersioningList random access is O(1) because it uses ArrayVersioningList.
                 for (int index = 0; index < transientAnnotations.Count; index++)

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
@@ -173,7 +173,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             bool needTombstone = false;
             if (immutableAnnotations != null)
             {
-                foreach (var existingAnnotation in immutableAnnotations)
+                foreach (IEdmDirectValueAnnotation existingAnnotation in immutableAnnotations)
                 {
                     if (existingAnnotation.NamespaceUri == namespaceName && existingAnnotation.Name == localName)
                     {

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/VersioningListTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/VersioningListTests.cs
@@ -29,27 +29,27 @@ namespace EdmLibTests.FunctionalTests
             TestList(list1, 0);
 
             VersioningList<int> list2 = list1.Add(0);
-            Assert.IsTrue(list2 is VersioningList<int>.LinkedVersioningList, "List type");
+            Assert.IsTrue(list2 is VersioningList<int>.ArrayVersioningList, "List type");
             TestList(list2, 1);
 
             VersioningList<int> list3 = list1.Add(0);
-            Assert.IsTrue(list3 is VersioningList<int>.LinkedVersioningList, "List type");
+            Assert.IsTrue(list3 is VersioningList<int>.ArrayVersioningList, "List type");
             TestList(list3, 1);
 
             VersioningList<int> list4 = list2.Add(10);
-            Assert.IsTrue(list4 is VersioningList<int>.LinkedVersioningList, "List type");
+            Assert.IsTrue(list4 is VersioningList<int>.ArrayVersioningList, "List type");
             TestList(list4, 2);
 
             VersioningList<int> list5 = list4.Add(20);
-            Assert.IsTrue(list5 is VersioningList<int>.LinkedVersioningList, "List type");
+            Assert.IsTrue(list5 is VersioningList<int>.ArrayVersioningList, "List type");
             TestList(list5, 3);
 
             VersioningList<int> list6 = list5.Add(30);
-            Assert.IsTrue(list6 is VersioningList<int>.LinkedVersioningList, "List type");
+            Assert.IsTrue(list6 is VersioningList<int>.ArrayVersioningList, "List type");
             TestList(list6, 4);
 
             VersioningList<int> list7 = list6.Add(40);
-            Assert.IsTrue(list7 is VersioningList<int>.LinkedVersioningList, "List type");
+            Assert.IsTrue(list7 is VersioningList<int>.ArrayVersioningList, "List type");
             TestList(list7, 5);
 
             VersioningList<int> list8 = list7.Add(50);
@@ -57,7 +57,7 @@ namespace EdmLibTests.FunctionalTests
             TestList(list8, 6);
 
             VersioningList<int> list9 = list8.Add(60);
-            Assert.IsTrue(list9 is VersioningList<int>.LinkedVersioningList, "List type");
+            Assert.IsTrue(list9 is VersioningList<int>.ArrayVersioningList, "List type");
             TestList(list9, 7);
 
             TestList(list8, 6);


### PR DESCRIPTION
### Issues

Total allocation of this method is at 3.09%: 
- 1% for delegate
- 1.61% for enumerator
- 0.48% for closure.

![image](https://user-images.githubusercontent.com/24846248/128579753-e439029b-b580-46c9-bd3b-42d53ab5b44a.png)

### Description

This change replaces the usage of Linq in this method, with manual implementation, avoiding lambda allocation. Every time we invoke Any, it allocates a lambda. This is normally meaningless, when not present in the hot path. Since this is present in AGS hot path, it is costing 1% of allocations just in this lambda. This is a lot.

Also removes the usage of enumerator, replacing with O(1) random access for loop. The ArrayVersioningList is better for search scenarios because we can save the enumerator allocation all together, and use O(1) random access. The LinkedVersioningList would only be useful if this data structure is changing very often at runtime, which I don't think is the case? Main scenario will be search at runtime? So I am proposing to replace with ArrayVersioningList. Furthermore, when adding a new element, it was swapping to ArrayVersioningList if there were 5 or more elements, hence I don't really see the benefit of not using ArrayVersioningList for all cases, particular if the search scenario is the main path.

Not using Linq.Any(), is not only good for memory but also for CPU as we can see in this benchmark:

![image](https://user-images.githubusercontent.com/24846248/128568057-54bf920e-1869-4d19-9e70-efdb81c5d209.png)

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*