### PR TITLE
Cache DuplicateNameChecker in the OutputContext

### DIFF
--- a/src/Microsoft.OData.Core/DuplicatePropertyNameChecker.cs
+++ b/src/Microsoft.OData.Core/DuplicatePropertyNameChecker.cs
@@ -120,7 +120,10 @@ namespace Microsoft.OData
         /// </summary>
         public void Reset()
         {
-            propertyState.Clear();
+            if (propertyState.Count > 0)
+            {
+                propertyState.Clear();
+            }
         }
     }
 

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -206,6 +206,10 @@ namespace Microsoft.OData
                     expectedType,
                     treatLikeOpenProperty,
                     this.valueSerializer.JsonLightOutputContext.DuplicatePropertyNameChecker);
+
+                // Reset the PropertyState Dictionary in the DuplicatePropertyNameChecker
+                this.valueSerializer.JsonLightOutputContext.DuplicatePropertyNameChecker.Reset();
+
                 return;
             }
 

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -205,7 +205,7 @@ namespace Microsoft.OData
                 this.valueSerializer.WriteResourceValue(resourceValue,
                     expectedType,
                     treatLikeOpenProperty,
-                    this.valueSerializer.CreateDuplicatePropertyNameChecker());
+                    this.valueSerializer.JsonLightOutputContext.DuplicatePropertyNameChecker);
                 return;
             }
 
@@ -394,7 +394,7 @@ namespace Microsoft.OData
                 await this.valueSerializer.WriteResourceValueAsync(resourceValue,
                     expectedType,
                     treatLikeOpenProperty,
-                    this.valueSerializer.CreateDuplicatePropertyNameChecker()).ConfigureAwait(false);
+                    this.valueSerializer.JsonLightOutputContext.DuplicatePropertyNameChecker).ConfigureAwait(false);
                 return;
             }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -82,7 +82,7 @@ namespace Microsoft.OData.JsonLight
                         property,
                         null /*owningType*/,
                         true /* isTopLevel */,
-                        this.CreateDuplicatePropertyNameChecker(),
+                        this.JsonLightOutputContext.DuplicatePropertyNameChecker,
                         null /* metadataBuilder */);
                     this.JsonLightValueSerializer.AssertRecursionDepthIsZero();
 
@@ -280,7 +280,7 @@ namespace Microsoft.OData.JsonLight
                         property,
                         null /*owningType*/,
                         true /* isTopLevel */,
-                        this.CreateDuplicatePropertyNameChecker(),
+                        this.JsonLightOutputContext.DuplicatePropertyNameChecker,
                         null /* metadataBuilder */).ConfigureAwait(false);
                     this.JsonLightValueSerializer.AssertRecursionDepthIsZero();
 
@@ -649,7 +649,7 @@ namespace Microsoft.OData.JsonLight
                 resourceValue,
                 this.currentPropertyInfo.MetadataType.TypeReference,
                 isOpenPropertyType,
-                this.CreateDuplicatePropertyNameChecker());
+                this.JsonLightOutputContext.DuplicatePropertyNameChecker);
         }
 
         /// <summary>
@@ -1074,7 +1074,7 @@ namespace Microsoft.OData.JsonLight
                 resourceValue,
                 this.currentPropertyInfo.MetadataType.TypeReference,
                 isOpenPropertyType,
-                this.CreateDuplicatePropertyNameChecker()).ConfigureAwait(false);
+                this.JsonLightOutputContext.DuplicatePropertyNameChecker).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -245,7 +245,7 @@ namespace Microsoft.OData.JsonLight
                     {
                         if (duplicatePropertyNamesChecker == null)
                         {
-                            duplicatePropertyNamesChecker = this.CreateDuplicatePropertyNameChecker();
+                            duplicatePropertyNamesChecker = this.JsonLightOutputContext.DuplicatePropertyNameChecker;
                         }
 
                         this.WriteResourceValue(
@@ -567,7 +567,7 @@ namespace Microsoft.OData.JsonLight
                     {
                         if (duplicatePropertyNamesChecker == null)
                         {
-                            duplicatePropertyNamesChecker = this.CreateDuplicatePropertyNameChecker();
+                            duplicatePropertyNamesChecker = this.JsonLightOutputContext.DuplicatePropertyNameChecker;
                         }
 
                         await this.WriteResourceValueAsync(

--- a/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
@@ -106,7 +106,7 @@ namespace Microsoft.OData
             {
                 return duplicatePropertyNameChecker
                        ?? (duplicatePropertyNameChecker
-                           = outputContext.MessageWriterSettings.Validator.CreateDuplicatePropertyNameChecker());
+                           = outputContext.DuplicatePropertyNameChecker);
             }
         }
 

--- a/src/Microsoft.OData.Core/ODataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataOutputContext.cs
@@ -57,6 +57,11 @@ namespace Microsoft.OData
         private readonly ODataSimplifiedOptions odataSimplifiedOptions;
 
         /// <summary>
+        /// Checker to detect duplicate property names.
+        /// </summary>
+        private readonly IDuplicatePropertyNameChecker duplicatePropertyNameChecker;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="format">The format for this output context.</param>
@@ -81,6 +86,7 @@ namespace Microsoft.OData
             this.payloadValueConverter = ODataPayloadValueConverter.GetPayloadValueConverter(this.container);
             this.writerValidator = messageWriterSettings.Validator;
             this.odataSimplifiedOptions = ODataSimplifiedOptions.GetODataSimplifiedOptions(this.container, messageWriterSettings.Version);
+            this.duplicatePropertyNameChecker = MessageWriterSettings.Validator.CreateDuplicatePropertyNameChecker();
         }
 
         /// <summary>
@@ -136,6 +142,17 @@ namespace Microsoft.OData
             get
             {
                 return this.payloadUriConverter;
+            }
+        }
+
+        /// <summary>
+        /// Checker to detect duplicate property names.
+        /// </summary>
+        internal IDuplicatePropertyNameChecker DuplicatePropertyNameChecker
+        {
+            get
+            {
+                return this.duplicatePropertyNameChecker;
             }
         }
 

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -83,8 +83,7 @@ namespace Microsoft.OData
             {
                 return this.duplicatePropertyNameChecker ??
                        (this.duplicatePropertyNameChecker =
-                           outputContext.MessageWriterSettings.Validator
-                           .CreateDuplicatePropertyNameChecker());
+                           outputContext.DuplicatePropertyNameChecker);
             }
         }
 

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -265,7 +265,7 @@ namespace Microsoft.OData
                         resourceValue, /* resourceValue */
                         null, /* metadataTypeReference */
                         true, /* isOpenPropertyType */
-                        serializer.CreateDuplicatePropertyNameChecker()));
+                        serializer.JsonLightOutputContext.DuplicatePropertyNameChecker));
             }
 
             return builder.ToString();


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2180 .*

### Description

When serializing a response, we are calling `[Serializer].CreateDuplicatePropertyNameChecker()` multiple times to create an instance of the `DuplicatePropertyNameChecker` each time. This causes lots of allocations from initializing and resizing the internal `propertyState` dictionary.

In this PR, we create an Instance of the `DuplicatePropertyNameChecker` when we create the `OutputContext`. This allows us to re-use the `DuplicatePropertyNameChecker` throughout the response serialization process.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
