### PR TITLE
Fix issues with performance tests

### DIFF
--- a/test/PerformanceTests/ComponentTests/ODataReader/ODataReaderFeedTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataReader/ODataReaderFeedTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.OData.Performance
 
         public Stream _stream;
 
-        [IterationSetup]
+        [GlobalSetup]
         public void InitModel()
         {
             Model = TestUtils.GetAdventureWorksModel(_isModelImmutable);

--- a/test/PerformanceTests/ComponentTests/ODataWriter/ODataWriterFeedTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataWriter/ODataWriterFeedTests.cs
@@ -32,11 +32,16 @@ namespace Microsoft.OData.Performance
         [Params(true, false)]
         public bool isModelImmutable;
 
-        [IterationSetup]
+        [GlobalSetup]
         public void InitModel()
         {
             Model = TestUtils.GetAdventureWorksModel(isModelImmutable);
             TestEntitySet = Model.EntityContainer.FindEntitySet("Product");
+        }
+
+        [IterationSetup]
+        public void ResetStream()
+        {
             WriteStream.Seek(0, SeekOrigin.Begin);
         }
 

--- a/test/PerformanceTests/SerializationBaselineTests/SerializationBenchmarks.cs
+++ b/test/PerformanceTests/SerializationBaselineTests/SerializationBenchmarks.cs
@@ -18,13 +18,10 @@ namespace SerializationBaselineTests
         IExperimentWriter odataSyncCharPoolWriter;
         IEnumerable<Customer> data;
 
-        [Params(1000, 5000, 10000)]
-        public int dataSize;
+        public int dataSize = 5000;
 
         [Params(true, false)]
         public bool isModelImmutable;
-
-        IEdmModel model;
 
         string tempFile;
         Stream fileStream;
@@ -33,9 +30,9 @@ namespace SerializationBaselineTests
         public void PrepareDataset()
         {
             data = DataSet.GetCustomers(dataSize);
+            InitWriters();
         }
 
-        [IterationSetup]
         public void InitWriters()
         {
             var model = DataModel.GetEdmModel();
@@ -101,14 +98,6 @@ namespace SerializationBaselineTests
         {
             tempFile = Path.GetTempFileName();
             fileStream = new FileStream(tempFile, FileMode.Create);
-
-            // for some reason the InitWriters() iteration setup is not
-            // being called for the file benchmarks. Not sure why.
-            // For now, manually call it if it has not been called
-            if (jsonWriter == null)
-            {
-                InitWriters();
-            }
         }
 
         [IterationCleanup(Targets = new[] {
@@ -155,7 +144,6 @@ namespace SerializationBaselineTests
 
         private void WriteToFile(IExperimentWriter writer)
         {
-            System.Console.WriteLine("WRITE TO FILE, writer is null {0}, fileStrem is null {1}, data null {2}",  writer == null, fileStream == null, data == null);
             writer.WriteCustomers(data, fileStream).Wait();
             fileStream.Close();
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Some performance tests were failing or not returning results. In most cases the issue was related to incorrect usage of `[IterationSetup]`. This attribute is meant to be used on a method that should execute before each invocation of a benchmark method (it's actually not recommended to use unless for benchmarks that run for 100ms+ per invocation because it can spoil the results). However the issue was because I had multiple methods with `[IterationSetup]` and `[IterationSetup(Target=...)]` expecting each to be executed for the same benchmark method. But only one gets executed, and so some benchmarks were executing with some values not being properly initialized.

In some of these cases, I realized that the setup code didn't need to run for each invocation of a benchmark method, it would be sufficient for it run once per method (e.g. the same model is reused in all invocations of a test). In such cases I moved the setup code in the `[GlobalSetup]` method which is meant for that.

For more info about setup and clean up code in BenchmarkDotNet see: https://benchmarkdotnet.org/articles/features/setup-and-cleanup.html

Some tests still make use of `IterationSetup`, especially when writing to a stream or file and I want to reset the stream or file each time the method is invoked.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
