### PR TITLE
Provide option for alternative form of delete link request Uri

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -173,6 +173,9 @@ namespace Microsoft.OData.Client
 
         private ConcurrentDictionary<string, Type> resolveTypesCache = new ConcurrentDictionary<string, Type>();
 
+        /// <summary>Used to specify the option for the form of Uri to be generated for a delete link request.</summary>
+        private DeleteLinkUriOption deleteLinkUriOption;
+
         #region Test hooks for header and payload verification
 
 #pragma warning disable 0169, 0649
@@ -285,6 +288,7 @@ namespace Microsoft.OData.Client
             this.UsingDataServiceCollection = false;
             this.UsePostTunneling = false;
             this.keyComparisonGeneratesFilterQuery = false;
+            this.deleteLinkUriOption = DeleteLinkUriOption.IdQueryParam;
         }
 
         #endregion
@@ -689,6 +693,14 @@ namespace Microsoft.OData.Client
             get { return this.keyComparisonGeneratesFilterQuery; }
             set { this.keyComparisonGeneratesFilterQuery = value; }
         }
+
+        /// <summary>Gets or sets the option for the form of Uri to be generated for a delete link request.</summary>
+        public virtual DeleteLinkUriOption DeleteLinkUriOption
+        {
+            get { return this.deleteLinkUriOption; }
+            set { this.deleteLinkUriOption = value; }
+        }
+
         /// <summary>Gets or sets whether to support undeclared properties.</summary>
         /// <returns>UndeclaredPropertyBehavior.</returns>
         internal UndeclaredPropertyBehavior UndeclaredPropertyBehavior

--- a/src/Microsoft.OData.Client/DeleteLinkUriOption.cs
+++ b/src/Microsoft.OData.Client/DeleteLinkUriOption.cs
@@ -1,0 +1,26 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DeleteLinkUriOption.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client
+{
+    /// <summary>
+    /// Used to specify the form of Uri to be used for a delete link request.
+    /// </summary>
+    public enum DeleteLinkUriOption
+    {
+        /// <summary>
+        /// Pass the id of the related entity as a query param, i.e.,
+        /// {ServiceUri}/{EntitySet}/{Key}/{NavigationProperty}/$ref?$id={ServiceUri}/{RelatedEntitySet}/{RelatedKey}
+        /// </summary>
+        IdQueryParam = 0,
+
+        /// <summary>
+        /// Pass the id of the related entity as a key segment, i.e.,
+        /// {ServiceUri}/{EntitySet}/{Key}/{NavigationProperty}/{RelatedKey}/$ref
+        /// </summary>
+        RelatedKeyAsSegment = 1,
+    }
+}

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Microsoft.OData.Client.TDDUnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Microsoft.OData.Client.TDDUnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="DateTimePrimitiveTypeReference.cs" />
     <Compile Include="Tests\Annotation\AnnotationTargetingOperationTestsProxy.cs" />
     <Compile Include="Tests\Annotation\ClientAnnotationTests.cs" />
+    <Compile Include="Tests\DeleteLinkTests.cs" />
     <Compile Include="Tests\CustomizedHttpWebRequestMessage.cs" />
     <Compile Include="Tests\Annotation\AnnotationTestsProxy.cs" />
     <Compile Include="Tests\Annotation\ClientMetadataAnnotationTests.cs" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DeleteLinkTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DeleteLinkTests.cs
