### PR TITLE
Configure remote profiles for running benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,32 @@ The easiest way to run the perf benchmarks is to use the [Microsoft.Crank](https
     crank --config benchmarks.yml --scenario UriParser --profile local
     ```
 
+#### Run benchmarks on remote dedicated agents
+
+The `local` profile is provided for testing purposes, but it's not ideal for running benchmarks.
+For more stable results and results that we can more reliably compare, the following profiles are also
+available and should be preferred whenever possible:
+
+Profile       | Machine Architecture | OS
+--------------|----------------------|------
+`lab-windows` | INTEL, 12 Cores      | Windows Server 2016
+`lab-linux`   | INTEL, 12 Cores      | Ubuntu 18.04, Kernel 4.x
+
+Use the `--profile` argument to specify the profile you want to use. For example,
+to run the components benchmark on the Windows agent, run the following command:
+
+```
+crank --config benchmarks.yml --scenario Components --profile lab-windows
+```
+
+And to run on the Linux agent:
+
+```
+crank --config benchmarks.yml --scenario Components --profile lab-linux
+```
+
+PS: We should not use these machines to run automated scheduled benchmarks.
+
 #### Run benchmarks against the official repo
 
 To run benchmarks against the official repo instead of your local repo, pass

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -1,4 +1,3 @@
-
 variables:
   # set to true to run benchmarks against master branch of main/official repo
   base: false
@@ -80,3 +79,17 @@ profiles:
       application:
         endpoints:
           - http://localhost:5010
+  # Remote lab machines for benchmarking
+  # These are also used by ASP.NET team
+  # for more info visit: https://github.com/aspnet/Benchmarks/tree/main/scenarios
+  # and https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml
+  lab-windows:
+    jobs:
+      application:
+        endpoints:
+          - http://asp-perf-win:5001
+  lab-linux:
+    jobs:
+      application:
+        endpoints:
+          - http://asp-perf-lin:5001


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fix #2167 

### Description

Added two profiles for running benchmarks: `lab-windows` and `lab-linux`. These are remote machines dedicated for running on-demand benchmarks with `Microsoft.Crank`.

They are used by the ASP.NET team for running their benchmarks, see: https://github.com/aspnet/Benchmarks/tree/main/scenarios and https://github.com/aspnet/Benchmarks/blob/main/scenarios/aspnet.profiles.yml

Here's how you'd use them to run benchmarks:

```
crank --config benchmarks.yml --scenario Components --profile lab-linux
```



### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
