### PR TITLE
Fix cast in expand

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -350,7 +350,16 @@ namespace Microsoft.OData.UriParser
             // If we are Binding the expanded property Trips, currentLevelEntityType should be the type of the VipCustomer
             if (this.parsedSegments.Count > 0 && this.parsedSegments.Last() is TypeSegment)
             {
-                currentLevelEntityType = this.parsedSegments.Last().EdmType as IEdmStructuredType;
+                IEdmType typeSegmentType = this.parsedSegments.Last().EdmType;
+
+                if (typeSegmentType.IsStructuredCollectionType())
+                {
+                    currentLevelEntityType = (typeSegmentType as IEdmCollectionType).ElementType.Definition as IEdmStructuredType;
+                }
+                else
+                {
+                    currentLevelEntityType = typeSegmentType as IEdmStructuredType;
+                }
             }
 
             List<ODataPathSegment> pathSoFar = new List<ODataPathSegment>();
@@ -681,7 +690,16 @@ namespace Microsoft.OData.UriParser
             // If we are Binding the selected property VipCustomerName, currentLevelEntityType should be the type of the VipCustomer
             if (this.parsedSegments.Count > 0 && this.parsedSegments.Last() is TypeSegment)
             {
-                currentLevelType = this.parsedSegments.Last().EdmType as IEdmStructuredType;
+                IEdmType typeSegmentType = this.parsedSegments.Last().EdmType;
+
+                if (typeSegmentType.IsStructuredCollectionType())
+                {
+                    currentLevelType = (typeSegmentType as IEdmCollectionType).ElementType.Definition as IEdmStructuredType;
+                }
+                else
+                {
+                    currentLevelType = typeSegmentType as IEdmStructuredType;
+                }
             }
 
             // first, walk through all type segments in a row, converting them from tokens into segments.

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -451,7 +451,7 @@ namespace Microsoft.OData.UriParser
             bool collapsed = applyOption?.Transformations.Any(t => t.Kind == TransformationNodeKind.Aggregate || t.Kind == TransformationNodeKind.GroupBy) ?? false;
 
             // $filter
-            FilterClause filterOption = BindFilter(tokenIn.FilterOption, this.ResourcePathNavigationSource, targetNavigationSource, null, generatedProperties, collapsed);
+            FilterClause filterOption = BindFilter(tokenIn.FilterOption, this.ResourcePathNavigationSource, targetNavigationSource, hasDerivedTypeSegment ? derivedType.ToTypeReference() : null, generatedProperties, collapsed);
 
             // $orderby
             OrderByClause orderbyOption = BindOrderby(tokenIn.OrderByOptions, this.ResourcePathNavigationSource, targetNavigationSource, null, generatedProperties, collapsed);

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -342,7 +342,7 @@ namespace Microsoft.OData.UriParser
 
             PathSegmentToken currentToken = tokenIn.PathToNavigationProp;
 
