### PR TITLE
Encode special chars in array elements in Contains expression

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
@@ -526,7 +526,7 @@ namespace Microsoft.OData.Client
             else if (m != null && ReflectionUtil.IsSequenceMethod(m.Method, SequenceMethod.Contains))
             {
                 StringBuilder listExpr = new StringBuilder();
-                ODataVersion version = CommonUtil.ConvertToODataVersion(this.uriVersion);
+
                 foreach (object item in (IEnumerable)c.Value)
                 {
                     if (listExpr.Length != 0)
@@ -534,7 +534,24 @@ namespace Microsoft.OData.Client
                         listExpr.Append(UriHelper.COMMA);
                     }
 
-                    string uriLiteral = ODataUriUtils.ConvertToUriLiteral(item, version);
+                    string uriLiteral;
+
+                    try
+                    {
+                        uriLiteral = LiteralFormatter.ForConstants.Format(item);
+                    }
+                    catch (InvalidOperationException)
+                    {
+                        if (this.cantTranslateExpression)
+                        {
+                            // There's already a problem in the parents.
+                            // Return.A up the stack will throw a better exception
+                            return c;
+                        }
+
+                        throw new NotSupportedException(Strings.ALinq_CouldNotConvert(item));
+                    }
+
                     listExpr.Append(uriLiteral);
                 }
 

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/DataServiceQueryProviderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/DataServiceQueryProviderTests.cs
@@ -62,6 +62,22 @@ namespace Microsoft.OData.Client.Tests
         }
 
         [Fact]
+        public void TranslatesEnumerableContainsWithSpecialCharactersToInOperator()
+        {
+            // Arrange
+            var sut = new DataServiceQueryProvider(dsc);
+            var productNames = new[] { "Mac & Cheese" };
+            var products = dsc.CreateQuery<Product>("Products")
+                .Where(product => productNames.Contains(product.Name));
+
+            // Act
+            var queryComponents = sut.Translate(products.Expression);
+
+            // Assert
+            Assert.Equal(@"http://root/Products?$filter=Name in ('Mac %26 Cheese')", queryComponents.Uri.ToString());
+        }
+
+        [Fact]
         public void ThrowsForEnumerableContainsWithEmptyCollection()
         {
             // Arrange


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2405.*

### Description

The `ConvertToUriLiteral` method used previous [does not do any escaping](https://github.com/OData/odata.net/blob/4e263ca4b94d01f2d105d8282c62ec272cfcd1bb/src/Microsoft.OData.Core/Uri/ODataUriUtils.cs#L93) so it's not the best fit for formatting literals.
In addition, `ConvertToUriLiteral` handles `ODataNullValue`, `ODataResourceValue`, `ODataCollectionValue`, `ODataEnumValue`, `ODataResource`, `ODataEntityReferenceLink`, `ODataEntityReferenceLinks`, `ODataResource` collection and primitive values. The only candidates for the "in" operator are primitive values so using this method is an overkill.

The change made in this PR is to use same method used to format values in other `Where` predicates

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
