### PR TITLE
Updated ODataUriParser to allow select and expand property names that…

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexer.cs
@@ -83,6 +83,11 @@ namespace Microsoft.OData.UriParser
         /// <summary>Whether the lexer is being used to parse function parameters. If true, will allow/recognize parameter aliases and typed nulls.</summary>
         private readonly bool parsingFunctionParameters;
 
+        /// <summary>
+        /// Whether or not to interpret the semantics of a token that appears to be an identifier (i.e. consider if it is a keyword instead of an identifier)
+        /// </summary>
+        private readonly bool applySemanticsToIdentifiers;
+
         /// <summary>Lexer ignores whitespace</summary>
         private bool ignoreWhitespace;
 
@@ -108,6 +113,19 @@ namespace Microsoft.OData.UriParser
         /// <param name="useSemicolonDelimiter">If true, the lexer will tokenize based on semicolons as well.</param>
         /// <param name="parsingFunctionParameters">Whether the lexer is being used to parse function parameters. If true, will allow/recognize parameter aliases and typed nulls.</param>
         internal ExpressionLexer(string expression, bool moveToFirstToken, bool useSemicolonDelimiter, bool parsingFunctionParameters)
+            : this(expression, moveToFirstToken, useSemicolonDelimiter, parsingFunctionParameters, true)
+        {
+        }
+
+        /// <summary>Initializes a new <see cref="ExpressionLexer"/>.</summary>
+        /// <param name="expression">Expression to parse.</param>
+        /// <param name="moveToFirstToken">If true, this constructor will call NextToken() to move to the first token.</param>
+        /// <param name="useSemicolonDelimiter">If true, the lexer will tokenize based on semicolons as well.</param>
+        /// <param name="parsingFunctionParameters">Whether the lexer is being used to parse function parameters. If true, will allow/recognize parameter aliases and typed nulls.</param>
+        /// <param name="applySemanticsToIdentifiers">
+        /// Whether or not to interpret the semantics of a token that appears to be an identifier (i.e. consider if it is a keyword instead of an identifier)
+        /// </param>
+        internal ExpressionLexer(string expression, bool moveToFirstToken, bool useSemicolonDelimiter, bool parsingFunctionParameters, bool applySemanticsToIdentifiers)
         {
             Debug.Assert(expression != null, "expression != null");
 
@@ -116,6 +134,7 @@ namespace Microsoft.OData.UriParser
             this.TextLen = this.Text.Length;
             this.useSemicolonDelimiter = useSemicolonDelimiter;
             this.parsingFunctionParameters = parsingFunctionParameters;
+            this.applySemanticsToIdentifiers = applySemanticsToIdentifiers;
             this.parsingDoubleQuotedString = false;
 
             this.SetTextPos(0);
@@ -810,7 +829,7 @@ namespace Microsoft.OData.UriParser
 
                 this.HandleQuotedValues();
             }