-            IEdmStructuredType currentLevelEntityType = this.edmType;
+            IEdmStructuredType currentLevelEntityType = this.EdmType;
             List<ODataPathSegment> pathSoFar = new List<ODataPathSegment>();
             PathSegmentToken firstNonTypeToken = currentToken;
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -352,7 +352,9 @@ namespace Microsoft.OData.UriParser
             {
                 IEdmType typeSegmentType = this.parsedSegments.Last().EdmType;
 
-                if (typeSegmentType.IsStructuredCollectionType())
+                IEdmCollectionType collection = typeSegmentType as IEdmCollectionType;
+
+                if (collection != null)
                 {
                     currentLevelEntityType = (typeSegmentType as IEdmCollectionType).ElementType.Definition as IEdmStructuredType;
                 }
@@ -692,7 +694,9 @@ namespace Microsoft.OData.UriParser
             {
                 IEdmType typeSegmentType = this.parsedSegments.Last().EdmType;
 
-                if (typeSegmentType.IsStructuredCollectionType())
+                IEdmCollectionType collection = typeSegmentType as IEdmCollectionType;
+
+                if (collection != null)
                 {
                     currentLevelType = (typeSegmentType as IEdmCollectionType).ElementType.Definition as IEdmStructuredType;
                 }

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -341,8 +341,8 @@ namespace Microsoft.OData.UriParser
             ExceptionUtils.CheckArgumentNotNull(tokenIn, "tokenIn");
 
             PathSegmentToken currentToken = tokenIn.PathToNavigationProp;
-            IEdmStructuredType currentLevelEntityType = this.edmType;
 
+            IEdmStructuredType currentLevelEntityType = this.edmType;
             List<ODataPathSegment> pathSoFar = new List<ODataPathSegment>();
             PathSegmentToken firstNonTypeToken = currentToken;
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -284,7 +284,7 @@ namespace Microsoft.OData.UriParser
 
             IEdmNavigationSource targetNavigationSource = null;
             ODataPathSegment lastSegment = selectedPath.Last();
-            IEdmType targetElementType = lastSegment.TargetEdmType;
+            IEdmType targetElementType = lastSegment.EdmType;
             IEdmCollectionType collection = targetElementType as IEdmCollectionType;
             if (collection != null)
             {
@@ -341,13 +341,7 @@ namespace Microsoft.OData.UriParser
             ExceptionUtils.CheckArgumentNotNull(tokenIn, "tokenIn");
 
             PathSegmentToken currentToken = tokenIn.PathToNavigationProp;
-
-            // If we have a previous level binding with the last segment as a Type segment,
-            // The currentLevelEntityType should be the Type of the TypeSegment
-            // E.g /Orders?$expand=Customer/NS.VipCustomer($expand=Trips)
-            // If we are Binding the expanded property Trips, currentLevelEntityType should be the type of the VipCustomer
-            IEdmStructuredType lastTypeSegmentType = GetLastTypeSegmentType(this.parsedSegments);
-            IEdmStructuredType currentLevelEntityType = lastTypeSegmentType != null ? lastTypeSegmentType : this.edmType;
+            IEdmStructuredType currentLevelEntityType = this.edmType;
 
             List<ODataPathSegment> pathSoFar = new List<ODataPathSegment>();
             PathSegmentToken firstNonTypeToken = currentToken;
@@ -668,13 +662,7 @@ namespace Microsoft.OData.UriParser
             Debug.Assert(tokenIn != null, "tokenIn != null");
 
             List<ODataPathSegment> pathSoFar = new List<ODataPathSegment>();
-
-            // If we have a previous level binding with the last segment as a Type segment,
-            // The currentLevelEntityType should be the Type of the TypeSegment
-            // E.g /Orders?$expand=Customer/NS.VipCustomer($select=VipCustomerName)
-            // If we are Binding the selected property VipCustomerName, currentLevelEntityType should be the type of the VipCustomer
-            IEdmStructuredType lastTypeSegmentType = GetLastTypeSegmentType(this.parsedSegments);
-            IEdmStructuredType currentLevelType = lastTypeSegmentType != null ? lastTypeSegmentType : this.edmType;
+            IEdmStructuredType currentLevelType = this.edmType;
 
             // first, walk through all type segments in a row, converting them from tokens into segments.
             if (tokenIn.IsNamespaceOrContainerQualified() && !UriParserHelper.IsAnnotation(tokenIn.Identifier))
@@ -804,29 +792,6 @@ namespace Microsoft.OData.UriParser
             }
 
             return pathSoFar;
-        }
-
-        private IEdmStructuredType GetLastTypeSegmentType(List<ODataPathSegment> pathSegments)
-        {
-            ODataPathSegment lastSegment = this.parsedSegments.Count > 0 ? this.parsedSegments[this.parsedSegments.Count - 1] : null;
-
-            if (lastSegment != null && lastSegment is TypeSegment)
-            {
-                IEdmType typeSegmentType = lastSegment.EdmType;
-
-                IEdmCollectionType collection = typeSegmentType as IEdmCollectionType;
-
-                if (collection != null)
-                {
-                    return collection.ElementType.Definition as IEdmStructuredType;
-                }
-                else
-                {
-                    return typeSegmentType as IEdmStructuredType;
-                }
-            }
-
-            return null;
         }
 
         private static HashSet<EndPathToken> GetGeneratedProperties(ComputeClause computeOption, ApplyClause applyOption)

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -343,6 +343,16 @@ namespace Microsoft.OData.UriParser
             PathSegmentToken currentToken = tokenIn.PathToNavigationProp;
 
             IEdmStructuredType currentLevelEntityType = this.EdmType;
+
+            // If we have a previous level binding with the last segment as a Type segment,
+            // The currentLevelEntityType should be the Type of the TypeSegment
+            // E.g Books?$expand=Authors/Ns.PrimaryAuthor($expand=Awards)
+            // If we are Binding the expanded property Awards, currentLevelEntityType should be the type of the PrimaryAuthor
+            if (this.parsedSegments.Count > 0 && this.parsedSegments.Last() is TypeSegment)
+            {
+                currentLevelEntityType = this.parsedSegments.Last().EdmType as IEdmStructuredType;
+            }
+
             List<ODataPathSegment> pathSoFar = new List<ODataPathSegment>();
             PathSegmentToken firstNonTypeToken = currentToken;
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -444,10 +444,10 @@ namespace Microsoft.OData.UriParser
             IEdmTypeReference elementTypeReference = hasDerivedTypeSegment ? derivedType.ToTypeReference() : null;
 
             // $apply
-            ApplyClause applyOption = BindApply(tokenIn.ApplyOptions, this.ResourcePathNavigationSource, targetNavigationSource);
+            ApplyClause applyOption = BindApply(tokenIn.ApplyOptions, this.ResourcePathNavigationSource, targetNavigationSource, elementTypeReference);
 
             // $compute
-            ComputeClause computeOption = BindCompute(tokenIn.ComputeOption, this.ResourcePathNavigationSource, targetNavigationSource);
+            ComputeClause computeOption = BindCompute(tokenIn.ComputeOption, this.ResourcePathNavigationSource, targetNavigationSource, elementTypeReference);
 
             var generatedProperties = GetGeneratedProperties(computeOption, applyOption);
             bool collapsed = applyOption?.Transformations.Any(t => t.Kind == TransformationNodeKind.Aggregate || t.Kind == TransformationNodeKind.GroupBy) ?? false;
@@ -487,12 +487,13 @@ namespace Microsoft.OData.UriParser
         /// <param name="applyToken">The apply tokens to visit.</param>
         /// <param name="resourcePathNavigationSource">The navigation source at the resource path.</param>
         /// <param name="targetNavigationSource">The target navigation source at the current level.</param>
+        /// <param name="elementType">The Edm element type.</param>
         /// <returns>The null or the built apply clause.</returns>
-        private ApplyClause BindApply(IEnumerable<QueryToken> applyToken, IEdmNavigationSource resourcePathNavigationSource, IEdmNavigationSource targetNavigationSource)
+        private ApplyClause BindApply(IEnumerable<QueryToken> applyToken, IEdmNavigationSource resourcePathNavigationSource, IEdmNavigationSource targetNavigationSource, IEdmTypeReference elementType = null)
         {
             if (applyToken != null && applyToken.Any())
             {
-                MetadataBinder binder = BuildNewMetadataBinder(this.Configuration, resourcePathNavigationSource, targetNavigationSource, null);
+                MetadataBinder binder = BuildNewMetadataBinder(this.Configuration, resourcePathNavigationSource, targetNavigationSource, elementType);
                 ApplyBinder applyBinder = new ApplyBinder(binder.Bind, binder.BindingState);
                 return applyBinder.BindApply(applyToken);
             }

--- a/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
@@ -35,10 +35,7 @@ namespace Microsoft.OData.UriParser
                 }
 
                 this.targetNavigationSource = lastSegment.TargetEdmNavigationSource;
-
-                // If the last segment is a TypeSegment, we should assign the targetEdmType as lastSegment.EdmType
-                // instead of lastSegment.TargetEdmType which references the Base Type EdmType.
-                this.targetEdmType = lastSegment is TypeSegment ? lastSegment.EdmType : lastSegment.TargetEdmType;
+                this.targetEdmType = lastSegment.TargetEdmType;
                 if (this.targetEdmType != null)
                 {
                     IEdmCollectionType collectionType = this.targetEdmType as IEdmCollectionType;

--- a/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
@@ -35,7 +35,10 @@ namespace Microsoft.OData.UriParser
                 }
 
                 this.targetNavigationSource = lastSegment.TargetEdmNavigationSource;
-                this.targetEdmType = lastSegment.TargetEdmType;
+
+                // If the last segment is a TypeSegment, we should assign the targetEdmType as lastSegment.EdmType
+                // instead of lastSegment.TargetEdmType which references the Base Type EdmType.
+                this.targetEdmType = lastSegment is TypeSegment ? lastSegment.EdmType : lastSegment.TargetEdmType;
                 if (this.targetEdmType != null)
                 {
                     IEdmCollectionType collectionType = this.targetEdmType as IEdmCollectionType;

--- a/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
@@ -35,7 +35,7 @@ namespace Microsoft.OData.UriParser
                 }
 
                 this.targetNavigationSource = lastSegment.TargetEdmNavigationSource;
-                this.targetEdmType = lastSegment.TargetEdmType;
+                this.targetEdmType = lastSegment.EdmType;
                 if (this.targetEdmType != null)
                 {
                     IEdmCollectionType collectionType = this.targetEdmType as IEdmCollectionType;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -1860,8 +1860,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Theory]
         [InlineData("MyPeople/Fully.Qualified.Namespace.Employee($select=Name)")] // Name is a property in the base type Person.
         [InlineData("MyPeople/Fully.Qualified.Namespace.Employee($select=WorkEmail)")] // WorkEmail is a property in the derived type Employee.
+        [InlineData("MyPeople/Fully.Qualified.Namespace.Employee($select=WorkAddress)")] // WorkAddress is a structured property in the derived type Employee.
         [InlineData("MyPeople/MainAlias.Employee($select=Name)")] // With schema alias
         [InlineData("MyPeople/MainAlias.Employee($select=WorkEmail)")] // With schema alias
+        [InlineData("MyPeople/MainAlias.Employee($select=WorkAddress)")] // With schema alias
         public void ExpandWithNavigationPropWithSelectAndFullyQualifiedTypeWorks(string query)
         {
             // Arrange

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SelectExpandFunctionalTests.cs
@@ -1887,6 +1887,78 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal("MyPeople", navPropSegment.Identifier);
             Assert.Equal("Collection(Fully.Qualified.Namespace.Person)", navPropSegment.EdmType.FullTypeName());
             Assert.Equal("Fully.Qualified.Namespace.Employee", typeSegment.EdmType.FullTypeName());
+
+            SelectExpandClause innerSelectExpandClause = expandedNavigationSelectItem.SelectAndExpand;
+            Assert.IsType<PathSelectItem>(Assert.Single(innerSelectExpandClause.SelectedItems));
+        }
+
+        // $expand=navProp/fully.qualified.type($expand=prop)
+        [Theory]
+        [InlineData("MyPeople/Fully.Qualified.Namespace.Employee($expand=MyLions)")] // MyLions is a navigation property in the base type Person.
+        [InlineData("MyPeople/Fully.Qualified.Namespace.Employee($expand=PaintingsInOffice)")] // PaintingsInOffice is a navigation property in the derived type Employee.
+        [InlineData("MyPeople/MainAlias.Employee($expand=MyLions)")] // With schema alias
+        [InlineData("MyPeople/MainAlias.Employee($expand=PaintingsInOffice)")] // With schema alias
+        public void ExpandWithNavigationPropWithExpandAndFullyQualifiedTypeWorks(string query)
+        {
+            // Arrange
+            var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,
+                HardCodedTestModel.GetDogType(), HardCodedTestModel.GetDogsSet(),
+                new Dictionary<string, string>()
+                {
+                    {"$expand", query}
+                });
+
+            // Act
+            var selectExpandClause = odataQueryOptionParser.ParseSelectAndExpand();
+
+            // Assert
+            Assert.NotNull(selectExpandClause);
+            ExpandedNavigationSelectItem expandedNavigationSelectItem = Assert.IsType<ExpandedNavigationSelectItem>(Assert.Single(selectExpandClause.SelectedItems));
+            Assert.Same(HardCodedTestModel.GetPeopleSet(), expandedNavigationSelectItem.NavigationSource);
+            Assert.NotNull(expandedNavigationSelectItem.SelectAndExpand);
+            Assert.Equal(2, expandedNavigationSelectItem.PathToNavigationProperty.Count);
+
+            NavigationPropertySegment navPropSegment = Assert.IsType<NavigationPropertySegment>(expandedNavigationSelectItem.PathToNavigationProperty.Segments.First());
+            TypeSegment typeSegment = Assert.IsType<TypeSegment>(expandedNavigationSelectItem.PathToNavigationProperty.Segments.Last());
+            Assert.Equal("MyPeople", navPropSegment.Identifier);
+            Assert.Equal("Collection(Fully.Qualified.Namespace.Person)", navPropSegment.EdmType.FullTypeName());
+            Assert.Equal("Fully.Qualified.Namespace.Employee", typeSegment.EdmType.FullTypeName());
+
+            SelectExpandClause innerSelectExpandClause = expandedNavigationSelectItem.SelectAndExpand;
+            Assert.IsType<ExpandedNavigationSelectItem>(Assert.Single(innerSelectExpandClause.SelectedItems));
+        }
+
+        // $expand=navProp/fully.qualified.type($orderby=prop)
+        [Theory]
+        [InlineData("MyPeople/Fully.Qualified.Namespace.Employee($orderby=Name)")] // Name is a property in the base type Person.
+        [InlineData("MyPeople/Fully.Qualified.Namespace.Employee($orderby=WorkEmail)")] // WorkEmail is a property in the derived type Employee.
+        [InlineData("MyPeople/MainAlias.Employee($orderby=Name)")] // With schema alias
+        [InlineData("MyPeople/MainAlias.Employee($orderby=WorkEmail)")] // With schema alias
+        public void ExpandWithNavigationPropWithOrderByAndFullyQualifiedTypeWorks(string query)
+        {
+            // Arrange
+            var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,
+                HardCodedTestModel.GetDogType(), HardCodedTestModel.GetDogsSet(),
+                new Dictionary<string, string>()
+                {
+                    {"$expand", query}
+                });
+
+            // Act
+            var selectExpandClause = odataQueryOptionParser.ParseSelectAndExpand();
+
+            // Assert
+            Assert.NotNull(selectExpandClause);
+            ExpandedNavigationSelectItem expandedNavigationSelectItem = Assert.IsType<ExpandedNavigationSelectItem>(Assert.Single(selectExpandClause.SelectedItems));
+            Assert.Same(HardCodedTestModel.GetPeopleSet(), expandedNavigationSelectItem.NavigationSource);
+            Assert.NotNull(expandedNavigationSelectItem.OrderByOption);
+            Assert.Equal(2, expandedNavigationSelectItem.PathToNavigationProperty.Count);
+
+            NavigationPropertySegment navPropSegment = Assert.IsType<NavigationPropertySegment>(expandedNavigationSelectItem.PathToNavigationProperty.Segments.First());
+            TypeSegment typeSegment = Assert.IsType<TypeSegment>(expandedNavigationSelectItem.PathToNavigationProperty.Segments.Last());
+            Assert.Equal("MyPeople", navPropSegment.Identifier);
+            Assert.Equal("Collection(Fully.Qualified.Namespace.Person)", navPropSegment.EdmType.FullTypeName());
+            Assert.Equal("Fully.Qualified.Namespace.Employee", typeSegment.EdmType.FullTypeName());
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -100,6 +100,7 @@ namespace Microsoft.OData.Tests.UriParser
             var FullyQualifiedNamespaceAddress = new EdmComplexType("Fully.Qualified.Namespace", "Address");
             var FullyQualifiedNamespaceOpenAddress = new EdmComplexType("Fully.Qualified.Namespace", "OpenAddress", null, false, true);
             var FullyQualifiedNamespaceHomeAddress = new EdmComplexType("Fully.Qualified.Namespace", "HomeAddress", FullyQualifiedNamespaceAddress);
