### PR TITLE
delta serialization response fix

### DIFF
--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -2978,7 +2978,7 @@ namespace Microsoft.OData
 
                     break;
                 case WriterState.NestedResourceInfoWithContent:
-                    if (newState != WriterState.ResourceSet && newState != WriterState.Resource && newState != WriterState.Primitive && (this.Version < ODataVersion.V401 || (newState != WriterState.DeltaResourceSet && newState != WriterState.DeletedResource)))
+                    if (newState != WriterState.ResourceSet && newState != WriterState.Resource && newState != WriterState.Primitive && newState != WriterState.DeltaResourceSet && newState != WriterState.DeletedResource)
                     {
                         throw new ODataException(Strings.ODataWriterCore_InvalidTransitionFromExpandedLink(this.State.ToString(), newState.ToString()));
                     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
@@ -1583,20 +1583,20 @@ namespace Microsoft.OData.Core.Tests.JsonLight
             deletedResource.Reason = reason;
 
             var exception = await Assert.ThrowsAsync<ODataException>
-                (() => SetupJsonLightWriterAndRunTestAsync(
-                async (jsonLightWriter) =>
-                {
-                    await jsonLightWriter.WriteStartAsync(orderResource);
-                    await jsonLightWriter.WriteStartAsync(customerNestedResourceInfo);
-                    await jsonLightWriter.WriteStartAsync(deletedResource);
-                },
-                this.orderEntitySet,
-                this.orderEntityType,
-                writingResourceSet: false,
-                writingDelta: true));
+               (() => SetupJsonLightWriterAndRunTestAsync(
+               async (jsonLightWriter) =>
+               {
+                   await jsonLightWriter.WriteStartAsync(orderResource);
+                   await jsonLightWriter.WriteStartAsync(customerNestedResourceInfo);
+                   await jsonLightWriter.WriteStartAsync(deletedResource);
+               },
+               this.orderEntitySet,
+               this.orderEntityType,
+               writingResourceSet: false,
+               writingDelta: true));
 
             Assert.Equal(
-                Strings.ODataWriterCore_InvalidTransitionFromExpandedLink("NestedResourceInfoWithContent", "DeletedResource"),
+                Strings.ODataWriterCore_NestedContentNotAllowedIn40DeletedEntry,
                 exception.Message);
         }
 
@@ -1624,13 +1624,13 @@ namespace Microsoft.OData.Core.Tests.JsonLight
         }
 
         [Fact]
-        public async Task WriteNestedDeltaResourceSetAsync_ThrowsException()
+        public async Task WriteNestedDeltaResourceSetAsync_DoesNotThrowException()
         {
             var customerResource = CreateCustomerResource();
             var orderCollectionNestedResource = CreateOrderCollectionNestedResourceInfo();
             var orderDeltaResourceSet = CreateOrderDeltaResourceSet();
 
-            var exception = await Assert.ThrowsAsync<ODataException>(
+            var exception = await Record.ExceptionAsync(
                 () => SetupJsonLightWriterAndRunTestAsync(
                     async (jsonLightWriter) =>
                     {
@@ -1643,9 +1643,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     writingResourceSet: false,
                     writingDelta: true));
 
-            Assert.Equal(
-                Strings.ODataWriterCore_InvalidTransitionFromExpandedLink("NestedResourceInfoWithContent", "DeltaResourceSet"),
-                exception.Message);
+            Assert.Null(exception);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

A response for a deep update of a `nested delta resource set`  is truncated if the `OData-Version` is not specified as `v4.01` in the request. This PR removes the check for the `OData-Version`.  This means that the `OData-Version` need not be passed in the request and the response should  be serialized properly. 
*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
