### PR TITLE
Implement asynchronous support in ODataJsonLightDeserializer

### DIFF
--- a/src/Microsoft.OData.Core/Json/IODataJsonOperationsDeserializerContext.cs
+++ b/src/Microsoft.OData.Core/Json/IODataJsonOperationsDeserializerContext.cs
@@ -21,6 +21,11 @@ namespace Microsoft.OData.Json
         IJsonReader JsonReader { get; }
 
         /// <summary>
+        /// The asynchronous JSON reader to read the operations value from.
+        /// </summary>
+        IJsonReaderAsync AsynchronousJsonReader { get; }
+
+        /// <summary>
         /// Given a URI from the payload, this method will try to make it absolute, or fail otherwise.
         /// </summary>
         /// <param name="uriFromPayload">The URI string from the payload to process.</param>

--- a/src/Microsoft.OData.Core/Json/ODataJsonReaderCoreUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonReaderCoreUtils.cs
@@ -194,7 +194,11 @@ namespace Microsoft.OData.Json
         /// <returns>true if a null value could be read from the JSON reader; otherwise false.</returns>
         /// <remarks>If the method detects a null value it will read it (position the reader after the null value);
         /// otherwise the reader does not move.</remarks>
+#if NETSTANDARD2_0
+        internal static async ValueTask<bool> TryReadNullValueAsync(
+#else
         internal static async Task<bool> TryReadNullValueAsync(
+#endif
             IJsonReaderAsync jsonReader,
             ODataInputContext inputContext,
             IEdmTypeReference expectedTypeReference,

--- a/src/Microsoft.OData.Core/JsonLight/JsonLightConstants.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightConstants.cs
@@ -116,5 +116,20 @@ namespace Microsoft.OData.JsonLight
 
         /// <summary>The simplified Removed property name.</summary>
         internal const string SimplifiedODataRemovedPropertyName = "@removed";
+
+        /// <summary>The prefixed OData Context property name.</summary>
+        internal const string PrefixedODataContextPropertyName = "@odata.context";
+
+        /// <summary>The prefixed OData Type property name.</summary>
+        internal const string PrefixedODataTypePropertyName = "@odata.type";
+
+        /// <summary>The prefixed OData Id property name.</summary>
+        internal const string PrefixedODataIdPropertyName = "@odata.id";
+
+        /// <summary>The prefixed OData Null property name.</summary>
+        internal const string PrefixedODataNullPropertyName = "@odata.null";
+
+        /// <summary>The prefixed OData Removed property name.</summary>
+        internal const string PrefixedODataRemovedPropertyName = "@odata.removed";
     }
 }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -11,12 +11,10 @@ namespace Microsoft.OData.JsonLight
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
-    using System.IO;
     using System.Linq;
-    using System.Text;
     using System.Threading.Tasks;
-    using Microsoft.OData.Edm;
     using Microsoft.OData;
+    using Microsoft.OData.Edm;
     using Microsoft.OData.Evaluation;
     using Microsoft.OData.Json;
     #endregion Namespaces
@@ -171,7 +169,30 @@ namespace Microsoft.OData.JsonLight
         /// <summary>
         /// Function called to read property custom annotation value.
         /// </summary>
