### PR TITLE
Avoid action allocations calling InterceptException

### DIFF
--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -499,7 +499,7 @@ namespace Microsoft.OData
         /// <param name="newState">The writer state to transition into.</param>
         protected void SetState(BatchWriterState newState)
         {
-            this.InterceptException(() => this.ValidateTransition(newState));
+            this.InterceptException((thisParam, newStateParam) => thisParam.ValidateTransition(newStateParam), newState);
 
             this.state = newState;
         }
@@ -669,11 +669,43 @@ namespace Microsoft.OData
         /// state ExceptionThrown and then re-throw the exception.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        private void InterceptException(Action action)
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private void InterceptException(Action<ODataBatchWriter> action)
         {
             try
             {
-                action();
+                action(this);
+            }
+            catch
+            {
+                if (!IsErrorState(this.state))
+                {
+                    this.SetState(BatchWriterState.Error);
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Catch any exception thrown by the action passed in; in the exception case move the writer into
+        /// state ExceptionThrown and then rethrow the exception.
+        /// </summary>
+        /// <typeparam name="TArg0">The action argument type.</typeparam>
+        /// <param name="action">The action to execute.</param>
+        /// <param name="arg0">The argument value provided to the action.</param>
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private void InterceptException<TArg0>(Action<ODataBatchWriter, TArg0> action, TArg0 arg0)
+        {
+            try
+            {
+                action(this, arg0);
             }
             catch
             {
@@ -716,11 +748,11 @@ namespace Microsoft.OData
         {
             if (!this.isInChangeset)
             {
-                this.InterceptException(this.IncreaseBatchSize);
+                this.InterceptException((thisParam) => thisParam.IncreaseBatchSize());
             }
             else
             {
-                this.InterceptException(this.IncreaseChangeSetSize);
+                this.InterceptException((thisParam) => thisParam.IncreaseChangeSetSize());
             }
 
             // Add a potential Content-ID header to the URL resolver so that it will be available
@@ -733,8 +765,9 @@ namespace Microsoft.OData
                 this.payloadUriConverter.AddContentId(this.currentOperationContentId);
             }
 
-            this.InterceptException(() =>
-                uri = ODataBatchUtils.CreateOperationRequestUri(uri, this.outputContext.MessageWriterSettings.BaseUri, this.payloadUriConverter));
+            // This action delegate is capturing state from the enclosing context, to re-assign the 'uri', hence allocations are incurred here.
+            this.InterceptException((thisParam) =>
+                uri = ODataBatchUtils.CreateOperationRequestUri(uri, thisParam.outputContext.MessageWriterSettings.BaseUri, thisParam.payloadUriConverter));
 
             this.CurrentOperationRequestMessage = this.CreateOperationRequestMessageImplementation(
                 method, uri, contentId, payloadUriOption, dependsOnIds);
@@ -774,11 +807,11 @@ namespace Microsoft.OData
         {
             if (!this.isInChangeset)
             {
-                this.InterceptException(this.IncreaseBatchSize);
+                this.InterceptException((thisParam) => thisParam.IncreaseBatchSize());
             }
             else
             {
-                this.InterceptException(this.IncreaseChangeSetSize);
+                this.InterceptException((thisParam) => thisParam.IncreaseChangeSetSize());
             }
 
             // Add a potential Content-ID header to the URL resolver so that it will be available
@@ -791,8 +824,9 @@ namespace Microsoft.OData
                 this.payloadUriConverter.AddContentId(this.currentOperationContentId);
             }
 
-            this.InterceptException(() =>
-                uri = ODataBatchUtils.CreateOperationRequestUri(uri, this.outputContext.MessageWriterSettings.BaseUri, this.payloadUriConverter));
+            // This action delegate is capturing state from the enclosing context, to re-assign the 'uri', hence allocations are incurred here.
+            this.InterceptException((thisParam) =>
+                uri = ODataBatchUtils.CreateOperationRequestUri(uri, thisParam.outputContext.MessageWriterSettings.BaseUri, thisParam.payloadUriConverter));
 
             this.CurrentOperationRequestMessage = await this.CreateOperationRequestMessageImplementationAsync(
                 method, uri, contentId, payloadUriOption, dependsOnIds).ConfigureAwait(false);
@@ -823,7 +857,7 @@ namespace Microsoft.OData
 
             // reset the size of the current changeset and increase the size of the batch.
             this.ResetChangeSetSize();
-            this.InterceptException(this.IncreaseBatchSize);
+            this.InterceptException((thisParam) => thisParam.IncreaseBatchSize());
             this.isInChangeset = true;
         }
 

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -104,7 +104,7 @@ namespace Microsoft.OData
             this.VerifyCanFlush(true /*synchronousCall*/);
 
             // make sure we switch to writer state Error if an exception is thrown during flushing.
-            this.InterceptException(this.FlushSynchronously);
+            this.InterceptException((thisParam) => thisParam.FlushSynchronously());
         }
 
 
@@ -126,7 +126,7 @@ namespace Microsoft.OData
         public sealed override void WriteStart()
         {
             this.VerifyCanWriteStart(true /*synchronousCall*/);
-            this.InterceptException(() => this.WriteStartImplementation());
+            this.InterceptException((thisParam) => thisParam.WriteStartImplementation());
         }
 
 
@@ -138,7 +138,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanWriteStart(false /*synchronousCall*/);
             await this.InterceptExceptionAsync(
-                () => this.WriteStartImplementationAsync()).ConfigureAwait(false);
+                (thisParam) => thisParam.WriteStartImplementationAsync()).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -150,7 +150,10 @@ namespace Microsoft.OData
         {
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference expectedTypeReference = this.VerifyCanWriteValueParameter(true /*synchronousCall*/, parameterName, parameterValue);
-            this.InterceptException(() => this.WriteValueImplementation(parameterName, parameterValue, expectedTypeReference));
+            this.InterceptException(
+                (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) => 
+                    thisParam.WriteValueImplementation(parameterName, parameterValue, expectedTypeReference),
+                parameterName, parameterValue, expectedTypeReference);
         }
 
 
@@ -165,7 +168,9 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference expectedTypeReference = this.VerifyCanWriteValueParameter(false /*synchronousCall*/, parameterName, parameterValue);
             await this.InterceptExceptionAsync(
-                () => this.WriteValueImplementationAsync(parameterName, parameterValue, expectedTypeReference)).ConfigureAwait(false);
+                (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) => 
+                    thisParam.WriteValueImplementationAsync(parameterNameParam, parameterValueParam, expectedTypeReferenceParam),
+                parameterName, parameterValue, expectedTypeReference).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -177,7 +182,10 @@ namespace Microsoft.OData
         {
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateCollectionWriter(true /*synchronousCall*/, parameterName);
-            return this.InterceptException(() => this.CreateCollectionWriterImplementation(parameterName, itemTypeReference));
+            return this.InterceptException(
+                (thisParam, parameterNameParam, itemTypeReferenceParam) => 
+                    thisParam.CreateCollectionWriterImplementation(parameterNameParam, itemTypeReferenceParam),
+                parameterName, itemTypeReference);
         }
 
 
@@ -192,7 +200,9 @@ namespace Microsoft.OData
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateCollectionWriter(false /*synchronousCall*/, parameterName);
 
             ODataCollectionWriter collectionWriter = await this.InterceptExceptionAsync(
-                () => this.CreateCollectionWriterImplementationAsync(parameterName, itemTypeReference)).ConfigureAwait(false);
+                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                    thisParam.CreateCollectionWriterImplementationAsync(parameterNameParam, itemTypeReferenceParam),
+                parameterName, itemTypeReference).ConfigureAwait(false);
 
             Debug.Assert(collectionWriter != null, "collectionWriter != null");
             return collectionWriter;
@@ -205,7 +215,10 @@ namespace Microsoft.OData
         {
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceWriter(true /*synchronousCall*/, parameterName);
-            return this.InterceptException(() => this.CreateResourceWriterImplementation(parameterName, itemTypeReference));
+            return this.InterceptException(
+                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                    thisParam.CreateResourceWriterImplementation(parameterNameParam, itemTypeReferenceParam),
+                parameterName, itemTypeReference);
         }
 
 
@@ -218,7 +231,9 @@ namespace Microsoft.OData
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceWriter(false /*synchronousCall*/, parameterName);
 
             ODataWriter resourceWriter = await this.InterceptExceptionAsync(
-                () => this.CreateResourceWriterImplementationAsync(parameterName, itemTypeReference)).ConfigureAwait(false);
+                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                    thisParam.CreateResourceWriterImplementationAsync(parameterNameParam, itemTypeReferenceParam),
+                parameterName, itemTypeReference).ConfigureAwait(false);
 
             Debug.Assert(resourceWriter != null, "resourceWriter != null");
             return resourceWriter;
@@ -231,7 +246,10 @@ namespace Microsoft.OData
         {
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceSetWriter(true /*synchronousCall*/, parameterName);
-            return this.InterceptException(() => this.CreateResourceSetWriterImplementation(parameterName, itemTypeReference));
+            return this.InterceptException(
+                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                    thisParam.CreateResourceSetWriterImplementation(parameterNameParam, itemTypeReferenceParam),
+                parameterName, itemTypeReference);
         }
 
 
