### PR TITLE
added publicapi tests to e2e solution and fixed test helper…

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -129,6 +129,15 @@ steps:
     arguments: '--configuration $(BuildConfiguration) --no-incremental'
     projects: |
      $(Build.SourcesDirectory)\test\FunctionalTests\Microsoft.OData.Client.Tests\Microsoft.OData.Client.Tests.csproj          
+
+     
+- task: DotNetCoreCLI@2
+  displayName: 'Build Unit Test - PublicApi'
+  inputs:
+    command: 'build'
+    arguments: '--configuration $(BuildConfiguration) --no-incremental'
+    projects: |
+     $(Build.SourcesDirectory)\test\PublicApiTests\Microsoft.OData.PublicApi.Tests.csproj
           
     
 
@@ -298,6 +307,14 @@ steps:
     arguments: '--configuration $(BuildConfiguration) --no-build --collect "Code coverage"'
     projects: |      
      $(Build.SourcesDirectory)\test\FunctionalTests\Microsoft.OData.Client.Tests\Microsoft.OData.Client.Tests.csproj
+
+- task: DotNetCoreCLI@2
+  displayName: 'PublicApi Test'
+  inputs:
+    command: 'test'
+    arguments: '--configuration $(BuildConfiguration) --no-build --collect "Code coverage"'
+    projects: |
+     $(Build.SourcesDirectory)\test\PublicApiTests\Microsoft.OData.PublicApi.Tests.csproj
 
 - task: DotNetCoreCLI@2  
   displayName: 'Test - E2E Test Suite'

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -126,7 +126,16 @@ steps:
     command: 'build'
     arguments: '--configuration $(BuildConfiguration) --no-incremental'
     projects: |
-     $(Build.SourcesDirectory)\test\FunctionalTests\Microsoft.OData.Client.Tests\Microsoft.OData.Client.Tests.csproj          
+     $(Build.SourcesDirectory)\test\FunctionalTests\Microsoft.OData.Client.Tests\Microsoft.OData.Client.Tests.csproj        
+
+     
+- task: DotNetCoreCLI@2
+  displayName: 'Build Unit Test - PublicApi'
+  inputs:
+    command: 'build'
+    arguments: '--configuration $(BuildConfiguration) --no-incremental'
+    projects: |
+     $(Build.SourcesDirectory)\test\PublicApiTests\Microsoft.OData.PublicApi.Tests.csproj
           
 
 - task: DotNetCoreCLI@2
@@ -275,6 +284,14 @@ steps:
     arguments: '--configuration $(BuildConfiguration) --no-build --collect "Code coverage"'
     projects: |      
      $(Build.SourcesDirectory)\test\FunctionalTests\Microsoft.OData.Client.Tests\Microsoft.OData.Client.Tests.csproj
+
+- task: DotNetCoreCLI@2
+  displayName: 'PublicApi Test'
+  inputs:
+    command: 'test'
+    arguments: '--configuration $(BuildConfiguration) --no-build --collect "Code coverage"'
+    projects: |
+     $(Build.SourcesDirectory)\test\PublicApiTests\Microsoft.OData.PublicApi.Tests.csproj
 
 - task: DotNetCoreCLI@2  
   displayName: 'Test - E2E Test Suite'