+        /// <Remarks>
+        /// Function takes:
+        /// * The duplicate property names checker
+        /// * The annotation name
+        /// Function returns:
+        /// * The read property annotation value
+        /// </Remarks>
         protected Func<PropertyAndAnnotationCollector, string, object> ReadPropertyCustomAnnotationValue
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
+        /// Delegate called to read property custom annotation value asynchronously.
+        /// </summary>
+        /// <Remarks>
+        /// Function takes:
+        /// * The duplicate property names checker
+        /// * The annotation name
+        /// Function returns:
+        /// * A task that represents the asynchronous read operation. The value of the TResult parameter contains the read property annotation value
+        /// </Remarks>
+        protected Func<PropertyAndAnnotationCollector, string, Task<object>> ReadPropertyCustomAnnotationValueAsync
         {
             get;
             set;
@@ -279,53 +300,52 @@ namespace Microsoft.OData.JsonLight
 
 
         /// <summary>
-        /// Read the start of the top-level data wrapper in JSON responses.
+        /// Asynchronously read the start of the top-level data wrapper in JSON responses.
         /// </summary>
         /// <param name="payloadKind">The kind of payload we are reading; this guides the parsing of the context URI.</param>
         /// <param name="propertyAndAnnotationCollector">The duplicate property names checker.</param>
         /// <param name="isReadingNestedPayload">true if we are deserializing a nested payload, e.g. a resource, a resource set or a collection within a parameters payload.</param>
         /// <param name="allowEmptyPayload">true if we allow a completely empty payload; otherwise false.</param>
-        /// <returns>The parsed context URI.</returns>
+        /// <returns>A task that represents the asynchronous read operation.</returns>
         /// <remarks>
         /// Pre-Condition:  JsonNodeType.None:      assumes that the JSON reader has not been used yet when not reading a nested payload.
         /// Post-Condition: The reader is positioned on the first property of the payload after having read (or skipped) the context URI property.
         ///                 Or the reader is positioned on an end-object node if there are no properties (other than the context URI which is required in responses and optional in requests).
         /// </remarks>
-        internal Task ReadPayloadStartAsync(
+        internal async Task ReadPayloadStartAsync(
             ODataPayloadKind payloadKind,
             PropertyAndAnnotationCollector propertyAndAnnotationCollector,
             bool isReadingNestedPayload,
             bool allowEmptyPayload)
         {
             this.JsonReader.AssertNotBuffering();
-            Debug.Assert(isReadingNestedPayload || this.JsonReader.NodeType == JsonNodeType.None, "Pre-Condition: JSON reader must not have been used yet when not reading a nested payload.");
+            Debug.Assert(
+                isReadingNestedPayload || this.JsonReader.NodeType == JsonNodeType.None,
+                "Pre-Condition: JSON reader must not have been used yet when not reading a nested payload.");
 
-            return TaskUtils.GetTaskForSynchronousOperation(() =>
-                {
-                    string contextUriAnnotationValue = this.ReadPayloadStartImplementation(
+            string contextUriAnnotationValue = await this.ReadPayloadStartImplementationAsync(
                         payloadKind,
                         propertyAndAnnotationCollector,
                         isReadingNestedPayload,
-                        allowEmptyPayload);
+                        allowEmptyPayload).ConfigureAwait(false);
 
-                    // The context URI is only recognized in non-error response top-level payloads.
-                    // If the payload is nested (for example when we read URL literals) we don't recognize the context URI.
-                    // Top-level error payloads don't need and use the context URI.
-                    if (!isReadingNestedPayload && payloadKind != ODataPayloadKind.Error && contextUriAnnotationValue != null)
-                    {
-                        this.contextUriParseResult = ODataJsonLightContextUriParser.Parse(
-                            this.Model,
-                            contextUriAnnotationValue,
-                            payloadKind,
-                            this.MessageReaderSettings.ClientCustomTypeResolver,
-                            this.JsonLightInputContext.ReadingResponse || payloadKind == ODataPayloadKind.Delta,
-                            this.JsonLightInputContext.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata);
-                    }
+            // The context URI is only recognized in non-error response top-level payloads.
+            // If the payload is nested (for example when we read URL literals) we don't recognize the context URI.
+            // Top-level error payloads don't need and use the context URI.
+            if (!isReadingNestedPayload && payloadKind != ODataPayloadKind.Error && contextUriAnnotationValue != null)
+            {
+                this.contextUriParseResult = ODataJsonLightContextUriParser.Parse(
+                    this.Model,
+                    contextUriAnnotationValue,
+                    payloadKind,
+                    this.MessageReaderSettings.ClientCustomTypeResolver,
+                    this.JsonLightInputContext.ReadingResponse || payloadKind == ODataPayloadKind.Delta,
+                    this.JsonLightInputContext.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata);
+            }
 
 #if DEBUG
-                    this.contextUriParseResultReady = true;
+            this.contextUriParseResultReady = true;
 #endif
-                });
         }
 
         /// <summary>
@@ -544,7 +564,7 @@ namespace Microsoft.OData.JsonLight
 
             // Must make sure the input odata.context has a '@' prefix
             string propertyName = this.JsonReader.GetPropertyName();
-            if (string.CompareOrdinal(JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataContext, propertyName) != 0
+            if (!string.Equals(JsonLightConstants.PrefixedODataContextPropertyName, propertyName, StringComparison.Ordinal)
                 && !this.CompareSimplifiedODataAnnotation(JsonLightConstants.SimplifiedODataContextPropertyName, propertyName))
             {
                 if (!failOnMissingContextUriAnnotation || payloadKind == ODataPayloadKind.Unsupported)
@@ -567,6 +587,203 @@ namespace Microsoft.OData.JsonLight
         }
 
         /// <summary>
+        /// Asynchronously reads and validates a string value from the json reader.
+        /// </summary>
+        /// <param name="annotationName">The name of the annotation being read (used for error reporting).</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the string that was read.
+        /// </returns>
+        internal async Task<string> ReadAndValidateAnnotationStringValueAsync(string annotationName)
+        {
+            string valueRead = await this.JsonReader.ReadStringValueAsync(annotationName)
+                .ConfigureAwait(false);
+            ODataJsonLightReaderUtils.ValidateAnnotationValue(valueRead, annotationName);
+            
+            return valueRead;
+        }
+
+        /// <summary>
+        /// Asynchronously reads a string value from the json reader.
+        /// </summary>
+        /// <param name="annotationName">The name of the annotation being read (used for error reporting).</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the string that was read.
+        /// </returns>
+        internal Task<string> ReadAnnotationStringValueAsync(string annotationName)
+        {
+            return this.JsonReader.ReadStringValueAsync(annotationName);
+        }
+
+        /// <summary>
+        /// Asynchronously reads a string value from the json reader and processes it as a Uri.
+        /// </summary>
+        /// <param name="annotationName">The name of the annotation being read (used for error reporting).</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the Uri that was read.
+        /// </returns>
+        internal async Task<Uri> ReadAnnotationStringValueAsUriAsync(string annotationName)
+        {
+            string stringValue = await this.JsonReader.ReadStringValueAsync(annotationName)
+                .ConfigureAwait(false);
+
+            if (stringValue == null)
+            {
+                return null;
+            }
+
+            return this.ReadingResponse ? this.ProcessUriFromPayload(stringValue) : new Uri(stringValue, UriKind.RelativeOrAbsolute);
+        }
+
+        /// <summary>
+        /// Asynchronously reads and validates a string value from the json reader and processes it as a Uri.
+        /// </summary>
+        /// <param name="annotationName">The name of the annotation being read (used for error reporting).</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the Uri that was read.
+        /// </returns>
+        internal async Task<Uri> ReadAndValidateAnnotationStringValueAsUriAsync(string annotationName)
+        {
+            string stringValue = await this.ReadAndValidateAnnotationStringValueAsync(annotationName)
+                .ConfigureAwait(false);
+            return this.ReadingResponse ? this.ProcessUriFromPayload(stringValue) : new Uri(stringValue, UriKind.RelativeOrAbsolute);
+        }
+
+        /// <summary>
+        /// Asynchronously reads and validates a value from the json reader and processes it as a long.
+        /// The input value could be string or number
+        /// </summary>
+        /// <param name="annotationName">The name of the annotation being read.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the <see cref="long"/> value that was read.
+        /// </returns>
+        internal async Task<long> ReadAndValidateAnnotationAsLongForIeee754CompatibleAsync(string annotationName)
+        {
+            object value = await this.JsonReader.ReadPrimitiveValueAsync()
+                .ConfigureAwait(false);
+
+            ODataJsonLightReaderUtils.ValidateAnnotationValue(value, annotationName);
+
+            if ((value is string) ^ this.JsonReader.IsIeee754Compatible)
+            {
+                throw new ODataException(Strings.ODataJsonReaderUtils_ConflictBetweenInputFormatAndParameter(Metadata.EdmConstants.EdmInt64TypeName));
+            }
+
+            return (long)ODataJsonLightReaderUtils.ConvertValue(
+                    value,
+                    EdmCoreModel.Instance.GetInt64(false),
+                    this.MessageReaderSettings,
+                    validateNullValue: true,
+                    propertyName: annotationName,
+                    converter: this.JsonLightInputContext.PayloadValueConverter);
+        }
+
+        /// <summary>
+        /// Asynchronously parses JSON object property starting with the current position of the JSON reader.
+        /// </summary>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker to use, it will also store the property annotations found.</param>
+        /// <param name="readPropertyAnnotationValueDelegate">Delegate to read property annotation value.</param>
+        /// <param name="handlePropertyDelegate">Delegate to handle the result of parsing property.</param>
+        /// <returns>A task that represents the asynchronous read operation.</returns>
+        internal async Task ProcessPropertyAsync(
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            Func<string, Task<object>> readPropertyAnnotationValueDelegate,
+            Func<PropertyParsingResult, string, Task> handlePropertyDelegate)
+        {
+            Debug.Assert(propertyAndAnnotationCollector != null, $"{nameof(propertyAndAnnotationCollector)} != null");
+            Debug.Assert(readPropertyAnnotationValueDelegate != null, $"{nameof(readPropertyAnnotationValueDelegate)} != null");
+            Debug.Assert(handlePropertyDelegate != null, $"{nameof(handlePropertyDelegate)} != null");
+            this.AssertJsonCondition(JsonNodeType.Property);
+
+            Tuple<PropertyParsingResult, string> parsePropertyResult = await this.ParsePropertyAsync(
+                propertyAndAnnotationCollector,
+                readPropertyAnnotationValueDelegate).ConfigureAwait(false);
+            PropertyParsingResult propertyParsingResult = parsePropertyResult.Item1;
+            string propertyName = parsePropertyResult.Item2;
+
+            while (propertyParsingResult == PropertyParsingResult.CustomInstanceAnnotation && this.ShouldSkipCustomInstanceAnnotation(propertyName))
+            {
+                // Read over the property name
+                await this.JsonReader.ReadAsync()
+                    .ConfigureAwait(false);
+
+                // Skip over the instance annotation value
+                await this.JsonReader.SkipValueAsync()
+                    .ConfigureAwait(false);
+                parsePropertyResult = await this.ParsePropertyAsync(
+                    propertyAndAnnotationCollector,
+                    readPropertyAnnotationValueDelegate).ConfigureAwait(false);
+                propertyParsingResult = parsePropertyResult.Item1;
+                propertyName = parsePropertyResult.Item2;
+            }
+
+            await handlePropertyDelegate(propertyParsingResult, propertyName)
+                .ConfigureAwait(false);
+            if (propertyParsingResult != PropertyParsingResult.EndOfObject
+                && propertyParsingResult != PropertyParsingResult.CustomInstanceAnnotation)
+            {
+                propertyAndAnnotationCollector.MarkPropertyAsProcessed(propertyName);
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads the odata.context annotation.
+        /// </summary>
+        /// <param name="payloadKind">The payload kind for which to read the context URI.</param>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker.</param>
+        /// <param name="failOnMissingContextUriAnnotation">true if the method should fail if the context URI annotation is missing, false if that can be ignored.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the value of the context URI annotation.
+        /// </returns>
+        internal async Task<string> ReadContextUriAnnotationAsync(
+            ODataPayloadKind payloadKind,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            bool failOnMissingContextUriAnnotation)
+        {
+            if (this.JsonReader.NodeType != JsonNodeType.Property)
+            {
+                if (!failOnMissingContextUriAnnotation || payloadKind == ODataPayloadKind.Unsupported)
+                {
+                    // Do not fail during payload kind detection
+                    return null;
+                }
+
+                throw new ODataException(Strings.ODataJsonLightDeserializer_ContextLinkNotFoundAsFirstProperty);
+            }
+
+            // Must make sure the input odata.context has a '@' prefix
+            string propertyName = await this.JsonReader.GetPropertyNameAsync()
+                .ConfigureAwait(false);
+            if (!string.Equals(JsonLightConstants.PrefixedODataContextPropertyName, propertyName, StringComparison.Ordinal)
+                && !this.CompareSimplifiedODataAnnotation(JsonLightConstants.SimplifiedODataContextPropertyName, propertyName))
+            {
+                if (!failOnMissingContextUriAnnotation || payloadKind == ODataPayloadKind.Unsupported)
+                {
+                    // Do not fail during payload kind detection
+                    return null;
+                }
+
+                throw new ODataException(Strings.ODataJsonLightDeserializer_ContextLinkNotFoundAsFirstProperty);
+            }
+
+            if (propertyAndAnnotationCollector != null)
+            {
+                propertyAndAnnotationCollector.MarkPropertyAsProcessed(propertyName);
+            }
+
+            // Read over the property name
+            await this.JsonReader.ReadNextAsync()
+                .ConfigureAwait(false);
+            return await this.JsonReader.ReadStringValueAsync()
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Compares the JSON property name with the simplified OData annotation property name.
         /// </summary>
         /// <param name="simplifiedPropertyName">The simplified OData annotation property name.</param>
@@ -578,7 +795,7 @@ namespace Microsoft.OData.JsonLight
             Debug.Assert(simplifiedPropertyName.IndexOf('.') == -1, "simplifiedPropertyName must not be namespace-qualified.");
 
             return this.JsonLightInputContext.OptionalODataPrefix &&
-                   string.CompareOrdinal(simplifiedPropertyName, propertyName) == 0;
+                   string.Equals(simplifiedPropertyName, propertyName, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -624,7 +841,7 @@ namespace Microsoft.OData.JsonLight
         /// <returns>true is the instance annotation, false is not</returns>
         private static bool IsInstanceAnnotation(string annotationName)
         {
-            if (!String.IsNullOrEmpty(annotationName) && annotationName[0] == JsonLightConstants.ODataPropertyAnnotationSeparatorChar)
+            if (!string.IsNullOrEmpty(annotationName) && annotationName[0] == JsonLightConstants.ODataPropertyAnnotationSeparatorChar)
             {
                 return true;
             }
@@ -642,9 +859,9 @@ namespace Microsoft.OData.JsonLight
         /// Note that when we add new odata annotations that cannot be skipped, we would bump the protocol version.
         /// </remarks>
         /// <param name="annotationName">The annotation name in question.</param>
-        /// <param name="annotationValue">Outputs the .</param>
+        /// <param name="annotationValue">The annotation value that was read.</param>
         /// <returns>Returns true if the annotation name and value is skipped; returns false otherwise.</returns>
-        private bool SkippedOverUnknownODataAnnotation(string annotationName, out object annotationValue)
+        private bool SkipOverUnknownODataAnnotation(string annotationName, out object annotationValue)
         {
             Debug.Assert(!string.IsNullOrEmpty(annotationName), "!string.IsNullOrEmpty(annotationName)");
             this.AssertJsonCondition(JsonNodeType.Property);
@@ -720,7 +937,7 @@ namespace Microsoft.OData.JsonLight
                 bool isPropertyAnnotation = TryParsePropertyAnnotation(nameFromReader, out propertyNameFromReader, out annotationNameFromReader);
 
                 // reading a nested delta resource set
-                if (isPropertyAnnotation && String.CompareOrdinal(this.CompleteSimplifiedODataAnnotation(annotationNameFromReader), ODataAnnotationNames.ODataDelta) == 0)
+                if (isPropertyAnnotation && string.Equals(this.CompleteSimplifiedODataAnnotation(annotationNameFromReader), ODataAnnotationNames.ODataDelta, StringComparison.Ordinal))
                 {
                     // Read over the property name.
                     this.JsonReader.Read();
@@ -737,7 +954,7 @@ namespace Microsoft.OData.JsonLight
 
                 // If parsedPropertyName is set and is different from the property name the reader is currently on,
                 // we have parsed a property annotation for a different property than the one at the current position.
-                if (parsedPropertyName != null && string.CompareOrdinal(parsedPropertyName, propertyNameFromReader) != 0)
+                if (parsedPropertyName != null && !string.Equals(parsedPropertyName, propertyNameFromReader, StringComparison.Ordinal))
                 {
                     if (ODataJsonLightReaderUtils.IsAnnotationProperty(parsedPropertyName))
                     {
@@ -752,10 +969,10 @@ namespace Microsoft.OData.JsonLight
                 {
                     annotationNameFromReader = this.CompleteSimplifiedODataAnnotation(annotationNameFromReader);
 
-                    // If this is a unknown odata annotation targeting a property, we skip over it. See remark on the method SkippedOverUnknownODataAnnotation() for detailed explanation.
+                    // If this is a unknown odata annotation targeting a property, we skip over it. See remark on the method SkipOverUnknownODataAnnotation() for detailed explanation.
                     // Note that we don't skip over unknown odata annotations targeting another annotation. We don't allow annotations (except odata.type) targeting other annotations,
                     // so this.ProcessPropertyAnnotation() will test and fail for that case.
-                    if (!ODataJsonLightReaderUtils.IsAnnotationProperty(propertyNameFromReader) && this.SkippedOverUnknownODataAnnotation(annotationNameFromReader, out annotationValue))
+                    if (!ODataJsonLightReaderUtils.IsAnnotationProperty(propertyNameFromReader) && this.SkipOverUnknownODataAnnotation(annotationNameFromReader, out annotationValue))
                     {
                         propertyAndAnnotationCollector.AddODataPropertyAnnotation(propertyNameFromReader, annotationNameFromReader, annotationValue);
                         continue;
@@ -769,8 +986,8 @@ namespace Microsoft.OData.JsonLight
                     continue;
                 }
 
-                // If this is a unknown odata annotation, skip over it. See remark on the method SkippedOverUnknownODataAnnotation() for detailed explanation.
-                if (isInstanceAnnotation && this.SkippedOverUnknownODataAnnotation(propertyNameFromReader, out annotationValue))
+                // If this is a unknown odata annotation, skip over it. See remark on the method SkipOverUnknownODataAnnotation() for detailed explanation.
+                if (isInstanceAnnotation && this.SkipOverUnknownODataAnnotation(propertyNameFromReader, out annotationValue))
                 {
                     // collect 'odata.<unknown>' annotation:
                     // here we know the original property name contains no '@', but '.' dot
@@ -834,7 +1051,7 @@ namespace Microsoft.OData.JsonLight
         private void ProcessPropertyAnnotation(string annotatedPropertyName, string annotationName, PropertyAndAnnotationCollector propertyAndAnnotationCollector, Func<string, object> readPropertyAnnotationValue)
         {
             // We don't currently support annotation targeting an instance annotation except for the @odata.type property annotation.
-            if (ODataJsonLightReaderUtils.IsAnnotationProperty(annotatedPropertyName) && string.CompareOrdinal(annotationName, ODataAnnotationNames.ODataType) != 0)
+            if (ODataJsonLightReaderUtils.IsAnnotationProperty(annotatedPropertyName) && !string.Equals(annotationName, ODataAnnotationNames.ODataType, StringComparison.Ordinal))
             {
                 throw new ODataException(Strings.ODataJsonLightDeserializer_OnlyODataTypeAnnotationCanTargetInstanceAnnotation(annotationName, annotatedPropertyName, ODataAnnotationNames.ODataType));
             }
@@ -918,6 +1135,408 @@ namespace Microsoft.OData.JsonLight
                     // In responses we expect the context URI to be the first thing in the payload
                     // (except for error payloads). In requests we ignore the context URI.
                     return this.ReadContextUriAnnotation(payloadKind, propertyAndAnnotationCollector, failOnMissingContextUriAnnotation);
+                }
+
+                this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// If <paramref name="annotationName"/> is under the odata namespace but is not known to ODataLib, move the JSON reader forward to skip the
+        /// annotation name and value then return true; return false otherwise.
+        /// </summary>
+        /// <remarks>
+        /// The unknown odata annotation is skipped so that when this version of the reader reads a resource set produced by a future version of ODataLib
+        /// that contains an odata annotation that is not recognized on this version, we would simply ignore the annotation rather than failing.
+        /// Note that when we add new odata annotations that cannot be skipped, we would bump the protocol version.
+        /// </remarks>
+        /// <param name="annotationName">The annotation name in question.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains a tuple comprising of:
+        /// 1) true if the annotation name and value is skipped; otherwise false.
+        /// 2) The annotation value that was read.
+        /// </returns>
+#if NETSTANDARD2_0
+        private async ValueTask<Tuple<bool, object>> SkipOverUnknownODataAnnotationAsync(
+#else
+        private async Task<Tuple<bool, object>> SkipOverUnknownODataAnnotationAsync(
+#endif
+            string annotationName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(annotationName), "!string.IsNullOrEmpty(annotationName)");
+            this.AssertJsonCondition(JsonNodeType.Property);
+
+            object annotationValue = null;
+            bool isUnknownODataAnnotationName = false;
+
+            if (ODataAnnotationNames.IsUnknownODataAnnotationName(annotationName))
+            {
+                annotationValue = await ReadODataOrCustomInstanceAnnotationValueAsync(annotationName)
+                    .ConfigureAwait(false);
+                isUnknownODataAnnotationName = true;
+            }
+
+            return Tuple.Create(isUnknownODataAnnotationName, annotationValue);
+        }
+
+        /// <summary>
+        /// Asynchronously reads "odata." or custom instance annotation's value.
+        /// </summary>
+        /// <param name="annotationName">The annotation name.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the annotation value.
+        /// </returns>
+        private async Task<object> ReadODataOrCustomInstanceAnnotationValueAsync(string annotationName)
+        {
+            // Read over the name.
+            await this.JsonReader.ReadAsync()
+                .ConfigureAwait(false);
+            object annotationValue;
+            if (this.JsonReader.NodeType != JsonNodeType.PrimitiveValue)
+            {
+                annotationValue = await this.JsonReader.ReadAsUntypedOrNullValueAsync()
+                    .ConfigureAwait(false);
+            }
+            else
+            {
+                annotationValue = await this.JsonReader.GetValueAsync()
+                    .ConfigureAwait(false);
+                await this.JsonReader.SkipValueAsync()
+                    .ConfigureAwait(false);
+            }
+
+            return annotationValue;
+        }
+
+        /// <summary>
+        /// Asynchronously parses JSON object property starting with the current position of the JSON reader.
+        /// </summary>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker to use, it will also store the property annotations found.</param>
+        /// <param name="readPropertyAnnotationValueDelegate">Delegate called to read property annotation value.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains a tuple containing:
+        /// 1). The first component contains PropertyWithValue if a property with value was found, while the second component contains the name of the property.
+        ///                             The reader is positioned on the property value.
+        /// 2). The first component contains PropertyWithoutValue if a property without a value was found, while the second component contains the name of the property.
+        ///                             The reader is positioned on the node after property annotations (so either a property or end of object).
+        /// 3). The first component contains ODataInstanceAnnotation if an odata instance annotation was found, while the second component contains the name of the annotation.
+        ///                             The reader is positioned on the value of the annotation.
+        /// 4). The first component contains CustomInstanceAnnotation if a custom instance annotation was found, while the second component contains name of the annotation.
+        ///                             The reader is positioned on the value of the annotation.
+        /// 5). The first component contains MetadataReferenceProperty if a property which is a reference into the metadata was found, while the second component contains the name of the property.
+        ///                             The reader is positioned on the value of the property.
+        /// 6). The first component contains NestedDeltaResourceSet if a property representing a nested delta resource set was found, while the second component contains the name of the property.
+        ///                             The reader is positioned on the array value of the property.
+        /// 7). The first component contains EndOfObject if end of the object scope was reached and no properties are to be reported, while the second component contains null.
+        ///                             This can only happen if there's a property annotation which is ignored (for example custom one) at the end of the object.
+        /// </returns>
+        private async Task<Tuple<PropertyParsingResult, string>> ParsePropertyAsync(
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            Func<string, Task<object>> readPropertyAnnotationValueDelegate)
+        {
+            Debug.Assert(propertyAndAnnotationCollector != null, $"{nameof(propertyAndAnnotationCollector)} != null");
+            Debug.Assert(readPropertyAnnotationValueDelegate != null, $"{nameof(readPropertyAnnotationValueDelegate)} != null");
+            string lastPropertyAnnotationNameFound = null;
+            string parsedPropertyName = null;
+
+            while (this.JsonReader.NodeType == JsonNodeType.Property)
+            {
+                string nameFromReader = await this.JsonReader.GetPropertyNameAsync()
+                    .ConfigureAwait(false);
+
+                string propertyNameFromReader, annotationNameFromReader;
+                bool isPropertyAnnotation = TryParsePropertyAnnotation(nameFromReader, out propertyNameFromReader, out annotationNameFromReader);
+
+                // Reading a nested delta resource set
+                if (isPropertyAnnotation && string.Equals(this.CompleteSimplifiedODataAnnotation(annotationNameFromReader), ODataAnnotationNames.ODataDelta, StringComparison.Ordinal))
+                {
+                    // Read over the property name.
+                    await this.JsonReader.ReadAsync()
+                        .ConfigureAwait(false);
+                    parsedPropertyName = propertyNameFromReader;
+                    return Tuple.Create(PropertyParsingResult.NestedDeltaResourceSet, parsedPropertyName);
+                }
+
+                bool isInstanceAnnotation = false;
+                // If this is not a property annotation, determine whether it's an instance annotation, i.e. starts with @ prefix
+                // If we find that it's an instance annotation and OptionalODataPrefix setting is set to true, complete the simplified
+                // annotation (if necessary) by prepending it with "odata."
+                if (!isPropertyAnnotation)
+                {
+                    isInstanceAnnotation = IsInstanceAnnotation(nameFromReader);
+                    propertyNameFromReader = isInstanceAnnotation ? this.CompleteSimplifiedODataAnnotation(nameFromReader.Substring(1)) : nameFromReader;
+                }
+
+                // If parsedPropertyName is set and is different from the property name the reader is currently on,
+                // we have parsed a property annotation for a different property than the one at the current position.
+                if (parsedPropertyName != null && !string.Equals(parsedPropertyName, propertyNameFromReader, StringComparison.Ordinal))
+                {
+                    if (ODataJsonLightReaderUtils.IsAnnotationProperty(parsedPropertyName))
+                    {
+                        throw new ODataException(Strings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue(
+                            lastPropertyAnnotationNameFound,
+                            parsedPropertyName));
+                    }
+
+                    return Tuple.Create(PropertyParsingResult.PropertyWithoutValue, parsedPropertyName);
+                }
+
+                object annotationValue = null;
+                if (isPropertyAnnotation)
+                {
+                    annotationNameFromReader = this.CompleteSimplifiedODataAnnotation(annotationNameFromReader);
+
+                    // If this is a unknown odata annotation targeting a property, we skip over it.
+                    // See remark on the method SkipOverUnknownODataAnnotationAsync() for detailed explanation.
+                    // Note that we don't skip over unknown odata annotations targeting another annotation.
+                    // We don't allow annotations (except odata.type) targeting other annotations,
+                    // so ProcessPropertyAnnotationAsync() will test and fail for that case.
+                    if (!ODataJsonLightReaderUtils.IsAnnotationProperty(propertyNameFromReader))
+                    {
+                        Tuple<bool, object> skipOverUnknownODataAnnotationResult = await this.SkipOverUnknownODataAnnotationAsync(annotationNameFromReader)
+                            .ConfigureAwait(false);
+                        if (skipOverUnknownODataAnnotationResult.Item1)
+                        {
+                            annotationValue = skipOverUnknownODataAnnotationResult.Item2;
+                            propertyAndAnnotationCollector.AddODataPropertyAnnotation(propertyNameFromReader, annotationNameFromReader, annotationValue);
+                            continue;
+                        }
+                    }
+
+                    // We have another property annotation for the same property we parsed.
+                    parsedPropertyName = propertyNameFromReader;
+                    lastPropertyAnnotationNameFound = annotationNameFromReader;
+
+                    await this.ProcessPropertyAnnotationAsync(
+                        propertyNameFromReader,
+                        annotationNameFromReader,
+                        propertyAndAnnotationCollector,
+                        readPropertyAnnotationValueDelegate).ConfigureAwait(false);
+                    continue;
+                }
+
+                // If this is a unknown odata annotation, skip over it. See remark on the method SkipOverUnknownODataAnnotationAsync() for detailed explanation.
+                if (isInstanceAnnotation)
+                {
+                    Tuple<bool, object> skipOverUnknownODataAnnotationResult = await this.SkipOverUnknownODataAnnotationAsync(propertyNameFromReader)
+                        .ConfigureAwait(false);
+                    if (skipOverUnknownODataAnnotationResult.Item1)
+                    {
+                        annotationValue = skipOverUnknownODataAnnotationResult.Item2;
+                        // collect 'odata.<unknown>' annotation:
+                        // here we know the original property name contains no '@', but '.' dot
+                        Debug.Assert(annotationNameFromReader == null, $"{nameof(annotationNameFromReader)} == null");
+                        propertyAndAnnotationCollector.AddODataScopeAnnotation(propertyNameFromReader, annotationValue);
+                        continue;
+                    }
+                }
+
+                // We are encountering the property name for the first time.
+                // Don't read over property name, as that would cause the buffering reader to read ahead in the StartObject
+                // state, which would break our ability to stream inline json. Instead, callers of ParsePropertyAsync will have to
+                // call this.JsonReader.ReadAsync() as appropriate to read past the property name.
+                parsedPropertyName = propertyNameFromReader;
+
+                if (!isInstanceAnnotation && ODataJsonLightUtils.IsMetadataReferenceProperty(propertyNameFromReader))
+                {
+                    return Tuple.Create(PropertyParsingResult.MetadataReferenceProperty, parsedPropertyName);
+                }
+
+                if (!isInstanceAnnotation && !ODataJsonLightReaderUtils.IsAnnotationProperty(propertyNameFromReader))
+                {
+                    // Normal property
+                    return Tuple.Create(PropertyParsingResult.PropertyWithValue, parsedPropertyName);
+                }
+
+                // collect 'xxx.yyyy' annotation:
+                // here we know the original property name contains no '@', but '.' dot
+                Debug.Assert(annotationNameFromReader == null, $"{nameof(annotationNameFromReader)} == null");
+
+                // Handle 'odata.XXXXX' annotations
+                if (isInstanceAnnotation && ODataJsonLightReaderUtils.IsODataAnnotationName(propertyNameFromReader))
+                {
+                    return Tuple.Create(PropertyParsingResult.ODataInstanceAnnotation, parsedPropertyName);
+                }
+
+                // Handle custom annotations
+                return Tuple.Create(PropertyParsingResult.CustomInstanceAnnotation, parsedPropertyName);
+            }
+
+            this.AssertJsonCondition(JsonNodeType.EndObject);
+            if (parsedPropertyName != null)
+            {
+                if (ODataJsonLightReaderUtils.IsAnnotationProperty(parsedPropertyName))
+                {
+                    throw new ODataException(
+                        Strings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue(
+                            lastPropertyAnnotationNameFound,
+                            parsedPropertyName));
+                }
+
+                return Tuple.Create(PropertyParsingResult.PropertyWithoutValue, parsedPropertyName);
+            }
+
+            return Tuple.Create(PropertyParsingResult.EndOfObject, parsedPropertyName);
+        }
+
+        /// <summary>
+        /// Asynchronously process the current property annotation.
+        /// </summary>
+        /// <param name="annotatedPropertyName">The name being annotated. Can be a property or an instance annotation.</param>
+        /// <param name="annotationName">The annotation targeting the <paramref name="annotatedPropertyName"/>.</param>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker.</param>
+        /// <param name="readPropertyAnnotationValueDelegate">Delegate to read the property annotation value.</param>
+        /// <returns>A task that represents the asynchronous read operation.</returns>
+        private Task ProcessPropertyAnnotationAsync(
+            string annotatedPropertyName,
+            string annotationName,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            Func<string, Task<object>> readPropertyAnnotationValueDelegate)
+        {
+            // We don't currently support annotation targeting an instance annotation except for the @odata.type property annotation.
+            if (ODataJsonLightReaderUtils.IsAnnotationProperty(annotatedPropertyName)
+                && !string.Equals(annotationName, ODataAnnotationNames.ODataType, StringComparison.Ordinal))
+            {
+                return TaskUtils.GetFaultedTask<ODataException>(
+                    new ODataException(Strings.ODataJsonLightDeserializer_OnlyODataTypeAnnotationCanTargetInstanceAnnotation(
+                        annotationName,
+                        annotatedPropertyName,
+                        ODataAnnotationNames.ODataType)));
+            }
+
+            return ReadODataOrCustomInstanceAnnotationValueAsync(
+                annotatedPropertyName,
+                annotationName,
+                propertyAndAnnotationCollector,
+                readPropertyAnnotationValueDelegate);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the end of the top-level data wrapper in JSON responses.
+        /// </summary>
+        /// <param name="isReadingNestedPayload">true if we are deserializing a nested payload, e.g. a resource, a resource set or a collection within a parameters payload.</param>
+        /// <returns>A task that represents the asynchronous read operation.</returns>
+        /// <remarks>
+        /// Pre-Condition:  any node:                when reading response or a nested payload, will fail if find anything else then EndObject.
+        ///                 JsonNodeType.EndOfInput: otherwise
+        /// Post-Condition: JsonNodeType.EndOfInput
+        /// </remarks>
+        [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", MessageId = "isReadingNestedPayload", Justification = "The parameter is used in debug builds.")]
+        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Needs to access this in debug only.")]
+        internal Task ReadPayloadEndAsync(bool isReadingNestedPayload)
+        {
+            Debug.Assert(
+                isReadingNestedPayload || this.JsonReader.NodeType == JsonNodeType.EndOfInput,
+                "Pre-Condition: JsonNodeType.EndOfInput if not reading a nested payload.");
+            this.JsonReader.AssertNotBuffering();
+
+            return TaskUtils.CompletedTask;
+        }
+
+        /// <summary>
+        /// Asynchronously reads built-in "odata." or custom instance annotation's value.
+        /// </summary>
+        /// <param name="annotatedPropertyName">The property name.</param>
+        /// <param name="annotationName">The annotation name</param>
+        /// <param name="propertyAndAnnotationCollector">The PropertyAndAnnotationCollector.</param>
+        /// <param name="readPropertyAnnotationValueDelegate">Delegate to read the property annotation value.</param>
+        /// <returns>A task that represents the asynchronous read operation.</returns>
+        private async Task ReadODataOrCustomInstanceAnnotationValueAsync(
+            string annotatedPropertyName,
+            string annotationName,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            Func<string, Task<object>> readPropertyAnnotationValueDelegate)
+        {
+            // Read over the property name.
+            await this.JsonReader.ReadAsync()
+                .ConfigureAwait(false);
+            if (ODataJsonLightReaderUtils.IsODataAnnotationName(annotationName))
+            {
+                // OData annotations are read
+                object propertyAnnotationValue = await readPropertyAnnotationValueDelegate(annotationName)
+                    .ConfigureAwait(false);
+                propertyAndAnnotationCollector.AddODataPropertyAnnotation(annotatedPropertyName, annotationName, propertyAnnotationValue);
+            }
+            else
+            {
+                if (this.ShouldSkipCustomInstanceAnnotation(annotationName)
+                    || (this is ODataJsonLightErrorDeserializer && this.MessageReaderSettings.ShouldIncludeAnnotation == null))
+                {
+                    propertyAndAnnotationCollector.CheckIfPropertyOpenForAnnotations(annotatedPropertyName, annotationName);
+                    await this.JsonReader.SkipValueAsync()
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    Debug.Assert(this.ReadPropertyCustomAnnotationValueAsync != null, $"{nameof(ReadPropertyCustomAnnotationValueAsync)} != null");
+                    object propertyCustomAnnotationValue = await this.ReadPropertyCustomAnnotationValueAsync(propertyAndAnnotationCollector, annotationName)
+                        .ConfigureAwait(false);
+                    propertyAndAnnotationCollector.AddCustomPropertyAnnotation(annotatedPropertyName, annotationName, propertyCustomAnnotationValue);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously read the start of the top-level data wrapper in JSON responses.
+        /// </summary>
+        /// <param name="payloadKind">The kind of payload we are reading; this guides the parsing of the context URI.</param>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker.</param>
+        /// <param name="isReadingNestedPayload">true if we are deserializing a nested payload,
+        /// e.g. a resource, a resource set or a collection within a parameters payload.</param>
+        /// <param name="allowEmptyPayload">true if we allow a completely empty payload; otherwise false.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the value of the context URI annotation (or null if it was not found).
+        /// </returns>
+        /// <remarks>
+        /// Pre-Condition:  JsonNodeType.None:      Assumes that the JSON reader has not been used yet when not reading a nested payload.
+        /// Post-Condition: The reader is positioned on the first property of the payload after having read (or skipped) the context URI property.
+        ///                 Or the reader is positioned on an end-object node if there are no properties (other than the context URI which is required in responses and optional in requests).
+        /// </remarks>
+        private async Task<string> ReadPayloadStartImplementationAsync(
+            ODataPayloadKind payloadKind,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            bool isReadingNestedPayload,
+            bool allowEmptyPayload)
+        {
+            this.JsonReader.AssertNotBuffering();
+            Debug.Assert(
+                isReadingNestedPayload || this.JsonReader.NodeType == JsonNodeType.None,
+                "Pre-Condition: JSON reader must not have been used yet when not reading a nested payload.");
+
+            if (!isReadingNestedPayload)
+            {
+                // Position the reader on the first node inside the outermost object.
+                await this.JsonReader.ReadAsync()
+                    .ConfigureAwait(false);
+
+                if (allowEmptyPayload && this.JsonReader.NodeType == JsonNodeType.EndOfInput)
+                {
+                    return null;
+                }
+
+                // Read the StartObject node and position the reader on the first property
+                // (or the end object node).
+                await this.JsonReader.ReadStartObjectAsync()
+                    .ConfigureAwait(false);
+
+                if (payloadKind != ODataPayloadKind.Error)
+                {
+                    // Skip over the context URI annotation in request payloads or when we've already read it
+                    // during payload kind detection.
+                    bool failOnMissingContextUriAnnotation = this.jsonLightInputContext.ReadingResponse;
+
+                    // In responses we expect the context URI to be the first thing in the payload
+                    // (except for error payloads). In requests we ignore the context URI.
+                    return await this.ReadContextUriAnnotationAsync(
+                        payloadKind,
+                        propertyAndAnnotationCollector,
+                        failOnMissingContextUriAnnotation).ConfigureAwait(false);
                 }
 
                 this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -12,8 +12,6 @@ namespace Microsoft.OData.JsonLight
     using System.Collections.ObjectModel;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
-    using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Json;
@@ -79,7 +77,7 @@ namespace Microsoft.OData.JsonLight
         /// </summary>
         /// <param name="expectedPropertyTypeReference">The expected type reference of the property to read.</param>
         /// <returns>A task which returns an <see cref="ODataProperty"/> representing the read property.</returns>
-        internal Task<ODataProperty> ReadTopLevelPropertyAsync(IEdmTypeReference expectedPropertyTypeReference)
+        internal async Task<ODataProperty> ReadTopLevelPropertyAsync(IEdmTypeReference expectedPropertyTypeReference)
         {
             Debug.Assert(this.JsonReader.NodeType == JsonNodeType.None, "Pre-Condition: expected JsonNodeType.None, the reader must not have been used yet.");
             this.JsonReader.AssertNotBuffering();
@@ -87,23 +85,19 @@ namespace Microsoft.OData.JsonLight
             // We use this to store annotations and check for duplicate annotation names, but we don't really store properties in it.
             PropertyAndAnnotationCollector propertyAndAnnotationCollector = this.CreatePropertyAndAnnotationCollector();
 
-            return this.ReadPayloadStartAsync(
-                ODataPayloadKind.Property,
-                propertyAndAnnotationCollector,
-                /*isReadingNestedPayload*/false,
-                /*allowEmptyPayload*/false)
+            await this.ReadPayloadStartAsync(ODataPayloadKind.Property, propertyAndAnnotationCollector, isReadingNestedPayload: false, allowEmptyPayload: false)
+                .ConfigureAwait(false);
 
-                .FollowOnSuccessWith(t =>
-                {
-                    ODataProperty resultProperty = this.ReadTopLevelPropertyImplementation(expectedPropertyTypeReference, propertyAndAnnotationCollector);
+            ODataProperty resultProperty = await this.ReadTopLevelPropertyImplementationAsync(expectedPropertyTypeReference, propertyAndAnnotationCollector)
+                .ConfigureAwait(false);
 
-                    this.ReadPayloadEnd(/*isReadingNestedPayload*/ false);
+            await this.ReadPayloadEndAsync(isReadingNestedPayload: false)
+                .ConfigureAwait(false);
 
-                    Debug.Assert(this.JsonReader.NodeType == JsonNodeType.EndOfInput, "Post-Condition: expected JsonNodeType.EndOfInput");
-                    this.JsonReader.AssertNotBuffering();
+            Debug.Assert(this.JsonReader.NodeType == JsonNodeType.EndOfInput, "Post-Condition: expected JsonNodeType.EndOfInput");
+            this.JsonReader.AssertNotBuffering();
 
-                    return resultProperty;
-                });
+            return resultProperty;
         }
 
         /// <summary>
@@ -328,6 +322,109 @@ namespace Microsoft.OData.JsonLight
         }
 
         /// <summary>
+        /// Asynchronously reads a primitive value, enum, resource (complex or entity) value or collection.
+        /// </summary>
+        /// <param name="payloadTypeName">The type name read from the payload as a property annotation, or null if none is available.</param>
+        /// <param name="expectedValueTypeReference">The expected type reference of the property value.</param>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker to use - if null the method should create a new one if necessary.</param>
+        /// <param name="collectionValidator">The collection validator instance if no expected item type has been specified; otherwise null.</param>
+        /// <param name="validateNullValue">true to validate null values; otherwise false.</param>
+        /// <param name="isTopLevelPropertyValue">true if we are reading a top-level property value; otherwise false.</param>
+        /// <param name="insideResourceValue">true if we are reading a resource value and the reader is already positioned inside the resource value; otherwise false.</param>
+        /// <param name="propertyName">The name of the property whose value is being read, if applicable (used for error reporting).</param>
+        /// <param name="isDynamicProperty">Indicates whether the property is dynamic or unknown.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the value of the property read, which can be one of:
+        /// 1). null
+        /// 2). Primitive value
+        /// 3). <see cref="ODataEnumValue"/>
+        /// 4). <see cref="ODataResourceValue"/>
+        /// 5). <see cref="ODataCollectionValue"/>
+        /// </returns>
+        /// <remarks>
+        /// Pre-Condition:  JsonNodeType.PrimitiveValue   - the value of the property is a primitive value,
+        ///                 JsonNodeType.StartObject      - the value of the property is an object,
+        ///                 JsonNodeType.StartArray       - the value of the property is an array - method will fail in this case.
+        /// Post-Condition: almost anything - the node after the property value.
+        /// </remarks>
+        internal async Task<object> ReadNonEntityValueAsync(
+            string payloadTypeName,
+            IEdmTypeReference expectedValueTypeReference,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            CollectionWithoutExpectedTypeValidator collectionValidator,
+            bool validateNullValue,
+            bool isTopLevelPropertyValue,
+            bool insideResourceValue,
+            string propertyName,
+            bool? isDynamicProperty = null)
+        {
+            this.AssertRecursionDepthIsZero();
+            object nonEntityValue = await this.ReadNonEntityValueImplementationAsync(
+                payloadTypeName,
+                expectedValueTypeReference,
+                propertyAndAnnotationCollector,
+                collectionValidator,
+                validateNullValue,
+                isTopLevelPropertyValue,
+                insideResourceValue,
+                propertyName,
+                isDynamicProperty).ConfigureAwait(false);
+            this.AssertRecursionDepthIsZero();
+
+            return nonEntityValue;
+        }
+
+        /// <summary>
+        /// Asynchronously reads the value of the instance annotation.
+        /// </summary>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker instance.</param>
+        /// <param name="name">The name of the instance annotation.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the value of the instance annotation.
+        /// </returns>
+        internal Task<object> ReadCustomInstanceAnnotationValueAsync(PropertyAndAnnotationCollector propertyAndAnnotationCollector, string name)
+        {
+            Debug.Assert(propertyAndAnnotationCollector != null, "propertyAndAnnotationCollector != null");
+            Debug.Assert(!string.IsNullOrEmpty(name), "!string.IsNullOrEmpty(name)");
+
+            object propertyAnnotation;
+            string odataType = null;
+            if (propertyAndAnnotationCollector.GetODataPropertyAnnotations(name)
+                .TryGetValue(ODataAnnotationNames.ODataType, out propertyAnnotation))
+            {
+                odataType = ReaderUtils.AddEdmPrefixOfTypeName(ReaderUtils.RemovePrefixOfTypeName((string)propertyAnnotation));
+            }
+
+            return ReadODataOrCustomInstanceAnnotationValueAsync(name, odataType);
+        }
+
+        /// <summary>
+        /// Asynchronously reads built-in "odata." or custom instance annotation's value.
+        /// </summary>
+        /// <param name="annotationName">The annotation name.</param>
+        /// <param name="odataType">the odata.type value if exists.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the annotation value.
+        /// </returns>
+        internal Task<object> ReadODataOrCustomInstanceAnnotationValueAsync(string annotationName, string odataType)
+        {
+            // If this term is defined in the model, look up its type. If the term is not in the model, this will be null.
+            IEdmTypeReference expectedTypeFromTerm = MetadataUtils.LookupTypeOfTerm(annotationName, this.Model);
+            return this.ReadNonEntityValueImplementationAsync(
+                odataType,
+                expectedTypeFromTerm,
+                propertyAndAnnotationCollector: null,
+                collectionValidator: null,
+                validateNullValue: false,
+                isTopLevelPropertyValue: false,
+                insideResourceValue: false, // Always pass false here to try read @odata.type annotation in custom instance annotations
+                propertyName: annotationName);
+        }
+
+        /// <summary>
         /// Try to read or peek the odata.type annotation.
         /// </summary>
         /// <param name="propertyAndAnnotationCollector">The current level's PropertyAndAnnotationCollector.</param>
@@ -468,10 +565,15 @@ namespace Microsoft.OData.JsonLight
         /// Validates that the value of a JSON property can represent expanded nested resource info.
         /// </summary>
         /// <param name="jsonReader">The IJsonReader.</param>
-        /// <param name="isCollection">true if the property is entity set reference property; false for a resource reference property, null if unknown.</param>
+        /// <param name="isCollection">true if the property is entity set reference property;
+        /// false for a resource reference property, null if unknown.</param>
         /// <param name="propertyName">Name for the navigation property, used in error message only.</param>
         /// <param name="typeReference">Type of navigation property</param>
-        protected static void ValidateExpandedNestedResourceInfoPropertyValue(IJsonReader jsonReader, bool? isCollection, string propertyName, IEdmTypeReference typeReference)
+        protected static void ValidateExpandedNestedResourceInfoPropertyValue(
+            IJsonReader jsonReader,
+            bool? isCollection,
+            string propertyName,
+            IEdmTypeReference typeReference)
         {
             // an expanded link with resource requires a StartObject node here;
             // an expanded link with resource set requires a StartArray node here;
@@ -498,7 +600,7 @@ namespace Microsoft.OData.JsonLight
                     {
                         throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_CannotReadCollectionNestedResource(nodeType, propertyName));
                     }
-                    
+
                 }
             }
             else
@@ -591,7 +693,7 @@ namespace Microsoft.OData.JsonLight
                 IsCollection = false
             };
 
-            foreach (var propertyAnnotation
+            foreach (KeyValuePair<string, object> propertyAnnotation
                      in resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(nestedResourceInfo.Name))
             {
                 switch (propertyAnnotation.Key)
@@ -662,7 +764,7 @@ namespace Microsoft.OData.JsonLight
                 expandedResourceSet = new ODataResourceSet();
             }
 
-            foreach (var propertyAnnotation
+            foreach (KeyValuePair<string, object> propertyAnnotation
                      in resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(nestedResourceInfo.Name))
             {
                 switch (propertyAnnotation.Key)
@@ -763,7 +865,7 @@ namespace Microsoft.OData.JsonLight
             };
 
             ODataEntityReferenceLink entityReferenceLink = null;
-            foreach (var propertyAnnotation
+            foreach (KeyValuePair<string, object> propertyAnnotation
                      in resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(nestedResourceInfo.Name))
             {
                 switch (propertyAnnotation.Key)
@@ -824,7 +926,7 @@ namespace Microsoft.OData.JsonLight
             };
 
             LinkedList<ODataEntityReferenceLink> entityReferenceLinksList = null;
-            foreach (var propertyAnnotation
+            foreach (KeyValuePair<string, object> propertyAnnotation
                      in resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(nestedResourceInfo.Name))
             {
                 switch (propertyAnnotation.Key)
@@ -865,10 +967,10 @@ namespace Microsoft.OData.JsonLight
             Debug.Assert(!string.IsNullOrEmpty(propertyName), "!string.IsNullOrEmpty(propertyName)");
 
             string propertyTypeName = null;
-            foreach (var propertyAnnotation
+            foreach (KeyValuePair<string, object> propertyAnnotation
                      in propertyAndAnnotationCollector.GetODataPropertyAnnotations(propertyName))
             {
-                if (string.CompareOrdinal(propertyAnnotation.Key, ODataAnnotationNames.ODataType) != 0)
+                if (!string.Equals(propertyAnnotation.Key, ODataAnnotationNames.ODataType, StringComparison.Ordinal))
                 {
                     // here allow other annotation name than odata.type, instead of throwing:
                     // ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedDataPropertyAnnotation
@@ -881,7 +983,7 @@ namespace Microsoft.OData.JsonLight
 
             if (propertyTypeName != null)
             {
-                var validator = propertyAndAnnotationCollector.GetDerivedTypeValidator(propertyName);
+                DerivedTypeValidator validator = propertyAndAnnotationCollector.GetDerivedTypeValidator(propertyName);
                 if (validator != null)
                 {
                     validator.ValidateResourceType(propertyTypeName);
@@ -905,7 +1007,7 @@ namespace Microsoft.OData.JsonLight
 
             ODataProperty property = new ODataProperty { Name = propertyName, Value = propertyValue };
             AttachODataAnnotations(resourceState, propertyName, property);
-            foreach (var annotation
+            foreach (KeyValuePair<string, object> annotation
                      in resourceState.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations(propertyName))
             {
                 if (annotation.Value != null)
@@ -926,7 +1028,7 @@ namespace Microsoft.OData.JsonLight
 
         protected static void AttachODataAnnotations(IODataJsonLightReaderResourceState resourceState, string propertyName, ODataProperty property)
         {
-            foreach (var annotation
+            foreach (KeyValuePair<string, object> annotation
                      in propertyName.Length == 0
                         ? resourceState.PropertyAndAnnotationCollector.GetODataScopeAnnotation()
                         : resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(propertyName))
@@ -972,7 +1074,7 @@ namespace Microsoft.OData.JsonLight
         {
             Debug.Assert(!string.IsNullOrEmpty(annotationName), "!string.IsNullOrEmpty(annotationName)");
 
-            if (string.CompareOrdinal(annotationName, ODataAnnotationNames.ODataType) == 0)
+            if (string.Equals(annotationName, ODataAnnotationNames.ODataType, StringComparison.Ordinal))
             {
                 value = this.ReadODataTypeAnnotationValue();
                 return true;
@@ -1068,7 +1170,7 @@ namespace Microsoft.OData.JsonLight
         {
             ODataResourceSet collectionResourceSet = new ODataResourceSet();
 
-            foreach (var propertyAnnotation
+            foreach (KeyValuePair<string, object> propertyAnnotation
                      in resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(propertyName))
             {
                 switch (propertyAnnotation.Key)
@@ -1115,7 +1217,7 @@ namespace Microsoft.OData.JsonLight
 
             bool result = false;
             string propertyName = this.JsonReader.GetPropertyName();
-            if (string.CompareOrdinal(propertyName, JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType) == 0
+            if (string.Equals(propertyName, JsonLightConstants.PrefixedODataTypePropertyName, StringComparison.Ordinal)
                 || this.CompareSimplifiedODataAnnotation(JsonLightConstants.SimplifiedODataTypePropertyName, propertyName))
             {
                 // Read over the property name
@@ -1125,6 +1227,7 @@ namespace Microsoft.OData.JsonLight
             }
 
             this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);
+
             return result;
         }
 
@@ -1148,7 +1251,7 @@ namespace Microsoft.OData.JsonLight
             expectedPropertyTypeReference = this.UpdateExpectedTypeBasedOnContextUri(expectedPropertyTypeReference);
 
             object propertyValue = missingPropertyValue;
-            var customInstanceAnnotations = new Collection<ODataInstanceAnnotation>();
+            Collection<ODataInstanceAnnotation> customInstanceAnnotations = new Collection<ODataInstanceAnnotation>();
 
             // Check for the special top-level OData 3.0 null marker in order to accommodate
             // the responses written by 6.x version of this library.
@@ -1212,7 +1315,7 @@ namespace Microsoft.OData.JsonLight
                                 switch (propertyParsingResult)
                                 {
                                     case PropertyParsingResult.ODataInstanceAnnotation:
-                                        if (string.CompareOrdinal(ODataAnnotationNames.ODataType, propertyName) == 0)
+                                        if (string.Equals(ODataAnnotationNames.ODataType, propertyName, StringComparison.Ordinal))
                                         {
                                             // When we are not using the reordering reader we have to ensure that the 'odata.type' property appears before
                                             // the 'value' property; otherwise we already scanned ahead and read the type name and have to now
@@ -1242,8 +1345,8 @@ namespace Microsoft.OData.JsonLight
                                         ODataAnnotationNames.ValidateIsCustomAnnotationName(propertyName);
                                         Debug.Assert(
                                             !this.MessageReaderSettings.ShouldSkipAnnotation(propertyName),
-                                            "!this.MessageReaderSettings.ShouldReadAndValidateAnnotation(annotationName) -- otherwise we should have already skipped the custom annotation and won't see it here.");
-                                        var customInstanceAnnotationValue = this.ReadCustomInstanceAnnotationValue(propertyAndAnnotationCollector, propertyName);
+                                            "!this.MessageReaderSettings.ShouldSkipAnnotation(annotationName) -- otherwise we should have already skipped the custom annotation and won't see it here.");
+                                        object customInstanceAnnotationValue = this.ReadCustomInstanceAnnotationValue(propertyAndAnnotationCollector, propertyName);
                                         customInstanceAnnotations.Add(new ODataInstanceAnnotation(propertyName, customInstanceAnnotationValue.ToODataValue()));
                                         break;
 
@@ -1251,7 +1354,7 @@ namespace Microsoft.OData.JsonLight
                                         throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_TopLevelPropertyAnnotationWithoutProperty(propertyName));
 
                                     case PropertyParsingResult.PropertyWithValue:
-                                        if (string.CompareOrdinal(JsonLightConstants.ODataValuePropertyName, propertyName) == 0)
+                                        if (string.Equals(JsonLightConstants.ODataValuePropertyName, propertyName, StringComparison.Ordinal))
                                         {
                                             // Now read the property value
                                             propertyValue = this.ReadNonEntityValue(
@@ -1311,7 +1414,7 @@ namespace Microsoft.OData.JsonLight
         private IEdmTypeReference UpdateExpectedTypeBasedOnContextUri(IEdmTypeReference expectedPropertyTypeReference)
         {
             Debug.Assert(!this.JsonLightInputContext.ReadingResponse || this.ContextUriParseResult != null, "Responses should always have a context uri, and that should already have been validated.");
-            if (this.ContextUriParseResult == null || this.ContextUriParseResult.EdmType == null)
+            if (this.ContextUriParseResult?.EdmType == null)
             {
                 return expectedPropertyTypeReference;
             }
@@ -1555,9 +1658,7 @@ namespace Microsoft.OData.JsonLight
                 {
                     string typeName = structuredTypeReference != null ? structuredTypeReference.FullName() : payloadTypeName;
                     throw new ODataException(
-                        string.Format(CultureInfo.InvariantCulture,
-                        "The property with name '{0}' was found with a value node of type '{1}'; however, a resource value of type '{2}' was expected.",
-                        propertyName, this.JsonReader.NodeType, typeName));
+                        ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ODataResourceExpectedForProperty(propertyName, this.JsonReader.NodeType, typeName));
                 }
 
                 this.JsonReader.Read();
@@ -1614,7 +1715,7 @@ namespace Microsoft.OData.JsonLight
                         switch (propertyParsingResult)
                         {
                             case PropertyParsingResult.ODataInstanceAnnotation: // odata.*
-                                if (string.CompareOrdinal(ODataAnnotationNames.ODataType, propertyName) == 0)
+                                if (string.Equals(ODataAnnotationNames.ODataType, propertyName, StringComparison.Ordinal))
                                 {
                                     throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ResourceTypeAnnotationNotFirst);
                                 }
@@ -1627,8 +1728,8 @@ namespace Microsoft.OData.JsonLight
                                 ODataAnnotationNames.ValidateIsCustomAnnotationName(propertyName);
                                 Debug.Assert(
                                     !this.MessageReaderSettings.ShouldSkipAnnotation(propertyName),
-                                    "!this.MessageReaderSettings.ShouldReadAndValidateAnnotation(annotationName) -- otherwise we should have already skipped the custom annotation and won't see it here.");
-                                var customInstanceAnnotationValue = this.ReadCustomInstanceAnnotationValue(propertyAndAnnotationCollector, propertyName);
+                                    "!this.MessageReaderSettings.ShouldSkipAnnotation(annotationName) -- otherwise we should have already skipped the custom annotation and won't see it here.");
+                                object customInstanceAnnotationValue = this.ReadCustomInstanceAnnotationValue(propertyAndAnnotationCollector, propertyName);
                                 resourceValue.InstanceAnnotations.Add(new ODataInstanceAnnotation(propertyName, customInstanceAnnotationValue.ToODataValue()));
                                 break;
 
@@ -1671,10 +1772,10 @@ namespace Microsoft.OData.JsonLight
                                 {
                                     propertyAndAnnotationCollector.CheckForDuplicatePropertyNames(property);
                                     property.Value = propertyValue;
-                                    var propertyAnnotations = propertyAndAnnotationCollector.GetCustomPropertyAnnotations(propertyName);
+                                    IEnumerable<KeyValuePair<string, object>> propertyAnnotations = propertyAndAnnotationCollector.GetCustomPropertyAnnotations(propertyName);
                                     if (propertyAnnotations != null)
                                     {
-                                        foreach (var annotation in propertyAnnotations)
+                                        foreach (KeyValuePair<string, object> annotation in propertyAnnotations)
                                         {
                                             if (annotation.Value != null)
                                             {
@@ -2021,7 +2122,7 @@ namespace Microsoft.OData.JsonLight
         /// <remarks>If the method detects the odata.null annotation, it will read it; otherwise the reader does not move.</remarks>
         private bool IsTopLevel6xNullValue()
         {
-            bool odataNullAnnotationInPayload = this.JsonReader.NodeType == JsonNodeType.Property && string.CompareOrdinal(JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataNull, JsonReader.GetPropertyName()) == 0;
+            bool odataNullAnnotationInPayload = this.JsonReader.NodeType == JsonNodeType.Property && string.Equals(JsonLightConstants.PrefixedODataNullPropertyName, JsonReader.GetPropertyName(), StringComparison.Ordinal);
             if (odataNullAnnotationInPayload)
             {
                 // If we found the expected annotation read over the property name
@@ -2083,6 +2184,1408 @@ namespace Microsoft.OData.JsonLight
                             throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty(propertyName));
                     }
                 });
+            }
+        }
+
+        /// <summary>
+        /// Try to asynchronously read or peek the odata.type annotation.
+        /// </summary>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker to use in current level.</param>
+        /// <param name="propertyName">The property name.</param>
+        /// <param name="insideResourceValue">If inside complex value.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the odata.type value or null.
+        /// </returns>
+        protected async Task<string> TryReadOrPeekPayloadTypeAsync(PropertyAndAnnotationCollector propertyAndAnnotationCollector, string propertyName, bool insideResourceValue)
+        {
+            string payloadTypeName = ValidateDataPropertyTypeNameAnnotation(propertyAndAnnotationCollector, propertyName);
+            bool valueIsJsonObject = this.JsonReader.NodeType == JsonNodeType.StartObject;
+            if (string.IsNullOrEmpty(payloadTypeName) && valueIsJsonObject)
+            {
+                try
+                {
+                    await this.JsonReader.StartBufferingAsync()
+                        .ConfigureAwait(false);
+
+                    // If we have an object value initialize the duplicate property names checker
+                    propertyAndAnnotationCollector = this.CreatePropertyAndAnnotationCollector();
+
+                    // Read the payload type name
+                    Tuple<bool, string> readPayloadTypeFromObjectResult = await this.TryReadPayloadTypeFromObjectAsync(
+                        propertyAndAnnotationCollector,
+                        insideResourceValue).ConfigureAwait(false);
+                    bool typeNameFoundInPayload = readPayloadTypeFromObjectResult.Item1;
+                    if (typeNameFoundInPayload)
+                    {
+                        payloadTypeName = readPayloadTypeFromObjectResult.Item2;
+                    }
+                }
+                finally
+                {
+                    this.JsonReader.StopBuffering();
+                }
+            }
+
+            return payloadTypeName;
+        }
+
+        /// <summary>
+        /// Asynchronously reads an entity or complex type's undeclared property.
+        /// </summary>
+        /// <param name="resourceState">The IODataJsonLightReaderResourceState.</param>
+        /// <param name="propertyName">Now this name can't be found in model.</param>
+        /// <param name="isTopLevelPropertyValue">bool</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the read result.
+        /// </returns>
+        protected async Task<ODataJsonLightReaderNestedResourceInfo> InnerReadUndeclaredPropertyAsync(
+            IODataJsonLightReaderResourceState resourceState,
+            string propertyName,
+            bool isTopLevelPropertyValue)
+        {
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector = resourceState.PropertyAndAnnotationCollector;
+            bool insideResourceValue = false;
+            string outerPayloadTypeName = ValidateDataPropertyTypeNameAnnotation(propertyAndAnnotationCollector, propertyName);
+            string payloadTypeName = await this.TryReadOrPeekPayloadTypeAsync(propertyAndAnnotationCollector, propertyName, insideResourceValue)
+                .ConfigureAwait(false);
+            EdmTypeKind payloadTypeKind;
+            IEdmType payloadType = ReaderValidationUtils.ResolvePayloadTypeName(
+                this.Model,
+                expectedTypeReference: null,
+                payloadTypeName: payloadTypeName,
+                expectedTypeKind: EdmTypeKind.Complex,
+                clientCustomTypeResolver: this.MessageReaderSettings.ClientCustomTypeResolver,
+                payloadTypeKind: out payloadTypeKind);
+            IEdmTypeReference payloadTypeReference = null;
+            if (!string.IsNullOrEmpty(payloadTypeName) && payloadType != null)
+            {
+                // only try resolving for known type (the below will throw on unknown type name) :
+                ODataTypeAnnotation typeAnnotation;
+                EdmTypeKind targetTypeKind;
+                payloadTypeReference = this.ReaderValidator.ResolvePayloadTypeNameAndComputeTargetType(
+                    EdmTypeKind.None,
+                    expectStructuredType: null,
+                    defaultPrimitivePayloadType: null,
+                    expectedTypeReference: null,
+                    payloadTypeName: payloadTypeName,
+                    model: this.Model,
+                    typeKindFromPayloadFunc: this.GetNonEntityValueKind,
+                    targetTypeKind: out targetTypeKind,
+                    typeAnnotation: out typeAnnotation);
+            }
+
+            object propertyValue = null;
+            payloadTypeReference = ResolveUntypedType(
+                this.JsonReader.NodeType,
+                await this.JsonReader.GetValueAsync().ConfigureAwait(false),
+                payloadTypeName,
+                payloadTypeReference,
+                this.MessageReaderSettings.PrimitiveTypeResolver,
+                this.MessageReaderSettings.ReadUntypedAsString,
+                !this.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata);
+
+            if (payloadTypeReference.ToStructuredType() != null)
+            {
+                ODataJsonLightReaderNestedResourceInfo readerNestedResourceInfo = null;
+
+                // Complex property or collection of complex property.
+                bool isCollection = payloadTypeReference.IsCollection();
+                await ValidateExpandedNestedResourceInfoPropertyValueAsync(
+                    this.JsonReader,
+                    isCollection,
+                    propertyName,
+                    payloadTypeReference).ConfigureAwait(false);
+
+                if (isCollection)
+                {
+                    readerNestedResourceInfo =
+                        ReadExpandedResourceSetNestedResourceInfo(resourceState, null, payloadTypeReference.ToStructuredType(), propertyName, isDeltaResourceSet: false);
+                }
+                else
+                {
+                    readerNestedResourceInfo = ReadExpandedResourceNestedResourceInfo(resourceState, null, propertyName, payloadTypeReference.ToStructuredType(), this.MessageReaderSettings);
+                }
+
+                resourceState.PropertyAndAnnotationCollector.ValidatePropertyUniquenessOnNestedResourceInfoStart(readerNestedResourceInfo.NestedResourceInfo);
+
+                return readerNestedResourceInfo;
+            }
+
+            if (!(payloadTypeReference is IEdmUntypedTypeReference))
+            {
+                this.JsonReader.AssertNotBuffering();
+                propertyValue = await this.ReadNonEntityValueImplementationAsync(
+                    outerPayloadTypeName,
+                    payloadTypeReference,
+                    propertyAndAnnotationCollector: null,
+                    collectionValidator: null,
+                    validateNullValue: false,
+                    isTopLevelPropertyValue: isTopLevelPropertyValue,
+                    insideResourceValue: insideResourceValue,
+                    propertyName: propertyName).ConfigureAwait(false);
+            }
+            else
+            {
+                propertyValue = await this.JsonReader.ReadAsUntypedOrNullValueAsync()
+                    .ConfigureAwait(false);
+            }
+
+            this.JsonReader.AssertNotBuffering();
+            Debug.Assert(
+                this.JsonReader.NodeType == JsonNodeType.Property || this.JsonReader.NodeType == JsonNodeType.EndObject,
+                "Post-Condition: expected JsonNodeType.Property or JsonNodeType.EndObject");
+            AddResourceProperty(resourceState, propertyName, propertyValue);
+            return null;
+        }
+
+        /// <summary>
+        /// Asynchronously validates that the value of a JSON property can represent expanded nested resource info.
+        /// </summary>
+        /// <param name="asyncJsonReader">The IJsonReaderAsync instance.</param>
+        /// <param name="isCollection">true if the property is entity set reference property;
+        /// false for a resource reference property, null if unknown.</param>
+        /// <param name="propertyName">Name for the navigation property, used in error message only.</param>
+        /// <param name="typeReference">Type of navigation property</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        protected static async Task ValidateExpandedNestedResourceInfoPropertyValueAsync(
+            IJsonReaderAsync asyncJsonReader,
+            bool? isCollection,
+            string propertyName,
+            IEdmTypeReference typeReference)
+        {
+            // An expanded link with resource requires a StartObject node here;
+            // An expanded link with resource set requires a StartArray node here;
+            // An expanded link with null resource requires a primitive null node here;
+            JsonNodeType nodeType = asyncJsonReader.NodeType;
+            if (nodeType == JsonNodeType.StartArray)
+            {
+                if (isCollection == false)
+                {
+                    throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_CannotReadSingletonNestedResource(nodeType, propertyName));
+                }
+            }
+            else if (
+                (nodeType == JsonNodeType.PrimitiveValue && (await asyncJsonReader.GetValueAsync().ConfigureAwait(false)) == null)
+                || nodeType == JsonNodeType.StartObject)
+            {
+                // Expanded resource (null or non-null)
+                if (isCollection == true)
+                {
+                    if (typeReference.IsNonEntityCollectionType())
+                    {
+                        ReaderValidationUtils.ValidateNullValue(
+                            expectedTypeReference: typeReference,
+                            enablePrimitiveTypeConversion: true,
+                            validateNullValue: true,
+                            propertyName: propertyName,
+                            isDynamicProperty: false);
+                    }
+                    else
+                    {
+                        throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_CannotReadCollectionNestedResource(nodeType, propertyName));
+                    }
+
+                }
+            }
+            else
+            {
+                Debug.Assert(nodeType == JsonNodeType.PrimitiveValue, "nodeType == JsonNodeType.PrimitiveValue");
+                throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_CannotReadNestedResource(propertyName));
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads the value of the OData type annotation.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the value of the OData type annotation.
+        /// </returns>
+        /// <remarks>
+        /// Pre-Condition:  JsonNodeType.PrimitiveValue - the value of the annotation, will fail if it's not PrimitiveValue
+        ///                 JsonNodeType.StartObject
+        ///                 JsonNodeType.StartArray
+        /// Post-Condition: JsonNodeType.Property    - the next property after the annotation
+        ///                 JsonNodeType.EndObject   - end of the parent object
+        /// </remarks>
+        protected async Task<string> ReadODataTypeAnnotationValueAsync()
+        {
+            this.AssertJsonCondition(JsonNodeType.PrimitiveValue, JsonNodeType.StartObject, JsonNodeType.StartArray);
+
+            string typeName = ReaderUtils.AddEdmPrefixOfTypeName(
+                ReaderUtils.RemovePrefixOfTypeName(
+                    await this.JsonReader.ReadStringValueAsync().ConfigureAwait(false)));
+            if (typeName == null)
+            {
+                throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_InvalidTypeName(typeName));
+            }
+
+            this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);
+
+            return typeName;
+        }
+
+        /// <summary>
+        /// Tries to asynchronously read an OData type annotation value.
+        /// </summary>
+        /// <param name="annotationName">The annotation name on which value the reader is positioned on.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains a tuple comprising of:
+        /// 1). true if an OData type annotation was consumed from the reader; otherwise false - the reader was not advanced.
+        /// 2). The annotation value (string) that was read.
+        /// </returns>
+        /// <remarks>
+        /// Pre-Condition:  JsonNodeType.PrimitiveValue - the value of the annotation
+        ///                 JsonNodeType.StartObject
+        ///                 JsonNodeType.StartArray
+        /// Post-Condition: JsonNodeType.Property       - the next property after the annotation
+        ///                 JsonNodeType.EndObject      - end of the parent object
+        ///                 JsonNodeType.PrimitiveValue - the reader didn't move
+        ///                 JsonNodeType.StartObject
+        ///                 JsonNodeType.StartArray
+        /// </remarks>
+        protected async Task<Tuple<bool, string>> TryReadODataTypeAnnotationValueAsync(string annotationName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(annotationName), "!string.IsNullOrEmpty(annotationName)");
+
+            if (string.Equals(annotationName, ODataAnnotationNames.ODataType, StringComparison.Ordinal))
+            {
+                return Tuple.Create(true, await this.ReadODataTypeAnnotationValueAsync().ConfigureAwait(false));
+            }
+
+            return Tuple.Create(false, (string)null);
+        }
+
+        /// <summary>
+        /// Asynchronously reads top-level property payload property annotation value.
+        /// </summary>
+        /// <param name="propertyAnnotationName">The name of the property annotation.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the value of the annotation.
+        /// </returns>
+        protected async Task<object> ReadTypePropertyAnnotationValueAsync(string propertyAnnotationName)
+        {
+            Debug.Assert(!string.IsNullOrEmpty(propertyAnnotationName), "!string.IsNullOrEmpty(propertyAnnotationName)");
+            Debug.Assert(
+                propertyAnnotationName.StartsWith(JsonLightConstants.ODataAnnotationNamespacePrefix, StringComparison.Ordinal),
+                "The method should only be called with OData. annotations");
+
+            Tuple<bool, string> readODataTypeAnnotationResult = await this.TryReadODataTypeAnnotationValueAsync(propertyAnnotationName)
+                .ConfigureAwait(false);
+            if (readODataTypeAnnotationResult.Item1)
+            {
+                string typeName = readODataTypeAnnotationResult.Item2;
+                return typeName;
+            }
+
+            throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedAnnotationProperties(propertyAnnotationName));
+        }
+
+        /// <summary>
+        /// Tries to asynchronously read an OData type annotation.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains a tuple comprising of:
+        /// 1). true if an OData type annotation was consumed from the reader; otherwise false - the reader was not advanced.
+        /// 2). The annotation value (string) that was read.
+        /// </returns>
+        /// <remarks>
+        /// Pre-Condition:  JsonNodeType.Property       - the property that possibly is an odata.type instance annotation
+        /// Post-Condition: JsonNodeType.Property       - the next property after the annotation or if the reader did not move
+        ///                 JsonNodeType.EndObject      - end of the parent object
+        /// </remarks>
+        private async Task<Tuple<bool, string>> TryReadODataTypeAnnotationAsync()
+        {
+            this.AssertJsonCondition(JsonNodeType.Property);
+            string payloadTypeName = null;
+
+            bool result = false;
+            string propertyName = await this.JsonReader.GetPropertyNameAsync()
+                .ConfigureAwait(false);
+            if (string.Equals(propertyName, JsonLightConstants.PrefixedODataTypePropertyName, StringComparison.Ordinal)
+                || this.CompareSimplifiedODataAnnotation(JsonLightConstants.SimplifiedODataTypePropertyName, propertyName))
+            {
+                // Read over the property name
+                await this.JsonReader.ReadNextAsync()
+                    .ConfigureAwait(false);
+                payloadTypeName = await this.ReadODataTypeAnnotationValueAsync()
+                    .ConfigureAwait(false);
+                result = true;
+            }
+
+            this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);
+
+            return Tuple.Create(result, payloadTypeName);
+        }
+
+        /// <summary>
+        /// Asynchronously reads the property from the input and
+        /// returns an <see cref="ODataProperty"/> representing the read property.
+        /// </summary>
+        /// <param name="expectedPropertyTypeReference">The expected type reference of the property to read.</param>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker to use.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains an <see cref="ODataProperty"/> representing the read property.
+        /// </returns>
+        /// <remarks>
+        /// The method assumes that the ReadPayloadStartAsync has already been called and it will not call ReadPayloadEndAsync.
+        /// </remarks>
+        private async Task<ODataProperty> ReadTopLevelPropertyImplementationAsync(
+            IEdmTypeReference expectedPropertyTypeReference,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector)
+        {
+            Debug.Assert(
+                expectedPropertyTypeReference == null || !expectedPropertyTypeReference.IsODataEntityTypeKind(),
+                "If the expected type is specified it must not be an entity type.");
+            Debug.Assert(propertyAndAnnotationCollector != null, "propertyAndAnnotationCollector != null");
+
+            expectedPropertyTypeReference = this.UpdateExpectedTypeBasedOnContextUri(expectedPropertyTypeReference);
+
+            object propertyValue = missingPropertyValue;
+            Collection<ODataInstanceAnnotation> customInstanceAnnotations = new Collection<ODataInstanceAnnotation>();
+
+            // Check for the special top-level OData 3.0 null marker in order to accommodate
+            // the responses written by 6.x version of this library.
+            if (await this.IsTopLevel6xNullValueAsync().ConfigureAwait(false))
+            {
+                // NOTE: When reading a null value we will never ask the type resolver (if present) to resolve the
+                //       type; we always fall back to the expected type.
+                this.ReaderValidator.ValidateNullValue(
+                    expectedPropertyTypeReference,
+                    validateNullValue: true,
+                    propertyName: null,
+                    isDynamicProperty: null);
+
+                // We don't allow properties or non-custom annotations in the null payload.
+                await this.ValidateNoPropertyInNullPayloadAsync(propertyAndAnnotationCollector)
+                    .ConfigureAwait(false);
+
+                propertyValue = null;
+            }
+            else
+            {
+                string payloadTypeName = null;
+                Tuple<bool, string> readingResourcePropertyResult = await this.ReadingResourcePropertyAsync(
+                    propertyAndAnnotationCollector,
+                    expectedPropertyTypeReference).ConfigureAwait(false);
+                bool isReadingResourceProperty = readingResourcePropertyResult.Item1;
+                payloadTypeName = readingResourcePropertyResult.Item2;
+
+                if (isReadingResourceProperty)
+                {
+                    // Figure out whether we are reading a resource property or not; resource properties are not wrapped while all others are.
+                    // Since we don't have metadata in all cases (open properties), we have to detect the type in some cases.
+                    this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);
+
+                    // Now read the property value
+                    propertyValue = await this.ReadNonEntityValueAsync(
+                        payloadTypeName,
+                        expectedPropertyTypeReference,
+                        propertyAndAnnotationCollector,
+                        collectionValidator: null,
+                        validateNullValue: true,
+                        isTopLevelPropertyValue: true,
+                        insideResourceValue: true,
+                        propertyName: null).ConfigureAwait(false);
+                }
+                else
+                {
+                    bool isReordering = this.JsonReader is ReorderingJsonReader;
+
+                    Func<string, Task<object>> readTopLevelPropertyAnnotationValueDelegate =
+                        (annotationName) =>
+                        {
+                            throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedODataPropertyAnnotation(annotationName));
+                        };
+
+                    // Read through all top-level properties, ignore the ones with reserved names (i.e., reserved
+                    // characters in their name) and throw if we find none or more than one properties without reserved name.
+                    while (this.JsonReader.NodeType == JsonNodeType.Property)
+                    {
+                        await this.ProcessPropertyAsync(
+                            propertyAndAnnotationCollector,
+                            readTopLevelPropertyAnnotationValueDelegate,
+                            async (propertyParsingResult, propertyName) =>
+                            {
+                                if (this.JsonReader.NodeType == JsonNodeType.Property)
+                                {
+                                    // Read over property name
+                                    await this.JsonReader.ReadAsync()
+                                        .ConfigureAwait(false);
+                                }
+
+                                switch (propertyParsingResult)
+                                {
+                                    case PropertyParsingResult.ODataInstanceAnnotation:
+                                        if (string.Equals(ODataAnnotationNames.ODataType, propertyName, StringComparison.Ordinal))
+                                        {
+                                            // When we are not using the reordering reader we have to ensure that the 'odata.type' property appears before
+                                            // the 'value' property; otherwise we already scanned ahead and read the type name and have to now
+                                            // ignore it (even if it is after the 'value' property).
+                                            if (isReordering)
+                                            {
+                                                await this.JsonReader.SkipValueAsync()
+                                                    .ConfigureAwait(false);
+                                            }
+                                            else
+                                            {
+                                                if (!object.ReferenceEquals(missingPropertyValue, propertyValue))
+                                                {
+                                                    throw new ODataException(
+                                                        ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_TypePropertyAfterValueProperty(ODataAnnotationNames.ODataType, JsonLightConstants.ODataValuePropertyName));
+                                                }
+
+                                                payloadTypeName = await this.ReadODataTypeAnnotationValueAsync()
+                                                    .ConfigureAwait(false);
+                                            }
+                                        }
+                                        else
+                                        {
+                                            throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedAnnotationProperties(propertyName));
+                                        }
+
+                                        break;
+                                    case PropertyParsingResult.CustomInstanceAnnotation:
+                                        ODataAnnotationNames.ValidateIsCustomAnnotationName(propertyName);
+                                        Debug.Assert(
+                                            !this.MessageReaderSettings.ShouldSkipAnnotation(propertyName),
+                                            "!this.MessageReaderSettings.ShouldSkipAnnotation(annotationName) -- otherwise we should have already skipped the custom annotation and won't see it here.");
+                                        object customInstanceAnnotationValue = await this.ReadCustomInstanceAnnotationValueAsync(
+                                            propertyAndAnnotationCollector,
+                                            propertyName).ConfigureAwait(false);
+                                        customInstanceAnnotations.Add(new ODataInstanceAnnotation(propertyName, customInstanceAnnotationValue.ToODataValue()));
+                                        break;
+
+                                    case PropertyParsingResult.PropertyWithoutValue:
+                                        throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_TopLevelPropertyAnnotationWithoutProperty(propertyName));
+
+                                    case PropertyParsingResult.PropertyWithValue:
+                                        if (string.Equals(JsonLightConstants.ODataValuePropertyName, propertyName, StringComparison.Ordinal))
+                                        {
+                                            // Now read the property value
+                                            propertyValue = await this.ReadNonEntityValueAsync(
+                                                    payloadTypeName,
+                                                    expectedPropertyTypeReference,
+                                                    propertyAndAnnotationCollector: null,
+                                                    collectionValidator: null,
+                                                    validateNullValue: true,
+                                                    isTopLevelPropertyValue: true,
+                                                    insideResourceValue: false,
+                                                    propertyName: propertyName).ConfigureAwait(false);
+                                        }
+                                        else
+                                        {
+                                            throw new ODataException(
+                                                ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_InvalidTopLevelPropertyName(propertyName, JsonLightConstants.ODataValuePropertyName));
+                                        }
+
+                                        break;
+
+                                    case PropertyParsingResult.EndOfObject:
+                                        break;
+
+                                    case PropertyParsingResult.MetadataReferenceProperty:
+                                        throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty(propertyName));
+                                }
+                            }).ConfigureAwait(false);
+                    }
+
+                    if (object.ReferenceEquals(missingPropertyValue, propertyValue))
+                    {
+                        // No property found; there should be exactly one property in the top-level property wrapper that does not have a reserved name.
+                        throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_InvalidTopLevelPropertyPayload);
+                    }
+                }
+            }
+
+            Debug.Assert(!object.ReferenceEquals(missingPropertyValue, propertyValue), "!object.ReferenceEquals(missingPropertyValue, propertyValue)");
+            ODataProperty resultProperty = new ODataProperty
+            {
+                // The property name is not on the context URI or the payload, we report null.
+                Name = null,
+                Value = propertyValue,
+                InstanceAnnotations = customInstanceAnnotations
+            };
+
+            // Read over the end object - note that this might be the last node in the input (in case there's no response wrapper)
+            await this.JsonReader.ReadAsync()
+                .ConfigureAwait(false);
+
+            return resultProperty;
+        }
+
+        /// <summary>
+        /// Asynchronously reads a collection value.
+        /// </summary>
+        /// <param name="collectionValueTypeReference">The collection type reference of the value.</param>
+        /// <param name="payloadTypeName">The type name read from the payload.</param>
+        /// <param name="typeAnnotation">The serialization type name for the collection value (possibly null).</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the collection value.
+        /// </returns>
+        /// <remarks>
+        /// Pre-Condition:  Fails if the current node is not a JsonNodeType.StartArray
+        /// Post-Condition: almost anything - the node after the collection value (after the EndArray)
+        /// </remarks>
+        private async Task<ODataCollectionValue> ReadCollectionValueAsync(
+            IEdmCollectionTypeReference collectionValueTypeReference,
+            string payloadTypeName,
+            ODataTypeAnnotation typeAnnotation)
+        {
+            Debug.Assert(
+                collectionValueTypeReference == null || collectionValueTypeReference.IsNonEntityCollectionType(),
+                "If the metadata is specified it must denote a Collection for this method to work.");
+
+            this.IncreaseRecursionDepth();
+
+            // Read over the start array
+            await this.JsonReader.ReadStartArrayAsync()
+                .ConfigureAwait(false);
+
+            ODataCollectionValue collectionValue = new ODataCollectionValue();
+            collectionValue.TypeName = collectionValueTypeReference != null ? collectionValueTypeReference.FullName() : payloadTypeName;
+            if (typeAnnotation != null)
+            {
+                collectionValue.TypeAnnotation = typeAnnotation;
+            }
+
+            List<object> items = new List<object>();
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector = this.CreatePropertyAndAnnotationCollector();
+            IEdmTypeReference itemType = null;
+            if (collectionValueTypeReference != null)
+            {
+                itemType = collectionValueTypeReference.CollectionDefinition().ElementType;
+            }
+
+            // NOTE: we do not support reading JSON Light without metadata right now so we always have an expected item type;
+            //       The collection validator is always null.
+            CollectionWithoutExpectedTypeValidator collectionValidator = null;
+
+            while (this.JsonReader.NodeType != JsonNodeType.EndArray)
+            {
+                object itemValue = await this.ReadNonEntityValueImplementationAsync(
+                    payloadTypeName: null,
+                    expectedTypeReference: itemType,
+                    propertyAndAnnotationCollector: propertyAndAnnotationCollector,
+                    collectionValidator: collectionValidator,
+                    validateNullValue: true,
+                    isTopLevelPropertyValue: false,
+                    insideResourceValue: false,
+                    propertyName: null).ConfigureAwait(false);
+
+                // Validate the item (for example that it's not null)
+                ValidationUtils.ValidateCollectionItem(itemValue, itemType.IsNullable());
+
+                // Note that the ReadNonEntityValue already validated that the actual type of the value matches
+                // the expected type (the itemType).
+                items.Add(itemValue);
+            }
+
+            Debug.Assert(this.JsonReader.NodeType == JsonNodeType.EndArray, "The results value must end with an end array.");
+            await this.JsonReader.ReadEndArrayAsync()
+                .ConfigureAwait(false);
+
+            collectionValue.Items = new ReadOnlyEnumerable<object>(items);
+
+            this.DecreaseRecursionDepth();
+
+            return collectionValue;
+        }
+
+        /// <summary>
+        /// Asynchronously reads a type definition value.
+        /// </summary>
+        /// <param name="insideJsonObjectValue">true if the reader is positioned on the first property of the value which is a JSON Object
+        ///     (or the second property if the first one was odata.type).</param>
+        /// <param name="expectedValueTypeReference">The expected type definition reference of the value, or null if none is available.</param>
+        /// <param name="validateNullValue">true to validate null values; otherwise false.</param>
+        /// <param name="propertyName">The name of the property whose value is being read, if applicable (used for error reporting).</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the type definition value.
+        /// </returns>
+        private async Task<object> ReadTypeDefinitionValueAsync(
+            bool insideJsonObjectValue,
+            IEdmTypeDefinitionReference expectedValueTypeReference,
+            bool validateNullValue,
+            string propertyName)
+        {
+            object result = await this.ReadPrimitiveValueAsync(
+                insideJsonObjectValue,
+                expectedValueTypeReference.AsPrimitive(),
+                validateNullValue,
+                propertyName).ConfigureAwait(false);
+
+            // Try convert to the expected CLR types from their underlying CLR types.
+            try
+            {
+                return this.Model.GetPrimitiveValueConverter(expectedValueTypeReference).ConvertFromUnderlyingType(result);
+            }
+            catch (OverflowException)
+            {
+                throw new ODataException(ODataErrorStrings.EdmLibraryExtensions_ValueOverflowForUnderlyingType(result, expectedValueTypeReference.FullName()));
+            }
+        }
+
+        /// <summary>
+        /// Asynchronously reads a primitive value.
+        /// </summary>
+        /// <param name="insideJsonObjectValue">true if the reader is positioned on the first property of the value which is a JSON Object
+        ///     (or the second property if the first one was odata.type).</param>
+        /// <param name="expectedValueTypeReference">The expected type reference of the value, or null if none is available.</param>
+        /// <param name="validateNullValue">true to validate null values; otherwise false.</param>
+        /// <param name="propertyName">The name of the property whose value is being read, if applicable (used for error reporting).</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the primitive value.
+        /// </returns>
+        /// <remarks>
+        /// Pre-Condition:  insideJsonObjectValue == false -> none - Fails if the current node is not a JsonNodeType.PrimitiveValue
+        ///                 insideJsonObjectValue == true -> JsonNodeType.Property or JsonNodeType.EndObject - the first property of the value object,
+        ///                     or the second property if first was odata.type, or the end-object.
+        /// Post-Condition: almost anything - the node after the primitive value.
+        /// </remarks>
+        private async Task<object> ReadPrimitiveValueAsync(
+            bool insideJsonObjectValue,
+            IEdmPrimitiveTypeReference expectedValueTypeReference,
+            bool validateNullValue,
+            string propertyName)
+        {
+            object result;
+
+            if (expectedValueTypeReference != null && expectedValueTypeReference.IsSpatial())
+            {
+                result = await ODataJsonReaderCoreUtils.ReadSpatialValueAsync(
+                    this.JsonReader,
+                    insideJsonObjectValue,
+                    this.JsonLightInputContext,
+                    expectedValueTypeReference,
+                    validateNullValue,
+                    this.recursionDepth,
+                    propertyName).ConfigureAwait(false);
+            }
+            else
+            {
+                if (insideJsonObjectValue)
+                {
+                    // We manually throw JSON exception here to get a nicer error message
+                    // (we expected primitive value and got object).
+                    // Otherwise the ReadPrimitiveValueAsync would fail with something like
+                    // "expected primitive value but found property/end object" which is rather confusing.
+                    throw new ODataException(
+                        ODataErrorStrings.JsonReaderExtensions_UnexpectedNodeDetectedWithPropertyName(
+                            JsonNodeType.PrimitiveValue,
+                            JsonNodeType.StartObject,
+                            propertyName));
+                }
+
+                result = await this.JsonReader.ReadPrimitiveValueAsync()
+                    .ConfigureAwait(false);
+
+                if (expectedValueTypeReference != null)
+                {
+                    if ((expectedValueTypeReference.IsDecimal() || expectedValueTypeReference.IsInt64())
+                        && result != null)
+                    {
+                        if ((result is string) ^ this.JsonReader.IsIeee754Compatible)
+                        {
+                            throw new ODataException(ODataErrorStrings.ODataJsonReaderUtils_ConflictBetweenInputFormatAndParameter(expectedValueTypeReference.FullName()));
+                        }
+                    }
+
+                    result = ODataJsonLightReaderUtils.ConvertValue(
+                        result,
+                        expectedValueTypeReference,
+                        this.MessageReaderSettings,
+                        validateNullValue,
+                        propertyName,
+                        this.JsonLightInputContext.PayloadValueConverter);
+                }
+                else
+                {
+                    if (result is decimal decimalResult)
+                    {
+                        // convert decimal back to double to follow legacy logic when target type is not specified and IEEE754Compatible=false.
+                        // we may lose precision for some range of int64 and decimal.
+                        return Convert.ToDouble(decimalResult);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Asynchronously reads a primitive string as enum value.
+        /// </summary>
+        /// <param name="insideJsonObjectValue">true if the reader is positioned on the first property of the value which is a JSON Object
+        ///     (or the second property if the first one was odata.type).</param>
+        /// <param name="expectedValueTypeReference">The expected type reference of the value, or null if none is available.</param>
+        /// <param name="validateNullValue">true to validate null values; otherwise false.</param>
+        /// <param name="propertyName">The name of the property whose value is being read, if applicable (used for error reporting).</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the enum value of the primitive string.
+        /// </returns>
+        private async Task<object> ReadEnumValueAsync(
+            bool insideJsonObjectValue,
+            IEdmEnumTypeReference expectedValueTypeReference,
+            bool validateNullValue,
+            string propertyName)
+        {
+            if (insideJsonObjectValue)
+            {
+                // We manually throw JSON exception here to get a nicer error message
+                // (we expect primitive value and got object).
+                // Otherwise the ReadPrimitiveValue would fail with something like
+                // "expected primitive value but found property/end object" which is rather confusing.
+                throw new ODataException(
+                    ODataErrorStrings.JsonReaderExtensions_UnexpectedNodeDetectedWithPropertyName(
+                        JsonNodeType.PrimitiveValue,
+                        JsonNodeType.StartObject,
+                        propertyName));
+            }
+
+            string enumAsString = await this.JsonReader.ReadStringValueAsync()
+                .ConfigureAwait(false);
+
+            return new ODataEnumValue(enumAsString, expectedValueTypeReference.FullName());
+        }
+
+        /// <summary>
+        /// Asynchronously reads a resource value, <see cref="ODataResourceValue"/>
+        /// </summary>
+        /// <param name="insideJsonObjectValue">true if the reader is positioned on the first property of the value which is a JSON Object
+        ///     (or the second property if the first one was odata.type).</param>
+        /// <param name="insideResourceValue">true if we are reading a resource value and the reader is already positioned inside the resource value; otherwise false.</param>
+        /// <param name="propertyName">The name of the property whose value is being read, if applicable (used for error reporting).</param>
+        /// <param name="structuredTypeReference">The expected type reference of the value.</param>
+        /// <param name="payloadTypeName">The type name read from the payload.</param>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the read resource value.
+        /// </returns>
+        private async Task<ODataResourceValue> ReadResourceValueAsync(
+            bool insideJsonObjectValue,
+            bool insideResourceValue,
+            string propertyName,
+            IEdmStructuredTypeReference structuredTypeReference,
+            string payloadTypeName,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector)
+        {
+            if (!insideJsonObjectValue && !insideResourceValue)
+            {
+                if (this.JsonReader.NodeType != JsonNodeType.StartObject)
+                {
+                    string typeName = structuredTypeReference != null ? structuredTypeReference.FullName() : payloadTypeName;
+                    throw new ODataException(
+                        ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ODataResourceExpectedForProperty(propertyName, this.JsonReader.NodeType, typeName));
+                }
+
+                await this.JsonReader.ReadAsync()
+                    .ConfigureAwait(false);
+            }
+
+            return await this.ReadResourceValueAsync(structuredTypeReference, payloadTypeName, propertyAndAnnotationCollector)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously reads a resource value.
+        /// </summary>
+        /// <param name="structuredTypeReference">The expected type reference of the value.</param>
+        /// <param name="payloadTypeName">The type name read from the payload.</param>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the read resource value.
+        /// </returns>
+        /// <remarks>
+        /// Pre-Condition:  JsonNodeType.Property - the first property of the resource value object, or the second one if the first one was odata.type.
+        ///                 JsonNodeType.EndObject - the end object of the resource value object.
+        /// Post-Condition: almost anything - the node after the resource value (after the EndObject)
+        /// </remarks>
+        private async Task<ODataResourceValue> ReadResourceValueAsync(
+            IEdmStructuredTypeReference structuredTypeReference,
+            string payloadTypeName,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector)
+        {
+            this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);
+            Debug.Assert(propertyAndAnnotationCollector != null, "propertyAndAnnotationCollector != null");
+
+            this.IncreaseRecursionDepth();
+
+            ODataResourceValue resourceValue = new ODataResourceValue();
+            resourceValue.TypeName = structuredTypeReference != null ? structuredTypeReference.FullName() : payloadTypeName;
+
+            if (structuredTypeReference != null)
+            {
+                resourceValue.TypeAnnotation = new ODataTypeAnnotation(resourceValue.TypeName);
+            }
+
+            List<ODataProperty> properties = new List<ODataProperty>();
+            while (this.JsonReader.NodeType == JsonNodeType.Property)
+            {
+                this.ReadPropertyCustomAnnotationValueAsync = this.ReadCustomInstanceAnnotationValueAsync;
+                await this.ProcessPropertyAsync(
+                    propertyAndAnnotationCollector,
+                    this.ReadTypePropertyAnnotationValueAsync,
+                    async (propertyParsingResult, propertyName) =>
+                    {
+                        if (this.JsonReader.NodeType == JsonNodeType.Property)
+                        {
+                            // Read over property name
+                            await this.JsonReader.ReadAsync()
+                                .ConfigureAwait(false);
+                        }
+
+                        switch (propertyParsingResult)
+                        {
+                            case PropertyParsingResult.ODataInstanceAnnotation: // odata.*
+                                if (string.Equals(ODataAnnotationNames.ODataType, propertyName, StringComparison.Ordinal))
+                                {
+                                    throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ResourceTypeAnnotationNotFirst);
+                                }
+                                else
+                                {
+                                    throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedAnnotationProperties(propertyName));
+                                }
+
+                            case PropertyParsingResult.CustomInstanceAnnotation: // custom instance annotation
+                                ODataAnnotationNames.ValidateIsCustomAnnotationName(propertyName);
+                                Debug.Assert(
+                                    !this.MessageReaderSettings.ShouldSkipAnnotation(propertyName),
+                                    "!this.MessageReaderSettings.ShouldSkipAnnotation(annotationName) -- otherwise we should have already skipped the custom annotation and won't see it here.");
+                                object customInstanceAnnotationValue = await this.ReadCustomInstanceAnnotationValueAsync(
+                                    propertyAndAnnotationCollector,
+                                    propertyName).ConfigureAwait(false);
+                                resourceValue.InstanceAnnotations.Add(new ODataInstanceAnnotation(propertyName, customInstanceAnnotationValue.ToODataValue()));
+                                break;
+
+                            case PropertyParsingResult.PropertyWithoutValue:
+                                throw new ODataException(
+                                    ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ResourceValuePropertyAnnotationWithoutProperty(propertyName));
+
+                            case PropertyParsingResult.PropertyWithValue:
+                                // Any other property is data
+                                ODataProperty property = new ODataProperty { Name = propertyName };
+
+                                // Lookup the property in metadata
+                                IEdmProperty edmProperty = null;
+                                if (structuredTypeReference != null)
+                                {
+                                    edmProperty = ReaderValidationUtils.ValidatePropertyDefined(
+                                        propertyName,
+                                        structuredTypeReference.StructuredDefinition(),
+                                        this.MessageReaderSettings.ThrowOnUndeclaredPropertyForNonOpenType,
+                                        this.MessageReaderSettings.EnablePropertyNameCaseInsensitive);
+                                }
+
+                                // EdmLib bridge marks all key properties as non-nullable, but Astoria allows them to be nullable.
+                                // If the property has an annotation to ignore null values, we need to omit the property in requests.
+                                ODataNullValueBehaviorKind nullValueReadBehaviorKind = this.ReadingResponse || edmProperty == null
+                                    ? ODataNullValueBehaviorKind.Default
+                                    : this.Model.NullValueReadBehaviorKind(edmProperty);
+
+                                // Read the property value
+                                object propertyValue = await this.ReadNonEntityValueImplementationAsync(
+                                    payloadTypeName: ValidateDataPropertyTypeNameAnnotation(propertyAndAnnotationCollector, propertyName),
+                                    expectedTypeReference: edmProperty == null ? null : edmProperty.Type,
+                                    propertyAndAnnotationCollector: null,
+                                    collectionValidator: null,
+                                    validateNullValue: nullValueReadBehaviorKind == ODataNullValueBehaviorKind.Default,
+                                    isTopLevelPropertyValue: false,
+                                    insideResourceValue: false,
+                                    propertyName: propertyName,
+                                    isDynamicProperty: edmProperty == null).ConfigureAwait(false);
+
+                                if (nullValueReadBehaviorKind != ODataNullValueBehaviorKind.IgnoreValue || propertyValue != null)
+                                {
+                                    propertyAndAnnotationCollector.CheckForDuplicatePropertyNames(property);
+                                    property.Value = propertyValue;
+                                    IEnumerable<KeyValuePair<string, object>> propertyAnnotations = propertyAndAnnotationCollector.GetCustomPropertyAnnotations(propertyName);
+                                    if (propertyAnnotations != null)
+                                    {
+                                        foreach (KeyValuePair<string, object> annotation in propertyAnnotations)
+                                        {
+                                            if (annotation.Value != null)
+                                            {
+                                                // annotation.Value == null indicates that this annotation should be skipped.
+                                                property.InstanceAnnotations.Add(new ODataInstanceAnnotation(annotation.Key, annotation.Value.ToODataValue()));
+                                            }
+                                        }
+                                    }
+
+                                    properties.Add(property);
+                                }
+
+                                break;
+
+                            case PropertyParsingResult.EndOfObject:
+                                break;
+
+                            case PropertyParsingResult.MetadataReferenceProperty:
+                                throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty(propertyName));
+                        }
+                    }).ConfigureAwait(false);
+            }
+
+            Debug.Assert(this.JsonReader.NodeType == JsonNodeType.EndObject, "After all the properties of a resource value are read the EndObject node is expected.");
+            await this.JsonReader.ReadEndObjectAsync()
+                .ConfigureAwait(false);
+
+            resourceValue.Properties = new ReadOnlyEnumerable<ODataProperty>(properties);
+
+            this.DecreaseRecursionDepth();
+
+            return resourceValue;
+        }
+
+        /// <summary>
+        ///  Asynchronously reads a primitive, enum, resource (complex or entity) or collection value.
+        /// </summary>
+        ///  <param name="payloadTypeName">The type name read from the payload as a property annotation, or null if none is available.</param>
+        ///  <param name="expectedTypeReference">The expected type reference of the property value.</param>
+        ///  <param name="propertyAndAnnotationCollector">The duplicate property names checker to use - if null the method should create a new one if necessary.</param>
+        ///  <param name="collectionValidator">The collection validator instance if no expected item type has been specified; otherwise null.</param>
+        ///  <param name="validateNullValue">true to validate null values; otherwise false.</param>
+        ///  <param name="isTopLevelPropertyValue">true if we are reading a top-level property value; otherwise false.</param>
+        ///  <param name="insideResourceValue">true if we are reading a complex value and the reader is already positioned inside the complex value; otherwise false.</param>
+        ///  <param name="propertyName">The name of the property whose value is being read, if applicable (used for error reporting).</param>
+        ///  <param name="isDynamicProperty">Indicates whether the property is dynamic or unknown.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains the value of the property read, which can be one of:
+        /// 1). null
+        /// 2). Primitive value
+        /// 3). <see cref="ODataEnumValue"/>
+        /// 4). <see cref="ODataResourceValue"/>
+        /// 5). <see cref="ODataCollectionValue"/>
+        /// </returns>
+        ///  <remarks>
+        ///  Pre-Condition:  JsonNodeType.PrimitiveValue   - the value of the property is a primitive value
+        ///                  JsonNodeType.StartArray       - the value of the property is an array
+        ///  Post-Condition: almost anything - the node after the property value.
+        /// </remarks>
+        [SuppressMessage("Microsoft.Maintainability", "CA1502:AvoidExcessiveComplexity", Justification = "No easy way to refactor.")]
+        private async Task<object> ReadNonEntityValueImplementationAsync(
+            string payloadTypeName,
+            IEdmTypeReference expectedTypeReference,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            CollectionWithoutExpectedTypeValidator collectionValidator,
+            bool validateNullValue,
+            bool isTopLevelPropertyValue,
+            bool insideResourceValue,
+            string propertyName,
+            bool? isDynamicProperty = null)
+        {
+            Debug.Assert(
+                this.JsonReader.NodeType == JsonNodeType.PrimitiveValue
+                || this.JsonReader.NodeType == JsonNodeType.StartObject
+                || this.JsonReader.NodeType == JsonNodeType.StartArray
+                || (insideResourceValue && (this.JsonReader.NodeType == JsonNodeType.Property || this.JsonReader.NodeType == JsonNodeType.EndObject)),
+                "Pre-Condition: expected JsonNodeType.PrimitiveValue or JsonNodeType.StartObject or JsonNodeType.StartArray or JsonNodeTypeProperty (when inside complex value).");
+            Debug.Assert(
+                expectedTypeReference == null || collectionValidator == null,
+                "If an expected value type reference is specified, no collection validator must be provided.");
+
+            bool valueIsJsonObject = this.JsonReader.NodeType == JsonNodeType.StartObject;
+
+            bool typeNameFoundInPayload = false;
+            if (valueIsJsonObject || insideResourceValue)
+            {
+                // If we have an object value initialize the duplicate property names checker
+                if (propertyAndAnnotationCollector == null)
+                {
+                    propertyAndAnnotationCollector = this.CreatePropertyAndAnnotationCollector();
+                }
+                else
+                {
+                    propertyAndAnnotationCollector.Reset();
+                }
+
+                // Read the payload type name
+                if (!insideResourceValue)
+                {
+                    Tuple<bool, string> readPayloadTypeFromObjectResult = await this.TryReadPayloadTypeFromObjectAsync(
+                        propertyAndAnnotationCollector,
+                        insideResourceValue).ConfigureAwait(false);
+                    typeNameFoundInPayload = readPayloadTypeFromObjectResult.Item1;
+                    if (typeNameFoundInPayload)
+                    {
+                        payloadTypeName = readPayloadTypeFromObjectResult.Item2;
+                    }
+                }
+            }
+
+            expectedTypeReference = expectedTypeReference != null && expectedTypeReference.IsUntyped() ? null : expectedTypeReference;
+            ODataTypeAnnotation typeAnnotation;
+            EdmTypeKind targetTypeKind;
+            IEdmTypeReference targetTypeReference = this.ReaderValidator.ResolvePayloadTypeNameAndComputeTargetType(
+                expectedTypeKind: EdmTypeKind.None,
+                expectStructuredType: null,
+                defaultPrimitivePayloadType: null,
+                expectedTypeReference: expectedTypeReference,
+                payloadTypeName: payloadTypeName,
+                model: this.Model,
+                typeKindFromPayloadFunc: this.GetNonEntityValueKind,
+                targetTypeKind: out targetTypeKind,
+                typeAnnotation: out typeAnnotation);
+
+            object result;
+
+            if (targetTypeKind == EdmTypeKind.Untyped || targetTypeKind == EdmTypeKind.None)
+            {
+                targetTypeReference = ResolveUntypedType(
+                    this.JsonReader.NodeType,
+                    await this.JsonReader.GetValueAsync().ConfigureAwait(false),
+                    payloadTypeName,
+                    expectedTypeReference,
+                    this.MessageReaderSettings.PrimitiveTypeResolver,
+                    this.MessageReaderSettings.ReadUntypedAsString,
+                    !this.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata);
+
+                targetTypeKind = targetTypeReference.TypeKind();
+            }
+
+            // Try to read a null value
+            if (await ODataJsonReaderCoreUtils.TryReadNullValueAsync(
+                this.JsonReader,
+                this.JsonLightInputContext,
+                targetTypeReference,
+                validateNullValue,
+                propertyName,
+                isDynamicProperty).ConfigureAwait(false))
+            {
+                if (this.JsonLightInputContext.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata && validateNullValue && targetTypeReference != null && !targetTypeReference.IsNullable)
+                {
+                    // For dynamic collection property, we should allow null value to be assigned to it.
+                    if (targetTypeKind != EdmTypeKind.Collection || isDynamicProperty != true)
+                    {
+                        // A null value was found for the property named '{0}', which has the expected type '{1}[Nullable=False]'. The expected type '{1}[Nullable=False]' does not allow null values.
+                        throw new ODataException(ODataErrorStrings.ReaderValidationUtils_NullNamedValueForNonNullableType(propertyName, targetTypeReference.FullName()));
+                    }
+                }
+
+                result = null;
+            }
+            else
+            {
+                Debug.Assert(
+                    !valueIsJsonObject || this.JsonReader.NodeType == JsonNodeType.Property || this.JsonReader.NodeType == JsonNodeType.EndObject,
+                    "If the value was an object the reader must be on either property or end object.");
+                switch (targetTypeKind)
+                {
+                    case EdmTypeKind.Primitive:
+                        Debug.Assert(targetTypeReference == null || targetTypeReference.IsODataPrimitiveTypeKind(), "Expected an OData primitive type.");
+                        IEdmPrimitiveTypeReference primitiveTargetTypeReference = targetTypeReference == null ? null : targetTypeReference.AsPrimitive();
+
+                        // If we found an odata.type annotation inside a primitive value, we have to fail; type annotations
+                        // for primitive values are property annotations, not instance annotations inside the value.
+                        if (typeNameFoundInPayload)
+                        {
+                            throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ODataTypeAnnotationInPrimitiveValue(ODataAnnotationNames.ODataType));
+                        }
+
+                        result = await this.ReadPrimitiveValueAsync(
+                            valueIsJsonObject,
+                            primitiveTargetTypeReference,
+                            validateNullValue,
+                            propertyName).ConfigureAwait(false);
+                        break;
+
+                    case EdmTypeKind.Enum:
+                        Debug.Assert(targetTypeReference == null || targetTypeReference.IsODataEnumTypeKind(), "Expected an OData enum type.");
+                        IEdmEnumTypeReference enumTargetTypeReference = targetTypeReference == null ? null : targetTypeReference.AsEnum();
+                        result = await this.ReadEnumValueAsync(
+                            valueIsJsonObject,
+                            enumTargetTypeReference,
+                            validateNullValue,
+                            propertyName).ConfigureAwait(false);
+                        break;
+
+                    case EdmTypeKind.Complex: // nested complex
+                    case EdmTypeKind.Entity: // nested entity
+                        Debug.Assert(targetTypeReference == null || targetTypeReference.IsODataComplexTypeKind() || targetTypeReference.IsODataEntityTypeKind(), "Expected an OData complex or entity type.");
+                        IEdmStructuredTypeReference structuredTypeTypeReference = targetTypeReference == null ? null : targetTypeReference.AsStructured();
+                        result = await this.ReadResourceValueAsync(
+                            valueIsJsonObject,
+                            insideResourceValue,
+                            propertyName,
+                            structuredTypeTypeReference,
+                            payloadTypeName,
+                            propertyAndAnnotationCollector).ConfigureAwait(false);
+
+                        break;
+
+                    case EdmTypeKind.Collection:
+                        IEdmCollectionTypeReference collectionTypeReference = ValidationUtils.ValidateCollectionType(targetTypeReference);
+                        if (valueIsJsonObject)
+                        {
+                            // We manually throw JSON exception here to get a nicer error message
+                            // (we expect array value and got object).
+                            // Otherwise the ReadCollectionValue would fail with something like
+                            // "expected array value but found property/end object" which is rather confusing.
+                            throw new ODataException(
+                                ODataErrorStrings.JsonReaderExtensions_UnexpectedNodeDetectedWithPropertyName(
+                                    JsonNodeType.StartArray,
+                                    JsonNodeType.StartObject,
+                                    propertyName));
+                        }
+
+                        result = await this.ReadCollectionValueAsync(
+                            collectionTypeReference,
+                            payloadTypeName,
+                            typeAnnotation).ConfigureAwait(false);
+                        break;
+
+                    case EdmTypeKind.TypeDefinition:
+                        result = await this.ReadTypeDefinitionValueAsync(
+                            valueIsJsonObject,
+                            expectedTypeReference.AsTypeDefinition(),
+                            validateNullValue,
+                            propertyName).ConfigureAwait(false);
+                        break;
+
+                    case EdmTypeKind.Untyped:
+                        result = await this.JsonReader.ReadAsUntypedOrNullValueAsync()
+                            .ConfigureAwait(false);
+                        break;
+
+                    default:
+                        throw new ODataException(ODataErrorStrings.General_InternalError(InternalErrorCodes.ODataJsonLightPropertyAndValueDeserializer_ReadPropertyValue));
+                }
+
+                // If we have no expected type make sure the collection items are of the same kind and specify the same name.
+                if (collectionValidator != null && targetTypeKind != EdmTypeKind.None)
+                {
+                    string payloadTypeNameFromResult = ODataJsonLightReaderUtils.GetPayloadTypeName(result);
+                    Debug.Assert(expectedTypeReference == null, "If a collection validator is specified there must not be an expected value type reference.");
+                    collectionValidator.ValidateCollectionItem(payloadTypeNameFromResult, targetTypeKind);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Asynchronously reads the payload type name from a JSON object (if it exists).
+        /// </summary>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker to track the detected 'odata.type' annotation (if any).</param>
+        /// <param name="insideResourceValue">true if we are reading a resource value and the reader is already positioned inside the resource value; otherwise false.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains a tuple comprising of:
+        /// 1). true if a type name was read from the payload; otherwise false.
+        /// 2). The value of the odata.type annotation or null if no such annotation exists.
+        /// </returns>
+        /// <remarks>
+        /// Precondition:   StartObject     the start of a JSON object
+        /// Postcondition:  Property        the first property of the object if no 'odata.type' annotation exists as first property
+        ///                                 or the first property after the 'odata.type' annotation.
+        ///                 EndObject       for an empty JSON object or an object with only the 'odata.type' annotation
+        /// </remarks>
+        private async Task<Tuple<bool, string>> TryReadPayloadTypeFromObjectAsync(
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            bool insideResourceValue)
+        {
+            Debug.Assert(propertyAndAnnotationCollector != null, "propertyAndAnnotationCollector != null");
+            Debug.Assert(
+                (this.JsonReader.NodeType == JsonNodeType.StartObject && !insideResourceValue) ||
+                ((this.JsonReader.NodeType == JsonNodeType.Property || this.JsonReader.NodeType == JsonNodeType.EndObject) && insideResourceValue),
+                "Pre-Condition: JsonNodeType.StartObject when not inside complex value; JsonNodeType.Property or JsonNodeType.EndObject otherwise.");
+            bool readTypeName = false;
+            string payloadTypeName = null;
+
+            // If not already positioned inside the JSON object, read over the object start
+            if (!insideResourceValue)
+            {
+                await this.JsonReader.ReadStartObjectAsync()
+                    .ConfigureAwait(false);
+            }
+
+            if (this.JsonReader.NodeType == JsonNodeType.Property)
+            {
+                Tuple<bool, string> readODataTypeAnnotationResult = await this.TryReadODataTypeAnnotationAsync()
+                    .ConfigureAwait(false);
+                readTypeName = readODataTypeAnnotationResult.Item1;
+                if (readTypeName)
+                {
+                    payloadTypeName = readODataTypeAnnotationResult.Item2;
+                    // Register the odata.type annotation we just found with the duplicate property names checker.
+                    propertyAndAnnotationCollector.MarkPropertyAsProcessed(ODataAnnotationNames.ODataType);
+                }
+            }
+
+            this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);
+
+            return Tuple.Create(readTypeName, payloadTypeName);
+        }
+
+        /// <summary>
+        /// Asynchronously detects whether we are currently reading a resource property or not.
+        /// This can be determined from metadata (if we have it)
+        /// or from the presence of the odata.type instance annotation in the payload.
+        /// </summary>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker in use for the resource content.</param>
+        /// <param name="expectedPropertyTypeReference">The expected type reference of the property to read.</param>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains a tuple comprising of:
+        /// 1). true if we are reading a resource property; otherwise false.
+        /// 2). The type name of the resource value if found in the payload; otherwise null.
+        /// </returns>
+        /// <remarks>
+        /// This method does not move the reader.
+        /// </remarks>
+        private async Task<Tuple<bool, string>> ReadingResourcePropertyAsync(
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector,
+            IEdmTypeReference expectedPropertyTypeReference)
+        {
+            string payloadTypeName = null;
+            bool readingResourceProperty = false;
+
+            // First try to use the metadata if is available
+            if (expectedPropertyTypeReference != null)
+            {
+                readingResourceProperty = expectedPropertyTypeReference.IsStructured();
+            }
+
+            // Then check whether the first property in the JSON object is the 'odata.type'
+            // annotation; if we don't have an expected property type reference, the 'odata.type'
+            // annotation has to exist for resource properties. (This can happen for top-level open
+            // properties).
+            if (this.JsonReader.NodeType == JsonNodeType.Property)
+            {
+                Tuple<bool, string> readODataTypeAnnotationResult = await this.TryReadODataTypeAnnotationAsync()
+                    .ConfigureAwait(false);
+                if (readODataTypeAnnotationResult.Item1)
+                {
+                    payloadTypeName = readODataTypeAnnotationResult.Item2;
+                    // Register the odata.type annotation we just found with the duplicate property names checker.
+                    propertyAndAnnotationCollector.MarkPropertyAsProcessed(ODataAnnotationNames.ODataType);
+
+                    IEdmType expectedPropertyType = null;
+                    if (expectedPropertyTypeReference != null)
+                    {
+                        expectedPropertyType = expectedPropertyTypeReference.Definition;
+                    }
+
+                    IEdmType actualWirePropertyTypeReference = MetadataUtils.ResolveTypeNameForRead(
+                        this.Model,
+                        expectedPropertyType,
+                        payloadTypeName,
+                        this.MessageReaderSettings.ClientCustomTypeResolver,
+                        out _);
+
+                    if (actualWirePropertyTypeReference != null)
+                    {
+                        readingResourceProperty = actualWirePropertyTypeReference.IsODataComplexTypeKind() || actualWirePropertyTypeReference.IsODataEntityTypeKind();
+                    }
+                }
+            }
+
+            return Tuple.Create(readingResourceProperty, payloadTypeName);
+        }
+
+        /// <summary>
+        /// Asynchronously tries to read a top-level null value from the JSON reader.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains true
+        /// if a null value could be read from the JSON reader; otherwise false.
+        /// </returns>
+        /// <remarks>If the method detects the odata.null annotation, it will read it; otherwise the reader does not move.</remarks>
+        private async Task<bool> IsTopLevel6xNullValueAsync()
+        {
+            bool odataNullAnnotationInPayload = this.JsonReader.NodeType == JsonNodeType.Property
+                && string.Equals(
+                    JsonLightConstants.PrefixedODataNullPropertyName,
+                    await this.JsonReader.GetPropertyNameAsync().ConfigureAwait(false), StringComparison.Ordinal);
+
+            if (odataNullAnnotationInPayload)
+            {
+                // If we found the expected annotation read over the property name
+                await this.JsonReader.ReadNextAsync()
+                    .ConfigureAwait(false);
+
+                // Now check the value of the annotation
+                object nullAnnotationValue = await this.JsonReader.ReadPrimitiveValueAsync()
+                    .ConfigureAwait(false);
+                if (!(nullAnnotationValue is bool) || (bool)nullAnnotationValue == false)
+                {
+                    throw new ODataException(
+                        ODataErrorStrings.ODataJsonLightReaderUtils_InvalidValueForODataNullAnnotation(
+                            ODataAnnotationNames.ODataNull,
+                            JsonLightConstants.ODataNullAnnotationTrueValue));
+                }
+            }
+
+            return odataNullAnnotationInPayload;
+        }
+
+        /// <summary>
+        /// Asynchronously make sure that we don't find any other odata.* annotations or properties after reading a payload with the odata.null annotation.
+        /// </summary>
+        /// <param name="propertyAndAnnotationCollector">The duplicate property names checker to use.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        private async Task ValidateNoPropertyInNullPayloadAsync(PropertyAndAnnotationCollector propertyAndAnnotationCollector)
+        {
+            Debug.Assert(propertyAndAnnotationCollector != null, "propertyAndAnnotationCollector != null");
+
+            // We use the ParsePropertyAsync method to ignore custom annotations.
+            Func<string, Task<object>> readTopLevelPropertyAnnotationValueDelegate =
+                (annotationName) =>
+                {
+                    throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedODataPropertyAnnotation(annotationName));
+                };
+
+            while (this.JsonReader.NodeType == JsonNodeType.Property)
+            {
+                await this.ProcessPropertyAsync(
+                    propertyAndAnnotationCollector,
+                    readTopLevelPropertyAnnotationValueDelegate,
+                    async (propertyParsingResult, propertyName) =>
+                    {
+                        if (this.JsonReader.NodeType == JsonNodeType.Property)
+                        {
+                            // Read over property name
+                            await this.JsonReader.ReadAsync()
+                                .ConfigureAwait(false);
+                        }
+
+                        switch (propertyParsingResult)
+                        {
+                            case PropertyParsingResult.ODataInstanceAnnotation:
+                                throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedAnnotationProperties(propertyName));
+
+                            case PropertyParsingResult.CustomInstanceAnnotation:
+                                await this.JsonReader.SkipValueAsync()
+                                    .ConfigureAwait(false);
+                                break;
+
+                            case PropertyParsingResult.PropertyWithoutValue:
+                                throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_TopLevelPropertyAnnotationWithoutProperty(propertyName));
+
+                            case PropertyParsingResult.PropertyWithValue:
+                                throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_NoPropertyAndAnnotationAllowedInNullPayload(propertyName));
+
+                            case PropertyParsingResult.EndOfObject:
+                                break;
+
+                            case PropertyParsingResult.MetadataReferenceProperty:
+                                throw new ODataException(ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty(propertyName));
+                        }
+                    }).ConfigureAwait(false);
             }
         }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -1886,7 +1886,7 @@ namespace Microsoft.OData.JsonLight
             ODataDeletedResource deletedResource = null;
             if (this.ReadingDelta && (resourceKind == ODataDeltaKind.Resource || resourceKind == ODataDeltaKind.DeletedEntry))
             {
-                deletedResource = this.jsonLightResourceDeserializer.IsDeletedResource();
+                deletedResource = this.jsonLightResourceDeserializer.ReadDeletedResource();
                 if (deletedResource != null)
                 {
                     resourceKind = ODataDeltaKind.DeletedEntry;

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -472,6 +472,7 @@ namespace Microsoft.OData
         internal const string ODataJsonLightPropertyAndValueDeserializer_NoPropertyAndAnnotationAllowedInNullPayload = "ODataJsonLightPropertyAndValueDeserializer_NoPropertyAndAnnotationAllowedInNullPayload";
         internal const string ODataJsonLightPropertyAndValueDeserializer_CollectionTypeNotExpected = "ODataJsonLightPropertyAndValueDeserializer_CollectionTypeNotExpected";
         internal const string ODataJsonLightPropertyAndValueDeserializer_CollectionTypeExpected = "ODataJsonLightPropertyAndValueDeserializer_CollectionTypeExpected";
+        internal const string ODataJsonLightPropertyAndValueDeserializer_ODataResourceExpectedForProperty = "ODataJsonLightPropertyAndValueDeserializer_ODataResourceExpectedForProperty";
         internal const string ODataJsonReaderCoreUtils_CannotReadSpatialPropertyValue = "ODataJsonReaderCoreUtils_CannotReadSpatialPropertyValue";
         internal const string ODataJsonLightReader_UnexpectedPrimitiveValueForODataResource = "ODataJsonLightReader_UnexpectedPrimitiveValueForODataResource";
         internal const string ODataJsonLightReaderUtils_AnnotationWithNullValue = "ODataJsonLightReaderUtils_AnnotationWithNullValue";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -535,6 +535,7 @@ ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty=E
 ODataJsonLightPropertyAndValueDeserializer_NoPropertyAndAnnotationAllowedInNullPayload=The property with name '{0}' was found in a null payload. In OData, no properties or OData annotations can appear in a null payload.
 ODataJsonLightPropertyAndValueDeserializer_CollectionTypeNotExpected=A collection type of '{0}' was specified for a non-collection value.
 ODataJsonLightPropertyAndValueDeserializer_CollectionTypeExpected=A non-collection type of '{0}' was specified for a collection value.
+ODataJsonLightPropertyAndValueDeserializer_ODataResourceExpectedForProperty=The property with name '{0}' was found with a value node of type '{1}'; however, a resource value of type '{2}' was expected.
 
 ODataJsonReaderCoreUtils_CannotReadSpatialPropertyValue=The value specified for the spatial property was not valid. You must specify a valid spatial value.
 

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -4132,6 +4132,14 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The property with name '{0}' was found with a value node of type '{1}'; however, a resource value of type '{2}' was expected."
+        /// </summary>
+        internal static string ODataJsonLightPropertyAndValueDeserializer_ODataResourceExpectedForProperty(object p0, object p1, object p2)
+        {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataJsonLightPropertyAndValueDeserializer_ODataResourceExpectedForProperty, p0, p1, p2);
+        }
+
+        /// <summary>
         /// A string like "The value specified for the spatial property was not valid. You must specify a valid spatial value."
         /// </summary>
         internal static string ODataJsonReaderCoreUtils_CannotReadSpatialPropertyValue

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeserializerTests.cs
@@ -8,11 +8,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.OData.Edm;
 using Microsoft.OData.Json;
 using Microsoft.OData.JsonLight;
-using Microsoft.OData.Edm;
+using Microsoft.Spatial;
 using Xunit;
 using ErrorStrings = Microsoft.OData.Strings;
+using PropertyParsingResult = Microsoft.OData.JsonLight.ODataJsonLightDeserializer.PropertyParsingResult;
 
 namespace Microsoft.OData.Tests.JsonLight
 {
@@ -30,7 +33,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingNormalPropertyShouldReturnItsName()
         {
-            this.RunPropertyParsingTest("{\"property\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithValue, "property",
+            this.RunPropertyParsingTest("{\"property\":42}", PropertyParsingResult.PropertyWithValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -42,7 +45,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             // test reading Char.Max \uffff.
             // TODO: json reader don't support reading Char.Min \0 yet.
-            this.RunPropertyParsingTest("{\"property\":\"N\\uffff\"}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithValue, "property",
+            this.RunPropertyParsingTest("{\"property\":\"N\\uffff\"}", PropertyParsingResult.PropertyWithValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, "N\uffff");
@@ -53,7 +56,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingCustomPropertyAnnotationShouldBeIgnored()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "custom.type") + "\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "custom.type") + "\":42}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.EndObject, null);
@@ -64,7 +67,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataPropertyAnnotationWithNothingAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\"}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.EndObject, null);
@@ -77,7 +80,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataPropertyAnnotationWithItsProperty()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"property\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"property\":42}", PropertyParsingResult.PropertyWithValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -90,7 +93,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataPropertyAnnotationWithDifferentPropertyAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"otherproperty\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"otherproperty\":42}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.Property, "otherproperty");
@@ -103,7 +106,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataPropertyAnnotationWithInsanceAnnotationAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.Property, JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType);
@@ -116,7 +119,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataPropertyAnnotationWithDifferentPropertyAnnotationAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"" + JsonLightUtils.GetPropertyAnnotationName("otherproperty", ODataAnnotationNames.ODataType) + "\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"" + JsonLightUtils.GetPropertyAnnotationName("otherproperty", ODataAnnotationNames.ODataType) + "\":42}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.Property, JsonLightUtils.GetPropertyAnnotationName("otherproperty", ODataAnnotationNames.ODataType));
@@ -129,7 +132,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingCustomPropertyAnnotationWithItsPropertyAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "foo.bar") + "\":\"foo\",\"property\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "foo.bar") + "\":\"foo\",\"property\":42}", PropertyParsingResult.PropertyWithValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -141,7 +144,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingCustomPropertyAnnotationWithDifferentPropertyAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "foo.bar") + "\":\"foo\",\"otherproperty\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "foo.bar") + "\":\"foo\",\"otherproperty\":42}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.Property, "otherproperty");
@@ -153,7 +156,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingCustomPropertyAnnotationWithInsanceAnnotationAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "foo.bar") + "\":\"foo\",\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "foo.bar") + "\":\"foo\",\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.Property, JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType);
@@ -165,7 +168,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingCustomPropertyAnnotationWithDifferentPropertyAnnotationAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "foo.bar") + "\":\"foo\",\"" + JsonLightUtils.GetPropertyAnnotationName("otherproperty", ODataAnnotationNames.ODataType) + "\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "foo.bar") + "\":\"foo\",\"" + JsonLightUtils.GetPropertyAnnotationName("otherproperty", ODataAnnotationNames.ODataType) + "\":42}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.Property, JsonLightUtils.GetPropertyAnnotationName("otherproperty", ODataAnnotationNames.ODataType));
@@ -177,7 +180,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataPropertyAnnotationWithMetadataReferencePropertyAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"#namespace.name\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"#namespace.name\":42}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.Property, "#namespace.name");
@@ -190,7 +193,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingCustomPropertyAnnotationWithMetadataReferencePropertyAfterIt()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "custom.annotation") + "\":\"foo\",\"#namespace.name\":42}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property",
+            this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "custom.annotation") + "\":\"foo\",\"#namespace.name\":42}", PropertyParsingResult.PropertyWithoutValue, "property",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.Property, "#namespace.name");
@@ -202,7 +205,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingDuplicateODataPropertyAnnotationShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename2\"}", ODataJsonLightDeserializer.PropertyParsingResult.EndOfObject, null,
+            Action action = () => this.RunPropertyParsingTest("{\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename\",\"" + JsonLightUtils.GetPropertyAnnotationName("property", ODataAnnotationNames.ODataType) + "\":\"typename2\"}", PropertyParsingResult.EndOfObject, null,
                 null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.DuplicateAnnotationForPropertyNotAllowed(ODataAnnotationNames.ODataType, "property"));
         }
@@ -212,7 +215,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             Action action = () => this.RunPropertyParsingTest(
                 "{\"" + JsonLightUtils.GetPropertyAnnotationName("property", "custom.type") + "\":\"typename\",\"" + JsonLightUtils.GetPropertyAnnotationName("property", "custom.type") + "\":\"typename2\"}",
-                ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "property", null, this.ReadODataTypePropertyAnnotation);
+                PropertyParsingResult.PropertyWithoutValue, "property", null, this.ReadODataTypePropertyAnnotation);
             action.DoesNotThrow();
         }
 
@@ -221,7 +224,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataInstanceAnnotationShouldReturnItsName()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
+            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42}", PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -232,7 +235,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingCustomInstanceAnnotationShouldReturnItsName()
         {
             this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("custom.*");
-            this.RunPropertyParsingTest("{\"@custom.type\":42}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
+            this.RunPropertyParsingTest("{\"@custom.type\":42}", PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -242,7 +245,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataInstanceAnnotationWithDifferentPropertyAfterItShouldReturnItsName()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42,\"foo\":42}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
+            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42,\"foo\":42}", PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -253,7 +256,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingCustomInstanceAnnotationWithDifferentPropertyAfterItShouldReturnItsName()
         {
             this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("custom.type");
-            this.RunPropertyParsingTest("{\"@custom.type\":42,\"foo\":42}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
+            this.RunPropertyParsingTest("{\"@custom.type\":42,\"foo\":42}", PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -263,7 +266,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataInstanceAnnotationWithDifferentPropertyAnnotationAfterItShouldReturnItsName()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42,\"foo@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
+            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42,\"foo@odata.type\":\"#typename\"}", PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -274,7 +277,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingCustomInstanceAnnotationWithDifferentPropertyAnnotationAfterItShouldReturnItsName()
         {
             this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
-            this.RunPropertyParsingTest("{\"@custom.type\":42,\"foo@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
+            this.RunPropertyParsingTest("{\"@custom.type\":42,\"foo@odata.type\":\"#typename\"}", PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -284,7 +287,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingCustomInstanceAnnotationBeforePropertyAnnotationWithoutOverridingDefaultAnnotationFilterShouldSkipCustomInstanceAnnotation()
         {
-            this.RunPropertyParsingTest("{\"@custom.type\":42,\"foo@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "foo",
+            this.RunPropertyParsingTest("{\"@custom.type\":42,\"foo@odata.type\":\"#typename\"}", PropertyParsingResult.PropertyWithoutValue, "foo",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.EndObject, null);
@@ -294,7 +297,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataInstanceAnnotationWithDifferentInstanceAnnotationAfterItShouldReturnItsName()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42,\"@custom.instance\":42}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
+            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42,\"@custom.instance\":42}", PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -305,7 +308,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingCustomInstanceAnnotationWithDifferentInstanceAnnotationAfterItShouldReturnItsName()
         {
             this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
-            this.RunPropertyParsingTest("{\"@custom.type\":42,\"@odata.unknown\":42}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
+            this.RunPropertyParsingTest("{\"@custom.type\":42,\"@odata.unknown\":42}", PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -315,7 +318,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingCustomInstanceAnnotationWithUnknownODataAnnotationAfterItShouldSkipBothAnotationsForExcludeFilter()
         {
-            this.RunPropertyParsingTest("{\"@custom.type\":42,\"@odata.unknown\":42}", ODataJsonLightDeserializer.PropertyParsingResult.EndOfObject, null,
+            this.RunPropertyParsingTest("{\"@custom.type\":42,\"@odata.unknown\":42}", PropertyParsingResult.EndOfObject, null,
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.EndObject, null);
@@ -325,7 +328,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataInstanceAnnotationWithDifferentAnnotationTargetingAnnotationAfterItShouldReturnItsName()
         {
-            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42,\"custom.instance@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
+            this.RunPropertyParsingTest("{\"" + JsonLightConstants.ODataPropertyAnnotationSeparatorChar + ODataAnnotationNames.ODataType + "\":42,\"custom.instance@odata.type\":\"#typename\"}", PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType,
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -336,7 +339,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingCustomInstanceAnnotationWithDifferentAnnotationTargetingAnnotationAfterItShouldReturnItsName()
         {
             this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
-            this.RunPropertyParsingTest("{\"@custom.type\":42,\"odata.unknown@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
+            this.RunPropertyParsingTest("{\"@custom.type\":42,\"odata.unknown@odata.type\":\"#typename\"}", PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -346,21 +349,21 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataTypeWithoutTheTargetingInstanceAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"odata.deltaLink@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "odata.deltaLink", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"odata.deltaLink@odata.type\":\"#typename\"}", PropertyParsingResult.PropertyWithoutValue, "odata.deltaLink", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "odata.deltaLink"));
         }
 
         [Fact]
         public void ParsingODataTypeWithoutTheTargetingCustomInstanceAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\"}", PropertyParsingResult.PropertyWithoutValue, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "custom.instance"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingODataInstanceAnnotationAfterItShouldReturnItsName()
         {
-            this.RunPropertyParsingTest("{\"odata.deltaLink@odata.type\":\"#typename\", \"@odata.deltaLink\":42}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, "odata.deltaLink",
+            this.RunPropertyParsingTest("{\"odata.deltaLink@odata.type\":\"#typename\", \"@odata.deltaLink\":42}", PropertyParsingResult.ODataInstanceAnnotation, "odata.deltaLink",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -374,7 +377,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingODataTypeTargetingCustomInstanceAnnotationAfterItShouldReturnItsName()
         {
             this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("custom.*");
-            this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"@custom.instance\":42}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.instance",
+            this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"@custom.instance\":42}", PropertyParsingResult.CustomInstanceAnnotation, "custom.instance",
                 (jsonReader, duplicateChecker) =>
                 {
                     jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -387,7 +390,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingWithoutOverridingDefaultAnnotationFilterShouldSkipOverAllCustomAnnotations()
         {
-            this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"@custom.instance\":42}", ODataJsonLightDeserializer.PropertyParsingResult.EndOfObject, null,
+            this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"@custom.instance\":42}", PropertyParsingResult.EndOfObject, null,
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.EndObject, null),
                 this.ReadODataTypePropertyAnnotation);
         }
@@ -395,98 +398,98 @@ namespace Microsoft.OData.Tests.JsonLight
         [Fact]
         public void ParsingODataAnnotationTargetingODataInstanceAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"odata.deltaLink@odata.unknown\":42,\"@odata.deltaLink\":42}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, "odata.deltaLink");
+            Action action = () => this.RunPropertyParsingTest("{\"odata.deltaLink@odata.unknown\":42,\"@odata.deltaLink\":42}", PropertyParsingResult.ODataInstanceAnnotation, "odata.deltaLink");
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_OnlyODataTypeAnnotationCanTargetInstanceAnnotation("odata.unknown", "odata.deltaLink", "odata.type"));
         }
 
         [Fact]
         public void ParsingCustomAnnotationTargetingODataInstanceAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"odata.deltaLink@custom.annotation\":42,\"@odata.deltaLink\":42}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, "odata.deltaLink");
+            Action action = () => this.RunPropertyParsingTest("{\"odata.deltaLink@custom.annotation\":42,\"@odata.deltaLink\":42}", PropertyParsingResult.ODataInstanceAnnotation, "odata.deltaLink");
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_OnlyODataTypeAnnotationCanTargetInstanceAnnotation("custom.annotation", "odata.deltaLink", "odata.type"));
         }
 
         [Fact]
         public void ParsingODataAnnotationTargetingCustomInstanceAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.unknown\":42,\"@custom.instance\":42}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.instance");
+            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.unknown\":42,\"@custom.instance\":42}", PropertyParsingResult.CustomInstanceAnnotation, "custom.instance");
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_OnlyODataTypeAnnotationCanTargetInstanceAnnotation("odata.unknown", "custom.instance", "odata.type"));
         }
 
         [Fact]
         public void ParsingCustomAnnotationTargetingCustomInstanceAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@custom.annotation\":42,\"@custom.instance\":42}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.instance");
+            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@custom.annotation\":42,\"@custom.instance\":42}", PropertyParsingResult.CustomInstanceAnnotation, "custom.instance");
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_OnlyODataTypeAnnotationCanTargetInstanceAnnotation("custom.annotation", "custom.instance", "odata.type"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingODataInstanceAnnotationWithDifferentPropertyAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"odata.deltaLink@odata.type\":\"#typename\",\"foo\":42}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType, null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"odata.deltaLink@odata.type\":\"#typename\",\"foo\":42}", PropertyParsingResult.ODataInstanceAnnotation, ODataAnnotationNames.ODataType, null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "odata.deltaLink"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingCustomInstanceAnnotationWithDifferentPropertyAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"foo\":42}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"foo\":42}", PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "custom.instance"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingODataInstanceAnnotationWithDifferentPropertyAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"odata.unknown@odata.type\":\"#typename\",\"foo@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, "odata.unknown", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"odata.unknown@odata.type\":\"#typename\",\"foo@odata.type\":\"#typename\"}", PropertyParsingResult.ODataInstanceAnnotation, "odata.unknown", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "odata.unknown"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingCustomInstanceAnnotationWithDifferentPropertyAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"foo@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"foo@odata.type\":\"#typename\"}", PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "custom.instance"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingODataInstanceAnnotationWithDifferentInstanceAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"odata.unknown@odata.type\":\"#typename\",\"@custom.instance\":42}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, "odata.unknown", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"odata.unknown@odata.type\":\"#typename\",\"@custom.instance\":42}", PropertyParsingResult.ODataInstanceAnnotation, "odata.unknown", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "odata.unknown"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingCustomInstanceAnnotationWithDifferentInstanceAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"@odata.unknown\":42}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"@odata.unknown\":42}", PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "custom.instance"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingODataInstanceAnnotationWithDifferentAnnotationTargetingAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"odata.unknown@odata.type\":\"#typename\",\"custom.instance@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, "odata.unknown", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"odata.unknown@odata.type\":\"#typename\",\"custom.instance@odata.type\":\"#typename\"}", PropertyParsingResult.ODataInstanceAnnotation, "odata.unknown", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "odata.unknown"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingCustomInstanceAnnotationWithDifferentAnnotationTargetingAnnotationAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"odata.unknown@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"odata.unknown@odata.type\":\"#typename\"}", PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "custom.instance"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingODataInstanceAnnotationWithMetadataReferencePropertyAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"odata.unknown@odata.type\":\"#typename\",\"@namespace.name\":42}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, "odata.unknown", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"odata.unknown@odata.type\":\"#typename\",\"@namespace.name\":42}", PropertyParsingResult.ODataInstanceAnnotation, "odata.unknown", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "odata.unknown"));
         }
 
         [Fact]
         public void ParsingODataTypeTargetingCustomInstanceAnnotationWithMetadataReferencePropertyAfterItShouldFail()
         {
-            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"@namespace.name\":42}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
+            Action action = () => this.RunPropertyParsingTest("{\"custom.instance@odata.type\":\"#typename\",\"@namespace.name\":42}", PropertyParsingResult.CustomInstanceAnnotation, "custom.instance", null, this.ReadODataTypePropertyAnnotation);
             action.Throws<ODataException>(ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", "custom.instance"));
         }
 
@@ -494,7 +497,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingDuplicateODataInstanceAnnotationShouldFail()
         {
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
-            Action action = () => this.RunPropertyParsingTest("{\"@odata.deltaLink\":\"url\",\"@odata.deltaLink\":\"url\"}", ODataJsonLightDeserializer.PropertyParsingResult.ODataInstanceAnnotation, "odata.deltaLink",
+            Action action = () => this.RunPropertyParsingTest("{\"@odata.deltaLink\":\"url\",\"@odata.deltaLink\":\"url\"}", PropertyParsingResult.ODataInstanceAnnotation, "odata.deltaLink",
                 null, this.ReadODataTypePropertyAnnotation, propertyAndAnnotationCollector);
             action();
             action.Throws<ODataException>(ErrorStrings.DuplicateAnnotationNotAllowed("odata.deltaLink"));
@@ -504,7 +507,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingDuplicateCustomInstanceAnnotationShouldNotFail1()
         {
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
-            Action action = () => this.RunPropertyParsingTest("{\"@custom.type\":\"typename\",\"@custom.type\":\"typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.EndOfObject,
+            Action action = () => this.RunPropertyParsingTest("{\"@custom.type\":\"typename\",\"@custom.type\":\"typename\"}", PropertyParsingResult.EndOfObject,
                 null, null, this.ReadODataTypePropertyAnnotation, propertyAndAnnotationCollector);
             action.DoesNotThrow();
         }
@@ -514,7 +517,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
-            Action action = () => this.RunPropertyParsingTest("{\"@custom.type\":\"typename\",\"@custom.type\":\"typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
+            Action action = () => this.RunPropertyParsingTest("{\"@custom.type\":\"typename\",\"@custom.type\":\"typename\"}", PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
                 null, this.ReadODataTypePropertyAnnotation, propertyAndAnnotationCollector);
             action();
             action.DoesNotThrow();
@@ -524,7 +527,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingDuplicateODataTypeAnnotationTargetingODataInstanceAnnotationShouldFail()
         {
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
-            Action action = () => this.RunPropertyParsingTest("{\"odata.annotation@odata.type\":\"#typename\",\"odata.annotation@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
+            Action action = () => this.RunPropertyParsingTest("{\"odata.annotation@odata.type\":\"#typename\",\"odata.annotation@odata.type\":\"#typename\"}", PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
                 null, this.ReadODataTypePropertyAnnotation, propertyAndAnnotationCollector);
             action.Throws<ODataException>(ErrorStrings.DuplicateAnnotationForInstanceAnnotationNotAllowed("odata.type", "odata.annotation"));
         }
@@ -533,7 +536,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void ParsingDuplicateODataTypeAnnotationTargetingCustomInstanceAnnotationShouldFail()
         {
             var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
-            Action action = () => this.RunPropertyParsingTest("{\"custom.annotation@odata.type\":\"#typename\",\"custom.annotation@odata.type\":\"#typename\"}", ODataJsonLightDeserializer.PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
+            Action action = () => this.RunPropertyParsingTest("{\"custom.annotation@odata.type\":\"#typename\",\"custom.annotation@odata.type\":\"#typename\"}", PropertyParsingResult.CustomInstanceAnnotation, "custom.type",
                 null, this.ReadODataTypePropertyAnnotation, propertyAndAnnotationCollector);
             action.Throws<ODataException>(ErrorStrings.DuplicateAnnotationForInstanceAnnotationNotAllowed("odata.type", "custom.annotation"));
         }
@@ -546,7 +549,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.RunPropertyParsingTest(
                 "{\"#myproperty\":42}",
-                ODataJsonLightDeserializer.PropertyParsingResult.MetadataReferenceProperty,
+                PropertyParsingResult.MetadataReferenceProperty,
                 "#myproperty",
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42));
         }
@@ -556,7 +559,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.RunPropertyParsingTest(
                 "{\"http://odata.org/$metadata#myaction\":42}",
-                ODataJsonLightDeserializer.PropertyParsingResult.MetadataReferenceProperty,
+                PropertyParsingResult.MetadataReferenceProperty,
                 "http://odata.org/$metadata#myaction",
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42));
         }
@@ -566,7 +569,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.RunPropertyParsingTest(
                 "{\"%23action\":42}",
-                ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithValue,
+                PropertyParsingResult.PropertyWithValue,
                 "%23action",
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42));
         }
@@ -588,7 +591,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.RunPropertyParsingTest(
                 "{\"#CaratIs^InvalidPerUriSpec\":42}",
-                ODataJsonLightDeserializer.PropertyParsingResult.MetadataReferenceProperty,
+                PropertyParsingResult.MetadataReferenceProperty,
                 "#CaratIs^InvalidPerUriSpec",
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42));
         }
@@ -598,7 +601,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.RunPropertyParsingTest(
                 "{\"#TwoHashes#Allowed\":42}",
-                ODataJsonLightDeserializer.PropertyParsingResult.MetadataReferenceProperty,
+                PropertyParsingResult.MetadataReferenceProperty,
                 "#TwoHashes#Allowed",
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42));
         }
@@ -608,13 +611,13 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.RunPropertyParsingTest(
                 "{\"@odata.unknown\":42}",
-                ODataJsonLightDeserializer.PropertyParsingResult.EndOfObject,
+                PropertyParsingResult.EndOfObject,
                 null,
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.EndObject, null));
 
             this.RunPropertyParsingTest(
                 "{\"@odata.unknown1\":42,\"@odata.unknown2\":42,\"@odata.unknown3\":42}",
-                ODataJsonLightDeserializer.PropertyParsingResult.EndOfObject,
+                PropertyParsingResult.EndOfObject,
                 null,
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.EndObject, null));
         }
@@ -624,7 +627,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.RunPropertyParsingTest(
                 "{\"NavProp@odata.navigationLink\":\"http://someUrl\",\"@odata.unknown\":42,\"NavProp@odata.associationLink\":\"http://someUrl\"}",
-                ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue,
+                PropertyParsingResult.PropertyWithoutValue,
                 "NavProp",
                 (jsonReader, duplicateChecker) =>
                 {
@@ -645,13 +648,13 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.RunPropertyParsingTest(
                 "{\"property@odata.unknown\":42}",
-                ODataJsonLightDeserializer.PropertyParsingResult.EndOfObject,
+                PropertyParsingResult.EndOfObject,
                 null,
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.EndObject, null));
 
             this.RunPropertyParsingTest(
                 "{\"property@odata.unknown1\":42,\"property@odata.unknown2\":42,\"property@odata.unknown3\":42}",
-                ODataJsonLightDeserializer.PropertyParsingResult.EndOfObject,
+                PropertyParsingResult.EndOfObject,
                 null,
                 (jsonReader, duplicateChecker) => jsonReader.ShouldBeOn(JsonNodeType.EndObject, null));
         }
@@ -661,7 +664,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             this.RunPropertyParsingTest(
                 "{\"NavProp@odata.navigationLink\":\"http://someUrl\",\"NavProp@odata.unknown\":42,\"NavProp@odata.associationLink\":\"http://someUrl\"}",
-                ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue,
+                PropertyParsingResult.PropertyWithoutValue,
                 "NavProp",
                 (jsonReader, duplicateChecker) =>
                 {
@@ -715,7 +718,7 @@ namespace Microsoft.OData.Tests.JsonLight
                             deserializer.JsonReader.Read();
                         }
 
-                        Assert.Equal(ODataJsonLightDeserializer.PropertyParsingResult.MetadataReferenceProperty, propertyParsingResult);
+                        Assert.Equal(PropertyParsingResult.MetadataReferenceProperty, propertyParsingResult);
                         Assert.Equal("#action", propertyName);
 
                         deserializer.JsonReader.ShouldBeOn(JsonNodeType.PrimitiveValue, 42);
@@ -748,14 +751,6 @@ namespace Microsoft.OData.Tests.JsonLight
                 var exception = Assert.Throws<ODataException>(readEntryContentAction);
                 Assert.Equal(ErrorStrings.ValidationUtils_InvalidMetadataReferenceProperty(propertyName), exception.Message);
             }
-        }
-
-        private static void AdvanceReaderToFirstProperty(BufferingJsonReader bufferingJsonReader)
-        {
-            // Read start and then over the object start.
-            bufferingJsonReader.Read();
-            bufferingJsonReader.Read();
-            Assert.Equal(JsonNodeType.Property, bufferingJsonReader.NodeType);
         }
         #endregion MetadataReferenceProperty tests
 
@@ -872,7 +867,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             var model = this.CreateEdmModelWithEntity();
             var primitiveTypeRef = ((IEdmEntityType)model.SchemaElements.First()).Properties().First().Type;
-            this.messageReaderSettings = new ODataMessageReaderSettings() { BaseUri = new Uri("http://odata.org/test/")};
+            this.messageReaderSettings = new ODataMessageReaderSettings() { BaseUri = new Uri("http://odata.org/test/") };
             ODataJsonLightPropertyAndValueDeserializer deserializer = new ODataJsonLightPropertyAndValueDeserializer(this.CreateJsonLightInputContext("{\"@odata.context\":\"Customers(1)/Name\",\"value\":\"Joe\"}", model));
             ODataProperty property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
 
@@ -971,7 +966,7 @@ namespace Microsoft.OData.Tests.JsonLight
             this.messageReaderSettings = new ODataMessageReaderSettings { ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*") };
             var odataReader = this.CreateJsonLightInputContext("{\"CountryRegion@Is.ReadOnly\":true,\"CountryRegion\":\"China\"}", model, false)
                 .CreateResourceReader(null, complexType);
-            while(odataReader.Read())
+            while (odataReader.Read())
             {
                 if (odataReader.State == ODataReaderState.ResourceEnd)
                 {
@@ -1143,7 +1138,7 @@ namespace Microsoft.OData.Tests.JsonLight
             var complexTypeRef = new EdmComplexTypeReference(complexType, false);
             var odataReader = this.CreateJsonLightInputContext("\"CountryRegion\":\"China\"", model, false)
                 .CreateResourceReader(null, complexType);
-            Action action = () => 
+            Action action = () =>
             {
                 while (odataReader.Read())
                 {
@@ -1158,23 +1153,1392 @@ namespace Microsoft.OData.Tests.JsonLight
             action.Throws<ODataException>(ErrorStrings.JsonReaderExtensions_UnexpectedNodeDetected("StartObject", "PrimitiveValue"));
         }
 
+        #region Async Tests
+
+        [Fact]
+        public async Task ReadAndValidateAnnotationStringValueAsync()
+        {
+            var payload = "{\"@odata.id\":\"Customers(1)\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                EdmCoreModel.Instance,
+                async (jsonLightDeserializer) =>
+                {
+                    await AdvanceReaderToFirstPropertyAsync(jsonLightDeserializer.JsonReader);
+                    await jsonLightDeserializer.JsonReader.ReadPropertyNameAsync();
+
+                    var annotationValue = await jsonLightDeserializer.ReadAndValidateAnnotationStringValueAsync("@odata.id");
+                    Assert.Equal("Customers(1)", annotationValue);
+                });
+        }
+
+        [Fact]
+        public async Task ReadAnnotationStringValueAsync()
+        {
+            var payload = "{\"@odata.id\":\"Customers(1)\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                EdmCoreModel.Instance,
+                async (jsonLightDeserializer) =>
+                {
+                    await AdvanceReaderToFirstPropertyAsync(jsonLightDeserializer.JsonReader);
+                    await jsonLightDeserializer.JsonReader.ReadPropertyNameAsync();
+
+                    var annotationValue = await jsonLightDeserializer.ReadAnnotationStringValueAsync("@odata.id");
+                    Assert.Equal("Customers(1)", annotationValue);
+                });
+        }
+
+        [Theory]
+        [InlineData("{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"}", ODataPayloadKind.Delta, "http://tempuri.org/$metadata#Customers/$entity")]
+        [InlineData("{\"err\":{\"code\":\"NRE\",\"message\":\"Object reference not set to an instance of an object.\"}}", ODataPayloadKind.Error, null)]
+        [InlineData("", ODataPayloadKind.Value, null)]
+        public async Task ReadPayloadStartAsync(string payload, ODataPayloadKind payloadKind, string expectedContextUri)
+        {
+            var model = InitializeModel();
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    await jsonLightDeserializer.ReadPayloadStartAsync(
+                    payloadKind,
+                    new PropertyAndAnnotationCollector(true),
+                    isReadingNestedPayload: false,
+                    allowEmptyPayload: true);
+
+                    if (expectedContextUri == null)
+                    {
+                        Assert.Null(jsonLightDeserializer.ContextUriParseResult);
+                    }
+                    else
+                    {
+                        Assert.Equal(expectedContextUri, jsonLightDeserializer.ContextUriParseResult?.ContextUri?.AbsoluteUri);
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData("{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"}", "http://tempuri.org/$metadata#Customers/$entity")]
+        [InlineData("{\"@odata.type\":\"#Collection(NS.Customer)\"}", null)]
+        [InlineData("{}", null)]
+        public async Task ReadContextUriAnnotationAsync(string payload, string expectedContextUri)
+        {
+            var model = InitializeModel();
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    await AdvanceReaderToFirstPropertyAsync(jsonLightDeserializer.JsonReader);
+                    var contextUri = await jsonLightDeserializer.ReadContextUriAnnotationAsync(
+                        ODataPayloadKind.Resource,
+                        new PropertyAndAnnotationCollector(true),
+                        failOnMissingContextUriAnnotation: false);
+
+                    Assert.Equal(expectedContextUri, contextUri);
+                });
+        }
+
+        [Theory]
+        [InlineData("{}")]
+        [InlineData("{\"@odata.type\":\"#Collection(NS.Customer)\"}")]
+        public async Task ReadContextUriAnnotationAsync_ThrowsExceptionForMissingContextUriAnnotation(string payload)
+        {
+            var model = InitializeModel();
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    async (jsonLightDeserializer) =>
+                    {
+                        await AdvanceReaderToFirstPropertyAsync(jsonLightDeserializer.JsonReader);
+
+                        await jsonLightDeserializer.ReadContextUriAnnotationAsync(
+                            ODataPayloadKind.Resource,
+                            new PropertyAndAnnotationCollector(true),
+                            failOnMissingContextUriAnnotation: true);
+                    }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightDeserializer_ContextLinkNotFoundAsFirstProperty,
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData("null", null)]
+        [InlineData("\"Customers?$deltatoken=13\"", "http://tempuri.org/Customers?$deltatoken=13")]
+        public async Task ReadAnnotationStringValueAsUriAsync(string deltaLink, string expected)
+        {
+            var model = InitializeModel();
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$delta\"," +
+                $"\"@odata.deltaLink\":{deltaLink}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    await jsonLightDeserializer.ReadPayloadStartAsync(ODataPayloadKind.Delta, new PropertyAndAnnotationCollector(true), false, true);
+                    Assert.Equal("@odata.deltaLink", await jsonLightDeserializer.JsonReader.ReadPropertyNameAsync());
+                    var annotationValueAsUri = await jsonLightDeserializer.ReadAnnotationStringValueAsUriAsync("@odata.deltaLink");
+
+                    var expectedUri = expected == null ? null : new Uri(expected);
+                    Assert.Equal(expectedUri, annotationValueAsUri);
+                    Assert.Equal(
+                        "http://tempuri.org/$metadata#Customers/$delta",
+                        jsonLightDeserializer.ContextUriParseResult.ContextUri.AbsoluteUri);
+                });
+        }
+
+        [Fact]
+        public async Task ReadAndValidateAnnotationStringValueAsUriAsync()
+        {
+            var model = InitializeModel();
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$delta\"," +
+                "\"@odata.deltaLink\":\"Customers?$deltatoken=13\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    await jsonLightDeserializer.ReadPayloadStartAsync(ODataPayloadKind.Delta, new PropertyAndAnnotationCollector(true), false, true);
+                    Assert.Equal("@odata.deltaLink", await jsonLightDeserializer.JsonReader.ReadPropertyNameAsync());
+                    var annotationValueAsUri = await jsonLightDeserializer.ReadAndValidateAnnotationStringValueAsUriAsync("@odata.deltaLink");
+
+                    Assert.Equal(
+                        "http://tempuri.org/$metadata#Customers/$delta",
+                        jsonLightDeserializer.ContextUriParseResult.ContextUri.AbsoluteUri);
+                    Assert.Equal(new Uri("http://tempuri.org/Customers?$deltatoken=13"), annotationValueAsUri);
+                });
+        }
+
+        [Theory]
+        [InlineData("13", false)]
+        [InlineData("\"13\"", true)]
+        public async Task ReadAndValidateAnnotationAsLongForIeee754CompatibleAsync(string data, bool isIeee754Compatible)
+        {
+            var payload = $"{{\"Data\":{data}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                EdmCoreModel.Instance,
+                async (jsonLightDeserializer) =>
+                {
+                    await AdvanceReaderToFirstPropertyAsync(jsonLightDeserializer.JsonReader);
+                    await jsonLightDeserializer.JsonReader.ReadPropertyNameAsync();
+
+                    var value = await jsonLightDeserializer.ReadAndValidateAnnotationAsLongForIeee754CompatibleAsync("@odata.count");
+
+                    Assert.Equal(13, value);
+                },
+                isIeee754Compatible: isIeee754Compatible);
+        }
+
+        [Fact]
+        public async Task ProcessPropertyWithValueAsync()
+        {
+            var payload = "{\"Colors@odata.type\":\"#Collection(Edm.String)\",\"Colors\":[\"Black\",\"White\"]}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    Assert.Equal("Colors", propertyName);
+                    Assert.Equal(
+                        PropertyParsingResult.PropertyWithValue,
+                        propertyParsingResult);
+                    var odataPropertyAnnotations = propertyAndAnnotationCollector.GetODataPropertyAnnotations("Colors");
+                    Assert.Contains("odata.type", odataPropertyAnnotations);
+                    Assert.Equal("#Collection(Edm.String)", odataPropertyAnnotations["odata.type"]);
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Fact]
+        public async Task ProcessPropertyWithoutValueAsync()
+        {
+            var payload = "{\"Prop@custom.annotation\":\"jiba jaba\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    Assert.Equal("Prop", propertyName);
+                    Assert.Equal(
+                        PropertyParsingResult.PropertyWithoutValue,
+                        propertyParsingResult);
+                    Assert.Empty(propertyAndAnnotationCollector.GetCustomScopeAnnotation());
+                    Assert.Empty(propertyAndAnnotationCollector.GetCustomPropertyAnnotations("Prop"));
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Fact]
+        public async Task ProcessPropertyAsync_CustomInstanceAnnotationIsSkippedByDefault()
+        {
+            var payload = "{\"@custom.annotation\":\"jiba jaba\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    Assert.Null(propertyName);
+                    Assert.Equal(
+                        PropertyParsingResult.EndOfObject,
+                        propertyParsingResult);
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Theory]
+        [InlineData("custom.annotation")]
+        [InlineData("custom.*")]
+        [InlineData("*")]
+        public async Task ReadTopLevelPropertyAsync_CustomInstanceAnnotationIsNotSkippedBasedOnSetting(string annotationFilter)
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter(annotationFilter);
+
+            var model = InitializeModel();
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)\"," +
+                "\"@odata.type\":\"#NS.Customer\",\"Name@custom.annotation\":\"jiba jaba\",\"Name\":\"Sue\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(null);
+
+                    var resource = Assert.IsType<ODataResourceValue>(property.ODataValue);
+                    var nameProperty = Assert.Single(resource.Properties);
+                    Assert.Equal("Name", nameProperty.Name);
+                    Assert.Equal("Sue", nameProperty.Value);
+                    var instanceAnnotation = Assert.Single(nameProperty.InstanceAnnotations);
+                    Assert.Equal("custom.annotation", instanceAnnotation.Name);
+                    var annotationValue = Assert.IsType<ODataPrimitiveValue>(instanceAnnotation.Value);
+                    Assert.Equal("jiba jaba", annotationValue.Value);
+                },
+                isResponse: false);
+        }
+
+        [Fact]
+        public async Task ProcessPropertyAsync_UnknownODataInstanceAnnotationIsSkipped()
+        {
+            var payload = "{\"@odata.unknown\":\"jiba jaba\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    Assert.Null(propertyName);
+                    Assert.Equal(
+                        PropertyParsingResult.EndOfObject,
+                        propertyParsingResult);
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Fact]
+        public async Task ProcessODataInstanceAnnotationPropertyAsync()
+        {
+            var payload = "{\"@odata.id\":\"Customers(1)\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    Assert.Equal("odata.id", propertyName);
+                    Assert.Equal(
+                        PropertyParsingResult.ODataInstanceAnnotation,
+                        propertyParsingResult);
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Fact]
+        public async Task ProcessMetadataResponsePropertyAsync()
+        {
+            var payload = "{\"#RefProp\":true}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    Assert.Equal("#RefProp", propertyName);
+                    Assert.Equal(
+                        PropertyParsingResult.MetadataReferenceProperty,
+                        propertyParsingResult);
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Fact]
+        public async Task ProcessPropertyAnnotationForUnrelatedPropertyAsync()
+        {
+            var payload = "{\"Colors@odata.type\":\"#Collection(Edm.String)\",\"LuckyNumber\":13}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    Assert.Equal("Colors", propertyName);
+                    Assert.Equal(
+                        PropertyParsingResult.PropertyWithoutValue,
+                        propertyParsingResult);
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Theory]
+        [InlineData("13", true)]
+        [InlineData("\"13\"", false)]
+        public async Task ReadAndValidateAnnotationAsLongForIeee754CompatibleAsync_ThrowsExceptionForConflictBetweenInputFormatAndParameter(
+            string data,
+            bool isIeee754Compatible)
+        {
+            var payload = $"{{\"Data\":{data}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    EdmCoreModel.Instance,
+                    async (jsonLightDeserializer) =>
+                    {
+                        await AdvanceReaderToFirstPropertyAsync(jsonLightDeserializer.JsonReader);
+                        await jsonLightDeserializer.JsonReader.ReadPropertyNameAsync();
+
+                        await jsonLightDeserializer.ReadAndValidateAnnotationAsLongForIeee754CompatibleAsync("@odata.count");
+                    },
+                    isIeee754Compatible: isIeee754Compatible));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonReaderUtils_ConflictBetweenInputFormatAndParameter("Edm.Int64"),
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData("{\"odata.deltaLink@custom.annotation\":\"foobar\",\"@odata.deltaLink\":\"http://tempuri.org/deltaLink\"}", "custom.annotation", "odata.deltaLink")]
+        [InlineData("{\"odata.deltaLink@odata.unknown\":\"unknown\",\"@odata.deltaLink\":\"http://tempuri.org/deltaLink\"}", "odata.unknown", "odata.deltaLink")]
+        [InlineData("{\"custom.annotation@odata.unknown\":\"unknown\",\"@custom.annotation\":\"foobar\"}", "odata.unknown", "custom.annotation")]
+        [InlineData("{\"custom.annotation@custom.temp\":\"temp\",\"@custom.annotation\":\"foobar\"}", "custom.temp", "custom.annotation")]
+        public async Task ProcessPropertyAsync_ThrowsExceptionForNonODataTypeAnnotationTargetingAnnotation(
+            string payload,
+            string annotation,
+            string targetedAnnotation)
+        {
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(payload));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightDeserializer_OnlyODataTypeAnnotationCanTargetInstanceAnnotation(
+                    annotation, targetedAnnotation, "odata.type"),
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData("{\"odata.deltaLink@odata.type\":\"#Edm.String\",\"@odata.deltaLink\":\"http://tempuri.org/deltaLink\"}", "odata.deltaLink")]
+        [InlineData("{\"custom.annotation@odata.type\":\"#Edm.String\",\"@custom.annotation\":\"foobar\"}", "custom.annotation")]
+        public async Task ProcessPropertyAsync_PermitsODataTypeAnnotationTargetingAnnotation(string payload, string annotationProperty)
+        {
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    var odataPropertyAnnotations = propertyAndAnnotationCollector.GetODataPropertyAnnotations(annotationProperty);
+                    Assert.Single(odataPropertyAnnotations);
+                    Assert.Contains("odata.type", odataPropertyAnnotations);
+                    Assert.Equal("#Edm.String", odataPropertyAnnotations["odata.type"]);
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Theory]
+        [InlineData("{\"odata.unknown@odata.type\":\"#Edm.String\",\"custom.annotation@odata.type\":\"#Edm.String\"}", "odata.unknown")]
+        [InlineData("{\"custom.annotation@odata.type\":\"#Edm.String\",\"odata.unknown@odata.type\":\"#Edm.String\"}", "custom.annotation")]
+        public async Task ProcessPropertyAsync_ThrowsExceptionForAnnotationTargetingAnnotationWithoutValue(string payload, string targetAnnotation)
+        {
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(payload));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightDeserializer_AnnotationTargetingInstanceAnnotationWithoutValue("odata.type", targetAnnotation),
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData("{\"Prop@odata.type\":\"#Edm.String\",\"#namespace.name\":\"noname\"}", "PropertyWithoutValue")]
+        [InlineData("{\"Prop@odata.unknown\":\"unknown\",\"#namespace.name\":\"noname\"}", "MetadataReferenceProperty")]
+        [InlineData("{\"Prop@custom.annotation\":\"foobar\",\"#namespace.name\":\"noname\"}", "PropertyWithoutValue")]
+        public async Task ParsePropertyAnnotationFollowedByMetadataReferencePropertyAsync(string payload, string expectedPropertyParsingResult)
+        {
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    // A parameter of PropertyParsingResult type isn't possible due to internal access level
+                    Assert.Equal(
+                        (PropertyParsingResult)Enum.Parse(typeof(PropertyParsingResult), expectedPropertyParsingResult),
+                        propertyParsingResult);
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Fact]
+        public async Task ProcessPropertyAsync_ThrowsExceptionForDuplicateODataAnnotation()
+        {
+            var payload = "{\"@odata.deltaLink\":\"http://tempuri.org/deltaLink\",\"@odata.deltaLink\":\"http://tempuri.org/deltaLink\"}";
+            var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
+
+            Func<Task> func = () => SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                propertyAndAnnotationCollector: propertyAndAnnotationCollector);
+
+            await func();
+            var exception = await Assert.ThrowsAsync<ODataException>(func);
+        }
+
+        [Fact]
+        public async Task ProcessPropertyAsync_ThrowsExceptionForDuplicateUnknownODataAnnotation()
+        {
+            var payload = "{\"@odata.unknown\":\"unknown\",\"@odata.unknown\":\"unknown\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(payload));
+
+            Assert.Equal(ErrorStrings.DuplicateAnnotationNotAllowed("odata.unknown"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ProcessPropertyAsync_PermitsDuplicateCustomAnnotation()
+        {
+            var payload = "{\"@custom.annotation\":\"foobar\",\"@custom.annotation\":\"foobar\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+                payload,
+                verificationDelegate: (jsonReader, propertyAndAnnotationCollector, propertyParsingResult, propertyName) =>
+                {
+                    Assert.Equal(PropertyParsingResult.EndOfObject, propertyParsingResult);
+
+                    return TaskUtils.CompletedTask;
+                });
+        }
+
+        [Theory]
+        [InlineData("{\"odata.deltaLink@odata.type\":\"#Edm.String\",\"odata.deltaLink@odata.type\":\"#Edm.String\"}", "odata.deltaLink")]
+        [InlineData("{\"custom.annotation@odata.type\":\"#Edm.String\",\"custom.annotation@odata.type\":\"#Edm.String\"}", "custom.annotation")]
+        public async Task ProcessPropertyAsync_ThrowsExceptionForDuplicateODataTypeAnnotationTargetingAnnotation(string payload, string annotationProperty)
+        {
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(payload));
+
+            Assert.Equal(
+                ErrorStrings.DuplicateAnnotationForInstanceAnnotationNotAllowed("odata.type", annotationProperty),
+                exception.Message);
+        }
+
+        public static IEnumerable<object[]> GetReadTopLevelPrimitivePropertyTestData()
+        {
+            return new List<object[]>
+            {
+                new object [] { "\"@odata.type\":\"#Int32\",\"value\":13", 13, EdmPrimitiveTypeKind.Int32, false },
+                new object [] { "\"@odata.type\":\"#Date\",\"value\":\"2021-07-13\"", new Date(2021, 7, 13), EdmPrimitiveTypeKind.Date, false },
+                new object [] { "\"@odata.type\":\"#Double\",\"value\":3.14159265359", 3.14159265359, EdmPrimitiveTypeKind.Double, false },
+                new object [] { "\"@odata.type\":\"#Boolean\",\"value\":true", true, EdmPrimitiveTypeKind.Boolean, false },
+                new object [] { "\"@odata.type\":\"#String\",\"value\":\"Sue\"", "Sue", EdmPrimitiveTypeKind.String, false },
+                new object [] { "\"@odata.type\":\"#Int64\",\"value\":6078747774547", 6078747774547L, EdmPrimitiveTypeKind.Int64, false },
+                new object [] { "\"@odata.type\":\"#Decimal\",\"value\":7654321", 7654321M, EdmPrimitiveTypeKind.Decimal, false },
+                new object [] { "\"@odata.type\":\"#Int64\",\"value\":\"6078747774547\"", 6078747774547L, EdmPrimitiveTypeKind.Int64, true },
+                new object [] { "\"@odata.type\":\"#Decimal\",\"value\":\"7654321\"", 7654321M, EdmPrimitiveTypeKind.Decimal, true }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetReadTopLevelPrimitivePropertyTestData))]
+        public async Task ReadTopLevelPrimitivePropertyAsync_ReturnsExpectedResult(
+            string valuePart,
+            object expected,
+            EdmPrimitiveTypeKind primitiveTypeKind,
+            bool isIeee754Compatible)
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", primitiveTypeKind);
+
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\",{valuePart}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    var primitiveValue = Assert.IsType<ODataPrimitiveValue>(property.ODataValue);
+                    Assert.Equal(expected, primitiveValue.Value);
+                },
+                isIeee754Compatible: isIeee754Compatible);
+        }
+
+        [Fact]
+        public async Task Test2Async()
+        {
+            this.messageReaderSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var addressComplexType = model.SchemaElements.Single(d => d.Name.Equals("Address")) as EdmComplexType;
+            var edmProperty = customerEntityType.AddStructuralProperty(
+                "TempProperty",
+                new EdmComplexTypeReference(addressComplexType, true));
+
+            var valuePart = "\"@odata.type\":\"#NS.Address\",\"Street\":\"S1\",\"City\":\"C1\",\"TempProperty\":17.30";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\",{valuePart}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+                });
+        }
+
+        public static IEnumerable<object[]> GetReadTopLevelPrimitivePropertyWithConflictingInputFormatAndParameterTestData()
+        {
+            return new List<object[]>
+            {
+                new object [] { "\"@odata.type\":\"#Int64\",\"value\":6078747774547", EdmPrimitiveTypeKind.Int64, true },
+                new object [] { "\"@odata.type\":\"#Decimal\",\"value\":7654321", EdmPrimitiveTypeKind.Decimal, true },
+                new object [] { "\"@odata.type\":\"#Int64\",\"value\":\"6078747774547\"", EdmPrimitiveTypeKind.Int64, false },
+                new object [] { "\"@odata.type\":\"#Decimal\",\"value\":\"7654321\"", EdmPrimitiveTypeKind.Decimal, false }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetReadTopLevelPrimitivePropertyWithConflictingInputFormatAndParameterTestData))]
+        public async Task ReadTopLevelPrimitivePropertyAsync_ThrowsExceptionForConflictingInputFormatAndParameter(
+            string valuePart,
+            EdmPrimitiveTypeKind primitiveTypeKind,
+            bool isIeee754Compatible)
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", primitiveTypeKind);
+
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\",{valuePart}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type),
+                    isIeee754Compatible: isIeee754Compatible));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonReaderUtils_ConflictBetweenInputFormatAndParameter(edmProperty.Type.FullName()),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelPrimitivePropertyAsync_ThrowsExceptionForValueAsJsonObject()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.Int32);
+
+            var valuePart = "\"value\":{}";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\",{valuePart}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                    ErrorStrings.JsonReaderExtensions_UnexpectedNodeDetectedWithPropertyName("PrimitiveValue", "StartObject", "value"),
+                    exception.Message);
+        }
+
+        public static IEnumerable<object[]> GetTopLevelPrimitivePropertyUnsupportedScenariosTestData()
+        {
+            return new List<object[]>
+            {
+                new object[] {
+                    "\"@odata.id\":\"#1\",\"value\":13",
+                    ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedAnnotationProperties("odata.id")
+                },
+                new object[] {
+                    "\"#action\":\"Action\"",
+                    ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty("#action")
+                },
+                new object[] {
+                    "\"value@custom.annotation\":\"foobar\"",
+                    ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_TopLevelPropertyAnnotationWithoutProperty("value")
+                }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTopLevelPrimitivePropertyUnsupportedScenariosTestData))]
+        public async Task ReadTopLevelPrimitivePropertyAsync_ThrowsExceptionForUnsupportedScenarios(string valuePart, string exceptionMessage)
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.Int32);
+
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\",{valuePart}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(exceptionMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("*")]
+        public async Task ReadTopLevelPrimitivePropertyAsync_PermitsCustomAnnotation(string annotationFilter)
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter(annotationFilter);
+
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.Int32);
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\"," +
+                    "\"@custom.annotation\":\"foobar\",\"value\":13}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    var primitiveValue = Assert.IsType<ODataPrimitiveValue>(property.ODataValue);
+                    Assert.Equal(13, primitiveValue.Value);
+                    if (!string.IsNullOrEmpty(annotationFilter))
+                    {
+                        var instanceAnnotation = Assert.Single(property.InstanceAnnotations);
+                        Assert.Equal("custom.annotation", instanceAnnotation.Name);
+                        var annotationValue = Assert.IsType<ODataPrimitiveValue>(instanceAnnotation.Value);
+                        Assert.Equal("foobar", annotationValue.Value);
+                    }
+                });
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("\"@custom.annotation\":\"foobar\",\"@odata.type\":\"#Collection(Edm.String)\",")]
+        public async Task ReadTopLevelPrimitiveCollectionPropertyAsync(string annotationsPart)
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty(
+                "TempProperty",
+                new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true))));
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\"," +
+                annotationsPart +
+                "\"value\":[\"foo\",\"bar\"]}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+                    var collectionValue = Assert.IsType<ODataCollectionValue>(property.Value);
+                    Assert.Equal(2, collectionValue.Items.Count());
+                    Assert.Equal("foo", collectionValue.Items.First());
+                    Assert.Equal("bar", collectionValue.Items.Last());
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelTypeDefinitionPropertyAsync_ReturnsExpectedResult()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var moneyTypeDefinition = new EdmTypeDefinition("NS", "Money", EdmPrimitiveTypeKind.Decimal);
+            model.AddElement(moneyTypeDefinition);
+            var edmProperty = customerEntityType.AddStructuralProperty(
+                "TempProperty",
+                new EdmTypeDefinitionReference(moneyTypeDefinition, false));
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\"," +
+                "\"value\":1730}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var tempProperty = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    Assert.Equal(1730M, tempProperty.Value);
+                });
+        }
+
+        [Theory]
+        [InlineData("\"value\":null")]
+        [InlineData("\"@odata.null\":true")]
+        public async Task ReadTopLevelNullPropertyAsync_ReturnsExpectedResult(string valuePart)
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.Properties().Single(d => d.Name.Equals("Name")) as EdmProperty;
+
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/Name\",{valuePart}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    Assert.IsType<ODataNullValue>(property.ODataValue);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourcePropertyAsync_ReturnsExpectedResult()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.Properties().First(d => d.Name.Equals("ShippingAddress"));
+
+            var valuePart = "\"@odata.type\":\"#NS.Address\",\"Street\":\"S2\",\"City\":\"C2\"";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/ShippingAddress\",{valuePart}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    var resource = Assert.IsType<ODataResourceValue>(property.ODataValue);
+                    var properties = resource.Properties.ToList();
+                    Assert.Equal(2, properties.Count);
+                    Assert.Equal("Street", properties[0].Name);
+                    Assert.Equal("S2", properties[0].Value);
+                    Assert.Equal("City", properties[1].Name);
+                    Assert.Equal("C2", properties[1].Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourcePropertyAsync_UndeclaredNumericPropertyOfUnspecifiedTypeReadAsDecimalThenConvertedToDouble()
+        {
+            this.messageReaderSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.Properties().First(d => d.Name.Equals("ShippingAddress"));
+
+            var valuePart = "\"@odata.type\":\"#NS.Address\",\"TempProperty\":17.30";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/ShippingAddress\",{valuePart}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    var resource = Assert.IsType<ODataResourceValue>(property.ODataValue);
+                    var tempProperty = Assert.Single(resource.Properties);
+                    Assert.Equal("TempProperty", tempProperty.Name);
+                    Assert.Equal(17.3, Assert.IsType<double>(tempProperty.Value));
+                });
+        }
+
+        public static IEnumerable<object[]> GetTopLevelResourcePropertyUnsupportedScenariosTestData()
+        {
+            yield return new object[]
+            {
+                "\"#action\":\"Action\"",
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty("#action")
+            };
+
+            yield return new object[]
+            {
+                "\"Street@custom.annotation\":\"foobar\"",
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ResourceValuePropertyAnnotationWithoutProperty("Street")
+            };
+
+            yield return new object[]
+            {
+                "\"@odata.id\":\"#1\"",
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedAnnotationProperties("odata.id")
+            };
+
+            yield return new object[]
+            {
+                "\"Street\":\"S1\",\"@odata.type\":\"#Edm.Int32\"",
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ResourceTypeAnnotationNotFirst
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTopLevelResourcePropertyUnsupportedScenariosTestData))]
+        public async Task ReadTopLevelResourcePropertyAsync_ThrowsExceptionForUnsupportedScenarios(string valuePart, string exceptionMessage)
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.Properties().First(d => d.Name.Equals("ShippingAddress"));
+
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/ShippingAddress\",{valuePart}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(exceptionMessage, exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourcePropertyAsync_PermitsODataTypePropertyAnnotation()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.Properties().First(d => d.Name.Equals("ShippingAddress"));
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/ShippingAddress\"," +
+                "\"Street@odata.type\":\"#Edm.String\"," +
+                "\"Street\":\"S1\"," +
+                "\"City@odata.type\":\"#Edm.String\"," +
+                "\"City\":\"C1\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    var resource = Assert.IsType<ODataResourceValue>(property.ODataValue);
+                    Assert.Equal(2, resource.Properties.Count());
+                    var streetProperty = Assert.Single(resource.Properties.Where(d => d.Name.Equals("Street")));
+                    var cityProperty = Assert.Single(resource.Properties.Where(d => d.Name.Equals("City")));
+                    Assert.Equal("S1", streetProperty.Value);
+                    Assert.Equal("C1", cityProperty.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourcePropertyAsync_ThrowsExceptionForODataTypePropertyAnnotationValueIsNull()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.Properties().First(d => d.Name.Equals("ShippingAddress"));
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/ShippingAddress\"," +
+                "\"Street@odata.type\":null," +
+                "\"Street\":\"S1\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_InvalidTypeName(null),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourcePropertyAsync_ThrowsExceptionForUnexpectedODataPropertyAnnotation()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.Properties().First(d => d.Name.Equals("ShippingAddress"));
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/ShippingAddress\"," +
+                "\"Street@odata.etag\":\"etag\"," +
+                "\"Street\":\"S1\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedAnnotationProperties("odata.etag"),
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("*")]
+        public async Task ReadTopLevelResourcePropertyAsync_PermitsCustomAnnotation(string annotationFilter)
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter(annotationFilter);
+
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.Properties().First(d => d.Name.Equals("ShippingAddress"));
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/ShippingAddress\"," +
+                "\"custom.annotation@odata.type\":\"#Edm.String\",\"custom.annotation\":\"foobar\"}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    var resource = Assert.IsType<ODataResourceValue>(property.ODataValue);
+                    if (!string.IsNullOrEmpty(annotationFilter))
+                    {
+                        var instanceAnnotation = Assert.Single(resource.InstanceAnnotations);
+                        Assert.Equal("custom.annotation", instanceAnnotation.Name);
+                        var annotationValue = Assert.IsType<ODataPrimitiveValue>(instanceAnnotation.Value);
+                        Assert.Equal("foobar", annotationValue.Value);
+                    }
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelEnumCollectionPropertyAsync_ReturnsExpectedResult()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var segmentEnumType = model.SchemaElements.Single(d => d.Name.Equals("Segment")) as EdmEnumType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TargetSegments",
+                new EdmCollectionTypeReference(
+                    new EdmCollectionType(
+                        new EdmEnumTypeReference(
+                            segmentEnumType, true))));
+
+            var valuePart = "\"@odata.type\":\"#Collection(NS.Segment)\"," +
+                "\"value\":[\"Retail\",\"Wholesale\"]";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Collection(NS.Segment)\",{valuePart}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    var collectionValue = Assert.IsType<ODataCollectionValue>(property.ODataValue);
+                    Assert.Equal(2, collectionValue.Items.Count());
+                    var retailEnumValue = Assert.IsType<ODataEnumValue>(collectionValue.Items.First());
+                    var wholesaleEnumValue = Assert.IsType<ODataEnumValue>(collectionValue.Items.Last());
+                    Assert.Equal("Retail", retailEnumValue.Value);
+                    Assert.Equal("Wholesale", wholesaleEnumValue.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelEnumCollectionPropertyAsync_ThrowsExceptionForValueAsJsonObject()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var segmentEnumType = model.SchemaElements.Single(d => d.Name.Equals("Segment")) as EdmEnumType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TargetSegment", new EdmEnumTypeReference(segmentEnumType, true));
+
+            var valuePart = "\"@odata.type\":\"#NS.Segment\",\"value\":{}";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TargetSegment\",{valuePart}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.JsonReaderExtensions_UnexpectedNodeDetectedWithPropertyName("PrimitiveValue", "StartObject", "value"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelSpatialPropertyAsync_ReturnsExpectedResult()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("Location",
+                EdmCoreModel.Instance.GetSpatial(EdmPrimitiveTypeKind.GeographyPoint, true));
+
+            var valuePart = "\"@odata.type\":\"#Edm.GeographyPoint\"," +
+                "\"value\":{\"type\":\"Point\",\"coordinates\":[-110.0,33.1],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/Location\",{valuePart}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    var primitiveValue = Assert.IsType<ODataPrimitiveValue>(property.ODataValue);
+                    var geographyPoint = Assert.IsAssignableFrom<GeographyPoint>(primitiveValue.Value);
+
+                    Assert.Equal(4326, geographyPoint.CoordinateSystem.EpsgId);
+                    Assert.Equal(-110.0d, geographyPoint.Longitude);
+                    Assert.Equal(33.1d, geographyPoint.Latitude);
+                });
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("*")]
+        public async Task ReadTopLevel6xNullPropertyAsync_PermitsCustomAnnotation(string annotationFilter)
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter(annotationFilter);
+
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.String);
+
+            var valuePart = "\"@odata.null\":true,\"@custom.annotation\":\"foobar\"";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\",{valuePart}}}";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    var property = await jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type);
+
+                    Assert.IsType<ODataNullValue>(property.ODataValue);
+                });
+        }
+
+        public static IEnumerable<object[]> GetTopLevel6xNullPropertyExceptionScenariosTestData()
+        {
+            yield return new object[]
+            {
+                "\"@odata.null\":true,\"value\":\"foobar\"",
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_NoPropertyAndAnnotationAllowedInNullPayload("value")
+            };
+
+            yield return new object[]
+            {
+                "\"@odata.null\":true,\"TempProperty@odata.type\":\"#Edm.String\"",
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedODataPropertyAnnotation("odata.type")
+            };
+
+            yield return new object[]
+            {
+                "\"@odata.null\":true,\"TempProperty@custom.annotation\":\"foobar\"",
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_TopLevelPropertyAnnotationWithoutProperty("TempProperty")
+            };
+
+            yield return new object[]
+            {
+                "\"@odata.null\":true,\"#action\":\"Action\"",
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty("#action")
+            };
+
+            yield return new object[]
+            {
+                "\"@odata.null\":true,\"@odata.type\":\"#Edm.String\"",
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedAnnotationProperties("odata.type")
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTopLevel6xNullPropertyExceptionScenariosTestData))]
+        public async Task ReadTopLevel6xNullPropertyAsync_ThrowsExceptionForDisallowedPropertyAndAnnotationInPayload(string valuePart, string exceptionMessage)
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.String);
+
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\",{valuePart}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(exceptionMessage, exception.Message);
+        }
+
+        [Theory]
+        [InlineData("false")]
+        [InlineData("13")]
+        public async Task ReadTopLevel6xNullPropertyAsync_ThrowsExceptionForInvalidValue(string value)
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.String);
+
+            var valuePart = $"\"@odata.null\":{value}";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\",{valuePart}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightReaderUtils_InvalidValueForODataNullAnnotation("odata.null", "true"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelPropertyAsync_ThrowsExceptionForConflictingODataTypeAnnotationInPayload()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.Int32);
+
+            var valuePart = "\"@odata.type\":\"#Collection(Edm.Int32)\",\"value\":42}";
+            var payload = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\",{valuePart}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.ValidationUtils_IncorrectTypeKind("Collection(Edm.Int32)", "Primitive", "Collection"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelPropertyAsync_ThrowsExceptionForUnexpectedODataPropertyAnnotation()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.Int32);
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\"," +
+                "\"value@odata.type\":\"#Edm.Int32\"," +
+                "\"value\":42}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedODataPropertyAnnotation("odata.type"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelPropertyAsync_ThrowsExceptionForODataTypeAnnotationAfterValueProperty()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.Int32);
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\"," +
+                "\"value\":42," +
+                "\"@odata.type\":\"#Edm.Int32\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_TypePropertyAfterValueProperty("odata.type", "value"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelPropertyAsync_ThrowsExceptionForInvalidTopLevelPropertyPayload()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.Int32);
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_InvalidTopLevelPropertyPayload,
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelPropertyAsync_ThrowsExceptionForInvalidTopLevelPropertyName()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty("TempProperty", EdmPrimitiveTypeKind.Int32);
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\"," +
+                "\"foobar\":42}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_InvalidTopLevelPropertyName("foobar", "value"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelPrimitiveCollectionPropertyAsync_ThrowsExceptionForValueAsJsonObject()
+        {
+            var model = this.InitializeModel();
+            var customerEntityType = model.SchemaElements.Single(d => d.Name.Equals("Customer")) as EdmEntityType;
+            var edmProperty = customerEntityType.AddStructuralProperty(
+                "TempProperty",
+                new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true))));
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers(1)/TempProperty\"," +
+                "\"@odata.type\":\"#Collection(Edm.String)\",\"value\":{\"foo\":\"bar\"}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    (jsonLightDeserializer) => jsonLightDeserializer.ReadTopLevelPropertyAsync(edmProperty.Type)));
+
+            Assert.Equal(
+                ErrorStrings.JsonReaderExtensions_UnexpectedNodeDetectedWithPropertyName("StartArray", "StartObject", "value"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadUntypedValueAsync()
+        {
+            var model = this.InitializeModel();
+            var payload = "\"foobar\"";
+
+            await SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                payload,
+                model,
+                async (jsonLightDeserializer) =>
+                {
+                    await jsonLightDeserializer.JsonReader.ReadAsync();
+                    var nonEntityValue = await jsonLightDeserializer.ReadNonEntityValueAsync(
+                        payloadTypeName: "Edm.Untyped",
+                        expectedValueTypeReference: EdmCoreModel.Instance.GetUntyped(),
+                        propertyAndAnnotationCollector: null,
+                        collectionValidator: null,
+                        validateNullValue: true,
+                        isTopLevelPropertyValue: false,
+                        insideResourceValue: false,
+                        propertyName: "UntypedProp",
+                        isDynamicProperty: false);
+
+                    var untypedValue = Assert.IsType<ODataUntypedValue>(nonEntityValue);
+                    Assert.Equal("\"foobar\"", untypedValue.RawValue);
+                });
+        }
+
+        [Fact]
+        public async Task ReadNonEntityValueAsync_ThrowsExceptionForResourcePropertyValueNotJsonObject()
+        {
+            var model = this.InitializeModel();
+            var addressComplexType = model.SchemaElements.Single(d => d.Name.Equals("Address")) as EdmComplexType;
+            var payload = "\"S1, C1\"";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+                    payload,
+                    model,
+                    async (jsonLightDeserializer) =>
+                    {
+                        await jsonLightDeserializer.JsonReader.ReadAsync();
+                        await jsonLightDeserializer.ReadNonEntityValueAsync(
+                            payloadTypeName: "NS.Address",
+                            expectedValueTypeReference: new EdmComplexTypeReference(addressComplexType, true),
+                            propertyAndAnnotationCollector: null,
+                            collectionValidator: null,
+                            validateNullValue: false,
+                            isTopLevelPropertyValue: false,
+                            insideResourceValue: false,
+                            propertyName: "HomeAddress",
+                            isDynamicProperty: false);
+                    }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ODataResourceExpectedForProperty("HomeAddress", "PrimitiveValue", "NS.Address"),
+                exception.Message);
+        }
+
+        #endregion Async Tests
+
         private ODataJsonLightInputContext CreateJsonLightInputContext(string payload)
         {
             return this.CreateJsonLightInputContext(payload, this.edmModel);
         }
 
