### PR TITLE
Default to using entityType for incomplete serializationInfo.

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
@@ -174,9 +174,10 @@ namespace Microsoft.OData.Evaluation
             IEdmEntityType actualEntityType,
             bool requiresId)
         {
+            Debug.Assert(resource != null, "GetKeyProperties called for a null resource.");
 
             KeyValuePair<string, object>[] keyProperties = null;
-            string actualEntityTypeName = resource.TypeName ?? actualEntityType?.FullName();
+            string actualEntityTypeName = string.IsNullOrEmpty(resource.TypeName) ? actualEntityType?.FullName() : resource.TypeName;
 
             // if we have serializationInfo, try that first
             if (serializationInfo != null)
@@ -288,7 +289,8 @@ namespace Microsoft.OData.Evaluation
 
             for (int keyProperty = 0; keyProperty < keyProperties.Length; keyProperty++)
             {
-                if (keyProperties[keyProperty].Value == null || (keyProperties[keyProperty].Value is ODataValue && !(keyProperties[keyProperty].Value is ODataEnumValue)))
+                object keyValue = keyProperties[keyProperty].Value;
+                if (keyValue == null || (keyValue is ODataValue && !(keyValue is ODataEnumValue)))
                 {
                     if (throwOnError)
                     {

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -2426,20 +2426,18 @@ namespace Microsoft.OData.JsonLight
         /// <returns>True if successfully append key segment.</returns>
         private bool TryAppendEntitySetKeySegment(ref ODataPath odataPath)
         {
-            try
+            if (EdmExtensionMethods.HasKey(this.CurrentScope.NavigationSource, this.CurrentScope.ResourceType as IEdmStructuredType))
             {
-                if (EdmExtensionMethods.HasKey(this.CurrentScope.NavigationSource, this.CurrentScope.ResourceType as IEdmStructuredType))
+                IEdmEntityType currentEntityType = this.CurrentScope.ResourceType as IEdmEntityType;
+                ODataResourceBase resource = this.CurrentScope.Item as ODataResourceBase;
+                KeyValuePair<string, object>[] keys = ODataResourceMetadataContext.GetKeyProperties(resource, null, currentEntityType, false);
+                if (keys.Length == 0)
                 {
-                    IEdmEntityType currentEntityType = this.CurrentScope.ResourceType as IEdmEntityType;
-                    ODataResourceBase resource = this.CurrentScope.Item as ODataResourceBase;
-                    KeyValuePair<string, object>[] keys = ODataResourceMetadataContext.GetKeyProperties(resource, null, currentEntityType);
-                    odataPath = odataPath.AddKeySegment(keys, currentEntityType, this.CurrentScope.NavigationSource);
+                    odataPath = null;
+                    return false;
                 }
-            }
-            catch (ODataException)
-            {
-                odataPath = null;
-                return false;
+
+                odataPath = odataPath.AddKeySegment(keys, currentEntityType, this.CurrentScope.NavigationSource);
             }
 
             return true;

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -1935,7 +1935,6 @@ namespace Microsoft.OData
             this.InterceptException(
                 (thisParam) =>
                 {
-                    bool wasenableDelta;
                     Scope currentScope = thisParam.CurrentScope;
 
                     switch (currentScope.State)
@@ -2868,7 +2867,7 @@ namespace Microsoft.OData
                 else 
                 {
                     KeyValuePair<string, object>[] keys = ODataResourceMetadataContext.GetKeyProperties(resource,
-                        this.GetResourceSerializationInfo(resource), currentEntityType);
+                        serializationInfo, currentEntityType, true);
 
                     path = path.AddKeySegment(keys, currentEntityType, this.CurrentScope.NavigationSource);
                 }                    

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -2810,7 +2810,7 @@ namespace Microsoft.OData
         /// <returns>The new odata path.</returns>
         private ODataPath AppendEntitySetKeySegment(ODataPath odataPath, bool throwIfFail)
         {
-            ODataPath path = odataPath;
+           ODataPath path = odataPath;
             
             if (EdmExtensionMethods.HasKey(this.CurrentScope.NavigationSource, this.CurrentScope.ResourceType))
             {
@@ -2821,72 +2821,13 @@ namespace Microsoft.OData
 
                 ODataResourceSerializationInfo serializationInfo = this.GetResourceSerializationInfo(resource);
 
-                if (!throwIfFail)
-                {
-                    if (resource.NonComputedProperties != null)
-                    {
-                        List<KeyValuePair<string, object>> keys = new List<KeyValuePair<string, object>>();
+                KeyValuePair<string, object>[] keys = ODataResourceMetadataContext.GetKeyProperties(resource,
+                        serializationInfo, currentEntityType, throwIfFail);
 
-                        if (serializationInfo != null)
-                        {
-                            foreach (ODataProperty property in resource.NonComputedProperties)
-                            {
-                                if (property.SerializationInfo != null && property.SerializationInfo.PropertyKind == ODataPropertyKind.Key)
-                                {
-                                    if(!CreateKeyValuePair(keys, property, property.Value))
-                                    {
-                                        return path;
-                                    }
-                                }
-                            }
-                        }
-                        else
-                        {
-                            HashSet<string> keySet = new HashSet<string>();
-
-                            foreach (IEdmStructuralProperty property in currentEntityType.Key())
-                            {
-                                keySet.Add(property.Name);
-                            }
-
-                            foreach (ODataProperty property in resource.NonComputedProperties)
-                            {
-                                if (keySet.Contains(property.Name))
-                                {
-                                    if (!CreateKeyValuePair(keys, property, property.Value))
-                                    {
-                                        return path;
-                                    }
-                                }
-                            }
-                        }
-
-                        path = path.AddKeySegment(keys.ToArray(), currentEntityType, this.CurrentScope.NavigationSource);
-                    }                        
-                }
-                else 
-                {
-                    KeyValuePair<string, object>[] keys = ODataResourceMetadataContext.GetKeyProperties(resource,
-                        serializationInfo, currentEntityType, true);
-
-                    path = path.AddKeySegment(keys, currentEntityType, this.CurrentScope.NavigationSource);
-                }                    
+                path = path.AddKeySegment(keys, currentEntityType, this.CurrentScope.NavigationSource);
             }
-
 
             return path;
-        }
-
-        private static bool CreateKeyValuePair(List<KeyValuePair<string, object>> keys, ODataProperty property, object propertyValue)
-        {
-            if (propertyValue == null || (propertyValue is ODataValue && !(propertyValue is ODataEnumValue)))
-            {
-                return false;
-            }
-
-            keys.Add(new KeyValuePair<string, object>(property.Name, propertyValue));
-
-            return true;
         }
 
         /// <summary>
@@ -3430,7 +3371,6 @@ namespace Microsoft.OData
             return this.InterceptExceptionAsync(
                 async (thisParam) =>
                 {
-                    bool wasenableDelta;
                     Scope currentScope = thisParam.CurrentScope;
 
                     switch (currentScope.State)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataEntryMetadataContextTest.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataEntryMetadataContextTest.cs
@@ -196,8 +196,8 @@ namespace Microsoft.OData.Tests.Evaluation
         {
             this.entry.Properties = new[]
             {
-                new ODataProperty { Name = "ID1", Value = 1, SerializationInfo = new ODataPropertySerializationInfo { PropertyKind = ODataPropertyKind.Key } },
-                new ODataProperty { Name = "ID2", Value = 2, SerializationInfo = new ODataPropertySerializationInfo { PropertyKind = ODataPropertyKind.Key } },
+                new ODataProperty { Name = "ID1", Value = 1 },
+                new ODataProperty { Name = "ID2", Value = 2 },
                 new ODataProperty { Name = "ID3", Value = 3 },
             };
 
@@ -206,6 +206,7 @@ namespace Microsoft.OData.Tests.Evaluation
             Assert.Contains(keys, p => p.Key == "ID2");
             Assert.Contains(keys, p => p.Key == "ID3");
         }
+
         #endregion KeyProperties
 
         #region ETagProperties

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -512,6 +512,146 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             Model.AddElement(function4);
         }
 
+        public enum SerializationType
+        {
+            NoSerializationInfo,
+            ResourceSerializationInfo,
+            ResourceAndPropertySerializationInfo
+        }
+
+        [Theory]
+        [InlineData(SerializationType.NoSerializationInfo, /*fullMetadata*/ false)]
+        [InlineData(SerializationType.ResourceAndPropertySerializationInfo, /*fullMetadata*/ false)]
+        [InlineData(SerializationType.ResourceSerializationInfo, /*fullMetadata*/ false)]
+        [InlineData(SerializationType.NoSerializationInfo, /*fullMetadata*/ true)]
+        [InlineData(SerializationType.ResourceAndPropertySerializationInfo, /*fullMetadata*/ true)]
+        [InlineData(SerializationType.ResourceSerializationInfo, /*fullMetadata*/ true)]
+        public void WritingNestedResourceInfoWithVariousSerializationInfoSucceeds(SerializationType serializationType, bool fullMetadata)
+        {
+            // setup model
+            var model = new EdmModel();
+            var entityType = new EdmEntityType("NS", "entityType");
+            entityType.AddKeys(
+                entityType.AddStructuralProperty("keyProperty", EdmPrimitiveTypeKind.Int64));
+            
+            var nestedEntityType = new EdmEntityType("NS", "nestedEntityType");
+            nestedEntityType.AddKeys(
+                nestedEntityType.AddStructuralProperty("keyProperty", EdmPrimitiveTypeKind.Int64));
+
+            entityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo {
+                Name = "nestedEntities",
+                Target = nestedEntityType,
+                TargetMultiplicity = EdmMultiplicity.Many,
+                ContainsTarget = true
+            });
+
+            var container = new EdmEntityContainer("NS", "Container");
+            var entitySet = container.AddEntitySet("EntitySet", entityType);
+
+            model.AddElements(new IEdmSchemaElement[] { entityType, nestedEntityType, container });
+
+            // setup writer
+            var stream = new MemoryStream();
+            var message = new InMemoryMessage { Stream = stream };
+            message.SetHeader("Content-Type", fullMetadata ? "application/json;odata.metadata=full" : "application/json");
+            var settings = new ODataMessageWriterSettings
+            {
+                ODataUri = new ODataUri
+                {
+                    ServiceRoot = new Uri("http://svc/"),
+                    Path = new ODataUriParser(model, new Uri("EntitySet",UriKind.Relative)).ParsePath()
+                },
+            };
+            var writer = new ODataMessageWriter((IODataResponseMessage)message, settings, model);
+
+            // write payload
+            var entitySetWriter = writer.CreateODataResourceSetWriter(entitySet, entitySet.EntityType());
+            entitySetWriter.WriteStart(new ODataResourceSet());
+            var resource = new ODataResource
+            {
+                Properties = new[]
+                    {
+                        new ODataProperty { 
+                            Name = "keyProperty", 
+                            Value = 1L,
+                            SerializationInfo = serializationType == SerializationType.ResourceAndPropertySerializationInfo ?
+                                new ODataPropertySerializationInfo {
+                                    PropertyKind = ODataPropertyKind.Key
+                                } : null
+                        }
+                    },
+                TypeName = serializationType == SerializationType.NoSerializationInfo ? null : entityType.FullName
+            };
+
+            if (serializationType != SerializationType.NoSerializationInfo)
+            {
+                resource.SerializationInfo = new ODataResourceSerializationInfo
+                {
+                    NavigationSourceName = "EntitySet",
+                    NavigationSourceKind = EdmNavigationSourceKind.EntitySet,
+                    NavigationSourceEntityTypeName = entityType.FullName,
+                    ExpectedTypeName = entityType.FullName,
+                    IsFromCollection = true
+                };
+            }
+
+            entitySetWriter.WriteStart( resource );
+            entitySetWriter.WriteStart(
+                new ODataNestedResourceInfo
+                {
+                    Name = "nestedEntities",
+                }
+            );
+            entitySetWriter.WriteStart(new ODataResourceSet());
+            var entityValue = new ODataResource
+            {
+                TypeName = "NS.nestedEntityType",
+                Properties = new[]
+                {
+                    new ODataProperty { Name = "keyProperty", Value = 1L }
+                }
+            };
+            entitySetWriter.WriteStart(entityValue);
+            entitySetWriter.WriteEnd(); // nestedEntity
+            entitySetWriter.WriteEnd(); // nested resourceSet
+            entitySetWriter.WriteEnd(); // nestedInfo
+            entitySetWriter.WriteEnd(); // entity
+            entitySetWriter.WriteEnd(); // resourceSet
+            var str = Encoding.UTF8.GetString(stream.ToArray());
+
+            var typeAnnotation =
+                serializationType == SerializationType.NoSerializationInfo ? "" :
+                "\"@odata.type\":\"#NS.entityType\",";
+
+            var expected = fullMetadata ?
+             "{\"@odata.context\":\"http://svc/$metadata#EntitySet\"," +
+                "\"value\":[{" +
+                typeAnnotation +
+                    "\"@odata.id\":\"EntitySet(1)\"," +
+                    "\"@odata.editLink\":\"EntitySet(1)\"," +
+                    "\"keyProperty@odata.type\":\"#Int64\"," +
+                    "\"keyProperty\":1," +
+                    "\"nestedEntities@odata.associationLink\":\"http://svc/EntitySet(1)/nestedEntities/$ref\"," +
+                    "\"nestedEntities@odata.navigationLink\":\"http://svc/EntitySet(1)/nestedEntities\"," +
+                    "\"nestedEntities\":[{" +
+                        "\"@odata.type\":\"#NS.nestedEntityType\"," +
+                        "\"@odata.id\":\"EntitySet(1)/nestedEntities(1)\"," +
+                        "\"@odata.editLink\":\"EntitySet(1)/nestedEntities(1)\"," +
+                        "\"keyProperty@odata.type\":\"#Int64\"," +
+                        "\"keyProperty\":1" +
+                    "}]" +
+                   "}]}" :
+             "{\"@odata.context\":\"http://svc/$metadata#EntitySet\"," +
+                "\"value\":[{" +
+                    "\"keyProperty\":1," +
+                    "\"nestedEntities\":[{" +
+                        "\"keyProperty\":1" +
+                    "}]" +
+                   "}]}";
+
+            Assert.Equal(expected, str);
+        }
+
         [Fact]
         public void WritingDynamicComplexPropertyWithModelSpecifiedInFullMetadataMode()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataReaderDerivedTypeConstraintTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataReaderDerivedTypeConstraintTests.cs
@@ -516,7 +516,7 @@ namespace Microsoft.OData.Tests
             // Negative test case --Structural property has the derived type constraint.
             SetDerivedTypeAnnotation(this.edmModel, locationProperty, "NS.CnAddress");
 
-            Action test = () => ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType); ;
+            Action test = () => ReadEntityPayload(payload, this.edmModel, this.edmMe, this.edmCustomerType);
             var exception = Assert.Throws<ODataException>(test);
             Assert.Equal(Strings.ReaderValidationUtils_ValueTypeNotAllowedInDerivedTypeConstraint("NS.UsAddress", "nested resource", "Location"), exception.Message);
         }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
@@ -2026,7 +2026,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             {
                 Indent = indent,
                 ConformanceLevel = ConformanceLevel.Auto
-            }); ;
+            });
             var schemaWriter = new EdmModelCsdlSchemaXmlWriter(model, xmlWriter, edmxVersion);
             var visitor = new EdmModelCsdlSerializationVisitor(model, schemaWriter);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2278*

### Description

ODL expects that, if you set SerializationInfo on the resource then you are taking responsibility for providing all of the information necessary for serialization.  

When ODL tries to get key properties in order to append the key segment, it checks to see if the serializationInfo for the resource is null -- if so, it uses the model to determine key properties and all is good. On the other hand, if serializationInfo on the resource is non-null then it looks for properties whose serializationInfo identify them as key properties.  Finding none, it errors.

This change makes ODL more robust by falling back to using the entityType to identify key properties if the resource has serializationInfo but none of the properties have serializationInfo that identifies them as key properties.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*None*