### PR TITLE
Enable property case insensitive reading

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -1645,7 +1645,8 @@ namespace Microsoft.OData.JsonLight
                                 if (structuredTypeReference != null)
                                 {
                                     edmProperty = ReaderValidationUtils.ValidatePropertyDefined(propertyName,
-                                        structuredTypeReference.StructuredDefinition(), this.MessageReaderSettings.ThrowOnUndeclaredPropertyForNonOpenType);
+                                        structuredTypeReference.StructuredDefinition(), this.MessageReaderSettings.ThrowOnUndeclaredPropertyForNonOpenType,
+                                        this.MessageReaderSettings.EnablePropertyNameCaseInsensitive);
                                 }
 
                                 // EdmLib bridge marks all key properties as non-nullable, but Astoria allows them to be nullable.

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -46,6 +46,7 @@ namespace Microsoft.OData
             this.EnableCharactersCheck = false;
             this.Version = odataVersion;
             this.LibraryCompatibility = ODataLibraryCompatibility.Latest;
+            this.EnablePropertyNameCaseInsensitive = false; // for back-compatible
 
             Validator = new ReaderValidator(this);
             if (odataVersion < ODataVersion.V401)
@@ -116,6 +117,11 @@ namespace Microsoft.OData
                 this.baseUri = UriUtils.EnsureTaillingSlash(value);
             }
         }
+
+        /// <summary>
+        /// Gets or sets a boolean value indicating whether or not supports property name case insensitive in reading.
+        /// </summary>
+        public bool EnablePropertyNameCaseInsensitive { get; set; }
 
         /// <summary>
         /// Gets or sets custom type resolver used by the Client.
@@ -288,6 +294,7 @@ namespace Microsoft.OData
             this.Version = other.Version;
             this.ReadAsStreamFunc = other.ReadAsStreamFunc;
             this.ArrayPool = other.ArrayPool;
+            this.EnablePropertyNameCaseInsensitive = other.EnablePropertyNameCaseInsensitive;
         }
     }
 }

--- a/src/Microsoft.OData.Core/ReaderValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ReaderValidationUtils.cs
@@ -116,8 +116,9 @@ namespace Microsoft.OData
         /// <returns>The <see cref="IEdmProperty"/> instance representing the property with name <paramref name="propertyName"/>
         /// or null if no metadata is available.</returns>
         internal static IEdmProperty ValidatePropertyDefined(string propertyName,
-                                                                  IEdmStructuredType owningStructuredType,
-                                                                  bool throwOnUndeclaredPropertyForNonOpenType)
+            IEdmStructuredType owningStructuredType,
+            bool throwOnUndeclaredPropertyForNonOpenType,
+            bool enablePropertyNameCaseInsensitive)
         {
             Debug.Assert(!string.IsNullOrEmpty(propertyName), "!string.IsNullOrEmpty(propertyName)");
 
@@ -126,7 +127,16 @@ namespace Microsoft.OData
                 return null;
             }
 
-            IEdmProperty property = owningStructuredType.FindProperty(propertyName);
+            IEdmProperty property = null;
+            try
+            {
+                property = owningStructuredType.FindProperty(propertyName, enablePropertyNameCaseInsensitive);
+            }
+            catch (InvalidOperationException)
+            {
+                // ODL should allow to read any undeclared property as dynamic property.
+            }
+
             if (property == null && !owningStructuredType.IsOpen)
             {
                 if (throwOnUndeclaredPropertyForNonOpenType)

--- a/src/Microsoft.OData.Core/ReaderValidator.cs
+++ b/src/Microsoft.OData.Core/ReaderValidator.cs
@@ -121,7 +121,8 @@ namespace Microsoft.OData
         public IEdmProperty ValidatePropertyDefined(string propertyName,
             IEdmStructuredType owningStructuredType)
         {
-            return ReaderValidationUtils.ValidatePropertyDefined(propertyName, owningStructuredType, this.settings.ThrowOnUndeclaredPropertyForNonOpenType);
+            return ReaderValidationUtils.ValidatePropertyDefined(propertyName, owningStructuredType, this.settings.ThrowOnUndeclaredPropertyForNonOpenType,
+                this.settings.EnablePropertyNameCaseInsensitive);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1945,7 +1945,7 @@ namespace Microsoft.OData.Edm
             // So, we can't find edm property whose name is exactly same as "propertyName"
             // Seach again using case-insensitive
             IEdmProperty[] foundProperties = structuredType.Properties()
-                .Where(p => p.Name.Equals(propertyName, StringComparison.OrdinalIgnoreCase)).ToArray();
+                .Where(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase)).ToArray();
 
             if (foundProperties.Length < 1)
             {

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
@@ -39,6 +39,7 @@ namespace Microsoft.OData.Edm
         internal const string Constructable_DependentPropertyCountMustMatchNumberOfPropertiesOnPrincipalType = "Constructable_DependentPropertyCountMustMatchNumberOfPropertiesOnPrincipalType";
         internal const string EdmType_UnexpectedEdmType = "EdmType_UnexpectedEdmType";
         internal const string NavigationPropertyBinding_PathIsNotValid = "NavigationPropertyBinding_PathIsNotValid";
+        internal const string MultipleMatchingPropertiesFound = "MultipleMatchingPropertiesFound";
         internal const string Edm_Evaluator_NoTermTypeAnnotationOnType = "Edm_Evaluator_NoTermTypeAnnotationOnType";
         internal const string Edm_Evaluator_NoValueAnnotationOnType = "Edm_Evaluator_NoValueAnnotationOnType";
         internal const string Edm_Evaluator_NoValueAnnotationOnElement = "Edm_Evaluator_NoValueAnnotationOnElement";

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -19,6 +19,7 @@ PathSegmentMustNotContainSlash=Path segments must not contain '/' character.
 Constructable_DependentPropertyCountMustMatchNumberOfPropertiesOnPrincipalType=The number of dependent properties must match the number of key properties on the principal entity type. '{0}' principal properties were provided, but {1} dependent properties were provided.
 EdmType_UnexpectedEdmType=Unexpected Edm type.
 NavigationPropertyBinding_PathIsNotValid=The navigation property binding path is not valid.
+MultipleMatchingPropertiesFound=More than one properties match the name '{0}' were found in type '{1}'.
 
 ; Evaluation messages
 Edm_Evaluator_NoTermTypeAnnotationOnType=Type '{0}' must have a single type annotation with term type '{1}'.

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -179,6 +179,14 @@ namespace Microsoft.OData.Edm {
         }
 
         /// <summary>
+        /// A string like "More than one properties match the name '{0}' were found in type '{1}'."
+        /// </summary>
+        internal static string MultipleMatchingPropertiesFound(object p0, object p1)
+        {
+            return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.MultipleMatchingPropertiesFound, p0, p1);
+        }
+
+        /// <summary>
         /// A string like "Type '{0}' must have a single type annotation with term type '{1}'."
         /// </summary>
         internal static string Edm_Evaluator_NoTermTypeAnnotationOnType(object p0, object p1)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

* This PR enables to read the property with the different cases as its property type.

```json
{
   "name": "ABC"
}
```

1) If customer enable "reading property case-insensitive", ODL reads the property value as string value.
2) if customer doesn't enable the setting, ODL reads the property value as untyped value.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