@@ -244,7 +262,9 @@ namespace Microsoft.OData
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceSetWriter(false /*synchronousCall*/, parameterName);
 
             ODataWriter resourceSetWriter = await this.InterceptExceptionAsync(
-                () => this.CreateResourceSetWriterImplementationAsync(parameterName, itemTypeReference)).ConfigureAwait(false);
+                (thisParam, parameterNameParam, itemTypeReferenceParam) =>
+                    thisParam.CreateResourceSetWriterImplementationAsync(parameterNameParam, itemTypeReferenceParam),
+                parameterName, itemTypeReference).ConfigureAwait(false);
 
             Debug.Assert(resourceSetWriter != null, "resourceSetWriter != null");
             return resourceSetWriter;
@@ -256,7 +276,7 @@ namespace Microsoft.OData
         public sealed override void WriteEnd()
         {
             this.VerifyCanWriteEnd(true /*synchronousCall*/);
-            this.InterceptException(() => this.WriteEndImplementation());
+            this.InterceptException((thisParam) => thisParam.WriteEndImplementation());
             if (this.State == ParameterWriterState.Completed)
             {
                 // Note that we intentionally go through the public API so that if the Flush fails the writer moves to the Error state.
@@ -272,15 +292,15 @@ namespace Microsoft.OData
         {
             this.VerifyCanWriteEnd(false /*synchronousCall*/);
             await this.InterceptExceptionAsync(
-                async () =>
+                async (thisParam) =>
                 {
-                    await this.WriteEndImplementationAsync()
+                    await thisParam.WriteEndImplementationAsync()
                         .ConfigureAwait(false);
 
-                    if (this.State == ParameterWriterState.Completed)
+                    if (thisParam.State == ParameterWriterState.Completed)
                     {
                         // Note that we intentionally go through the public API so that if the FlushAsync fails the writer moves to the Error state.
-                        await this.FlushAsync()
+                        await thisParam.FlushAsync()
                             .ConfigureAwait(false);
                     }
                 }).ConfigureAwait(false);
@@ -450,7 +470,7 @@ namespace Microsoft.OData
         private void WriteStartImplementation()
         {
             Debug.Assert(this.State == ParameterWriterState.Start, "this.State == ParameterWriterState.Start");
-            this.InterceptException(this.StartPayload);
+            this.InterceptException((thisParam) => thisParam.StartPayload());
             this.EnterScope(ParameterWriterState.CanWriteParameter);
         }
 
@@ -591,7 +611,10 @@ namespace Microsoft.OData
         private void WriteValueImplementation(string parameterName, object parameterValue, IEdmTypeReference expectedTypeReference)
         {
             Debug.Assert(this.State == ParameterWriterState.CanWriteParameter, "this.State == ParameterWriterState.CanWriteParameter");
-            this.InterceptException(() => this.WriteValueParameter(parameterName, parameterValue, expectedTypeReference));
+            this.InterceptException(
+                (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) =>
+                    thisParam.WriteValueParameter(parameterName, parameterValue, expectedTypeReference),
+                parameterName, parameterValue, expectedTypeReference);
         }
 
         /// <summary>
@@ -691,7 +714,7 @@ namespace Microsoft.OData
         /// </summary>
         private void WriteEndImplementation()
         {
-            this.InterceptException(() => this.EndPayload());
+            this.InterceptException((thisParam) => thisParam.EndPayload());
             this.LeaveScope();
         }
 
@@ -743,11 +766,43 @@ namespace Microsoft.OData
         /// state ExceptionThrown and then rethrow the exception.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        private void InterceptException(Action action)
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private void InterceptException(Action<ODataParameterWriterCore> action)
         {
             try
             {
-                action();
+                action(this);
+            }
+            catch
+            {
+                this.EnterErrorScope();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Catch any exception thrown by the action passed in; in the exception case move the writer into
+        /// state ExceptionThrown and then rethrow the exception.
+        /// </summary>
+        /// <typeparam name="TArg0">The delegate first argument type.</typeparam>
+        /// <typeparam name="TArg1">The delegate second argument type.</typeparam>
+        /// <typeparam name="TArg2">The delegate third argument type.</typeparam>
+        /// <param name="action">The action to execute.</param>
+        /// <param name="arg0">The first argument value provided to the action.</param>
+        /// <param name="arg1">The second argument value provided to the action.</param>
+        /// <param name="arg2">The third argument value provided to the action.</param>
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private void InterceptException<TArg0, TArg1, TArg2>(Action<ODataParameterWriterCore, TArg0, TArg1, TArg2> action, TArg0 arg0, TArg1 arg1, TArg2 arg2)
+        {
+            try
+            {
+                action(this, arg0, arg1, arg2);
             }
             catch
             {
@@ -761,13 +816,21 @@ namespace Microsoft.OData
         /// state ExceptionThrown and then rethrow the exception.
         /// </summary>
         /// <typeparam name="T">The return type of <paramref name="function"/>.</typeparam>
+        /// <typeparam name="TArg0">The delegate first argument type.</typeparam>
+        /// <typeparam name="TArg1">The delegate second argument type.</typeparam>
         /// <param name="function">The function to execute.</param>
+        /// <param name="arg0">The first argument value provided to the action.</param>
+        /// <param name="arg1">The second argument value provided to the action.</param>
         /// <returns>Returns the return value from executing <paramref name="function"/>.</returns>
-        private T InterceptException<T>(Func<T> function)
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private T InterceptException<T, TArg0, TArg1>(Func<ODataParameterWriterCore, TArg0, TArg1, T> function, TArg0 arg0, TArg1 arg1)
         {
             try
             {
-                return function();
+                return function(this, arg0, arg1);
             }
             catch
             {
@@ -885,11 +948,15 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="func">The delegate to execute asynchronously.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        private async Task InterceptExceptionAsync(Func<Task> func)
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private async Task InterceptExceptionAsync(Func<ODataParameterWriterCore, Task> func)
         {
             try
             {
-                await func().ConfigureAwait(false);
+                await func(this).ConfigureAwait(false);
             }
             catch
             {
@@ -902,14 +969,51 @@ namespace Microsoft.OData
         /// Asynchronously catch any exception thrown by the action passed in; in the exception case move the writer into
         /// state ExceptionThrown and then rethrow the exception.
         /// </summary>
+        /// <typeparam name="TArg0">The delegate first argument type.</typeparam>
+        /// <typeparam name="TArg1">The delegate second argument type.</typeparam>
+        /// <typeparam name="TArg2">The delegate third argument type.</typeparam>
         /// <param name="func">The delegate to execute asynchronously.</param>
-        /// <returns>A task that represents the asynchronous operation. 
-        /// The value of the TResult parameter contains a T instance.</returns>
-        private async Task<T> InterceptExceptionAsync<T>(Func<Task<T>> func)
+        /// <param name="arg0">The first argument value provided to the action.</param>
+        /// <param name="arg1">The second argument value provided to the action.</param>
+        /// <param name="arg2">The third argument value provided to the action.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private async Task InterceptExceptionAsync<TArg0, TArg1, TArg2>(Func<ODataParameterWriterCore, TArg0, TArg1, TArg2, Task> func, TArg0 arg0, TArg1 arg1, TArg2 arg2)
         {
             try
             {
-                return await func().ConfigureAwait(false);
+                await func(this, arg0, arg1, arg2).ConfigureAwait(false);
+            }
+            catch
+            {
+                this.EnterErrorScope();
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously catch any exception thrown by the action passed in; in the exception case move the writer into
+        /// state ExceptionThrown and then rethrow the exception.
+        /// </summary>
+        /// <typeparam name="TArg0">The delegate first argument type.</typeparam>
+        /// <typeparam name="TArg1">The delegate second argument type.</typeparam>
+        /// <param name="func">The delegate to execute asynchronously.</param>
+        /// <param name="arg0">The first argument value provided to the action.</param>
+        /// <param name="arg1">The second argument value provided to the action.</param>
+        /// <returns>A task that represents the asynchronous operation. 
+        /// The value of the TResult parameter contains a T instance.</returns>
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private async Task<T> InterceptExceptionAsync<T, TArg0, TArg1>(Func<ODataParameterWriterCore, TArg0, TArg1, Task<T>> func, TArg0 arg0, TArg1 arg1)
+        {
+            try
+            {
+                return await func(this, arg0, arg1).ConfigureAwait(false);
             }
             catch
             {
@@ -926,7 +1030,7 @@ namespace Microsoft.OData
         {
             Debug.Assert(this.State == ParameterWriterState.Start, "this.State == ParameterWriterState.Start");
 
-            await this.InterceptExceptionAsync(this.StartPayloadAsync)
+            await this.InterceptExceptionAsync((thisParam) => thisParam.StartPayloadAsync())
                 .ConfigureAwait(false);
             this.EnterScope(ParameterWriterState.CanWriteParameter);
         }
@@ -942,7 +1046,7 @@ namespace Microsoft.OData
         {
             Debug.Assert(this.State == ParameterWriterState.CanWriteParameter, "this.State == ParameterWriterState.CanWriteParameter");
 
-            return this.InterceptExceptionAsync(() => this.WriteValueParameterAsync(parameterName, parameterValue, expectedTypeReference));
+            return this.InterceptExceptionAsync((thisParam) => thisParam.WriteValueParameterAsync(parameterName, parameterValue, expectedTypeReference));
         }
 
         /// <summary>
@@ -1004,7 +1108,7 @@ namespace Microsoft.OData
 		/// <returns>A task that represents the asynchronous write operation.</returns>
         private async Task WriteEndImplementationAsync()
         {
-            await this.InterceptExceptionAsync(() => this.EndPayloadAsync())
+            await this.InterceptExceptionAsync((thisParam) => thisParam.EndPayloadAsync())
                 .ConfigureAwait(false);
             this.LeaveScope();
         }

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -1583,22 +1583,23 @@ namespace Microsoft.OData
 
             if (!this.SkipWriting)
             {
-                this.InterceptException(() =>
-                {
-                    // Verify query count
-                    if (resourceSet.Count.HasValue)
+                this.InterceptException(
+                    (thisParam, resourceSetParam) =>
                     {
-                        // Check that Count is not set for requests
-                        if (!this.outputContext.WritingResponse)
+                        // Verify query count
+                        if (resourceSetParam.Count.HasValue)
                         {
-                            this.ThrowODataException(Strings.ODataWriterCore_QueryCountInRequest, resourceSet);
+                            // Check that Count is not set for requests
+                            if (!thisParam.outputContext.WritingResponse)
+                            {
+                                thisParam.ThrowODataException(Strings.ODataWriterCore_QueryCountInRequest, resourceSetParam);
+                            }
+
+                            // Verify version requirements
                         }
 
-                        // Verify version requirements
-                    }
-
-                    this.StartResourceSet(resourceSet);
-                });
+                        thisParam.StartResourceSet(resourceSetParam);
+                    }, resourceSet);
             }
         }
 
@@ -1626,24 +1627,25 @@ namespace Microsoft.OData
             this.CheckForNestedResourceInfoWithContent(ODataPayloadKind.ResourceSet, deltaResourceSet);
             this.EnterScope(WriterState.DeltaResourceSet, deltaResourceSet);
 
-            this.InterceptException(() =>
-            {
-                // Check that links are not set for requests
-                if (!this.outputContext.WritingResponse)
+            this.InterceptException(
+                (thisParam, deltaResourceSetParam) =>
                 {
-                    if (deltaResourceSet.NextPageLink != null)
+                    // Check that links are not set for requests
+                    if (!thisParam.outputContext.WritingResponse)
                     {
-                        this.ThrowODataException(Strings.ODataWriterCore_QueryNextLinkInRequest, deltaResourceSet);
+                        if (deltaResourceSetParam.NextPageLink != null)
+                        {
+                            thisParam.ThrowODataException(Strings.ODataWriterCore_QueryNextLinkInRequest, deltaResourceSetParam);
+                        }
+
+                        if (deltaResourceSetParam.DeltaLink != null)
+                        {
+                            thisParam.ThrowODataException(Strings.ODataWriterCore_QueryDeltaLinkInRequest, deltaResourceSetParam);
+                        }
                     }
 
-                    if (deltaResourceSet.DeltaLink != null)
-                    {
-                        this.ThrowODataException(Strings.ODataWriterCore_QueryDeltaLinkInRequest, deltaResourceSet);
-                    }
-                }
-
-                this.StartDeltaResourceSet(deltaResourceSet);
-            });
+                    thisParam.StartDeltaResourceSet(deltaResourceSetParam);
+                }, deltaResourceSet);
         }
 
         /// <summary>
@@ -1683,21 +1685,22 @@ namespace Microsoft.OData
             if (!this.SkipWriting)
             {
                 this.IncreaseResourceDepth();
-                this.InterceptException(() =>
-                {
-                    if (resource != null)
+                this.InterceptException(
+                    (thisParam, resourceParam) =>
                     {
-                        ResourceScope resourceScope = (ResourceScope)this.CurrentScope;
-                        this.ValidateResourceForResourceSet(resource, resourceScope);
-                        this.PrepareResourceForWriteStart(
-                            resourceScope,
-                            resource,
-                            this.outputContext.WritingResponse,
-                            resourceScope.SelectedProperties);
-                    }
+                        if (resourceParam != null)
+                        {
+                            ResourceScope resourceScope = (ResourceScope)thisParam.CurrentScope;
+                            thisParam.ValidateResourceForResourceSet(resourceParam, resourceScope);
+                            thisParam.PrepareResourceForWriteStart(
+                                resourceScope,
+                                resourceParam,
+                                thisParam.outputContext.WritingResponse,
+                                resourceScope.SelectedProperties);
+                        }
 
-                    this.StartResource(resource);
-                });
+                        thisParam.StartResource(resourceParam);
+                    }, resource);
             }
         }
 
@@ -1714,17 +1717,18 @@ namespace Microsoft.OData
             this.EnterScope(WriterState.DeletedResource, resource);
             this.IncreaseResourceDepth();
 
-            this.InterceptException(() =>
-            {
-                DeletedResourceScope resourceScope = this.CurrentScope as DeletedResourceScope;
-                this.ValidateResourceForResourceSet(resource, resourceScope);
-                this.PrepareDeletedResourceForWriteStart(
-                    resourceScope,
-                    resource,
-                    this.outputContext.WritingResponse,
-                    resourceScope.SelectedProperties);
-                this.StartDeletedResource(resource);
-            });
+            this.InterceptException(
+                (thisParam, resourceParam) =>
+                {
+                    DeletedResourceScope resourceScope = thisParam.CurrentScope as DeletedResourceScope;
+                    thisParam.ValidateResourceForResourceSet(resourceParam, resourceScope);
+                    thisParam.PrepareDeletedResourceForWriteStart(
+                        resourceScope,
+                        resourceParam,
+                        thisParam.outputContext.WritingResponse,
+                        resourceScope.SelectedProperties);
+                    thisParam.StartDeletedResource(resourceParam);
+                }, resource);
         }
 
         /// <summary>
@@ -1749,16 +1753,17 @@ namespace Microsoft.OData
             this.EnterScope(WriterState.Property, property);
             if (!this.SkipWriting)
             {
-                this.InterceptException(() =>
-                {
-                    this.StartProperty(property);
-                    if (property is ODataProperty)
+                this.InterceptException(
+                    (thisParam, propertyParam) =>
                     {
-                        PropertyInfoScope scope = this.CurrentScope as PropertyInfoScope;
-                        Debug.Assert(scope != null, "Scope for ODataPropertyInfo is not ODataPropertyInfoScope");
-                        scope.ValueWritten = true;
-                    }
-                });
+                        thisParam.StartProperty(propertyParam);
+                        if (propertyParam is ODataProperty)
+                        {
+                            PropertyInfoScope scope = thisParam.CurrentScope as PropertyInfoScope;
+                            Debug.Assert(scope != null, "Scope for ODataPropertyInfo is not ODataPropertyInfoScope");
+                            scope.ValueWritten = true;
+                        }
+                    }, property);
             }
         }
 
@@ -1835,19 +1840,20 @@ namespace Microsoft.OData
         /// <param name="primitiveValue">Primitive value to write.</param>
         private void WritePrimitiveValueImplementation(ODataPrimitiveValue primitiveValue)
         {
-            this.InterceptException(() =>
-            {
-                this.EnterScope(WriterState.Primitive, primitiveValue);
-                if (!(this.CurrentResourceSetValidator == null) && primitiveValue != null)
+            this.InterceptException(
+                (thisParam, primitiveValueParam) =>
                 {
-                    Debug.Assert(primitiveValue.Value != null, "PrimitiveValue.Value should never be null!");
-                    IEdmType itemType = EdmLibraryExtensions.GetPrimitiveTypeReference(primitiveValue.Value.GetType()).Definition;
-                    this.CurrentResourceSetValidator.ValidateResource(itemType);
-                }
+                    thisParam.EnterScope(WriterState.Primitive, primitiveValueParam);
+                    if (!(thisParam.CurrentResourceSetValidator == null) && primitiveValueParam != null)
+                    {
+                        Debug.Assert(primitiveValueParam.Value != null, "PrimitiveValue.Value should never be null!");
+                        IEdmType itemType = EdmLibraryExtensions.GetPrimitiveTypeReference(primitiveValueParam.Value.GetType()).Definition;
+                        thisParam.CurrentResourceSetValidator.ValidateResource(itemType);
+                    }
 
-                this.WritePrimitiveValue(primitiveValue);
-                this.WriteEnd();
-            });
+                    thisParam.WritePrimitiveValue(primitiveValueParam);
+                    thisParam.WriteEnd();
+                }, primitiveValue);
         }
 
         /// <summary>
@@ -1859,20 +1865,21 @@ namespace Microsoft.OData
         {
             EnterScope(WriterState.Primitive, primitiveValue);
 
-            await InterceptExceptionAsync(async () =>
-            {
-                if (!(CurrentResourceSetValidator == null) && primitiveValue != null)
+            await InterceptExceptionAsync(
+                async (thisParam, primiteValueParam) =>
                 {
-                    Debug.Assert(primitiveValue.Value != null, "PrimitiveValue.Value should never be null!");
-                    IEdmType itemType = EdmLibraryExtensions.GetPrimitiveTypeReference(primitiveValue.Value.GetType()).Definition;
-                    CurrentResourceSetValidator.ValidateResource(itemType);
-                }
+                    if (!(CurrentResourceSetValidator == null) && primiteValueParam != null)
+                    {
+                        Debug.Assert(primiteValueParam.Value != null, "PrimitiveValue.Value should never be null!");
+                        IEdmType itemType = EdmLibraryExtensions.GetPrimitiveTypeReference(primiteValueParam.Value.GetType()).Definition;
+                        CurrentResourceSetValidator.ValidateResource(itemType);
+                    }
 
-                await WritePrimitiveValueAsync(primitiveValue)
-                    .ConfigureAwait(false);
-                await this.WriteEndAsync()
-                    .ConfigureAwait(false);
-            }).ConfigureAwait(false);
+                    await thisParam.WritePrimitiveValueAsync(primiteValueParam)
+                        .ConfigureAwait(false);
+                    await thisParam.WriteEndAsync()
+                        .ConfigureAwait(false);
+                }, primitiveValue).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1930,102 +1937,103 @@ namespace Microsoft.OData
         /// </summary>
         private void WriteEndImplementation()
         {
-            this.InterceptException(() =>
-            {
-                Scope currentScope = this.CurrentScope;
-
-                switch (currentScope.State)
+            this.InterceptException(
+                (thisParam) =>
                 {
-                    case WriterState.Resource:
-                        if (!this.SkipWriting)
-                        {
-                            ODataResource resource = (ODataResource)currentScope.Item;
+                    Scope currentScope = thisParam.CurrentScope;
 
-                            this.EndResource(resource);
-                            this.DecreaseResourceDepth();
-                        }
+                    switch (currentScope.State)
+                    {
+                        case WriterState.Resource:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataResource resource = (ODataResource)currentScope.Item;
 
-                        break;
-                    case WriterState.DeletedResource:
-                        if (!this.SkipWriting)
-                        {
-                            ODataDeletedResource resource = (ODataDeletedResource)currentScope.Item;
+                                thisParam.EndResource(resource);
+                                thisParam.DecreaseResourceDepth();
+                            }
 
-                            this.EndDeletedResource(resource);
-                            this.DecreaseResourceDepth();
-                        }
+                            break;
+                        case WriterState.DeletedResource:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataDeletedResource resource = (ODataDeletedResource)currentScope.Item;
 
-                        break;
-                    case WriterState.ResourceSet:
-                        if (!this.SkipWriting)
-                        {
-                            ODataResourceSet resourceSet = (ODataResourceSet)currentScope.Item;
-                            WriterValidationUtils.ValidateResourceSetAtEnd(resourceSet, !this.outputContext.WritingResponse);
-                            this.EndResourceSet(resourceSet);
-                        }
+                                thisParam.EndDeletedResource(resource);
+                                thisParam.DecreaseResourceDepth();
+                            }
 
-                        break;
-                    case WriterState.DeltaLink:
-                    case WriterState.DeltaDeletedLink:
-                        break;
-                    case WriterState.DeltaResourceSet:
-                        if (!this.SkipWriting)
-                        {
-                            ODataDeltaResourceSet deltaResourceSet = (ODataDeltaResourceSet)currentScope.Item;
-                            WriterValidationUtils.ValidateDeltaResourceSetAtEnd(deltaResourceSet, !this.outputContext.WritingResponse);
-                            this.EndDeltaResourceSet(deltaResourceSet);
-                        }
+                            break;
+                        case WriterState.ResourceSet:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataResourceSet resourceSet = (ODataResourceSet)currentScope.Item;
+                                WriterValidationUtils.ValidateResourceSetAtEnd(resourceSet, !thisParam.outputContext.WritingResponse);
+                                thisParam.EndResourceSet(resourceSet);
+                            }
 
-                        break;
-                    case WriterState.NestedResourceInfo:
-                        if (!this.outputContext.WritingResponse)
-                        {
-                            throw new ODataException(Strings.ODataWriterCore_DeferredLinkInRequest);
-                        }
+                            break;
+                        case WriterState.DeltaLink:
+                        case WriterState.DeltaDeletedLink:
+                            break;
+                        case WriterState.DeltaResourceSet:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataDeltaResourceSet deltaResourceSet = (ODataDeltaResourceSet)currentScope.Item;
+                                WriterValidationUtils.ValidateDeltaResourceSetAtEnd(deltaResourceSet, !thisParam.outputContext.WritingResponse);
+                                thisParam.EndDeltaResourceSet(deltaResourceSet);
+                            }
 
-                        if (!this.SkipWriting)
-                        {
-                            ODataNestedResourceInfo link = (ODataNestedResourceInfo)currentScope.Item;
-                            this.DuplicatePropertyNameChecker.ValidatePropertyUniqueness(link);
-                            this.WriteDeferredNestedResourceInfo(link);
+                            break;
+                        case WriterState.NestedResourceInfo:
+                            if (!thisParam.outputContext.WritingResponse)
+                            {
+                                throw new ODataException(Strings.ODataWriterCore_DeferredLinkInRequest);
+                            }
 
-                            this.MarkNestedResourceInfoAsProcessed(link);
-                        }
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataNestedResourceInfo link = (ODataNestedResourceInfo)currentScope.Item;
+                                thisParam.DuplicatePropertyNameChecker.ValidatePropertyUniqueness(link);
+                                thisParam.WriteDeferredNestedResourceInfo(link);
 
-                        break;
-                    case WriterState.NestedResourceInfoWithContent:
-                        if (!this.SkipWriting)
-                        {
-                            ODataNestedResourceInfo link = (ODataNestedResourceInfo)currentScope.Item;
-                            this.EndNestedResourceInfoWithContent(link);
+                                thisParam.MarkNestedResourceInfoAsProcessed(link);
+                            }
 
-                            this.MarkNestedResourceInfoAsProcessed(link);
-                        }
+                            break;
+                        case WriterState.NestedResourceInfoWithContent:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataNestedResourceInfo link = (ODataNestedResourceInfo)currentScope.Item;
+                                thisParam.EndNestedResourceInfoWithContent(link);
 
-                        break;
-                    case WriterState.Property:
-                        {
-                            ODataPropertyInfo property = (ODataPropertyInfo)currentScope.Item;
-                            this.EndProperty(property);
-                        }
+                                thisParam.MarkNestedResourceInfoAsProcessed(link);
+                            }
 
-                        break;
-                    case WriterState.Primitive:
-                        // WriteEnd for WriterState.Primitive is a no-op; just leave scope
-                        break;
-                    case WriterState.Stream:
-                    case WriterState.String:
-                        throw new ODataException(Strings.ODataWriterCore_StreamNotDisposed);
-                    case WriterState.Start:                 // fall through
-                    case WriterState.Completed:             // fall through
-                    case WriterState.Error:                 // fall through
-                        throw new ODataException(Strings.ODataWriterCore_WriteEndCalledInInvalidState(currentScope.State.ToString()));
-                    default:
-                        throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataWriterCore_WriteEnd_UnreachableCodePath));
-                }
+                            break;
+                        case WriterState.Property:
+                            {
+                                ODataPropertyInfo property = (ODataPropertyInfo)currentScope.Item;
+                                thisParam.EndProperty(property);
+                            }
 
-                this.LeaveScope();
-            });
+                            break;
+                        case WriterState.Primitive:
+                            // WriteEnd for WriterState.Primitive is a no-op; just leave scope
+                            break;
+                        case WriterState.Stream:
+                        case WriterState.String:
+                            throw new ODataException(Strings.ODataWriterCore_StreamNotDisposed);
+                        case WriterState.Start:                 // fall through
+                        case WriterState.Completed:             // fall through
+                        case WriterState.Error:                 // fall through
+                            throw new ODataException(Strings.ODataWriterCore_WriteEndCalledInInvalidState(currentScope.State.ToString()));
+                        default:
+                            throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataWriterCore_WriteEnd_UnreachableCodePath));
+                    }
+
+                    thisParam.LeaveScope();
+                });
         }
 
         /// <summary>
