### PR TITLE
Refactor alternate key resolver to avoid relying on exceptions

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -780,7 +780,6 @@ namespace Microsoft.OData
         internal const string OpenNavigationPropertiesNotSupportedOnOpenTypes = "OpenNavigationPropertiesNotSupportedOnOpenTypes";
         internal const string BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation = "BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation";
         internal const string DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion = "DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion";
-        internal const string BadRequest_KeyCountMismatch = "BadRequest_KeyCountMismatch";
         internal const string BadRequest_KeyMismatch = "BadRequest_KeyMismatch";
         internal const string BadRequest_KeyOrAlternateKeyMismatch = "BadRequest_KeyOrAlternateKeyMismatch";
         internal const string RequestUriProcessor_KeysMustBeNamed = "RequestUriProcessor_KeysMustBeNamed";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -781,6 +781,7 @@ namespace Microsoft.OData
         internal const string BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation = "BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation";
         internal const string DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion = "DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion";
         internal const string BadRequest_KeyCountMismatch = "BadRequest_KeyCountMismatch";
+        internal const string BadRequest_KeyOrAlternateKeyMismatch = "BadRequest_KeyOrAlternateKeyMismatch";
         internal const string RequestUriProcessor_KeysMustBeNamed = "RequestUriProcessor_KeysMustBeNamed";
         internal const string RequestUriProcessor_ResourceNotFound = "RequestUriProcessor_ResourceNotFound";
         internal const string RequestUriProcessor_BatchedActionOnEntityCreatedInSameChangeset = "RequestUriProcessor_BatchedActionOnEntityCreatedInSameChangeset";
@@ -796,8 +797,8 @@ namespace Microsoft.OData
         internal const string ExceptionUtils_ArgumentStringNullOrEmpty = "ExceptionUtils_ArgumentStringNullOrEmpty";
         internal const string ExpressionToken_OnlyRefAllowWithStarInExpand = "ExpressionToken_OnlyRefAllowWithStarInExpand";
         internal const string ExpressionToken_DollarCountNotAllowedInSelect = "ExpressionToken_DollarCountNotAllowedInSelect";
-        internal const string ExpressionToken_NoPropAllowedAfterRef = "ExpressionToken_NoPropAllowedAfterRef";
         internal const string ExpressionToken_NoPropAllowedAfterDollarCount = "ExpressionToken_NoPropAllowedAfterDollarCount";
+        internal const string ExpressionToken_NoPropAllowedAfterRef = "ExpressionToken_NoPropAllowedAfterRef";
         internal const string ExpressionToken_NoSegmentAllowedBeforeStarInExpand = "ExpressionToken_NoSegmentAllowedBeforeStarInExpand";
         internal const string ExpressionToken_IdentifierExpected = "ExpressionToken_IdentifierExpected";
         internal const string ExpressionLexer_UnterminatedStringLiteral = "ExpressionLexer_UnterminatedStringLiteral";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -780,6 +780,7 @@ namespace Microsoft.OData
         internal const string OpenNavigationPropertiesNotSupportedOnOpenTypes = "OpenNavigationPropertiesNotSupportedOnOpenTypes";
         internal const string BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation = "BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation";
         internal const string DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion = "DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion";
+        internal const string BadRequest_KeyCountMismatch = "BadRequest_KeyCountMismatch";
         internal const string BadRequest_KeyMismatch = "BadRequest_KeyMismatch";
         internal const string BadRequest_KeyOrAlternateKeyMismatch = "BadRequest_KeyOrAlternateKeyMismatch";
         internal const string RequestUriProcessor_KeysMustBeNamed = "RequestUriProcessor_KeysMustBeNamed";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -781,6 +781,7 @@ namespace Microsoft.OData
         internal const string BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation = "BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation";
         internal const string DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion = "DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion";
         internal const string BadRequest_KeyCountMismatch = "BadRequest_KeyCountMismatch";
+        internal const string BadRequest_KeyMismatch = "BadRequest_KeyMismatch";
         internal const string BadRequest_KeyOrAlternateKeyMismatch = "BadRequest_KeyOrAlternateKeyMismatch";
         internal const string RequestUriProcessor_KeysMustBeNamed = "RequestUriProcessor_KeysMustBeNamed";
         internal const string RequestUriProcessor_ResourceNotFound = "RequestUriProcessor_ResourceNotFound";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -900,6 +900,7 @@ RequestUriProcessor_InvalidTypeIdentifier_UnrelatedType=The type '{0}' specified
 OpenNavigationPropertiesNotSupportedOnOpenTypes=Open navigation properties are not supported on OpenTypes. Property name: '{0}'.
 BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation=Error processing request stream. In batch mode, a resource can be cross-referenced only for bind/unbind operations.
 DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion=The response requires that version {0} of the protocol be used, but the MaxProtocolVersion of the data service is set to {1}.
