### PR TITLE
updated Microsoft.OData.Core.Tests and Microsoft.OData.Core reference…

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -96,4 +96,10 @@
       <Version>6.0.3</Version>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
+      <Version>5.0.0</Version>
+    </PackageReference>
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -90,10 +90,4 @@
       <DependentUpon>Parameterized.Microsoft.OData.Core.tt</DependentUpon>
     </Compile>
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>5.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -65,13 +65,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>1.0.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>1.0.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -44,7 +44,7 @@
   <ItemGroup>
     <Compile Remove="Properties\AssemblyInfo.cs" />
   </ItemGroup>
-
+  
   <ItemGroup>
     <Compile Include="..\Tests\TestUtils\Common\Microsoft.Test.OData.Utils\Common\ExceptionUtilities.cs" Link="ExceptionUtilities.cs" />
     <Compile Include="..\Tests\TestUtils\Common\Microsoft.Test.OData.Utils\Metadata\EdmConstants.cs" Link="EdmConstants.cs" />
@@ -65,13 +65,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>5.0.0</Version>
+      <Version>1.0.0</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>5.0.0</Version>
+      <Version>1.0.0</Version>
     </PackageReference>
   </ItemGroup>
 


### PR DESCRIPTION
…s to Microsoft.Bcl.AsyncInterfaces to not conflict with other packages

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2296.*

### Description

*The `Microsoft.OData.Core.Tests project does not support incremental builds, and therefore always rebuilds even if no changes have occurred. This is due to a conflict in the version of `Microsoft.Bcl.AsyncInterfaces`. It is currently using version 5.0.0, while other projects in the repo reference a nuget packages which depends on version 1.0.0.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
