### PR TITLE
Validate key not defined multiple times in type hierarchy

### DIFF
--- a/src/Microsoft.OData.Edm/PublicApi/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicApi/net45/PublicAPI.Unshipped.txt
@@ -1766,6 +1766,7 @@ static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntitySetTypeMust
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeBoundEscapeFunctionMustBeUnique -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeDuplicatePropertyNameSpecifiedInEntityKey -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeEntityKeyMustBeScalar -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
+static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeInvalidKeyKeyDefinedInAncestor -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeInvalidKeyKeyDefinedInBaseClass -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeInvalidKeyNullablePart -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeKeyMissingOnEntityType -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>

--- a/src/Microsoft.OData.Edm/PublicApi/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicApi/netstandard1.1/PublicAPI.Unshipped.txt
@@ -1766,6 +1766,7 @@ static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntitySetTypeMust
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeBoundEscapeFunctionMustBeUnique -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeDuplicatePropertyNameSpecifiedInEntityKey -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeEntityKeyMustBeScalar -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
+static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeInvalidKeyKeyDefinedInAncestor -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeInvalidKeyKeyDefinedInBaseClass -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeInvalidKeyNullablePart -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeKeyMissingOnEntityType -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>

--- a/src/Microsoft.OData.Edm/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicApi/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1790,6 +1790,7 @@ static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntitySetTypeMust
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeBoundEscapeFunctionMustBeUnique -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeDuplicatePropertyNameSpecifiedInEntityKey -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeEntityKeyMustBeScalar -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
+static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeInvalidKeyKeyDefinedInAncestor -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeInvalidKeyKeyDefinedInBaseClass -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeInvalidKeyNullablePart -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>
 static readonly Microsoft.OData.Edm.Validation.ValidationRules.EntityTypeKeyMissingOnEntityType -> Microsoft.OData.Edm.Validation.ValidationRule<Microsoft.OData.Edm.IEdmEntityType>

--- a/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRuleSet.cs
@@ -33,9 +33,13 @@ namespace Microsoft.OData.Edm.Validation
                 ValidationRules.EntityTypeDuplicatePropertyNameSpecifiedInEntityKey,
                 ValidationRules.EntityTypeInvalidKeyNullablePart,
                 ValidationRules.EntityTypeEntityKeyMustBeScalar,
+                // in 8.x, replace ValidationRules.EntityTypeInvalidKeyKeyDefinedInBaseClass with 
+                // ValidationRules.EntityTypeInvalidKeyKeyDefinedInAncestor,
                 ValidationRules.EntityTypeInvalidKeyKeyDefinedInBaseClass,
                 ValidationRules.EntityTypeBoundEscapeFunctionMustBeUnique,
-////                ValidationRules.EntityTypeKeyMissingOnEntityType,
+                // in 8.x, replace (commented out) ValidationRules.EntityTypeKeyMissingOnEntityType with
+                // ValidationRules.NavigationSourceTypeHasNoKeys, 
+                // ValidationRules.EntityTypeKeyMissingOnEntityType,
                 ValidationRules.StructuredTypeInvalidMemberNameMatchesTypeName,
                 ValidationRules.StructuredTypePropertyNameAlreadyDefined,
                 ValidationRules.StructuralPropertyInvalidPropertyType,

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRuleSetTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRuleSetTests.cs
@@ -24,7 +24,8 @@ namespace Microsoft.OData.Edm.Tests.Validation
             var items = typeof(ValidationRules).GetFields().Where(f =>
                 f.Name != "NavigationPropertyEntityMustNotIndirectlyContainItself" &&
                 f.Name != "EntityTypeKeyMissingOnEntityType" &&
-                f.Name != "VocabularyAnnotationTargetAllowedApplyToElement")
+                f.Name != "VocabularyAnnotationTargetAllowedApplyToElement" &&
+                f.Name != "EntityTypeInvalidKeyKeyDefinedInAncestor")
                 .Select(f=> new KeyValuePair<object, string>(f.GetValue(null), f.Name));
             foreach (var item in items)
             {

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
@@ -1144,6 +1144,39 @@ namespace Microsoft.OData.Edm.Tests.Validation
                 Strings.EdmModel_Validator_Semantic_EdmPrimitiveTypeCannotBeUsedAsTypeOfKey("Id", "NS.Entity"));
         }
 
