### PR TITLE
Fix unnecessary delegate allocations across OData writers

### DIFF
--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -380,6 +380,7 @@ namespace Microsoft.OData
             catch
             {
                 this.SetState(BatchWriterState.Error);
+
                 throw;
             }
         }

--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -386,14 +386,12 @@ namespace Microsoft.OData
 
         /// <summary>Flushes the write buffer to the underlying stream asynchronously.</summary>
         /// <returns>A task instance that represents the asynchronous operation.</returns>
-        public async Task FlushAsync()
+        public Task FlushAsync()
         {
             this.VerifyCanFlush(false);
 
             // Make sure we switch to writer state Error if an exception is thrown during flushing.
-            await this.FlushAsynchronously()
-                .FollowOnFaultWith(t => this.SetState(BatchWriterState.Error))
-                .ConfigureAwait(false);
+            return this.InterceptExceptionAsync((thisParam) => thisParam.FlushAsynchronously());
         }
 
         /// <summary>
@@ -706,6 +704,29 @@ namespace Microsoft.OData
             try
             {
                 action(this, arg0);
+            }
+            catch
+            {
+                if (!IsErrorState(this.state))
+                {
+                    this.SetState(BatchWriterState.Error);
+                }
+
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Catch any exception thrown by the action passed in; in the exception case move the reader into
+        /// state Error and then rethrow the exception.
+        /// </summary>
+        /// <param name="action">The action to execute.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        private async Task InterceptExceptionAsync(Func<ODataBatchWriter, Task> action)
+        {
+            try
+            {
+                await action(this).ConfigureAwait(false);
             }
             catch
             {

--- a/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
@@ -147,6 +147,7 @@ namespace Microsoft.OData
             catch
             {
                 this.ReplaceScope(CollectionWriterState.Error, null);
+
                 throw;
             }
         }

--- a/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
@@ -159,8 +159,7 @@ namespace Microsoft.OData
         {
             this.VerifyCanFlush(false);
 
-            // make sure we switch to writer state Error if an exception is thrown during flushing.
-            return this.FlushAsynchronously().FollowOnFaultWith(t => this.ReplaceScope(CollectionWriterState.Error, null));
+            return this.FlushImplementationAsync();
         }
 
         /// <summary>
@@ -857,6 +856,26 @@ namespace Microsoft.OData
                 await this.InterceptExceptionAsync((thisParam) => thisParam.EndPayloadAsync())
                     .ConfigureAwait(false);
                 this.NotifyListener(CollectionWriterState.Completed);
+            }
+        }
+
+        /// <summary>
+        /// Flush asynchronously - actual implementation
+        /// </summary>
+        /// <returns>A task instance that represents the asynchronous operation.</returns>
+        private async Task FlushImplementationAsync()
+        {
+            // Make sure we switch to writer state Error if an exception is thrown during flushing.
+            try
+            {
+                await this.FlushAsynchronously()
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                this.ReplaceScope(CollectionWriterState.Error, null);
+
+                throw;
             }
         }
 

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -779,6 +779,7 @@ namespace Microsoft.OData
             catch
             {
                 this.EnterErrorScope();
+
                 throw;
             }
         }
@@ -807,6 +808,7 @@ namespace Microsoft.OData
             catch
             {
                 this.EnterErrorScope();
+
                 throw;
             }
         }
@@ -835,6 +837,7 @@ namespace Microsoft.OData
             catch
             {
                 this.EnterErrorScope();
+
                 throw;
             }
         }
@@ -961,6 +964,7 @@ namespace Microsoft.OData
             catch
             {
                 this.EnterErrorScope();
+
                 throw;
             }
         }
@@ -990,6 +994,7 @@ namespace Microsoft.OData
             catch
             {
                 this.EnterErrorScope();
+
                 throw;
             }
         }
@@ -1019,6 +1024,7 @@ namespace Microsoft.OData
             catch
             {
                 this.EnterErrorScope();
+
                 throw;
             }
         }
