### PR TITLE
Fix memory leak

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -2784,8 +2784,11 @@ namespace Microsoft.OData.Client
                 (callback, state) =>
                 {
                     IAsyncResult asyncResult = beginMethod(callback, state);
-                    cancellationToken.Register(() => this.CancelRequest(asyncResult));
-                    cancellationToken.ThrowIfCancellationRequested();
+                    using (CancellationTokenRegistration cancellationTokenRegistration = cancellationToken.Register(() => this.CancelRequest(asyncResult)))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     return asyncResult;
                 },
                 endMethod,
@@ -2814,8 +2817,11 @@ namespace Microsoft.OData.Client
                 (arg1, callback, state) =>
                 {
                     IAsyncResult asyncResult = beginMethod(arg1, callback, state);
-                    cancellationToken.Register(() => this.CancelRequest(asyncResult));
-                    cancellationToken.ThrowIfCancellationRequested();
+                    using (CancellationTokenRegistration cancellationTokenRegistration = cancellationToken.Register(() => this.CancelRequest(asyncResult)))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     return asyncResult;
                 },
                 endMethod,
@@ -2845,8 +2851,11 @@ namespace Microsoft.OData.Client
                 (a1, a2, callback, state) =>
                 {
                     IAsyncResult asyncResult = beginMethod(a1, a2, callback, state);
-                    cancellationToken.Register(() => this.CancelRequest(asyncResult));
-                    cancellationToken.ThrowIfCancellationRequested();
+                    using (CancellationTokenRegistration cancellationTokenRegistration = cancellationToken.Register(() => this.CancelRequest(asyncResult)))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     return asyncResult;
                 },
                 endMethod,
@@ -2880,8 +2889,11 @@ namespace Microsoft.OData.Client
                 (a1, a2, a3, callback, state) =>
                 {
                     IAsyncResult asyncResult = beginMethod(a1, a2, a3, callback, state);
-                    cancellationToken.Register(() => this.CancelRequest(asyncResult));
-                    cancellationToken.ThrowIfCancellationRequested();
+                    using (CancellationTokenRegistration cancellationTokenRegistration = cancellationToken.Register(() => this.CancelRequest(asyncResult)))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                    }
+
                     return asyncResult;
                 },
                 endMethod,


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2234 .*

### Description

*Current problem*
`CancellationTokenRegistration` is a callback delegate that has been registered with a `CancellationToken`. https://docs.microsoft.com/en-us/dotnet/api/system.threading.cancellationtokenregistration?view=net-5.0
We are not calling `CancellationTokenRegistration.Dispose()` to release all resources used by the current instance of the `CancellationTokenRegistration`.
In this case, what happens is that the callback is not unregistered.

It's also important to note, the cancellation callback is registered with the CancellationTokenSource (see https://referencesource.microsoft.com/#mscorlib/system/threading/CancellationToken.cs,31a5196df8e4df6d), not with CancellationToken. So, if CancellationTokenRegistration.Dispose() is not correctly scoped, the registration will remain active for the lifetime of the parent CancellationTokenSource object. This may lead to an unexpected callback when the scope of the async operation is over.

*Solution*
When a callback is registered to a CancellationToken (`CancellationToken.Register(Action)`), the returned object is a `CancellationTokenRegistration`. This is a light struct type that is IDiposable, and disposing this registration object causes the callback to be deregistered. A guarantee is made that after the Dispose() method has returned, the registered callback is neither running nor will subsequently commence. Source https://devblogs.microsoft.com/pfxteam/net-4-cancellation-framework/

The `using` pattern is a convenient way to make sure CancellationTokenRegistration.Unregister() is called automatically.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
