### PR TITLE
EdmLib Vocabulary Annotation Default Values

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
@@ -341,6 +341,9 @@ namespace Microsoft.OData.Edm.Csdl
                         model.SetEdmVersion(edmVersion);
                     }
 
+                    // Note: Considered manually replacing expressions after adding the terms to the model
+                    // so I could initialize them with default values. (Would need to replace because
+                    // the annotation.Value property is readonly.) However, this is somewhat expensive/complex.
                     /*IEnumerable<IEdmVocabularyAnnotation> annotations = model.VocabularyAnnotations;
                     for (int i = 0; i < annotations.Count(); i++)
                     {

--- a/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
@@ -340,6 +340,18 @@ namespace Microsoft.OData.Edm.Csdl
                     {
                         model.SetEdmVersion(edmVersion);
                     }
+
+                    /*IEnumerable<IEdmVocabularyAnnotation> annotations = model.VocabularyAnnotations;
+                    for (int i = 0; i < annotations.Count(); i++)
+                    {
+                        IEdmVocabularyAnnotation currAnnotation = annotations.ElementAt(i);
+                        if (currAnnotation.UsesDefault)
+                        {
+                            IEdmVocabularyAnnotation replacementValue = new EdmExpression(...);
+                            IEdmVocabularyAnnotation replacementAnnotation = new IEdmExpression(...);
+                            annotations.SetElement(i, replacementAnnotation);
+                        }
+                    }*/
                 }
                 else
                 {

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAnnotation.cs
@@ -14,6 +14,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         private readonly CsdlExpressionBase expression;
         private readonly string qualifier;
         private readonly string term;
+        private readonly bool usesDefault;
 
         public CsdlAnnotation(string term, string qualifier, CsdlExpressionBase expression, CsdlLocation location)
             : base(location)
@@ -21,6 +22,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
             this.expression = expression;
             this.qualifier = qualifier;
             this.term = term;
+            this.usesDefault = expression == null;
         }
 
         public CsdlExpressionBase Expression
@@ -36,6 +38,11 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         public string Term
         {
             get { return this.term; }
+        }
+
+        public bool UsesDefault
+        {
+            get { return this.usesDefault; }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlAnnotation.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
         private readonly CsdlExpressionBase expression;
         private readonly string qualifier;
         private readonly string term;
-        private readonly bool usesDefault;
+        private readonly bool usesDefault; // Note: I may take off this property again if it's not needed for the implementation
 
         public CsdlAnnotation(string term, string qualifier, CsdlExpressionBase expression, CsdlLocation location)
             : base(location)
@@ -22,7 +22,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
             this.expression = expression;
             this.qualifier = qualifier;
             this.term = term;
-            this.usesDefault = expression == null;
+            this.usesDefault = expression == null; // if the expression is missing, we want the term's default value
         }
 
         public CsdlExpressionBase Expression

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParserBase.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParserBase.cs
@@ -364,6 +364,16 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             string qualifier = Optional(CsdlConstants.Attribute_Qualifier);
             CsdlExpressionBase expression = this.ParseAnnotationExpression(element, childValues);
 
+
+            // if expression is null, set it to term's default value
+            if (expression == null)
+            {
+                //IEdmTerm defaultTerm = element.FindTerm("NS.MyDefaultTerm");
+                //Assert.Equal("This is a test", defaultTerm.DefaultValue);
+                XmlAttributeInfo termComponent = element.Attributes[CsdlConstants.Attribute_Term]; // my attempt to start getting to term's default value
+                //termComponent. // doesn't have UsesDefault
+            }
+
             return new CsdlAnnotation(term, qualifier, expression, element.Location);
         }
 

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParserBase.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParserBase.cs
@@ -365,14 +365,13 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             CsdlExpressionBase expression = this.ParseAnnotationExpression(element, childValues);
 
 
-            // if expression is null, set it to term's default value
-            if (expression == null)
+            // Note: Attempted to set the expression to the term's default value,
+            // but there wasn't a good way to access that value -- just the term's name.
+            /* (expression == null)
             {
-                //IEdmTerm defaultTerm = element.FindTerm("NS.MyDefaultTerm");
-                //Assert.Equal("This is a test", defaultTerm.DefaultValue);
-                XmlAttributeInfo termComponent = element.Attributes[CsdlConstants.Attribute_Term]; // my attempt to start getting to term's default value
-                //termComponent. // doesn't have UsesDefault
-            }
+                XmlAttributeInfo termComponent = element.Attributes[CsdlConstants.Attribute_Term];
+                //termComponent. // doesn't have DefaultValue
+            }*/
 
             return new CsdlAnnotation(term, qualifier, expression, element.Location);
         }

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
@@ -26,6 +26,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         private readonly CsdlSemanticsAnnotations annotationsContext;
         private readonly Cache<CsdlSemanticsVocabularyAnnotation, IEdmExpression> valueCache = new Cache<CsdlSemanticsVocabularyAnnotation, IEdmExpression>();
         private static readonly Func<CsdlSemanticsVocabularyAnnotation, IEdmExpression> ComputeValueFunc = (me) => me.ComputeValue();
+        private readonly bool usesDefault;
 
         private readonly Cache<CsdlSemanticsVocabularyAnnotation, IEdmTerm> termCache = new Cache<CsdlSemanticsVocabularyAnnotation, IEdmTerm>();
         private static readonly Func<CsdlSemanticsVocabularyAnnotation, IEdmTerm> ComputeTermFunc = (me) => me.ComputeTerm();
@@ -43,6 +44,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             this.qualifier = qualifier ?? annotation.Qualifier;
             this.targetContext = targetContext;
             this.annotationsContext = annotationsContext;
+            this.usesDefault = false;
         }
 
         public CsdlSemanticsSchema Schema { get; }
