### PR TITLE
Fix e2e tests build error

### DIFF
--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Annotation/InstanceAnnotationDictWeakKeyComparerTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Annotation/InstanceAnnotationDictWeakKeyComparerTests.cs
@@ -359,7 +359,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests.Annotation
             {
                 RemoveCollectedEntriesRules = new List<Func<object, bool>>
                 {
-                    InstanceAnnotationDictWeakKeyComparer.Default.RemoveRule
+                    InstanceAnnotationDictWeakKeyComparer.RemoveRule
                 },
                 CreateWeakKey = InstanceAnnotationDictWeakKeyComparer.Default.CreateKey
             };


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

A [recent commit](https://github.com/OData/odata.net/commit/7dcad74478debcfe54e93c63f47b7cb57f2d2e67) made the `RemoveRule` method of the `InstanceAnnotationDictWeakKeyComparer` class static. This broke the e2e tests that were still referencing the method as if it were an instance method. This PR fixes that issue and gets the tests building again.

PS: Some tests are still failing locally, and are not running on CI (which is likely why this build error was not caught when the PR that introduced the issue was merged). There are other open issues to tackle those problems:
- https://github.com/OData/odata.net/issues/2295

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
