### PR TITLE
Fix AggregateException thrown by OData writers async API

### DIFF
--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -190,8 +190,9 @@ namespace Microsoft.OData
         {
             this.VerifyCanWriteEndBatch(false);
             await this.WriteEndBatchImplementationAsync()
-                // Note that we intentionally go through the public API so that if the Flush fails the writer moves to the Error state.
-                .FollowOnSuccessWithTask(task => this.FlushAsync())
+                .ConfigureAwait(false);
+            // Note that we intentionally go through the public API so that if the FlushAsync fails the writer moves to the Error state.
+            await this.FlushAsync()
                 .ConfigureAwait(false);
         }
 
@@ -238,8 +239,8 @@ namespace Microsoft.OData
 
             this.VerifyCanWriteStartChangeset(false);
             await this.WriteStartChangesetImplementationAsync(changesetId)
-                .FollowOnSuccessWith(t => this.FinishWriteStartChangeset())
                 .ConfigureAwait(false);
+            this.FinishWriteStartChangeset();
         }
 
         /// <summary>Ends an active changeset; this can only be called after WriteStartChangeset and only once for each changeset.</summary>
@@ -256,8 +257,8 @@ namespace Microsoft.OData
         {
             this.VerifyCanWriteEndChangeset(false);
             await this.WriteEndChangesetImplementationAsync()
-                .FollowOnSuccessWith(t => this.FinishWriteEndChangeset())
                 .ConfigureAwait(false);
+            this.FinishWriteEndChangeset();
         }
 
         /// <summary>Creates an <see cref="Microsoft.OData.ODataBatchOperationRequestMessage" /> for writing an operation of a batch request.</summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchWriter.cs
@@ -182,8 +182,8 @@ namespace Microsoft.OData.JsonLight
             // Asynchronously flush the async buffered stream to the underlying message stream (if there's any);
             // then dispose the batch writer (since we are now writing the operation content) and set the corresponding state.
             await this.JsonLightOutputContext.FlushBuffersAsync()
-                .FollowOnSuccessWith(task => this.SetState(BatchWriterState.OperationStreamRequested))
                 .ConfigureAwait(false);
+            this.SetState(BatchWriterState.OperationStreamRequested);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -519,7 +519,8 @@ namespace Microsoft.OData.JsonLight
 
             Debug.Assert(this.asynchronousOutputStream != null, "In async writing we must have the async buffered stream.");
             await this.asynchronousOutputStream.FlushAsync()
-                .FollowOnSuccessWithTask(_ => this.messageOutputStream.FlushAsync())
+                .ConfigureAwait(false);
+            await this.messageOutputStream.FlushAsync()
                 .ConfigureAwait(false);
         }
 

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -124,8 +124,8 @@ namespace Microsoft.OData.MultipartMixed
             // Asynchronously flush the async buffered stream to the underlying message stream (if there's any);
             // then dispose the batch writer (since we are now writing the operation content) and set the corresponding state.
             await this.RawOutputContext.FlushBuffersAsync()
-                .FollowOnSuccessWith(task => this.DisposeBatchWriterAndSetContentStreamRequestedState())
                 .ConfigureAwait(false);
