### PR TITLE
Improving logging for release script, and fixing issue causing only o…

### DIFF
--- a/tools/IncrementVersion.ps1
+++ b/tools/IncrementVersion.ps1
@@ -50,14 +50,13 @@ ForEach ($line in $($changedFiles -split [System.Environment]::NewLine))
   elseif ($fileName -eq "PublicAPI.Unshipped.txt")
   {
     # if that file represents an API change that isn't breaking, go ahead and move the API changes to the shipped file for future releases
-    Write-Host "There are API changes in $fileName. Updating the associated PublicAPI.Shipped.txt"
+    Write-Host "There are API changes in $line. Updating the associated PublicAPI.Shipped.txt"
     $unshipped = Join-Path -Path $PSScriptRoot -ChildPath ..\$line
     $shipped = [System.IO.Path]::GetDirectoryName($unshipped) + "\PublicAPI.Shipped.txt"
 
     Copy-Item $unshipped -Destination $shipped
 
     $apiChanges = $true
-    break;
   }
 }
 


### PR DESCRIPTION
…ne PublicAPI.Unshipped.txt file to get updated even if multiple changes have occured

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2388.*

### Description

*See title.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

