### PR TITLE
fix filter using in operator with open types

### DIFF
--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -625,6 +625,7 @@ namespace Microsoft.OData
         {
             ODataMessageReaderSettings settings = new ODataMessageReaderSettings();
             settings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+            settings.ReadUntypedAsString = false;
 
             using (StringReader reader = new StringReader(value))
             {

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -46,8 +46,17 @@ namespace Microsoft.OData.UriParser
             ExceptionUtils.CheckArgumentNotNull(inToken, "inToken");
 
             SingleValueNode left = this.GetSingleValueOperandFromToken(inToken.Left);
-            CollectionNode right = this.GetCollectionOperandFromToken(
-                inToken.Right, new EdmCollectionTypeReference(new EdmCollectionType(left.TypeReference)), state.Model);
+            CollectionNode right = null;
+            if (left.TypeReference != null)
+            {
+                right = this.GetCollectionOperandFromToken(
+                    inToken.Right, new EdmCollectionTypeReference(new EdmCollectionType(left.TypeReference)), state.Model);
+            }
+            else 
+            {
+                right = this.GetCollectionOperandFromToken(
+                    inToken.Right, new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetUntyped())), state.Model);
+            }
 
             return new InNode(left, right);
         }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/InNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/InNode.cs
@@ -50,11 +50,14 @@ namespace Microsoft.OData.UriParser
             this.left = left;
             this.right = right;
 
-            if (!this.left.GetEdmTypeReference().IsAssignableFrom(this.right.ItemType) &&
-                !this.right.ItemType.IsAssignableFrom(this.left.GetEdmTypeReference()))
+            if (!right.GetEdmTypeReference().IsUntyped())
             {
-                throw new ArgumentException(ODataErrorStrings.Nodes_InNode_CollectionItemTypeMustBeSameAsSingleItemType(
-                    this.right.ItemType.FullName(), this.left.GetEdmTypeReference().FullName()));
+                if (!this.left.GetEdmTypeReference().IsAssignableFrom(this.right.ItemType) &&
+                    !this.right.ItemType.IsAssignableFrom(this.left.GetEdmTypeReference()))
+                {
+                    throw new ArgumentException(ODataErrorStrings.Nodes_InNode_CollectionItemTypeMustBeSameAsSingleItemType(
+                        this.right.ItemType.FullName(), this.left.GetEdmTypeReference().FullName()));
+                }
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2818,7 +2818,19 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal(new object[] {null},
                 Assert.IsType<CollectionConstantNode>(inNode.Right).Collection.Select(x => x.Value));
         }
-#endregion
+
+        [Fact]
+        public void FilterWithInOperationWithOpenTypes()
+        {
+            FilterClause filter = ParseFilter("example in ('examplepainting')",
+                HardCodedTestModel.TestModel, HardCodedTestModel.GetPaintingType());
+
+            var inNode = Assert.IsType<InNode>(filter.Expression);
+            Assert.Equal("example", Assert.IsType<SingleValueOpenPropertyAccessNode>(inNode.Left).Name);
+            Assert.Equal("('examplepainting')",
+                Assert.IsType<CollectionConstantNode>(inNode.Right).LiteralText);
+        }
+        #endregion
 
         private static FilterClause ParseFilter(string text, IEdmModel edmModel, IEdmType edmType, IEdmNavigationSource edmEntitySet = null)
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2270.*

### Description

*Briefly describe the changes of this pull request.*
For open types, the <code>TypeReference</code> of the left Node in an InBind Operation is always null. Have therefore put a null check to check for the left Node's TypeReference.  If it is null, then an <code> UnTyped Typerefence </code> is used. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