+            this.DisposeBatchWriterAndSetContentStreamRequestedState();
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
@@ -230,19 +230,14 @@ namespace Microsoft.OData
         {
             this.VerifyCanWriteEnd(false);
             await this.WriteEndImplementationAsync()
-                .FollowOnSuccessWithTask(
-                    task =>
-                    {
-                        if (this.scopes.Peek().State == CollectionWriterState.Completed)
-                        {
-                            // Note that we intentionally go through the public API so that if the Flush fails the writer moves to the Error state.
-                            return this.FlushAsync();
-                        }
-                        else
-                        {
-                            return TaskUtils.CompletedTask;
-                        }
-                    }).ConfigureAwait(false);
+                .ConfigureAwait(false);
+
+            if (this.scopes.Peek().State == CollectionWriterState.Completed)
+            {
+                // Note that we intentionally go through the public API so that if the FlushAsync fails the writer moves to the Error state.
+                await this.FlushAsync()
+                    .ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -272,19 +272,18 @@ namespace Microsoft.OData
         {
             this.VerifyCanWriteEnd(false /*synchronousCall*/);
             await this.InterceptExceptionAsync(
-                () => this.WriteEndImplementationAsync()).FollowOnSuccessWithTask(
-                    task =>
+                async () =>
+                {
+                    await this.WriteEndImplementationAsync()
+                        .ConfigureAwait(false);
+
+                    if (this.State == ParameterWriterState.Completed)
                     {
-                        if (this.State == ParameterWriterState.Completed)
-                        {
-                            // Note that we intentionally go through the public API so that if the Flush fails the writer moves to the Error state.
-                            return this.FlushAsync();
-                        }
-                        else
-                        {
-                            return TaskUtils.CompletedTask;
-                        }
-                    }).ConfigureAwait(false);
+                        // Note that we intentionally go through the public API so that if the FlushAsync fails the writer moves to the Error state.
+                        await this.FlushAsync()
+                            .ConfigureAwait(false);
+                    }
+                }).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataRawOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawOutputContext.cs
@@ -133,7 +133,8 @@ namespace Microsoft.OData
 
             Debug.Assert(this.asynchronousOutputStream != null, "In async writing we must have the async buffered stream.");
             await this.asynchronousOutputStream.FlushAsync()
-                .FollowOnSuccessWithTask((asyncBufferedStreamFlushTask) => this.messageOutputStream.FlushAsync())
+                .ConfigureAwait(false);
+            await this.messageOutputStream.FlushAsync()
                 .ConfigureAwait(false);
         }
 

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -692,19 +692,13 @@ namespace Microsoft.OData
         {
             this.VerifyCanWriteEnd(false);
             await this.WriteEndImplementationAsync()
-                .FollowOnSuccessWithTask(
-                    task =>
-                    {
-                        if (this.CurrentScope.State == WriterState.Completed)
-                        {
-                            // Note that we intentionally go through the public API so that if the Flush fails the writer moves to the Error state.
-                            return this.FlushAsync();
-                        }
-                        else
-                        {
-                            return TaskUtils.CompletedTask;
-                        }
-                    }).ConfigureAwait(false);
+                .ConfigureAwait(false);
+
+            if (this.CurrentScope.State == WriterState.Completed)
+            {
+                await this.FlushAsync()
+                    .ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -1788,7 +1782,9 @@ namespace Microsoft.OData
         {
             EnterScope(deltaLink is ODataDeltaLink ? WriterState.DeltaLink : WriterState.DeltaDeletedLink, deltaLink);
             await this.StartDeltaLinkAsync(deltaLink)
-                .FollowOnSuccessWithTask((t) => WriteEndAsync()).ConfigureAwait(false);
+                .ConfigureAwait(false);
+            await this.WriteEndAsync()
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1873,7 +1869,9 @@ namespace Microsoft.OData
                 }
 
                 await WritePrimitiveValueAsync(primitiveValue)
-                    .FollowOnSuccessWithTask((t) => WriteEndAsync()).ConfigureAwait(false);
+                    .ConfigureAwait(false);
+                await this.WriteEndAsync()
+                    .ConfigureAwait(false);
             }).ConfigureAwait(false);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