+            var FullyQualifiedNamespaceWorkAddress = new EdmComplexType("Fully.Qualified.Namespace", "WorkAddress", FullyQualifiedNamespaceAddress);
 
             var FullyQualifiedNamespaceHeartbeat = new EdmComplexType("Fully.Qualified.Namespace", "Heartbeat");
             var FullyQualifiedNamespaceFilm = new EdmEntityType("Fully.Qualified.Namespace", "Film", null, false, false);
@@ -131,6 +132,7 @@ namespace Microsoft.OData.Tests.UriParser
 
             var FullyQualifiedNamespaceAddressTypeReference = new EdmComplexTypeReference(FullyQualifiedNamespaceAddress, true);
             var FullyQualifiedNamespaceOpenAddressTypeReference = new EdmComplexTypeReference(FullyQualifiedNamespaceOpenAddress, true);
+            var FullyQualifiedNamespaceWorkAddressTypeReference = new EdmComplexTypeReference(FullyQualifiedNamespaceWorkAddress, true);
             var FullyQualifiedNamespacePerson_ID = FullyQualifiedNamespacePerson.AddStructuralProperty("ID", EdmCoreModel.Instance.GetInt32(false));
             var FullyQualifiedNamespacePerson_SSN = FullyQualifiedNamespacePerson.AddStructuralProperty("SSN", EdmCoreModel.Instance.GetString(true));
             FullyQualifiedNamespacePerson.AddStructuralProperty("Shoe", EdmCoreModel.Instance.GetString(true));
