### PR TITLE
Avoid creating unused objects when calling ODataUri.Clone()

### DIFF
--- a/src/Microsoft.OData.Core/Uri/ODataUri.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUri.cs
@@ -30,13 +30,13 @@ namespace Microsoft.OData
         /// </summary>
         private Uri serviceRoot;
 
+        private ParameterAliasValueAccessor parameterAliasValueAccessor;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ODataUri"/> class.
         /// </summary>
         public ODataUri()
         {
-            IDictionary<string, string> dictionary = new Dictionary<string, string>(StringComparer.Ordinal);
-            this.ParameterAliasValueAccessor = new ParameterAliasValueAccessor(dictionary);
         }
 
         /// <summary>
@@ -214,7 +214,23 @@ namespace Microsoft.OData
         /// <summary>
         /// Gets or sets the ParameterAliasValueAccessor.
         /// </summary>
-        internal ParameterAliasValueAccessor ParameterAliasValueAccessor { get; set; }
+        internal ParameterAliasValueAccessor ParameterAliasValueAccessor
+        {
+            get
+            {
+                if (parameterAliasValueAccessor == null)
+                {
+                    IDictionary<string, string> dictionary = new Dictionary<string, string>(StringComparer.Ordinal);
+                    parameterAliasValueAccessor = new ParameterAliasValueAccessor(dictionary);
+                }
+
+                return parameterAliasValueAccessor;
+            }
+            set
+            {
+                parameterAliasValueAccessor = value;
+            }
+        }
 
         /// <summary>
         /// Return a copy of current ODataUri.


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request (partially) addresses #2163 .* 

### Description

#### The fix

`ODataUri.Clone()` creates a new instance of `ODataUri` using `new ODataUri()` then shallow copies the properties (references) from the "old" `ODataUri` to the new one. However, the default `ODataUri` constructor creates a new instance of `Dictionary<string, string>` and a new instance of `ParameterAliasValueAccessor`. The  `ODataUri.ParameterAliasValueaAccessor` property is immediately replaced by `ODataUri.Clone()` with the reference from the old uri. So the instances created in the default constructor are a waste of memory and unnecessary allocation/GC overhead.

I fixed this issue by creating the `ParameterAliasValueAccessor` instance lazily in the property getter. I thought this to be the safest solution, below are other solutions that I considered:
- Removing the new instances from the constructor without modifying the property getter
  -  I cannot guarantee that this would not lead to null reference exceptions in cases where the default constructor is used outside of `Clone()`, and I did not have time to investigate all those usage scenarios
- Using the overloaded constructor that accepts more arguments (including `ParameterAliasValueAccessor`) that are then directly passed to properties. This constructor seems close to what `ODataUri.Clone` is doing, except that when setting the `CustomQueryOptions` property: `this.CustomQueryOptions = new ReadOnlyCollection<QueryNode>(customQueryOptions.ToList());`, where as in `ODataUri.Clone()` the property reference is simply copied without creating any new object. So this would not be a suitable substitute.
- Creating a new constructor that does not create new instances. This felt unnecessary.

#### Expected impact
While this change does not reduce the number of `ODataUri` instances allocated (which is what the original issue pointed to in the screenshot), it does significantly reduce the number of `Dictionary` instances created as a result of `ODataUri.Clone()`.

This CPR screenshot shows that `Dictionary<string, string>`  created from `ODataUri.Clone()` account for and 1.3% (0.69 + 0.61) of allocated size:
![image](https://user-images.githubusercontent.com/8460169/132836659-6dd59bce-3352-4a6f-88bd-37aee1ce0e47.png)

The following screenshot shows `Dictionary<string, SingleValueNode>`  from `ODataUri.Clone()` account for  0.65%.
![AGS SingleValueNode dict allocation size](https://user-images.githubusercontent.com/8460169/132837890-928a14f3-d274-4d9d-9032-f959f790cc19.png)

The following screenshot shows `ParameterAliasValueAccessor` from `ODataUri.Clone()` accounts for 0.23%

![ParameterAliasValueAccessor alloc size](https://user-images.githubusercontent.com/8460169/132852357-5d9c62f7-de6e-4c6a-953d-2baf71c707f1.png)

So in total, there's up to 2.18% that we can potentially shed off. This is based on the assumptions that the sizes indicated in the screenshots do not include sizes of referenced objects (otherwise `ParameterAliasValueAccessor` would have a larger inclusive size than the dictionaries it contains).

I've done some local profiling before and after the fix to get a better estimate of how much we can expect to reduce. The profiling were based on running a simple service that uses that OData writer to write a response of 5000 entities (base on [this experments project](https://github.com/habbes/experiments/tree/master/ODataWriterVsSystemTextJson)) and collecting allocation data using the .NET Object Allocation Tracker tool that's part of the Visual Studio Performance Profiler toolset.

The following estimates may not hold true in production given the difference in usage patterns and data, but it may be a good idea to compare the results once we measure them in production with the estimates here later on. I think that will help us make better estimates over time.

##### Impact on number of allocations
The first 2 screenshots below show the total allocations from `ODataUri.Clone()` from my local profile before and after this change. You can see total allocations dropped from 175k to 35k, i.e. about 140k drop in allocations, which is about 80%. `ODataUri.Clone()` accounts in total for 4.13% of allocations (inclusive), 80% drop would should **shed off about 3.3% of allocations in AGS** assuming the experiment data is a reflection of what happens in production.

![ODataUri.Clone() Function Allocations Before](https://user-images.githubusercontent.com/8460169/132841077-19214cf4-d4a0-4662-b781-195573953bf9.png)

![ODataUri.Clone() Function Allocations After](https://user-images.githubusercontent.com/8460169/132841390-15098d6a-7e39-4e7e-a6fe-b9945666e66c.png)

![ODataUri.Clone() allocations on CPR](https://user-images.githubusercontent.com/8460169/132842671-5da122e3-8093-4a85-aa9c-05eb679a9bfb.png)

##### Impact on allocation size

Impact on allocation size is trickier to estimate cause the .NET allocation tracker in VS doesn't display the inclusive allocation size for a given type. I'm also not sure how the inclusive size is computed in CPR (on the stack tab, both inclusive and exclusive columns have the same value), on the Frames tab, they have different values, but this tab doesn't show the breakdown of the types allocated by a function.

That said, I thin we can realistically estimate that at least all `Dictionary<string, string>`, `Dictionary<string, SingleValueNode>` and `ParameterAliasValueAccessor` allocated from `ODataUri.Clone()` will be eliminated, and I've already calculated that above to be **2.18% of total allocated bytes**.

Below are some screenshots from my local profile showing the allocated size of `Dictionary` instances before and after the change.

![Dictionaries alloc size local before](https://user-images.githubusercontent.com/8460169/132853695-ab39f518-0b75-4acf-8539-f7e4c2ac544a.png)

![Dictionaries alloc size local after](https://user-images.githubusercontent.com/8460169/132853889-0d50c3e1-a4c5-4076-b481-f93f249c78c9.png)

##### Impact on collection

On my local profile, there were 3 fewer GC collections after the change. But I'm not sure if this is reliable.


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