+BadRequest_KeyCountMismatch=The number of keys specified in the URI does not match number of key properties for the resource '{0}'.
 BadRequest_KeyMismatch=The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared key of the resource '{0}'.
 BadRequest_KeyOrAlternateKeyMismatch=The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared or alternate key properties for the resource '{0}'.
 RequestUriProcessor_KeysMustBeNamed=Segments with multiple key values must specify them in 'name=value' form.

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -901,7 +901,8 @@ OpenNavigationPropertiesNotSupportedOnOpenTypes=Open navigation properties are n
 BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation=Error processing request stream. In batch mode, a resource can be cross-referenced only for bind/unbind operations.
 DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion=The response requires that version {0} of the protocol be used, but the MaxProtocolVersion of the data service is set to {1}.
 BadRequest_KeyCountMismatch=The number of keys specified in the URI does not match number of key properties for the resource '{0}'.
-BadRequest_KeyOrAlternateKeyMismatch=The number or names of keys specified in the URI do not match the declared or alternate key properties for the resource '{0}'.
+BadRequest_KeyMismatch=The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared key of the resource '{0}'.
+BadRequest_KeyOrAlternateKeyMismatch=The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared or alternate key properties for the resource '{0}'.
 RequestUriProcessor_KeysMustBeNamed=Segments with multiple key values must specify them in 'name=value' form.
 RequestUriProcessor_ResourceNotFound=Resource not found for the segment '{0}'.
 RequestUriProcessor_BatchedActionOnEntityCreatedInSameChangeset=Batched service action '{0}' cannot be invoked because it was bound to an entity created in the same changeset.

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -900,7 +900,6 @@ RequestUriProcessor_InvalidTypeIdentifier_UnrelatedType=The type '{0}' specified
 OpenNavigationPropertiesNotSupportedOnOpenTypes=Open navigation properties are not supported on OpenTypes. Property name: '{0}'.
 BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation=Error processing request stream. In batch mode, a resource can be cross-referenced only for bind/unbind operations.
 DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion=The response requires that version {0} of the protocol be used, but the MaxProtocolVersion of the data service is set to {1}.
-BadRequest_KeyCountMismatch=The number of keys specified in the URI does not match number of key properties for the resource '{0}'.
 BadRequest_KeyMismatch=The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared key of the resource '{0}'.
 BadRequest_KeyOrAlternateKeyMismatch=The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared or alternate key properties for the resource '{0}'.
 RequestUriProcessor_KeysMustBeNamed=Segments with multiple key values must specify them in 'name=value' form.

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -846,8 +846,8 @@ PathParser_TypeCastOnlyAllowedInDerivedTypeConstraint=Type cast segment '{0}' on
 
 ODataResourceSet_MustNotContainBothNextPageLinkAndDeltaLink=A resource set may contain a next page link, a delta link or neither, but must not contain both.
 
-ODataExpandPath_OnlyLastSegmentCanBeNavigationProperty =The last segment, and only the last segment, can be a navigation property in $expand.
-ODataExpandPath_LastSegmentMustBeNavigationPropertyOrTypeSegment =The last segment must be a navigation property or type segment in $expand.
+ODataExpandPath_OnlyLastSegmentCanBeNavigationProperty=The last segment, and only the last segment, can be a navigation property in $expand.
+ODataExpandPath_LastSegmentMustBeNavigationPropertyOrTypeSegment=The last segment must be a navigation property or type segment in $expand.
 ODataExpandPath_InvalidExpandPathSegment=Found a segment of type '{0} in an expand path, but only NavigationProperty, Property and Type segments are allowed.
 
 ODataSelectPath_CannotOnlyHaveTypeSegment=TypeSegment cannot be the only segment in a $select.
@@ -901,6 +901,7 @@ OpenNavigationPropertiesNotSupportedOnOpenTypes=Open navigation properties are n
 BadRequest_ResourceCanBeCrossReferencedOnlyForBindOperation=Error processing request stream. In batch mode, a resource can be cross-referenced only for bind/unbind operations.
 DataServiceConfiguration_ResponseVersionIsBiggerThanProtocolVersion=The response requires that version {0} of the protocol be used, but the MaxProtocolVersion of the data service is set to {1}.
 BadRequest_KeyCountMismatch=The number of keys specified in the URI does not match number of key properties for the resource '{0}'.
+BadRequest_KeyOrAlternateKeyMismatch=The number or names of keys specified in the URI do not match the declared or alternate key properties for the resource '{0}'.
 RequestUriProcessor_KeysMustBeNamed=Segments with multiple key values must specify them in 'name=value' form.
 RequestUriProcessor_ResourceNotFound=Resource not found for the segment '{0}'.
 RequestUriProcessor_BatchedActionOnEntityCreatedInSameChangeset=Batched service action '{0}' cannot be invoked because it was bound to an entity created in the same changeset.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -5215,9 +5215,12 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "Only $filter and $search query options are allowed within $count."
         /// </summary>
-        internal static string UriQueryExpressionParser_IllegalQueryOptioninDollarCount()
+        internal static string UriQueryExpressionParser_IllegalQueryOptioninDollarCount
         {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriQueryExpressionParser_IllegalQueryOptioninDollarCount);
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriQueryExpressionParser_IllegalQueryOptioninDollarCount);
+            }
         }
 
         /// <summary>
@@ -5506,9 +5509,12 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "The next token in a CountSegmentNode must be a collection."
         /// </summary>
