### PR TITLE
Temporarily moving build pipelines from `windows-latest` to `windows-2019`

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -15,7 +15,7 @@ schedules:
     - master
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2019'
 
 variables:
   buildPlatform: 'Any CPU'

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -13,7 +13,7 @@ pr:
 - master
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2019'
   
 
 variables:


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request addresses #2361.

### Description

Moving from `windows-lastest` pool to `windows-2019` pool to mitigate failures while the issue is being investigated. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

More work is necessary, pending discussion on the issue. 
