### PR TITLE
Issue #2269: Names starting with underscore must be allowed. Changes …

### DIFF
--- a/src/Microsoft.OData.Edm/EdmUtil.cs
+++ b/src/Microsoft.OData.Edm/EdmUtil.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.Edm
         //    characters that Char.GetUnicodeCategory says are in Nl and Cf but which the RegEx does not accept (and which C# does allow).
         //
         // we could create the StartCharacterExp and OtherCharacterExp dynamically to force inclusion of the missing Nl and Cf characters...
-        private const string StartCharacterExp = @"[\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Nl}]";
+        private const string StartCharacterExp = @"[\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Nl}_]";
         private const string OtherCharacterExp = @"[\p{Ll}\p{Lu}\p{Lt}\p{Lo}\p{Lm}\p{Nl}\p{Mn}\p{Mc}\p{Nd}\p{Pc}\p{Cf}]";
         private const string NameExp = StartCharacterExp + OtherCharacterExp + "{0,}";
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/EdmUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/EdmUtilTests.cs
@@ -48,5 +48,21 @@ namespace Microsoft.OData.Edm.Tests
             var actual = EdmUtil.IsQualifiedName(name);
             Assert.Equal(expected, actual);
         }
+        
+        [Theory]
+        [InlineData("", false)]
+        [InlineData(" ", false)]
+        [InlineData("a.B", false)]
+        [InlineData("_abc", true)]
+        [InlineData("_ABC", true)]
+        [InlineData("AB/CD", false)]
+        [InlineData("ab_CD", true)]
+        [InlineData("AB12CD", true)]
+        [InlineData("12ABCD", false)]
+        public void IsValidUndottedName_Test(string name, bool expected)
+        {
+            var actual = EdmUtil.IsValidUndottedName(name);
+            Assert.Equal(expected, actual);
+        }
     }
 }


### PR DESCRIPTION
Names starting with underscore must be allowed. 

<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2269

### Description

Changed pattern of `StartCharacterExp` in Odata.Edm\EdmUtils.cs and added an "underscore" to the pattern.