+        [Fact]
+        public void TestInterfaceEntityTypeCannotDefineDuplicateKey()
+        {
+            EdmEntityType baseEntity = new EdmEntityType("NS", "Base");
+            baseEntity.AddKeys(baseEntity.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String));
+            EdmEntityType entity = new EdmEntityType("NS", "Entity", baseEntity);
+            entity.AddKeys(entity.AddStructuralProperty("Id2", EdmPrimitiveTypeKind.String));
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            ValidateError(
+                ValidationRules.EntityTypeInvalidKeyKeyDefinedInBaseClass,
+                entity,
+                EdmErrorCode.InvalidKey,
+                Strings.EdmModel_Validator_Semantic_InvalidKeyKeyDefinedInBaseClass(entity.Name, entity.BaseEntityType().Name));
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        [Fact]
+        public void TestInterfaceEntityTypeCannotDefineDuplicateIndirectKey()
+        {
+            EdmEntityType baseEntity = new EdmEntityType("NS", "Base");
+            baseEntity.AddKeys(baseEntity.AddStructuralProperty("Id", EdmPrimitiveTypeKind.String));
+            EdmEntityType interimEntity = new EdmEntityType("NS", "InterimEntity", baseEntity);
+            EdmEntityType entity = new EdmEntityType("NS", "Entity", interimEntity);
+            entity.AddKeys(entity.AddStructuralProperty("Id2", EdmPrimitiveTypeKind.String));
+
+            ValidateError(
+                ValidationRules.EntityTypeInvalidKeyKeyDefinedInAncestor,
+                entity,
+                EdmErrorCode.InvalidKey,
+                Strings.EdmModel_Validator_Semantic_InvalidKeyKeyDefinedInBaseClass(entity.Name, baseEntity.Name));
+        }
+
         [Theory]
         [InlineData(EdmTypeKind.Complex)]
         [InlineData(EdmTypeKind.Primitive)]

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -1903,6 +1903,16 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static Microsoft.OData.Edm.IEdmProperty FindProperty (Microsoft.OData.Edm.IEdmStructuredType structuredType, string propertyName, bool caseInsensitive)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.IEdmProperty FindProperty (Microsoft.OData.Edm.IEdmStructuredTypeReference structuredType, string propertyName, bool caseInsensitive)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static Microsoft.OData.Edm.Vocabularies.IEdmTerm FindTerm (Microsoft.OData.Edm.IEdmModel model, string qualifiedName)
 
     [
@@ -3389,9 +3399,18 @@ public sealed class Microsoft.OData.Edm.Validation.ValidationRules {
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeBoundEscapeFunctionMustBeUnique = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeDuplicatePropertyNameSpecifiedInEntityKey = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeEntityKeyMustBeScalar = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+    public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeInvalidKeyKeyDefinedInAncestor = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+    [
+    ObsoleteAttribute(),
+    ]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeInvalidKeyKeyDefinedInBaseClass = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeInvalidKeyNullablePart = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+    [
+    ObsoleteAttribute(),
+    ]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeKeyMissingOnEntityType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeKeyPropertyMustBelongToEntity = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeKeyTypeCannotBeEdmPrimitiveType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEnumMember]] EnumMemberValueMustHaveSameTypeAsUnderlyingType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEnumMember]
@@ -3741,6 +3760,21 @@ public abstract class Microsoft.OData.Edm.Vocabularies.EdmValue : IEdmElement, I
 
     Microsoft.OData.Edm.IEdmTypeReference Type  { public virtual get; }
     Microsoft.OData.Edm.Vocabularies.EdmValueKind ValueKind  { public abstract get; }