-        private ODataJsonLightInputContext CreateJsonLightInputContext(string payload, IEdmModel model, bool isResponse = true)
+        private ODataJsonLightInputContext CreateJsonLightInputContext(
+            string payload,
+            IEdmModel model,
+            bool isResponse = true,
+            bool isAsync = false,
+            bool isIeee754Compatible = false)
         {
             var messageInfo = new ODataMessageInfo
             {
                 IsResponse = isResponse,
-                MediaType = JsonLightUtils.JsonLightStreamingMediaType,
-                IsAsync = false,
+                MediaType = CreateMediaType(isIeee754Compatible),
+                IsAsync = isAsync,
                 Model = model,
             };
 
             return new ODataJsonLightInputContext(
                 new StringReader(payload), messageInfo, this.messageReaderSettings);
+        }
+
+        private ODataMediaType CreateMediaType(bool isIeee754Compatible = false)
+        {
+            return new ODataMediaType(
+                MimeConstants.MimeApplicationType,
+                MimeConstants.MimeJsonSubType,
+                new[]{
+                    new KeyValuePair<string, string>(
+                        MimeConstants.MimeMetadataParameterName,
+                        MimeConstants.MimeMetadataParameterValueMinimal),
+                    new KeyValuePair<string, string>(
+                        MimeConstants.MimeStreamingParameterName,
+                        MimeConstants.MimeParameterValueTrue),
+                    new KeyValuePair<string, string>(
+                        MimeConstants.MimeIeee754CompatibleParameterName,
+                        isIeee754Compatible ? MimeConstants.MimeParameterValueTrue : MimeConstants.MimeParameterValueFalse)
+                });
         }
 
         private object ReadODataTypePropertyAnnotation(IJsonReader jsonReader, string name)
