### PR TITLE
FunctionCallBinder promotes arguments without checking return type

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -315,7 +315,7 @@ namespace Microsoft.OData.UriParser
 
             string canonicalName = nameSignature.Key;
             FunctionSignatureWithReturnType signature = nameSignature.Value;
-            if (signature.ReturnType != null)
+            if (signature != null)
             {
                 TypePromoteArguments(signature, argumentNodes);
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -723,7 +723,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var result = ParseFilter("day(null)", HardCodedTestModel.TestModel, HardCodedTestModel.GetPaintingType());
 
             var typeReference = result.Expression.ShouldBeSingleValueFunctionCallQueryNode("day")
-                .Parameters.Single().ShouldBeConstantQueryNode<object>(null).TypeReference;
+                .Parameters.Single().ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.DateTimeOffset)
+                .Source.ShouldBeConstantQueryNode<object>(null).TypeReference;
             Assert.Null(typeReference);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/OpenPropertiesFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/OpenPropertiesFunctionalTests.cs
@@ -148,7 +148,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             var orderBy = ParseOrderBy("day(Genre)", HardCodedTestModel.TestModel, HardCodedTestModel.GetPaintingType());
 
             var functionNode = orderBy.Expression.ShouldBeSingleValueFunctionCallQueryNode("day");
-            functionNode.Parameters.Single().ShouldBeSingleValueOpenPropertyAccessQueryNode("Genre");
+            functionNode.Parameters.Single().ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.DateTimeOffset)
+                .Source.ShouldBeSingleValueOpenPropertyAccessQueryNode("Genre");
             Assert.Null(functionNode.TypeReference);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
@@ -51,7 +51,8 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             var arguments = new List<QueryToken>() { new LiteralToken("ignored") };
             var token = new FunctionCallToken("year", arguments);
             var result = functionCallBinder.BindFunctionCall(token);
-            Assert.Null(result.ShouldBeSingleValueFunctionCallQueryNode("year").Parameters.Single().ShouldBeConstantQueryNode<object>(null).TypeReference);
+            var argumentNode = result.ShouldBeSingleValueFunctionCallQueryNode("year").Parameters.Single();
+            Assert.Null(argumentNode.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.DateTimeOffset).Source.ShouldBeConstantQueryNode<object>(null).TypeReference);
         }
 
         [Fact]
@@ -61,10 +62,10 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             var arguments = new List<QueryToken>() { new LiteralToken("ignored"), new LiteralToken("ignored") };
             var token = new FunctionCallToken("substring", arguments);
             var result = functionCallBinder.BindFunctionCall(token);
-            var functionCallNode = result.ShouldBeSingleValueFunctionCallQueryNode("substring");
-            Assert.Equal(2, functionCallNode.Parameters.Count());
-            Assert.Null(functionCallNode.Parameters.First().ShouldBeConstantQueryNode<object>(null).TypeReference);
-            Assert.Null(functionCallNode.Parameters.Last().ShouldBeConstantQueryNode<object>(null).TypeReference);
+            var parameters = result.ShouldBeSingleValueFunctionCallQueryNode("substring").Parameters;
+            Assert.Equal(2, parameters.Count());
+            Assert.Null(parameters.First().ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String).Source.ShouldBeConstantQueryNode<object>(null).TypeReference);
+            Assert.Null(parameters.Last().ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.Int32).Source.ShouldBeConstantQueryNode<object>(null).TypeReference);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2241

Related to
OData/WebApi#1180
OData/WebApi#2173
OData/AspNetCoreOData#325

### Description

In the `FunctionCallBinder`, the function signature's return type was checked before processing the arguments nodes. There is no apparent reason for this check which leads to some arguments being mistyped. 
The check has been removed, allowing the arguments to be `promoted` as they should.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

Unfortunately, I'm not able to launch the tests. If anybody could double check this commit and maybe add some tests, it would be very much appreciated! ❤️ 