@@ -2087,20 +2095,21 @@ namespace Microsoft.OData
 
             if (!this.SkipWriting)
             {
-                this.InterceptException(() =>
-                {
-                    WriterValidationUtils.ValidateEntityReferenceLink(entityReferenceLink);
-
-                    ODataNestedResourceInfo nestedInfo = this.CurrentScope.Item as ODataNestedResourceInfo;
-                    if (nestedInfo == null)
+                this.InterceptException(
+                    (thisParam, entityReferenceLinkParam) =>
                     {
-                        NestedResourceInfoScope nestedResourceInfoScope = this.ParentNestedResourceInfoScope;
-                        Debug.Assert(nestedResourceInfoScope != null);
-                        nestedInfo = (ODataNestedResourceInfo)nestedResourceInfoScope.Item;
-                    }
+                        WriterValidationUtils.ValidateEntityReferenceLink(entityReferenceLinkParam);
 
-                    this.WriteEntityReferenceInNavigationLinkContent(nestedInfo, entityReferenceLink);
-                });
+                        ODataNestedResourceInfo nestedInfo = thisParam.CurrentScope.Item as ODataNestedResourceInfo;
+                        if (nestedInfo == null)
+                        {
+                            NestedResourceInfoScope nestedResourceInfoScope = thisParam.ParentNestedResourceInfoScope;
+                            Debug.Assert(nestedResourceInfoScope != null);
+                            nestedInfo = (ODataNestedResourceInfo)nestedResourceInfoScope.Item;
+                        }
+
+                        thisParam.WriteEntityReferenceInNavigationLinkContent(nestedInfo, entityReferenceLinkParam);
+                    }, entityReferenceLink);
             }
         }
 
