### PR TITLE
method to get all navigation property bindings

### DIFF
--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1646,6 +1646,39 @@ namespace Microsoft.OData.Edm
             return container.AllElements().OfType<IEdmOperationImport>();
         }
 
+        /// <summary>
+        /// Returns NavigationPropertyBindings with their corresponding container elements (EntitySet or Singelton)
+        /// </summary>
+        /// <param name="container">Reference to the calling object.</param>
+        /// <returns>collection of pairs of container element and NavigationPropertyBindings.</returns>
+        public static IEnumerable<(IEdmEntityContainerElement, IEdmNavigationPropertyBinding)> GetNavigationPropertyBindings(this IEdmEntityContainer container)
+        {
+            EdmUtil.CheckArgumentNull(container, "container");
+
+            var elements = container.AllElements();
+            foreach(var element in elements)
+            {
+                switch (element)
+                {
+                    case IEdmEntitySet entitySet:
+                        foreach(var binding in entitySet.NavigationPropertyBindings)
+                        {
+                            yield return (entitySet, binding);
+                        }
+                        break;
+                    case IEdmSingleton singleton:
+                        foreach (var binding in singleton.NavigationPropertyBindings)
+                        {
+                            yield return (singleton, binding);
+                        }
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+
+
         #endregion
 
         #region IEdmTypeReference

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1651,7 +1651,7 @@ namespace Microsoft.OData.Edm
         /// </summary>
         /// <param name="container">Reference to the calling object.</param>
         /// <returns>collection of pairs of container element and NavigationPropertyBindings.</returns>
-        public static IEnumerable<(IEdmEntityContainerElement, IEdmNavigationPropertyBinding)> GetNavigationPropertyBindings(this IEdmEntityContainer container)
+        public static IEnumerable<Tuple<IEdmEntityContainerElement, IEdmNavigationPropertyBinding>> GetNavigationPropertyBindings(this IEdmEntityContainer container)
         {
             EdmUtil.CheckArgumentNull(container, "container");
 
@@ -1663,13 +1663,13 @@ namespace Microsoft.OData.Edm
                     case IEdmEntitySet entitySet:
                         foreach(var binding in entitySet.NavigationPropertyBindings)
                         {
-                            yield return (entitySet, binding);
+                            yield return Tuple.Create<IEdmEntityContainerElement, IEdmNavigationPropertyBinding>(entitySet, binding);
                         }
                         break;
                     case IEdmSingleton singleton:
                         foreach (var binding in singleton.NavigationPropertyBindings)
                         {
-                            yield return (singleton, binding);
+                            yield return Tuple.Create< IEdmEntityContainerElement, IEdmNavigationPropertyBinding>(singleton, binding);
                         }
                         break;
                     default:

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1647,10 +1647,10 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Returns NavigationPropertyBindings with their corresponding container elements (EntitySet or Singelton)
+        /// Returns navigation property bindings with their corresponding container elements (entity set or singleton)
         /// </summary>
         /// <param name="container">Reference to the calling object.</param>
-        /// <returns>collection of pairs of container element and NavigationPropertyBindings.</returns>
+        /// <returns>Collection of pairs of container element and navigation property bindings.</returns>
         public static IEnumerable<Tuple<IEdmEntityContainerElement, IEdmNavigationPropertyBinding>> GetNavigationPropertyBindings(this IEdmEntityContainer container)
         {
             EdmUtil.CheckArgumentNull(container, "container");

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1655,19 +1655,20 @@ namespace Microsoft.OData.Edm
         {
             EdmUtil.CheckArgumentNull(container, "container");
 
-            var elements = container.AllElements();
-            foreach(var element in elements)
+            IEnumerable<IEdmEntityContainerElement> elements = container.AllElements();
+
+            foreach(IEdmEntityContainerElement element in elements)
             {
                 switch (element)
                 {
                     case IEdmEntitySet entitySet:
-                        foreach(var binding in entitySet.NavigationPropertyBindings)
+                        foreach(IEdmNavigationPropertyBinding binding in entitySet.NavigationPropertyBindings)
                         {
                             yield return Tuple.Create<IEdmEntityContainerElement, IEdmNavigationPropertyBinding>(entitySet, binding);
                         }
                         break;
                     case IEdmSingleton singleton:
-                        foreach (var binding in singleton.NavigationPropertyBindings)
+                        foreach (IEdmNavigationPropertyBinding binding in singleton.NavigationPropertyBindings)
                         {
                             yield return Tuple.Create< IEdmEntityContainerElement, IEdmNavigationPropertyBinding>(singleton, binding);
                         }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsEntityContainerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsEntityContainerTests.cs
@@ -70,5 +70,28 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Semantics
             Assert.Equal(EdmContainerElementKind.ActionImport, imports[0].ContainerElementKind);
             Assert.Null(imports[0].EntitySet);
         }
+
+        [Fact]
+        public void NavigationPropertyBindingsReturned()
+        {
+            // arrange
+            var entitySet1 = new CsdlEntitySet("EntitySet1", "unknown", new[] { 
+                new CsdlNavigationPropertyBinding("foo", "bar", testLocation)
+            }, testLocation);
+            var singleton1 = new CsdlSingleton("Singleton", "unknown", new[] {
+                new CsdlNavigationPropertyBinding("foo", "bar", testLocation)
+            }, testLocation);
+            var csdlEntityContainer = CsdlBuilder.EntityContainer("Container", entitySets: new [] { entitySet1 }, singletons: new[] { singleton1 } );
+            var schema = CsdlBuilder.Schema("FQ.NS", csdlEntityContainers: new CsdlEntityContainer[] { csdlEntityContainer });
+            var csdlModel = new CsdlModel();
+            csdlModel.AddSchema(schema);
+            
+            // act
+            var container = (IEdmEntityContainer)csdlEntityContainer;
+            var bindings = container.GetNavigationPropertyBindings().ToList();
+
+            // assert
+            Assert.Equal(2, bindings.Count);
+        }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsEntityContainerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsEntityContainerTests.cs
@@ -87,7 +87,14 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Semantics
             csdlModel.AddSchema(schema);
             
             // act
-            var container = (IEdmEntityContainer)csdlEntityContainer;
+            var container = new CsdlSemanticsEntityContainer(
+                new CsdlSemanticsSchema(
+                    new CsdlSemanticsModel(
+                        csdlModel,
+                        new EdmDirectValueAnnotationsManager(),
+                        Enumerable.Empty<IEdmModel>()),
+                    schema),
+                csdlEntityContainer);
             var bindings = container.GetNavigationPropertyBindings().ToList();
 
             // assert

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsEntityContainerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Semantics/CsdlSemanticsEntityContainerTests.cs
@@ -99,6 +99,16 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Semantics
 
             // assert
             Assert.Equal(2, bindings.Count);
+            var entitySet = Assert.IsType<CsdlSemanticsEntitySet>(bindings[0].Item1);
+            var singleton = Assert.IsType<CsdlSemanticsSingleton>(bindings[1].Item1);
+            Assert.Equal("EntitySet1", entitySet.Name);
+            Assert.Equal("Singleton", singleton.Name);
+            var navigationPropertyBinding1 = Assert.IsType<EdmNavigationPropertyBinding>(bindings[0].Item2);
+            var navigationPropertyBinding2 = Assert.IsType<EdmNavigationPropertyBinding>(bindings[1].Item2);
+            Assert.Equal("foo", navigationPropertyBinding1.Path.Path);
+            Assert.Equal("bar", navigationPropertyBinding1.Target.Name);
+            Assert.Equal("foo", navigationPropertyBinding2.Path.Path);
+            Assert.Equal("bar", navigationPropertyBinding2.Target.Name);
         }
     }
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -2028,6 +2028,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static System.Collections.Generic.IEnumerable`1[[System.Tuple`2[[Microsoft.OData.Edm.IEdmEntityContainerElement],[Microsoft.OData.Edm.IEdmNavigationPropertyBinding]]]] GetNavigationPropertyBindings (Microsoft.OData.Edm.IEdmEntityContainer container)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static Microsoft.OData.Edm.IEdmPathExpression GetPartnerPath (Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty)
 
     [

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -2028,6 +2028,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static System.Collections.Generic.IEnumerable`1[[System.Tuple`2[[Microsoft.OData.Edm.IEdmEntityContainerElement],[Microsoft.OData.Edm.IEdmNavigationPropertyBinding]]]] GetNavigationPropertyBindings (Microsoft.OData.Edm.IEdmEntityContainer container)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static Microsoft.OData.Edm.IEdmPathExpression GetPartnerPath (Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty)
 
     [

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -2028,6 +2028,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static System.Collections.Generic.IEnumerable`1[[System.Tuple`2[[Microsoft.OData.Edm.IEdmEntityContainerElement],[Microsoft.OData.Edm.IEdmNavigationPropertyBinding]]]] GetNavigationPropertyBindings (Microsoft.OData.Edm.IEdmEntityContainer container)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static Microsoft.OData.Edm.IEdmPathExpression GetPartnerPath (Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty)
 
     [


### PR DESCRIPTION
Add an officially supported method to get all navigation property bindings.

Retrieving all navigation property bindings requires quite some knowledge of the edm model implementation and casting.
This method encapsulated this logic. 

<!-- markdownlint-disable MD002 MD041 -->

### Issues

addresses #2060 