@@ -217,6 +219,7 @@ namespace Microsoft.OData.Tests.UriParser
 
             FullyQualifiedNamespaceEmployee.AddStructuralProperty("WorkEmail", EdmCoreModel.Instance.GetString(true));
             FullyQualifiedNamespaceEmployee.AddStructuralProperty("WorkID", EdmCoreModel.Instance.GetInt32(false));
+            FullyQualifiedNamespaceEmployee.AddStructuralProperty("WorkAddress", FullyQualifiedNamespaceWorkAddressTypeReference);
             var FullyQualifiedNamespaceEmployee_PaintingsInOffice = FullyQualifiedNamespaceEmployee.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "PaintingsInOffice", TargetMultiplicity = EdmMultiplicity.Many, Target = FullyQualifiedNamespacePainting });
             var FullyQualifiedNamespaceEmployee_Manager = FullyQualifiedNamespaceEmployee.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "Manager", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = FullyQualifiedNamespaceManager });
             var FullyQualifiedNamespaceEmployee_OfficeDog = FullyQualifiedNamespaceDog.AddBidirectionalNavigation
@@ -344,6 +347,9 @@ namespace Microsoft.OData.Tests.UriParser
 
             FullyQualifiedNamespaceHomeAddress.AddStructuralProperty("HomeNO", EdmCoreModel.Instance.GetString(true));
             model.AddElement(FullyQualifiedNamespaceHomeAddress);