@@ -1185,7 +2549,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
         private void RunPropertyParsingTest(
             string jsonInput,
-            ODataJsonLightDeserializer.PropertyParsingResult expectedPropertyParsingResult,
+            PropertyParsingResult expectedPropertyParsingResult,
             string expectedName,
             Action<IJsonReader, PropertyAndAnnotationCollector> additionalVerification = null,
             Func<IJsonReader, string, object> readPropertyAnnotationValue = null,
@@ -1211,7 +2575,7 @@ namespace Microsoft.OData.Tests.JsonLight
                     (propertyName) => readPropertyAnnotationValue(deserializer.JsonReader, propertyName),
                     (propertyParsingResult, propertyName) =>
                     {
-                        if (propertyParsingResult != ODataJsonLightDeserializer.PropertyParsingResult.PropertyWithoutValue && deserializer.JsonReader.NodeType == JsonNodeType.Property)
+                        if (propertyParsingResult != PropertyParsingResult.PropertyWithoutValue && deserializer.JsonReader.NodeType == JsonNodeType.Property)
                         {
                             // Read over property name
                             deserializer.JsonReader.Read();
@@ -1227,6 +2591,90 @@ namespace Microsoft.OData.Tests.JsonLight
             }
         }
 
+        private static void AdvanceReaderToFirstProperty(BufferingJsonReader bufferingJsonReader)
+        {
+            // Read start and then over the object start.
+            bufferingJsonReader.Read();
+            bufferingJsonReader.Read();
+            Assert.Equal(JsonNodeType.Property, bufferingJsonReader.NodeType);
+        }
+
+        private async Task SetupJsonLightPropertyAndValueDeserializerAndRunTestAsync(
+            string payload,
+            IEdmModel model,
+            Func<ODataJsonLightPropertyAndValueDeserializer, Task> func,
+            bool isResponse = true,
+            bool isIeee754Compatible = false)
+        {
+            using (var jsonInputContext = CreateJsonLightInputContext(
+                payload,
+                model,
+                isResponse: isResponse,
+                isAsync: true,
+                isIeee754Compatible: isIeee754Compatible))
+            {
+                var jsonLightDeserializer = new ODataJsonLightPropertyAndValueDeserializer(jsonInputContext);
+
+                await func(jsonLightDeserializer);
+            }
+        }
+
+        private async Task SetupJsonLightPropertyAndValueDeserializerAndRunProcessPropertyTestAsync(
+            string payload,
+            PropertyAndAnnotationCollector propertyAndAnnotationCollector = null,
+            Func<IJsonReaderAsync, string, Task<object>> readPropertyAnnotationValueDelegate = null,
+            Func<IJsonReaderAsync, Task> setupDelegate = null,
+            Func<IJsonReaderAsync, PropertyAndAnnotationCollector, PropertyParsingResult, string, Task> verificationDelegate = null)
+        {
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, EdmCoreModel.Instance, isAsync: true))
+            {
+                var jsonLightDeserializer = new ODataJsonLightPropertyAndValueDeserializer(jsonInputContext);
+
+                if (readPropertyAnnotationValueDelegate == null)
+                {
+                    readPropertyAnnotationValueDelegate = (jsonReader, propertyName) => jsonReader.ReadPrimitiveValueAsync();
+                }
+
+                if (setupDelegate == null)
+                {
+                    setupDelegate = async (jsonReader) =>
+                    {
+                        await jsonReader.ReadAsync(); // Position the reader on the first node
+                        await jsonReader.ReadAsync(); // Read StartObject
+                    };
+                }
+
+                if (verificationDelegate == null)
+                {
+                    verificationDelegate = (arg1, arg2, arg3, arg4) => TaskUtils.CompletedTask;
+                }
+
+                if (propertyAndAnnotationCollector == null)
+                {
+                    propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
+                }
+
+                await setupDelegate(jsonLightDeserializer.JsonReader);
+
+                await jsonLightDeserializer.ProcessPropertyAsync(
+                    propertyAndAnnotationCollector: propertyAndAnnotationCollector,
+                    readPropertyAnnotationValueDelegate: (propertyName) => readPropertyAnnotationValueDelegate(
+                        jsonLightDeserializer.JsonReader,
+                        propertyName),
+                    handlePropertyDelegate: (propertyParsingResult, propertyName) => verificationDelegate(
+                        jsonLightDeserializer.JsonReader,
+                        propertyAndAnnotationCollector,
+                        propertyParsingResult,
+                        propertyName));
+            }
+        }
+
+        private static async Task AdvanceReaderToFirstPropertyAsync(BufferingJsonReader bufferingJsonReader)
+        {
+            await bufferingJsonReader.ReadAsync(); // Position the reader on the first node
+            await bufferingJsonReader.ReadAsync(); // Read StartObject
+        }
+
         private EdmModel CreateEdmModelWithEntity()
         {
             var model = new EdmModel();
@@ -1240,6 +2688,33 @@ namespace Microsoft.OData.Tests.JsonLight
             var entitySet = new EdmEntitySet(defaultContainer, "Customers", entityType);
             defaultContainer.AddEntitySet(entitySet.Name, entityType);
             model.AddElement(defaultContainer);
+            return model;
+        }
+
+        private EdmModel InitializeModel()
+        {
+            var model = new EdmModel();
+
+            var segmentEnumType = new EdmEnumType("NS", "Segment");
+            segmentEnumType.AddMember("Retail", new EdmEnumMemberValue(0));
+            segmentEnumType.AddMember("Wholesale", new EdmEnumMemberValue(1));
+            model.AddElement(segmentEnumType);
+
+            var addressComplexType = new EdmComplexType("NS", "Address");
+            addressComplexType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+            addressComplexType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
+            model.AddElement(addressComplexType);
+
+            var customerEntityType = new EdmEntityType("NS", "Customer");
+            customerEntityType.AddKeys(customerEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            customerEntityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            customerEntityType.AddStructuralProperty("ShippingAddress", new EdmComplexTypeReference(addressComplexType, true));
+            model.AddElement(customerEntityType);
+
+            var defaultContainer = new EdmEntityContainer("NS", "Default");
+            defaultContainer.AddEntitySet("Customers", customerEntityType);
+            model.AddElement(defaultContainer);
+
             return model;
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceDeserializerTests.cs
@@ -1,0 +1,2176 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataJsonLightResourceDeserializerTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Evaluation;
+using Microsoft.OData.Json;
+using Microsoft.OData.JsonLight;
+using Microsoft.Spatial;
+using Xunit;
+using ErrorStrings = Microsoft.OData.Strings;
+
+namespace Microsoft.OData.Tests.JsonLight
+{
+    public class ODataJsonLightResourceDeserializerTests
+    {
+        private EdmModel model;
+        private EdmEntityType customerEntityType;
+        private EdmEntityType categoryEntityType;
+        private EdmEntityType productEntityType;
+        private EdmEntitySet customersEntitySet;
+        private EdmEntitySet categoriesEntitySet;
+        private EdmEntitySet productsEntitySet;
+        private ODataMessageReaderSettings messageReaderSettings;
+
+        public ODataJsonLightResourceDeserializerTests()
+        {
+            this.InitializeModel();
+            this.messageReaderSettings = new ODataMessageReaderSettings();
+        }
+
+        [Fact]
+        public async Task ReadResourceSetContentAsync()
+        {
+            using (var jsonInputContext = CreateJsonLightInputContext("{\"value\":[]}", model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+                var jsonReader = jsonLightResourceDeserializer.JsonReader;
+
+                await AdvanceReaderToFirstPropertyAsync(jsonReader);
+                await jsonReader.ReadAsync();
+
+                await jsonLightResourceDeserializer.ReadResourceSetContentStartAsync();
+                Assert.Equal(JsonNodeType.EndArray, jsonReader.NodeType);
+                await jsonLightResourceDeserializer.ReadResourceSetContentEndAsync();
+                Assert.Equal(JsonNodeType.EndObject, jsonReader.NodeType);
+            }
+        }
+
+        [Theory]
+        [InlineData("@odata.type")]
+        [InlineData("@type")]
+        public async Task ReadResourceTypeNameAsync(string odataTypeAnnotationName)
+        {
+            this.messageReaderSettings.Version = ODataVersion.V401;
+            var payload = $"{{\"{odataTypeAnnotationName}\":\"NS.Customer\",\"Id\":1,\"Name\":\"Sue\"}}";
+
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await AdvanceReaderToFirstPropertyAsync(jsonLightResourceDeserializer.JsonReader);
+
+                var resourceState = new TestJsonLightReaderResourceState(this.customersEntitySet, this.customerEntityType);
+
+                await jsonLightResourceDeserializer.ReadResourceTypeNameAsync(resourceState);
+
+                Assert.Equal("NS.Customer", resourceState.Resource.TypeName);
+            }
+        }
+
+        [Theory]
+        [InlineData("{\"@odata.removed\":{\"reason\":\"deleted\"},\"@odata.id\":\"http://tempuri.org/Customers(1)\"}", DeltaDeletedEntryReason.Deleted, ODataVersion.V4)]
+        [InlineData("{\"@odata.removed\":{\"reason\":\"changed\"},\"@odata.id\":\"http://tempuri.org/Customers(1)\"}", DeltaDeletedEntryReason.Changed, ODataVersion.V4)]
+        [InlineData("{\"@removed\":{\"reason\":\"deleted\"},\"@id\":\"http://tempuri.org/Customers(1)\"}", DeltaDeletedEntryReason.Deleted, ODataVersion.V401)]
+        [InlineData("{\"@removed\":{\"reason\":\"changed\"},\"@id\":\"http://tempuri.org/Customers(1)\"}", DeltaDeletedEntryReason.Changed, ODataVersion.V401)]
+        public async Task ReadDeletedResourceAsync(string payload, DeltaDeletedEntryReason deletedEntryReason, ODataVersion odataVersion)
+        {
+            this.messageReaderSettings.Version = odataVersion;
+
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await AdvanceReaderToFirstPropertyAsync(jsonLightResourceDeserializer.JsonReader);
+
+                var deletedResource = await jsonLightResourceDeserializer.ReadDeletedResourceAsync();
+
+                Assert.Equal(deletedEntryReason, deletedResource.Reason);
+                Assert.Equal("http://tempuri.org/Customers(1)", deletedResource.Id.AbsoluteUri);
+            }
+        }
+
+        [Theory]
+        [InlineData("{\"id\":\"http://tempuri.org/Customers(1)\",\"reason\":\"deleted\"}", DeltaDeletedEntryReason.Deleted)]
+        [InlineData("{\"id\":\"http://tempuri.org/Customers(1)\",\"reason\":\"changed\"}", DeltaDeletedEntryReason.Changed)]
+        public async Task ReadDeletedEntryAsync(string payload, DeltaDeletedEntryReason deletedEntryReason)
+        {
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await AdvanceReaderToFirstPropertyAsync(jsonLightResourceDeserializer.JsonReader);
+
+                var deletedResource = await jsonLightResourceDeserializer.ReadDeletedEntryAsync();
+
+                Assert.Equal(deletedEntryReason, deletedResource.Reason);
+                Assert.Equal("http://tempuri.org/Customers(1)", deletedResource.Id.AbsoluteUri);
+            }
+        }
+
+        [Fact]
+        public async Task ReadDeletedEntryAsync_IgnoresUnexpectedPrimitiveProperties()
+        {
+            var payload = "{\"id\":\"http://tempuri.org/Customers(1)\",\"reason\":\"deleted\",\"unexpected\":true}";
+
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await AdvanceReaderToFirstPropertyAsync(jsonLightResourceDeserializer.JsonReader);
+
+                var deletedResource = await jsonLightResourceDeserializer.ReadDeletedEntryAsync();
+
+                Assert.Equal(DeltaDeletedEntryReason.Deleted, deletedResource.Reason);
+                Assert.Equal("http://tempuri.org/Customers(1)", deletedResource.Id.AbsoluteUri);
+            }
+        }
+
+        [Fact]
+        public async Task ReadDeltaLinkAsync()
+        {
+            var payload = "{\"source\":\"http://tempuri.org/Categories(1)\",\"relationship\":\"BestSeller\",\"target\":\"http://tempuri.org/Products(1)\"}";
+
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await AdvanceReaderToFirstPropertyAsync(jsonLightResourceDeserializer.JsonReader);
+
+                var deltaLink = new ODataDeltaLink(null, null, null);
+
+                await jsonLightResourceDeserializer.ReadDeltaLinkSourceAsync(deltaLink);
+                await jsonLightResourceDeserializer.ReadDeltaLinkRelationshipAsync(deltaLink);
+                await jsonLightResourceDeserializer.ReadDeltaLinkTargetAsync(deltaLink);
+
+                Assert.Equal("http://tempuri.org/Categories(1)", deltaLink.Source.AbsoluteUri);
+                Assert.Equal("BestSeller", deltaLink.Relationship);
+                Assert.Equal("http://tempuri.org/Products(1)", deltaLink.Target.AbsoluteUri);
+            }
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                commonVerifyAction);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredPrimitivePropertyAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"YTDTotal@odata.type\":\"#Decimal\",\"YTDTotal\":7130}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    var resource = resourceState.Resource;
+                    Assert.NotNull(resource);
+                    var properties = resource.Properties.ToArray();
+                    Assert.Equal(3, properties.Length);
+                    var idProperty = properties[0];
+                    var nameProperty = properties[1];
+                    var ytdTotalProperty = properties[2];
+                    Assert.Equal("Id", idProperty.Name);
+                    Assert.Equal(1, idProperty.Value);
+                    Assert.Equal("Name", nameProperty.Name);
+                    Assert.Equal("Food", nameProperty.Value);
+                    Assert.Equal("YTDTotal", ytdTotalProperty.Name);
+                    Assert.Equal(7130m, ytdTotalProperty.Value);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("YTDTotal");
+                    var odataType = Assert.Contains("odata.type", odataPropertyAnnotations);
+                    Assert.Equal("Edm.Decimal", odataType);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithODataAnnotationsAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"@odata.id\":\"http://tempuri.org/Categories(1)\"," +
+                "\"@odata.editLink\":\"http://tempuri.org/Categories(1)\"," +
+                "\"@odata.readLink\":\"http://tempuri.org/Categories(1)\"," +
+                "\"@odata.etag\":\"etag\"," +
+                "\"@odata.mediaEditLink\":\"http://tempuri.org/Categories(1)/Img\"," +
+                "\"@odata.mediaReadLink\":\"http://tempuri.org/Categories(1)/Img\"," +
+                "\"@odata.mediaContentType\":\"image/png\"," +
+                "\"@odata.mediaEtag\":\"media-etag\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataScopeAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataScopeAnnotation();
+
+                    var odataId = (Uri)Assert.Contains("odata.id", odataScopeAnnotations);
+                    var odataEditLink = (Uri)Assert.Contains("odata.editLink", odataScopeAnnotations);
+                    var odataReadLink = (Uri)Assert.Contains("odata.readLink", odataScopeAnnotations);
+                    var odataEtag = Assert.Contains("odata.etag", odataScopeAnnotations);
+                    var odataMediaEditLink = (Uri)Assert.Contains("odata.mediaEditLink", odataScopeAnnotations);
+                    var odataMediaReadLink = (Uri)Assert.Contains("odata.mediaReadLink", odataScopeAnnotations);
+                    var odataMediaContentType = Assert.Contains("odata.mediaContentType", odataScopeAnnotations);
+                    var odataMediaEtag = Assert.Contains("odata.mediaEtag", odataScopeAnnotations);
+                    Assert.Equal("http://tempuri.org/Categories(1)", odataId.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)", odataEditLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)", odataReadLink.AbsoluteUri);
+                    Assert.Equal("etag", odataEtag);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Img", odataMediaEditLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Img", odataMediaReadLink.AbsoluteUri);
+                    Assert.Equal("image/png", odataMediaContentType);
+                    Assert.Equal("media-etag", odataMediaEtag);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithODataPropertyAnnotationsAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name@odata.mediaEditLink\":\"http://tempuri.org/Categories(1)/Name\"," +
+                "\"Name@odata.mediaReadLink\":\"http://tempuri.org/Categories(1)/Name\"," +
+                "\"Name@odata.mediaContentType\":\"text/plain\"," +
+                "\"Name@odata.mediaEtag\":\"media-etag\"," +
+                "\"Name\":\"Food\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("Name");
+
+                    var odataMediaEditLink = (Uri)Assert.Contains("odata.mediaEditLink", odataPropertyAnnotations);
+                    var odataMediaReadLink = (Uri)Assert.Contains("odata.mediaReadLink", odataPropertyAnnotations);
+                    var odataMediaContentType = Assert.Contains("odata.mediaContentType", odataPropertyAnnotations);
+                    var odataMediaEtag = Assert.Contains("odata.mediaEtag", odataPropertyAnnotations);
+
+                    Assert.Equal("http://tempuri.org/Categories(1)/Name", odataMediaEditLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Name", odataMediaReadLink.AbsoluteUri);
+                    Assert.Equal("text/plain", odataMediaContentType);
+                    Assert.Equal("media-etag", odataMediaEtag);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithCustomAnnotationsAsync()
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("attr.remark");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"@attr.remark\":\"Perishable\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var customScopeAnnotations = resourceState.PropertyAndAnnotationCollector.GetCustomScopeAnnotation();
+                    Assert.Contains(new KeyValuePair<string, object>("attr.remark", "Perishable"), customScopeAnnotations);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithExpandedSingletonNavigationPropertyInResponsePayloadAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"BestSeller@odata.type\":\"#NS.Product\"," +
+                "\"BestSeller@odata.associationLink\":\"http://tempuri.org/Categories(1)/BestSeller\"," +
+                "\"BestSeller@odata.navigationLink\":\"http://tempuri.org/Products(1)\"," +
+                "\"BestSeller\":{\"Id\":1,\"Name\":\"Sugar\"}}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("BestSeller");
+
+                    var odataType = Assert.Contains("odata.type", odataPropertyAnnotations);
+                    var odataAssociationLink = (Uri)Assert.Contains("odata.associationLink", odataPropertyAnnotations);
+                    var odataNavigationLink = (Uri)Assert.Contains("odata.navigationLink", odataPropertyAnnotations);
+                    Assert.Equal("NS.Product", odataType);
+                    Assert.Equal("http://tempuri.org/Categories(1)/BestSeller", odataAssociationLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Products(1)", odataNavigationLink.AbsoluteUri);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithExpandedCollectionNavigationPropertyInResponsePayloadAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"Products@odata.type\":\"#Collection(NS.Product)\"," +
+                "\"Products@odata.associationLink\":\"http://tempuri.org/Categories(1)/Products\"," +
+                "\"Products@odata.navigationLink\":\"http://tempuri.org/Categories(1)/Products\"," +
+                "\"Products@odata.nextLink\":\"http://tempuri.org/Categories(1)/Products/nextLink\"," +
+                "\"Products@odata.count\":3," +
+                "\"Products\":[{\"Id\":1,\"Name\":\"Sugar\"},{\"Id\":2,\"Name\":\"Coffee\"}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("Products");
+
+                    var odataType = Assert.Contains("odata.type", odataPropertyAnnotations);
+                    var odataAssociationLink = (Uri)Assert.Contains("odata.associationLink", odataPropertyAnnotations);
+                    var odataNavigationLink = (Uri)Assert.Contains("odata.navigationLink", odataPropertyAnnotations);
+                    var odataNextLink = (Uri)Assert.Contains("odata.nextLink", odataPropertyAnnotations);
+                    var odataCount = (long)Assert.Contains("odata.count", odataPropertyAnnotations);
+                    Assert.Equal("Collection(NS.Product)", odataType);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Products", odataAssociationLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Products", odataNavigationLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Products/nextLink", odataNextLink.AbsoluteUri);
+                    Assert.Equal(3, odataCount);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithNonExpandedSingletonNavigationPropertyInResponsePayloadAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"BestSeller@odata.type\":\"#NS.Product\"," +
+                "\"BestSeller@odata.associationLink\":\"http://tempuri.org/Categories(1)/BestSeller\"," +
+                "\"BestSeller@odata.navigationLink\":\"http://tempuri.org/Products(1)\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("BestSeller");
+
+                    var odataType = Assert.Contains("odata.type", odataPropertyAnnotations);
+                    var odataAssociationLink = (Uri)Assert.Contains("odata.associationLink", odataPropertyAnnotations);
+                    var odataNavigationLink = (Uri)Assert.Contains("odata.navigationLink", odataPropertyAnnotations);
+                    Assert.Equal("NS.Product", odataType);
+                    Assert.Equal("http://tempuri.org/Categories(1)/BestSeller", odataAssociationLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Products(1)", odataNavigationLink.AbsoluteUri);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithNonExpandedSingletonNavigationPropertyInRequestPayloadAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"BestSeller@odata.bind\":\"http://tempuri.org/Products(1)\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("BestSeller");
+
+                    var entityReferenceLink = Assert.Contains("odata.bind", odataPropertyAnnotations) as ODataEntityReferenceLink;
+                    Assert.NotNull(entityReferenceLink);
+                    Assert.Equal("http://tempuri.org/Products(1)", entityReferenceLink.Url.AbsoluteUri);
+                },
+                isResponse: false);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithNonExpandedCollectionNavigationPropertyInRequestPayloadAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"Products@odata.bind\":[\"http://tempuri.org/Products(1)\"]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("Products");
+
+                    var entityReferenceLinks = Assert.Contains("odata.bind", odataPropertyAnnotations) as LinkedList<ODataEntityReferenceLink>;
+                    Assert.NotNull(entityReferenceLinks);
+                    var entityReferenceLink = Assert.Single(entityReferenceLinks);
+                    Assert.Equal("http://tempuri.org/Products(1)", entityReferenceLink.Url.AbsoluteUri);
+                },
+                isResponse: false);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithODataActionAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"#NS.RateProducts\":{\"title\":\"RateProducts\",\"target\":\"http://tempuri.org/Categories(1)/RateProducts\",\"IgnoreProp\":true}}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var rateProductsAction = Assert.Single(resourceState.Resource.Actions);
+                    Assert.Equal("RateProducts", rateProductsAction.Title);
+                    Assert.Equal("http://tempuri.org/Categories(1)/RateProducts", rateProductsAction.Target.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/$metadata#NS.RateProducts", rateProductsAction.Metadata.AbsoluteUri);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithODataFunctionAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"#NS.Top5Products\":[" +
+                "{\"title\":\"Top5Products\",\"target\":\"http://tempuri.org/Categories(1)/Top5Products\",\"IgnoreProp\":true}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var top5ProductsAction = Assert.Single(resourceState.Resource.Functions);
+                    Assert.Equal("Top5Products", top5ProductsAction.Title);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Top5Products", top5ProductsAction.Target.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/$metadata#NS.Top5Products", top5ProductsAction.Metadata.AbsoluteUri);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_IgnoresUnrecognizedOperation()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"#NS.UnrecognizedOperation\":{\"title\":\"UnrecognizedOperation\",\"target\":\"http://tempuri.org/Categories(1)/UnrecognizedOperation\"}}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    Assert.Empty(resourceState.Resource.Actions);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithNestedDeltaResourceSetAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"Products@delta\":[{\"@odata.id\":\"http://tempuri.org/Products(1)\",\"Id\":1,\"Name\":\"Tea\"}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                commonVerifyAction);
+        }
+
+        [Fact]
+        public async Task ReadV401ResourceContentWithNestedDeltaResourceSetAsync()
+        {
+            this.messageReaderSettings.Version = ODataVersion.V401;
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"Products@odata.type\":\"#Collection(NS.Product)\"," +
+                "\"Products@odata.associationLink\":\"http://tempuri.org/Categories(1)/Products\"," +
+                "\"Products@odata.navigationLink\":\"http://tempuri.org/Categories(1)/Products\"," +
+                "\"Products@odata.nextLink\":\"http://tempuri.org/Categories(1)/Products/nextLink\"," +
+                "\"Products@odata.count\":3," +
+                "\"Products@delta\":[{\"Id\":1,\"Name\":\"Sugar\"},{\"Id\":2,\"Name\":\"Coffee\"}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("Products");
+
+                    var odataType = Assert.Contains("odata.type", odataPropertyAnnotations);
+                    var odataAssociationLink = (Uri)Assert.Contains("odata.associationLink", odataPropertyAnnotations);
+                    var odataNavigationLink = (Uri)Assert.Contains("odata.navigationLink", odataPropertyAnnotations);
+                    var odataNextLink = (Uri)Assert.Contains("odata.nextLink", odataPropertyAnnotations);
+                    var odataCount = (long)Assert.Contains("odata.count", odataPropertyAnnotations);
+                    Assert.Equal("Collection(NS.Product)", odataType);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Products", odataAssociationLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Products", odataNavigationLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Products/nextLink", odataNextLink.AbsoluteUri);
+                    Assert.Equal(3, odataCount);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithPrimitivePropertyReadAsStreamAsync()
+        {
+            this.messageReaderSettings.ReadAsStreamFunc = (primitiveType, isCollection, propertyName, edmProperty) => propertyName.Equals("Name");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    var idProperty = Assert.Single(resourceState.Resource.Properties);
+                    Assert.Equal("Id", idProperty.Name);
+                    Assert.Equal(1, idProperty.Value);
+                    // Name property treated as a nested property
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredStreamPropertyAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"Media@odata.type\":\"#Edm.Stream\"," +
+                "\"Media@odata.mediaEditLink\":\"http://tempuri.org/Categories(1)/Media\"," +
+                "\"Media@odata.mediaReadLink\":\"http://tempuri.org/Categories(1)/Media\"," +
+                "\"Media@odata.mediaContentType\":\"text/plain\"," +
+                "\"Media@odata.mediaEtag\":\"media-etag\"," +
+                "\"Media\":\"AQIDBAUGBwgJAA==\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    var mediaProperty = Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Media")));
+                    var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(mediaProperty.Value);
+
+                    Assert.Equal("http://tempuri.org/Categories(1)/Media", streamReferenceValue.EditLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Media", streamReferenceValue.ReadLink.AbsoluteUri);
+                    Assert.Equal("text/plain", streamReferenceValue.ContentType);
+                    Assert.Equal("media-etag", streamReferenceValue.ETag);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("Media");
+
+                    var odataMediaEditLink = (Uri)Assert.Contains("odata.mediaEditLink", odataPropertyAnnotations);
+                    var odataMediaReadLink = (Uri)Assert.Contains("odata.mediaReadLink", odataPropertyAnnotations);
+                    var odataMediaContentType = Assert.Contains("odata.mediaContentType", odataPropertyAnnotations);
+                    var odataMediaEtag = Assert.Contains("odata.mediaEtag", odataPropertyAnnotations);
+
+                    Assert.Equal("http://tempuri.org/Categories(1)/Media", odataMediaEditLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Categories(1)/Media", odataMediaReadLink.AbsoluteUri);
+                    Assert.Equal("text/plain", odataMediaContentType);
+                    Assert.Equal("media-etag", odataMediaEtag);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredStreamCollectionPropertyAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"Images@odata.type\":\"#Collection(Edm.Stream)\"," +
+                "\"Images\":[\"AQIDBAUGBwgJAA==\"]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+                    // Images property treated as a nested property
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredSpatialPropertyAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"WarehousePin@odata.type\":\"#Edm.GeographyPoint\"," +
+                "\"WarehousePin\":{\"type\":\"Point\",\"coordinates\":[22.2,22.2],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    Assert.Equal(3, resourceState.Resource.Properties.Count());
+
+                    var warehousePinProperty = Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("WarehousePin")));
+                    var geographyPoint = Assert.IsAssignableFrom<GeographyPoint>(warehousePinProperty.Value);
+                    Assert.Equal(22.2, geographyPoint.Latitude);
+                    Assert.Equal(22.2, geographyPoint.Longitude);
+                    Assert.Equal(4326, geographyPoint.CoordinateSystem.EpsgId);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredPropertyAsUntypedAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"Pi\":3.1428571429}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    Assert.Equal(3, resourceState.Resource.Properties.Count());
+
+                    var piProperty = Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Pi")));
+                    var untypedValue = Assert.IsType<ODataUntypedValue>(piProperty.Value);
+                    Assert.Equal("3.1428571429", untypedValue.RawValue);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredPrimitivePropertyForNonOpenTypeAsync()
+        {
+            this.messageReaderSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"CreditLimit\":1730}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.customersEntitySet,
+                this.customerEntityType,
+                (resourceState) =>
+                {
+                    Assert.Equal(3, resourceState.Resource.Properties.Count());
+
+                    var creditLimitProperty = Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("CreditLimit")));
+                    var untypedValue = Assert.IsType<ODataUntypedValue>(creditLimitProperty.Value);
+                    Assert.Equal("1730", untypedValue.RawValue);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredButAnnotatedPrimitivePropertyForNonOpenTypeAsync()
+        {
+            this.messageReaderSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"CreditLimit@odata.type\":\"#Edm.Decimal\"," +
+                "\"CreditLimit\":1730}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.customersEntitySet,
+                this.customerEntityType,
+                (resourceState) =>
+                {
+                    Assert.Equal(3, resourceState.Resource.Properties.Count());
+
+                    var creditLimitProperty = Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("CreditLimit")));
+                    Assert.Equal(1730M, creditLimitProperty.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredComplexPropertySingletonForNonOpenTypeAsync()
+        {
+            this.messageReaderSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"HomeAddress@odata.type\":\"#NS.Address\"," +
+                "\"HomeAddress\":{\"Street\":\"Street 2\",\"City\":\"City 2\"}}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.customersEntitySet,
+                this.customerEntityType,
+                (resourceState) =>
+                {
+                    Assert.Equal(2, resourceState.Resource.Properties.Count());
+
+                    var odataTypeAnnotation = Assert.Single(resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("HomeAddress"));
+                    Assert.Equal("odata.type", odataTypeAnnotation.Key);
+                    Assert.Equal("NS.Address", odataTypeAnnotation.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredComplexPropertySingletonForNonOpenTypeAsync_ThrowsExceptionForValueIsJsonArray()
+        {
+            this.messageReaderSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"HomeAddress@odata.type\":\"#NS.Address\"," +
+                "\"HomeAddress\":[{\"Street\":\"Street 2\",\"City\":\"City 2\"}]}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.customersEntitySet,
+                    this.customerEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_CannotReadSingletonNestedResource("StartArray", "HomeAddress"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredComplexCollectionPropertyForNonOpenTypeAsync()
+        {
+            this.messageReaderSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"PhysicalAddresses@odata.type\":\"#Collection(NS.Address)\"," +
+                "\"PhysicalAddresses\":[{\"Street\":\"Street 2\",\"City\":\"City 2\"}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.customersEntitySet,
+                this.customerEntityType,
+                (resourceState) =>
+                {
+                    Assert.Equal(2, resourceState.Resource.Properties.Count());
+
+                    var odataTypeAnnotation = Assert.Single(resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("PhysicalAddresses"));
+                    Assert.Equal("odata.type", odataTypeAnnotation.Key);
+                    Assert.Equal("Collection(NS.Address)", odataTypeAnnotation.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredComplexCollectionPropertyForNonOpenTypeAsync_ThrowsExceptionForValueIsJsonObject()
+        {
+            this.messageReaderSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"PhysicalAddresses@odata.type\":\"#Collection(NS.Address)\"," +
+                "\"PhysicalAddresses\":{\"Street\":\"Street 2\",\"City\":\"City 2\"}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.customersEntitySet,
+                    this.customerEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ReaderValidationUtils_NullNamedValueForNullableType("PhysicalAddresses", "Collection(NS.Address)"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredEntityCollectionPropertyForNonOpenTypeAsync_ThrowsExceptionForValueIsJsonObject()
+        {
+            this.messageReaderSettings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"ReviewedProducts@odata.type\":\"#Collection(NS.Product)\"," +
+                "\"ReviewedProducts\":{\"Id\":1,\"Name\":\"Tea\"}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.customersEntitySet,
+                    this.customerEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_CannotReadCollectionNestedResource("StartObject", "ReviewedProducts"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredExpandedSingletonNavigationPropertyInResponsePayloadAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"WorstSeller@odata.type\":\"#NS.Product\"," +
+                "\"WorstSeller@odata.associationLink\":\"http://tempuri.org/Categories(1)/WorstSeller\"," +
+                "\"WorstSeller@odata.navigationLink\":\"http://tempuri.org/Products(2)\"," +
+                "\"WorstSeller\":{\"Id\":2,\"Name\":\"Coffee\"}}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("WorstSeller");
+
+                    var odataType = Assert.Contains("odata.type", odataPropertyAnnotations);
+                    var odataAssociationLink = (Uri)Assert.Contains("odata.associationLink", odataPropertyAnnotations);
+                    var odataNavigationLink = (Uri)Assert.Contains("odata.navigationLink", odataPropertyAnnotations);
+
+                    Assert.Equal("NS.Product", odataType);
+                    Assert.Equal("http://tempuri.org/Categories(1)/WorstSeller", odataAssociationLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Products(2)", odataNavigationLink.AbsoluteUri);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredNonExpandedSingletonNavigationPropertyInResponsePayloadAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"WorstSeller@odata.type\":\"#NS.Product\"," +
+                "\"WorstSeller@odata.associationLink\":\"http://tempuri.org/Categories(1)/WorstSeller\"," +
+                "\"WorstSeller@odata.navigationLink\":\"http://tempuri.org/Products(2)\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("WorstSeller");
+
+                    var odataType = Assert.Contains("odata.type", odataPropertyAnnotations);
+                    var odataAssociationLink = (Uri)Assert.Contains("odata.associationLink", odataPropertyAnnotations);
+                    var odataNavigationLink = (Uri)Assert.Contains("odata.navigationLink", odataPropertyAnnotations);
+
+                    Assert.Equal("NS.Product", odataType);
+                    Assert.Equal("http://tempuri.org/Categories(1)/WorstSeller", odataAssociationLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Products(2)", odataNavigationLink.AbsoluteUri);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredExpandedSingletonComplexPropertyInResponsePayloadAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"WarehouseAddress\":{\"@odata.type\":\"#NS.Address\",\"Id\":2,\"Name\":\"Coffee\"}}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithUndeclaredExpandedCollectionComplexPropertyInResponsePayloadAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"WarehouseAddresses@odata.type\":\"#Collection(NS.Address)\"," +
+                "\"WarehouseAddresses\":[{\"Id\":2,\"Name\":\"Coffee\"}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    commonVerifyAction(resourceState);
+
+                    var odataPropertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations("WarehouseAddresses");
+                    var odataType = Assert.Contains("odata.type", odataPropertyAnnotations);
+                    Assert.Equal("Collection(NS.Address)", odataType);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithStreamPropertyAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Products/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Tea\"," +
+                "\"Photo\":\"AQIDBAUGBwgJAA==\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.productsEntitySet,
+                this.productEntityType,
+                (resourceState) =>
+                {
+                    Assert.Equal(3, resourceState.Resource.Properties.Count());
+
+                    var photoProperty = Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Photo")));
+                    var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(photoProperty.Value);
+
+                    Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.EditLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.ReadLink.AbsoluteUri);
+                    Assert.Null(streamReferenceValue.ContentType);
+                    Assert.Null(streamReferenceValue.ETag);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithDeferredStreamPropertyAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Products/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Tea\"," +
+                "\"Photo@odata.type\":\"#Edm.Stream\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.productsEntitySet,
+                this.productEntityType,
+                (resourceState) =>
+                {
+                    Assert.Equal(3, resourceState.Resource.Properties.Count());
+
+                    var photoProperty = Assert.Single(resourceState.Resource.Properties.Where(d => d.Name.Equals("Photo")));
+                    var streamReferenceValue = Assert.IsType<ODataStreamReferenceValue>(photoProperty.Value);
+
+                    Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.EditLink.AbsoluteUri);
+                    Assert.Equal("http://tempuri.org/Products(1)/Photo", streamReferenceValue.ReadLink.AbsoluteUri);
+                    Assert.Null(streamReferenceValue.ContentType);
+                    Assert.Null(streamReferenceValue.ETag);
+                });
+        }
+
+        public static IEnumerable<object[]> GetReadResourceContentWithNestedComplexPropertyTestData()
+        {
+            yield return new object[]
+            {
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"BillingAddress\":{\"@odata.type\":\"#NS.Address\",\"Street\":\"Street 1\",\"City\":\"City 1\"}}"
+            };
+
+            yield return new object[]
+            {
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"ShippingAddresses@odata.type\":\"#Collection(NS.Address)\"," +
+                "\"ShippingAddresses\":[{\"@odata.type\":\"#NS.Address\",\"Street\":\"Street 1\",\"City\":\"City 1\"}]}"
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetReadResourceContentWithNestedComplexPropertyTestData))]
+        public async Task ReadResourceContentWithNestedComplexPropertyAsync(string payload)
+        {
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.customersEntitySet,
+                this.customerEntityType,
+                (resourceState) =>
+                {
+                    var resource = resourceState.Resource;
+                    Assert.NotNull(resource);
+                    var properties = resource.Properties.ToArray();
+                    Assert.Equal(2, properties.Length);
+                    var idProperty = properties[0];
+                    var nameProperty = properties[1];
+                    Assert.Equal("Id", idProperty.Name);
+                    Assert.Equal(1, idProperty.Value);
+                    Assert.Equal("Name", nameProperty.Name);
+                    Assert.Equal("Sue", nameProperty.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourceSetAnnotationsAsync()
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("attr.remark");
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"@odata.count\":2," +
+                "\"@odata.type\":\"#Collection(NS.Category)\"," +
+                "\"@odata.nextLink\":\"http://tempuri.org/Categories/nextLink\"," +
+                "\"@attr.remark\":\"Collection\"," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                categoriesResourceSet,
+                payload,
+                (resourceSet, propertyAndAnnotationCollector) =>
+                {
+                    var odataScopeAnnotations = propertyAndAnnotationCollector.GetODataScopeAnnotation();
+
+                    var odataType = Assert.Contains("odata.type", odataScopeAnnotations);
+                    var odataNextLink = Assert.Contains("odata.nextLink", odataScopeAnnotations);
+                    var odataCount = Assert.Contains("odata.count", odataScopeAnnotations);
+
+                    Assert.Equal("#Collection(NS.Category)", odataType);
+                    Assert.Equal("http://tempuri.org/Categories/nextLink", odataNextLink);
+                    Assert.Equal(2, odataCount);
+
+                    var customInstanceAnnotation = Assert.Single(resourceSet.InstanceAnnotations);
+                    Assert.Equal("attr.remark", customInstanceAnnotation.Name);
+                    var annotationValue = Assert.IsType<ODataPrimitiveValue>(customInstanceAnnotation.Value);
+                    Assert.Equal("Collection", annotationValue.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourceSetAnnotationsWithMetadataReferencePropertyAsync()
+        {
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"#NS.RateCategories\":[{\"title\":\"RateCategories\",\"target\":\"http://tempuri.org/RateCategories\",\"IgnoreProp\":true}]," +
+                "\"#NS.Top2Categories\":{\"title\":\"Top2Categories\",\"target\":\"http://tempuri.org/Top2Categories\",\"IgnoreProp\":true}," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                categoriesResourceSet,
+                payload,
+                (resourceSet, propertyAndAnnotationCollector) =>
+                {
+                    var rateCategoriesAction = Assert.Single(((ODataResourceSet)resourceSet).Actions);
+                    var top2CategoriesFunction = Assert.Single(((ODataResourceSet)resourceSet).Functions);
+
+                    Assert.Equal("RateCategories", rateCategoriesAction.Title);
+                    Assert.Equal("http://tempuri.org/RateCategories", rateCategoriesAction.Target.AbsoluteUri);
+                    Assert.Equal("Top2Categories", top2CategoriesFunction.Title);
+                    Assert.Equal("http://tempuri.org/Top2Categories", top2CategoriesFunction.Target.AbsoluteUri);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourceSetAnnotationsWithReorderingAsync()
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("attr.remark");
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"@odata.count\":2," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]," +
+                "\"@odata.nextLink\":\"http://tempuri.org/Categories/nextLink\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                categoriesResourceSet,
+                payload,
+                (resourceSet, propertyAndAnnotationCollector) =>
+                {
+                    // Reading does not stop at resource set (i.e., value) property
+                    var odataScopeAnnotations = propertyAndAnnotationCollector.GetODataScopeAnnotation();
+
+                    var odataNextLink = Assert.Contains("odata.nextLink", odataScopeAnnotations);
+                    var odataCount = Assert.Contains("odata.count", odataScopeAnnotations);
+
+                    Assert.Equal("http://tempuri.org/Categories/nextLink", odataNextLink);
+                    Assert.Equal(2, odataCount);
+                },
+                readAllResourceSetProperties: true);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelDeltaResourceSetAnnotationsAsync()
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("attr.remark");
+            var categoriesDeltaResourceSet = CreateDeltaResourceSet("Categories", "NS.Categories", new Uri("http://tempuri.org/Categories/deltaLink"));
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"@odata.count\":2," +
+                "\"@odata.type\":\"#Collection(NS.Category)\"," +
+                "\"@odata.deltaLink\":\"http://tempuri.org/Categories/deltaLink\"," +
+                "\"@attr.remark\":\"Collection\"," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                categoriesDeltaResourceSet,
+                payload,
+                (resourceSet, propertyAndAnnotationCollector) =>
+                {
+                    var odataScopeAnnotations = propertyAndAnnotationCollector.GetODataScopeAnnotation();
+
+                    var odataType = Assert.Contains("odata.type", odataScopeAnnotations);
+                    var odataDeltaLink = Assert.Contains("odata.deltaLink", odataScopeAnnotations);
+                    var odataCount = Assert.Contains("odata.count", odataScopeAnnotations);
+
+                    Assert.Equal("#Collection(NS.Category)", odataType);
+                    Assert.Equal("http://tempuri.org/Categories/deltaLink", odataDeltaLink);
+                    Assert.Equal(2, odataCount);
+
+                    var customInstanceAnnotation = Assert.Single(resourceSet.InstanceAnnotations);
+                    Assert.Equal("attr.remark", customInstanceAnnotation.Name);
+                    var annotationValue = Assert.IsType<ODataPrimitiveValue>(customInstanceAnnotation.Value);
+                    Assert.Equal("Collection", annotationValue.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourceSetAnnotationsAsync_IgnoresUnrecognizedOperation()
+        {
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"#NS.UnrecognizedOperation\":{\"title\":\"UnrecognizedOperation\",\"target\":\"http://tempuri.org/UnrecognizedOperation\"}," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]}";
+
+            await SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                categoriesResourceSet,
+                payload,
+                (resourceSet, propertyAndAnnotationCollector) =>
+                {
+                    Assert.Empty(((ODataResourceSet)resourceSet).Actions);
+                });
+        }
+
+        [Fact]
+        public async Task ReadNextLinkAnnotationAtTopLevelResourceSetEndAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"@odata.count\":2," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]," +
+                "\"@odata.nextLink\":\"http://tempuri.org/Categories?$skip=1\"}";
+
+            var resourceSet = CreateResourceSet("Categories", "NS.Category");
+
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, this.model, isResponse: true))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+                var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
+
+                await jsonLightResourceDeserializer.ReadPayloadStartAsync(
+                    ODataPayloadKind.ResourceSet,
+                    propertyAndAnnotationCollector,
+                    false,
+                    true);
+
+                await jsonLightResourceDeserializer.ReadNextLinkAnnotationAtResourceSetEndAsync(
+                    resourceSet,
+                    expandedNestedResourceInfo: null,
+                    propertyAndAnnotationCollector);
+
+                var odataScopeAnnotationKvPair = Assert.Single(propertyAndAnnotationCollector.GetODataScopeAnnotation());
+
+                Assert.Equal("odata.count", odataScopeAnnotationKvPair.Key);
+                Assert.Equal(2, odataScopeAnnotationKvPair.Value);
+            }
+        }
+
+        [Fact]
+        public async Task ReadNextLinkAnnotationAtResourceSetEndAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories(Products())/$entity\"," +
+                "\"Products\":[{\"Id\":1,\"Name\":\"Tea\"},{\"Id\":2,\"Name\":\"Coffee\"}]," +
+                "\"Products@odata.nextLink\":\"http://tempuri.org/Categories(1)/Products?$skip=2\"," +
+                "\"Products@odata.count\":3}";
+
+            var productsResourceSet = CreateResourceSet("Products", "NS.Product");
+            var expandedNestedResourceInfo = CreateProductsNavigationPropertyNestedResourceInfo(productsResourceSet);
+
+            await SetupJsonLightResourceSerializerAndRunReadNextLinkAnnotationAtResourceSetEndAsync(
+                productsResourceSet,
+                expandedNestedResourceInfo,
+                payload,
+                (nestedResourceSet) =>
+                {
+                    Assert.Equal("http://tempuri.org/Categories(1)/Products?$skip=2", nestedResourceSet.NextPageLink.AbsoluteUri);
+                    Assert.Equal(3, nestedResourceSet.Count);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForDeferredPrimitiveProperty()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Products/$entity\"," +
+                "\"Id\":1," +
+                "\"Name@odata.type\":\"#Edm.String\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.productsEntitySet,
+                    this.productEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType("Name", "Edm.String"),
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData("{\"title\":\"Top5Products\",\"title\":\"Top5Products\",\"target\":\"http://tempuri.org/Top5Products\"}", "title")]
+        [InlineData("{\"title\":\"Top5Products\",\"target\":\"http://tempuri.org/Top5Products\",\"target\":\"http://tempuri.org/Top5Products\"}", "target")]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForRepeatedPropertyInOperation(string operationPart, string repeatedProperty)
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                $"\"#NS.Top5Products\":{operationPart}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_MultipleOptionalPropertiesInOperation(repeatedProperty, "#NS.Top5Products"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForOperationMissingTargetProperty()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"#NS.Top5Products\":[{\"title\":\"Top5Products\"}]}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_OperationMissingTargetProperty("#NS.Top5Products"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForOperationPropertyValueNotObject()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"#NS.Top5Products\":\"Top5Products\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonOperationsDeserializerUtils_OperationsPropertyMustHaveObjectValue("#NS.Top5Products", JsonNodeType.PrimitiveValue),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForODataIdAnnotationPrecededByProperty()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"@odata.id\":\"http://tempuri.org/Categories(1)\"," +
+                "\"Name\":\"Food\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_ResourceInstanceAnnotationPrecededByProperty("odata.id"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForODataEtagAnnotationPrecededByProperty()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"@odata.etag\":\"etag\"," +
+                "\"Name\":\"Food\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_ResourceInstanceAnnotationPrecededByProperty("odata.etag"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForUnexpectedODataRemovedAnnotation()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"@odata.removed\":{\"reason\":\"deleted\"}," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_UnexpectedDeletedEntryInResponsePayload,
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForODataBindPropertyAnnotationValueIsEmptyJsonArray()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"Products@odata.bind\":[]}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_EmptyBindArray("odata.bind"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForUndeclaredNonExpandedComplexProperty()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"WarehouseAddress@odata.type\":\"#NS.Address\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_OpenPropertyWithoutValue("WarehouseAddress"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForODataTypeAnnotationInsidePrimitiveValue()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"," +
+                "\"WarehousePin\":{\"@odata.type\":\"#Edm.GeographyPoint\",\"type\":\"Point\",\"coordinates\":[22.2,22.2],\"crs\":{\"type\":\"name\",\"properties\":{\"name\":\"EPSG:4326\"}}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_ODataTypeAnnotationInPrimitiveValue("odata.type"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadEntryInstanceAnnotationAsync_ThrowsExceptionForMultipleODataTypeAnnotation()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"@odata.type\":\"NS.Category\"," +
+                "\"@odata.type\":\"NS.Category\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"}";
+
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, this.model, isResponse: true))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await jsonLightResourceDeserializer.ReadPayloadStartAsync(
+                    ODataPayloadKind.Resource,
+                    new PropertyAndAnnotationCollector(true),
+                    false,
+                    true);
+
+                var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
+
+                await jsonLightResourceDeserializer.JsonReader.ReadAsync(); // Read over property name
+                var annotationValue = await jsonLightResourceDeserializer.ReadEntryInstanceAnnotationAsync(
+                    annotationName: "odata.type",
+                    anyPropertyFound: false,
+                    typeAnnotationFound: false,
+                    propertyAndAnnotationCollector);
+                Assert.Equal("NS.Category", annotationValue);
+
+                await jsonLightResourceDeserializer.JsonReader.ReadAsync(); // Read over property name
+                var exception = await Assert.ThrowsAsync<ODataException>(
+                    () => jsonLightResourceDeserializer.ReadEntryInstanceAnnotationAsync(
+                        annotationName: "odata.type",
+                        anyPropertyFound: false,
+                        typeAnnotationFound: true, // Type annotation was in a previous call
+                        propertyAndAnnotationCollector));
+
+                Assert.Equal(
+                    ErrorStrings.ODataJsonLightResourceDeserializer_ResourceTypeAnnotationNotFirst,
+                    exception.Message);
+            }
+        }
+
+        [Fact]
+        public async Task ReadResourceContentAsync_ThrowsExceptionForUnexpectedODataDeltaPropertyAnnotation()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name@odata.deltaLink\":\"http://tempuri.org/Categories(1)/Name/deltaLink\"," +
+                "\"Name\":\"Food\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                    payload,
+                    this.categoriesEntitySet,
+                    this.categoryEntityType,
+                    (resourceState) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedAnnotationProperties("odata.deltaLink"),
+                exception.Message);
+        }
+
+
+
+        [Fact]
+        public async Task ReadTopLevelResourceSetAnnotationsAsync_ThrowsExceptionForMissingValueProperty()
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("attr.remark");
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                    categoriesResourceSet,
+                    payload,
+                    (resourceSet, propertyAndAnnotationCollector) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_ExpectedResourceSetPropertyNotFound("value"),
+                exception.Message);
+        }
+
+        [Theory]
+        [InlineData("{\"title\":\"RateCategories\",\"title\":\"RateCategories\",\"target\":\"http://tempuri.org/RateCategories\"}", "title")]
+        [InlineData("{\"title\":\"RateCategories\",\"target\":\"http://tempuri.org/RateCategories\",\"target\":\"http://tempuri.org/RateCategories\"}", "target")]
+        public async Task ReadTopLevelResourceSetAnnotationsAsync_ThrowsExceptionForRepeatedPropertyInOperation(string operationPart, string repeatedProperty)
+        {
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                $"\"#NS.RateCategories\":{operationPart}," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                    categoriesResourceSet,
+                    payload,
+                    (resourceSet, propertyAndAnnotationCollector) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_MultipleOptionalPropertiesInOperation(repeatedProperty, "#NS.RateCategories"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourceSetAnnotationsAsync_ThrowsExceptionForOperationMissingTargetProperty()
+        {
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"#NS.RateCategories\":[{\"title\":\"RateCategories\"}]," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                    categoriesResourceSet,
+                    payload,
+                    (resourceSet, propertyAndAnnotationCollector) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_OperationMissingTargetProperty("#NS.RateCategories"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourceSetAnnotationsAsync_ThrowsExceptionForOperationPropertyValueNotObject()
+        {
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"#NS.RateCategories\":\"RateCategories\"," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                    categoriesResourceSet,
+                    payload,
+                    (resourceSet, propertyAndAnnotationCollector) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonOperationsDeserializerUtils_OperationsPropertyMustHaveObjectValue("#NS.RateCategories", JsonNodeType.PrimitiveValue),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourceSetAnnotationsAsync_ThrowsExceptionForRequiredPropertyWithoutValue()
+        {
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"value@attr.remark\":\"Missing value property\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                    categoriesResourceSet,
+                    payload,
+                    (resourceSet, propertyAndAnnotationCollector) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_InvalidPropertyAnnotationInTopLevelResourceSet("value"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelResourceSetAnnotationsAsync_ThrowsExceptionForUnexpectedProperty()
+        {
+            var categoriesResourceSet = CreateResourceSet("Categories", "NS.Categories");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"Id\":1," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                    categoriesResourceSet,
+                    payload,
+                    (resourceSet, propertyAndAnnotationCollector) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_InvalidPropertyInTopLevelResourceSet("Id", "value"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelDeltaResourceSetAnnotationsAsync_ThrowsExceptionForUnexpectedMetadataReferenceProperty()
+        {
+            var categoriesDeltaResourceSet = CreateDeltaResourceSet("Categories", "NS.Categories", new Uri("http://tempuri.org/Categories/deltaLink"));
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories\"," +
+                "\"#NS.RateCategories\":[{\"title\":\"RateCategories\",\"target\":\"http://tempuri.org/RateCategories\"}]," +
+                "\"value\":[{\"Id\":1,\"Name\":\"Food\"}]}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+                    categoriesDeltaResourceSet,
+                    payload,
+                    (resourceSet, propertyAndAnnotationCollector) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty("#NS.RateCategories"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadResourceSetContentAsync_ThrowsExceptionForValuePropertyNotAnArray()
+        {
+            using (var jsonInputContext = CreateJsonLightInputContext("{\"value\":{}}", model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+                var jsonReader = jsonLightResourceDeserializer.JsonReader;
+
+                await AdvanceReaderToFirstPropertyAsync(jsonReader);
+                await jsonReader.ReadAsync();
+
+                var exception = await Assert.ThrowsAsync<ODataException>(
+                    () => jsonLightResourceDeserializer.ReadResourceSetContentStartAsync());
+
+                Assert.Equal(
+                    ErrorStrings.ODataJsonLightResourceDeserializer_CannotReadResourceSetContentStart("StartObject"),
+                    exception.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData("{\"@odata.removed\":{\"reason\":\"deleted\"}}", ODataVersion.V4)]
+        [InlineData("{\"@removed\":{\"reason\":\"deleted\"}}", ODataVersion.V401)]
+        public async Task ReadDeletedResourceAsync_ThrowsExceptionForMissingODataIdAnnotation(string payload, ODataVersion odataVersion)
+        {
+            this.messageReaderSettings.Version = odataVersion;
+
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await AdvanceReaderToFirstPropertyAsync(jsonLightResourceDeserializer.JsonReader);
+
+                var exception = await Assert.ThrowsAsync<ODataException>(
+                    () => jsonLightResourceDeserializer.ReadDeletedResourceAsync());
+
+                Assert.Equal(
+                    ErrorStrings.ODataWriterCore_DeltaResourceWithoutIdOrKeyProperties,
+                    exception.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData("{\"@odata.removed\":\"NaO\"}", ODataVersion.V4)]
+        [InlineData("{\"@removed\":\"NaO\"}", ODataVersion.V401)]
+        public async Task ReadDeletedResourceAsync_ThrowsExceptionForODataRemovedAnnotationValueNotAnObject(string payload, ODataVersion odataVersion)
+        {
+            this.messageReaderSettings.Version = odataVersion;
+
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await AdvanceReaderToFirstPropertyAsync(jsonLightResourceDeserializer.JsonReader);
+
+                var exception = await Assert.ThrowsAsync<ODataException>(
+                    () => jsonLightResourceDeserializer.ReadDeletedResourceAsync());
+
+                Assert.Equal(
+                    ErrorStrings.ODataJsonLightResourceDeserializer_DeltaRemovedAnnotationMustBeObject("NaO"),
+                    exception.Message);
+            }
+        }
+
+        [Theory]
+        [InlineData("{\"id\":\"http://tempuri.org/Customers(1)\",\"reason\":\"deleted\",\"nested\":{\"foo\":\"bar\"}}")]
+        [InlineData("{\"id\":\"http://tempuri.org/Customers(1)\",\"reason\":\"deleted\",\"nested\":[{\"foo\":\"bar\"}]}")]
+        public async Task ReadDeletedEntryAsync_ThrowsExceptionForNestedContent(string payload)
+        {
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, model))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await AdvanceReaderToFirstPropertyAsync(jsonLightResourceDeserializer.JsonReader);
+
+                var exception = await Assert.ThrowsAsync<ODataException>(
+                    () => jsonLightResourceDeserializer.ReadDeletedEntryAsync());
+
+                Assert.Equal(
+                    ErrorStrings.ODataWriterCore_NestedContentNotAllowedIn40DeletedEntry,
+                    exception.Message);
+            }
+        }
+
+        [Fact]
+        public async Task ReadNextLinkAnnotationAtResourceSetEndAsync_ThrowsExceptionForDuplicateODataNextLinkAnnotation()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories(Products())/$entity\"," +
+                "\"Products\":[{\"Id\":1,\"Name\":\"Tea\"},{\"Id\":2,\"Name\":\"Coffee\"}]," +
+                "\"Products@odata.nextLink\":\"http://tempuri.org/Categories(1)/Products?$skip=2\"," +
+                "\"Products@odata.nextLink\":\"http://tempuri.org/Categories(1)/Products?$skip=2\"}";
+
+            var productsResourceSet = CreateResourceSet("Products", "NS.Product");
+            var expandedNestedResourceInfo = CreateProductsNavigationPropertyNestedResourceInfo(productsResourceSet);
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadNextLinkAnnotationAtResourceSetEndAsync(
+                    productsResourceSet,
+                    expandedNestedResourceInfo,
+                    payload,
+                    (nestedResourceSet) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_DuplicateNestedResourceSetAnnotation("odata.nextLink", "Products"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadNextLinkAnnotationAtResourceSetEndAsync_ThrowsExceptionForDuplicateODataCountAnnotation()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories(Products())/$entity\"," +
+                "\"Products\":[{\"Id\":1,\"Name\":\"Tea\"},{\"Id\":2,\"Name\":\"Coffee\"}]," +
+                "\"Products@odata.count\":3," +
+                "\"Products@odata.count\":3}";
+
+            var productsResourceSet = CreateResourceSet("Products", "NS.Product");
+            var expandedNestedResourceInfo = CreateProductsNavigationPropertyNestedResourceInfo(productsResourceSet);
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadNextLinkAnnotationAtResourceSetEndAsync(
+                    productsResourceSet,
+                    expandedNestedResourceInfo,
+                    payload,
+                    (nestedResourceSet) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_DuplicateNestedResourceSetAnnotation("odata.count", "Products"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadNextLinkAnnotationAtResourceSetEndAsync_ThrowsExceptionForUnexpectedODataDeltaLinkAnnotation()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories(Products())/$entity\"," +
+                "\"Products\":[{\"Id\":1,\"Name\":\"Tea\"},{\"Id\":2,\"Name\":\"Coffee\"}]," +
+                "\"Products@odata.deltaLink\":\"http://tempuri.org/Categories(1)/Products/delta\"}";
+
+            var productsResourceSet = CreateResourceSet("Products", "NS.Product");
+            var expandedNestedResourceInfo = CreateProductsNavigationPropertyNestedResourceInfo(productsResourceSet);
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadNextLinkAnnotationAtResourceSetEndAsync(
+                    productsResourceSet,
+                    expandedNestedResourceInfo,
+                    payload,
+                    (nestedResourceSet) => { }));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightResourceDeserializer_UnexpectedPropertyAnnotationAfterExpandedResourceSet("odata.deltaLink", "Products"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadNextLinkAnnotationAtResourceSetEndAsync_ThrowsExceptionForResourceSetEndAnnotationsInRequestPayload()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories(Products())/$entity\"," +
+                "\"Products\":[{\"Id\":1,\"Name\":\"Tea\"},{\"Id\":2,\"Name\":\"Coffee\"}]," +
+                "\"Products@odata.nextLink\":\"http://tempuri.org/Categories(1)/Products?$skip=2\"}";
+
+            var productsResourceSet = CreateResourceSet("Products", "NS.Product");
+            var expandedNestedResourceInfo = CreateProductsNavigationPropertyNestedResourceInfo(productsResourceSet);
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightResourceSerializerAndRunReadNextLinkAnnotationAtResourceSetEndAsync(
+                    productsResourceSet,
+                    expandedNestedResourceInfo,
+                    payload,
+                    (nestedResourceSet) => { },
+                    isResponse: false));
+
+            Assert.Equal(
+                ErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedPropertyAnnotation("Products", "odata.nextLink"),
+                exception.Message);
+        }
+
+        private Action<TestJsonLightReaderResourceState> commonVerifyAction = (resourceState) =>
+        {
+            var resource = resourceState.Resource;
+            Assert.NotNull(resource);
+            var properties = resource.Properties.ToArray();
+            Assert.Equal(2, properties.Length);
+            var idProperty = properties[0];
+            var nameProperty = properties[1];
+            Assert.Equal("Id", idProperty.Name);
+            Assert.Equal(1, idProperty.Value);
+            Assert.Equal("Name", nameProperty.Name);
+            Assert.Equal("Food", nameProperty.Value);
+        };
+
+        private async Task SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+            string payload,
+            IEdmNavigationSource navigationSource,
+            IEdmStructuredType structuredType,
+            Action<TestJsonLightReaderResourceState> verifyAction,
+            bool isResponse = true)
+        {
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, this.model, isResponse: isResponse))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+
+                await jsonLightResourceDeserializer.ReadPayloadStartAsync(
+                    ODataPayloadKind.Resource,
+                    new PropertyAndAnnotationCollector(true),
+                    false,
+                    true);
+
+                var resourceState = new TestJsonLightReaderResourceState(navigationSource, structuredType);
+
+                await jsonLightResourceDeserializer.ReadResourceContentAsync(resourceState);
+
+                verifyAction(resourceState);
+            }
+        }
+
+        private async Task SetupJsonLightResourceSerializerAndRunReadTopLevelDeltaResourceSetAnnotationsAsync(
+            ODataResourceSetBase resourceSet,
+            string payload,
+            Action<ODataResourceSetBase, PropertyAndAnnotationCollector> verifyAction,
+            bool forResourceSetStart = true,
+            bool readAllResourceSetProperties = false)
+        {
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, this.model, isResponse: true))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+                var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
+
+                await jsonLightResourceDeserializer.ReadPayloadStartAsync(
+                    ODataPayloadKind.ResourceSet,
+                    propertyAndAnnotationCollector,
+                    false,
+                    true);
+
+                await jsonLightResourceDeserializer.ReadTopLevelResourceSetAnnotationsAsync(
+                    resourceSet,
+                    propertyAndAnnotationCollector,
+                    forResourceSetStart: forResourceSetStart,
+                    readAllResourceSetProperties: readAllResourceSetProperties);
+
+                verifyAction(resourceSet, propertyAndAnnotationCollector);
+            }
+        }
+
+        private async Task SetupJsonLightResourceSerializerAndRunReadNextLinkAnnotationAtResourceSetEndAsync(
+            ODataResourceSetBase nestedResourceSet,
+            ODataJsonLightReaderNestedResourceInfo expandedNestedResourceInfo,
+            string payload,
+            Action<ODataResourceSetBase> verifyAction,
+            bool isResponse = true)
+        {
+            using (var jsonInputContext = CreateJsonLightInputContext(payload, this.model, isResponse: isResponse))
+            {
+                var jsonLightResourceDeserializer = new ODataJsonLightResourceDeserializer(jsonInputContext);
+                var propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
+                var jsonReader = jsonLightResourceDeserializer.JsonReader;
+
+                await jsonLightResourceDeserializer.ReadPayloadStartAsync(
+                    ODataPayloadKind.Resource,
+                    propertyAndAnnotationCollector,
+                    false,
+                    true);
+
+                // Advance reader to end of resource set
+                await jsonReader.ReadAsync(); // Read over expanded navigation property
+                await jsonReader.SkipValueAsync();
+
+                await jsonLightResourceDeserializer.ReadNextLinkAnnotationAtResourceSetEndAsync(
+                    nestedResourceSet,
+                    expandedNestedResourceInfo: expandedNestedResourceInfo,
+                    propertyAndAnnotationCollector);
+
+                verifyAction(nestedResourceSet);
+            }
+        }
+
+        private static async Task AdvanceReaderToFirstPropertyAsync(BufferingJsonReader bufferingJsonReader)
+        {
+            await bufferingJsonReader.ReadAsync(); // Position the reader on the first node
+            await bufferingJsonReader.ReadAsync(); // Read StartObject
+            Assert.Equal(JsonNodeType.Property, bufferingJsonReader.NodeType);
+        }
+
+        private void InitializeModel()
+        {
+            this.model = new EdmModel();
+
+            var segmentEnumType = new EdmEnumType("NS", "Segment");
+            segmentEnumType.AddMember("Retail", new EdmEnumMemberValue(0));
+            segmentEnumType.AddMember("Wholesale", new EdmEnumMemberValue(1));
+            this.model.AddElement(segmentEnumType);
+
+            var addressComplexType = new EdmComplexType("NS", "Address");
+            addressComplexType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String);
+            addressComplexType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
+            this.model.AddElement(addressComplexType);
+
+            this.customerEntityType = new EdmEntityType("NS", "Customer");
+            this.customerEntityType.AddKeys(this.customerEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.customerEntityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            this.customerEntityType.AddStructuralProperty("BillingAddress", new EdmComplexTypeReference(addressComplexType, true));
+            this.customerEntityType.AddStructuralProperty(
+                "ShippingAddresses",
+                new EdmCollectionTypeReference(new EdmCollectionType(new EdmComplexTypeReference(addressComplexType, true))));
+            this.model.AddElement(this.customerEntityType);
+
+            this.categoryEntityType = new EdmEntityType("NS", "Category", baseType: null, isAbstract: false, isOpen: true, hasStream: true);
+            this.productEntityType = new EdmEntityType("NS", "Product");
+
+            this.categoryEntityType.AddKeys(this.categoryEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.categoryEntityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            this.categoryEntityType.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "BestSeller",
+                    Target = this.productEntityType,
+                    TargetMultiplicity = EdmMultiplicity.ZeroOrOne
+                });
+            this.categoryEntityType.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Products",
+                    Target = this.productEntityType,
+                    TargetMultiplicity = EdmMultiplicity.Many
+                });
+            this.model.AddElement(this.categoryEntityType);
+
+            this.productEntityType.AddKeys(this.productEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            this.productEntityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            this.productEntityType.AddStructuralProperty("Photo", EdmPrimitiveTypeKind.Stream);
+            productEntityType.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Category",
+                    Target = this.categoryEntityType,
+                    TargetMultiplicity = EdmMultiplicity.One
+                });
+            this.model.AddElement(this.productEntityType);
+
+            var defaultContainer = model.AddEntityContainer("NS", "Default");
+
+            var rateProductsAction = new EdmAction(namespaceName: "NS", name: "RateProducts", returnType: null, isBound: true, entitySetPathExpression: null);
+            rateProductsAction.AddParameter("bindingParameter", new EdmEntityTypeReference(this.categoryEntityType, true));
+            model.AddElement(rateProductsAction);
+
+            var top5ProductsFunction = new EdmFunction(
+                namespaceName: "NS",
+                name: "Top5Products",
+                returnType: new EdmCollectionTypeReference(new EdmCollectionType(new EdmEntityTypeReference(this.productEntityType, true))),
+                isBound: true,
+                entitySetPathExpression: null,
+                isComposable: false);
+            top5ProductsFunction.AddParameter("bindingParameter", new EdmEntityTypeReference(this.categoryEntityType, true));
+            this.model.AddElement(top5ProductsFunction);
+
+            var rateCategoriesAction = new EdmAction(namespaceName: "NS", name: "RateCategories", returnType: null, isBound: false, entitySetPathExpression: null);
+            this.model.AddElement(rateCategoriesAction);
+
+            var top2CategoriesFunction = new EdmFunction(
+                namespaceName: "NS",
+                name: "Top2Categories",
+                returnType: new EdmCollectionTypeReference(new EdmCollectionType(new EdmEntityTypeReference(this.categoryEntityType, true))),
+                isBound: false,
+                entitySetPathExpression: null,
+                isComposable: false);
+            this.model.AddElement(top2CategoriesFunction);
+
+            defaultContainer.AddActionImport(rateProductsAction);
+            defaultContainer.AddFunctionImport(top5ProductsFunction);
+            defaultContainer.AddActionImport(rateCategoriesAction);
+            defaultContainer.AddFunctionImport(top2CategoriesFunction);
+
+            this.customersEntitySet = defaultContainer.AddEntitySet("Customers", this.customerEntityType);
+            this.categoriesEntitySet = defaultContainer.AddEntitySet("Categories", this.categoryEntityType);
+            this.productsEntitySet = defaultContainer.AddEntitySet("Products", this.productEntityType);
+        }
+
+        private ODataJsonLightInputContext CreateJsonLightInputContext(
+            string payload,
+            IEdmModel model,
+            bool isResponse = true,
+            bool isAsync = true,
+            bool isIeee754Compatible = false)
+        {
+            var messageInfo = new ODataMessageInfo
+            {
+                IsResponse = isResponse,
+                MediaType = CreateMediaType(isIeee754Compatible),
+                IsAsync = isAsync,
+                Model = model,
+            };
+
+            return new ODataJsonLightInputContext(
+                new StringReader(payload), messageInfo, this.messageReaderSettings);
+        }
+
+        private ODataMediaType CreateMediaType(bool isIeee754Compatible = false)
+        {
+            return new ODataMediaType(
+                MimeConstants.MimeApplicationType,
+                MimeConstants.MimeJsonSubType,
+                new[]{
+                    new KeyValuePair<string, string>(
+                        MimeConstants.MimeMetadataParameterName,
+                        MimeConstants.MimeMetadataParameterValueMinimal),
+                    new KeyValuePair<string, string>(
+                        MimeConstants.MimeStreamingParameterName,
+                        MimeConstants.MimeParameterValueTrue),
+                    new KeyValuePair<string, string>(
+                        MimeConstants.MimeIeee754CompatibleParameterName,
+                        isIeee754Compatible ? MimeConstants.MimeParameterValueTrue : MimeConstants.MimeParameterValueFalse)
+                });
+        }
+
+        #region Helper Methods
+
+        private static ODataResourceSet CreateResourceSet(
+            string navigationSourceName,
+            string entityTypeName,
+            EdmNavigationSourceKind navigationSourceKind = EdmNavigationSourceKind.EntitySet)
+        {
+            return new ODataResourceSet
+            {
+                TypeName = $"Collection({entityTypeName})",
+                SerializationInfo = new ODataResourceSerializationInfo
+                {
+                    NavigationSourceName = navigationSourceName,
+                    ExpectedTypeName = entityTypeName,
+                    NavigationSourceEntityTypeName = entityTypeName,
+                    NavigationSourceKind = navigationSourceKind
+                }
+            };
+        }
+
+        private static ODataDeltaResourceSet CreateDeltaResourceSet(
+            string navigationSource,
+            string entityTypeName,
+            Uri deltaLink = null,
+            EdmNavigationSourceKind navigationSourceKind = EdmNavigationSourceKind.EntitySet)
+        {
+            return new ODataDeltaResourceSet
+            {
+                TypeName = $"Collection({entityTypeName})",
+                DeltaLink = deltaLink,
+                SerializationInfo = new ODataResourceSerializationInfo
+                {
+                    NavigationSourceName = navigationSource,
+                    ExpectedTypeName = entityTypeName,
+                    NavigationSourceEntityTypeName = entityTypeName,
+                    NavigationSourceKind = navigationSourceKind
+                }
+            };
+        }
+
+        private ODataJsonLightReaderNestedResourceInfo CreateProductsNavigationPropertyNestedResourceInfo(ODataResourceSet productsResourceSet)
+        {
+            var nestedResourceInfo = new ODataNestedResourceInfo
+            {
+                Name = "Products",
+                Url = new Uri("http://tempuri.org/Categories(1)/Products"),
+                IsCollection = true,
+                SerializationInfo = new ODataNestedResourceInfoSerializationInfo(),
+            };
+
+            return ODataJsonLightReaderNestedResourceInfo.CreateResourceSetReaderNestedResourceInfo(
+                nestedResourceInfo,
+                this.categoryEntityType.FindProperty("Products"),
+                this.productEntityType,
+                productsResourceSet);
+        }
+
+        #endregion
+    }
+
+    internal class TestJsonLightReaderResourceState : IODataJsonLightReaderResourceState
+    {
+        private ODataResourceBase resource = ReaderUtils.CreateNewResource();
+        private IEdmNavigationSource navigationSource;
+        private IEdmStructuredType structuredType;
+        private PropertyAndAnnotationCollector propertyAndAnnotationCollector = new PropertyAndAnnotationCollector(true);
+
+        public TestJsonLightReaderResourceState(IEdmNavigationSource navigationSource, IEdmStructuredType structuredType)
+        {
+            this.navigationSource = navigationSource;
+            this.structuredType = structuredType;
+        }
+
+        public ODataResourceBase Resource => this.resource;
+
+        public IEdmStructuredType ResourceType => this.structuredType;
+
+        public IEdmStructuredType ResourceTypeFromMetadata { get; set; }
+
+        public IEdmNavigationSource NavigationSource => this.navigationSource;
+
+        public ODataResourceMetadataBuilder MetadataBuilder { get; set; }
+
+        public bool AnyPropertyFound { get; set; }
+
+        public ODataJsonLightReaderNestedInfo FirstNestedInfo { get; set; }
+
+        public PropertyAndAnnotationCollector PropertyAndAnnotationCollector => this.propertyAndAnnotationCollector;
+
+        public SelectedPropertiesNode SelectedProperties => new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree);
+
+        public List<string> NavigationPropertiesRead => throw new NotImplementedException();
+
+        public bool ProcessingMissingProjectedNestedResourceInfos { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request partially fulfills #2019.

### Description

This PR implements support for the following 3 classes:
- `ODataJsonLightDeserializer`
- `ODataJsonLightPropertyAndValueDeserializer`
- `ODataJsonLightResourceDeserializer`

It would have been desirable to have separate PRs for the above 3 classes but there exists a dependency that was not that easy to navigate around without risking a breaking change.
Using the synchronous API to illustrate, the `ODataJsonLightDeserializer` expects the `ReadPropertyCustomAnnotationValue` `Func` delegate property to be initialized from the derived classes (`ODataJsonLightPropertyAndValueDeserializer` or `ODataJsonLightResourceDeserializer`). Implementation of asynchronous support `ODataJsonLightDeserializer` involved introducing an asynchronous `Func` delegate `ReadPropertyCustomAnnotationValueAsync`. Merging changes to `ODataJsonLightDeserializer` without relevant changes to the derived classes would have caused a breaking changes if someone invoked the asynchronous API that was previously implemented as an asynchronous wrapper on top of the synchronous methods. In particular, if the `ProcessPropertyAsync` method defined in `ODataJsonLightDeserializer` class was to be invoked before the `Func` delegate is initialized, particular code paths would break.

`ODataJsonLightDeserializer` is an abstract class that classes that handle the actual deserialization implement
`ODataJsonLightPropertyAndValueDeserializer` implements the logic for deserializing properties and their corresponding values
`ODataJsonLightResourceDeserializer` implements the logic for deserializing an OData resource

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