@@ -495,7 +495,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
         [Fact]
         public async Task WriteBatchRequestAsync_ThrowsExceptionForChangesetStartedWithinChangeset()
         {
-            var exception = await Assert.ThrowsAsync<AggregateException>(
+            var exception = await Assert.ThrowsAsync<ODataException>(
                 () => SetupJsonLightBatchWriterAndRunTestAsync(
                     async (jsonLightBatchWriter) =>
                     {
@@ -505,14 +505,13 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                         await jsonLightBatchWriter.WriteStartChangesetAsync();
                     }));
 
-            Assert.IsType<ODataException>(exception.InnerException);
-            Assert.Equal(Strings.ODataBatchWriter_CannotStartChangeSetWithActiveChangeSet, exception.InnerException.Message);
+            Assert.Equal(Strings.ODataBatchWriter_CannotStartChangeSetWithActiveChangeSet, exception.Message);
         }
 
         [Fact]
         public async Task WriteBatchRequestAsync_ThrowsExceptionForEndChangesetNotPrecededByStartChangeset()
         {
-            var exception = await Assert.ThrowsAsync<AggregateException>(
+            var exception = await Assert.ThrowsAsync<ODataException>(
                 () => SetupJsonLightBatchWriterAndRunTestAsync(
                     async (jsonLightBatchWriter) =>
                     {
@@ -521,14 +520,13 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                         await jsonLightBatchWriter.WriteEndChangesetAsync();
                     }));
 
-            Assert.IsType<ODataException>(exception.InnerException);
-            Assert.Equal(Strings.ODataBatchWriter_CannotCompleteChangeSetWithoutActiveChangeSet, exception.InnerException.Message);
+            Assert.Equal(Strings.ODataBatchWriter_CannotCompleteChangeSetWithoutActiveChangeSet, exception.Message);
         }
 
         [Fact]
         public async Task WriteBatchRequestAsync_ThrowsExceptionForEndBatchBeforeEndChangeset()
         {
-            var exception = await Assert.ThrowsAsync<AggregateException>(
+            var exception = await Assert.ThrowsAsync<ODataException>(
                 () => SetupJsonLightBatchWriterAndRunTestAsync(
                     async (jsonLightBatchWriter) =>
                     {
@@ -538,14 +536,13 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                         await jsonLightBatchWriter.WriteEndBatchAsync();
                     }));
 
-            Assert.IsType<ODataException>(exception.InnerException);
-            Assert.Equal(Strings.ODataBatchWriter_CannotCompleteBatchWithActiveChangeSet, exception.InnerException.Message);
+            Assert.Equal(Strings.ODataBatchWriter_CannotCompleteBatchWithActiveChangeSet, exception.Message);
         }
 
         [Fact]
         public async Task WriteBatchRequestAsync_ThrowsExceptionForNoStartBatch()
         {
-            var exception = await Assert.ThrowsAsync<AggregateException>(
+            var exception = await Assert.ThrowsAsync<ODataException>(
                 () => SetupJsonLightBatchWriterAndRunTestAsync(
                 async (jsonLightBatchWriter) =>
                 {
@@ -553,8 +550,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     await jsonLightBatchWriter.WriteStartChangesetAsync();
                 }));
 
-            Assert.IsType<ODataException>(exception.InnerException);
-            Assert.Equal(Strings.ODataBatchWriter_InvalidTransitionFromStart, exception.InnerException.Message);
+            Assert.Equal(Strings.ODataBatchWriter_InvalidTransitionFromStart, exception.Message);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightParameterWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightParameterWriterTests.cs
@@ -918,6 +918,37 @@ namespace Microsoft.OData.Tests.JsonLight
                     (jsonLightParameterWriter) => jsonLightParameterWriter.CreateResourceSetWriterAsync(null)));
         }
 
+        [Fact]
+        public async Task WriteStartAsync_ThrowsExceptionForWriterInCanWriteParameterState()
+        {
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                async () =>
+                {
+                    var jsonLightOutputContext = CreateJsonLightOutputContext(new MemoryStream(), writingResponse: false, synchronous: false);
+                    var jsonLightParameterWriter = new ODataJsonLightParameterWriter(jsonLightOutputContext, operation: null);
+
+                    await jsonLightParameterWriter.WriteStartAsync();
+                    await jsonLightParameterWriter.WriteStartAsync();
+                });
+
+            Assert.Equal(Strings.ODataParameterWriterCore_CannotWriteStart, exception.Message);
+        }
+
+        [Fact]
+        public async Task WriteEndAsync_ThrowsExceptionForWriterInStartState()
+        {
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                async () =>
+                {
+                    var jsonLightOutputContext = CreateJsonLightOutputContext(new MemoryStream(), writingResponse: false, synchronous: false);
+                    var jsonLightParameterWriter = new ODataJsonLightParameterWriter(jsonLightOutputContext, operation: null);
+
+                    await jsonLightParameterWriter.WriteEndAsync();
+                });
+
+            Assert.Equal(Strings.ODataParameterWriterCore_CannotWriteEnd, exception.Message);
+        }
+
         /// <summary>
         /// Sets up an ODataJsonLightParameterWriter,
         /// then runs the given test code asynchronously,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
