### PR TITLE
Add direct reference to Microsoft.Bcl.AsyncInterfaces package to fix missing reference issue observed in dependent libraries

### DIFF
--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
@@ -15,8 +15,15 @@
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>    
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <dependency id="Microsoft.Spatial" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
-      <dependency id="Microsoft.OData.Edm" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
+      <group>
+        <dependency id="Microsoft.Spatial" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
+        <dependency id="Microsoft.OData.Edm" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Spatial" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
+        <dependency id="Microsoft.OData.Edm" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
@@ -16,8 +16,15 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
     <releaseNotes>https://docs.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <dependency id="Microsoft.Spatial" version="[$VersionNuGetSemantic$]" />
-      <dependency id="Microsoft.OData.Edm" version="[$VersionNuGetSemantic$]" />
+      <group>
+        <dependency id="Microsoft.Spatial" version="[$VersionNuGetSemantic$]" />
+        <dependency id="Microsoft.OData.Edm" version="[$VersionNuGetSemantic$]" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="Microsoft.Spatial" version="[$VersionNuGetSemantic$]" />
+        <dependency id="Microsoft.OData.Edm" version="[$VersionNuGetSemantic$]" />
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -86,4 +86,10 @@
     </Compile>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2181.*

### Description

Add direct reference to `Microsoft.Bcl.AsyncInterfaces` package to fix missing reference issue observed in dependent libraries.
Particular features of the library were introduced to support async disposal when the target framework is .netstandard2.0. However, when Microsoft.OData.Core library is added as a dependency in some other libraries (particularly Microsoft.AspNetCore.OData), it has been observed in some cases that the dependency cannot be found. To mitigate this, the reference is added directly (instead of relying on .netstandard2.0 framework)

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
