### PR TITLE
Clone the reader setting when creating reader setting

### DIFF
--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -245,7 +245,7 @@ namespace Microsoft.OData
             }
             else
             {
-                readerSettings = container.GetRequiredService<ODataMessageReaderSettings>();
+                readerSettings = container.GetRequiredService<ODataMessageReaderSettings>().Clone();
             }
 
             if (other != null)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

* Web API OData typically re-set the BaseUri in the ReaderSetting.
* When retrieves the ReaderSetting from DI , in the same request, since it's scoped, the only singleton reader setting returns.
* So, It's better to clone the reader setting any time to use the reader setting.
* That's a fix for BingAds.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