--- a/sln/OData.E2E.sln
+++ b/sln/OData.E2E.sln
@@ -166,6 +166,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.OData.Edm.Tests",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Spatial.Tests", "..\test\FunctionalTests\Microsoft.Spatial.Tests\Microsoft.Spatial.Tests.csproj", "{1D6FE7E1-BA5B-49DB-BA74-C019009CAFDD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.OData.PublicApi.Tests", "..\test\PublicApiTests\Microsoft.OData.PublicApi.Tests.csproj", "{D482D182-ABFA-41FF-B4E2-67ED968CEE99}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Cover|Any CPU = Cover|Any CPU
@@ -1455,6 +1457,24 @@ Global
 		{1D6FE7E1-BA5B-49DB-BA74-C019009CAFDD}.Release|x64.Build.0 = Release|Any CPU
 		{1D6FE7E1-BA5B-49DB-BA74-C019009CAFDD}.Release|x86.ActiveCfg = Release|Any CPU
 		{1D6FE7E1-BA5B-49DB-BA74-C019009CAFDD}.Release|x86.Build.0 = Release|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Cover|Any CPU.Build.0 = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Cover|x64.ActiveCfg = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Cover|x64.Build.0 = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Cover|x86.ActiveCfg = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Cover|x86.Build.0 = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Debug|x64.Build.0 = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Debug|x86.Build.0 = Debug|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Release|x64.ActiveCfg = Release|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Release|x64.Build.0 = Release|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Release|x86.ActiveCfg = Release|Any CPU
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -1540,6 +1560,7 @@ Global
 		{DD3A9064-D828-4F12-BFB8-AEE241A6DE20} = {8CCBB4F7-EBD1-48B6-8A77-BD733EB9CB6B}
 		{63AFF9B5-2A39-4920-ADD2-DCD50EA71199} = {8CCBB4F7-EBD1-48B6-8A77-BD733EB9CB6B}
 		{1D6FE7E1-BA5B-49DB-BA74-C019009CAFDD} = {8CCBB4F7-EBD1-48B6-8A77-BD733EB9CB6B}
+		{D482D182-ABFA-41FF-B4E2-67ED968CEE99} = {8CCBB4F7-EBD1-48B6-8A77-BD733EB9CB6B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3381754F-0117-444E-9D95-4845461632CB}

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -3026,24 +3026,6 @@ public sealed class Microsoft.OData.Edm.Csdl.SerializationExtensionMethods {
     public static void SetSerializationLocation (Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation annotation, Microsoft.OData.Edm.IEdmModel model, System.Nullable`1[[Microsoft.OData.Edm.Csdl.EdmVocabularyAnnotationSerializationLocation]] location)
 }
 
-public class Microsoft.OData.Edm.Csdl.CsdlJsonReaderSettings : Microsoft.OData.Edm.Csdl.CsdlReaderSettingsBase {
-    public static Microsoft.OData.Edm.Csdl.CsdlJsonReaderSettings Default = Microsoft.OData.Edm.Csdl.CsdlJsonReaderSettings
-
-    public CsdlJsonReaderSettings ()
-
-    bool IgnoreUnexpectedJsonElements  { public get; public set; }
-    bool IncludeDefaultVocabularies  { public get; public set; }
-    bool IsBracketNotation  { public get; public set; }
-    Microsoft.OData.Edm.Csdl.CsdlJsonReaderFactory JsonSchemaReaderFactory  { public get; public set; }
-    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmModel]] ReferencedModels  { public get; public set; }
-}
-
-public class Microsoft.OData.Edm.Csdl.CsdlJsonWriterSettings {
-    public CsdlJsonWriterSettings ()
-
-    bool IsIeee754Compatible  { public get; public set; }
-}
-
 public class Microsoft.OData.Edm.Csdl.CsdlLocation : Microsoft.OData.Edm.EdmLocation {
     int LineNumber  { public get; }
     int LinePosition  { public get; }
@@ -3054,15 +3036,11 @@ public class Microsoft.OData.Edm.Csdl.CsdlLocation : Microsoft.OData.Edm.EdmLoca
 }
 
 public class Microsoft.OData.Edm.Csdl.CsdlReader {
-    public static Microsoft.OData.Edm.IEdmModel Parse (System.Text.Json.Utf8JsonReader& reader)
     public static Microsoft.OData.Edm.IEdmModel Parse (System.Xml.XmlReader reader)
-    public static Microsoft.OData.Edm.IEdmModel Parse (System.Text.Json.Utf8JsonReader& reader, Microsoft.OData.Edm.Csdl.CsdlJsonReaderSettings settings)
     public static Microsoft.OData.Edm.IEdmModel Parse (System.Xml.XmlReader reader, Microsoft.OData.Edm.IEdmModel referencedModel)
     public static Microsoft.OData.Edm.IEdmModel Parse (System.Xml.XmlReader reader, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmModel]] referencedModels)
     public static Microsoft.OData.Edm.IEdmModel Parse (System.Xml.XmlReader reader, System.Func`2[[System.Uri],[System.Xml.XmlReader]] getReferencedModelReaderFunc)
-    public static bool TryParse (System.Text.Json.Utf8JsonReader& reader, out Microsoft.OData.Edm.IEdmModel& model, out System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]]& errors)
     public static bool TryParse (System.Xml.XmlReader reader, out Microsoft.OData.Edm.IEdmModel& model, out System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]]& errors)