+
+            FullyQualifiedNamespaceWorkAddress.AddStructuralProperty("WorkNO", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(FullyQualifiedNamespaceWorkAddress);
 
             model.AddElement(FullyQualifiedNamespaceOpenAddress);
 
@@ -1061,6 +1067,7 @@ namespace Microsoft.OData.Tests.UriParser
       <EntityType Name=""Employee"" BaseType=""Fully.Qualified.Namespace.Person"">
         <Property Name=""WorkEmail"" Type=""Edm.String"" />
         <Property Name=""WorkID"" Type=""Edm.Int32"" />
+        <Property Name=""WorkAddress"" Type=""Fully.Qualified.Namespace.WorkAddress"" />
         <NavigationProperty Name=""PaintingsInOffice"" Type=""Collection(Fully.Qualified.Namespace.Painting)"" />
         <NavigationProperty Name=""Manager"" Type=""Fully.Qualified.Namespace.Manager"" />
         <NavigationProperty Name=""OfficeDog"" Type=""Fully.Qualified.Namespace.Dog"" Nullable=""false"" Partner=""EmployeeOwner"" />
@@ -1152,6 +1159,9 @@ namespace Microsoft.OData.Tests.UriParser
       </ComplexType>
       <ComplexType Name=""HomeAddress"" BaseType=""Fully.Qualified.Namespace.Address"">
         <Property Name=""HomeNO"" Type=""Edm.String"" />
+      </ComplexType>
+      <ComplexType Name=""WorkAddress"" BaseType=""Fully.Qualified.Namespace.Address"">
+        <Property Name=""WorkNO"" Type=""Edm.String"" />
       </ComplexType>
       <ComplexType Name=""OpenAddress"" OpenType=""true"" />
       <EntityType Name=""Pet1"">

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -216,6 +216,7 @@ namespace Microsoft.OData.Tests.UriParser
             model.AddElement(FullyQualifiedNamespacePerson);
 
             FullyQualifiedNamespaceEmployee.AddStructuralProperty("WorkEmail", EdmCoreModel.Instance.GetString(true));
+            FullyQualifiedNamespaceEmployee.AddStructuralProperty("WorkID", EdmCoreModel.Instance.GetInt32(false));
             var FullyQualifiedNamespaceEmployee_PaintingsInOffice = FullyQualifiedNamespaceEmployee.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "PaintingsInOffice", TargetMultiplicity = EdmMultiplicity.Many, Target = FullyQualifiedNamespacePainting });
             var FullyQualifiedNamespaceEmployee_Manager = FullyQualifiedNamespaceEmployee.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "Manager", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = FullyQualifiedNamespaceManager });
             var FullyQualifiedNamespaceEmployee_OfficeDog = FullyQualifiedNamespaceDog.AddBidirectionalNavigation
