### PR TITLE
Fix issue #2276: should use for @type for serializing record in CSDL JSON

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
@@ -868,7 +868,8 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
 
             if (expression.DeclaredType != null)
             {
-                this.jsonWriter.WriteRequiredProperty("$Type", expression.DeclaredType.FullName());
+                // The type of a record expression is represented as the @type control information.
+                this.jsonWriter.WriteRequiredProperty("@type", expression.DeclaredType.FullName());
             }
             // It MAY contain annotations for itself. It's not supported now.
         }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -1125,7 +1125,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
       },
       ""NS.TestFunction(Edm.String, Edm.String, Edm.String)/optionalParamWithDefault"": {
         ""@Org.OData.Core.V1.OptionalParameter"": {
-          ""$Type"": ""Org.OData.Core.V1.OptionalParameterType"",
+          ""@type"": ""Org.OData.Core.V1.OptionalParameterType"",
           ""DefaultValue"": ""Smith""
         }
       }
@@ -1194,7 +1194,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
     ""$Annotations"": {
       ""NS.TestFunction(Edm.String)/optionalParamWithDefault"": {
         ""@Org.OData.Core.V1.OptionalParameter"": {
-          ""$Type"": ""Org.OData.Core.V1.OptionalParameterType"",
+          ""@type"": ""Org.OData.Core.V1.OptionalParameterType"",
           ""DefaultValue"": ""OutofLineValue""
         }
       }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
@@ -2007,7 +2007,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             // Act & Assert for Json
             VisitAndVerifyJson(v => v.VisitVocabularyAnnotation(annotation), @"{
   ""@Person.Employee"": {
-    ""$Type"": ""NS.Address"",
+    ""@type"": ""NS.Address"",
     ""Street"": ""148th ave"",
     ""City"": ""Redmond""
   }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
@@ -33,6 +33,16 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
+    <PackageReference Include="xunit.core" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.OData.Edm\Microsoft.OData.Edm.csproj" />
   </ItemGroup>
 
@@ -42,13 +52,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452' or '$(TargetFramework)' == 'netcoreapp1.1'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="xunit.assert" Version="2.4.1" />
-    <PackageReference Include="xunit.core" Version="2.4.1" />
   </ItemGroup>
  
 </Project>


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2276.*

### Description

#### 7     Structural Property
A structural property is a property of a structured type that has one of the following types:

·         Primitive type

·         Complex type

·         Enumeration type

·         A collection of one of the above

A structural property MUST specify a unique name as well as a type.

The property’s name MUST be a simple identifier. It is used when referencing, serializing or deserializing the property. It MUST be unique within the set of structural and navigation properties of the declaring structured type, and MUST NOT match the name of any navigation property in any of its base types. If a structural property with the same name is defined in any of this type’s base types, then the property’s type MUST be a type derived from the type specified for the property of the base type and constrains this property to be of the specified subtype for instances of this structured type. The name MUST NOT match the name of any structural or navigation property of any of this type’s base types for OData 4.0 responses.

Names are case-sensitive, but service authors SHOULD NOT choose names that differ only in case.

Property Object

Structural properties are represented as members of the object representing a structured type. The member name is the property name, the member value is an object.

The property object MAY contain the member $Kind with a string value of Property. This member SHOULD be omitted to reduce document size.

It MAY contain the member $Type, $Collection, $Nullable, $MaxLength, $Unicode, $Precision, $Scale, $SRID, and $DefaultValue.

It also MAY contain annotations.

Example 15: complex type with two properties Dimension and Length

"Measurement": {

  "$Kind": "ComplexType",

  "Dimension": {

    "$MaxLength": 50,

    "$DefaultValue": "Unspecified"

  },

  "Length": {

    "$Type": "Edm.Decimal",

    "$Precision": 18,

    "$Scale": 2

  }

}


For the record:

14.4.12 Record
The record expression enables a new entity type or complex type instance to be constructed.

A record expression MAY specify the structured type of its result, which MUST be an entity type or complex type in scope. If not explicitly specified, the type is derived from the expression’s context.

A record expression contains zero or more property value expressions. For each single-valued structural or navigation property of the record expression’s type that is neither nullable nor specifies a default value a property value expression MUST be provided. The only exception is if the record expression is the value of an annotation for a term that has a base term whose type is structured and directly or indirectly inherits from the type of its base term. In this case, property values that already have been specified in the annotation for the base term or its base term etc. need not be specified again.

For collection-valued properties the absence of a property value expression is equivalent to specifying an empty collection as its value.

Record expressions are represented as objects with one member per property value expression. The member name is the property name, and the member value is the property value expression.

The type of a record expression is represented as the @type control information, see  [OData‑JSON].

It MAY contain annotations for itself and its members. Annotations for record members are prefixed with the member name.



### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