@@ -55,6 +57,15 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public string Qualifier
         {
             get { return this.qualifier; }
+        }
+
+        /// <summary>
+        /// Gets whether the annotation uses a default value
+        /// (not defined with a provided value).
+        /// </summary>
+        public bool UsesDefault
+        {
+            get { return this.usesDefault; }
         }
 
         public override CsdlSemanticsModel Model

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
@@ -26,7 +26,6 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         private readonly CsdlSemanticsAnnotations annotationsContext;
         private readonly Cache<CsdlSemanticsVocabularyAnnotation, IEdmExpression> valueCache = new Cache<CsdlSemanticsVocabularyAnnotation, IEdmExpression>();
         private static readonly Func<CsdlSemanticsVocabularyAnnotation, IEdmExpression> ComputeValueFunc = (me) => me.ComputeValue();
-        private readonly bool usesDefault;
 
         private readonly Cache<CsdlSemanticsVocabularyAnnotation, IEdmTerm> termCache = new Cache<CsdlSemanticsVocabularyAnnotation, IEdmTerm>();
         private static readonly Func<CsdlSemanticsVocabularyAnnotation, IEdmTerm> ComputeTermFunc = (me) => me.ComputeTerm();
@@ -44,7 +43,6 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
             this.qualifier = qualifier ?? annotation.Qualifier;
             this.targetContext = targetContext;
             this.annotationsContext = annotationsContext;
-            this.usesDefault = false;
         }
 
         public CsdlSemanticsSchema Schema { get; }
@@ -65,7 +63,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         /// </summary>
         public bool UsesDefault
         {
-            get { return this.usesDefault; }
+            get { return this.Annotation.UsesDefault; }
         }
 
         public override CsdlSemanticsModel Model
