### PR TITLE
Key Alias support

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlPropertyReference.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Ast/CsdlPropertyReference.cs
@@ -12,6 +12,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
     internal class CsdlPropertyReference : CsdlElement
     {
         private readonly string propertyName;
+        private readonly string propertyAlias;
 
         public CsdlPropertyReference(string propertyName, CsdlLocation location)
             : base(location)
@@ -19,9 +20,21 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Ast
             this.propertyName = propertyName;
         }
 
+        public CsdlPropertyReference(string propertyName, string propertyAlias, CsdlLocation location)
+            : base(location)
+        {
+            this.propertyName = propertyName;
+            this.propertyAlias = propertyAlias;
+        }
+
         public string PropertyName
         {
             get { return this.propertyName; }
+        }
+
+        public string PropertyAlias
+        {
+            get { return this.propertyAlias; }
         }
     }
 }

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlDocumentParser.cs
@@ -364,7 +364,7 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
 
         private CsdlPropertyReference OnPropertyRefElement(XmlElementInfo element, XmlElementValueCollection childValues)
         {
-            return new CsdlPropertyReference(Required(CsdlConstants.Attribute_Name), element.Location);
+            return new CsdlPropertyReference(Required(CsdlConstants.Attribute_Name), Optional(CsdlConstants.Attribute_Alias), element.Location);
         }
 
         private CsdlEnumType OnEnumTypeElement(XmlElementInfo element, XmlElementValueCollection childValues)

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/SchemaJsonParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/SchemaJsonParser.cs
@@ -655,13 +655,20 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
             {
                 if (v.ValueKind == JsonValueKind.Object)
                 {
-                    // TODO: ODL doesn't support the key referencing a property of a complex type as below.
                     // "$Key": [
                     //    {
                     //      "EntityInfoID": "Info/ID"
                     //    }
                     //  ]
-                    p.ReportError(EdmErrorCode.InvalidKeyValue, "It doesn't support the key object.");
+                    string pName = "";
+                    string pValue = "";
+                    v.ParseAsObject(p, (keyAlias, keyName) =>
+                    {
+                        pName = keyName.ParseAsString(p);
+                        pValue = keyAlias;
+                    });
+
+                    return new CsdlPropertyReference(pName, pValue, context.Location());
                 }
 
                 string propertyName = v.ParseAsString(context);

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
@@ -208,8 +208,18 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         {
             // Key properties without a key alias are represented as strings containing the property name.
             // Key properties with a key alias are represented as objects with one member whose name is the key alias and whose value is a string containing the path to the property.
-            // TODO: It seems the second one is not supported.
-            this.jsonWriter.WriteStringValue(property.Name);
+            IEdmStructuralPropertyAlias prop = property as IEdmStructuralPropertyAlias;
+            if (prop == null)
+            {
+                this.jsonWriter.WriteStringValue(property.Name);
+            }
+            else
+            {
+                this.jsonWriter.WriteStartObject();
+                this.jsonWriter.WritePropertyName(prop.PropertyAlias);
+                this.jsonWriter.WriteStringValue(string.Join("/", prop.Path));
+                this.jsonWriter.WriteEndObject();
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
@@ -208,17 +208,16 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         {
             // Key properties without a key alias are represented as strings containing the property name.
             // Key properties with a key alias are represented as objects with one member whose name is the key alias and whose value is a string containing the path to the property.
-            IEdmStructuralPropertyAlias prop = property as IEdmStructuralPropertyAlias;
-            if (prop == null)
-            {
-                this.jsonWriter.WriteStringValue(property.Name);
-            }
-            else
+            if (property is IEdmStructuralPropertyAlias propertyAlias)
             {
                 this.jsonWriter.WriteStartObject();
-                this.jsonWriter.WritePropertyName(prop.PropertyAlias);
-                this.jsonWriter.WriteStringValue(string.Join("/", prop.Path));
+                this.jsonWriter.WritePropertyName(propertyAlias.PropertyAlias);
+                this.jsonWriter.WriteStringValue(string.Join("/", propertyAlias.Path));
                 this.jsonWriter.WriteEndObject();
+            }
+            else 
+            {
+                this.jsonWriter.WriteStringValue(property.Name);
             }
         }
 

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
@@ -153,7 +153,17 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         internal override void WritePropertyRefElement(IEdmStructuralProperty property)
         {
             this.xmlWriter.WriteStartElement(CsdlConstants.Element_PropertyRef);
-            this.WriteRequiredAttribute(CsdlConstants.Attribute_Name, property.Name, EdmValueWriter.StringAsXml);
+            IEdmStructuralPropertyAlias prop = property as IEdmStructuralPropertyAlias;
+            if (prop == null)
+            {
+                this.WriteRequiredAttribute(CsdlConstants.Attribute_Name, property.Name, EdmValueWriter.StringAsXml);
+            }
+            else
+            {
+                this.WriteRequiredAttribute(CsdlConstants.Attribute_Name, string.Join("/", prop.Path), EdmValueWriter.StringAsXml);
+                this.WriteRequiredAttribute(CsdlConstants.Attribute_Alias, prop.PropertyAlias, EdmValueWriter.StringAsXml);
+            }
+
             this.WriteEndElement();
         }
 

--- a/src/Microsoft.OData.Edm/EdmStructuralPropertyAlias.cs
+++ b/src/Microsoft.OData.Edm/EdmStructuralPropertyAlias.cs
@@ -1,0 +1,75 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="EdmStructuralPropertyAlias.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Represents an EDM structural (i.e. non-navigation) property with an alias.
+    /// </summary>
+    public class EdmStructuralPropertyAlias : EdmProperty, IEdmStructuralPropertyAlias
+    {
+        private string propertyAlias;
+        private IEnumerable<string> path;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmStructuralPropertyAlias"/> class.
+        /// </summary>
+        /// <param name="declaringType">The type that owns this property.</param>
+        /// <param name="name">Name of the property.</param>
+        /// <param name="type">The type of the property.</param>
+        /// <param name="alias">The property alias.</param>
+        /// <param name="path">The path to the referenced property.</param>
+        public EdmStructuralPropertyAlias(IEdmStructuredType declaringType, string name, IEdmTypeReference type, string propertyAlias, IEnumerable<string> path)
+            : base(declaringType, name, type)
+        {
+            if (propertyAlias == null)
+            {
+                throw new ArgumentNullException(nameof(propertyAlias));
+            }
+
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+
+            this.propertyAlias = propertyAlias;
+            this.path = path;
+        }
+
+        /// <inheritdoc/>
+        public string PropertyAlias
+        {
+            get { return this.propertyAlias; }
+
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<string> Path
+        {
+            get { return this.path; }
+        }
+
+        /// <summary>
+        /// Gets the default value of this property.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Naming", "CA1720:IdentifiersShouldNotContainTypeNames", Justification = "defaultValue might be confused for an IEdmValue.")]
+        public string DefaultValueString
+        {
+            get;
+        }
+
+        /// <summary>
+        /// Gets the kind of this property.
+        /// </summary>
+        public override EdmPropertyKind PropertyKind
+        {
+            get { return EdmPropertyKind.Structural; }
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/IEdmStructuralPropertyAlias.cs
+++ b/src/Microsoft.OData.Edm/IEdmStructuralPropertyAlias.cs
@@ -1,0 +1,26 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="IEdmStructuralPropertyAlias.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Represents a property alias.
+    /// </summary>
+    public interface IEdmStructuralPropertyAlias : IEdmStructuralProperty
+    {
+        /// <summary>
+        /// The path to the property.
+        /// </summary>
+        IEnumerable<string> Path { get; }
+
+        /// <summary>
+        /// The property alias.
+        /// </summary>
+        string PropertyAlias { get; }
+    }
+}

--- a/src/Microsoft.OData.Edm/PropertyAliasHelpers.cs
+++ b/src/Microsoft.OData.Edm/PropertyAliasHelpers.cs
@@ -1,0 +1,42 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="PropertyAliasHelpers.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Linq;
+
+namespace Microsoft.OData.Edm
+{
+    internal static class PropertyAliasHelpers
+    {
+        internal static IEdmStructuralProperty GetKeyProperty(IEdmStructuralProperty property, string[] keyPropertySegments, string propertyAlias)
+        {
+            IEdmStructuralProperty structuralProperty = property;
+            for (int i = 1; i < keyPropertySegments.Length; i++)
+            {
+                if (structuralProperty.Type.Definition.TypeKind == EdmTypeKind.Complex)
+                {
+                    structuralProperty = structuralProperty.Type.AsComplex().FindProperty(keyPropertySegments[i]) as IEdmStructuralProperty;
+                }
+                else if (structuralProperty.Type.Definition.TypeKind == EdmTypeKind.Entity)
+                {
+                    structuralProperty = structuralProperty.Type.AsEntity().FindProperty(keyPropertySegments[i]) as IEdmStructuralProperty;
+                }
+                else
+                {
+                    throw new InvalidOperationException(Strings.Bad_UnresolvedType(structuralProperty));
+                }
+            }
+
+            if (structuralProperty != null)
+            {
+                structuralProperty = new EdmStructuralPropertyAlias(structuralProperty.DeclaringType, structuralProperty.Name, structuralProperty.Type, propertyAlias, keyPropertySegments);
+            }
+
+            return structuralProperty;
+
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Schema/EdmStructuredType.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmStructuredType.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Microsoft.OData.Edm
 {
@@ -159,6 +160,25 @@ namespace Microsoft.OData.Edm
 
             EdmNavigationProperty property = EdmNavigationProperty.CreateNavigationProperty(this, propertyInfo);
 
+            this.AddProperty(property);
+            return property;
+        }
+
+        /// <summary>
+        /// Creates and adds a structural property alias to this type.
+        /// </summary>
+        /// <param name="type">Type of the property.</param>
+        /// <param name="alias">The property alias.</param>
+        /// <param name="path">The key path segments</param>
+        /// <returns>Created structural property.</returns>
+        public EdmStructuralPropertyAlias AddStructuralPropertyAlias(IEdmTypeReference type, string alias, IEnumerable<string> path)
+        {
+            if (path == null)
+            {
+                throw new ArgumentNullException(nameof(path));
+            }
+            string propertyName = path.FirstOrDefault();
+            EdmStructuralPropertyAlias property = new EdmStructuralPropertyAlias(this, propertyName, type, alias, path);
             this.AddProperty(property);
             return property;
         }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -1043,6 +1043,11 @@ public interface Microsoft.OData.Edm.IEdmStructuralProperty : IEdmElement, IEdmN
     string DefaultValueString  { public abstract get; }
 }
 
+public interface Microsoft.OData.Edm.IEdmStructuralPropertyAlias : IEdmElement, IEdmNamedElement, IEdmProperty, IEdmStructuralProperty, IEdmVocabularyAnnotatable {
+    System.Collections.Generic.IEnumerable`1[[System.String]] Path  { public abstract get; }
+    string PropertyAlias  { public abstract get; }
+}
+
 public interface Microsoft.OData.Edm.IEdmStructuredType : IEdmElement, IEdmType {
     Microsoft.OData.Edm.IEdmStructuredType BaseType  { public abstract get; }
     System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmProperty]] DeclaredProperties  { public abstract get; }
@@ -1208,6 +1213,7 @@ public abstract class Microsoft.OData.Edm.EdmStructuredType : Microsoft.OData.Ed
     public Microsoft.OData.Edm.EdmStructuralProperty AddStructuralProperty (string name, Microsoft.OData.Edm.IEdmTypeReference type)
     public Microsoft.OData.Edm.EdmStructuralProperty AddStructuralProperty (string name, Microsoft.OData.Edm.EdmPrimitiveTypeKind type, bool isNullable)
     public Microsoft.OData.Edm.EdmStructuralProperty AddStructuralProperty (string name, Microsoft.OData.Edm.IEdmTypeReference type, string defaultValue)
+    public Microsoft.OData.Edm.EdmStructuralPropertyAlias AddStructuralPropertyAlias (Microsoft.OData.Edm.IEdmTypeReference type, string alias, System.Collections.Generic.IEnumerable`1[[System.String]] path)
     public Microsoft.OData.Edm.EdmNavigationProperty AddUnidirectionalNavigation (Microsoft.OData.Edm.EdmNavigationPropertyInfo propertyInfo)
     public virtual Microsoft.OData.Edm.IEdmProperty FindProperty (string name)
 }
@@ -2823,6 +2829,15 @@ public class Microsoft.OData.Edm.EdmStructuralProperty : Microsoft.OData.Edm.Edm
     public EdmStructuralProperty (Microsoft.OData.Edm.IEdmStructuredType declaringType, string name, Microsoft.OData.Edm.IEdmTypeReference type, string defaultValueString)
 
     string DefaultValueString  { public virtual get; }
+    Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
+}
+
+public class Microsoft.OData.Edm.EdmStructuralPropertyAlias : Microsoft.OData.Edm.EdmProperty, IEdmElement, IEdmNamedElement, IEdmProperty, IEdmStructuralProperty, IEdmStructuralPropertyAlias, IEdmVocabularyAnnotatable {
+    public EdmStructuralPropertyAlias (Microsoft.OData.Edm.IEdmStructuredType declaringType, string name, Microsoft.OData.Edm.IEdmTypeReference type, string propertyAlias, System.Collections.Generic.IEnumerable`1[[System.String]] path)
+
+    string DefaultValueString  { public virtual get; }
+    System.Collections.Generic.IEnumerable`1[[System.String]] Path  { public virtual get; }
+    string PropertyAlias  { public virtual get; }
     Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
 }
 

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -1043,6 +1043,11 @@ public interface Microsoft.OData.Edm.IEdmStructuralProperty : IEdmElement, IEdmN
     string DefaultValueString  { public abstract get; }
 }
 
+public interface Microsoft.OData.Edm.IEdmStructuralPropertyAlias : IEdmElement, IEdmNamedElement, IEdmProperty, IEdmStructuralProperty, IEdmVocabularyAnnotatable {
+    System.Collections.Generic.IEnumerable`1[[System.String]] Path  { public abstract get; }
+    string PropertyAlias  { public abstract get; }
+}
+
 public interface Microsoft.OData.Edm.IEdmStructuredType : IEdmElement, IEdmType {
     Microsoft.OData.Edm.IEdmStructuredType BaseType  { public abstract get; }
     System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmProperty]] DeclaredProperties  { public abstract get; }
@@ -1208,6 +1213,7 @@ public abstract class Microsoft.OData.Edm.EdmStructuredType : Microsoft.OData.Ed
     public Microsoft.OData.Edm.EdmStructuralProperty AddStructuralProperty (string name, Microsoft.OData.Edm.IEdmTypeReference type)
     public Microsoft.OData.Edm.EdmStructuralProperty AddStructuralProperty (string name, Microsoft.OData.Edm.EdmPrimitiveTypeKind type, bool isNullable)
     public Microsoft.OData.Edm.EdmStructuralProperty AddStructuralProperty (string name, Microsoft.OData.Edm.IEdmTypeReference type, string defaultValue)
+    public Microsoft.OData.Edm.EdmStructuralPropertyAlias AddStructuralPropertyAlias (Microsoft.OData.Edm.IEdmTypeReference type, string alias, System.Collections.Generic.IEnumerable`1[[System.String]] path)
     public Microsoft.OData.Edm.EdmNavigationProperty AddUnidirectionalNavigation (Microsoft.OData.Edm.EdmNavigationPropertyInfo propertyInfo)
     public virtual Microsoft.OData.Edm.IEdmProperty FindProperty (string name)
 }
@@ -2823,6 +2829,15 @@ public class Microsoft.OData.Edm.EdmStructuralProperty : Microsoft.OData.Edm.Edm
     public EdmStructuralProperty (Microsoft.OData.Edm.IEdmStructuredType declaringType, string name, Microsoft.OData.Edm.IEdmTypeReference type, string defaultValueString)
 
     string DefaultValueString  { public virtual get; }
+    Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
+}
+
+public class Microsoft.OData.Edm.EdmStructuralPropertyAlias : Microsoft.OData.Edm.EdmProperty, IEdmElement, IEdmNamedElement, IEdmProperty, IEdmStructuralProperty, IEdmStructuralPropertyAlias, IEdmVocabularyAnnotatable {
+    public EdmStructuralPropertyAlias (Microsoft.OData.Edm.IEdmStructuredType declaringType, string name, Microsoft.OData.Edm.IEdmTypeReference type, string propertyAlias, System.Collections.Generic.IEnumerable`1[[System.String]] path)
+
+    string DefaultValueString  { public virtual get; }
+    System.Collections.Generic.IEnumerable`1[[System.String]] Path  { public virtual get; }
+    string PropertyAlias  { public virtual get; }
     Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
 }
 

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -1043,6 +1043,11 @@ public interface Microsoft.OData.Edm.IEdmStructuralProperty : IEdmElement, IEdmN
     string DefaultValueString  { public abstract get; }
 }
 
+public interface Microsoft.OData.Edm.IEdmStructuralPropertyAlias : IEdmElement, IEdmNamedElement, IEdmProperty, IEdmStructuralProperty, IEdmVocabularyAnnotatable {
+    System.Collections.Generic.IEnumerable`1[[System.String]] Path  { public abstract get; }
+    string PropertyAlias  { public abstract get; }
+}
+
 public interface Microsoft.OData.Edm.IEdmStructuredType : IEdmElement, IEdmType {
     Microsoft.OData.Edm.IEdmStructuredType BaseType  { public abstract get; }
     System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmProperty]] DeclaredProperties  { public abstract get; }
@@ -1208,6 +1213,7 @@ public abstract class Microsoft.OData.Edm.EdmStructuredType : Microsoft.OData.Ed
     public Microsoft.OData.Edm.EdmStructuralProperty AddStructuralProperty (string name, Microsoft.OData.Edm.IEdmTypeReference type)
     public Microsoft.OData.Edm.EdmStructuralProperty AddStructuralProperty (string name, Microsoft.OData.Edm.EdmPrimitiveTypeKind type, bool isNullable)
     public Microsoft.OData.Edm.EdmStructuralProperty AddStructuralProperty (string name, Microsoft.OData.Edm.IEdmTypeReference type, string defaultValue)
+    public Microsoft.OData.Edm.EdmStructuralPropertyAlias AddStructuralPropertyAlias (Microsoft.OData.Edm.IEdmTypeReference type, string alias, System.Collections.Generic.IEnumerable`1[[System.String]] path)
     public Microsoft.OData.Edm.EdmNavigationProperty AddUnidirectionalNavigation (Microsoft.OData.Edm.EdmNavigationPropertyInfo propertyInfo)
     public virtual Microsoft.OData.Edm.IEdmProperty FindProperty (string name)
 }
@@ -2823,6 +2829,15 @@ public class Microsoft.OData.Edm.EdmStructuralProperty : Microsoft.OData.Edm.Edm
     public EdmStructuralProperty (Microsoft.OData.Edm.IEdmStructuredType declaringType, string name, Microsoft.OData.Edm.IEdmTypeReference type, string defaultValueString)
 
     string DefaultValueString  { public virtual get; }
+    Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
+}
+
+public class Microsoft.OData.Edm.EdmStructuralPropertyAlias : Microsoft.OData.Edm.EdmProperty, IEdmElement, IEdmNamedElement, IEdmProperty, IEdmStructuralProperty, IEdmStructuralPropertyAlias, IEdmVocabularyAnnotatable {
+    public EdmStructuralPropertyAlias (Microsoft.OData.Edm.IEdmStructuredType declaringType, string name, Microsoft.OData.Edm.IEdmTypeReference type, string propertyAlias, System.Collections.Generic.IEnumerable`1[[System.String]] path)
+
+    string DefaultValueString  { public virtual get; }
+    System.Collections.Generic.IEnumerable`1[[System.String]] Path  { public virtual get; }
+    string PropertyAlias  { public virtual get; }
     Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes https://github.com/OData/odata.net/issues/1817

Key Alias support in ODL
Here's an example for Key alias:

```C SHARP
"Category": {
  "$Kind": "EntityType",
  "$Key": [
    {
      "EntityInfoID": "Info/ID"
    }
  ],
  "Info": {
    "$Type": "self.EntityInfo"
  },
  "Name": {
    "$Nullable": true
  }
},
"EntityInfo": {
  "$Kind": "ComplexType",
  "ID": {
    "$Type": "Edm.Int32"
  },
  "Created": {
    "$Type": "Edm.DateTimeOffset",
    "$Precision": 0
  }
}
```
<code>EntityInfoID</code> is the alias and <code>Info/ID</code> is the path to the key.

Changes made in this PR:
**New interfaces and Classes;**
1. **IEdmStructuralPropertyAlias : IEdmStructuralProperty** - this interface has two properties: - <code>IEnumerable<string> Path { get; } </code> and <code> string PropertyAlias { get; } </code>
2. **EdmStructuralPropertyAlias : EdmProperty, IEdmStructuralPropertyAlias**

**EdmStructuredType**
Added a new method 
public EdmStructuralPropertyAlias AddStructuralPropertyAlias(IEdmTypeReference type, string alias, IEnumerable<string> path) - This is the method that users will use to add key aliases. 
1. type is the type of the complex property 
2. alias is the key alias to use
4. path is a list of the path segments to the key property. 

**EdmEntityType** 
In the <code>AddKeys(IEnumerable<IEdmStructuralProperty> keyProperties) </code> method, when looping through each property, we cast it into an <code>IEdmStructuralPropertyAlias</code> and check if the key has an alias or not. If it does,  we loop through the keyProperties till we get to the last path segment which is the key  and create an <code>EdmStructuralPropertyAlias </code> and add it to the declaredKeys IEnumerable. 
### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