-        internal static string MetadataBinder_CountSegmentNextTokenNotCollectionValue()
+        internal static string MetadataBinder_CountSegmentNextTokenNotCollectionValue
         {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.MetadataBinder_CountSegmentNextTokenNotCollectionValue);
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.MetadataBinder_CountSegmentNextTokenNotCollectionValue);
+            }
         }
 
         /// <summary>
@@ -6215,9 +6221,12 @@ namespace Microsoft.OData {
         /// <summary>
         /// A string like "Empty parenthesis not allowed."
         /// </summary>
-        internal static string UriParser_EmptyParenthesis()
+        internal static string UriParser_EmptyParenthesis
         {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriParser_EmptyParenthesis);
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriParser_EmptyParenthesis);
+            }
         }
 
         /// <summary>
@@ -6823,6 +6832,14 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The number or names of keys specified in the URI do not match the declared or alternate key properties for the resource '{0}'."
+        /// </summary>
+        internal static string BadRequest_KeyOrAlternateKeyMismatch(object p0)
+        {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.BadRequest_KeyOrAlternateKeyMismatch, p0);
+        }
+
+        /// <summary>
         /// A string like "Segments with multiple key values must specify them in 'name=value' form."
         /// </summary>
         internal static string RequestUriProcessor_KeysMustBeNamed
@@ -6953,13 +6970,13 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "No property is allowed after $ref segment."
+        /// A string like "$count is not allowed in $select option."
         /// </summary>
-        internal static string ExpressionToken_NoPropAllowedAfterRef
+        internal static string ExpressionToken_DollarCountNotAllowedInSelect
         {
             get
             {
-                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ExpressionToken_NoPropAllowedAfterRef);
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ExpressionToken_DollarCountNotAllowedInSelect);
             }
         }
 
@@ -6975,13 +6992,13 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "$count is not allowed in $select option."
+        /// A string like "No property is allowed after $ref segment."
         /// </summary>
-        internal static string ExpressionToken_DollarCountNotAllowedInSelect
+        internal static string ExpressionToken_NoPropAllowedAfterRef
         {
             get
             {
-                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ExpressionToken_DollarCountNotAllowedInSelect);
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ExpressionToken_NoPropAllowedAfterRef);
             }
         }
 

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -6824,6 +6824,14 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The number of keys specified in the URI does not match number of key properties for the resource '{0}'."
+        /// </summary>
+        internal static string BadRequest_KeyCountMismatch(object p0)
+        {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.BadRequest_KeyCountMismatch, p0);
+        }
+
+        /// <summary>
         /// A string like "The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared key of the resource '{0}'."
         /// </summary>
         internal static string BadRequest_KeyMismatch(object p0)

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -6832,7 +6832,15 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "The number or names of keys specified in the URI do not match the declared or alternate key properties for the resource '{0}'."
+        /// A string like "The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared key of the resource '{0}'."
+        /// </summary>
+        internal static string BadRequest_KeyMismatch(object p0)
+        {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.BadRequest_KeyMismatch, p0);
+        }
+
+        /// <summary>
+        /// A string like "The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared or alternate key properties for the resource '{0}'."
         /// </summary>
         internal static string BadRequest_KeyOrAlternateKeyMismatch(object p0)
         {

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -6824,14 +6824,6 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
-        /// A string like "The number of keys specified in the URI does not match number of key properties for the resource '{0}'."
-        /// </summary>
-        internal static string BadRequest_KeyCountMismatch(object p0)
-        {
-            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.BadRequest_KeyCountMismatch, p0);
-        }
-
-        /// <summary>
         /// A string like "The key in the request URI is not valid for resource '{0}'. Ensure that the names and number of key properties match the declared key of the resource '{0}'."
         /// </summary>
         internal static string BadRequest_KeyMismatch(object p0)

--- a/src/Microsoft.OData.Core/UriParser/Binders/CountSegmentBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/CountSegmentBinder.cs
@@ -49,7 +49,7 @@ namespace Microsoft.OData.UriParser
 
             if(node == null)
             {
-                throw new ODataException(ODataErrorStrings.MetadataBinder_CountSegmentNextTokenNotCollectionValue());
+                throw new ODataException(ODataErrorStrings.MetadataBinder_CountSegmentNextTokenNotCollectionValue);
             }
 
             FilterClause filterClause = null;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/CountSegmentParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/CountSegmentParser.cs
@@ -75,7 +75,7 @@ namespace Microsoft.OData.UriParser
                 // Check for (), which is not allowed.
                 if (this.lexer.CurrentToken.Kind == ExpressionTokenKind.CloseParen)
                 {
-                    throw new ODataException(ODataErrorStrings.UriParser_EmptyParenthesis());
+                    throw new ODataException(ODataErrorStrings.UriParser_EmptyParenthesis);
                 }
 
                 // Look for all the supported query options
@@ -103,7 +103,7 @@ namespace Microsoft.OData.UriParser
 
                         default:
                             {
-                                throw new ODataException(ODataErrorStrings.UriQueryExpressionParser_IllegalQueryOptioninDollarCount());
+                                throw new ODataException(ODataErrorStrings.UriQueryExpressionParser_IllegalQueryOptioninDollarCount);
                             }
                     }
                 }

