### PR TITLE
Expose http client handler

### DIFF
--- a/src/Microsoft.OData.Client/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI.Unshipped.txt
@@ -495,6 +495,7 @@ Microsoft.OData.Client.HasStreamAttribute
 Microsoft.OData.Client.HasStreamAttribute.HasStreamAttribute() -> void
 Microsoft.OData.Client.HttpClientRequestMessage
 Microsoft.OData.Client.HttpClientRequestMessage.Dispose() -> void
+Microsoft.OData.Client.HttpClientRequestMessage.HttpClientHandler.get -> System.Net.Http.HttpClientHandler
 Microsoft.OData.Client.HttpClientRequestMessage.HttpClientRequestMessage(Microsoft.OData.Client.DataServiceClientRequestMessageArgs args) -> void
 Microsoft.OData.Client.HttpRequestTransportMode
 Microsoft.OData.Client.HttpRequestTransportMode.HttpClient = 1 -> Microsoft.OData.Client.HttpRequestTransportMode

--- a/src/Microsoft.OData.Client/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI.Unshipped.txt
@@ -497,6 +497,7 @@ Microsoft.OData.Client.HttpClientRequestMessage
 Microsoft.OData.Client.HttpClientRequestMessage.Dispose() -> void
 Microsoft.OData.Client.HttpClientRequestMessage.HttpClientHandler.get -> System.Net.Http.HttpClientHandler
 Microsoft.OData.Client.HttpClientRequestMessage.HttpClientRequestMessage(Microsoft.OData.Client.DataServiceClientRequestMessageArgs args) -> void
+Microsoft.OData.Client.HttpClientRequestMessage.HttpRequestMessage.get -> System.Net.Http.HttpRequestMessage
 Microsoft.OData.Client.HttpRequestTransportMode
 Microsoft.OData.Client.HttpRequestTransportMode.HttpClient = 1 -> Microsoft.OData.Client.HttpRequestTransportMode
 Microsoft.OData.Client.HttpRequestTransportMode.HttpWebRequest = 0 -> Microsoft.OData.Client.HttpRequestTransportMode

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -207,6 +207,17 @@ namespace Microsoft.OData.Client
 #endif
 
         /// <summary>
+        /// Returns the underlying <see cref="HttpClientHandler"/>.
+        /// </summary>
+        public HttpClientHandler HttpClientHandler
+        {
+            get
+            {
+                return _handler;
+            }
+        }
+
+        /// <summary>
         /// Returns the value of the header with the given name.
         /// </summary>
         /// <param name="headerName">Name of the header.</param>

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -447,7 +447,7 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary> Returns the underlying HttpRequestMessage </summary>
-        internal HttpRequestMessage HttpRequestMessage
+        public HttpRequestMessage HttpRequestMessage
         {
             get
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2417 *

Expose the underyling request components of a `HttpClientRequestMessage` to provide more opportunities for customers to override or customize request behaviour (e.g. certificate validation).

### Description

- Makes `HttpClientRequestMessage.HttpRequestMessage` public
- Add public property `HttpClientRequestMessage.HttpClientHandler`

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
