### PR TITLE
DataServiceEntityAttribute and DataServiceKeyAttribute / maintenance-5.x branch

### DIFF
--- a/WCFDataService/Client/System/Data/Services/Client/Common/DataServiceEntityAttribute.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Common/DataServiceEntityAttribute.cs
@@ -24,7 +24,7 @@ namespace System.Data.Services.Common
     using System;
 
     /// <summary>Marks a class as an entity type in WCF Data Services.</summary>
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false)]
     public sealed class DataServiceEntityAttribute : System.Attribute
     {
         /// <summary>Creates a new instance of the <see cref="T:System.Data.Services.Common.DataServiceEntityAttribute" /> class.</summary>

--- a/WCFDataService/Client/System/Data/Services/Client/Common/DataServiceKeyAttribute.cs
+++ b/WCFDataService/Client/System/Data/Services/Client/Common/DataServiceKeyAttribute.cs
@@ -28,7 +28,7 @@ namespace System.Data.Services.Common
 
     /// <summary>Denotes the key property or properties of an entity. </summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1019:DefineAccessorsForAttributeArguments", Justification = "Accessors are available for processed input.")]
-    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false)]
     public sealed class DataServiceKeyAttribute : System.Attribute
     {
         /// <summary>Name of the properties that form the key.</summary>


### PR DESCRIPTION
### Description

It should be possible to use DataServiceEntityAttribute and DataServiceKeyAttribute attribute types on interfaces as well, not
only classes.