--- a/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
@@ -39,24 +39,17 @@ namespace Microsoft.OData.UriParser
         /// <returns>The resolved key list.</returns>
         public override IEnumerable<KeyValuePair<string, object>> ResolveKeys(IEdmEntityType type, IDictionary<string, string> namedValues, Func<IEdmTypeReference, string, object> convertFunc)
         {
-            IEnumerable<KeyValuePair<string, object>> convertedPairs;
-            string[] keyNames = type.Key().Select(keyProperty => keyProperty.Name).ToArray();
-
-            if (namedValues.Keys.Count == keyNames.Length)
+            if (base.TryResolveKeys(type, namedValues, convertFunc, out IEnumerable<KeyValuePair<string, object>> convertedPairs))
             {
-                if (namedValues.Keys.All(keyProperty => keyNames.Contains(keyProperty, StringComparer.OrdinalIgnoreCase)))
-                {
-                    convertedPairs = base.ResolveKeys(type, namedValues, convertFunc);
-                    return convertedPairs;
-                }
+                return convertedPairs;
             }
 
-            if (!TryResolveAlternateKeys(type, namedValues, convertFunc, out convertedPairs))
+            if (!TryResolveAlternateKeys(type, namedValues, convertFunc, out IEnumerable<KeyValuePair<string, object>> alternateConvertedPairs))
             {
                 throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyOrAlternateKeyMismatch(type.FullName()));
             }
 
-            return convertedPairs;
+            return alternateConvertedPairs;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
@@ -39,16 +39,21 @@ namespace Microsoft.OData.UriParser
         /// <returns>The resolved key list.</returns>
         public override IEnumerable<KeyValuePair<string, object>> ResolveKeys(IEdmEntityType type, IDictionary<string, string> namedValues, Func<IEdmTypeReference, string, object> convertFunc)
         {
-            IEnumerable<KeyValuePair<string, object>> convertedPairs;
-            try
+            IEnumerable<KeyValuePair<string, object>> convertedPairs = null;
+            string[] keyNames = type.DeclaredKey.Select(keyProperty => keyProperty.Name).ToArray();
+
+            if (namedValues.Keys.Count == keyNames.Length)
             {
-                convertedPairs = base.ResolveKeys(type, namedValues, convertFunc);
+                if (namedValues.Keys.All(keyProperty => keyNames.Contains(keyProperty, StringComparer.OrdinalIgnoreCase)))
+                {
+                    convertedPairs = base.ResolveKeys(type, namedValues, convertFunc);
+                }
             }
-            catch (ODataException)
+            else
             {
                 if (!TryResolveAlternateKeys(type, namedValues, convertFunc, out convertedPairs))
                 {
-                    throw;
+                    throw ExceptionUtil.CreateSyntaxError();
                 }
             }
 

--- a/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OData.UriParser
         /// <returns>The resolved key list.</returns>
         public override IEnumerable<KeyValuePair<string, object>> ResolveKeys(IEdmEntityType type, IDictionary<string, string> namedValues, Func<IEdmTypeReference, string, object> convertFunc)
         {
-            IEnumerable<KeyValuePair<string, object>> convertedPairs = null;
+            IEnumerable<KeyValuePair<string, object>> convertedPairs;
             string[] keyNames = type.DeclaredKey.Select(keyProperty => keyProperty.Name).ToArray();
 
             if (namedValues.Keys.Count == keyNames.Length)
@@ -47,14 +47,13 @@ namespace Microsoft.OData.UriParser
                 if (namedValues.Keys.All(keyProperty => keyNames.Contains(keyProperty, StringComparer.OrdinalIgnoreCase)))
                 {
                     convertedPairs = base.ResolveKeys(type, namedValues, convertFunc);
+                    return convertedPairs;
                 }
             }
-            else
+
+            if (!TryResolveAlternateKeys(type, namedValues, convertFunc, out convertedPairs))
             {
-                if (!TryResolveAlternateKeys(type, namedValues, convertFunc, out convertedPairs))
-                {
-                    throw ExceptionUtil.CreateSyntaxError();
-                }
+                throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyOrAlternateKeyMismatch(type.FullName()));
             }
 
             return convertedPairs;