@@ -138,14 +136,29 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         private IEdmExpression ComputeValue()
         {
             IEdmTypeReference termType = Term is UnresolvedVocabularyTerm ? null : Term.Type;
-            CsdlExpressionBase adjustedExpression = AdjustStringConstantUsingTermType((this.Annotation).Expression, termType);
+            /*CsdlExpressionBase adjustedExpression;
+            if (!this.Annotation.UsesDefault)
+            {
+                adjustedExpression = AdjustStringConstantUsingTermType((this.Annotation).Expression, termType);
+            } else
+            {
+                adjustedExpression = AdjustStringConstantUsingTermType(this.Term.DefaultValue, termType);
+            }*/
 
+            /*if (!this.Annotation.UsesDefault)
+            {
+                var defaultExpression = new CsdlSemanticsStringConstantExpression(Term.DefaultValue, this.Schema);
+                return CsdlSemanticsModel.WrapExpression(defaultExpression, TargetBindingContext, this.Schema);
+            }*/
+
+            CsdlExpressionBase adjustedExpression = AdjustStringConstantUsingTermType((this.Annotation).Expression, termType);
             return CsdlSemanticsModel.WrapExpression(adjustedExpression, TargetBindingContext, this.Schema);
         }
 
         private static CsdlExpressionBase AdjustStringConstantUsingTermType(CsdlExpressionBase expression, IEdmTypeReference termType)
         {
             if (expression == null || termType == null)
+            // if (expression == null || (expression != null && termType == null))
             {
                 return expression;
             }

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
@@ -136,15 +136,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         private IEdmExpression ComputeValue()
         {
             IEdmTypeReference termType = Term is UnresolvedVocabularyTerm ? null : Term.Type;
-            /*CsdlExpressionBase adjustedExpression;
-            if (!this.Annotation.UsesDefault)
-            {
-                adjustedExpression = AdjustStringConstantUsingTermType((this.Annotation).Expression, termType);
-            } else
-            {
-                adjustedExpression = AdjustStringConstantUsingTermType(this.Term.DefaultValue, termType);
-            }*/
-
+            // Note: Attempted to create a wrapped version for the term's default value, but could not access said value.
             /*if (!this.Annotation.UsesDefault)
             {
                 var defaultExpression = new CsdlSemanticsStringConstantExpression(Term.DefaultValue, this.Schema);
@@ -157,9 +149,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
         private static CsdlExpressionBase AdjustStringConstantUsingTermType(CsdlExpressionBase expression, IEdmTypeReference termType)
         {
-            if (expression == null || termType == null)
-            // if (expression == null || (expression != null && termType == null))
-            {
+            if (expression == null || termType == null)            {
                 return expression;
             }
 

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
@@ -504,7 +504,10 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.WriteOptionalAttribute(CsdlConstants.Attribute_Qualifier, annotation.Qualifier, EdmValueWriter.StringAsXml);
             if (isInline)
             {
-                if (!annotation.UsesDefault) // interface doesn't have UsesDefault -> I added it
+                if (!annotation.UsesDefault)
+                // Note: If I recall correctly, casting didn't work here (it caused problems in other tests),
+                // so I added UsesDefault to the interface. This is a breaking change, so it'll need to become
+                // an interface extension or similar in the future.
                 {
                     this.WriteInlineExpression(annotation.Value);
                 }                

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
@@ -504,7 +504,10 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.WriteOptionalAttribute(CsdlConstants.Attribute_Qualifier, annotation.Qualifier, EdmValueWriter.StringAsXml);
             if (isInline)
             {
-                this.WriteInlineExpression(annotation.Value);
+                if (!annotation.UsesDefault) // interface doesn't have UsesDefault -> I added it
+                {
+                    this.WriteInlineExpression(annotation.Value);
+                }                
             }
         }
 

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
@@ -344,7 +344,16 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
 
         protected override void ProcessAnnotation(IEdmVocabularyAnnotation annotation)
         {
-            bool isInline = IsInlineExpression(annotation.Value);
+            bool isInline;
+            // Note: This currently needs to be separated out because CsdlSemanticsVocabularyAnnotation
+            // doesn't return the default value from Value at the moment.
+            if (!annotation.UsesDefault)
+            {
+                isInline = IsInlineExpression(annotation.Value);
+            } else
+            {
+                isInline = IsInlineExpression(new EdmStringConstant(annotation.Term.DefaultValue));
+            }
             this.BeginElement(annotation, t => this.schemaWriter.WriteVocabularyAnnotationElementHeader(t, isInline));
             if (!isInline)
             {

--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -642,7 +642,13 @@ namespace Microsoft.OData.Edm
         protected virtual void ProcessAnnotation(IEdmVocabularyAnnotation annotation)
         {
             this.ProcessVocabularyAnnotation(annotation);
-            this.VisitExpression(annotation.Value);
+            if (!annotation.UsesDefault)
+            {
+                this.VisitExpression(annotation.Value);
+            } else
+            {
+                this.VisitExpression(new EdmStringConstant(annotation.Term.DefaultValue));
+            }
         }
 
         protected virtual void ProcessPropertyValueBinding(IEdmPropertyValueBinding binding)

--- a/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
+++ b/src/Microsoft.OData.Edm/Validation/EdmErrorCode.cs
@@ -1384,6 +1384,12 @@ namespace Microsoft.OData.Edm.Validation
         AnnotationApplyToNotAllowedAnnotatable = 400,
 
         /// <summary>
+        /// The vocabulary annotation has an unspecified value and uses a term without a default value --
+        /// should have at least one.
+        /// </summary>
+        ExpressionMissingValueOrTermWithDefaultValue = 401,
+
+        /// <summary>
         /// Invalid $Key value.
         /// </summary>
         InvalidKeyValue,

--- a/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
+++ b/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
@@ -1828,7 +1828,7 @@ namespace Microsoft.OData.Edm.Validation
                 }
                 else if (annotation.Term.DefaultValue != null)
                 {
-                    //followup.Add(new EdmStringConstant(annotation.Term.DefaultValue));
+                    followup.Add(new EdmStringConstant(annotation.Term.DefaultValue));
                 }
                 else
                 {

--- a/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
+++ b/src/Microsoft.OData.Edm/Validation/InterfaceValidator.cs
@@ -1826,6 +1826,10 @@ namespace Microsoft.OData.Edm.Validation
                 {
                     followup.Add(annotation.Value);
                 }
+                else if (annotation.Term.DefaultValue != null)
+                {
+                    //followup.Add(new EdmStringConstant(annotation.Term.DefaultValue));
+                }
                 else
                 {
                     CollectErrors(CreatePropertyMustNotBeNullError(annotation, "Value"), ref errors);

--- a/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
@@ -67,6 +67,7 @@ namespace Microsoft.OData.Edm.Validation
                 ValidationRules.StringTypeReferenceStringUnboundedNotValidForMaxLength,
                 ValidationRules.ImmediateValueAnnotationElementAnnotationIsValid,
                 ValidationRules.VocabularyAnnotationAssertCorrectExpressionType,
+                ValidationRules.VocabularyAnnotationUseDefaultTermMustHaveDefaultValue,
                 ValidationRules.IfExpressionAssertCorrectTestType,
                 ValidationRules.CollectionExpressionAllElementsCorrectType,
                 ValidationRules.RecordExpressionPropertiesMatchType,

--- a/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
@@ -2485,15 +2485,34 @@ namespace Microsoft.OData.Edm.Validation
                 (context, annotation) =>
                 {
                     IEnumerable<EdmError> errors;
-                    if (!annotation.Value.TryCast(annotation.Term.Type, out errors))
+                    if (!annotation.UsesDefault)
                     {
-                        foreach (EdmError error in errors)
+                        if (!annotation.Value.TryCast(annotation.Term.Type, out errors))
                         {
-                            if (error.ErrorCode != EdmErrorCode.RecordExpressionMissingRequiredProperty)
+                            foreach (EdmError error in errors)
                             {
-                                context.AddError(error);
+                                if (error.ErrorCode != EdmErrorCode.RecordExpressionMissingRequiredProperty)
+                                {
+                                    context.AddError(error);
+                                }
                             }
                         }
+                    }
+                });
+
+        /// <summary>
+        /// Validates that if a vocabulary annotation doesn't have a value, it should declare a type with a default value.
+        /// </summary>
+        public static readonly ValidationRule<IEdmVocabularyAnnotation> VocabularyAnnotationUseDefaultTermMustHaveDefaultValue =
+            new ValidationRule<IEdmVocabularyAnnotation>(
+                (context, annotation) =>
+                {
+                    if (annotation.UsesDefault && annotation.Term.DefaultValue == null)
+                    {
+                        context.AddError(
+                            annotation.Location(),
+                            EdmErrorCode.ExpressionMissingValueOrTermWithDefaultValue,
+                            "Annotation expressions must specify a value or use a term with a specified default value.");
                     }
                 });
 

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmVocabularyAnnotation.cs
@@ -52,17 +52,17 @@ namespace Microsoft.OData.Edm.Vocabularies
         }
 
         /// <summary>
-        /// NEW: Initializes a new instance of the EdmVocabularyAnnotation class
+        /// Initializes a new instance of the EdmVocabularyAnnotation class
         /// to the default value.
         /// </summary>
         /// <param name=“target”>Element the annotation applies to.</param>
         /// <param name=“term”>Term bound by the annotation</param>
         public EdmVocabularyAnnotation(IEdmVocabularyAnnotatable target, IEdmTerm term)
-            //: this(target, term, null, new EdmStringConstant(term.DefaultValue))
         {
             // Check arguments
             if (term.DefaultValue == null) // throw error if no default value
             {
+                // Note: I'm not sure which is the better way of throwing the exception:
                 //throw new ArgumentNullException("value");
                 EdmUtil.CheckArgumentNull(new EdmStringConstant(null), "value");
             }
@@ -77,31 +77,35 @@ namespace Microsoft.OData.Edm.Vocabularies
             this.target = target;
             this.term = term;
             this.qualifier = null;
-            //this.value = BuildDefaultValue(term);
-            this.value = new EdmStringConstant(term.DefaultValue);
+            //this.value = BuildDefaultValue(term); // Note: Eventually this method will parse the default value
+            this.value = new EdmStringConstant(term.DefaultValue); // Note: temporarily only supporting Strings
             this.usesDefault = true;
         }
 
+        /// <summary>
+        /// Parses a <paramref name="defaultValue"/> into an IEdmExpression value of the correct type.
+        /// </summary>
+        /// <param name=“typeReference”>The type of value.</param>
+        /// <param name=“defaultValue”>Original default value.</param>
+        /// <returns>An IEdmExpression of type <paramref name="typeReference".</paramref></returns>
         /*private static IEdmExpression BuildDefaultValue(IEdmTypeReference typeReference, string defaultValue)
         {
             //string defaultValue = term.DefaultValue;
             EdmTypeKind termTypeKind = typeReference.TypeKind();
 
+            // Create constants for the corresponding types
             switch(termTypeKind)
             {
                 case EdmTypeKind.Primitive:
                     return BuildPrimitiveValue(typeReference.AsPrimitive(), defaultValue);
-
                 case EdmTypeKind.Enum:
-
-                    // EdmEnumMemberExpression
-                    // do the enum express
-                    return new EdmEnumMemberExpression(....);
-
+                    // TODO: return new EdmEnumMemberExpression(....);
                 case EdmTypeKind.Complex:
+                    // TODO
                 case EdmTypeKind.Entity:
+                    // Example:
                     // {
-                    //   "City":"Remodn",
+                    //   "City":"Redmond",
                     //   "Street": "156TH, AVE..."
                     // }
                     var properties = ParseObject(defaultValue);
@@ -114,16 +118,14 @@ namespace Microsoft.OData.Edm.Vocabularies
 
                     // build the properties expression one by one
                     return new EdmRecordExpression(....);
-
                 case EdmTypeKind.Collection:
                     IEdmCollectionTypeReference collectionType = (IEdmCollectionTypeReference)typeReference;
                     IEdmTypeReference elementType = collectionType.ElementType();
-                    // Be sure is it in the scope?
-                    // If ti's in the scope
+                    // If it's in the scope:
                     // term.DefaultValue could be a JSON string
                     // [5, 6, 9]
-                    // [{"city":"red,[]mond", },{}]
-                    // Have to parse the JSON array into Items
+                    // [{"city":["redmond","seattle"]},{}]
+                    // Have to recursively parse the JSON array into items
 
                     var items = ParseCollection(defaultValue);
                     IList<IEdmExpression> itemExpressions = new List<IEdmExpression>();
@@ -135,40 +137,18 @@ namespace Microsoft.OData.Edm.Vocabularies
 
                     return new EdmCollectionExpression(elementType, itemExpressions);
 
-                case EdmTypeKind.TypeDefinition:
-                    ....
-
-
-            }*/
-
-            //return new EdmNavigationPropertyPathExpression(defaultValue);
-
-            //IEdmExpression defaultValueExp = new EdmStringConstant(defaultValue);
-
-            /*if (object.Equals(termTypeKind, IEdmExpression.BinaryConstant))
-            {
-                return new EdmBinaryConstant(System.Binary.Parse(defaultValue));
+                //case EdmTypeKind.TypeDefinition:
+                //    ....
+                // Note: Need to have cases for the following types:
+                // DateTimeOffsetConstant, DecimalConstant, FloatingConstant, GuidConstant, IntegerConstant,
+                // StringConstant, DurationConstant, Null, Record, Collection, Path, If, Cast, IsType,
+                // FunctionApplication, LabeledExpressionReference, Labeled, PropertyPath, NavigationPropertyPath,
+                // DateConstant, TimeOfDayConstant, EnumMember, AnnotationPath
             }
-            else if (object.Equals(termTypeKind, IEdmExpression.BooleanConstant))
-            {
-                return new EdmBooleanConstant(System.Boolean.Parse(defaultValue));
-            }
-            // ...
-            else
-            {
-                return new EdmStringConstant(defaultValue);
-            }
-
-
-            // DateTimeOffsetConstant, DecimalConstant, FloatingConstant, GuidConstant, IntegerConstant,
-            // StringConstant, DurationConstant, Null, Record, Collection, Path, If, Cast, IsType,
-            // FunctionApplication, LabeledExpressionReference, Labeled, PropertyPath, NavigationPropertyPath,
-            // DateConstant, TimeOfDayConstant, EnumMember, AnnotationPath
-
-            //return defaultValueExp;
         }*/
 
-        /* static IDictionary<string, string> ParseObject(string defaultValue)
+        // Parse an object from a string
+        /*private static IDictionary<string, string> ParseObject(string defaultValue)
         {
             // parse the JSON array into items
             // "[5, 6, 8]"  => return "5", "6", "8"
@@ -176,6 +156,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             return null;
         }
 
+        // Parse a collection from a string
         private static IEnumerable<string> ParseCollection(string defaultValue)
         {
             // parse the JSON array into items
@@ -184,6 +165,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             return null;
         }*/
 
+        // Return an IEdmExpression for a primitive value from a string
         /*private static IEdmExpression BuildPrimitiveValue(IEdmPrimitiveTypeReference reference, string defaultValue)
         {
             switch (reference.PrimitiveKind())
@@ -206,31 +188,37 @@ namespace Microsoft.OData.Edm.Vocabularies
                     this.ProcessTemporalTypeReference(reference.AsTemporal());
                     break;
                 case EdmPrimitiveTypeKind.Boolean:
-                    // add code to create bollean cont
+                    // TODO: return constant
                     break;
                 case EdmPrimitiveTypeKind.Byte:
-                    // add code to creat 
+                    // TODO: return constant
                 case EdmPrimitiveTypeKind.Double:
+                    // TODO: return constant
                     break;
                 case EdmPrimitiveTypeKind.Guid:
-                    // add code to create Guid Contant
+                    // TODO: return constant
                     break;
                 case EdmPrimitiveTypeKind.Int16:
+                    // TODO: return constant
                     break;
                 case EdmPrimitiveTypeKind.Int32:
+                    // TODO: return constant
                     break;
                 case EdmPrimitiveTypeKind.Int64:
+                    // TODO: return constant
                     break;
                 case EdmPrimitiveTypeKind.SByte:
+                    // TODO: return constant
                     break;
                 case EdmPrimitiveTypeKind.Single:
+                    // TODO: return constant
                     break;
                 case EdmPrimitiveTypeKind.Date:
+                    // TODO: return constant
                     break;
 
-                    // below type kinds are not supported for expression?
+                    // Note: Ignoring these for now - should they be supported for expressions?
                 case EdmPrimitiveTypeKind.Stream:
-                    ///fkasdlkjfasdlfjdsal;jflaj
                 case EdmPrimitiveTypeKind.Geography:
                 case EdmPrimitiveTypeKind.GeographyPoint:
                 case EdmPrimitiveTypeKind.GeographyLineString:
@@ -250,12 +238,12 @@ namespace Microsoft.OData.Edm.Vocabularies
                 case EdmPrimitiveTypeKind.PrimitiveType:
                 case EdmPrimitiveTypeKind.None:
                 default:
-                    // Throw exception here for notsupported tyep kind
+                    // Throw exception here for not supported TypeKind
                     throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_PrimitiveKind(reference.PrimitiveKind().ToString()));
             }
         }*/
 
-        /* This constructor is ambiguous with the other three-param constructor...
+        /* Note: This constructor is ambiguous with the other three-param constructor...
         /// <summary>
         /// NEW: Initializes a new instance of the EdmVocabularyAnnotation class 
         /// to the default value.

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmVocabularyAnnotation.cs
@@ -15,6 +15,7 @@ namespace Microsoft.OData.Edm.Vocabularies
         private readonly IEdmTerm term;
         private readonly string qualifier;
         private readonly IEdmExpression value;
+        private readonly bool usesDefault;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmVocabularyAnnotation"/> class.
@@ -44,7 +45,54 @@ namespace Microsoft.OData.Edm.Vocabularies
             this.term = term;
             this.qualifier = qualifier;
             this.value = value;
+            this.usesDefault = false;
         }
+
+        /// <summary>
+        /// NEW: Initializes a new instance of the EdmVocabularyAnnotation class
+        /// to the default value.
+        /// </summary>
+        /// <param name=“target”>Element the annotation applies to.</param>
+        /// <param name=“term”>Term bound by the annotation</param>
+        public EdmVocabularyAnnotation(IEdmVocabularyAnnotatable target, IEdmTerm term)
+            //: this(target, term, null, new EdmStringConstant(term.DefaultValue))
+        {
+            // Check arguments
+            if (term.DefaultValue == null) // throw error if no default value
+            {
+                //throw new ArgumentNullException("value");
+                EdmUtil.CheckArgumentNull(new EdmStringConstant(null), "value");
+            }
+            EdmUtil.CheckArgumentNull(target, "target");
+            EdmUtil.CheckArgumentNull(term, "term");
+
+            // Find default value
+            string defaultValue = term.DefaultValue;
+            IEdmExpression defaultValueExp = new EdmStringConstant(defaultValue);
+
+            // Check arguments
+            EdmUtil.CheckArgumentNull(target, "target");
+            EdmUtil.CheckArgumentNull(term, "term");
+
+            // Initialize
+            this.target = target;
+            this.term = term;
+            this.qualifier = null;
+            this.value = defaultValueExp;
+            this.usesDefault = true;
+        }
+
+        /* This constructor is ambiguous with the other three-param constructor...
+        /// <summary>
+        /// NEW: Initializes a new instance of the EdmVocabularyAnnotation class 
+        /// to the default value.
+        /// </summary>
+        /// <param name=“target”>Element the annotation applies to.</param>
+        /// <param name=“term”>Term bound by the annotation</param>
+        /// <param name=“qualifier”>Qualifier used to distinguish bindings.</param>
+        public EdmVocabularyAnnotation(IEdmVocabularyAnnotatable target, IEdmTerm term,
+        string qualifier)
+        { }*/
 
         /// <summary>
         /// Gets the element the annotation applies to.
@@ -76,6 +124,14 @@ namespace Microsoft.OData.Edm.Vocabularies
         public IEdmExpression Value
         {
             get { return this.value; }
+        }
+
+        /// <summary>
+        /// Gets Whether the annotation uses a default value
+        /// (not defined with a provided value).
+        /// </summary>
+        public bool UsesDefault {
+            get { return this.usesDefault; }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmVocabularyAnnotation.cs
@@ -4,6 +4,9 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using Microsoft.OData.Edm.Csdl;
+using System.Collections.Generic;
+
 namespace Microsoft.OData.Edm.Vocabularies
 {
     /// <summary>
@@ -66,10 +69,6 @@ namespace Microsoft.OData.Edm.Vocabularies
             EdmUtil.CheckArgumentNull(target, "target");
             EdmUtil.CheckArgumentNull(term, "term");
 
-            // Find default value
-            string defaultValue = term.DefaultValue;
-            IEdmExpression defaultValueExp = new EdmStringConstant(defaultValue);
-
             // Check arguments
             EdmUtil.CheckArgumentNull(target, "target");
             EdmUtil.CheckArgumentNull(term, "term");
@@ -78,9 +77,183 @@ namespace Microsoft.OData.Edm.Vocabularies
             this.target = target;
             this.term = term;
             this.qualifier = null;
-            this.value = defaultValueExp;
+            //this.value = BuildDefaultValue(term);
+            this.value = new EdmStringConstant(term.DefaultValue);
             this.usesDefault = true;
         }
+
+        /*private static IEdmExpression BuildDefaultValue(IEdmTypeReference typeReference, string defaultValue)
+        {
+            //string defaultValue = term.DefaultValue;
+            EdmTypeKind termTypeKind = typeReference.TypeKind();
+
+            switch(termTypeKind)
+            {
+                case EdmTypeKind.Primitive:
+                    return BuildPrimitiveValue(typeReference.AsPrimitive(), defaultValue);
+
+                case EdmTypeKind.Enum:
+
+                    // EdmEnumMemberExpression
+                    // do the enum express
+                    return new EdmEnumMemberExpression(....);
+
+                case EdmTypeKind.Complex:
+                case EdmTypeKind.Entity:
+                    // {
+                    //   "City":"Remodn",
+                    //   "Street": "156TH, AVE..."
+                    // }
+                    var properties = ParseObject(defaultValue);
+                    foreach (var item in properties)
+                    {
+                        // get the property
+                        // get the property type from strucutral type
+                        // build the propertyvalue
+                    }
+
+                    // build the properties expression one by one
+                    return new EdmRecordExpression(....);
+
+                case EdmTypeKind.Collection:
+                    IEdmCollectionTypeReference collectionType = (IEdmCollectionTypeReference)typeReference;
+                    IEdmTypeReference elementType = collectionType.ElementType();
+                    // Be sure is it in the scope?
+                    // If ti's in the scope
+                    // term.DefaultValue could be a JSON string
+                    // [5, 6, 9]
+                    // [{"city":"red,[]mond", },{}]
+                    // Have to parse the JSON array into Items
+
+                    var items = ParseCollection(defaultValue);
+                    IList<IEdmExpression> itemExpressions = new List<IEdmExpression>();
+                    foreach (var item in items)
+                    {
+                        IEdmExpression itemExpr = BuildDefaultValue(elementType, item);
+                        itemExpressions.Add(itemExpr);
+                    }
+
+                    return new EdmCollectionExpression(elementType, itemExpressions);
+
+                case EdmTypeKind.TypeDefinition:
+                    ....
+
+
+            }*/
+
+            //return new EdmNavigationPropertyPathExpression(defaultValue);
+
+            //IEdmExpression defaultValueExp = new EdmStringConstant(defaultValue);
+
+            /*if (object.Equals(termTypeKind, IEdmExpression.BinaryConstant))
+            {
+                return new EdmBinaryConstant(System.Binary.Parse(defaultValue));
+            }
+            else if (object.Equals(termTypeKind, IEdmExpression.BooleanConstant))
+            {
+                return new EdmBooleanConstant(System.Boolean.Parse(defaultValue));
+            }
+            // ...
+            else
+            {
+                return new EdmStringConstant(defaultValue);
+            }
+
+
+            // DateTimeOffsetConstant, DecimalConstant, FloatingConstant, GuidConstant, IntegerConstant,
+            // StringConstant, DurationConstant, Null, Record, Collection, Path, If, Cast, IsType,
+            // FunctionApplication, LabeledExpressionReference, Labeled, PropertyPath, NavigationPropertyPath,
+            // DateConstant, TimeOfDayConstant, EnumMember, AnnotationPath
+
+            //return defaultValueExp;
+        }*/
+
+        /* static IDictionary<string, string> ParseObject(string defaultValue)
+        {
+            // parse the JSON array into items
+            // "[5, 6, 8]"  => return "5", "6", "8"
+            // defaultValue.
+            return null;
+        }
+
+        private static IEnumerable<string> ParseCollection(string defaultValue)
+        {
+            // parse the JSON array into items
+            // "[5, 6, 8]"  => return "5", "6", "8"
+            // defaultValue.
+            return null;
+        }*/
+
+        /*private static IEdmExpression BuildPrimitiveValue(IEdmPrimitiveTypeReference reference, string defaultValue)
+        {
+            switch (reference.PrimitiveKind())
+            {
+                case EdmPrimitiveTypeKind.Binary:
+                    byte[] binary = new byte[0];
+                    EdmValueParser.TryParseBinary(defaultValue, out binary);
+                    return new EdmBinaryConstant(binary);
+         
+                // ...
+                case EdmPrimitiveTypeKind.Decimal:
+                    this.ProcessDecimalTypeReference(reference.AsDecimal());
+                    break;
+                case EdmPrimitiveTypeKind.String:
+                    this.ProcessStringTypeReference(reference.AsString());
+                    break;
+                case EdmPrimitiveTypeKind.DateTimeOffset:
+                case EdmPrimitiveTypeKind.Duration:
+                case EdmPrimitiveTypeKind.TimeOfDay:
+                    this.ProcessTemporalTypeReference(reference.AsTemporal());
+                    break;
+                case EdmPrimitiveTypeKind.Boolean:
+                    // add code to create bollean cont
+                    break;
+                case EdmPrimitiveTypeKind.Byte:
+                    // add code to creat 
+                case EdmPrimitiveTypeKind.Double:
+                    break;
+                case EdmPrimitiveTypeKind.Guid:
+                    // add code to create Guid Contant
+                    break;
+                case EdmPrimitiveTypeKind.Int16:
+                    break;
+                case EdmPrimitiveTypeKind.Int32:
+                    break;
+                case EdmPrimitiveTypeKind.Int64:
+                    break;
+                case EdmPrimitiveTypeKind.SByte:
+                    break;
+                case EdmPrimitiveTypeKind.Single:
+                    break;
+                case EdmPrimitiveTypeKind.Date:
+                    break;
+
+                    // below type kinds are not supported for expression?
+                case EdmPrimitiveTypeKind.Stream:
+                    ///fkasdlkjfasdlfjdsal;jflaj
+                case EdmPrimitiveTypeKind.Geography:
+                case EdmPrimitiveTypeKind.GeographyPoint:
+                case EdmPrimitiveTypeKind.GeographyLineString:
+                case EdmPrimitiveTypeKind.GeographyPolygon:
+                case EdmPrimitiveTypeKind.GeographyCollection:
+                case EdmPrimitiveTypeKind.GeographyMultiPolygon:
+                case EdmPrimitiveTypeKind.GeographyMultiLineString:
+                case EdmPrimitiveTypeKind.GeographyMultiPoint:
+                case EdmPrimitiveTypeKind.Geometry:
+                case EdmPrimitiveTypeKind.GeometryPoint:
+                case EdmPrimitiveTypeKind.GeometryLineString:
+                case EdmPrimitiveTypeKind.GeometryPolygon:
+                case EdmPrimitiveTypeKind.GeometryCollection:
+                case EdmPrimitiveTypeKind.GeometryMultiPolygon:
+                case EdmPrimitiveTypeKind.GeometryMultiLineString:
+                case EdmPrimitiveTypeKind.GeometryMultiPoint:
+                case EdmPrimitiveTypeKind.PrimitiveType:
+                case EdmPrimitiveTypeKind.None:
+                default:
+                    // Throw exception here for notsupported tyep kind
+                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_PrimitiveKind(reference.PrimitiveKind().ToString()));
+            }
+        }*/
 
         /* This constructor is ambiguous with the other three-param constructor...
         /// <summary>
@@ -127,7 +300,7 @@ namespace Microsoft.OData.Edm.Vocabularies
         }
 
         /// <summary>
-        /// Gets Whether the annotation uses a default value
+        /// Gets whether the annotation uses a default value
         /// (not defined with a provided value).
         /// </summary>
         public bool UsesDefault {

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/IEdmVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/IEdmVocabularyAnnotation.cs
@@ -30,5 +30,11 @@ namespace Microsoft.OData.Edm.Vocabularies
         /// Gets the expression producing the value of the annotation.
         /// </summary>
         IEdmExpression Value { get; }
+
+        /// <summary>
+        /// Gets whether the annotation uses a default value
+        /// (not defined with a provided value).
+        /// </summary>
+        bool UsesDefault { get; }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -429,29 +429,23 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                      "</Schema>" +
                    "</edmx:DataServices>" +
                  "</edmx:Edmx>";
+            // Parse into CSDL
             var model = CsdlReader.Parse(XElement.Parse(csdl).CreateReader());
             IEdmTerm defaultTerm = model.FindTerm("NS.MyDefaultTerm");
             Assert.Equal("This is a test", defaultTerm.DefaultValue);
-            IEnumerable<IEdmVocabularyAnnotation> annotations = model.VocabularyAnnotations; // in debugger: Errors/Term/Value for [0] and [1]: "Cannot evaluate expression because the code of the current method is optimized"
+            IEnumerable<IEdmVocabularyAnnotation> annotations = model.VocabularyAnnotations;
             Assert.Equal(2, annotations.Count());
             IEdmVocabularyAnnotation annotationWithSpecifiedValue = annotations.ElementAt(0);
             IEdmVocabularyAnnotation annotationWithDefaultValue = annotations.ElementAt(1);
             Assert.False(annotationWithSpecifiedValue.UsesDefault);
             Assert.True(annotationWithDefaultValue.UsesDefault);
 
-            //IEdmExpression defaultAnnotationValue = annotationWithDefaultValue.Value;
-            //Assert.Equal("This is a test", annotationWithDefaultValue.Value);
-            //IEdmExpression test = annotationWithSpecifiedValue.Value;
-            //Assert.Equal("abc/efg", annotationWithSpecifiedValue.Value.ToString);
-            //Assert.Equal("abc/efg", annotationWithSpecifiedValue.Value.ToString());
-            //System.Diagnostics.Debug.WriteLine("test 1");
+            // Validate model
             IEnumerable<EdmError> errors;
             bool validated = model.Validate(out errors);
             Assert.True(validated);
 
-            //System.Diagnostics.Debug.WriteLine("test 2");
-
-            // Act & Assert for XML
+            // Act & Assert for Reserialized XML
             WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
              "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
                "<edmx:DataServices>" +
@@ -465,22 +459,6 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                  "</Schema>" +
                "</edmx:DataServices>" +
              "</edmx:Edmx>");
-
-
-            //IEdmTerm defaultTerm2 = model.FindDeclaredTerm("NS.DefaultTerm"); // null
-
-            /*var setA = model.FindDeclaredNavigationSource("Root");
-            var target = setA.NavigationPropertyBindings.First().Target;
-            Assert.True(target is IEdmContainedEntitySet);
-            Assert.Equal("SetB", target.Name);
-            var targetSegments = target.Path.PathSegments.ToList();
-            Assert.Equal(2, targetSegments.Count());
-            Assert.Equal("Root", targetSegments[0]);
-            Assert.Equal("SetB", targetSegments[1]);
-            var pathSegments = setA.NavigationPropertyBindings.First().Path.PathSegments.ToList();
-            Assert.Equal(2, pathSegments.Count());
-            Assert.Equal("EntityA", pathSegments[0]);
-            Assert.Equal("EntityAToB", pathSegments[1]);*/
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -2243,8 +2243,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             Assert.Throws<ArgumentNullException>(() => annotation = new EdmVocabularyAnnotation(complex, term1));
 
             IEnumerable<EdmError> errors;
-            bool test = model.Validate(out errors);
-            Assert.True(test);
+            Assert.True(model.Validate(out errors));
 
             // Act & Assert for XML
             WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
@@ -2260,6 +2259,29 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                  "</Schema>" +
                "</edmx:DataServices>" +
              "</edmx:Edmx>");
+
+            // Act & Assert for JSON - for some reason, doesn't list the type for MyDefaultTerm
+            /*WriteAndVerifyJson(model, @"{
+  ""$Version"": ""4.0"",
+  ""NS"": {
+    ""Complex"": {
+      ""$Kind"": ""ComplexType"",
+      ""@NS.MyAnnotationPathTerm"": ""abc/efg"",
+      ""@NS.MyDefaultTerm"": ""This is a test""
+    },
+    ""MyAnnotationPathTerm"": {
+      ""$Kind"": ""Term"",
+      ""$Type"": ""Edm.AnnotationPath""
+    },
+    ""MyDefaultTerm"": {
+      ""$Kind"": ""Term"",
+      ""$AppliesTo"": [
+        ""Property Term""
+      ],
+      ""$DefaultValue"": ""This is a test""
+    }
+  }
+}");*/
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -2215,6 +2215,52 @@ namespace Microsoft.OData.Edm.Tests.Csdl
         }
 
         [Fact]
+        public void CanWriteAnnotationWithoutSpecifiedValue()
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+            EdmComplexType complex = new EdmComplexType("NS", "Complex");
+            model.AddElement(complex);
+            EdmTerm term1 = new EdmTerm("NS", "MyAnnotationPathTerm", EdmCoreModel.Instance.GetAnnotationPath(false));
+            EdmTerm term2 = new EdmTerm("NS", "MyNavigationPathTerm", EdmCoreModel.Instance.GetNavigationPropertyPath(false), "Property Term", "true");
+
+            model.AddElement(term1);
+            model.AddElement(term2);
+
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(complex, term1, new EdmAnnotationPathExpression("abc/efg"));
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+            model.SetVocabularyAnnotation(annotation);
+
+            // Succeeds at using term's default value when value not specified
+            annotation = new EdmVocabularyAnnotation(complex, term2);
+            Assert.True(annotation.UsesDefault);
+            Assert.Equal(annotation.Term.DefaultValue, ((EdmStringConstant)annotation.Value).Value);
+
+            // Fails when trying to not specify a value to a term without a default value
+            Assert.Throws<ArgumentNullException>(() => annotation = new EdmVocabularyAnnotation(complex, term1));
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors));
+
+            // Act & Assert for XML
+            /*WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+             "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+               "<edmx:DataServices>" +
+                 "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                   "<ComplexType Name=\"Complex\">" +
+                     "<Annotation Term=\"NS.MyAnnotationPathTerm\" AnnotationPath=\"abc/efg\" />" +
+                     "<Annotation Term=\"NS.MyNavigationPathTerm\" />" + // no longer has value
+                   "</ComplexType>" +
+                   "<Term Name=\"MyAnnotationPathTerm\" Type=\"Edm.AnnotationPath\" Nullable=\"false\" />" +
+                   "<Term Name=\"MyNavigationPathTerm\" Type=\"Edm.NavigationPropertyPath\" Nullable=\"false\" DefaultValue="true"
+ AppliesTo="Property Term"
+ />" +
+                 "</Schema>" +
+               "</edmx:DataServices>" +
+             "</edmx:Edmx>");*/
+        }
+
+        [Fact]
         public void CanWriteNavigationPropertyBindingTargetOnContainmentNavigationProperty()
         {
             EdmModel model = new EdmModel();

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -2222,7 +2222,8 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             EdmComplexType complex = new EdmComplexType("NS", "Complex");
             model.AddElement(complex);
             EdmTerm term1 = new EdmTerm("NS", "MyAnnotationPathTerm", EdmCoreModel.Instance.GetAnnotationPath(false));
-            EdmTerm term2 = new EdmTerm("NS", "MyNavigationPathTerm", EdmCoreModel.Instance.GetNavigationPropertyPath(false), "Property Term", "true");
+            //EdmTerm term2 = new EdmTerm("NS", "MyNavigationPathTerm", EdmCoreModel.Instance.GetNavigationPropertyPath(false), "Property Term", "true");
+            EdmTerm term2 = new EdmTerm("NS", "MyDefaultTerm", EdmCoreModel.Instance.GetString(false), "Property Term", "This is a test");
 
             model.AddElement(term1);
             model.AddElement(term2);
@@ -2235,29 +2236,30 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             annotation = new EdmVocabularyAnnotation(complex, term2);
             Assert.True(annotation.UsesDefault);
             Assert.Equal(annotation.Term.DefaultValue, ((EdmStringConstant)annotation.Value).Value);
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+            model.SetVocabularyAnnotation(annotation);
 
             // Fails when trying to not specify a value to a term without a default value
             Assert.Throws<ArgumentNullException>(() => annotation = new EdmVocabularyAnnotation(complex, term1));
 
             IEnumerable<EdmError> errors;
-            Assert.True(model.Validate(out errors));
+            bool test = model.Validate(out errors);
+            Assert.True(test);
 
             // Act & Assert for XML
-            /*WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+            WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
              "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
                "<edmx:DataServices>" +
                  "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
                    "<ComplexType Name=\"Complex\">" +
                      "<Annotation Term=\"NS.MyAnnotationPathTerm\" AnnotationPath=\"abc/efg\" />" +
-                     "<Annotation Term=\"NS.MyNavigationPathTerm\" />" + // no longer has value
+                     "<Annotation Term=\"NS.MyDefaultTerm\" />" + // no longer has value
                    "</ComplexType>" +
                    "<Term Name=\"MyAnnotationPathTerm\" Type=\"Edm.AnnotationPath\" Nullable=\"false\" />" +
-                   "<Term Name=\"MyNavigationPathTerm\" Type=\"Edm.NavigationPropertyPath\" Nullable=\"false\" DefaultValue="true"
- AppliesTo="Property Term"
- />" +
+                   "<Term Name=\"MyDefaultTerm\" Type=\"Edm.String\" DefaultValue=\"This is a test\" AppliesTo=\"Property Term\" Nullable=\"false\" />" +
                  "</Schema>" +
                "</edmx:DataServices>" +
-             "</edmx:Edmx>");*/
+             "</edmx:Edmx>");
         }
 
         [Fact]


### PR DESCRIPTION
### Description

This pull request adds support for using default values in vocabulary annotations in EdmLib.

### Checklist

- [x] *Add default values*
- [x] *Serialization*
- [x] *Deserialization*
- [x] *Reserialization*
- [x] *Add test cases*

### Additional work necessary

- Currently only supports default values of type String -> Support all kinds of value types
- Currently introduces breaking interface change -> Turn this into an extension