### PR TITLE
Perf: Optimize collections and enumerators

### DIFF
--- a/src/Microsoft.OData.Core/InstanceAnnotationWriteTracker.cs
+++ b/src/Microsoft.OData.Core/InstanceAnnotationWriteTracker.cs
@@ -18,14 +18,13 @@ namespace Microsoft.OData
         /// Maintains the write status for each annotation using its key.
         /// If a key exists in the list then it is considered written.
         /// </summary>
-        private readonly HashSet<string> writeStatus;
+        private HashSet<string> writeStatus;
 
         /// <summary>
         /// Creates a new <see cref="InstanceAnnotationWriteTracker"/> to hold write status for instance annotations.
         /// </summary>
         public InstanceAnnotationWriteTracker()
         {
-            this.writeStatus = new HashSet<string>(StringComparer.Ordinal);
         }
 
         /// <summary>
@@ -35,7 +34,7 @@ namespace Microsoft.OData
         /// <param name="key">The key of the element to check if its written.</param>
         public bool IsAnnotationWritten(string key)
         {
-            return this.writeStatus.Contains(key);
+            return this.writeStatus != null && this.writeStatus.Contains(key);
         }
 
         /// <summary>
@@ -45,6 +44,11 @@ namespace Microsoft.OData
         /// <param name="key">The key of the element to mark as written.</param>
         public bool MarkAnnotationWritten(string key)
         {
+            if (this.writeStatus == null)
+            {
+                this.writeStatus = new HashSet<string>(StringComparer.Ordinal);
+            }
+
             return this.writeStatus.Add(key);
         }
     }

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -94,16 +94,16 @@ namespace Microsoft.OData
 
             // this method runs in a hot path hence the optimizations
 
-            // initialize to null to avoid instantiating a HashSet if there are no annotations
-            HashSet<string> instanceAnnotationNames;
-            if (instanceAnnotations?.Count > 0)
-            {
-                instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
-            }
-            else
+            if (instanceAnnotations.Count == 0)
             {
                 return;
             }
+
+#if NETSTANDARD2_1_OR_GREATER
+            HashSet<string> instanceAnnotationNames = new HashSet<string>(instanceAnnotations.Count, StringComparer.Ordinal);
+#else
+            HashSet<string> instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
+#endif
 
             // this method is called with a List most of the time
             // foreach against a List does not allocate the enumerator to the heap,
@@ -332,16 +332,16 @@ namespace Microsoft.OData
 
             // this method runs in a hot path hence the optimizations
 
-            // initialize to null to avoid instantiating a HashSet if there are no annotations
-            HashSet<string> instanceAnnotationNames;
-            if (instanceAnnotations?.Count >0)
-            {
-                instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
-            }
-            else
+            if (instanceAnnotations.Count == 0)
             {
                 return;
             }
+
+#if NETSTANDARD2_1_OR_GREATER
+            HashSet<string> instanceAnnotationNames = new HashSet<string>(instanceAnnotations.Count, StringComparer.Ordinal);
+#else
+            HashSet<string> instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
+#endif
 
             // this method is called with a List most of the time
             // foreach against a List does not allocate the enumerator to the heap,

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -155,13 +155,13 @@ namespace Microsoft.OData
 
         /// <summary>
         /// Write all the instance annotations specified in <paramref name="instanceAnnotations"/> for the