--- a/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/AlternateKeysODataUriResolver.cs
@@ -40,7 +40,7 @@ namespace Microsoft.OData.UriParser
         public override IEnumerable<KeyValuePair<string, object>> ResolveKeys(IEdmEntityType type, IDictionary<string, string> namedValues, Func<IEdmTypeReference, string, object> convertFunc)
         {
             IEnumerable<KeyValuePair<string, object>> convertedPairs;
-            string[] keyNames = type.DeclaredKey.Select(keyProperty => keyProperty.Name).ToArray();
+            string[] keyNames = type.Key().Select(keyProperty => keyProperty.Name).ToArray();
 
             if (namedValues.Keys.Count == keyNames.Length)
             {

--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -450,8 +450,8 @@ namespace Microsoft.OData.UriParser
             }
 
             // Fail if key size from url doesn't match that from model.
-            // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
-            // should override the ResolveKeys method.
+            // Classes that extend ODataUriResolver to provide alternative key-resolution logic
+            // should override the ResolveKeys method (e.g. the built-in AlternateKeysODataUriResolver)
             if (keyCount != namedValues.Count)
             {
                 return false;

--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -342,15 +342,7 @@ namespace Microsoft.OData.UriParser
         /// <returns>The resolved key list.</returns>
         public virtual IEnumerable<KeyValuePair<string, object>> ResolveKeys(IEdmEntityType type, IList<string> positionalValues, Func<IEdmTypeReference, string, object> convertFunc)
         {
-            // Throw an error if key size from url doesn't match that from model.
-            // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
-            // should override this ResolveKeys method.
             IEnumerable<IEdmStructuralProperty> keys = type.Key();
-            if (keys.Count() != positionalValues.Count)
-            {
-                throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyCountMismatch(type.FullName()));
-            }
-
             var keyPairList = new List<KeyValuePair<string, object>>(positionalValues.Count);
 
             int i = 0;
@@ -364,6 +356,14 @@ namespace Microsoft.OData.UriParser
                 }
 
                 keyPairList.Add(new KeyValuePair<string, object>(keyProperty.Name, convertedValue));
+            }
+
+            // Throw an error if key size from url doesn't match that from model.
+            // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
+            // should override this ResolveKeys method.
+            if (i != positionalValues.Count)
+            {
+                throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyCountMismatch(type.FullName()));
             }
 
             return keyPairList;

--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -342,7 +342,15 @@ namespace Microsoft.OData.UriParser
         /// <returns>The resolved key list.</returns>
         public virtual IEnumerable<KeyValuePair<string, object>> ResolveKeys(IEdmEntityType type, IList<string> positionalValues, Func<IEdmTypeReference, string, object> convertFunc)
         {
+            // Throw an error if key size from url doesn't match that from model.
+            // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
+            // should override this ResolveKeys method.
             IEnumerable<IEdmStructuralProperty> keys = type.Key();
+            if (keys.Count() != positionalValues.Count)
+            {
+                throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyCountMismatch(type.FullName()));
+            }
+
             var keyPairList = new List<KeyValuePair<string, object>>(positionalValues.Count);
 
             int i = 0;
@@ -356,14 +364,6 @@ namespace Microsoft.OData.UriParser
                 }
 
                 keyPairList.Add(new KeyValuePair<string, object>(keyProperty.Name, convertedValue));
-            }
-
-            // Throw an error if key size from url doesn't match that from model.
-            // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
-            // should override this ResolveKeys method.
-            if (i != positionalValues.Count)
-            {
-                throw ExceptionUtil.CreateBadRequestError(Strings.BadRequest_KeyCountMismatch(type.FullName()));
             }
 
             return keyPairList;

--- a/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/ODataUriResolver.cs
@@ -400,17 +400,12 @@ namespace Microsoft.OData.UriParser
             resolvedKeys = null;
             var convertedPairs = new Dictionary<string, object>(StringComparer.Ordinal);
 
-            // Throw an error if key size from url doesn't match that from model.
-            // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
-            // should override this ResolveKeys method.
             IEnumerable<IEdmStructuralProperty> keys = type.Key();
-            if (keys.Count() != namedValues.Count)
-            {
-                return false;
-            }
+            int keyCount = 0;
 
             foreach (IEdmStructuralProperty property in keys)
             {
+                keyCount++;
                 string valueText;
 
                 if (!namedValues.TryGetValue(property.Name, out valueText))
@@ -452,6 +447,14 @@ namespace Microsoft.OData.UriParser
                 }
 
                 convertedPairs[property.Name] = convertedValue;
+            }
+
+            // Fail if key size from url doesn't match that from model.
+            // Other derived ODataUriResolver intended for alternative key resolution, such as the built in AlternateKeysODataUriResolver,
+            // should override the ResolveKeys method.
+            if (keyCount != namedValues.Count)
+            {
+                return false;
             }
 
             resolvedKeys = convertedPairs;

--- a/test/EndToEndTests/Framework/Core/Verification/StringResourceUtil.cs
+++ b/test/EndToEndTests/Framework/Core/Verification/StringResourceUtil.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Test.OData.Framework.Verification
             new Lazy<StringResourceVerifier>(() => new StringResourceVerifier(new AssemblyResourceLookup(Assembly.Load(new AssemblyName("Microsoft.OData.Client").FullName))));
 
         private static readonly Lazy<StringResourceVerifier> odataLibStringResourceVerifier =
