### PR TITLE
Fix the issue when read nested resource untyped in the request

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -425,15 +425,12 @@ namespace Microsoft.OData.JsonLight
                 ValidateExpandedNestedResourceInfoPropertyValue(this.JsonReader, isCollection, propertyName, payloadTypeReference);
                 if (isCollection)
                 {
-                    readerNestedResourceInfo = this.ReadingResponse
-                        ? ReadExpandedResourceSetNestedResourceInfo(resourceState, null, payloadTypeReference.ToStructuredType(), propertyName, /*isDeltaResourceSet*/ false)
-                        : ReadEntityReferenceLinksForCollectionNavigationLinkInRequest(resourceState, null, propertyName, /*isExpanded*/ true);
+                    readerNestedResourceInfo =
+                        ReadExpandedResourceSetNestedResourceInfo(resourceState, null, payloadTypeReference.ToStructuredType(), propertyName, /*isDeltaResourceSet*/ false);
                 }
                 else
                 {
-                    readerNestedResourceInfo = this.ReadingResponse
-                        ? ReadExpandedResourceNestedResourceInfo(resourceState, null, propertyName, payloadTypeReference.ToStructuredType(), this.MessageReaderSettings)
-                        : ReadEntityReferenceLinkForSingletonNavigationLinkInRequest(resourceState, null, propertyName, /*isExpanded*/ true);
+                    readerNestedResourceInfo = ReadExpandedResourceNestedResourceInfo(resourceState, null, propertyName, payloadTypeReference.ToStructuredType(), this.MessageReaderSettings);
                 }
 
                 resourceState.PropertyAndAnnotationCollector.ValidatePropertyUniquenessOnNestedResourceInfoStart(readerNestedResourceInfo.NestedResourceInfo);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             message.SetHeader("Content-Type", "application/json");
 
             using (var msgReader = readRequest ?
-                new ODataMessageReader((IODataResponseMessage)message, readerSettings, this.serverModel) :
+                new ODataMessageReader((IODataRequestMessage)message, readerSettings, this.serverModel) :
                 new ODataMessageReader((IODataResponseMessage)message, readerSettings, this.serverModel))
             {
                 var reader = msgReader.CreateODataResourceReader(entitySet, entityType);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
@@ -80,12 +80,15 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
         }
         // ----------- end of edm for entry reader ----------- 
 
-        private void ReadEntryPayload(string payload, EdmEntitySet entitySet, EdmEntityType entityType, Action<ODataReader> action, bool readUntypedAsValue = false)
+        private void ReadEntryPayload(string payload, EdmEntitySet entitySet, EdmEntityType entityType, Action<ODataReader> action, bool readUntypedAsValue = false, bool readRequest = false)
         {
             ODataMessageReaderSettings readerSettings = readUntypedAsValue ? UntypedAsValueReaderSettings : UntypedAsStringReaderSettings;
             var message = new InMemoryMessage() { Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload)) };
             message.SetHeader("Content-Type", "application/json");
-            using (var msgReader = new ODataMessageReader((IODataResponseMessage)message, readerSettings, this.serverModel))
+
+            using (var msgReader = readRequest ?
+                new ODataMessageReader((IODataResponseMessage)message, readerSettings, this.serverModel) :
+                new ODataMessageReader((IODataResponseMessage)message, readerSettings, this.serverModel))
             {
                 var reader = msgReader.CreateODataResourceReader(entitySet, entityType);
                 while (reader.Read())
@@ -625,6 +628,37 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
         }
 
         [Fact]