-            else
+            else if (this.applySemanticsToIdentifiers)
             {
                 // Handle keywords.
                 // Get built in type literal prefix.

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandParser.cs
@@ -81,7 +81,7 @@ namespace Microsoft.OData.UriParser
 
             // Sets up our lexer. We don't turn useSemicolonDelimiter on since the parsing code for expand options,
             // which is the only thing that needs it, is in a different class that uses it's own lexer.
-            this.lexer = clauseToParse != null ? new ExpressionLexer(clauseToParse, false /*moveToFirstToken*/, false /*useSemicolonDelimiter*/) : null;
+            this.lexer = clauseToParse != null ? new ExpressionLexer(clauseToParse, false, false, false, false) : null;
 
             this.enableCaseInsensitiveBuiltinIdentifier = enableCaseInsensitiveBuiltinIdentifier;
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -26,6 +26,410 @@ namespace Microsoft.OData.Tests.UriParser
         private readonly Uri ServiceRoot = new Uri("http://host");
         private readonly Uri FullUri = new Uri("http://host/People");
 
+        /// <summary>
+        /// Selects a property named "true"
+        /// </summary>
+        [Fact]
+        public void SelectTrue()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            foo.AddStructuralProperty("true", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$select=true", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var pathSelectItem = selectedItems[0] as PathSelectItem;
+            var segments = pathSelectItem.SelectedPath.Segments.ToArray();
+            Assert.Single(segments);
+            Assert.Equal("true", segments[0].Identifier);
+            Assert.Equal("Edm.String", segments[0].EdmType.FullTypeName());
+        }
+
+        /// <summary>
+        /// Selects a property named "false"
+        /// </summary>
+        [Fact]
+        public void SelectFalse()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            foo.AddStructuralProperty("false", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$select=false", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var pathSelectItem = selectedItems[0] as PathSelectItem;
+            var segments = pathSelectItem.SelectedPath.Segments.ToArray();
+            Assert.Single(segments);
+            Assert.Equal("false", segments[0].Identifier);
+            Assert.Equal("Edm.String", segments[0].EdmType.FullTypeName());
+        }
+
+        /// <summary>
+        /// Selects a property named "INF"
+        /// </summary>
+        [Fact]
+        public void SelectInfinity()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            foo.AddStructuralProperty("INF", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$select=INF", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var pathSelectItem = selectedItems[0] as PathSelectItem;
+            var segments = pathSelectItem.SelectedPath.Segments.ToArray();
+            Assert.Single(segments);
+            Assert.Equal("INF", segments[0].Identifier);
+            Assert.Equal("Edm.String", segments[0].EdmType.FullTypeName());
+        }
+
+        /// <summary>
+        /// Selects a property named "NaN"
+        /// </summary>
+        [Fact]
+        public void SelectNotANumber()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            foo.AddStructuralProperty("NaN", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$select=NaN", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var pathSelectItem = selectedItems[0] as PathSelectItem;
+            var segments = pathSelectItem.SelectedPath.Segments.ToArray();
+            Assert.Single(segments);
+            Assert.Equal("NaN", segments[0].Identifier);
+            Assert.Equal("Edm.String", segments[0].EdmType.FullTypeName());
+        }
+
+        /// <summary>
+        /// Selects a property named "null"
+        /// </summary>
+        [Fact]
+        public void SelectNull()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            foo.AddStructuralProperty("null", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$select=null", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var pathSelectItem = selectedItems[0] as PathSelectItem;
+            var segments = pathSelectItem.SelectedPath.Segments.ToArray();
+            Assert.Single(segments);
+            Assert.Equal("null", segments[0].Identifier);
+            Assert.Equal("Edm.String", segments[0].EdmType.FullTypeName());
+        }
+
+        /// <summary>
+        /// Selects a property named "null" when such a property doesn't exist on the entity
+        /// </summary>
+        [Fact]
+        public void SelectNullNotFound()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            foo.AddStructuralProperty("true", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$select=null", UriKind.Relative));
+            var odataException = Assert.Throws<ODataException>(() => parser.ParseUri());
+
+            Assert.Equal("Could not find a property named 'null' on type 'foobar.foo'.", odataException.Message);
+        }
+
+        /// <summary>
+        /// Expands a property named "true"
+        /// </summary>
+        [Fact]
+        public void ExpandTrue()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            var bar = new EdmEntityType("foobar", "bar");
+            bar.AddKeys(bar.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            model.AddElement(bar);
+            foo.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo() 
+            { 
+                Name = "true", 
+                ContainsTarget = true, 
+                TargetMultiplicity = EdmMultiplicity.ZeroOrOne, 
+                Target = bar ,
+            });
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$expand=true", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var expandedNavigationSelectItem = selectedItems[0] as ExpandedNavigationSelectItem;
+            Assert.Equal("true", expandedNavigationSelectItem.NavigationSource.Name);
+            Assert.Equal("foobar.bar", expandedNavigationSelectItem.NavigationSource.EntityType().FullTypeName());
+            Assert.Empty(expandedNavigationSelectItem.SelectAndExpand.SelectedItems);
+        }
+
+        /// <summary>
+        /// Expands a property named "false"
+        /// </summary>
+        [Fact]
+        public void ExpandFalse()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            var bar = new EdmEntityType("foobar", "bar");
+            bar.AddKeys(bar.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            model.AddElement(bar);
+            foo.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo() 
+            { 
+                Name = "false",
+                ContainsTarget = true,
+                TargetMultiplicity = EdmMultiplicity.ZeroOrOne,
+                Target = bar,
+            });
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$expand=false", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var expandedNavigationSelectItem = selectedItems[0] as ExpandedNavigationSelectItem;
+            Assert.Equal("false", expandedNavigationSelectItem.NavigationSource.Name);
+            Assert.Equal("foobar.bar", expandedNavigationSelectItem.NavigationSource.EntityType().FullTypeName());
+            Assert.Empty(expandedNavigationSelectItem.SelectAndExpand.SelectedItems);
+        }
+
+        /// <summary>
+        /// Expands a property named "INF"
+        /// </summary>
+        [Fact]
+        public void ExpandInfinity()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            var bar = new EdmEntityType("foobar", "bar");
+            bar.AddKeys(bar.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            model.AddElement(bar);
+            foo.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo() 
+            { 
+                Name = "INF",
+                ContainsTarget = true,
+                TargetMultiplicity = EdmMultiplicity.ZeroOrOne,
+                Target = bar,
+            });
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$expand=INF", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var expandedNavigationSelectItem = selectedItems[0] as ExpandedNavigationSelectItem;
+            Assert.Equal("INF", expandedNavigationSelectItem.NavigationSource.Name);
+            Assert.Equal("foobar.bar", expandedNavigationSelectItem.NavigationSource.EntityType().FullTypeName());
+            Assert.Empty(expandedNavigationSelectItem.SelectAndExpand.SelectedItems);
+        }
+
+        /// <summary>
+        /// Expands a property named "NaN"
+        /// </summary>
+        [Fact]
+        public void ExpandNotANumber()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            var bar = new EdmEntityType("foobar", "bar");
+            bar.AddKeys(bar.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            model.AddElement(bar);
+            foo.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo() 
+            { 
+                Name = "NaN",
+                ContainsTarget = true,
+                TargetMultiplicity = EdmMultiplicity.ZeroOrOne,
+                Target = bar,
+            });
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$expand=NaN", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var expandedNavigationSelectItem = selectedItems[0] as ExpandedNavigationSelectItem;
+            Assert.Equal("NaN", expandedNavigationSelectItem.NavigationSource.Name);
+            Assert.Equal("foobar.bar", expandedNavigationSelectItem.NavigationSource.EntityType().FullTypeName());
+            Assert.Empty(expandedNavigationSelectItem.SelectAndExpand.SelectedItems);
+        }
+
+        /// <summary>
+        /// Expands a property named "null"
+        /// </summary>
+        [Fact]
+        public void ExpandNull()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            var bar = new EdmEntityType("foobar", "bar");
+            bar.AddKeys(bar.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            model.AddElement(bar);
+            foo.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo() 
+            { 
+                Name = "null",
+                ContainsTarget = true,
+                TargetMultiplicity = EdmMultiplicity.ZeroOrOne,
+                Target = bar,
+            });
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$expand=null", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var selectedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var expandedNavigationSelectItem = selectedItems[0] as ExpandedNavigationSelectItem;
+            Assert.Equal("null", expandedNavigationSelectItem.NavigationSource.Name);
+            Assert.Equal("foobar.bar", expandedNavigationSelectItem.NavigationSource.EntityType().FullTypeName());
+            Assert.Empty(expandedNavigationSelectItem.SelectAndExpand.SelectedItems);
+        }
+
+        /// <summary>
+        /// Expands a property named "null" when such a property doesn't exist on the entity
+        /// </summary>
+        [Fact]
+        public void ExpandNullNotFound()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            var bar = new EdmEntityType("foobar", "bar");
+            bar.AddKeys(bar.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            model.AddElement(bar);
+            foo.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo() 
+            {
+                Name = "true",
+                ContainsTarget = true,
+                TargetMultiplicity = EdmMultiplicity.ZeroOrOne,
+                Target = bar,
+            });
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$expand=null", UriKind.Relative));
+            var odataException = Assert.Throws<ODataException>(() => parser.ParseUri());
+
+            Assert.Equal("Could not find a property named 'null' on type 'foobar.foo'.", odataException.Message);
+        }
+
+        /// <summary>
+        /// Expands a property named "true" and selects its property named "false"
+        /// </summary>
+        [Fact]
+        public void ExpandTrueSelectFalse()
+        {
+            var model = new EdmModel();
+            var foo = new EdmEntityType("foobar", "foo");
+            foo.AddKeys(foo.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            var bar = new EdmEntityType("foobar", "bar");
+            bar.AddKeys(bar.AddStructuralProperty("id", EdmCoreModel.Instance.GetInt32(false)));
+            bar.AddStructuralProperty("false", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(bar);
+            foo.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo()
+            { 
+                Name = "true",
+                ContainsTarget = true,
+                TargetMultiplicity = EdmMultiplicity.ZeroOrOne,
+                Target = bar,
+            });
+            model.AddElement(foo);
+            var container = new EdmEntityContainer("foobar", "FooService");
+            container.AddEntitySet("foos", foo);
+            model.AddElement(container);
+
+            var parser = new ODataUriParser(model, new Uri("/foos?$expand=true($select=false)", UriKind.Relative));
+            var odataUri = parser.ParseUri();
+
+            var expandedItems = odataUri.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(expandedItems);
+            var expandedNavigationSelectItem = expandedItems[0] as ExpandedNavigationSelectItem;
+            Assert.Equal("true", expandedNavigationSelectItem.NavigationSource.Name);
+            Assert.Equal("foobar.bar", expandedNavigationSelectItem.NavigationSource.EntityType().FullTypeName());
+
+            var selectedItems = expandedNavigationSelectItem.SelectAndExpand.SelectedItems.ToArray();
+            Assert.Single(selectedItems);
+            var pathSelectItem = selectedItems[0] as PathSelectItem;
+            var segments = pathSelectItem.SelectedPath.Segments.ToArray();
+            Assert.Single(segments);
+            Assert.Equal("false", segments[0].Identifier);
+            Assert.Equal("Edm.String", segments[0].EdmType.FullTypeName());
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]


### PR DESCRIPTION
… conflict with reserved keywords

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2410.*

### Description

The `SelectExpandParser` used by the `ODataUriParser` takes a two-pass approach to parsing the select and expand options. The first pass is intended to be syntactic only, while the second pass applies semantics. For code re-use, The syntactic pass leverages the `ExpressionLexer`. However, `ExpressionLexer` applies some semantics while parsing when a perceived "identifier" token is reached. I have added a flag in `ExpressionLexer` to optionally disable these semantics, and updated the `SelectExpandParser` to disable this behavior for its lexer. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