-            new Lazy<StringResourceVerifier>(() => new StringResourceVerifier(new AssemblyResourceLookup(Assembly.Load(new AssemblyName("Microsoft.OData.Core").FullName))));
+            new Lazy<StringResourceVerifier>(() => new StringResourceVerifier(new AssemblyResourceLookup(Assembly.Load(new AssemblyName("Microsoft.OData.Core").FullName), "Microsoft.OData.Core")));
 
         /// <summary>
         /// Verifies an error message against a string resource from the Microsoft.OData.Service assembly.

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Test.OData.Tests.Client
                 {
                     Assert.True(testCase.Value);
                     Assert.Equal(400, ex.Response.StatusCode);
-                    StringResourceUtil.VerifyDataServicesString(ClientExceptionUtil.ExtractServerErrorMessage(ex), "BadRequest_KeyCountMismatch", "Microsoft.Test.OData.Services.AstoriaDefaultService.Message");
+                    StringResourceUtil.VerifyDataServicesString(ClientExceptionUtil.ExtractServerErrorMessage(ex), "BadRequest_KeyMismatch", "Microsoft.Test.OData.Services.AstoriaDefaultService.Message");
                     //InnerException for DataServiceClientException must be set with the exception response from the server.
                     ODataErrorException oDataErrorException = ex.InnerException.InnerException as ODataErrorException;
                     Assert.True(oDataErrorException != null, "InnerException for DataServiceClientException has not been set.");

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientQueryTests.cs
@@ -150,31 +150,32 @@ namespace Microsoft.Test.OData.Tests.Client
             }
         }
 