@@ -2165,7 +2174,7 @@ namespace Microsoft.OData
         {
             if (this.State == WriterState.Start)
             {
-                this.InterceptException(this.StartPayload);
+                this.InterceptException((thisParam) => thisParam.StartPayload());
             }
         }
 
@@ -2187,38 +2196,39 @@ namespace Microsoft.OData
             if (currentScope.State == WriterState.NestedResourceInfo || currentScope.State == WriterState.NestedResourceInfoWithContent)
             {
                 ODataNestedResourceInfo currentNestedResourceInfo = (ODataNestedResourceInfo)currentScope.Item;
-                this.InterceptException(() =>
-                {
-                    if (this.ParentResourceType != null)
+                this.InterceptException(
+                    (thisParam, contentPayloadKindParam) =>
                     {
-                        IEdmStructuralProperty structuralProperty = this.ParentResourceType.FindProperty(currentNestedResourceInfo.Name) as IEdmStructuralProperty;
-                        if (structuralProperty != null)
+                        if (thisParam.ParentResourceType != null)
                         {
-                            this.CurrentScope.ItemType = structuralProperty.Type.Definition.AsElementType();
-                            IEdmNavigationSource parentNavigationSource = this.ParentResourceNavigationSource;
-
-                            this.CurrentScope.NavigationSource = parentNavigationSource;
-                        }
-                        else
-                        {
-                            IEdmNavigationProperty navigationProperty =
-                                 this.WriterValidator.ValidateNestedResourceInfo(currentNestedResourceInfo, this.ParentResourceType, contentPayloadKind);
-                            if (navigationProperty != null)
+                            IEdmStructuralProperty structuralProperty = thisParam.ParentResourceType.FindProperty(currentNestedResourceInfo.Name) as IEdmStructuralProperty;
+                            if (structuralProperty != null)
                             {
-                                this.CurrentScope.ResourceType = navigationProperty.ToEntityType();
-                                IEdmNavigationSource parentNavigationSource = this.ParentResourceNavigationSource;
+                                thisParam.CurrentScope.ItemType = structuralProperty.Type.Definition.AsElementType();
+                                IEdmNavigationSource parentNavigationSource = thisParam.ParentResourceNavigationSource;
 
-                                if (this.CurrentScope.NavigationSource == null)
+                                thisParam.CurrentScope.NavigationSource = parentNavigationSource;
+                            }
+                            else
+                            {
+                                IEdmNavigationProperty navigationProperty =
+                                     thisParam.WriterValidator.ValidateNestedResourceInfo(currentNestedResourceInfo, thisParam.ParentResourceType, contentPayloadKindParam);
+                                if (navigationProperty != null)
                                 {
-                                    IEdmPathExpression bindingPath;
-                                    this.CurrentScope.NavigationSource = parentNavigationSource == null ?
-                                        null :
-                                        parentNavigationSource.FindNavigationTarget(navigationProperty, BindingPathHelper.MatchBindingPath, this.CurrentScope.ODataUri.Path.Segments, out bindingPath);
+                                    thisParam.CurrentScope.ResourceType = navigationProperty.ToEntityType();
+                                    IEdmNavigationSource parentNavigationSource = thisParam.ParentResourceNavigationSource;
+
+                                    if (thisParam.CurrentScope.NavigationSource == null)
+                                    {
+                                        IEdmPathExpression bindingPath;
+                                        thisParam.CurrentScope.NavigationSource = parentNavigationSource == null ?
+                                            null :
+                                            parentNavigationSource.FindNavigationTarget(navigationProperty, BindingPathHelper.MatchBindingPath, thisParam.CurrentScope.ODataUri.Path.Segments, out bindingPath);
+                                    }
                                 }
                             }
                         }
-                    }
-                });
+                    }, contentPayloadKind);
 
                 if (currentScope.State == WriterState.NestedResourceInfoWithContent)
                 {
@@ -2241,15 +2251,16 @@ namespace Microsoft.OData
 
                     if (!this.SkipWriting)
                     {
-                        this.InterceptException(() =>
-                        {
-                            if (!(currentNestedResourceInfo.SerializationInfo != null && currentNestedResourceInfo.SerializationInfo.IsComplex)
-                                && (this.CurrentScope.ItemType == null || this.CurrentScope.ItemType.IsEntityOrEntityCollectionType()))
+                        this.InterceptException(
+                            (thisParam, currentNestedResourceInfoParam) =>
                             {
-                                this.DuplicatePropertyNameChecker.ValidatePropertyUniqueness(currentNestedResourceInfo);
-                                this.StartNestedResourceInfoWithContent(currentNestedResourceInfo);
-                            }
-                        });
+                                if (!(currentNestedResourceInfoParam.SerializationInfo != null && currentNestedResourceInfoParam.SerializationInfo.IsComplex)
+                                    && (thisParam.CurrentScope.ItemType == null || thisParam.CurrentScope.ItemType.IsEntityOrEntityCollectionType()))
+                                {
+                                    thisParam.DuplicatePropertyNameChecker.ValidatePropertyUniqueness(currentNestedResourceInfoParam);
+                                    thisParam.StartNestedResourceInfoWithContent(currentNestedResourceInfoParam);
+                                }
+                            }, currentNestedResourceInfo);
                     }
                 }
             }