@@ -1042,6 +1048,7 @@ namespace Microsoft.OData
             catch
             {
                 this.EnterErrorScope();
+
                 throw;
             }
         }

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -2446,6 +2446,7 @@ namespace Microsoft.OData
         /// state Error and then rethrow the exception.
         /// </summary>
         /// <param name="action">The action to execute.</param>
+        /// <param name="currentScopeItem">The item to associate with the new scope if transitioning to state Error.</param>
         /// <returns>The task.</returns>
         /// <remarks>
         /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -415,6 +415,7 @@ namespace Microsoft.OData
             catch
             {
                 this.EnterScope(WriterState.Error, null);
+
                 throw;
             }
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightParameterWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightParameterWriterTests.cs
@@ -561,28 +561,6 @@ namespace Microsoft.OData.Tests.JsonLight
             WriteAndValidate(test, "{\"feed\":[{\"ID\":1,\"Property1\":[{\"ID\":1,\"Name\":\"TestName\"}]}]}", writingResponse: false);
         }
 
-        //[Fact]
-        //public void AsyncShouldWriteParameterPayloadInRequestWithoutModelAndWithoutFunctionImport()
-        //{
-        //    Action<ODataJsonLightOutputContext> test = outputContext =>
-        //    {
-        //        var parameterWriter = new ODataJsonLightParameterWriter(outputContext, operation: null);
-        //        parameterWriter.WriteStartAsync().Wait();
-        //        parameterWriter.WriteValueAsync("primitive", Guid.Empty).Wait();
-        //        var complexWriter = parameterWriter.CreateResourceWriterAsync("complex").Result;
-        //        complexWriter.WriteStartAsync(new ODataResource { Properties = new[] { new ODataProperty { Name = "prop1", Value = 1 } } }).Wait();
-        //        complexWriter.WriteEndAsync().Wait();
-        //        var collectionWriter = parameterWriter.CreateCollectionWriterAsync("collection").Result;
-        //        collectionWriter.WriteStartAsync(new ODataCollectionStart()).Wait();
-        //        collectionWriter.WriteItemAsync("item1").Wait();
-        //        collectionWriter.WriteEndAsync().Wait();
-        //        parameterWriter.WriteEndAsync().Wait();
-        //        parameterWriter.FlushAsync().Wait();
-        //    };
-
-        //    WriteAndValidate(test, "{\"primitive\":\"00000000-0000-0000-0000-000000000000\",\"complex\":{\"prop1\":1},\"collection\":[\"item1\"]}", writingResponse: false, synchronous: false);
-        //}
-
         [Fact]
         public void ShouldWriteParameterPayloadInRequestWithTypeDefinition()
         {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -4497,11 +4497,7 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataOutputInStreamErr
     protected abstract Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation (string contentId)
     protected virtual System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageImplementationAsync (string contentId)
     public void Flush ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task FlushAsync ()
-
     protected abstract System.Threading.Tasks.Task FlushAsynchronously ()
     protected abstract void FlushSynchronously ()
     protected abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetDependsOnRequestIds (System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -4497,11 +4497,7 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataOutputInStreamErr
     protected abstract Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation (string contentId)
     protected virtual System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageImplementationAsync (string contentId)
     public void Flush ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task FlushAsync ()
-
     protected abstract System.Threading.Tasks.Task FlushAsynchronously ()
     protected abstract void FlushSynchronously ()
     protected abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetDependsOnRequestIds (System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -4497,11 +4497,7 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataOutputInStreamErr
     protected abstract Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation (string contentId)
     protected virtual System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageImplementationAsync (string contentId)
     public void Flush ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task FlushAsync ()
-
     protected abstract System.Threading.Tasks.Task FlushAsynchronously ()
     protected abstract void FlushSynchronously ()
     protected abstract System.Collections.Generic.IEnumerable`1[[System.String]] GetDependsOnRequestIds (System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Fix unnecessary delegate allocations across OData writers.
Also fixes buggy behaviour observed in exception cases where `TaskUtils`'s `FollowOnFaultWith` method is applied.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
