### PR TITLE
#1208 Support relative context URI starting with "$metadata"

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -249,10 +249,12 @@ namespace Microsoft.OData.JsonLight
             {
                 // If the Base uri string is http://odata.org/test
                 // The MetadataDocumentUri will be http://odata.org/test/$metadata
-                // If the contextUriAnnotation value is Customers(1)/Name
+                // If the contextUriAnnotation value is Customers(1)/Name or $metadata#Customers(1)/Name
                 // The generated context uri will be http://odata.org/test/$metadata#Customers(1)/Name
                 ODataUri oDataUri = new ODataUri() { ServiceRoot = this.BaseUri };
-                contextUriAnnotationValue = oDataUri.MetadataDocumentUri.ToString() + ODataConstants.ContextUriFragmentIndicator + contextUriAnnotationValue;
+                contextUriAnnotationValue = contextUriAnnotationValue.StartsWith("$metadata", StringComparison.OrdinalIgnoreCase)
+                    ? new Uri(this.BaseUri, contextUriAnnotationValue).ToString()
+                    : oDataUri.MetadataDocumentUri.ToString() + ODataConstants.ContextUriFragmentIndicator + contextUriAnnotationValue;
             }
 
             ODataJsonLightContextUriParseResult parseResult = null;

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -252,7 +252,7 @@ namespace Microsoft.OData.JsonLight
                 // If the contextUriAnnotation value is Customers(1)/Name or $metadata#Customers(1)/Name
                 // The generated context uri will be http://odata.org/test/$metadata#Customers(1)/Name
                 ODataUri oDataUri = new ODataUri() { ServiceRoot = this.BaseUri };
-                contextUriAnnotationValue = contextUriAnnotationValue.StartsWith("$metadata", StringComparison.OrdinalIgnoreCase)
+                contextUriAnnotationValue = contextUriAnnotationValue.StartsWith("$metadata#", StringComparison.OrdinalIgnoreCase)
                     ? this.BaseUri + contextUriAnnotationValue
                     : oDataUri.MetadataDocumentUri.ToString() + ODataConstants.ContextUriFragmentIndicator + contextUriAnnotationValue;
             }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -253,7 +253,7 @@ namespace Microsoft.OData.JsonLight
                 // The generated context uri will be http://odata.org/test/$metadata#Customers(1)/Name
                 ODataUri oDataUri = new ODataUri() { ServiceRoot = this.BaseUri };
                 contextUriAnnotationValue = contextUriAnnotationValue.StartsWith("$metadata", StringComparison.OrdinalIgnoreCase)
-                    ? new Uri(this.BaseUri, contextUriAnnotationValue).ToString()
+                    ? this.BaseUri + contextUriAnnotationValue
                     : oDataUri.MetadataDocumentUri.ToString() + ODataConstants.ContextUriFragmentIndicator + contextUriAnnotationValue;
             }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeserializerTests.cs
@@ -878,6 +878,12 @@ namespace Microsoft.OData.Tests.JsonLight
 
             Assert.NotNull(property);
             Assert.Equal("http://odata.org/test/$metadata#Customers(1)/Name", deserializer.ContextUriParseResult.ContextUri.ToString());
+
+            deserializer = new ODataJsonLightPropertyAndValueDeserializer(this.CreateJsonLightInputContext("{\"@odata.context\":\"$metadata#Customers(1)/Name\",\"value\":\"Joe\"}", model));
+            property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
+
+            Assert.NotNull(property);
+            Assert.Equal("http://odata.org/test/$metadata#Customers(1)/Name", deserializer.ContextUriParseResult.ContextUri.ToString());
         }
 
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1208.*

### Description

*Relative context URI could start with "$metadata". This PR covers the case in addition to the fix of [#2132: Relative URIs for @oData.context are not supported.](https://github.com/OData/odata.net/pull/2216)*

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