@@ -1700,10 +1700,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
             var customerResource = CreateCustomerResource();
             var orderCollectionNestedResourceInfo = CreateOrderCollectionNestedResourceInfo();
 
-            // TODO: Create a PR to fix TaskUtils.FollowOnSuccessWithContinuation such that the
-            // InnerException (ODataException) is set in the TaskCompletionSource object
-            // rather than AggregateException
-            var exception = await Assert.ThrowsAsync<AggregateException>(
+            var exception = await Assert.ThrowsAsync<ODataException>(
                 () => SetupJsonLightWriterAndRunTestAsync(
                 async (jsonLightWriter) =>
                 {
@@ -1721,8 +1718,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                 /*writingParameter*/ false,
                 /*writingRequest*/ true));
 
-            Assert.IsType<ODataException>(exception.InnerException);
-            Assert.Equal(Strings.ODataWriterCore_DeferredLinkInRequest, exception.InnerException.Message);
+            Assert.Equal(Strings.ODataWriterCore_DeferredLinkInRequest, exception.Message);
         }
 
         [Fact]
@@ -1753,7 +1749,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
         {
             var customerResource = CreateCustomerResource();
 
-            var exception = await Assert.ThrowsAsync<AggregateException>(
+            var exception = await Assert.ThrowsAsync<ODataException>(
                 () => SetupJsonLightWriterAndRunTestAsync(
                     async (jsonLightWriter) =>
                     {
@@ -1766,10 +1762,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     this.customerEntitySet,
                     this.customerEntityType));
 
-            Assert.IsType<ODataException>(exception.InnerException);
-            Assert.Equal(
-                Strings.ODataWriterCore_WriteEndCalledInInvalidState("Completed"),
-                exception.InnerException.Message);
+            Assert.Equal(Strings.ODataWriterCore_WriteEndCalledInInvalidState("Completed"), exception.Message);
         }
 
         [Fact]
@@ -1784,7 +1777,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                 ContentType = "text/plain"
             };
 
-            var exception = await Assert.ThrowsAsync<AggregateException>(
+            var exception = await Assert.ThrowsAsync<ODataException>(
                 () => SetupJsonLightWriterAndRunTestAsync(
                 async (jsonLightWriter) =>
                 {
@@ -1804,8 +1797,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                 this.orderEntitySet,
                 this.orderEntityType));
 
-            Assert.IsType<ODataException>(exception.InnerException);
-            Assert.Equal(Strings.ODataWriterCore_StreamNotDisposed, exception.InnerException.Message);
+            Assert.Equal(Strings.ODataWriterCore_StreamNotDisposed, exception.Message);
         }
 
         #endregion Exception Cases


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request is in partial fulfilment of issue #2019.
Fix `AggregateException` thrown by OData writers async API

### Description

As indicated in [this TODO](https://github.com/OData/odata.net/blob/d49b8b9d9a77816b2cf6664be6493ae71906fc0b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs#L1703), there was a scenario causing an `AggregateException` to be thrown instead of the expected `ODataException`. This PR fixes that by avoiding the use of `TaskUtils.FollowSuccessWithTask` that was responsible for that behaviour.

In the process added a bunch of tests to verify behaviour in scenarios where exceptions are thrown.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