+        public void ReadNonOpenWithoutTypeComplexAsValueTest_InRequest()
+        {
+            // non-open entity's unknown property type including string & numeric values
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredAddress1"":"
+                + @"{'Street':""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":'No.10000000999,Zixing Rd Minhang'}}";
+            ODataResource entry = null;
+            ODataResource undeclaredAddress1 = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    if (entry == null)
+                    {
+                        entry = (reader.Item as ODataResource);
+                    }
+                    else if (undeclaredAddress1 == null)
+                    {
+                        undeclaredAddress1 = (reader.Item as ODataResource);
+                    }
+                }
+            },
+            /*readUntypedAsValue*/ true,
+            /*readRequest*/ true);
+
+            Assert.Single(entry.Properties);
+            Assert.Equal("Edm.Untyped", undeclaredAddress1.TypeName);
+            Assert.Equal(2, undeclaredAddress1.Properties.Count());
+            Assert.Equal("No.10000000999,Zixing Rd Minhang", undeclaredAddress1.Properties.First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value);
+        }
+
+        [Fact]
         public void ReadNonOpenUnknownTypeInvalidComplexNestedAsValueTest()
         {
             // non-open entity's unknown property type including string & numeric values
@@ -764,6 +798,63 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             Assert.Equal("Collection(Server.NS.UnknownCollectionType)", undeclaredCollection1.TypeAnnotation.TypeName);
             Assert.Equal(3, untypedCollection.Count());
             Assert.Equal("email1@163.comemail2@gmail.comemail3@gmail2.com", String.Concat(untypedCollection.Select(c=>((ODataResource)c).Properties.Single(p => string.Equals(p.Name, "email", StringComparison.Ordinal)).Value)));
+            Assert.Equal(2, address.Properties.Count());
+            Assert.Equal("No.999,Zixing Rd Minhang", address.Properties.First(s => string.Equals("Street", s.Name, StringComparison.Ordinal)).Value);
+            Assert.Equal("No.10000000999,Zixing Rd Minhang", address.Properties.First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value);
+        }
+
+        [Fact]
+        public void ReadNonOpenUnknownComplexTypeCollectionWithInvalidTypeAsValueTest_InRequest()
+        {
+            const string payload = @"{""@odata.context"":""http://www.sampletest.com/$metadata#serverEntitySet/$entity"",""Id"":61880128,""UndeclaredFloatId"":12.3,
+                ""UndeclaredCollection1@odata.type"":""Collection(Server.NS.UnknownCollectionType)"",""UndeclaredCollection1"":[{""email"":""email1@163.com""},{""email"":""email2@gmail.com""},{""email"":""email3@gmail2.com""}],""Address"":{""Street"":""No.999,Zixing Rd Minhang"",""UndeclaredStreet"":""No.10000000999,Zixing Rd Minhang""}}";
+            ODataResource entry = null;
+            ODataResource address = null;
+            ODataNestedResourceInfo undeclaredCollection1 = null;
+            List<ODataResource> untypedCollection = new List<ODataResource>();
+            bool insideCollection = false;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    if (insideCollection)
+                    {
+                        untypedCollection.Add(reader.Item as ODataResource);
+                    }
+                    else if (entry == null)
+                    {
+                        entry = (reader.Item as ODataResource);
+                    }
+                    else if (address == null)
+                    {
+                        address = (reader.Item as ODataResource);
+                    }
+                }
+                else if (reader.State == ODataReaderState.NestedResourceInfoStart)
+                {
+                    ODataNestedResourceInfo nestedInfo = (reader.Item as ODataNestedResourceInfo);
+                    if (insideCollection = nestedInfo.IsCollection == true)
+                    {
+                        undeclaredCollection1 = nestedInfo;
+                    }
+                }
+                else if (reader.State == ODataReaderState.NestedResourceInfoEnd)
+                {
+                    ODataNestedResourceInfo nestedInfo = (reader.Item as ODataNestedResourceInfo);
+                    insideCollection = !(nestedInfo.IsCollection == true);
+                }
+                else if (reader.State == ODataReaderState.ResourceSetStart)
+                {
+                    undeclaredCollection1.TypeAnnotation = new ODataTypeAnnotation((reader.Item as ODataResourceSet).TypeName);
+                }
+            },
+            /*readUntypedAsValue*/ true,
+            /*readRequest*/ true);
+
+            Assert.Equal(2, entry.Properties.Count());
+            Assert.Equal("Collection(Server.NS.UnknownCollectionType)", undeclaredCollection1.TypeAnnotation.TypeName);
+            Assert.Equal(3, untypedCollection.Count());
+            Assert.Equal("email1@163.comemail2@gmail.comemail3@gmail2.com", String.Concat(untypedCollection.Select(c => ((ODataResource)c).Properties.Single(p => string.Equals(p.Name, "email", StringComparison.Ordinal)).Value)));
             Assert.Equal(2, address.Properties.Count());
             Assert.Equal("No.999,Zixing Rd Minhang", address.Properties.First(s => string.Equals("Street", s.Name, StringComparison.Ordinal)).Value);
             Assert.Equal("No.10000000999,Zixing Rd Minhang", address.Properties.First(s => string.Equals("UndeclaredStreet", s.Name, StringComparison.Ordinal)).Value);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -9,6 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <RestorePackages>true</RestorePackages>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
@@ -8,6 +8,7 @@
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute> <!--check this in attributes-->
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -33,7 +34,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.OData.Edm\Microsoft.OData.Edm.csproj" />
-    <ProjectReference Include="..\Microsoft.OData.TestCommon\Microsoft.OData.TestCommon.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp3.1'">

--- a/test/FunctionalTests/Microsoft.OData.TestCommon/Microsoft.OData.TestCommon.csproj
+++ b/test/FunctionalTests/Microsoft.OData.TestCommon/Microsoft.OData.TestCommon.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net45;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\sln\</SolutionDir>
   </PropertyGroup>
   

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.csproj
@@ -8,6 +8,7 @@
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes https://github.com/OData/odata.net/issues/2165

### Description

* If we have a nested resource whose property name is wrong case or its undeclared property,
* When we put that property in to the request body, ODL can't read it as Untyped even we set the ReadUntypedAsString=false.
* Since we understand it's undeclared property, can we directly read it as normal untyped value.
* This is a simple fix for this issue

### Checklist (Uncheck if it is not completed)

- [x ] *Test cases added*
- [x ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