-    public static bool TryParse (System.Text.Json.Utf8JsonReader& reader, Microsoft.OData.Edm.Csdl.CsdlJsonReaderSettings settings, out Microsoft.OData.Edm.IEdmModel& model, out System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]]& errors)
     public static bool TryParse (System.Xml.XmlReader reader, Microsoft.OData.Edm.IEdmModel reference, out Microsoft.OData.Edm.IEdmModel& model, out System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]]& errors)
     public static bool TryParse (System.Xml.XmlReader reader, bool ignoreUnexpectedAttributesAndElements, out Microsoft.OData.Edm.IEdmModel& model, out System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]]& errors)
     public static bool TryParse (System.Xml.XmlReader reader, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmModel]] references, out Microsoft.OData.Edm.IEdmModel& model, out System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]]& errors)
@@ -3075,8 +3053,6 @@ public class Microsoft.OData.Edm.Csdl.CsdlWriter {
     protected CsdlWriter (Microsoft.OData.Edm.IEdmModel model, System.Version edmxVersion)
 
     protected static string GetVersionString (System.Version version)
-    public static bool TryWriteCsdl (Microsoft.OData.Edm.IEdmModel model, System.Text.Json.Utf8JsonWriter writer, out System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]]& errors)
-    public static bool TryWriteCsdl (Microsoft.OData.Edm.IEdmModel model, System.Text.Json.Utf8JsonWriter writer, Microsoft.OData.Edm.Csdl.CsdlJsonWriterSettings settings, out System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]]& errors)
     public static bool TryWriteCsdl (Microsoft.OData.Edm.IEdmModel model, System.Xml.XmlWriter writer, Microsoft.OData.Edm.Csdl.CsdlTarget target, out System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]]& errors)
     protected virtual void WriteCsdl ()
 }
@@ -3088,14 +3064,6 @@ public class Microsoft.OData.Edm.Csdl.EdmParseException : System.Exception, ISer
     public EdmParseException (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Validation.EdmError]] parseErrors)
 
     System.Collections.ObjectModel.ReadOnlyCollection`1[[Microsoft.OData.Edm.Validation.EdmError]] Errors  { public get; }
-}
-
-public sealed class Microsoft.OData.Edm.Csdl.CsdlJsonReaderFactory : System.MulticastDelegate, ICloneable, ISerializable {
-    public CsdlJsonReaderFactory (object object, System.IntPtr method)
-
-    public virtual System.IAsyncResult BeginInvoke (System.Uri uri, out System.Boolean& skip, System.AsyncCallback callback, object object)
-    public virtual System.Text.Json.Utf8JsonReader EndInvoke (out System.Boolean& skip, System.IAsyncResult result)
-    public virtual System.Text.Json.Utf8JsonReader Invoke (System.Uri uri, out System.Boolean& skip)
 }
 
 public sealed class Microsoft.OData.Edm.Csdl.CsdlReaderSettings : Microsoft.OData.Edm.Csdl.CsdlReaderSettingsBase {


### PR DESCRIPTION
…to prevent local test runs from crashing

<!-- markdownlint-disable MD002 MD041 -->

### Issues

N/A

### Description

Local test runs of the public api tests were failing due to "The active test run was aborted. Reason: Test host process crashed". This was because of an exception while generating the api dump, which was handled with a `Environment.Exit(1)`. The exception was being thrown because we were attempting to load an assembly that already had been loaded (this appears to have been happening due loading `Microsoft.OData.Client` first, which will cause `Microsoft.Spatial` to also be loaded, so when we go to the `Microsoft.Spatial` file, we had already loaded it). This change handles that `FileLoadException` by finding the loaded assembly in the current `AppDomain`. 

I also updated the `Environment.Exit(1)` call to simply rethrow the exception so that we will see a test failure in the future instead of crashing to the test host process. 

Lastly, I added the public api tests to the E2E solution.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

N/A
