### PR TITLE
update namespaces to use aliases if aliases for the namespaces are set

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/CsdlXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlXmlWriter.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Xml;
 using Microsoft.OData.Edm.Csdl.Serialization;
@@ -96,8 +97,31 @@ namespace Microsoft.OData.Edm.Csdl
 
         private void WriteReferenceElements()
         {
-            EdmModelReferenceElementsXmlVisitor visitor = new EdmModelReferenceElementsXmlVisitor(this.model, this.writer, this.edmxVersion);
-            visitor.VisitEdmReferences(this.model);
+            EdmModelReferenceElementsXmlVisitor visitor;
+            IEnumerable<IEdmReference> references = model.GetEdmReferences();
+            if (references != null)
+            {
+                foreach (IEdmReference reference in references)
+                {
+                    //loop through the includes and set the namespace alias 
+                    if (reference.Includes != null)
+                    {
+                        foreach (IEdmInclude include in reference.Includes)
+                        {
+                            if (include.Alias != null)
+                            {
+                                model.SetNamespaceAlias(include.Namespace, include.Alias);
+                            }
+                        }
+                    }
+                }
+
+                foreach (IEdmReference edmReference in references)
+                {
+                    visitor = new EdmModelReferenceElementsXmlVisitor(this.model, this.writer, this.edmxVersion);
+                    visitor.VisitEdmReferences(this.model, edmReference);
+                }
+            }
         }
 
         private void WriteDataServicesElement()

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelReferenceElementsXmlVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelReferenceElementsXmlVisitor.cs
@@ -24,40 +24,33 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         }
 
         #region write IEdmModel.References for referenced models.
-        internal void VisitEdmReferences(IEdmModel model)
+        internal void VisitEdmReferences(IEdmModel model, IEdmReference reference)
         {
-            IEnumerable<IEdmReference> references = model.GetEdmReferences();
-            if (model != null && references != null)
+            this.schemaWriter.WriteReferenceElementHeader(reference);
+
+            if (reference.Includes != null)
             {
-                foreach (IEdmReference tmp in references)
+                foreach (IEdmInclude include in reference.Includes)
                 {
-                    this.schemaWriter.WriteReferenceElementHeader(tmp);
+                    this.schemaWriter.WritIncludeElementHeader(include);
 
-                    if (tmp.Includes != null)
-                    {
-                        foreach (IEdmInclude include in tmp.Includes)
-                        {
-                            this.schemaWriter.WritIncludeElementHeader(include);
+                    WriteAnnotations(model, include);
 
-                            WriteAnnotations(model, include);
-
-                            this.schemaWriter.WriteIncludeElementEnd(include);
-                        }
-                    }
-
-                    if (tmp.IncludeAnnotations != null)
-                    {
-                        foreach (IEdmIncludeAnnotations includeAnnotations in tmp.IncludeAnnotations)
-                        {
-                            this.schemaWriter.WriteIncludeAnnotationsElement(includeAnnotations);
-                        }
-                    }
-
-                    WriteAnnotations(model, tmp);
-
-                    this.schemaWriter.WriteReferenceElementEnd(tmp);
+                    this.schemaWriter.WriteIncludeElementEnd(include);
                 }
             }
+
+            if (reference.IncludeAnnotations != null)
+            {
+                foreach (IEdmIncludeAnnotations includeAnnotations in reference.IncludeAnnotations)
+                {
+                    this.schemaWriter.WriteIncludeAnnotationsElement(includeAnnotations);
+                }
+            }
+
+            WriteAnnotations(model, reference);
+            this.schemaWriter.WriteReferenceElementEnd(reference);
+
         }
 
         private void WriteAnnotations(IEdmModel model, IEdmVocabularyAnnotatable target)

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
               "<edmx:Reference Uri=\"https://example.com/Org.OData.Authorization.V1.xml\">" +
                 "<edmx:Include Namespace=\"Org.OData.Authorization.V1\" Alias=\"Auth\">" +
-                  "<Annotation Term=\"Org.OData.Core.V1.LongDescription\" String=\"Include Description.\" />" +
+                  "<Annotation Term=\"Core.LongDescription\" String=\"Include Description.\" />" +
                 "</edmx:Include>" +
                 "<edmx:IncludeAnnotations TermNamespace=\"org.example.validation\" />" +
                 "<edmx:IncludeAnnotations TermNamespace=\"org.example.display\" Qualifier=\"Tablet\" />" +
@@ -66,7 +66,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                 "<edmx:Include Namespace=\"Org.OData.Core.V1\" Alias=\"Core\" />" +
                 "<edmx:IncludeAnnotations TermNamespace=\"org.example.hcm\" TargetNamespace=\"com.example.Sales\" />" +
                 "<edmx:IncludeAnnotations TermNamespace=\"org.example.hcm\" Qualifier=\"Tablet\" TargetNamespace=\"com.example.Person\" />" +