-        [Fact]
-        public void QueryEntityNavigationWithImplicitKeys()
+        [Theory]
+        [InlineData("Login('1')/SentMessages(FromUsername='1',MessageId=-10)", true, -10, "")]
+        [InlineData("Login('1')/SentMessages(MessageId = -10)", false, 0, "BadRequest_KeyMismatch")]
+        [InlineData("Login('1')/SentMessages(-10)", false, 0, "BadRequest_KeyCountMismatch")]
+        public void QueryEntityNavigationWithImplicitKeys(
+            string endpoint, bool expectSuccess, /* only used on success */ int messageId, /* only used on error */string errorStringIdentifier)
         {
-            // this test is to baseline the WCF Data Service behavior that is not modified to support implicit keys 
-            Dictionary<string, bool> testCases = new Dictionary<string, bool>()
-            {
-                {"Login('1')/SentMessages(FromUsername='1',MessageId=-10)", false /*expect error*/},
-                {"Login('1')/SentMessages(MessageId=-10)", true /*expect error*/},
-                {"Login('1')/SentMessages(-10)", true /*expect error*/},
-            };
-
+            // this test is to baseline the WCF Data Service behavior that is not modified to support implicit keys
             var contextWrapper = this.CreateContext();
-            foreach (var testCase in testCases)
+
+            if (expectSuccess)
+            {
+                var message = contextWrapper.Execute<Message>(new Uri(this.ServiceUri.OriginalString.TrimEnd('/') + "/" + endpoint)).Single();
+                Assert.Equal(messageId, message.MessageId);
+            }
+            else
             {
                 try
                 {
-                    var message = contextWrapper.Execute<Message>(new Uri(this.ServiceUri.OriginalString.TrimEnd('/') + "/" + testCase.Key)).Single();
-                    Assert.False(testCase.Value);
-                    Assert.Equal(-10, message.MessageId);
+                    var message = contextWrapper.Execute<Message>(new Uri(this.ServiceUri.OriginalString.TrimEnd('/') + "/" + endpoint)).Single();
+                    Assert.False(true, "This statement should not have executed because the request should have thrown an exception.");
                 }
                 catch (DataServiceQueryException ex)
                 {
-                    Assert.True(testCase.Value);
                     Assert.Equal(400, ex.Response.StatusCode);
-                    StringResourceUtil.VerifyDataServicesString(ClientExceptionUtil.ExtractServerErrorMessage(ex), "BadRequest_KeyMismatch", "Microsoft.Test.OData.Services.AstoriaDefaultService.Message");
+                    StringResourceUtil.VerifyODataLibString(ClientExceptionUtil.ExtractServerErrorMessage(ex), errorStringIdentifier, true, "Microsoft.Test.OData.Services.AstoriaDefaultService.Message");
                     //InnerException for DataServiceClientException must be set with the exception response from the server.
                     ODataErrorException oDataErrorException = ex.InnerException.InnerException as ODataErrorException;
                     Assert.True(oDataErrorException != null, "InnerException for DataServiceClientException has not been set.");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -430,14 +430,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void ParseFilterWithEntityCollectionCountWithEmptyParenthesisThrows()
         {
             Action parse = () => ParseFilter("MyFriendsDogs/$count()", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
-            parse.Throws<ODataException>(ODataErrorStrings.UriParser_EmptyParenthesis());
+            parse.Throws<ODataException>(ODataErrorStrings.UriParser_EmptyParenthesis);
         }
 
         [Fact]
         public void ParseFilterWithEntityCollectionCountWithIllegalQueryOptionThrows()
         {
             Action parse = () => ParseFilter("MyFriendsDogs/$count($orderby=Color) gt 1", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
-            parse.Throws<ODataException>(ODataErrorStrings.UriQueryExpressionParser_IllegalQueryOptioninDollarCount());
+            parse.Throws<ODataException>(ODataErrorStrings.UriQueryExpressionParser_IllegalQueryOptioninDollarCount);
         }
 
         [Fact]
@@ -471,7 +471,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void ParseFilterWithSingleValueCountWithFilterAndSearchOptionsThrows()
         {
             Action parse = () => ParseFilter("ID/$count($filter=Color eq 'Brown';$search=brown) gt 1", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
-            parse.Throws<ODataException>(ODataErrorStrings.MetadataBinder_CountSegmentNextTokenNotCollectionValue());
+            parse.Throws<ODataException>(ODataErrorStrings.MetadataBinder_CountSegmentNextTokenNotCollectionValue);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
@@ -814,7 +814,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void IfKeyIsExplicitlySetToValueOfImplicitKeyThrowError()
         {
-            PathFunctionalTestsUtil.RunParseErrorPath("People(32)/MyLions(ID1=64)", ODataErrorStrings.BadRequest_KeyCountMismatch(HardCodedTestModel.GetLionType().FullName()));
+            PathFunctionalTestsUtil.RunParseErrorPath("People(32)/MyLions(ID1=64)", ODataErrorStrings.BadRequest_KeyMismatch(HardCodedTestModel.GetLionType().FullName()));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
@@ -1507,7 +1507,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void KeyOfIncompatibleTypeDefinitionShouldFail()
         {
             Action action = () => PathFunctionalTestsUtil.RunParsePath("Pet6Set(ID='abc')");
-            action.Throws<ODataException>(ODataErrorStrings.RequestUriProcessor_SyntaxError);
+            action.Throws<ODataException>(ODataErrorStrings.BadRequest_KeyMismatch(HardCodedTestModel.GetPet6Type().FullTypeName()));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -1590,6 +1590,11 @@ namespace Microsoft.OData.Tests.UriParser
             return TestModel.FindType("Fully.Qualified.Namespace.Pet5") as IEdmEntityType;
         }
 
+        public static IEdmEntityType GetPet6Type()
+        {
+            return TestModel.FindType("Fully.Qualified.Namespace.Pet6") as IEdmEntityType;
+        }
+
         public static IEdmEntitySet GetPet1Set()
         {
             return TestModel.FindEntityContainer("Context").FindEntitySet("Pet1Set");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/CaseInsensitiveResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/CaseInsensitiveResolverTests.cs
@@ -240,7 +240,7 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
                "PetSet(key1=1, KEY2='stm')",
                parser => parser.ParsePath(),
                path => path.LastSegment.ShouldBeKeySegment(new KeyValuePair<string, object>("key1", 1), new KeyValuePair<string, object>("key2", "stm")),
-               Strings.RequestUriProcessor_SyntaxError);
+               Strings.BadRequest_KeyMismatch(PetType.FullTypeName()));
         }
 
         [Fact]
@@ -251,7 +251,7 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
                "PetSetCon(KeY=1, kEy='stm')",
                parser => parser.ParsePath(),
                path => path.LastSegment.ShouldBeKeySegment(new KeyValuePair<string, object>("key", 1), new KeyValuePair<string, object>("KEY", "stm")),
-               "More than one keys match the name 'key' were found.");
+               Strings.BadRequest_KeyMismatch(PetCon.FullTypeName()));
         }
 
         [Fact]
@@ -260,7 +260,7 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
             this.TestCaseInsensitiveNotExist(
                "PetSet(key1=1, key3='stm')",
                parser => parser.ParsePath(),
-               Strings.RequestUriProcessor_SyntaxError);
+               Strings.BadRequest_KeyMismatch(PetType.FullTypeName()));
         }
         #endregion
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ExtensionTestBase.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ExtensionTestBase.cs
@@ -27,8 +27,10 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
         protected static IEdmEntityType PersonType;
         protected static IEdmEntityType StarPencil;
         protected static IEdmEntityType PetType;
+        protected static IEdmEntityType PetCon;
         protected static IEdmEntitySet PeopleSet;
         protected static IEdmEntitySet PetSet;
+        protected static IEdmEntitySet PetSetCon;
         protected static IEdmOperation FindPencil2P;
         protected static IEdmOperation FindPencil1P;
         protected static IEdmOperation FindPencilCon;
@@ -180,11 +182,13 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
             var petSet = container.AddEntitySet("PetSet", pet);
 
             var petCon = new EdmEntityType("TestNS", "PetCon");
+            PetCon = petCon;
             model.AddElement(petCon);
             var key1Con = pet.AddStructuralProperty("key", EdmCoreModel.Instance.GetInt32(false));
             var key2Con = pet.AddStructuralProperty("KEY", EdmCoreModel.Instance.GetString(false));
             petCon.AddKeys(key1Con, key2Con);
             var petSetCon = container.AddEntitySet("PetSetCon", petCon);
+            PetSetCon = petSetCon;
 
             EdmEnumType colorType = new EdmEnumType("TestNS", "Color");
             Color = colorType;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/ODataUriResolverTests.cs
@@ -264,7 +264,7 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
                     Assert.Equal("id", keyInfo1.Key);
                     Assert.Equal(1, keyInfo1.Value);
                 },
-                Strings.RequestUriProcessor_SyntaxError);
+                Strings.BadRequest_KeyMismatch(MoonType2.FullTypeName()));
         }
         #endregion
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/UnqualifiedODataUriResolverTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/UnqualifiedODataUriResolverTests.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 using System;
+using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
 using Xunit;
 