+}
+
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.OData.Edm.Vocabularies.IEdmTermExtensions {
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation CreateVocabularyAnnotation (Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation CreateVocabularyAnnotation (Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target, string qualifier)
 }
 
 public class Microsoft.OData.Edm.Vocabularies.EdmAnnotationPathExpression : Microsoft.OData.Edm.EdmPathExpression, IEdmElement, IEdmExpression, IEdmPathExpression {
@@ -5482,6 +5516,7 @@ public sealed class Microsoft.OData.ODataMessageReaderSettings {
     bool EnableCharactersCheck  { public get; public set; }
     bool EnableMessageStreamDisposal  { public get; public set; }
     bool EnablePrimitiveTypeConversion  { public get; public set; }
+    bool EnablePropertyNameCaseInsensitive  { public get; public set; }
     Microsoft.OData.ODataLibraryCompatibility LibraryCompatibility  { public get; public set; }
     Microsoft.OData.ODataVersion MaxProtocolVersion  { public get; public set; }
     Microsoft.OData.ODataMessageQuotas MessageQuotas  { public get; public set; }
@@ -5800,7 +5835,7 @@ public interface Microsoft.OData.Json.IJsonReader {
     bool Read ()
 }
 
-public interface Microsoft.OData.Json.IJsonReaderAsync {
+public interface Microsoft.OData.Json.IJsonReaderAsync : IJsonReader {
     System.Threading.Tasks.Task`1[[System.Object]] GetValueAsync ()
     System.Threading.Tasks.Task`1[[System.Boolean]] ReadAsync ()
 }
@@ -5819,7 +5854,8 @@ public interface Microsoft.OData.Json.IJsonStreamReader : IJsonReader {
     System.IO.TextReader CreateTextReader ()
 }
 
-public interface Microsoft.OData.Json.IJsonStreamReaderAsync : IJsonReaderAsync {
+public interface Microsoft.OData.Json.IJsonStreamReaderAsync : IJsonReader, IJsonReaderAsync {
+    System.Threading.Tasks.Task`1[[System.Boolean]] CanStreamAsync ()
     System.Threading.Tasks.Task`1[[System.IO.Stream]] CreateReadStreamAsync ()
     System.Threading.Tasks.Task`1[[System.IO.TextReader]] CreateTextReaderAsync ()
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -1903,6 +1903,16 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static Microsoft.OData.Edm.IEdmProperty FindProperty (Microsoft.OData.Edm.IEdmStructuredType structuredType, string propertyName, bool caseInsensitive)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.IEdmProperty FindProperty (Microsoft.OData.Edm.IEdmStructuredTypeReference structuredType, string propertyName, bool caseInsensitive)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static Microsoft.OData.Edm.Vocabularies.IEdmTerm FindTerm (Microsoft.OData.Edm.IEdmModel model, string qualifiedName)
 
     [
@@ -3389,9 +3399,18 @@ public sealed class Microsoft.OData.Edm.Validation.ValidationRules {
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeBoundEscapeFunctionMustBeUnique = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeDuplicatePropertyNameSpecifiedInEntityKey = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeEntityKeyMustBeScalar = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+    public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeInvalidKeyKeyDefinedInAncestor = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+    [
+    ObsoleteAttribute(),
+    ]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeInvalidKeyKeyDefinedInBaseClass = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeInvalidKeyNullablePart = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+    [
+    ObsoleteAttribute(),
+    ]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeKeyMissingOnEntityType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeKeyPropertyMustBelongToEntity = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeKeyTypeCannotBeEdmPrimitiveType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEnumMember]] EnumMemberValueMustHaveSameTypeAsUnderlyingType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEnumMember]
@@ -3741,6 +3760,21 @@ public abstract class Microsoft.OData.Edm.Vocabularies.EdmValue : IEdmElement, I
 
     Microsoft.OData.Edm.IEdmTypeReference Type  { public virtual get; }
     Microsoft.OData.Edm.Vocabularies.EdmValueKind ValueKind  { public abstract get; }
+}
+
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.OData.Edm.Vocabularies.IEdmTermExtensions {
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation CreateVocabularyAnnotation (Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation CreateVocabularyAnnotation (Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target, string qualifier)
 }
 
 public class Microsoft.OData.Edm.Vocabularies.EdmAnnotationPathExpression : Microsoft.OData.Edm.EdmPathExpression, IEdmElement, IEdmExpression, IEdmPathExpression {
@@ -5482,6 +5516,7 @@ public sealed class Microsoft.OData.ODataMessageReaderSettings {
     bool EnableCharactersCheck  { public get; public set; }
     bool EnableMessageStreamDisposal  { public get; public set; }
     bool EnablePrimitiveTypeConversion  { public get; public set; }
+    bool EnablePropertyNameCaseInsensitive  { public get; public set; }
     Microsoft.OData.ODataLibraryCompatibility LibraryCompatibility  { public get; public set; }
     Microsoft.OData.ODataVersion MaxProtocolVersion  { public get; public set; }
     Microsoft.OData.ODataMessageQuotas MessageQuotas  { public get; public set; }
@@ -5800,7 +5835,7 @@ public interface Microsoft.OData.Json.IJsonReader {
     bool Read ()
 }
 
-public interface Microsoft.OData.Json.IJsonReaderAsync {
+public interface Microsoft.OData.Json.IJsonReaderAsync : IJsonReader {
     System.Threading.Tasks.Task`1[[System.Object]] GetValueAsync ()
     System.Threading.Tasks.Task`1[[System.Boolean]] ReadAsync ()
 }
@@ -5819,7 +5854,8 @@ public interface Microsoft.OData.Json.IJsonStreamReader : IJsonReader {
     System.IO.TextReader CreateTextReader ()
 }
 
-public interface Microsoft.OData.Json.IJsonStreamReaderAsync : IJsonReaderAsync {
+public interface Microsoft.OData.Json.IJsonStreamReaderAsync : IJsonReader, IJsonReaderAsync {
+    System.Threading.Tasks.Task`1[[System.Boolean]] CanStreamAsync ()
     System.Threading.Tasks.Task`1[[System.IO.Stream]] CreateReadStreamAsync ()
     System.Threading.Tasks.Task`1[[System.IO.TextReader]] CreateTextReaderAsync ()
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -1903,6 +1903,16 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static Microsoft.OData.Edm.IEdmProperty FindProperty (Microsoft.OData.Edm.IEdmStructuredType structuredType, string propertyName, bool caseInsensitive)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.IEdmProperty FindProperty (Microsoft.OData.Edm.IEdmStructuredTypeReference structuredType, string propertyName, bool caseInsensitive)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static Microsoft.OData.Edm.Vocabularies.IEdmTerm FindTerm (Microsoft.OData.Edm.IEdmModel model, string qualifiedName)
 
     [
@@ -2163,6 +2173,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static bool IsImmutable (Microsoft.OData.Edm.IEdmModel model)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static bool IsKey (Microsoft.OData.Edm.IEdmProperty property)
 
     [
@@ -2194,6 +2209,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.EdmLocation Location (Microsoft.OData.Edm.IEdmElement item)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static void MarkAsImmutable (Microsoft.OData.Edm.IEdmModel model)
 
     [
     ExtensionAttribute(),
@@ -3411,9 +3431,18 @@ public sealed class Microsoft.OData.Edm.Validation.ValidationRules {
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeBoundEscapeFunctionMustBeUnique = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeDuplicatePropertyNameSpecifiedInEntityKey = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeEntityKeyMustBeScalar = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+    public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeInvalidKeyKeyDefinedInAncestor = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+    [
+    ObsoleteAttribute(),
+    ]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeInvalidKeyKeyDefinedInBaseClass = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeInvalidKeyNullablePart = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+    [
+    ObsoleteAttribute(),
+    ]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeKeyMissingOnEntityType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
+
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeKeyPropertyMustBelongToEntity = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEntityType]] EntityTypeKeyTypeCannotBeEdmPrimitiveType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEntityType]
     public static readonly Microsoft.OData.Edm.Validation.ValidationRule`1[[Microsoft.OData.Edm.IEdmEnumMember]] EnumMemberValueMustHaveSameTypeAsUnderlyingType = Microsoft.OData.Edm.Validation.ValidationRule`1[Microsoft.OData.Edm.IEdmEnumMember]
@@ -3763,6 +3792,21 @@ public abstract class Microsoft.OData.Edm.Vocabularies.EdmValue : IEdmElement, I
 
     Microsoft.OData.Edm.IEdmTypeReference Type  { public virtual get; }
     Microsoft.OData.Edm.Vocabularies.EdmValueKind ValueKind  { public abstract get; }
+}
+
+[
+ExtensionAttribute(),
+]
+public sealed class Microsoft.OData.Edm.Vocabularies.IEdmTermExtensions {
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation CreateVocabularyAnnotation (Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation CreateVocabularyAnnotation (Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target, string qualifier)
 }
 
 public class Microsoft.OData.Edm.Vocabularies.EdmAnnotationPathExpression : Microsoft.OData.Edm.EdmPathExpression, IEdmElement, IEdmExpression, IEdmPathExpression {
@@ -5504,6 +5548,7 @@ public sealed class Microsoft.OData.ODataMessageReaderSettings {
     bool EnableCharactersCheck  { public get; public set; }
     bool EnableMessageStreamDisposal  { public get; public set; }
     bool EnablePrimitiveTypeConversion  { public get; public set; }
+    bool EnablePropertyNameCaseInsensitive  { public get; public set; }
     Microsoft.OData.ODataLibraryCompatibility LibraryCompatibility  { public get; public set; }
     Microsoft.OData.ODataVersion MaxProtocolVersion  { public get; public set; }
     Microsoft.OData.ODataMessageQuotas MessageQuotas  { public get; public set; }
@@ -5822,14 +5867,29 @@ public interface Microsoft.OData.Json.IJsonReader {
     bool Read ()
 }
 
+public interface Microsoft.OData.Json.IJsonReaderAsync : IJsonReader {
+    System.Threading.Tasks.Task`1[[System.Object]] GetValueAsync ()
+    System.Threading.Tasks.Task`1[[System.Boolean]] ReadAsync ()
+}
+
 public interface Microsoft.OData.Json.IJsonReaderFactory {
     Microsoft.OData.Json.IJsonReader CreateJsonReader (System.IO.TextReader textReader, bool isIeee754Compatible)
+}
+
+public interface Microsoft.OData.Json.IJsonReaderFactoryAsync {
+    Microsoft.OData.Json.IJsonReaderAsync CreateAsynchronousJsonReader (System.IO.TextReader textReader, bool isIeee754Compatible)
 }
 
 public interface Microsoft.OData.Json.IJsonStreamReader : IJsonReader {
     bool CanStream ()
     System.IO.Stream CreateReadStream ()
     System.IO.TextReader CreateTextReader ()
+}
+
+public interface Microsoft.OData.Json.IJsonStreamReaderAsync : IJsonReader, IJsonReaderAsync {
+    System.Threading.Tasks.Task`1[[System.Boolean]] CanStreamAsync ()
+    System.Threading.Tasks.Task`1[[System.IO.Stream]] CreateReadStreamAsync ()
+    System.Threading.Tasks.Task`1[[System.IO.TextReader]] CreateTextReaderAsync ()
 }
 
 [
@@ -7797,6 +7857,11 @@ public enum Microsoft.OData.Client.DataServiceResponsePreference : int {
     None = 0
 }
 
+public enum Microsoft.OData.Client.DeleteLinkUriOption : int {
+    IdQueryParam = 0
+    RelatedKeyAsSegment = 1
+}
+
 public enum Microsoft.OData.Client.EntityParameterSendOption : int {
     SendFullProperties = 0
     SendOnlySetProperties = 1
@@ -8076,6 +8141,7 @@ public class Microsoft.OData.Client.DataServiceContext {
     System.Uri BaseUri  { public virtual get; public virtual set; }
     Microsoft.OData.Client.DataServiceClientConfigurations Configurations  { public virtual get; }
     System.Net.ICredentials Credentials  { public virtual get; public virtual set; }
+    Microsoft.OData.Client.DeleteLinkUriOption DeleteLinkUriOption  { public virtual get; public virtual set; }
     bool DisableInstanceAnnotationMaterialization  { public virtual get; public virtual set; }
     bool EnableWritingODataAnnotationWithoutPrefix  { public virtual get; public virtual set; }
     System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Client.EntityDescriptor]] Entities  { public virtual get; }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2340.*

### Description

Exiting rule for validating that a key is not redefined only checks immediate base type. Fix makes sure that key is only defined once in the hierarchy.

For backward compatibility, this is added as a new rule, not part of the default ruleset, in order to ensure we don't break apps whose current schema validates but violate this rule.  The existing rule is marked as deprecated, and in 8.x. we should remove the old rule and make this rule part of the default ruleset.

Also marked an existing rule as obsolete because it is no longer valid due to a change in protocol. This was already removed from the default ruleset, but I added a comment explaining why and that it should also be removed in 8.x.

### Checklist (Uncheck if it is not completed)

- [ x ] *Test cases added*
- [ x ] *Build and test with one-click build and test script passed*

### Additional work necessary

In 8.x, remove the deprecated rules and update the ruleset accordingly.