@@ -2356,11 +2367,15 @@ namespace Microsoft.OData
         /// state ExceptionThrown and then rethrow the exception.
         /// </summary>
         /// <param name="action">The action to execute.</param>
-        private void InterceptException(Action action)
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private void InterceptException(Action<ODataWriterCore> action)
         {
             try
             {
-                action();
+                action(this);
             }
             catch
             {
@@ -2373,6 +2388,33 @@ namespace Microsoft.OData
             }
         }
 
+        /// <summary>
+        /// Catch any exception thrown by the action passed in; in the exception case move the writer into
+        /// state ExceptionThrown and then rethrow the exception.
+        /// </summary>
+        /// <typeparam name="TArg0">The action argument type.</typeparam>
+        /// <param name="action">The action to execute.</param>
+        /// <param name="arg0">The argument value provided to the action.</param>
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private void InterceptException<TArg0>(Action<ODataWriterCore, TArg0> action, TArg0 arg0)
+        {
+            try
+            {
+                action(this, arg0);
+            }
+            catch
+            {
+                if (!IsErrorState(this.State))
+                {
+                    this.EnterScope(WriterState.Error, this.CurrentScope.Item);
+                }
+
+                throw;
+            }
+        }
 
         /// <summary>
         /// Catch any exception thrown by the action passed in; in the exception case move the writer into
@@ -2380,11 +2422,44 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="action">The action to execute.</param>
         /// <returns>The task.</returns>
