### PR TITLE
fixed notsupportedexception due to resource table lookup in edmlibtests when run locally

### DIFF
--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -34,19 +34,29 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="Microsoft.OData.Edm.tt">
+    <Content Include="Microsoft.OData.Edm.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Microsoft.OData.Edm.cs</LastGenOutput>
-    </None>
-    <None Include="Parameterized.Microsoft.OData.Edm.tt">
+    </Content>
+    <Content Include="Parameterized.Microsoft.OData.Edm.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Parameterized.Microsoft.OData.Edm.cs</LastGenOutput>
-    </None>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\AssemblyInfo\AssemblyKeys.cs" Link="AssemblyKeys.cs" />
     <Compile Include="..\PlatformHelper.cs" Link="PlatformHelper.cs" />
+    <Compile Update="Microsoft.OData.Edm.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Microsoft.OData.Edm.tt</DependentUpon>
+    </Compile>
+    <Compile Update="Parameterized.Microsoft.OData.Edm.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Parameterized.Microsoft.OData.Edm.tt</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -34,29 +34,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Resource Include="Microsoft.OData.Edm.tt">
+    <None Include="Microsoft.OData.Edm.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Microsoft.OData.Edm.cs</LastGenOutput>
-    </Resource>
-    <Resource Include="Parameterized.Microsoft.OData.Edm.tt">
+    </None>
+    <None Include="Parameterized.Microsoft.OData.Edm.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Parameterized.Microsoft.OData.Edm.cs</LastGenOutput>
-    </Resource>
+    </None>
   </ItemGroup>
 
   <ItemGroup>
     <Compile Include="..\AssemblyInfo\AssemblyKeys.cs" Link="AssemblyKeys.cs" />
     <Compile Include="..\PlatformHelper.cs" Link="PlatformHelper.cs" />
-    <Compile Update="Microsoft.OData.Edm.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Microsoft.OData.Edm.tt</DependentUpon>
-    </Compile>
-    <Compile Update="Parameterized.Microsoft.OData.Edm.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>Parameterized.Microsoft.OData.Edm.tt</DependentUpon>
-    </Compile>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request helps address #2295.*

### Description

*When the EdmLibTests project is run locally, there are test failures due to a `NotSupportedException` when looking up resources in the embedded resource table*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*There will be future PRs to address the other test project failures. This PR is scoped specifically to the EdmLibTests project*