@@ -1059,6 +1060,7 @@ namespace Microsoft.OData.Tests.UriParser
       </EntityType>
       <EntityType Name=""Employee"" BaseType=""Fully.Qualified.Namespace.Person"">
         <Property Name=""WorkEmail"" Type=""Edm.String"" />
+        <Property Name=""WorkID"" Type=""Edm.Int32"" />
         <NavigationProperty Name=""PaintingsInOffice"" Type=""Collection(Fully.Qualified.Namespace.Painting)"" />
         <NavigationProperty Name=""Manager"" Type=""Fully.Qualified.Namespace.Manager"" />
         <NavigationProperty Name=""OfficeDog"" Type=""Fully.Qualified.Namespace.Dog"" Nullable=""false"" Partner=""EmployeeOwner"" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes https://github.com/OData/AspNetCoreOData/issues/445*

### Description

In #2160 we added support for the `TypeSegment` after `NavigationPropertySegment`. 
Example: `~/Orders?$expand=Customer/Model.VipCustomer`
This means that we will expand only the Customers that are an instance of Model.VipCustomer.
Note: `Model.VipCustomer` is a derived type of the `Customer`.

Something that was not captured in that PR is scenarios where we have query options affecting properties that are only in the derived type but not in the base type.

Examples: 
`~/Orders?$expand=Customer/Model.VipCustomer($filter=VipCustomerID eq '12345')`
`~/Orders?$expand=Customer/Model.VipCustomer($expand=VipCustomerOrders')`
`~/Orders?$expand=Customer/Model.VipCustomer($orderby=VipEmail)`

This PR fixes that by ensuring when we are doing semantic binding, we can bind the properties in the derived type.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