-        private async Task InterceptExceptionAsync(Func<Task> action)
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private async Task InterceptExceptionAsync(Func<ODataWriterCore, Task> action)
         {
             try
             {
-                await action().ConfigureAwait(false);
+                await action(this).ConfigureAwait(false);
+            }
+            catch
+            {
+                if (!IsErrorState(this.State))
+                {
+                    this.EnterScope(WriterState.Error, this.CurrentScope.Item);
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Catch any exception thrown by the action passed in; in the exception case move the writer into
+        /// state ExceptionThrown and then rethrow the exception.
+        /// </summary>
+        /// <typeparam name="TArg0">The action argument type.</typeparam>
+        /// <param name="action">The action to execute.</param>
+        /// <param name="arg0">The argument value provided to the action.</param>
+        /// <returns>The task.</returns>
+        /// <remarks>
+        /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
+        /// so the compiler optimizes the code to avoid creating allocations on every call to this method.
+        /// </remarks>
+        private async Task InterceptExceptionAsync<TArg0>(Func<ODataWriterCore, TArg0, Task> action, TArg0 arg0)
+        {
+            try
+            {
+                await action(this, arg0).ConfigureAwait(false);
             }
             catch
             {
@@ -2449,7 +2524,7 @@ namespace Microsoft.OData
         [SuppressMessage("Microsoft.Performance", "CA1800:DoNotCastUnnecessarily", Justification = "Debug only cast.")]
         private void EnterScope(WriterState newState, ODataItem item)
         {
-            this.InterceptException(() => this.ValidateTransition(newState));
+            this.InterceptException((thisParam, newStateParam) => thisParam.ValidateTransition(newStateParam), newState);
 
             // If the parent scope was marked for skipping content, the new child scope should be as well.
             bool skipWriting = this.SkipWriting;
@@ -2809,7 +2884,7 @@ namespace Microsoft.OData
                 Scope startScope = this.scopeStack.Pop();
                 Debug.Assert(startScope.State == WriterState.Start, "startScope.State == WriterState.Start");
                 this.PushScope(WriterState.Completed, /*item*/null, startScope.NavigationSource, startScope.ResourceType, /*skipWriting*/false, startScope.SelectedProperties, startScope.ODataUri, null);
-                this.InterceptException(this.EndPayload);
+                this.InterceptException((thisParam) => thisParam.EndPayload());
                 this.NotifyListener(WriterState.Completed);
             }
         }
@@ -3131,21 +3206,22 @@ namespace Microsoft.OData
 
             if (!this.SkipWriting)
             {
-                await this.InterceptExceptionAsync(async () =>
-                {
-                    // Verify query count
-                    if (resourceSet.Count.HasValue)
+                await this.InterceptExceptionAsync(
+                    async (thisParam, resourceSetParam) =>
                     {
-                        // Check that Count is not set for requests
-                        if (!this.outputContext.WritingResponse)
+                        // Verify query count
+                        if (resourceSetParam.Count.HasValue)
                         {
-                            this.ThrowODataException(Strings.ODataWriterCore_QueryCountInRequest, resourceSet);
+                            // Check that Count is not set for requests
+                            if (!thisParam.outputContext.WritingResponse)
+                            {
+                                thisParam.ThrowODataException(Strings.ODataWriterCore_QueryCountInRequest, resourceSetParam);
+                            }
                         }
-                    }
 
-                    await this.StartResourceSetAsync(resourceSet)
-                        .ConfigureAwait(false);
-                }).ConfigureAwait(false);
+                        await thisParam.StartResourceSetAsync(resourceSetParam)
+                            .ConfigureAwait(false);
+                    }, resourceSet).ConfigureAwait(false);
             }
         }
 
@@ -3178,25 +3254,26 @@ namespace Microsoft.OData
                 .ConfigureAwait(false);
             this.EnterScope(WriterState.DeltaResourceSet, deltaResourceSet);
 
-            await this.InterceptExceptionAsync(async () =>
-            {
-                if (!this.outputContext.WritingResponse)
+            await this.InterceptExceptionAsync(
+                async (thisParam, deltaResourceSetParam) =>
                 {
-                    // Check that links are not set for requests
-                    if (deltaResourceSet.NextPageLink != null)
+                    if (!thisParam.outputContext.WritingResponse)
                     {
-                        this.ThrowODataException(Strings.ODataWriterCore_QueryNextLinkInRequest, deltaResourceSet);
+                        // Check that links are not set for requests
+                        if (deltaResourceSetParam.NextPageLink != null)
+                        {
+                            thisParam.ThrowODataException(Strings.ODataWriterCore_QueryNextLinkInRequest, deltaResourceSetParam);
+                        }
+
+                        if (deltaResourceSetParam.DeltaLink != null)
+                        {
+                            thisParam.ThrowODataException(Strings.ODataWriterCore_QueryDeltaLinkInRequest, deltaResourceSetParam);
+                        }
                     }
 
-                    if (deltaResourceSet.DeltaLink != null)
-                    {
-                        this.ThrowODataException(Strings.ODataWriterCore_QueryDeltaLinkInRequest, deltaResourceSet);
-                    }
-                }
-
-                await this.StartDeltaResourceSetAsync(deltaResourceSet)
-                    .ConfigureAwait(false);
-            }).ConfigureAwait(false);
+                    await thisParam.StartDeltaResourceSetAsync(deltaResourceSetParam)
+                        .ConfigureAwait(false);
+                }, deltaResourceSet).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3215,22 +3292,23 @@ namespace Microsoft.OData
             if (!this.SkipWriting)
             {
                 this.IncreaseResourceDepth();
-                await this.InterceptExceptionAsync(async () =>
-                {
-                    if (resource != null)
+                await this.InterceptExceptionAsync(
+                    async (thisParam, resourceParam) =>
                     {
-                        ResourceScope resourceScope = (ResourceScope)this.CurrentScope;
-                        this.ValidateResourceForResourceSet(resource, resourceScope);
-                        await this.PrepareResourceForWriteStartAsync(
-                            resourceScope,
-                            resource,
-                            this.outputContext.WritingResponse,
-                            resourceScope.SelectedProperties).ConfigureAwait(false);
-                    }
+                        if (resourceParam != null)
+                        {
+                            ResourceScope resourceScope = (ResourceScope)thisParam.CurrentScope;
+                            thisParam.ValidateResourceForResourceSet(resourceParam, resourceScope);
+                            await thisParam.PrepareResourceForWriteStartAsync(
+                                resourceScope,
+                                resourceParam,
+                                thisParam.outputContext.WritingResponse,
+                                resourceScope.SelectedProperties).ConfigureAwait(false);
+                        }
 
-                    await this.StartResourceAsync(resource)
-                        .ConfigureAwait(false);
-                }).ConfigureAwait(false);
+                        await thisParam.StartResourceAsync(resourceParam)
+                            .ConfigureAwait(false);
+                    }, resource).ConfigureAwait(false);
             }
         }
 
@@ -3250,19 +3328,20 @@ namespace Microsoft.OData
             this.EnterScope(WriterState.DeletedResource, resource);
             this.IncreaseResourceDepth();
 
-            await this.InterceptExceptionAsync(async () =>
-            {
-                DeletedResourceScope resourceScope = this.CurrentScope as DeletedResourceScope;
-                this.ValidateResourceForResourceSet(resource, resourceScope);
+            await this.InterceptExceptionAsync(
+                async (thisParam, resourceParam) =>
+                {
+                    DeletedResourceScope resourceScope = thisParam.CurrentScope as DeletedResourceScope;
+                    this.ValidateResourceForResourceSet(resourceParam, resourceScope);
 
-                await this.PrepareDeletedResourceForWriteStartAsync(
-                    resourceScope,
-                    resource,
-                    this.outputContext.WritingResponse,
-                    resourceScope.SelectedProperties).ConfigureAwait(false);
-                await this.StartDeletedResourceAsync(resource)
-                    .ConfigureAwait(false);
-            }).ConfigureAwait(false);
+                    await this.PrepareDeletedResourceForWriteStartAsync(
+                        resourceScope,
+                        resourceParam,
+                        thisParam.outputContext.WritingResponse,
+                        resourceScope.SelectedProperties).ConfigureAwait(false);
+                    await thisParam.StartDeletedResourceAsync(resource)
+                        .ConfigureAwait(false);
+                }, resource).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3276,18 +3355,19 @@ namespace Microsoft.OData
 
             if (!this.SkipWriting)
             {
-                await this.InterceptExceptionAsync(async () =>
-                {
-                    await this.StartPropertyAsync(property)
-                        .ConfigureAwait(false);
-
-                    if (property is ODataProperty)
+                await this.InterceptExceptionAsync(
+                    async (thisParam, propertyParam) =>
                     {
-                        PropertyInfoScope scope = this.CurrentScope as PropertyInfoScope;
-                        Debug.Assert(scope != null, "Scope for ODataPropertyInfo is not ODataPropertyInfoScope");
-                        scope.ValueWritten = true;
-                    }
-                }).ConfigureAwait(false);
+                        await thisParam.StartPropertyAsync(propertyParam)
+                            .ConfigureAwait(false);
+
+                        if (propertyParam is ODataProperty)
+                        {
+                            PropertyInfoScope scope = thisParam.CurrentScope as PropertyInfoScope;
+                            Debug.Assert(scope != null, "Scope for ODataPropertyInfo is not ODataPropertyInfoScope");
+                            scope.ValueWritten = true;
+                        }
+                    }, property).ConfigureAwait(false);
             }
         }
 