-        /// undecalared property called <paramref name="propertyName"/>
+        /// undeclared property called <paramref name="propertyName"/>
         /// </summary>
         /// <param name="instanceAnnotations">The collection of instance annotations</param>
         /// <param name="propertyName">The name of the property the instance annotations apply to</param>
         private void WriteInstanceAnnotationsForUndeclaredProperty(ICollection<ODataInstanceAnnotation> instanceAnnotations, string propertyName)
         {
-            // write undeclared property's all annotations
+            // write all the annotations of the undeclared property
             // optimize the foreach when instanceAnnotations is a List
             if (instanceAnnotations is List<ODataInstanceAnnotation> instanceAnnotationsList)
             {
@@ -321,6 +321,7 @@ namespace Microsoft.OData
         /// <param name="tracker">The tracker to track if instance annotations are written.</param>
         /// <param name="ignoreFilter">Whether to ignore the filter in settings.</param>
         /// <param name="propertyName">The name of the property this instance annotation applies to</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
         internal async Task WriteInstanceAnnotationsAsync(
             ICollection<ODataInstanceAnnotation> instanceAnnotations,
             InstanceAnnotationWriteTracker tracker,
@@ -373,7 +374,7 @@ namespace Microsoft.OData
         /// <param name="instanceAnnotationNames">Set used to detect a duplicate annotation.</param>
         /// <param name="ignoreFilter">Whether to ignore the filter in settings.</param>
         /// <param name="propertyName">The name of the property this instance annotation applies to.</param>
-        /// <returns></returns>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
         private async Task WriteAndTrackInstanceAnnotationAsync(
             ODataInstanceAnnotation annotation,
             InstanceAnnotationWriteTracker tracker,
@@ -426,7 +427,7 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="instanceAnnotations">The collection of instance annotations</param>
         /// <param name="propertyName">he name of the property the instance annotations apply to</param>
-        /// <returns></returns>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
         private async Task WriteInstanceAnnotationsForUndeclaredPropertyAsync(ICollection<ODataInstanceAnnotation> instanceAnnotations, string propertyName)
         {
             // write undeclared property's all annotations

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -110,7 +110,8 @@ namespace Microsoft.OData
             string propertyName = null)
         {
             // this method runs in a hot path hence the optimizations
-            
+
+            // initialize to null to avoid instatiating a HashSet if there are no annotations
             HashSet<string> instanceAnnotationNames = null;
             
             // this method is called with a List most of the time
@@ -358,6 +359,7 @@ namespace Microsoft.OData
         {
             // this method runs in a hot path hence the optimizations
 
+            // initialize to null to avoid instatiating a HashSet if there are no annotations
             HashSet<string> instanceAnnotationNames = null;
 
             if (instanceAnnotations is List<ODataInstanceAnnotation> instanceAnnotationsList)
@@ -366,7 +368,7 @@ namespace Microsoft.OData
                 foreach (ODataInstanceAnnotation annotation in instanceAnnotationsList)
                 {
 
-                    if (instanceAnnotations == null)
+                    if (instanceAnnotationNames == null)
                     {
                         instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
                     }
@@ -390,7 +392,7 @@ namespace Microsoft.OData
             {
                 foreach (ODataInstanceAnnotation annotation in instanceAnnotations)
                 {
-                    if (instanceAnnotations == null)
+                    if (instanceAnnotationNames == null)
                     {
                         instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
                     }

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -94,7 +94,7 @@ namespace Microsoft.OData
 
             // this method runs in a hot path hence the optimizations
 
-            // initialize to null to avoid instatiating a HashSet if there are no annotations
+            // initialize to null to avoid instantiating a HashSet if there are no annotations
             HashSet<string> instanceAnnotationNames = null;
 
             // this method is called with a List most of the time
@@ -334,7 +334,7 @@ namespace Microsoft.OData
 
             // this method runs in a hot path hence the optimizations
 
-            // initialize to null to avoid instatiating a HashSet if there are no annotations
+            // initialize to null to avoid instantiating a HashSet if there are no annotations
             HashSet<string> instanceAnnotationNames = null;
 
             // this method is called with a List most of the time

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -84,7 +84,7 @@ namespace Microsoft.OData
         /// <param name="ignoreFilter">Whether to ignore the filter in settings.</param>
         /// <param name="propertyName">The name of the property this instance annotation applies to</param>
         internal void WriteInstanceAnnotations(
-            IEnumerable<ODataInstanceAnnotation> instanceAnnotations,
+            ICollection<ODataInstanceAnnotation> instanceAnnotations,
             InstanceAnnotationWriteTracker tracker,
             bool ignoreFilter = false,
             string propertyName = null)
@@ -95,7 +95,15 @@ namespace Microsoft.OData
             // this method runs in a hot path hence the optimizations
 
             // initialize to null to avoid instantiating a HashSet if there are no annotations
-            HashSet<string> instanceAnnotationNames = null;
+            HashSet<string> instanceAnnotationNames;
+            if (instanceAnnotations?.Count > 0)
+            {
+                instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
+            }
+            else
+            {
+                return;
+            }
 
             // this method is called with a List most of the time
             // foreach against a List does not allocate the enumerator to the heap,
@@ -104,11 +112,6 @@ namespace Microsoft.OData
             {
                 foreach (var annotation in instanceAnnotationsList)
                 {
-                    if (instanceAnnotationNames == null)
-                    {
-                        instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
-                    }
-
                     this.WriteAndTrackInstanceAnnotation(annotation, tracker, instanceAnnotationNames, ignoreFilter, propertyName);
                 }
             }
@@ -116,11 +119,6 @@ namespace Microsoft.OData
             {
                 foreach (var annotation in instanceAnnotations)
                 {
-                    if (instanceAnnotationNames == null)
-                    {
-                        instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
-                    }
-
                     this.WriteAndTrackInstanceAnnotation(annotation, tracker, instanceAnnotationNames, ignoreFilter, propertyName);
                 }
             }
@@ -161,7 +159,7 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="instanceAnnotations">The collection of instance annotations</param>
         /// <param name="propertyName">The name of the property the instance annotations apply to</param>
-        private void WriteInstanceAnnotationsForUndeclaredProperty(IEnumerable<ODataInstanceAnnotation> instanceAnnotations, string propertyName)
+        private void WriteInstanceAnnotationsForUndeclaredProperty(ICollection<ODataInstanceAnnotation> instanceAnnotations, string propertyName)
         {
             // write undeclared property's all annotations
             // optimize the foreach when instanceAnnotations is a List
@@ -188,7 +186,7 @@ namespace Microsoft.OData
         /// <param name="propertyName">The name of the property this instance annotation applies to</param>
         /// <param name="isUndeclaredProperty">If writing an undeclared property.</param>
         internal void WriteInstanceAnnotations(
-            IEnumerable<ODataInstanceAnnotation> instanceAnnotations,
+            ICollection<ODataInstanceAnnotation> instanceAnnotations,
             string propertyName = null,
             bool isUndeclaredProperty = false)
         {
@@ -208,7 +206,7 @@ namespace Microsoft.OData
         /// Writes all the instance annotations specified in <paramref name="instanceAnnotations"/> of error.
         /// </summary>
         /// <param name="instanceAnnotations">Collection of instance annotations to write.</param>
-        internal void WriteInstanceAnnotationsForError(IEnumerable<ODataInstanceAnnotation> instanceAnnotations)
+        internal void WriteInstanceAnnotationsForError(ICollection<ODataInstanceAnnotation> instanceAnnotations)
         {
             Debug.Assert(instanceAnnotations != null, "instanceAnnotations should not be null if we called this");
             this.WriteInstanceAnnotations(instanceAnnotations, new InstanceAnnotationWriteTracker(), true);
@@ -324,7 +322,7 @@ namespace Microsoft.OData
         /// <param name="ignoreFilter">Whether to ignore the filter in settings.</param>
         /// <param name="propertyName">The name of the property this instance annotation applies to</param>
         internal async Task WriteInstanceAnnotationsAsync(
-            IEnumerable<ODataInstanceAnnotation> instanceAnnotations,
+            ICollection<ODataInstanceAnnotation> instanceAnnotations,
             InstanceAnnotationWriteTracker tracker,
             bool ignoreFilter = false,
             string propertyName = null)
@@ -335,7 +333,15 @@ namespace Microsoft.OData
             // this method runs in a hot path hence the optimizations
 
             // initialize to null to avoid instantiating a HashSet if there are no annotations
-            HashSet<string> instanceAnnotationNames = null;
+            HashSet<string> instanceAnnotationNames;
+            if (instanceAnnotations?.Count >0)
+            {
+                instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
+            }
+            else
+            {
+                return;
+            }
 
             // this method is called with a List most of the time
             // foreach against a List does not allocate the enumerator to the heap,
@@ -344,12 +350,6 @@ namespace Microsoft.OData
             {
                 foreach (ODataInstanceAnnotation annotation in instanceAnnotationsList)
                 {
-
-                    if (instanceAnnotationNames == null)
-                    {
-                        instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
-                    }
-
                     await this.WriteAndTrackInstanceAnnotationAsync(annotation, tracker, instanceAnnotationNames, ignoreFilter, propertyName)
                         .ConfigureAwait(false);
                 }
@@ -359,11 +359,6 @@ namespace Microsoft.OData
             {
                 foreach (ODataInstanceAnnotation annotation in instanceAnnotations)
                 {
-                    if (instanceAnnotationNames == null)
-                    {
-                        instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
-                    }
-
                     await this.WriteAndTrackInstanceAnnotationAsync(annotation, tracker, instanceAnnotationNames, ignoreFilter, propertyName)
                         .ConfigureAwait(false);
                 }
@@ -407,7 +402,7 @@ namespace Microsoft.OData
         /// <param name="propertyName">The name of the property this instance annotation applies to</param>
         /// <param name="isUndeclaredProperty">If writing an undeclared property.</param>
         internal async Task WriteInstanceAnnotationsAsync(
-            IEnumerable<ODataInstanceAnnotation> instanceAnnotations,
+            ICollection<ODataInstanceAnnotation> instanceAnnotations,
             string propertyName = null,
             bool isUndeclaredProperty = false)
         {
@@ -432,7 +427,7 @@ namespace Microsoft.OData
         /// <param name="instanceAnnotations">The collection of instance annotations</param>
         /// <param name="propertyName">he name of the property the instance annotations apply to</param>
         /// <returns></returns>
-        private async Task WriteInstanceAnnotationsForUndeclaredPropertyAsync(IEnumerable<ODataInstanceAnnotation> instanceAnnotations, string propertyName)
+        private async Task WriteInstanceAnnotationsForUndeclaredPropertyAsync(ICollection<ODataInstanceAnnotation> instanceAnnotations, string propertyName)
         {
             // write undeclared property's all annotations
             // optimize the foreach when instanceAnnotations is a List to avoid enumerator allocations on the heap
@@ -458,7 +453,7 @@ namespace Microsoft.OData
         /// Asynchronously writes all the instance annotations specified in <paramref name="instanceAnnotations"/> of error.
         /// </summary>
         /// <param name="instanceAnnotations">Collection of instance annotations to write.</param>
-        internal Task WriteInstanceAnnotationsForErrorAsync(IEnumerable<ODataInstanceAnnotation> instanceAnnotations)
+        internal Task WriteInstanceAnnotationsForErrorAsync(ICollection<ODataInstanceAnnotation> instanceAnnotations)
         {
             Debug.Assert(instanceAnnotations != null, "instanceAnnotations should not be null if we called this");
             return this.WriteInstanceAnnotationsAsync(instanceAnnotations, new InstanceAnnotationWriteTracker(), true);

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -99,7 +99,7 @@ namespace Microsoft.OData
                 return;
             }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1
             HashSet<string> instanceAnnotationNames = new HashSet<string>(instanceAnnotations.Count, StringComparer.Ordinal);
 #else
             HashSet<string> instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
@@ -337,7 +337,7 @@ namespace Microsoft.OData
                 return;
             }
 
-#if NETSTANDARD2_1_OR_GREATER
+#if NETSTANDARD2_1
             HashSet<string> instanceAnnotationNames = new HashSet<string>(instanceAnnotations.Count, StringComparer.Ordinal);
 #else
             HashSet<string> instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -99,11 +99,7 @@ namespace Microsoft.OData
                 return;
             }
 
-#if NETSTANDARD2_1
-            HashSet<string> instanceAnnotationNames = new HashSet<string>(instanceAnnotations.Count, StringComparer.Ordinal);
-#else
             HashSet<string> instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
-#endif
 
             // this method is called with a List most of the time
             // foreach against a List does not allocate the enumerator to the heap,
@@ -338,11 +334,7 @@ namespace Microsoft.OData
                 return;
             }
 
-#if NETSTANDARD2_1
-            HashSet<string> instanceAnnotationNames = new HashSet<string>(instanceAnnotations.Count, StringComparer.Ordinal);
-#else
             HashSet<string> instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
-#endif
 
             // this method is called with a List most of the time
             // foreach against a List does not allocate the enumerator to the heap,
@@ -426,7 +418,7 @@ namespace Microsoft.OData
         /// undecalared property called <paramref name="propertyName"/>
         /// </summary>
         /// <param name="instanceAnnotations">The collection of instance annotations</param>
-        /// <param name="propertyName">he name of the property the instance annotations apply to</param>
+        /// <param name="propertyName">The name of the property the instance annotations apply to</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         private async Task WriteInstanceAnnotationsForUndeclaredPropertyAsync(ICollection<ODataInstanceAnnotation> instanceAnnotations, string propertyName)
         {

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -109,14 +109,22 @@ namespace Microsoft.OData
             bool ignoreFilter = false,
             string propertyName = null)
         {
-            HashSet<string> instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
-            // this method runs in a hot path and is called with a List most of the time,
+            // this method runs in a hot path hence the optimizations
+            
+            HashSet<string> instanceAnnotationNames = null;
+            
+            // this method is called with a List most of the time
             // foreach against a List does not allocate the enumerator to the heap,
             // but foreach against an IEnumerable does
             if (instanceAnnotations is List<ODataInstanceAnnotation> instanceAnnotationsList)
             {
                 foreach (var annotation in instanceAnnotationsList)
                 {
+                    if (instanceAnnotationNames == null)
+                    {
+                        instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
+                    }
+
                     if (!instanceAnnotationNames.Add(annotation.Name))
                     {
                         throw new ODataException(ODataErrorStrings.JsonLightInstanceAnnotationWriter_DuplicateAnnotationNameInCollection(annotation.Name));
@@ -134,6 +142,11 @@ namespace Microsoft.OData
             {
                 foreach (var annotation in instanceAnnotations)
                 {
+                    if (instanceAnnotationNames == null)
+                    {
+                        instanceAnnotationNames = new HashSet<string>(StringComparer.Ordinal);
+                    }
+
                     if (!instanceAnnotationNames.Add(annotation.Name))
                     {
                         throw new ODataException(ODataErrorStrings.JsonLightInstanceAnnotationWriter_DuplicateAnnotationNameInCollection(annotation.Name));

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -110,14 +110,14 @@ namespace Microsoft.OData
             // but foreach against an IEnumerable does
             if (instanceAnnotations is List<ODataInstanceAnnotation> instanceAnnotationsList)
             {
-                foreach (var annotation in instanceAnnotationsList)
+                foreach (ODataInstanceAnnotation annotation in instanceAnnotationsList)
                 {
                     this.WriteAndTrackInstanceAnnotation(annotation, tracker, instanceAnnotationNames, ignoreFilter, propertyName);
                 }
             }
             else
             {
-                foreach (var annotation in instanceAnnotations)
+                foreach (ODataInstanceAnnotation annotation in instanceAnnotations)
                 {
                     this.WriteAndTrackInstanceAnnotation(annotation, tracker, instanceAnnotationNames, ignoreFilter, propertyName);
                 }
@@ -165,14 +165,14 @@ namespace Microsoft.OData
             // optimize the foreach when instanceAnnotations is a List
             if (instanceAnnotations is List<ODataInstanceAnnotation> instanceAnnotationsList)
             {
-                foreach (var annotation in instanceAnnotationsList)
+                foreach (ODataInstanceAnnotation annotation in instanceAnnotationsList)
                 {
                     this.WriteInstanceAnnotation(annotation, true, propertyName);
                 }
             }
             else
             {
-                foreach (var annotation in instanceAnnotations)
+                foreach (ODataInstanceAnnotation annotation in instanceAnnotations)
                 {
                     this.WriteInstanceAnnotation(annotation, true, propertyName);
                 }

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -433,7 +433,7 @@ namespace Microsoft.OData
             // optimize the foreach when instanceAnnotations is a List to avoid enumerator allocations on the heap
             if (instanceAnnotations is List<ODataInstanceAnnotation> instanceAnnotationsList)
             {
-                foreach (var annotation in instanceAnnotationsList)
+                foreach (ODataInstanceAnnotation annotation in instanceAnnotationsList)
                 {
                     await this.WriteInstanceAnnotationAsync(annotation, true, propertyName)
                         .ConfigureAwait(false);
@@ -441,7 +441,7 @@ namespace Microsoft.OData
             }
             else
             {
-                foreach (var annotation in instanceAnnotations)
+                foreach (ODataInstanceAnnotation annotation in instanceAnnotations)
                 {
                     await this.WriteInstanceAnnotationAsync(annotation, true, propertyName)
                         .ConfigureAwait(false);

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OData.Json
         /// <param name="writingJsonLight">true if we're writing JSON lite, false if we're writing verbose JSON.</param>
         internal static void WriteError(
             IJsonWriter jsonWriter,
-            Action<IEnumerable<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate,
+            Action<ICollection<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate,
             ODataError error,
             bool includeDebugInformation,
             int maxInnerErrorDepth,
@@ -137,7 +137,7 @@ namespace Microsoft.OData.Json
         /// <returns>A task that represents the asynchronous write operation.</returns>
         internal static Task WriteErrorAsync(
             IJsonWriterAsync jsonWriter,
-            Func<IEnumerable<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate,
+            Func<ICollection<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate,
             ODataError error,
             bool includeDebugInformation,
             int maxInnerErrorDepth)
@@ -221,8 +221,8 @@ namespace Microsoft.OData.Json
             string target,
             IEnumerable<ODataErrorDetail> details,
             ODataInnerError innerError,
-            IEnumerable<ODataInstanceAnnotation> instanceAnnotations,
-            Action<IEnumerable<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate,
+            ICollection<ODataInstanceAnnotation> instanceAnnotations,
+            Action<ICollection<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate,
             int maxInnerErrorDepth,
             bool writingJsonLight)
         {
@@ -453,8 +453,8 @@ namespace Microsoft.OData.Json
             string target,
             IEnumerable<ODataErrorDetail> details,
             ODataInnerError innerError,
-            IEnumerable<ODataInstanceAnnotation> instanceAnnotations,
-            Func<IEnumerable<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate,
+            ICollection<ODataInstanceAnnotation> instanceAnnotations,
+            Func<ICollection<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate,
             int maxInnerErrorDepth)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");

--- a/src/Microsoft.OData.Core/ODataAnnotatable.cs
+++ b/src/Microsoft.OData.Core/ODataAnnotatable.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData
 #if ORCAS
         [NonSerialized]
 #endif
-        private ICollection<ODataInstanceAnnotation> instanceAnnotations = new List<ODataInstanceAnnotation>();
+        private ICollection<ODataInstanceAnnotation> instanceAnnotations;
 
         /// <summary>
         /// The annotation for storing @odata.type.
@@ -38,7 +38,11 @@ namespace Microsoft.OData
         /// <returns>The custom instance annotations.</returns>
         internal ICollection<ODataInstanceAnnotation> GetInstanceAnnotations()
         {
-            Debug.Assert(this.instanceAnnotations != null, "this.instanceAnnotations != null");
+            if (this.instanceAnnotations == null)
+            {
+                this.instanceAnnotations = new List<ODataInstanceAnnotation>();
+            }
+
             return this.instanceAnnotations;
         }
 

--- a/src/Microsoft.OData.Core/ODataAnnotatable.cs
+++ b/src/Microsoft.OData.Core/ODataAnnotatable.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData
 #if ORCAS
         [NonSerialized]
 #endif
-        private ICollection<ODataInstanceAnnotation> instanceAnnotations = new Collection<ODataInstanceAnnotation>();
+        private ICollection<ODataInstanceAnnotation> instanceAnnotations = new List<ODataInstanceAnnotation>();
 
         /// <summary>
         /// The annotation for storing @odata.type.

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -285,7 +285,7 @@ namespace Microsoft.OData
             get
             {
                 Debug.Assert(this.scopeStack.Count > 1);
-                return this.scopeStack.Scopes.Skip(1).First();
+                return this.scopeStack.Parent;
             }
         }
 
@@ -3739,7 +3739,7 @@ namespace Microsoft.OData
             /// <summary>
             /// Use a list to store the scopes instead of a true stack so that parent/grandparent lookups will be fast.
             /// </summary>
-            private readonly Stack<Scope> scopes = new Stack<Scope>();
+            private readonly List<Scope> scopes = new List<Scope>();
 
             /// <summary>
             /// Initializes a new instance of the <see cref="ScopeStack"/> class.
@@ -3767,10 +3767,7 @@ namespace Microsoft.OData
                 get
                 {
                     Debug.Assert(this.scopes.Count > 1, "this.scopes.Count > 1");
-                    Scope current = this.scopes.Pop();
-                    Scope parent = this.scopes.Peek();
-                    this.scopes.Push(current);
-                    return parent;
+                    return this.scopes[this.scopes.Count - 2];
                 }
             }
 
@@ -3782,12 +3779,7 @@ namespace Microsoft.OData
                 get
                 {
                     Debug.Assert(this.scopes.Count > 2, "this.scopes.Count > 2");
-                    Scope current = this.scopes.Pop();
-                    Scope parent = this.scopes.Pop();
-                    Scope parentOfParent = this.scopes.Peek();
-                    this.scopes.Push(parent);
-                    this.scopes.Push(current);
-                    return parentOfParent;
+                    return this.scopes[this.scopes.Count - 3];
                 }
             }
 
@@ -3802,11 +3794,6 @@ namespace Microsoft.OData
                 }
             }
 
-            internal Stack<Scope> Scopes
-            {
-                get { return this.scopes; }
-            }
-
             /// <summary>
             /// Pushes the specified scope onto the stack.
             /// </summary>
@@ -3814,7 +3801,7 @@ namespace Microsoft.OData
             internal void Push(Scope scope)
             {
                 Debug.Assert(scope != null, "scope != null");
-                this.scopes.Push(scope);
+                this.scopes.Add(scope);
             }
 
             /// <summary>
@@ -3824,7 +3811,10 @@ namespace Microsoft.OData
             internal Scope Pop()
             {
                 Debug.Assert(this.scopes.Count > 0, "this.scopes.Count > 0");
-                return this.scopes.Pop();
+                int last = this.scopes.Count - 1;
+                Scope current = this.scopes[last];
+                this.scopes.RemoveAt(last);
+                return current;
             }
 
             /// <summary>
@@ -3834,7 +3824,7 @@ namespace Microsoft.OData
             internal Scope Peek()
             {
                 Debug.Assert(this.scopes.Count > 0, "this.scopes.Count > 0");
-                return this.scopes.Peek();
+                return this.scopes[this.scopes.Count - 1];
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonLightInstanceAnnotationWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonLightInstanceAnnotationWriterTests.cs
@@ -374,7 +374,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 verifierCalls++;
             };
-            this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotations(Enumerable.Empty<ODataInstanceAnnotation>());
+            this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotations(new List<ODataInstanceAnnotation>());
             Assert.Equal(0, verifierCalls);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
@@ -22,14 +22,14 @@ namespace Microsoft.OData.Tests.Json
         private StringWriter stringWriter;
         private IJsonWriterAsync jsonWriter;
         private ODataMessageWriterSettings settings;
-        private Func<IEnumerable<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate;
+        private Func<ICollection<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate;
 
         public ODataJsonWriterUtilsAsyncTests()
         {
             this.stringWriter = new StringWriter();
             this.jsonWriter = new JsonWriter(this.stringWriter, isIeee754Compatible: true);
             this.settings = new ODataMessageWriterSettings();
-            this.writeInstanceAnnotationsDelegate = async (IEnumerable<ODataInstanceAnnotation> instanceAnnotations) => await TaskUtils.CompletedTask;
+            this.writeInstanceAnnotationsDelegate = async (ICollection<ODataInstanceAnnotation> instanceAnnotations) => await TaskUtils.CompletedTask;
         }
 
         [Fact]
@@ -297,7 +297,7 @@ namespace Microsoft.OData.Tests.Json
 
             await ODataJsonWriterUtils.WriteErrorAsync(
                 this.jsonWriter,
-                async (IEnumerable<ODataInstanceAnnotation> instanceAnnotations) =>
+                async (ICollection<ODataInstanceAnnotation> instanceAnnotations) =>
                 {
                     foreach (var annotation in instanceAnnotations)
                     {

--- a/test/PerformanceTests/ComponentTests/ODataWriter/ODataWriterFeedTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataWriter/ODataWriterFeedTests.cs
@@ -37,11 +37,6 @@ namespace Microsoft.OData.Performance
         {
             Model = TestUtils.GetAdventureWorksModel(isModelImmutable);
             TestEntitySet = Model.EntityContainer.FindEntitySet("Product");
-        }
-
-        [IterationSetup]
-        public void RewindStream()
-        {
             WriteStream.Seek(0, SeekOrigin.Begin);
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2190.*

### Description

*Briefly describe the changes of this pull request.*
- [x] Eliminate `IEnumerator` heap allocations in `WriteInstanceAnnotations` when called with a `List<T>` argument:
  - initialize `ODataAnnotatable` `instanceAnnotations` with a `List<T>` instead of `Collection<T>`
  - cast annotations `IEnumerable` to a `List<T>` if possible when running `foreach` loop
- [x] Reduce `List<InstanceAnnotation>` allocations where it's not used
  - lazy initialization of the `instanceAnnotations` collection in `ODataAnnotatable`
- [x] Eliminate `HashSet<string>` heap allocations when instance annotations collection is empty
  - Lazy initialization of the `writeStatus` hash set in `InstanceAnnotationWriterTracker`
- [x] Eliminate enumerators and iterators allocations from accessing ScopeStack's parent and grandparent:
  - Implement `ScopeStack` using `List<Scope>` instead of `Stack<Scope>` so we can access parents cheaply using index
- [x] Replicate optimizations in async versions where applicable

The optimizations in `WriteInstanceAnnotations` have 2 versions of a foreach loop, one against a `List<T>` instance and the other against the `IEnumerable<T>` instance. When performing the foreach loop against a `List<T>`, the `List<T>.Enumerator` is not allocated on the heap because it's a struct. However, when running a foreach loop against the same collection through an `IEnumerable<T>` interface, the enumerator will be accessed through an `IEnumerator<T>` reference which causes it to be boxed and therefore copied to the heap. There are a lot of such allocations that would add up to noticeable improvements if we optimized them, but I admit that duplicating the foreach loop isn't ideal. And since some of these properties are exposed in public APIs as `IEnumerable<T>` or `ICollection<T>`, I can't just hardcode them to `List<T>`. That's why I did not go ahead and apply these optimizations to more areas of the code. The for loops in the `WriteIntsanceAnnotations` method account for 0.29% of allocations AGS, that's why I thought it would still be worth going ahead with it. If I addressed all such allocations, it would probably save 1+% in AGS, but I wanted to get feedback on whether this duplicate foreach-loop is worth the price.

There was a suggestion from @g2mula to create helper methods that encapsulate this "double" for-each loop, something like `collection.ForEach(action)` extension method that tries to cast the collection to a list before running the loop. However for this approach to be effective, I'd have two create multiple overloads for different versions to allow the action to accept multiple arguments without leading to closure allocations from captured variables (in same cases I may need to pass as much as 6 variables) (e.g. `ForEach<T>(this IEnumerable<T>, Action<T>)`, `ForEach<T, TArg1>(this IEnumerable<T>, Action<T, TArg1>)`, `ForEach<T, TArg1, TArg2>(this IEnumerable<T>, Action<TArg1>, Action<TArg2>)`, etc.). I would also need to account for async versions of those methods. And in some cases the loop needs to terminate prematurely when a condition is met. This seemed to be an explosion of complexity that seems to be overkill, it made very hesitant to commit it to this PR.

### Benchmarks

There's seems to be a 15-25% reduction in allocated memory size across the benchmarks as a result of the changes.

| Slower                                                                           | diff/base | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| -------- |
| SerializationBaselineTests.SerializationBenchmarks.WriteJson(dataSize: 5000, isM |      1.05 |       8898300.00 |       9318600.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteJson(dataSize: 5000, isM |      1.04 |       8811100.00 |       9146850.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteJson(dataSize: 10000, is |      1.03 |      17782200.00 |      18353600.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteJson(dataSize: 10000, is |      1.03 |      17808000.00 |      18339200.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteJson(dataSize: 1000, isM |      1.02 |       1920100.00 |       1958800.00 | several?|

| Faster                                                                           | base/diff | Base Median (ns) | Diff Median (ns) | Modality|
| -------------------------------------------------------------------------------- | ---------:| ----------------:| ----------------:| --------:|
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncFile(dataSize:  |      1.24 |      25225200.00 |      20343300.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSync(dataSize: 1000 |      1.24 |      23862600.00 |      19262100.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSync(dataSize: 5000 |      1.23 |     118341100.00 |      95905100.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSync(dataSize: 1000 |      1.23 |      25351900.00 |      20552100.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPool(dataS |      1.23 |      23740000.00 |      19270400.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSync(dataSize: 1000 |      1.23 |     237077400.00 |     192992900.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSync(dataSize: 1000 |      1.23 |     252622700.00 |     205743500.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncFile(dataSize:  |      1.23 |     123499700.00 |     100619500.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPool(dataS |      1.23 |     118660300.00 |      96805100.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncFile(dataSize:  |      1.23 |     260084050.00 |     212241800.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPool(dataS |      1.22 |     237068500.00 |     193569850.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPool(dataS |      1.22 |     126436600.00 |     103321700.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncFile(dataSize:  |      1.22 |     243478000.00 |     199052750.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPoolFile(d |      1.22 |     260673500.00 |     213368700.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPoolFile(d |      1.22 |     123509100.00 |     101132600.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSync(dataSize: 5000 |      1.22 |     125474200.00 |     102864000.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPoolFile(d |      1.22 |     129935600.00 |     106530300.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPoolFile(d |      1.22 |      24971900.00 |      20498700.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPool(dataS |      1.22 |     251591850.00 |     206530700.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPoolFile(d |      1.22 |     243142250.00 |     199607300.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncFile(dataSize:  |      1.22 |      26332700.00 |      21657100.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncFile(dataSize:  |      1.21 |     129795700.00 |     107022400.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPool(dataS |      1.21 |      25103000.00 |      20721100.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataSyncArrayPoolFile(d |      1.20 |      26290200.00 |      21824850.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataFile(dataSize: 1000 |      1.09 |      81137800.00 |      74461350.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteOData(dataSize: 1000, is |      1.09 |      81192600.00 |      74658700.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPoolFile(dataS |      1.09 |      81098100.00 |      74643500.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPool(dataSize: |      1.09 |      79381500.00 |      73063700.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteOData(dataSize: 1000, is |      1.09 |      79374950.00 |      73058300.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataFile(dataSize: 5000 |      1.08 |     406913950.00 |     375129800.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPool(dataSize: |      1.08 |      81239100.00 |      74901000.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataFile(dataSize: 1000 |      1.08 |     813155600.00 |     750092800.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataFile(dataSize: 1000 |      1.08 |     792749100.00 |     732295100.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataFile(dataSize: 5000 |      1.08 |     396905100.00 |     366955100.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteOData(dataSize: 10000, i |      1.08 |     809794600.00 |     748916450.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPoolFile(dataS |      1.08 |     792409500.00 |     733425600.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPool(dataSize: |      1.08 |     808588600.00 |     748517400.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteOData(dataSize: 10000, i |      1.08 |     790945750.00 |     732221800.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPoolFile(dataS |      1.08 |     396616900.00 |     367378500.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPoolFile(dataS |      1.08 |     810447100.00 |     751194400.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteOData(dataSize: 5000, is |      1.08 |     394974000.00 |     366193000.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPool(dataSize: |      1.08 |     394269300.00 |     365613000.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPoolFile(dataS |      1.08 |     405924650.00 |     376516100.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPool(dataSize: |      1.08 |     789774950.00 |     732646500.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPool(dataSize: |      1.07 |     404467400.00 |     376915400.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteOData(dataSize: 5000, is |      1.07 |     404288000.00 |     376802400.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataFile(dataSize: 1000 |      1.07 |      82057300.00 |      76606000.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteODataArrayPoolFile(dataS |      1.07 |      82417800.00 |      77090850.00 |         |
| SerializationBaselineTests.SerializationBenchmarks.WriteJsonFile(dataSize: 1000, |      1.02 |       2372650.00 |       2330900.00 |         |

The column headers have been truncate because the tables were too long, but here they are:
- Method
- Category
- dataSize
- isModelImmutable
- Mean
- Error
- StdDev
- Median
- Ratio
- RatioSD
- Gen 0
- Gen 1
- Allocated

**Before**

![image](https://user-images.githubusercontent.com/8460169/137278294-16eb6f2f-da7c-42dc-955c-562efd4d5c2e.png)

**After**

![image](https://user-images.githubusercontent.com/8460169/137278356-5228521b-92f1-4e2d-9e46-433c7c3d9466.png)

**Before**

![image](https://user-images.githubusercontent.com/8460169/137701428-b43d3b3a-819f-4264-a9a1-34fc0742c66c.png)


**After**

![image](https://user-images.githubusercontent.com/8460169/137701284-0aa53d6a-6dab-46e6-9fce-baf21cc22e92.png)


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