-                "<Annotation Term=\"Org.OData.Core.V1.LongDescription\" String=\"EdmReference Description.\" />" +
+                "<Annotation Term=\"Core.LongDescription\" String=\"EdmReference Description.\" />" +
               "</edmx:Reference>" +
               "<edmx:DataServices />" +
             "</edmx:Edmx>");
@@ -80,7 +80,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
         {
           ""$Namespace"": ""Org.OData.Authorization.V1"",
           ""$Alias"": ""Auth"",
-          ""@Org.OData.Core.V1.LongDescription"": ""Include Description.""
+          ""@Core.LongDescription"": ""Include Description.""
         }
       ],
       ""$IncludeAnnotations"": [
@@ -111,7 +111,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
           ""$TargetNamespace"": ""com.example.Person""
         }
       ],
-      ""@Org.OData.Core.V1.LongDescription"": ""EdmReference Description.""
+      ""@Core.LongDescription"": ""EdmReference Description.""
     }
   }
 }");
@@ -2731,6 +2731,86 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                 Assert.Equal(expected, actual);
             }
 #endif
+        }
+
+        [Fact]
+        public void ShouldSubstituteFullyQualifiedNamespaceWithAliasIfAliasIsSet()
+        {
+            // Arrange
+            var stringTypeReference = new EdmStringTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.String), false);
+            var model = new EdmModel();
+            model.SetNamespaceAlias("Org.OData.Core.V1", "Core");
+            var function = new EdmFunction("test", "TestFunction", stringTypeReference);
+            var requiredParam = new EdmOperationParameter(function, "requiredParam", stringTypeReference);
+            var optionalParam = new EdmOptionalParameter(function, "optionalParam", stringTypeReference, null);
+            var optionalParamWithDefault = new EdmOptionalParameter(function, "optionalParamWithDefault", stringTypeReference, "Smith");
+            function.AddParameter(requiredParam);
+            function.AddParameter(optionalParam);
+            function.AddParameter(optionalParamWithDefault);
+            model.AddElement(function);
+            model.AddEntityContainer("test", "Default").AddFunctionImport("TestFunction", function);
+
+            // Act & Assert for XML
+            WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+            "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+              "<edmx:DataServices>" +
+                "<Schema Namespace=\"test\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                  "<Function Name=\"TestFunction\">" +
+                    "<Parameter Name=\"requiredParam\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                    "<Parameter Name=\"optionalParam\" Type=\"Edm.String\" Nullable=\"false\">" +
+                        "<Annotation Term=\"Core.OptionalParameter\" />" +
+                    "</Parameter>" +
+                    "<Parameter Name=\"optionalParamWithDefault\" Type=\"Edm.String\" Nullable=\"false\">" +
+                        "<Annotation Term=\"Core.OptionalParameter\">" +
+                          "<Record>" +
+                            "<PropertyValue Property=\"DefaultValue\" String=\"Smith\" />" +
+                          "</Record>" +
+                        "</Annotation>" +
+                    "</Parameter>" +
+                    "<ReturnType Type=\"Edm.String\" Nullable=\"false\" />" +
+                  "</Function>" +
+                  "<EntityContainer Name=\"Default\">" +
+                    "<FunctionImport Name=\"TestFunction\" Function=\"test.TestFunction\" />" +
+                  "</EntityContainer>" +
+                "</Schema>" +
+              "</edmx:DataServices>" +
+            "</edmx:Edmx>");
+
+            // Act & Assert for JSON
+            WriteAndVerifyJson(model, @"{
+  ""$Version"": ""4.0"",
+  ""$EntityContainer"": ""test.Default"",
+  ""test"": {
+    ""TestFunction"": [
+      {
+        ""$Kind"": ""Function"",
+        ""$Parameter"": [
+          {
+            ""$Name"": ""requiredParam""
+          },
+          {
+            ""$Name"": ""optionalParam"",
+            ""@Core.OptionalParameter"": {}
+          },
+          {
+            ""$Name"": ""optionalParamWithDefault"",
+            ""@Core.OptionalParameter"": {
+              ""DefaultValue"": ""Smith""
+            }
+          }
+        ],
+        ""$ReturnType"": {}
+      }
+    ],
+    ""Default"": {
+      ""$Kind"": ""EntityContainer"",
+      ""TestFunction"": {
+        ""$Kind"": ""FunctionImport"",
+        ""$Function"": ""test.TestFunction""
+      }
+    }
+  }
+}");
         }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes issue #xxx.*

OData spec says:

5.1 Alias
A schema MAY specify an alias which MUST be a simple identifier.

If a schema specifies an alias, the alias MUST be used instead of the namespace within qualified names throughout the document to identify model elements of that schema. A mixed use of namespace-qualified names and alias-qualified names is not allowed.

https://docs.oasis-open.org/odata/odata-csdl-json/v4.01/odata-csdl-json-v4.01.html#sec_Alias

### Description

*Currently the issue is with using aliases for referenced models if they are set instead of using fully qualified names when writing the csdl.*

### Checklist (Uncheck if it is not completed)

- [x] *Ensure aliases are document global and do not apply only to the schema defining them*
- [x] *Add support for namespace aliases in referenced models*


### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