@@ -1,0 +1,204 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DeleteLinkTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.TDDUnitTests.Tests
+{
+    using System;
+    using System.ComponentModel;
+    using Microsoft.OData.Edm;
+    using Xunit;
+
+    public class DeleteLinkTests
+    {
+        private const string NamespaceName = "Microsoft.OData.Client.TDDUnitTests.Tests";
+        private const string ServiceUri = "http://tempuri.svc";
+        private EdmModel model;
+        private TestDataServiceContext dataServiceContext;
+
+        public DeleteLinkTests()
+        {
+            this.InitializeEdmModel();
+            this.dataServiceContext = new TestDataServiceContext(new Uri(ServiceUri), this.model);
+        }
+
+        [Theory]
+        [InlineData(DeleteLinkUriOption.DollarIdQueryParam, "http://tempuri.svc/Customers(1)/Orders/$ref?$id=http://tempuri.svc/Orders(1)")]
+        [InlineData(DeleteLinkUriOption.RelatedKeyAsSegment, "http://tempuri.svc/Customers(1)/Orders(1)/$ref")]
+        public void ExpectedDeleteLinkUriShouldBeGenerated(DeleteLinkUriOption deleteLinkUriOption, string expectedUri)
+        {
+            this.dataServiceContext.DeleteLinkUriOption = deleteLinkUriOption;
+
+            var customer = new Customer { Id = 1 };
+            var order = new Order { Id = 1 };
+
+            var customerCollection = new DataServiceCollection<Customer>(
+                dataServiceContext, new[] { customer },
+                TrackingMode.AutoChangeTracking,
+                "Customers",
+                null,
+                null);
+            var orderCollection = new DataServiceCollection<Order>(
+                dataServiceContext,
+                new[] { order },
+                TrackingMode.AutoChangeTracking,
+                "Orders",
+                null,
+                null);
+
+            this.dataServiceContext.DeleteLink(customer, "Orders", order);
+            var saveResult = new TestSaveResult(this.dataServiceContext, "SaveChanges", SaveChangesOptions.None, null, null);
+
+            // The API does not offer an easy way to grap the created request and inspect the Uri so we ride on an extensibility hook
+            this.dataServiceContext.SendingRequest2 += (sender, args) =>
+            {
+                Assert.Equal(expectedUri, args.RequestMessage.Url.AbsoluteUri);
+            };
+
+            // If SendingRequest2 event if not fired, an exception is thrown and the test will fail
+            saveResult.CreateRequestAndFireSendingEvent();
+        }
+
+        private void InitializeEdmModel()
+        {
+            model = new EdmModel();
+
+            var orderEntityType = new EdmEntityType(NamespaceName, "Order");
+            orderEntityType.AddKeys(orderEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            model.AddElement(orderEntityType);
+
+            var customerEntityType = new EdmEntityType(NamespaceName, "Customer");
+            customerEntityType.AddKeys(customerEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            var ordersNavProperty = customerEntityType.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Orders",
+                    Target = orderEntityType,
+                    TargetMultiplicity = EdmMultiplicity.Many
+                });
+            model.AddElement(customerEntityType);
+
+            var entityContainer = new EdmEntityContainer(NamespaceName, "Container");
+            model.AddElement(entityContainer);
+
+            var orderEntitySet = entityContainer.AddEntitySet("Orders", orderEntityType);
+            var customerEntitySet = entityContainer.AddEntitySet("Customers", customerEntityType);
+            customerEntitySet.AddNavigationTarget(ordersNavProperty, orderEntitySet);
+        }
+
+        [Key("Id")]
+        internal partial class Customer : BaseEntityType, INotifyPropertyChanged
+        {
+            public virtual int Id
+            {
+                get
+                {
+                    return this._Id;
+                }
+                set
+                {
+                    this.OnIdChanging(value);
+                    this._Id = value;
+                    this.OnIdChanged();
+                    this.OnPropertyChanged("Id");
+                }
+            }
+            private int _Id;
+            partial void OnIdChanging(int value);
+            partial void OnIdChanged();
+
+            public virtual DataServiceCollection<Order> Orders
+            {
+                get
+                {
+                    return this._Orders;
+                }
+                set
+                {
+                    this.OnOrdersChanging(value);
+                    this._Orders = value;
+                    this.OnOrdersChanged();
+                    this.OnPropertyChanged("Orders");
+                }
+            }
+            private DataServiceCollection<Order> _Orders = new DataServiceCollection<Order>(null, TrackingMode.None);
+            partial void OnOrdersChanging(DataServiceCollection<Order> value);
+            partial void OnOrdersChanged();
+
+            public event PropertyChangedEventHandler PropertyChanged;
+            protected virtual void OnPropertyChanged(string property)
+            {
+                if ((this.PropertyChanged != null))
+                {
+                    this.PropertyChanged(this, new PropertyChangedEventArgs(property));
+                }
+            }
+        }
+
+        [Key("Id")]
+        internal partial class Order : BaseEntityType, INotifyPropertyChanged
+        {
+            public virtual int Id
+            {
+                get
+                {
+                    return this._Id;
+                }
+                set
+                {
+                    this.OnIdChanging(value);
+                    this._Id = value;
+                    this.OnIdChanged();
+                    this.OnPropertyChanged("Id");
+                }
+            }
+            private int _Id;
+            partial void OnIdChanging(int value);
+            partial void OnIdChanged();
+
+            public event PropertyChangedEventHandler PropertyChanged;
+            protected virtual void OnPropertyChanged(string property)
+            {
+                if ((this.PropertyChanged != null))
+                {
+                    this.PropertyChanged(this, new PropertyChangedEventArgs(property));
+                }
+            }
+        }
+
+        internal partial class TestDataServiceContext : DataServiceContext
+        {
+            public TestDataServiceContext(Uri serviceRoot, IEdmModel serviceModel) :
+                    base(serviceRoot, ODataProtocolVersion.V4)
+            {
+                this.Format.UseJson(serviceModel);
+            }
+        }
+
+        internal class TestSaveResult : SaveResult
+        {
+            public TestSaveResult(DataServiceContext context, string method, SaveChangesOptions options, AsyncCallback callback, object state)
+                : base(context, method, options, callback, state)
+            {
+            }
+
+            internal void CreateRequestAndFireSendingEvent()
+            {
+                if (this.ChangedEntries.Count > 0)
+                {
+                    if (this.ChangedEntries[0] is LinkDescriptor descriptor)
+                    {
+                        var requestMessageWrapper = this.CreateRequest(descriptor);
+                        requestMessageWrapper.FireSendingEventHandlers(descriptor);
+
+                        return;
+                    }
+                }
+
+                throw new Exception(); // Throw exception to signal unexpected outcome
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2201.*

### Description

Provide option for form of delete link request Uri.

According to the OData spec, a delete link request should have a Uri like:
```
{ServiceUri}/{EntitySet}/{Key}/{NavigationProperty}/$ref?$id={ServiceUri}/{RelatedEntitySet}/{RelatedKey}
```
But in V3 and V4.01, the following alternative form is supported:
```
{ServiceUri}/{EntitySet}/{Key}/{NavigationProperty}/{RelatedKey}/$ref
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
