### PR TITLE
Implement asynchronous support in ODataJsonLightErrorDeserializer

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightErrorDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightErrorDeserializerTests.cs
@@ -4,11 +4,14 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.OData.Edm;
 using Microsoft.OData.JsonLight;
 using Xunit;
+using ODataErrorStrings = Microsoft.OData.Strings;
 
 namespace Microsoft.OData.Tests.JsonLight
 {
@@ -21,7 +24,7 @@ namespace Microsoft.OData.Tests.JsonLight
             const string payload =
                 @"{""error"":{""code"":"""",""message"":"""",""target"":""any target"","
                 + @"""details"":[{""code"":""500"",""target"":""another target"",""message"":""any msg""}]}}";
-            var context = GetInputContext(payload);
+            var context = CreateJsonLightInputContext(payload);
             var deserializer = new ODataJsonLightErrorDeserializer(context);
 
             // Act
@@ -36,28 +39,6 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.Equal("any msg", detail.Message);
         }
 
-        //[Fact]
-        //public void ReadTopLevelErrorAsync_Works()
-        //{
-        //    // Arrange
-        //    const string payload =
-        //        @"{""error"":{""code"":"""",""message"":"""",""target"":""any target"","
-        //        + @"""details"":[{""code"":""500"",""target"":""another target"",""message"":""any msg""}]}}";
-        //    var context = GetInputContext(payload);
-        //    var deserializer = new ODataJsonLightErrorDeserializer(context);
-
-        //    // Act
-        //    var error = deserializer.ReadTopLevelErrorAsync().Result;
-
-        //    // Assert
-        //    Assert.Equal("any target", error.Target);
-        //    Assert.Equal(1, error.Details.Count);
-        //    var detail = error.Details.Single();
-        //    Assert.Equal("500", detail.ErrorCode);
-        //    Assert.Equal("another target", detail.Target);
-        //    Assert.Equal("any msg", detail.Message);
-        //}
-
         [Fact]
         public void ReadTopLevelErrorWithResourceValueInstanceAnnotation_Works()
         {
@@ -65,7 +46,7 @@ namespace Microsoft.OData.Tests.JsonLight
             const string payload =
                 @"{""error"":{""code"":"""",""message"":"""","
                 + @"""@sample.error"":{""@odata.type"":""#NS.Entity"",""Sample"":""sample value""}}}";
-            var context = GetInputContext(payload, GetEdmModel());
+            var context = CreateJsonLightInputContext(payload, GetEdmModel());
             var deserializer = new ODataJsonLightErrorDeserializer(context);
 
             // Act
@@ -91,7 +72,7 @@ namespace Microsoft.OData.Tests.JsonLight
             const string payload =
                 @"{""error"":{""code"":"""",""message"":"""","
                 + @"""sample.error@odata.type"":""Collection(NS.Entity)"",""@sample.error"":[{""@odata.type"":""#NS.Entity"",""Sample"":""sample value""}]}}";
-            var context = GetInputContext(payload, GetEdmModel());
+            var context = CreateJsonLightInputContext(payload, GetEdmModel());
             var deserializer = new ODataJsonLightErrorDeserializer(context);
 
             // Act
@@ -142,8 +123,8 @@ namespace Microsoft.OData.Tests.JsonLight
                                  "}" +
                             "}" +
                        "}}";
-                    
-            var context = GetInputContext(payload, GetEdmModel());
+
+            var context = CreateJsonLightInputContext(payload, GetEdmModel());
             var deserializer = new ODataJsonLightErrorDeserializer(context);
 
             // Act
@@ -166,7 +147,7 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.NotNull(objectValue);
 
             ODataResourceValue nestedInnerObject = error.InnerError.Properties["innererror"] as ODataResourceValue;
-            ODataResourceValue nestedMyNewObject    = nestedInnerObject.Properties.FirstOrDefault(p => p.Name == "MyNewObject").ODataValue as ODataResourceValue;
+            ODataResourceValue nestedMyNewObject = nestedInnerObject.Properties.FirstOrDefault(p => p.Name == "MyNewObject").ODataValue as ODataResourceValue;
 
             Assert.Equal(5, nestedMyNewObject.Properties.Count());
             Assert.Equal("StringProperty", nestedMyNewObject.Properties.ElementAt(0).Name);
@@ -184,12 +165,12 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.Equal("NestedNull", nestedMyNewObject.Properties.ElementAt(4).Name);
 
             ODataResourceValue innerValue = nestedMyNewObject.Properties.ElementAt(4).Value as ODataResourceValue;
-            
+
             Assert.NotNull(innerValue);
 
-            Assert.Equal(2,innerValue.Properties.Count());
-            Assert.Equal("InnerMostPropertyName",innerValue.Properties.ElementAt(0).Name);
-            Assert.Equal("InnerMostPropertyValue",innerValue.Properties.ElementAt(0).Value);
+            Assert.Equal(2, innerValue.Properties.Count());
+            Assert.Equal("InnerMostPropertyName", innerValue.Properties.ElementAt(0).Name);
+            Assert.Equal("InnerMostPropertyValue", innerValue.Properties.ElementAt(0).Value);
 
             Assert.Equal("InnerMostNull", innerValue.Properties.ElementAt(1).Name);
             Assert.Null(innerValue.Properties.ElementAt(1).Value);
@@ -201,7 +182,7 @@ namespace Microsoft.OData.Tests.JsonLight
             // Arrange
             const string payload = "{\"error\":{\"code\":\"\",\"message\":\"\",\"target\":\"any target\",\"details\":[{\"code\":\"500\",\"target\":\"any target\",\"message\":\"any msg\"}],\"innererror\":{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"\",\"ResourceValue\":{\"PropertyName\":\"PropertyValue\",\"NullProperty\":null},\"NullProperty\":null,\"CollectionValue\":[null,\"CollectionValue\",1]}}}";
 
-            var context = GetInputContext(payload, GetEdmModel());
+            var context = CreateJsonLightInputContext(payload, GetEdmModel());
             var deserializer = new ODataJsonLightErrorDeserializer(context);
 
             // Act
@@ -213,14 +194,252 @@ namespace Microsoft.OData.Tests.JsonLight
             Assert.Equal(3, (error.InnerError.Properties["CollectionValue"] as ODataCollectionValue).Items.Count());
         }
 
-        private ODataJsonLightInputContext GetInputContext(string payload, IEdmModel model = null)
+        [Fact]
+        public async Task ReadTopLevelErrorAsync()
+        {
+            var payload = "{\"error\":{" +
+                "\"code\":\"forbidden\"," +
+                "\"message\":\"Access to the resource is forbidden\"," +
+                "\"target\":\"Resource\"," +
+                "\"details\":[{\"code\":\"insufficientPrivileges\",\"message\":\"You don't have the required privileges\",\"target\":\"\",\"ignore\":true}]," +
+                "\"innererror\":{" +
+                    "\"message\":\"Contact administrator\"," +
+                    "\"type\":\"\"," +
+                    "\"stacktrace\":\"\"," +
+                    "\"correlationId\":\"4784efae-d1c4-4f1f-baba-e811b3b0826c\"," +
+                    "\"internalexception\":{}}," +
+                "\"ns.workloadId@odata.type\":\"#Guid\"," +
+                "\"@ns.workloadId\":\"5a3c4b92-f401-416f-bf88-106cb03efaf4\"}}";
+
+            await SetupJsonLightErrorDeserializerAndRunTestAsync(
+                payload,
+                async (jsonLightErrorDeserializer) =>
+                {
+                    var error = await jsonLightErrorDeserializer.ReadTopLevelErrorAsync();
+
+                    Assert.NotNull(error);
+                    Assert.Equal("forbidden", error.ErrorCode);
+                    Assert.Equal("Access to the resource is forbidden", error.Message);
+                    Assert.Equal("Resource", error.Target);
+                    Assert.NotNull(error.InnerError);
+                    Assert.Equal("Contact administrator", error.InnerError.Message);
+                    Assert.Equal("", error.InnerError.TypeName);
+                    Assert.Equal("", error.InnerError.StackTrace);
+                    Assert.NotNull(error.InnerError.InnerError);
+                    Assert.True(error.InnerError.Properties.TryGetValue("correlationId", out ODataValue correlationIdValue));
+                    var correlationId = Assert.IsType<ODataPrimitiveValue>(correlationIdValue);
+                    Assert.Equal("4784efae-d1c4-4f1f-baba-e811b3b0826c", correlationId.Value);
+                    Assert.NotNull(error.Details);
+                    var errorDetail = Assert.Single(error.Details);
+                    Assert.Equal("insufficientPrivileges", errorDetail.ErrorCode);
+                    Assert.Equal("You don't have the required privileges", errorDetail.Message);
+                    Assert.Equal("", errorDetail.Target);
+                    var nsWorkloadIdAnnotation = Assert.Single(error.GetInstanceAnnotations());
+                    var nsWorkloadId = Assert.IsType<ODataPrimitiveValue>(nsWorkloadIdAnnotation.Value);
+                    Assert.Equal(Guid.Parse("5a3c4b92-f401-416f-bf88-106cb03efaf4"), nsWorkloadId.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorWithResourceValueInstanceAnnotationAsync()
+        {
+            var model = new EdmModel();
+            var errorTokenComplexType = new EdmComplexType("NS", "ErrorToken");
+            errorTokenComplexType.AddStructuralProperty("Severity", EdmPrimitiveTypeKind.String);
+            model.AddElement(errorTokenComplexType);
+
+            var payload = "{\"error\":{\"@custom.annotation\":{\"@odata.type\":\"#NS.ErrorToken\",\"Severity\":\"Critical\"}}}";
+
+            await SetupJsonLightErrorDeserializerAndRunTestAsync(
+                payload,
+                async (jsonLightErrorDeserializer) =>
+                {
+                    var error = await jsonLightErrorDeserializer.ReadTopLevelErrorAsync();
+
+                    Assert.NotNull(error);
+                    var errorTokenInstanceAnnotation = Assert.Single(error.GetInstanceAnnotations());
+                    var errorTokenResourceValue = Assert.IsType<ODataResourceValue>(errorTokenInstanceAnnotation.Value);
+                    var severityProperty = Assert.Single(errorTokenResourceValue.Properties);
+                    Assert.Equal("Severity", severityProperty.Name);
+                    Assert.Equal("Critical", severityProperty.Value);
+                },
+                model);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorWithResourceValueInInnerErrorObjectAsync()
+        {
+            var payload = "{\"error\":{\"innererror\":{\"errorToken\":{\"Severity\":\"Critical\"}}}}";
+
+            await SetupJsonLightErrorDeserializerAndRunTestAsync(
+                payload,
+                async (jsonLightErrorDeserializer) =>
+                {
+                    var error = await jsonLightErrorDeserializer.ReadTopLevelErrorAsync();
+
+                    Assert.NotNull(error);
+                    Assert.NotNull(error.InnerError);
+                    Assert.True(error.InnerError.Properties.TryGetValue("errorToken", out ODataValue resourceValue));
+                    var errorToken = Assert.IsType<ODataResourceValue>(resourceValue);
+                    var severityProperty = Assert.Single(errorToken.Properties);
+                    Assert.Equal("Severity", severityProperty.Name);
+                    Assert.Equal("Critical", severityProperty.Value);
+                });
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorAsync_ThrowsExceptionForMultipleErrorProperties()
+        {
+            var payload = "{\"error\":{" +
+                "\"code\":\"forbidden\"," +
+                "\"message\":\"Access to the resource is forbidden\"," +
+                "\"target\":\"Resource\"}," +
+                "\"error\":{}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightErrorDeserializerAndRunTestAsync(
+                    payload,
+                    (jsonLightErrorDeserializer) => jsonLightErrorDeserializer.ReadTopLevelErrorAsync()));
+
+            Assert.Equal(
+                ODataErrorStrings.ODataJsonReaderUtils_MultipleErrorPropertiesWithSameName("error"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorAsync_ThrowsExceptionForUnexpectedTopLevelProperty()
+        {
+            var payload = "{\"UnexpectedProp\":\"foobar\"}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightErrorDeserializerAndRunTestAsync(
+                    payload,
+                    (jsonLightErrorDeserializer) => jsonLightErrorDeserializer.ReadTopLevelErrorAsync()));
+
+            Assert.Equal(
+                ODataErrorStrings.ODataJsonErrorDeserializer_TopLevelErrorWithInvalidProperty("UnexpectedProp"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorAsync_ThrowsExceptionForODataAnnotationInErrorObject()
+        {
+            var payload = "{\"error\":{" +
+                "\"@odata.type\":\"#NS.ODataError\"}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightErrorDeserializerAndRunTestAsync(
+                    payload,
+                    (jsonLightErrorDeserializer) => jsonLightErrorDeserializer.ReadTopLevelErrorAsync()));
+
+            Assert.Equal(
+                ODataErrorStrings.ODataJsonLightErrorDeserializer_InstanceAnnotationNotAllowedInErrorPayload("odata.type"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorAsync_ThrowsExceptionForPropertyWithoutValueInErrorObject()
+        {
+            var payload = "{\"error\":{" +
+                "\"target@odata.type\":\"#Edm.String\"}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightErrorDeserializerAndRunTestAsync(
+                    payload,
+                    (jsonLightErrorDeserializer) => jsonLightErrorDeserializer.ReadTopLevelErrorAsync()));
+
+            Assert.Equal(
+                ODataErrorStrings.ODataJsonLightErrorDeserializer_PropertyAnnotationWithoutPropertyForError("target"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorAsync_ThrowsExceptionForUnexpectedMetadataReferencePropertyInErrorObject()
+        {
+            var payload = "{\"error\":{" +
+                "\"#NS.ResolveError\":{\"title\":\"ResolveError\",\"target\":\"http://tempuri.org/ResolveError\"}}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightErrorDeserializerAndRunTestAsync(
+                    payload,
+                    (jsonLightErrorDeserializer) => jsonLightErrorDeserializer.ReadTopLevelErrorAsync()));
+
+            Assert.Equal(
+                ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_UnexpectedMetadataReferenceProperty("#NS.ResolveError"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorAsync_ThrowsExceptionForUnexpectedODataPropertyAnnotationInErrorObject()
+        {
+            var payload = "{\"error\":{" +
+                "\"message@odata.etag\":\"etag\"," +
+                "\"message\":\"Access to the resource is forbidden\"}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightErrorDeserializerAndRunTestAsync(
+                    payload,
+                    (jsonLightErrorDeserializer) => jsonLightErrorDeserializer.ReadTopLevelErrorAsync()));
+
+            Assert.Equal(
+                ODataErrorStrings.ODataJsonLightErrorDeserializer_PropertyAnnotationNotAllowedInErrorPayload("odata.etag"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorAsync_ThrowsExceptionForInvalidODataTypeInErrorObject()
+        {
+            var payload = "{\"error\":{" +
+                "\"message@odata.type\":null," +
+                "\"message\":\"Access to the resource is forbidden\"}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightErrorDeserializerAndRunTestAsync(
+                    payload,
+                    (jsonLightErrorDeserializer) => jsonLightErrorDeserializer.ReadTopLevelErrorAsync()));
+
+            Assert.Equal(
+                ODataErrorStrings.ODataJsonLightPropertyAndValueDeserializer_InvalidTypeName("odata.type"),
+                exception.Message);
+        }
+
+        [Fact]
+        public async Task ReadTopLevelErrorAsync_ThrowsExceptionForUnexpectedPropertyInErrorObject()
+        {
+            var payload = "{\"error\":{" +
+                "\"UnexpectedProp\":\"foobar\"}}";
+
+            var exception = await Assert.ThrowsAsync<ODataException>(
+                () => SetupJsonLightErrorDeserializerAndRunTestAsync(
+                    payload,
+                    (jsonLightErrorDeserializer) => jsonLightErrorDeserializer.ReadTopLevelErrorAsync()));
+
+            Assert.Equal(
+                ODataErrorStrings.ODataJsonLightErrorDeserializer_TopLevelErrorValueWithInvalidProperty("UnexpectedProp"),
+                exception.Message);
+        }
+
+        private async Task SetupJsonLightErrorDeserializerAndRunTestAsync(
+            string payload,
+            Func<ODataJsonLightErrorDeserializer, Task> func,
+            IEdmModel model = null)
+        {
+            using (var jsonLightInputContext = CreateJsonLightInputContext(payload, model, isAsync: true))
+            {
+                var jsonLightErrorDeserializer = new ODataJsonLightErrorDeserializer(jsonLightInputContext);
+
+                await func(jsonLightErrorDeserializer);
+            }
+        }
+
+        private ODataJsonLightInputContext CreateJsonLightInputContext(string payload, IEdmModel model = null, bool isAsync = false)
         {
             var messageInfo = new ODataMessageInfo
             {
                 IsResponse = true,
                 MediaType = JsonLightUtils.JsonLightStreamingMediaType,
-                IsAsync = false,
-                Model = model ?? new EdmModel(),
+                IsAsync = isAsync,
+                Model = model ?? EdmCoreModel.Instance,
             };
 
             return new ODataJsonLightInputContext(


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request partially fulfills #2019.

### Description

Implement asynchronous support in `ODataJsonLightErrorDeserializer`.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
