### PR TITLE
Compute navigation path should return null if navigation source kind is none in context uri info

### DIFF
--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -240,10 +240,7 @@ namespace Microsoft.OData
 
         private static string ComputeNavigationPath(EdmNavigationSourceKind kind, ODataUri odataUri, string navigationSource)
         {
-            bool isContained = kind == EdmNavigationSourceKind.ContainedEntitySet;
-            bool isUnknownEntitySet = kind == EdmNavigationSourceKind.UnknownEntitySet;
-
-            if (isUnknownEntitySet)
+            if (kind == EdmNavigationSourceKind.UnknownEntitySet)
             {
                 // If the navigation target is not specified, i.e., UnknownEntitySet,
                 // the navigation path should be null so that type name will be used
@@ -252,7 +249,7 @@ namespace Microsoft.OData
             }
 
             string navigationPath = null;
-            if (isContained && odataUri != null && odataUri.Path != null)
+            if (kind == EdmNavigationSourceKind.ContainedEntitySet && odataUri != null && odataUri.Path != null)
             {
                 ODataPath odataPath = odataUri.Path.TrimEndingTypeSegment().TrimEndingKeySegment();
                 if (!(odataPath.LastSegment is NavigationPropertySegment) && !(odataPath.LastSegment is OperationSegment))


### PR DESCRIPTION


<!-- markdownlint-disable MD002 MD041 -->

### Issues

If the operation returns not resource, the context uri info should support to use type to generate the context Uri.


```xml
<?xml version="1.0" encoding="utf-8"?>
<edmx:Edmx Version="4.0" xmlns:edmx=http://docs.oasis-open.org/odata/ns/edmx xmlns:ags=http://aggregator.microsoft.com/internal xmlns:odata=http://schemas.microsoft.com/oDataCapabilities>
  <edmx:DataServices>
    <Schema Namespace="microsoft.management.services.api" xmlns:ags=http://aggregator.microsoft.com/internal xmlns=http://docs.oasis-open.org/odata/ns/edm>
        <EntityType Name="managedTenant" ags:AddressUrl="[ServiceEndpoint:MTMAPI]" ags:IsMaster="true" ags:AddressContainsEntitySetSegment="false" OpenType="true">
        </EntityType>
        <EntityType Name="tenantRelationship" ags:AddressUrl="[ServiceEndpoint:MTMAPI]" ags:IsMaster="true" ags:AddressContainsEntitySetSegment="true">
        <NavigationProperty Name="managedTenants" Type="microsoft.management.services.api.managedTenant" ContainsTarget="true" ags:AddressUrl="[ServiceEndpoint:MTMAPI]" ags:AddressContainsEntitySetSegment="true" />
        </EntityType>
        <Action Name="onboardPartner" IsBound="true">
            <Parameter Name="bindingParameter" Type="Collection(microsoft.management.services.api.managedTenant)"/>
            <ReturnType Type="Edm.String"/>
        </Action>
        <Function Name="partnerValidation" IsBound="true">
            <Parameter Name="bindingParameter" Type="Collection(microsoft.management.services.api.managedTenant)"/>
            <ReturnType Type="Edm.String"/>
        </Function>
        <EntityContainer Name="EntityContainer">
            <Singleton Name="tenantRelationships" Type="microsoft.management.services.api.tenantRelationship" />
            <FunctionImport Name="partnerValidation" Function="microsoft.management.services.api.partnerValidation" IncludeInServiceDocument="true" />
            <ActionImport Name="onboardPartner" Action="microsoft.management.services.api.onboardPartner" />
        </EntityContainer>
    </Schema>
  </edmx:DataServices>
</edmx:Edmx>
```

And I receive this error   
```json  
{
        "error": {
            "code": "InternalServerError",
            "message": "The Path property 'tenantRelationships/managedTenants/partnerValidation' of ODataMessageWriterSetting.ODataUri must end with the navigation property which the contained elements being written belong to.",
            "innerError": {
                "date": "2021-09-13T15:45:07",
                "request-id": "01f1870b-ac31-4738-867c-52766c3ac57d",
                "client-request-id": "01f1870b-ac31-4738-867c-52766c3ac57d"
            }
        }
    }
```

Call stack
```c#
[Microsoft.Graph.AGS.Contracts.InternalServerErrorException: The Path property 'tenantRelationships/managedTenants/partnerValidation' of ODataMessageWriterSetting.ODataUri must end with the navigation property which the contained elements being written belong to.;;[Microsoft.OData.ODataException: The Path property 'tenantRelationships/managedTenants/partnerValidation' of ODataMessageWriterSetting.ODataUri must end with the navigation property which the contained elements being written belong to.; at Microsoft.OData.ODataContextUrlInfo.ComputeNavigationPath(EdmNavigationSourceKind kind, ODataUri odataUri, String navigationSource) at Microsoft.OData.ODataContextUrlInfo.Create(ODataResourceTypeContext typeContext, ODataVersion version, Boolean isSingle, ODataUri odataUri) at Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.<>c__DisplayClass11_0.<WriteResourceContextUri>b__0() at Microsoft.OData.JsonLight.ODataJsonLightSerializer.WriteContextUriProperty(ODataPayloadKind payloadKind, Func`1 contextUrlInfoGen, ODataContextUrlInfo parentContextUrlInfo, String propertyName) at Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteResourceContextUri(ODataResourceTypeContext typeContext, ODataContextUrlInfo parentContextUrlInfo) at Microsoft.OData.JsonLight.ODataJsonLightWriter.StartResource(ODataResource resource) at Microsoft.OData.ODataWriterCore.InterceptException(Action action) at Microsoft.Online.AggregatorService.Controller.ODataResponseWriter.WriteODataEntry(RequestContext context, ParsedRequestState state, ResourceSchema currentInferredResourceSchema, JObject item, ODataWriter odataWriter, IEdmNavigationSource navigationSource, HashSet`1 schemaPropertySet, IDictionary`2 linksMap, ODataContextDeltaSync odataContextResponse, ODataResourceSerializationInfo serializationInfo, Boolean forceCustomODataId, ExpandedNavigationSelectItem currentExpand, Boolean forceClientFilter) in C:\__w\1\s\src\dev\Controller\ODataResponseWriter.cs:line 1811 at Microsoft.Online.AggregatorService.Controller.ODataResponseWriter.WriteResponse(RequestContext context, JObject jsonObject, ParsedRequestState state, Stream responseStream, Boolean disableStreamDisposal, Boolean writeFullMetadata) in C:\__w\1\s\src\dev\Controller\ODataResponseWriter.cs:line 366 at Microsoft.Online.AggregatorService.Controller.RequestController.HandleRequestInternal(RequestContext requestContext) in C:\__w\1\s\src\dev\Controller\Controllers\RequestController.cs:line 329;]]
```

Request URI: "https://canary.graph.microsoft.com/testprodbeta_testMTMSelfHost/tenantRelationships/managedTenants/partnerValidation"



### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