@@ -126,7 +127,7 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
                 "PetSet(KeY1=1, KeY2='aStr')",
                 parser => parser.ParsePath(),
                 _ => { /*no-op*/ },
-                Strings.RequestUriProcessor_SyntaxError,
+                Strings.BadRequest_KeyMismatch(PetType.FullTypeName()),
                 Model,
                 parser => parser.Resolver = new UnqualifiedODataUriResolver() {EnableCaseInsensitive = true});
         }
@@ -140,7 +141,7 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
                 Resolver = new UnqualifiedODataUriResolver() {EnableCaseInsensitive = false}
             };
             Action action = () => parser.ParsePath();
-            action.Throws<ODataException>(Strings.BadRequest_KeyCountMismatch("TestNS.Pet"));
+            action.Throws<ODataException>(Strings.BadRequest_KeyMismatch("TestNS.Pet"));
         }
 
         [Fact]
@@ -149,7 +150,7 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
             Uri uriUnmatchedKeysCount = new Uri("PetSet(key1=1, key2='aStr', nonExistingKey='bStr')", UriKind.Relative);
             ODataUriParser parser = new ODataUriParser(Model, uriUnmatchedKeysCount);
             Action action = () => parser.ParsePath();
-            action.Throws<ODataException>(Strings.BadRequest_KeyCountMismatch("TestNS.Pet"));
+            action.Throws<ODataException>(Strings.BadRequest_KeyMismatch("TestNS.Pet"));
         }
 
         private void TestUnqualified<TResult>(

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -427,7 +427,7 @@ namespace Microsoft.OData.Tests.UriParser
                 Resolver = new AlternateKeysODataUriResolver(HardCodedTestModel.TestModel)
             }.ParsePath();
 
-            action.Throws<ODataException>(ODataErrorStrings.BadRequest_KeyCountMismatch(HardCodedTestModel.GetPersonType().FullTypeName()));
+            action.Throws<ODataException>(ODataErrorStrings.BadRequest_KeyOrAlternateKeyMismatch(HardCodedTestModel.GetPersonType().FullTypeName()));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -415,7 +415,7 @@ namespace Microsoft.OData.Tests.UriParser
                 Resolver = new AlternateKeysODataUriResolver(HardCodedTestModel.TestModel)
             }.ParsePath();
 
-            action.Throws<ODataException>("Bad Request - Error in query syntax.");
+            action.Throws<ODataException>(ODataErrorStrings.BadRequest_KeyOrAlternateKeyMismatch(HardCodedTestModel.GetPersonType().FullTypeName()));
         }
 
         [Fact]
@@ -439,7 +439,7 @@ namespace Microsoft.OData.Tests.UriParser
                 Resolver = new ODataUriResolver()
             }.ParsePath();
 
-            action.Throws<ODataException>("Bad Request - Error in query syntax.");
+            action.Throws<ODataException>(ODataErrorStrings.BadRequest_KeyMismatch(HardCodedTestModel.GetPersonType().FullTypeName()));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralParserTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
     /// <summary>
     /// Test the public API of CustomUriLiteralParser class
     /// </summary>
+    [Collection("CustomUriLiteralTests")] // these tests modify the shared CustomUriLiteralPrefixes
     public class CustomUriLiteralParserUnitTests
     {
         #region Consts
@@ -861,6 +862,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 IEdmTypeReference booleanTypeReference = EdmCoreModel.Instance.GetBoolean(false);
                 CustomUriLiteralPrefixes.AddCustomLiteralPrefix(BOOLEAN_LITERAL_PREFIX, booleanTypeReference);
                 CustomUriLiteralParsers.AddCustomUriLiteralParser(customBooleanAndIntUriLiteralParser);
+                
 
                 var fullUri = new Uri("http://www.odata.com/OData/Chimeras" + string.Format("?$filter=Upgraded eq {0}'{1}'", BOOLEAN_LITERAL_PREFIX, CUSTOM_PARSER_BOOLEAN_VALID_VALUE_TRUE));
                 ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://www.odata.com/OData/"), fullUri);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/CustomUriLiteralPrefixesTests.cs
@@ -14,6 +14,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
     /// <summary>
     /// Tests the CustomUriLiteralPreix class public API
     /// </summary>
+    [Collection("CustomUriLiteralTests")] // these tests modify the shared CustomUriLiteralPrefixes
     public class CustomUriLiteralPrefixUnitsTests
     {
         #region AddCustomLiteralPrefix Method
@@ -311,6 +312,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             // Ensure the prefix under test is registered. Handle the exception gracefully if
             // the prefix is already registered.
             IEdmTypeReference booleanTypeReference = EdmCoreModel.Instance.GetBoolean(false);
+            //const string BOOLEAN_LITERAL_PREFIX = "booleanLiteralPrefix";
 
             try
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2221 .*

### Description

*Briefly describe the changes of this pull request.*

The `AlternateKeyODataUriResolver.ResolveKeys` first calls the `base.ResolveKeys()` to attempt to resolve the keys, and if it fails (exception thrown), it tries to resolve alternate keys. Relying on the exception being thrown adds "noise" when debugging due to first chance exceptions causing the debugger to break (as mentioned in the issue). We are also paying the price of try-catch when we don't need to.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