@@ -3325,110 +3405,111 @@ namespace Microsoft.OData
         /// <returns>A task that represents the asynchronous write operation.</returns>
         private Task WriteEndImplementationAsync()
         {
-            return this.InterceptExceptionAsync(async () =>
-            {
-                Scope currentScope = this.CurrentScope;
-
-                switch (currentScope.State)
+            return this.InterceptExceptionAsync(
+                async (thisParam) =>
                 {
-                    case WriterState.Resource:
-                        if (!this.SkipWriting)
-                        {
-                            ODataResource resource = (ODataResource)currentScope.Item;
+                    Scope currentScope = thisParam.CurrentScope;
 
-                            await this.EndResourceAsync(resource)
-                                .ConfigureAwait(false);
-                            this.DecreaseResourceDepth();
-                        }
+                    switch (currentScope.State)
+                    {
+                        case WriterState.Resource:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataResource resource = (ODataResource)currentScope.Item;
 
-                        break;
-                    case WriterState.DeletedResource:
-                        if (!this.SkipWriting)
-                        {
-                            ODataDeletedResource resource = (ODataDeletedResource)currentScope.Item;
+                                await thisParam.EndResourceAsync(resource)
+                                    .ConfigureAwait(false);
+                                thisParam.DecreaseResourceDepth();
+                            }
 
-                            await this.EndDeletedResourceAsync(resource)
-                                .ConfigureAwait(false);
-                            this.DecreaseResourceDepth();
-                        }
+                            break;
+                        case WriterState.DeletedResource:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataDeletedResource resource = (ODataDeletedResource)currentScope.Item;
 
-                        break;
-                    case WriterState.ResourceSet:
-                        if (!this.SkipWriting)
-                        {
-                            ODataResourceSet resourceSet = (ODataResourceSet)currentScope.Item;
-                            WriterValidationUtils.ValidateResourceSetAtEnd(resourceSet, !this.outputContext.WritingResponse);
-                            await this.EndResourceSetAsync(resourceSet)
-                                .ConfigureAwait(false);
-                        }
+                                await thisParam.EndDeletedResourceAsync(resource)
+                                    .ConfigureAwait(false);
+                                thisParam.DecreaseResourceDepth();
+                            }
 
-                        break;
-                    case WriterState.DeltaLink:
-                    case WriterState.DeltaDeletedLink:
-                        break;
-                    case WriterState.DeltaResourceSet:
-                        if (!this.SkipWriting)
-                        {
-                            ODataDeltaResourceSet deltaResourceSet = (ODataDeltaResourceSet)currentScope.Item;
-                            WriterValidationUtils.ValidateDeltaResourceSetAtEnd(deltaResourceSet, !this.outputContext.WritingResponse);
-                            await this.EndDeltaResourceSetAsync(deltaResourceSet)
-                                .ConfigureAwait(false);
-                        }
+                            break;
+                        case WriterState.ResourceSet:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataResourceSet resourceSet = (ODataResourceSet)currentScope.Item;
+                                WriterValidationUtils.ValidateResourceSetAtEnd(resourceSet, !thisParam.outputContext.WritingResponse);
+                                await thisParam.EndResourceSetAsync(resourceSet)
+                                    .ConfigureAwait(false);
+                            }
 
-                        break;
-                    case WriterState.NestedResourceInfo:
-                        if (!this.outputContext.WritingResponse)
-                        {
-                            throw new ODataException(Strings.ODataWriterCore_DeferredLinkInRequest);
-                        }
+                            break;
+                        case WriterState.DeltaLink:
+                        case WriterState.DeltaDeletedLink:
+                            break;
+                        case WriterState.DeltaResourceSet:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataDeltaResourceSet deltaResourceSet = (ODataDeltaResourceSet)currentScope.Item;
+                                WriterValidationUtils.ValidateDeltaResourceSetAtEnd(deltaResourceSet, !thisParam.outputContext.WritingResponse);
+                                await thisParam.EndDeltaResourceSetAsync(deltaResourceSet)
+                                    .ConfigureAwait(false);
+                            }
 
-                        if (!this.SkipWriting)
-                        {
-                            ODataNestedResourceInfo link = (ODataNestedResourceInfo)currentScope.Item;
-                            this.DuplicatePropertyNameChecker.ValidatePropertyUniqueness(link);
-                            await this.WriteDeferredNestedResourceInfoAsync(link)
-                                .ConfigureAwait(false);
+                            break;
+                        case WriterState.NestedResourceInfo:
+                            if (!thisParam.outputContext.WritingResponse)
+                            {
+                                throw new ODataException(Strings.ODataWriterCore_DeferredLinkInRequest);
+                            }
 
-                            this.MarkNestedResourceInfoAsProcessed(link);
-                        }
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataNestedResourceInfo link = (ODataNestedResourceInfo)currentScope.Item;
+                                thisParam.DuplicatePropertyNameChecker.ValidatePropertyUniqueness(link);
+                                await thisParam.WriteDeferredNestedResourceInfoAsync(link)
+                                    .ConfigureAwait(false);
 
-                        break;
-                    case WriterState.NestedResourceInfoWithContent:
-                        if (!this.SkipWriting)
-                        {
-                            ODataNestedResourceInfo link = (ODataNestedResourceInfo)currentScope.Item;
-                            await this.EndNestedResourceInfoWithContentAsync(link)
-                                .ConfigureAwait(false);
+                                thisParam.MarkNestedResourceInfoAsProcessed(link);
+                            }
 
-                            this.MarkNestedResourceInfoAsProcessed(link);
-                        }
+                            break;
+                        case WriterState.NestedResourceInfoWithContent:
+                            if (!thisParam.SkipWriting)
+                            {
+                                ODataNestedResourceInfo link = (ODataNestedResourceInfo)currentScope.Item;
+                                await thisParam.EndNestedResourceInfoWithContentAsync(link)
+                                    .ConfigureAwait(false);
 
-                        break;
-                    case WriterState.Property:
-                        {
-                            ODataPropertyInfo property = (ODataPropertyInfo)currentScope.Item;
-                            await this.EndPropertyAsync(property)
-                                .ConfigureAwait(false);
-                        }
+                                thisParam.MarkNestedResourceInfoAsProcessed(link);
+                            }
 
-                        break;
-                    case WriterState.Primitive:
-                        // WriteEnd for WriterState.Primitive is a no-op; just leave scope
-                        break;
-                    case WriterState.Stream:
-                    case WriterState.String:
-                        throw new ODataException(Strings.ODataWriterCore_StreamNotDisposed);
-                    case WriterState.Start:                 // fall through
-                    case WriterState.Completed:             // fall through
-                    case WriterState.Error:                 // fall through
-                        throw new ODataException(Strings.ODataWriterCore_WriteEndCalledInInvalidState(currentScope.State.ToString()));
-                    default:
-                        throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataWriterCore_WriteEnd_UnreachableCodePath));
-                }
+                            break;
+                        case WriterState.Property:
+                            {
+                                ODataPropertyInfo property = (ODataPropertyInfo)currentScope.Item;
+                                await thisParam.EndPropertyAsync(property)
+                                    .ConfigureAwait(false);
+                            }
 
-                await this.LeaveScopeAsync()
-                    .ConfigureAwait(false);
-            });
+                            break;
+                        case WriterState.Primitive:
+                            // WriteEnd for WriterState.Primitive is a no-op; just leave scope
+                            break;
+                        case WriterState.Stream:
+                        case WriterState.String:
+                            throw new ODataException(Strings.ODataWriterCore_StreamNotDisposed);
+                        case WriterState.Start:                 // fall through
+                        case WriterState.Completed:             // fall through
+                        case WriterState.Error:                 // fall through
+                            throw new ODataException(Strings.ODataWriterCore_WriteEndCalledInInvalidState(currentScope.State.ToString()));
+                        default:
+                            throw new ODataException(Strings.General_InternalError(InternalErrorCodes.ODataWriterCore_WriteEnd_UnreachableCodePath));
+                    }
+
+                    await thisParam.LeaveScopeAsync()
+                        .ConfigureAwait(false);
+                });
         }
 
         /// <summary>
@@ -3448,21 +3529,22 @@ namespace Microsoft.OData
 
             if (!this.SkipWriting)
             {
-                await this.InterceptExceptionAsync(async () =>
-                {
-                    WriterValidationUtils.ValidateEntityReferenceLink(entityReferenceLink);
-
-                    ODataNestedResourceInfo nestedInfo = this.CurrentScope.Item as ODataNestedResourceInfo;
-                    if (nestedInfo == null)
+                await this.InterceptExceptionAsync(
+                    async (thisParam, entityReferenceLinkParam) =>
                     {
-                        NestedResourceInfoScope nestedResourceInfoScope = this.ParentNestedResourceInfoScope;
-                        Debug.Assert(nestedResourceInfoScope != null);
-                        nestedInfo = (ODataNestedResourceInfo)nestedResourceInfoScope.Item;
-                    }
+                        WriterValidationUtils.ValidateEntityReferenceLink(entityReferenceLinkParam);
 
-                    await this.WriteEntityReferenceInNavigationLinkContentAsync(nestedInfo, entityReferenceLink)
-                        .ConfigureAwait(false);
-                }).ConfigureAwait(false);
+                        ODataNestedResourceInfo nestedInfo = thisParam.CurrentScope.Item as ODataNestedResourceInfo;
+                        if (nestedInfo == null)
+                        {
+                            NestedResourceInfoScope nestedResourceInfoScope = thisParam.ParentNestedResourceInfoScope;
+                            Debug.Assert(nestedResourceInfoScope != null);
+                            nestedInfo = (ODataNestedResourceInfo)nestedResourceInfoScope.Item;
+                        }
+
+                        await thisParam.WriteEntityReferenceInNavigationLinkContentAsync(nestedInfo, entityReferenceLinkParam)
+                            .ConfigureAwait(false);
+                    }, entityReferenceLink).ConfigureAwait(false);
             }
         }
 
@@ -3474,7 +3556,7 @@ namespace Microsoft.OData
         {
             if (this.State == WriterState.Start)
             {
-                return this.InterceptExceptionAsync(this.StartPayloadAsync);
+                return this.InterceptExceptionAsync((thisParam) => thisParam.StartPayloadAsync());
             }
 
             return TaskUtils.CompletedTask;
@@ -3500,43 +3582,44 @@ namespace Microsoft.OData
             {
                 ODataNestedResourceInfo currentNestedResourceInfo = (ODataNestedResourceInfo)currentScope.Item;
 
-                this.InterceptException(() =>
-                {
-                    if (this.ParentResourceType != null)
+                this.InterceptException(
+                    (thisParam, contentPayloadKindParam) =>
                     {
-                        IEdmStructuralProperty structuralProperty = this.ParentResourceType.FindProperty(
-                            currentNestedResourceInfo.Name) as IEdmStructuralProperty;
-                        if (structuralProperty != null)
+                        if (thisParam.ParentResourceType != null)
                         {
-                            this.CurrentScope.ItemType = structuralProperty.Type.Definition.AsElementType();
-                            IEdmNavigationSource parentNavigationSource = this.ParentResourceNavigationSource;
-
-                            this.CurrentScope.NavigationSource = parentNavigationSource;
-                        }
-                        else
-                        {
-                            IEdmNavigationProperty navigationProperty = this.WriterValidator.ValidateNestedResourceInfo(
-                                currentNestedResourceInfo,
-                                this.ParentResourceType,
-                                contentPayloadKind);
-                            if (navigationProperty != null)
+                            IEdmStructuralProperty structuralProperty = thisParam.ParentResourceType.FindProperty(
+                                currentNestedResourceInfo.Name) as IEdmStructuralProperty;
+                            if (structuralProperty != null)
                             {
-                                this.CurrentScope.ResourceType = navigationProperty.ToEntityType();
-                                IEdmNavigationSource parentNavigationSource = this.ParentResourceNavigationSource;
+                                thisParam.CurrentScope.ItemType = structuralProperty.Type.Definition.AsElementType();
+                                IEdmNavigationSource parentNavigationSource = thisParam.ParentResourceNavigationSource;
 
-                                if (this.CurrentScope.NavigationSource == null)
+                                thisParam.CurrentScope.NavigationSource = parentNavigationSource;
+                            }
+                            else
+                            {
+                                IEdmNavigationProperty navigationProperty = thisParam.WriterValidator.ValidateNestedResourceInfo(
+                                    currentNestedResourceInfo,
+                                    thisParam.ParentResourceType,
+                                    contentPayloadKindParam);
+                                if (navigationProperty != null)
                                 {
-                                    IEdmPathExpression bindingPath;
-                                    this.CurrentScope.NavigationSource = parentNavigationSource?.FindNavigationTarget(
-                                        navigationProperty,
-                                        BindingPathHelper.MatchBindingPath,
-                                        this.CurrentScope.ODataUri.Path.Segments,
-                                        out bindingPath);
+                                    thisParam.CurrentScope.ResourceType = navigationProperty.ToEntityType();
+                                    IEdmNavigationSource parentNavigationSource = thisParam.ParentResourceNavigationSource;
+
+                                    if (thisParam.CurrentScope.NavigationSource == null)
+                                    {
+                                        IEdmPathExpression bindingPath;
+                                        thisParam.CurrentScope.NavigationSource = parentNavigationSource?.FindNavigationTarget(
+                                            navigationProperty,
+                                            BindingPathHelper.MatchBindingPath,
+                                            thisParam.CurrentScope.ODataUri.Path.Segments,
+                                            out bindingPath);
+                                    }
                                 }
                             }
                         }
-                    }
-                });
+                    }, contentPayloadKind);
 
                 if (currentScope.State == WriterState.NestedResourceInfoWithContent)
                 {
@@ -3559,16 +3642,17 @@ namespace Microsoft.OData
 
                     if (!this.SkipWriting)
                     {
-                        await this.InterceptExceptionAsync(async () =>
-                        {
-                            if (!(currentNestedResourceInfo.SerializationInfo != null && currentNestedResourceInfo.SerializationInfo.IsComplex)
-                                && (this.CurrentScope.ItemType == null || this.CurrentScope.ItemType.IsEntityOrEntityCollectionType()))
+                        await this.InterceptExceptionAsync(
+                            async (thisParam, currentNestedResourceInfoParam) =>
                             {
-                                this.DuplicatePropertyNameChecker.ValidatePropertyUniqueness(currentNestedResourceInfo);
-                                await this.StartNestedResourceInfoWithContentAsync(currentNestedResourceInfo)
-                                    .ConfigureAwait(false);
-                            }
-                        }).ConfigureAwait(false);
+                                if (!(currentNestedResourceInfoParam.SerializationInfo != null && currentNestedResourceInfoParam.SerializationInfo.IsComplex)
+                                    && (thisParam.CurrentScope.ItemType == null || thisParam.CurrentScope.ItemType.IsEntityOrEntityCollectionType()))
+                                {
+                                    thisParam.DuplicatePropertyNameChecker.ValidatePropertyUniqueness(currentNestedResourceInfoParam);
+                                    await thisParam.StartNestedResourceInfoWithContentAsync(currentNestedResourceInfoParam)
+                                        .ConfigureAwait(false);
+                                }
+                            }, currentNestedResourceInfo).ConfigureAwait(false);
                     }
                 }
             }
@@ -3611,7 +3695,7 @@ namespace Microsoft.OData
                     startScope.SelectedProperties,
                     startScope.ODataUri,
                     /*derivedTypeConstraints*/ null);
-                await this.InterceptExceptionAsync(this.EndPayloadAsync)
+                await this.InterceptExceptionAsync((thisParam) => thisParam.EndPayloadAsync())
                     .ConfigureAwait(false);
                 this.NotifyListener(WriterState.Completed);
             }


### PR DESCRIPTION
### Issues
2% of allocations in AGS are result of the InterceptException pattern.

![image](https://user-images.githubusercontent.com/24846248/129147605-fa05da8d-b258-47f2-9e8a-41b6a3172039.png)

*This pull request fixes issue #xxx.*

### Description

Every time InterceptException() is invoked, allocation is done to create an Action and capture state from the enclosing context. 

One way to fix such unnecessary allocations is to have the compiler optimizing the underlying code, however it requires using anonymous functions that don't capture state from the enclosing context, so the compiler optimizes the code to avoid creating allocations on every call to this method.

[Compiler generated code, capturing enclosing context](https://sharplab.io/#v2:EYLgZgpghgLgrgJwgZwLRIMYHsEBNXIwJwYzIA+AAgEwCMAsAFCUAMABJbQHQBKcAdjACWAWwhcAwlhEAHIQBsICAMpKAbkIwoA3EyaUAzB2psAsgE8J8qMmRsA3kzbO2TlzIRC1sCBwAsbACigkrK2DIQABRCgmz8EADuyjA+AJRuzo6MLjlsMAAWQshcAJIhCFoyMIEAHpXCWPyRkalsALwAfHmFxQBqUPJCuD4AKghQ/MhCDU3xSSkwEKmputkuAL56a84eXj7+bP2Dw4tjE1Mz0bFC6dsOGWybdw8A2qYQBVi4JbLyke+fb6/ADyVSEjWKAEEAObQpC2LwQMqDfgxaGpAC6D123kWBzKiwqECqtXq4KanBMUFI5NuOSyuRcRHMD3prMZbGplxW7OcTw5bAwsAw+V59zuAoKCCwCVWAv5Gy26yAA=)

[Compiler generated code, without enclosing context](https://sharplab.io/#v2:EYLgZgpghgLgrgJwgZwLRIMYHsEBNXIwJwYzIA+AAgEwCMAsAFCUAMABJbQHQBKcAdjACWAWwhcAwlhEAHIQBsICAMpKAbkIwoA3EyaUAzB2psAsgE8J8qMmRsA3kzbO2TlzIRC1sCBwAsbACigkrK2DIQABRCgmz8EADuyjA+AJRuzo6MLjlsMAAWQshcAJIhCFoyMIEAHpXCWPyRkcgQ8mAANHGJyT4AClAIUCKpbAC8AHxsre1cAGpQ8kK4PgAqQ/zIQg1N8UkpMBADQyNde72HqbrZLgC+ejfOHl4+/mwLSyuH61Cb20KNaKxITpR4ODJse5giHPbyHN5lQ4VCBVWr1AH8AA8qwAgggAOYsCaRTjUTEWKw2ZBdXEEolsKCkDE0vGEhl00E5LK5FxEcwQrkCnkMpmAgpFLqDQlXIXOKHCtgYWAYfKy8FghUFBBYBLXBXyu4PW5AA=)

In the second example, the compiler is able to optimize the code by caching the action delegate, so subsequent calls don't result in unnecessary allocations.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*