### PR TITLE
Fix synchronous operations disallowed error when using Kestrel web server

### DIFF
--- a/src/Microsoft.OData.Core/Batch/ODataBatchUtils.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchUtils.cs
@@ -77,11 +77,13 @@ namespace Microsoft.OData
         /// <param name="batchReaderStream">The batch stream to create the operation read stream for.</param>
         /// <param name="headers">The headers of the current part; based on the header we create different, optimized stream implementations.</param>
         /// <param name="operationListener">The operation listener to be passed to the newly created read stream.</param>
+        /// <param name="synchronous">true if the stream is to be created for synchronous operation; false for asynchronous.</param>
         /// <returns>A new <see cref="ODataReadStream"/> instance.</returns>
         internal static ODataReadStream CreateBatchOperationReadStream(
             ODataBatchReaderStream batchReaderStream,
             ODataBatchOperationHeaders headers,
-            IODataStreamListener operationListener)
+            IODataStreamListener operationListener,
+            bool synchronous)
         {
             Debug.Assert(batchReaderStream != null, "batchReaderStream != null");
             Debug.Assert(operationListener != null, "operationListener != null");
@@ -96,10 +98,10 @@ namespace Microsoft.OData
                     throw new ODataException(Strings.ODataBatchReaderStream_InvalidContentLengthSpecified(contentLengthValue));
                 }
 
-                return ODataReadStream.Create(batchReaderStream, operationListener, length);
+                return ODataReadStream.Create(batchReaderStream, operationListener, length, synchronous);
             }
 
-            return ODataReadStream.Create(batchReaderStream, operationListener);
+            return ODataReadStream.Create(batchReaderStream, operationListener, synchronous);
         }
 
         /// <summary>
@@ -107,11 +109,12 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="outputStream">The output stream to create the operation write stream over.</param>
         /// <param name="operationListener">The operation listener to be passed to the newly created write stream.</param>
+        /// <param name="synchronous">true if the stream is to be created for synchronous operation; false for asynchronous.</param>
         /// <returns>A new <see cref="ODataWriteStream"/> instance.</returns>
         internal static ODataWriteStream CreateBatchOperationWriteStream(
             Stream outputStream,
             IODataStreamListener operationListener,
-            bool synchronous = true)
+            bool synchronous)
         {
             Debug.Assert(outputStream != null, "outputStream != null");
             Debug.Assert(operationListener != null, "operationListener != null");

--- a/src/Microsoft.OData.Core/Batch/ODataBatchUtils.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchUtils.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OData
             ODataBatchReaderStream batchReaderStream,
             ODataBatchOperationHeaders headers,
             IODataStreamListener operationListener,
-            bool synchronous)
+            bool synchronous = true)
         {
             Debug.Assert(batchReaderStream != null, "batchReaderStream != null");
             Debug.Assert(operationListener != null, "operationListener != null");
@@ -114,7 +114,7 @@ namespace Microsoft.OData
         internal static ODataWriteStream CreateBatchOperationWriteStream(
             Stream outputStream,
             IODataStreamListener operationListener,
-            bool synchronous)
+            bool synchronous = true)
         {
             Debug.Assert(outputStream != null, "outputStream != null");
             Debug.Assert(operationListener != null, "operationListener != null");

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -97,7 +97,7 @@ namespace Microsoft.OData.MultipartMixed
             }
 
             ODataBatchOperationRequestMessage requestMessage = BuildOperationRequestMessage(
-                () => ODataBatchUtils.CreateBatchOperationReadStream(this.batchStream, headers, this),
+                () => ODataBatchUtils.CreateBatchOperationReadStream(this.batchStream, headers, this, this.InputContext.Synchronous),
                 httpMethod,
                 requestUri,
                 headers,
@@ -139,7 +139,7 @@ namespace Microsoft.OData.MultipartMixed
             // We don't have correlation of changeset boundary between request and response messages in
             // changesets, so use null value for groupId.
             ODataBatchOperationResponseMessage responseMessage = BuildOperationResponseMessage(
-                () => ODataBatchUtils.CreateBatchOperationReadStream(this.batchStream, headers, this),
+                () => ODataBatchUtils.CreateBatchOperationReadStream(this.batchStream, headers, this, this.InputContext.Synchronous),
                 statusCode,
                 headers,
                 this.currentContentId,

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -125,7 +125,7 @@ namespace Microsoft.OData.MultipartMixed
             // then dispose the batch writer (since we are now writing the operation content) and set the corresponding state.
             await this.RawOutputContext.FlushBuffersAsync()
                 .ConfigureAwait(false);
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
             await this.DisposeBatchWriterAndSetContentStreamRequestedStateAsync()
                 .ConfigureAwait(false);
 #else
@@ -758,7 +758,7 @@ namespace Microsoft.OData.MultipartMixed
             }
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         /// <summary>
         /// Disposes the batch writer and set the 'OperationStreamRequested' batch writer state;
         /// called after the flush operation(s) have completed.

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -125,7 +125,12 @@ namespace Microsoft.OData.MultipartMixed
             // then dispose the batch writer (since we are now writing the operation content) and set the corresponding state.
             await this.RawOutputContext.FlushBuffersAsync()
                 .ConfigureAwait(false);
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+            await this.DisposeBatchWriterAndSetContentStreamRequestedStateAsync()
+                .ConfigureAwait(false);
+#else
             this.DisposeBatchWriterAndSetContentStreamRequestedState();
+#endif
         }
 
         /// <summary>
@@ -752,5 +757,19 @@ namespace Microsoft.OData.MultipartMixed
                 }
             }
         }
+
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+        /// <summary>
+        /// Disposes the batch writer and set the 'OperationStreamRequested' batch writer state;
+        /// called after the flush operation(s) have completed.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        private async Task DisposeBatchWriterAndSetContentStreamRequestedStateAsync()
+        {
+            await this.RawOutputContext.CloseWriterAsync().ConfigureAwait(false);
+
+            this.SetState(BatchWriterState.OperationStreamRequested);
+        }
+#endif
     }
 }

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -760,10 +760,10 @@ namespace Microsoft.OData.MultipartMixed
 
 #if NETCOREAPP3_1_OR_GREATER
         /// <summary>
-        /// Disposes the batch writer and set the 'OperationStreamRequested' batch writer state;
+        /// Asynchronously disposes the batch writer and set the 'OperationStreamRequested' batch writer state;
         /// called after the flush operation(s) have completed.
         /// </summary>
-        /// <returns>A task that represents the asynchronous write operation.</returns>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         private async Task DisposeBatchWriterAndSetContentStreamRequestedStateAsync()
         {
             await this.RawOutputContext.CloseWriterAsync().ConfigureAwait(false);

--- a/src/Microsoft.OData.Core/ODataRawOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawOutputContext.cs
@@ -322,7 +322,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Closes the text writer asynchronously.
         /// </summary>
-        /// <returns><returns>A task that represents the asynchronous operation.</returns></returns>
+        /// <returns>A task that represents the asynchronous operation.</returns>
         internal async Task CloseWriterAsync()
         {
             Debug.Assert(this.rawValueWriter != null, "The text writer has not been initialized yet.");

--- a/src/Microsoft.OData.Core/ODataRawOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawOutputContext.cs
@@ -318,6 +318,20 @@ namespace Microsoft.OData
             }
         }
 
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+        /// <summary>
+        /// Closes the text writer asynchronously.
+        /// </summary>
+        /// <returns><returns>A task that represents the asynchronous operation.</returns></returns>
+        internal async Task CloseWriterAsync()
+        {
+            Debug.Assert(this.rawValueWriter != null, "The text writer has not been initialized yet.");
+
+            await this.rawValueWriter.DisposeAsync().ConfigureAwait(false);
+            this.rawValueWriter = null;
+        }
+#endif
+
         /// <summary>
         /// Perform the actual cleanup work.
         /// </summary>

--- a/src/Microsoft.OData.Core/ODataRawOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawOutputContext.cs
@@ -318,7 +318,7 @@ namespace Microsoft.OData
             }
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         /// <summary>
         /// Closes the text writer asynchronously.
         /// </summary>

--- a/src/Microsoft.OData.Core/ODataReadStream.cs
+++ b/src/Microsoft.OData.Core/ODataReadStream.cs
@@ -29,8 +29,9 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="batchReaderStream">The underlying stream to read from.</param>
         /// <param name="listener">Listener interface to be notified of operation changes.</param>
-        private ODataReadStream(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener)
-            : base(listener)
+        /// <param name="synchronous">true if the stream is created for synchronous operation; false for asynchronous.</param>
+        private ODataReadStream(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, bool synchronous)
+            : base(listener, synchronous)
         {
             Debug.Assert(batchReaderStream != null, "batchReaderStream != null");
             this.batchReaderStream = batchReaderStream;
@@ -111,10 +112,11 @@ namespace Microsoft.OData
         /// <param name="batchReaderStream">The batch stream underlying the operation stream to create.</param>
         /// <param name="listener">The batch operation listener.</param>
         /// <param name="length">The content length of the operation stream.</param>
+        /// <param name="synchronous">true if the stream is created for synchronous operation; false for asynchronous.</param>
         /// <returns>A <see cref="ODataReadStream"/> to read the content of a batch operation from.</returns>
-        internal static ODataReadStream Create(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, int length)
+        internal static ODataReadStream Create(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, int length, bool synchronous)
         {
-            return new ODataBatchOperationReadStreamWithLength(batchReaderStream, listener, length);
+            return new ODataBatchOperationReadStreamWithLength(batchReaderStream, listener, length, synchronous);
         }
 
         /// <summary>
@@ -122,10 +124,11 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="batchReaderStream">The batch stream underlying the operation stream to create.</param>
         /// <param name="listener">The batch operation listener.</param>
+        /// <param name="synchronous">true if the stream is created for synchronous operation; false for asynchronous.</param>
         /// <returns>A <see cref="ODataReadStream"/> to read the content of a batch operation from.</returns>
-        internal static ODataReadStream Create(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener)
+        internal static ODataReadStream Create(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, bool synchronous)
         {
-            return new ODataBatchOperationReadStreamWithDelimiter(batchReaderStream, listener);
+            return new ODataBatchOperationReadStreamWithDelimiter(batchReaderStream, listener, synchronous);
         }
 
         /// <summary>
@@ -142,8 +145,8 @@ namespace Microsoft.OData
             /// <param name="batchReaderStream">The underlying batch stream to write the message to.</param>
             /// <param name="listener">Listener interface to be notified of operation changes.</param>
             /// <param name="length">The total length of the stream.</param>
-            internal ODataBatchOperationReadStreamWithLength(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, int length)
-                : base(batchReaderStream, listener)
+            internal ODataBatchOperationReadStreamWithLength(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, int length, bool synchronous)
+                : base(batchReaderStream, listener, synchronous)
             {
                 ExceptionUtils.CheckIntegerNotNegative(length, "length");
                 this.length = length;
@@ -189,8 +192,8 @@ namespace Microsoft.OData
             /// </summary>
             /// <param name="batchReaderStream">The underlying batch stream to write the message to.</param>
             /// <param name="listener">Listener interface to be notified of operation changes.</param>
-            internal ODataBatchOperationReadStreamWithDelimiter(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener)
-                : base(batchReaderStream, listener)
+            internal ODataBatchOperationReadStreamWithDelimiter(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, bool synchronous)
+                : base(batchReaderStream, listener, synchronous)
             {
             }
 

--- a/src/Microsoft.OData.Core/ODataReadStream.cs
+++ b/src/Microsoft.OData.Core/ODataReadStream.cs
@@ -114,7 +114,11 @@ namespace Microsoft.OData
         /// <param name="length">The content length of the operation stream.</param>
         /// <param name="synchronous">true if the stream is created for synchronous operation; false for asynchronous.</param>
         /// <returns>A <see cref="ODataReadStream"/> to read the content of a batch operation from.</returns>
-        internal static ODataReadStream Create(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, int length, bool synchronous)
+        internal static ODataReadStream Create(
+            ODataBatchReaderStream batchReaderStream,
+            IODataStreamListener listener,
+            int length,
+            bool synchronous = true)
         {
             return new ODataBatchOperationReadStreamWithLength(batchReaderStream, listener, length, synchronous);
         }
@@ -126,7 +130,10 @@ namespace Microsoft.OData
         /// <param name="listener">The batch operation listener.</param>
         /// <param name="synchronous">true if the stream is created for synchronous operation; false for asynchronous.</param>
         /// <returns>A <see cref="ODataReadStream"/> to read the content of a batch operation from.</returns>
-        internal static ODataReadStream Create(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, bool synchronous)
+        internal static ODataReadStream Create(
+            ODataBatchReaderStream batchReaderStream,
+            IODataStreamListener listener,
+            bool synchronous = true)
         {
             return new ODataBatchOperationReadStreamWithDelimiter(batchReaderStream, listener, synchronous);
         }
@@ -145,7 +152,11 @@ namespace Microsoft.OData
             /// <param name="batchReaderStream">The underlying batch stream to write the message to.</param>
             /// <param name="listener">Listener interface to be notified of operation changes.</param>
             /// <param name="length">The total length of the stream.</param>
-            internal ODataBatchOperationReadStreamWithLength(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, int length, bool synchronous)
+            internal ODataBatchOperationReadStreamWithLength(
+                ODataBatchReaderStream batchReaderStream,
+                IODataStreamListener listener,
+                int length,
+                bool synchronous)
                 : base(batchReaderStream, listener, synchronous)
             {
                 ExceptionUtils.CheckIntegerNotNegative(length, "length");
@@ -192,7 +203,10 @@ namespace Microsoft.OData
             /// </summary>
             /// <param name="batchReaderStream">The underlying batch stream to write the message to.</param>
             /// <param name="listener">Listener interface to be notified of operation changes.</param>
-            internal ODataBatchOperationReadStreamWithDelimiter(ODataBatchReaderStream batchReaderStream, IODataStreamListener listener, bool synchronous)
+            internal ODataBatchOperationReadStreamWithDelimiter(
+                ODataBatchReaderStream batchReaderStream,
+                IODataStreamListener listener,
+                bool synchronous)
                 : base(batchReaderStream, listener, synchronous)
             {
             }

--- a/src/Microsoft.OData.Core/ODataStream.cs
+++ b/src/Microsoft.OData.Core/ODataStream.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OData
     /// or representing a stream value.
     /// This stream communicates status changes to an IODataStreamListener instance.
     /// </summary>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_0
     internal abstract class ODataStream : Stream, IAsyncDisposable
 #else
     internal abstract class ODataStream : Stream
@@ -37,7 +37,6 @@ namespace Microsoft.OData
         /// Constructor.
         /// </summary>
         /// <param name="listener">Listener interface to be notified of operation changes.</param>
-        /// <param name="synchronous">true if the stream is created for synchronous operation; false for asynchronous.</param>
         internal ODataStream(IODataStreamListener listener, bool synchronous = true)
         {
             Debug.Assert(listener != null, "listener != null");
@@ -83,7 +82,17 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
+        public override async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore()
+                .ConfigureAwait(false);
+
+            // Dispose unmanaged resources
+            // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
+            this.Dispose(false);
+        }
+#elif NETSTANDARD2_0
         public async ValueTask DisposeAsync()
         {
             await DisposeAsyncCore()
@@ -93,7 +102,9 @@ namespace Microsoft.OData
             // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
             this.Dispose(false);
         }
+#endif
 
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         /// <summary>
         /// Encapsulates the common asynchronous cleanup operations.
         /// </summary>

--- a/src/Microsoft.OData.Core/ODataStream.cs
+++ b/src/Microsoft.OData.Core/ODataStream.cs
@@ -37,6 +37,7 @@ namespace Microsoft.OData
         /// Constructor.
         /// </summary>
         /// <param name="listener">Listener interface to be notified of operation changes.</param>
+        /// <param name="synchronous">true if the stream is created for synchronous operation; false for asynchronous.</param>
         internal ODataStream(IODataStreamListener listener, bool synchronous = true)
         {
             Debug.Assert(listener != null, "listener != null");

--- a/src/Microsoft.OData.Core/ODataWriteStream.cs
+++ b/src/Microsoft.OData.Core/ODataWriteStream.cs
@@ -28,6 +28,7 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="stream">The underlying stream to write the message to.</param>
         /// <param name="listener">Listener interface to be notified of operation changes.</param>
+        /// <param name="synchronous">true if the stream is created for synchronous operation; false for asynchronous.</param>
         internal ODataWriteStream(Stream stream, IODataStreamListener listener, bool synchronous = true)
             : base(listener, synchronous)
         {

--- a/src/Microsoft.OData.Core/RawValueWriter.cs
+++ b/src/Microsoft.OData.Core/RawValueWriter.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData
     /// <summary>
     /// Class that handles writing top level raw values to a stream.
     /// </summary>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
     internal sealed class RawValueWriter : IDisposable, IAsyncDisposable
 #else
     internal sealed class RawValueWriter : IDisposable
@@ -90,18 +90,22 @@ namespace Microsoft.OData
             this.textWriter = null;
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         public ValueTask DisposeAsync()
         {
-            return DisposeAsyncCore();
-        }
+            return DisposeInnerAsync();
 
-        private async ValueTask DisposeAsyncCore()
-        {
-            Debug.Assert(this.textWriter != null, "The text writer has not been initialized yet.");
+            async ValueTask DisposeInnerAsync()
+            {
+                Debug.Assert(this.textWriter != null, "The text writer has not been initialized yet.");
 
-            await this.textWriter.FlushAsync().ConfigureAwait(false);
-            this.textWriter = null;
+                if (this.textWriter != null)
+                {
+                    await this.textWriter.DisposeAsync().ConfigureAwait(false);
+                }
+
+                this.textWriter = null;
+            }
         }
 #endif
 

--- a/src/Microsoft.OData.Core/RawValueWriter.cs
+++ b/src/Microsoft.OData.Core/RawValueWriter.cs
@@ -91,6 +91,11 @@ namespace Microsoft.OData
         }
 
 #if NETCOREAPP3_1_OR_GREATER
+        /// <summary>
+        /// Asynchronously disposes the <see cref="RawValueWriter"/>.
+        /// It flushes itself and then disposes its inner <see cref="System.IO.TextWriter"/>.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
         public ValueTask DisposeAsync()
         {
             return DisposeInnerAsync();

--- a/src/Microsoft.OData.Core/RawValueWriter.cs
+++ b/src/Microsoft.OData.Core/RawValueWriter.cs
@@ -17,7 +17,11 @@ namespace Microsoft.OData
     /// <summary>
     /// Class that handles writing top level raw values to a stream.
     /// </summary>
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+    internal sealed class RawValueWriter : IDisposable, IAsyncDisposable
+#else
     internal sealed class RawValueWriter : IDisposable
+#endif
     {
         /// <summary>
         /// Writer settings.
@@ -85,6 +89,21 @@ namespace Microsoft.OData
             this.textWriter.Dispose();
             this.textWriter = null;
         }
+
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+        public ValueTask DisposeAsync()
+        {
+            return DisposeAsyncCore();
+        }
+
+        private async ValueTask DisposeAsyncCore()
+        {
+            Debug.Assert(this.textWriter != null, "The text writer has not been initialized yet.");
+
+            await this.textWriter.FlushAsync().ConfigureAwait(false);
+            this.textWriter = null;
+        }
+#endif
 
         /// <summary>
         /// Start writing a raw output. This should only be called once.

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchReaderTests.cs
@@ -183,6 +183,10 @@ Accept-Charset: UTF-8
                     }
                 },
                 batchRequestBoundary);
+
+            Assert.Empty(verifyUrlStack);
+            Assert.Empty(verifyDependsOnIdsStack);
+            Assert.Empty(verifyResourceStack);
         }
 
         [Fact]
@@ -324,6 +328,10 @@ Accept-Charset: UTF-8
                     }
                 },
                 batchRequestBoundary);
+
+            Assert.Empty(verifyUrlStack);
+            Assert.Empty(verifyDependsOnIdsStack);
+            Assert.Empty(verifyResourceStack);
         }
 
         [Fact]
@@ -340,6 +348,7 @@ OData-Version: 4.0
 {""@odata.context"":""http://tempuri.org/$metadata#Customers/$entity"",""Id"":1,""Name"":""Sue""}
 --batchresponse_aed653ab--
 ";
+            bool resourceRead = false;
 
             SetupMultipartMixedBatchReaderAndRunTest(
                 payload,
@@ -362,6 +371,7 @@ OData-Version: 4.0
                                         {
                                             case ODataReaderState.ResourceEnd:
                                                 var resource = jsonLightResourceReader.Item as ODataResource;
+                                                resourceRead = true;
                                                 Assert.NotNull(resource);
                                                 Assert.Equal("NS.Customer", resource.TypeName);
                                                 var properties = resource.Properties.ToArray();
@@ -381,6 +391,8 @@ OData-Version: 4.0
                 },
                 batchResponseBoundary,
                 isRequest: false);
+
+            Assert.True(resourceRead);
         }
 
         [Fact]
@@ -397,6 +409,7 @@ OData-Version: 4.0
 {""@odata.context"":""http://tempuri.org/$metadata#Customers/$entity"",""Id"":1,""Name"":""Sue""}
 --batchresponse_aed653ab--
 ";
+            bool resourceRead = false;
 
             await SetupMultipartMixedBatchReaderAndRunTestAsync(
                 payload,
@@ -419,6 +432,7 @@ OData-Version: 4.0
                                         {
                                             case ODataReaderState.ResourceEnd:
                                                 var resource = jsonLightResourceReader.Item as ODataResource;
+                                                resourceRead = true;
                                                 Assert.NotNull(resource);
                                                 Assert.Equal("NS.Customer", resource.TypeName);
                                                 var properties = resource.Properties.ToArray();
@@ -438,6 +452,8 @@ OData-Version: 4.0
                 },
                 batchResponseBoundary,
                 isRequest: false);
+
+            Assert.True(resourceRead);
         }
 
         #region BatchOperationReadStream

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchReaderTests.cs
@@ -460,7 +460,7 @@ OData-Version: 4.0
             Assert.Equal(expected, contents);
         }
 
-#if NETSTANDARD20 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public async Task ODataBatchReaderStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -508,7 +508,7 @@ OData-Version: 4.0
             Assert.Equal("StreamDisposedAsync", contents);
         }
 #else
-[Fact]
+        [Fact]
         public async Task ODataBatchReaderStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
             var payload = @"
@@ -576,7 +576,7 @@ OData-Version: 4.0
             Assert.Equal(expected, contents);
         }
 
-#if NETSTANDARD20 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public async Task ODataBatchWriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchReaderTests.cs
@@ -1,0 +1,820 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataMultipartMixedBatchReaderTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.OData.Edm;
+using Microsoft.OData.MultipartMixed;
+using Xunit;
+
+namespace Microsoft.OData.Tests
+{
+    public class ODataMultipartMixedBatchReaderTests
+    {
+        private const string batchRequestBoundary = "batch_aed653ab";
+        private const string batchResponseBoundary = "batchresponse_aed653ab";
+        private readonly ODataMediaType mediaType;
+        private readonly ODataMessageReaderSettings messageReaderSettings;
+        private readonly ODataBatchOperationHeaders batchOperationHeaders;
+
+        private EdmModel model;
+
+        public ODataMultipartMixedBatchReaderTests()
+        {
+            this.InitializeEdmModel();
+            this.messageReaderSettings = new ODataMessageReaderSettings();
+            this.mediaType = new ODataMediaType(
+                "Multipart",
+                "Mixed",
+                new KeyValuePair<string, string>[] { new KeyValuePair<string, string>("boundary", batchRequestBoundary) });
+
+            this.batchOperationHeaders = new ODataBatchOperationHeaders
+            {
+                { "OData-Version", "4.0" },
+                { "OData-MaxVersion", "4.0" },
+                { "Content-Type", "application/json;odata.metadata=minimal" },
+                { "Accept", "application/json;odata.metadata=minimal" },
+                { "Accept-Charset", "UTF-8" }
+            };
+        }
+
+        [Fact]
+        public void ReadMultipartMixedBatchRequest()
+        {
+            var payload = @"--batch_aed653ab
+Content-Type: multipart/mixed; boundary=changeset_5e368128
+
+--changeset_5e368128
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+POST http://tempuri.org/Customers HTTP/1.1
+OData-Version: 4.0
+OData-MaxVersion: 4.0
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{""@odata.type"":""NS.Customer"",""Id"":1,""Name"":""Sue""}
+--changeset_5e368128
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 2
+
+POST http://tempuri.org/Orders HTTP/1.1
+OData-Version: 4.0
+OData-MaxVersion: 4.0
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{""@odata.type"":""NS.Order"",""Id"":1,""Amount"":13}
+--changeset_5e368128
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 3
+
+POST $1/Orders/$ref HTTP/1.1
+OData-Version: 4.0
+OData-MaxVersion: 4.0
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{""@odata.id"":""$2""}
+--changeset_5e368128--
+--batch_aed653ab--
+";
+
+            var verifyUrlStack = new Stack<string>(new[] { "$1/Orders/$ref", "http://tempuri.org/Orders", "http://tempuri.org/Customers" });
+
+            var verifyDependsOnIdsStack = new Stack<Action<IEnumerable<string>>>();
+            verifyDependsOnIdsStack.Push((dependsOnIds) =>
+            {
+                Assert.Equal(2, dependsOnIds.Count());
+                Assert.Equal("1", dependsOnIds.First());
+                Assert.Equal("2", dependsOnIds.Last());
+            });
+            verifyDependsOnIdsStack.Push((dependsOnIds) => Assert.Equal("1", Assert.Single(dependsOnIds)));
+            verifyDependsOnIdsStack.Push((dependsOnIds) => Assert.Empty(dependsOnIds));
+
+            var verifyResourceStack = new Stack<Action<ODataResource>>();
+            verifyResourceStack.Push((resource) =>
+            {
+                Assert.NotNull(resource);
+                Assert.Equal("NS.Order", resource.TypeName);
+                var properties = resource.Properties.ToArray();
+                Assert.Equal(2, properties.Length);
+                Assert.Equal("Id", properties[0].Name);
+                Assert.Equal(1, properties[0].Value);
+                Assert.Equal("Amount", properties[1].Name);
+                Assert.Equal(13M, properties[1].Value);
+            });
+            verifyResourceStack.Push((resource) =>
+            {
+                Assert.NotNull(resource);
+                Assert.Equal("NS.Customer", resource.TypeName);
+                var properties = resource.Properties.ToArray();
+                Assert.Equal(2, properties.Length);
+                Assert.Equal("Id", properties[0].Name);
+                Assert.Equal(1, properties[0].Value);
+                Assert.Equal("Name", properties[1].Name);
+                Assert.Equal("Sue", properties[1].Value);
+            });
+
+            SetupMultipartMixedBatchReaderAndRunTest(
+                payload,
+                (multipartMixedBatchReader) =>
+                {
+                    var operationCount = 0;
+
+                    while (multipartMixedBatchReader.Read())
+                    {
+                        switch (multipartMixedBatchReader.State)
+                        {
+                            case ODataBatchReaderState.Operation:
+                                var operationRequestMessage = multipartMixedBatchReader.CreateOperationRequestMessage();
+                                operationCount++;
+
+                                Assert.Equal("POST", operationRequestMessage.Method);
+
+                                Assert.NotEmpty(verifyUrlStack);
+                                Assert.NotNull(operationRequestMessage.Url);
+                                Assert.Equal(verifyUrlStack.Pop(), operationRequestMessage.Url.OriginalString);
+
+                                Assert.NotEmpty(verifyDependsOnIdsStack);
+                                var verifyDependsOnId = verifyDependsOnIdsStack.Pop();
+                                verifyDependsOnId(operationRequestMessage.DependsOnIds);
+
+                                using (var messageReader = new ODataMessageReader(operationRequestMessage, new ODataMessageReaderSettings(), this.model))
+                                {
+                                    if (operationCount == 3)
+                                    {
+                                        var entityReferenceLink = messageReader.ReadEntityReferenceLink();
+
+                                        Assert.Equal("$2", entityReferenceLink.Url.OriginalString);
+                                    }
+                                    else
+                                    {
+                                        var jsonLightResourceReader = messageReader.CreateODataResourceReader();
+
+                                        while (jsonLightResourceReader.Read())
+                                        {
+                                            switch (jsonLightResourceReader.State)
+                                            {
+                                                case ODataReaderState.ResourceEnd:
+                                                    Assert.NotEmpty(verifyResourceStack);
+                                                    var innerVerifyResourceStack = verifyResourceStack.Pop();
+                                                    innerVerifyResourceStack(jsonLightResourceReader.Item as ODataResource);
+                                                    break;
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
+                        }
+                    }
+                },
+                batchRequestBoundary);
+        }
+
+        [Fact]
+        public async Task ReadMultipartMixedBatchRequestAsync()
+        {
+            var payload = @"--batch_aed653ab
+Content-Type: multipart/mixed; boundary=changeset_5e368128
+
+--changeset_5e368128
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+POST http://tempuri.org/Customers HTTP/1.1
+OData-Version: 4.0
+OData-MaxVersion: 4.0
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{""@odata.type"":""NS.Customer"",""Id"":1,""Name"":""Sue""}
+--changeset_5e368128
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 2
+
+POST http://tempuri.org/Orders HTTP/1.1
+OData-Version: 4.0
+OData-MaxVersion: 4.0
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{""@odata.type"":""NS.Order"",""Id"":1,""Amount"":13}
+--changeset_5e368128
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 3
+
+POST $1/Orders/$ref HTTP/1.1
+OData-Version: 4.0
+OData-MaxVersion: 4.0
+Content-Type: application/json;odata.metadata=minimal
+Accept: application/json;odata.metadata=minimal
+Accept-Charset: UTF-8
+
+{""@odata.id"":""$2""}
+--changeset_5e368128--
+--batch_aed653ab--
+";
+
+            var verifyUrlStack = new Stack<string>(new[] { "$1/Orders/$ref", "http://tempuri.org/Orders", "http://tempuri.org/Customers" });
+
+            var verifyDependsOnIdsStack = new Stack<Action<IEnumerable<string>>>();
+            verifyDependsOnIdsStack.Push((dependsOnIds) =>
+            {
+                Assert.Equal(2, dependsOnIds.Count());
+                Assert.Equal("1", dependsOnIds.First());
+                Assert.Equal("2", dependsOnIds.Last());
+            });
+            verifyDependsOnIdsStack.Push((dependsOnIds) => Assert.Equal("1", Assert.Single(dependsOnIds)));
+            verifyDependsOnIdsStack.Push((dependsOnIds) => Assert.Empty(dependsOnIds));
+
+            var verifyResourceStack = new Stack<Action<ODataResource>>();
+            verifyResourceStack.Push((resource) =>
+            {
+                Assert.NotNull(resource);
+                Assert.Equal("NS.Order", resource.TypeName);
+                var properties = resource.Properties.ToArray();
+                Assert.Equal(2, properties.Length);
+                Assert.Equal("Id", properties[0].Name);
+                Assert.Equal(1, properties[0].Value);
+                Assert.Equal("Amount", properties[1].Name);
+                Assert.Equal(13M, properties[1].Value);
+            });
+            verifyResourceStack.Push((resource) =>
+            {
+                Assert.NotNull(resource);
+                Assert.Equal("NS.Customer", resource.TypeName);
+                var properties = resource.Properties.ToArray();
+                Assert.Equal(2, properties.Length);
+                Assert.Equal("Id", properties[0].Name);
+                Assert.Equal(1, properties[0].Value);
+                Assert.Equal("Name", properties[1].Name);
+                Assert.Equal("Sue", properties[1].Value);
+            });
+
+            await SetupMultipartMixedBatchReaderAndRunTestAsync(
+                payload,
+                async (multipartMixedBatchReader) =>
+                {
+                    var operationCount = 0;
+
+                    while (await multipartMixedBatchReader.ReadAsync())
+                    {
+                        switch (multipartMixedBatchReader.State)
+                        {
+                            case ODataBatchReaderState.Operation:
+                                var operationRequestMessage = await multipartMixedBatchReader.CreateOperationRequestMessageAsync();
+                                operationCount++;
+
+                                Assert.Equal("POST", operationRequestMessage.Method);
+
+                                Assert.NotEmpty(verifyUrlStack);
+                                Assert.NotNull(operationRequestMessage.Url);
+                                Assert.Equal(verifyUrlStack.Pop(), operationRequestMessage.Url.OriginalString);
+
+                                Assert.NotEmpty(verifyDependsOnIdsStack);
+                                var verifyDependsOnId = verifyDependsOnIdsStack.Pop();
+                                verifyDependsOnId(operationRequestMessage.DependsOnIds);
+
+                                using (var messageReader = new ODataMessageReader(operationRequestMessage, new ODataMessageReaderSettings(), this.model))
+                                {
+                                    if (operationCount == 3)
+                                    {
+                                        var entityReferenceLink = await messageReader.ReadEntityReferenceLinkAsync();
+
+                                        Assert.Equal("$2", entityReferenceLink.Url.OriginalString);
+                                    }
+                                    else
+                                    {
+                                        var jsonLightResourceReader = await messageReader.CreateODataResourceReaderAsync();
+
+                                        while (await jsonLightResourceReader.ReadAsync())
+                                        {
+                                            switch (jsonLightResourceReader.State)
+                                            {
+                                                case ODataReaderState.ResourceEnd:
+                                                    Assert.NotEmpty(verifyResourceStack);
+                                                    var innerVerifyResourceStack = verifyResourceStack.Pop();
+                                                    innerVerifyResourceStack(jsonLightResourceReader.Item as ODataResource);
+                                                    break;
+                                            }
+                                        }
+                                    }
+                                }
+                                break;
+                        }
+                    }
+                },
+                batchRequestBoundary);
+        }
+
+        [Fact]
+        public void ReadMultipartMixedBatchResponse()
+        {
+            var payload = @"--batchresponse_aed653ab
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 200 OK
+Content-Type: application/json;odata.metadata=minimal;odata.streaming=true
+OData-Version: 4.0
+
+{""@odata.context"":""http://tempuri.org/$metadata#Customers/$entity"",""Id"":1,""Name"":""Sue""}
+--batchresponse_aed653ab--
+";
+
+            SetupMultipartMixedBatchReaderAndRunTest(
+                payload,
+                (multipartMixedBatchReader) =>
+                {
+                    while (multipartMixedBatchReader.Read())
+                    {
+                        switch (multipartMixedBatchReader.State)
+                        {
+                            case ODataBatchReaderState.Operation:
+                                var operationResponseMessage = multipartMixedBatchReader.CreateOperationResponseMessage();
+
+                                using (var messageReader = new ODataMessageReader(operationResponseMessage, new ODataMessageReaderSettings(), this.model))
+                                {
+                                    var jsonLightResourceReader = messageReader.CreateODataResourceReader();
+
+                                    while (jsonLightResourceReader.Read())
+                                    {
+                                        switch (jsonLightResourceReader.State)
+                                        {
+                                            case ODataReaderState.ResourceEnd:
+                                                var resource = jsonLightResourceReader.Item as ODataResource;
+                                                Assert.NotNull(resource);
+                                                Assert.Equal("NS.Customer", resource.TypeName);
+                                                var properties = resource.Properties.ToArray();
+                                                Assert.Equal(2, properties.Length);
+                                                Assert.Equal("Id", properties[0].Name);
+                                                Assert.Equal(1, properties[0].Value);
+                                                Assert.Equal("Name", properties[1].Name);
+                                                Assert.Equal("Sue", properties[1].Value);
+
+                                                break;
+                                        }
+                                    }
+                                }
+                                break;
+                        }
+                    }
+                },
+                batchResponseBoundary,
+                isRequest: false);
+        }
+
+        [Fact]
+        public async Task ReadMultipartMixedBatchResponseAsync()
+        {
+            var payload = @"--batchresponse_aed653ab
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 200 OK
+Content-Type: application/json;odata.metadata=minimal;odata.streaming=true
+OData-Version: 4.0
+
+{""@odata.context"":""http://tempuri.org/$metadata#Customers/$entity"",""Id"":1,""Name"":""Sue""}
+--batchresponse_aed653ab--
+";
+
+            await SetupMultipartMixedBatchReaderAndRunTestAsync(
+                payload,
+                async (multipartMixedBatchReader) =>
+                {
+                    while (await multipartMixedBatchReader.ReadAsync())
+                    {
+                        switch (multipartMixedBatchReader.State)
+                        {
+                            case ODataBatchReaderState.Operation:
+                                var operationResponseMessage = await multipartMixedBatchReader.CreateOperationResponseMessageAsync();
+
+                                using (var messageReader = new ODataMessageReader(operationResponseMessage, new ODataMessageReaderSettings(), this.model))
+                                {
+                                    var jsonLightResourceReader = await messageReader.CreateODataResourceReaderAsync();
+
+                                    while (await jsonLightResourceReader.ReadAsync())
+                                    {
+                                        switch (jsonLightResourceReader.State)
+                                        {
+                                            case ODataReaderState.ResourceEnd:
+                                                var resource = jsonLightResourceReader.Item as ODataResource;
+                                                Assert.NotNull(resource);
+                                                Assert.Equal("NS.Customer", resource.TypeName);
+                                                var properties = resource.Properties.ToArray();
+                                                Assert.Equal(2, properties.Length);
+                                                Assert.Equal("Id", properties[0].Name);
+                                                Assert.Equal(1, properties[0].Value);
+                                                Assert.Equal("Name", properties[1].Name);
+                                                Assert.Equal("Sue", properties[1].Value);
+
+                                                break;
+                                        }
+                                    }
+                                }
+                                break;
+                        }
+                    }
+                },
+                batchResponseBoundary,
+                isRequest: false);
+        }
+
+        #region BatchOperationReadStream
+
+        [Theory]
+        [InlineData(true, "StreamDisposed")]
+        [InlineData(false, "StreamDisposedAsync")]
+        public void ODataBatchReaderStreamDisposeShouldInvokeStreamDisposed(bool synchronous, string expected)
+        {
+            var payload = @"
+
+{""@odata.type"":""NS.Customer"",""Id"":1,""Name"":""Sue""}
+--batch_aed653ab--
+";
+            var stream = new MemoryStream();
+            using (var batchReaderStream = ODataBatchUtils.CreateBatchOperationReadStream(
+                CreateBatchReaderStream(payload),
+                this.batchOperationHeaders,
+                new MockODataStreamListener(new StreamWriter(stream)),
+                synchronous: synchronous))
+            {
+            }
+
+            stream.Position = 0;
+            var contents = new StreamReader(stream).ReadToEnd();
+
+            Assert.Equal(expected, contents);
+        }
+
+        [Theory]
+        [InlineData(true, "StreamDisposed")]
+        [InlineData(false, "StreamDisposedAsync")]
+        public void ODataBatchReaderStreamDisposeShouldBeIdempotent(bool synchronous, string expected)
+        {
+            var payload = @"
+
+{""@odata.type"":""NS.Customer"",""Id"":1,""Name"":""Sue""}
+--batch_aed653ab--
+";
+            var stream = new MemoryStream();
+            var batchReaderStream = ODataBatchUtils.CreateBatchOperationReadStream(
+                CreateBatchReaderStream(payload),
+                this.batchOperationHeaders,
+                new MockODataStreamListener(new StreamWriter(stream)),
+                synchronous: synchronous);
+
+            // 1st call to Dispose
+            batchReaderStream.Dispose();
+            // 2nd call to Dispose
+            batchReaderStream.Dispose();
+
+            stream.Position = 0;
+            var contents = new StreamReader(stream).ReadToEnd();
+
+            // StreamDisposed/StreamDisposeAsync was written only once
+            Assert.Equal(expected, contents);
+        }
+
+#if NETSTANDARD20 || NETCOREAPP3_1
+        [Fact]
+        public async Task ODataBatchReaderStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
+        {
+            var payload = @"
+
+{""@odata.type"":""NS.Customer"",""Id"":1,""Name"":""Sue""}
+--batch_aed653ab--
+";
+            var stream = new MemoryStream();
+            await using (var batchReaderStream = ODataBatchUtils.CreateBatchOperationReadStream(
+                CreateBatchReaderStream(payload),
+                this.batchOperationHeaders,
+                new MockODataStreamListener(new StreamWriter(stream))))// `synchronous` argument becomes irrelevant since we'll directly call DisposeAsync
+            {
+            }
+
+            stream.Position = 0;
+            var contents = await new StreamReader(stream).ReadToEndAsync();
+
+            Assert.Equal("StreamDisposedAsync", contents);
+        }
+
+        [Fact]
+        public async Task ODataBatchReaderStreamDisposeAsyncShouldBeIdempotent()
+        {
+            var payload = @"
+
+{""@odata.type"":""NS.Customer"",""Id"":1,""Name"":""Sue""}
+--batch_aed653ab--
+";
+            var stream = new MemoryStream();
+            var batchReaderStream = ODataBatchUtils.CreateBatchOperationReadStream(
+                CreateBatchReaderStream(payload),
+                this.batchOperationHeaders,
+                new MockODataStreamListener(new StreamWriter(stream)));// `synchronous` argument becomes irrelevant since we'll directly call DisposeAsync
+
+            // 1st call to DisposeAsync
+            await batchReaderStream.DisposeAsync();
+            // 2nd call to DisposeAsync
+            await batchReaderStream.DisposeAsync();
+
+            stream.Position = 0;
+            var contents = await new StreamReader(stream).ReadToEndAsync();
+
+            Assert.Equal("StreamDisposedAsync", contents);
+        }
+#else
+[Fact]
+        public async Task ODataBatchReaderStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
+        {
+            var payload = @"
+
+{""@odata.type"":""NS.Customer"",""Id"":1,""Name"":""Sue""}
+--batch_aed653ab--
+";
+            var stream = new MemoryStream();
+            using (var batchReaderStream = ODataBatchUtils.CreateBatchOperationReadStream(
+                CreateBatchReaderStream(payload),
+                this.batchOperationHeaders,
+                new MockODataStreamListener(new StreamWriter(stream)),
+                synchronous: false))
+            {
+            }
+
+            stream.Position = 0;
+            var contents = await new StreamReader(stream).ReadToEndAsync();
+
+            Assert.Equal("StreamDisposedAsync", contents);
+        }
+#endif
+
+        #endregion BatchOperationReadStream
+        #region BatchOperationWriteStream
+
+        [Theory]
+        [InlineData(true, "StreamDisposed")]
+        [InlineData(false, "StreamDisposedAsync")]
+        public void ODataBatchWriteStreamDisposeShouldInvokeStreamDisposed(bool synchronous, string expected)
+        {
+            var stream = new MemoryStream();
+            using (var batchWriteStream = ODataBatchUtils.CreateBatchOperationWriteStream(
+                new MemoryStream(),
+                new MockODataStreamListener(new StreamWriter(stream)),
+                synchronous: synchronous))
+            {
+            }
+
+            stream.Position = 0;
+            var contents = new StreamReader(stream).ReadToEnd();
+
+            Assert.Equal(expected, contents);
+        }
+
+        [Theory]
+        [InlineData(true, "StreamDisposed")]
+        [InlineData(false, "StreamDisposedAsync")]
+        public void ODataBatchWriterStreamDisposeShouldBeIdempotent(bool synchronous, string expected)
+        {
+            var stream = new MemoryStream();
+            var batchWriteStream = ODataBatchUtils.CreateBatchOperationWriteStream(
+                new MemoryStream(),
+                new MockODataStreamListener(new StreamWriter(stream)),
+                synchronous: synchronous);
+
+            // 1st call to Dispose
+            batchWriteStream.Dispose();
+            // 2nd call to Dispose
+            batchWriteStream.Dispose();
+
+            stream.Position = 0;
+            var contents = new StreamReader(stream).ReadToEnd();
+
+            Assert.Equal(expected, contents);
+        }
+
+#if NETSTANDARD20 || NETCOREAPP3_1
+        [Fact]
+        public async Task ODataBatchWriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
+        {
+            var stream = new MemoryStream();
+            await using (var batchWriteStream = ODataBatchUtils.CreateBatchOperationWriteStream(
+                new MemoryStream(),
+                new MockODataStreamListener(new StreamWriter(stream))))// `synchronous` argument becomes irrelevant since we'll directly call DisposeAsync
+            {
+            }
+
+            stream.Position = 0;
+            var contents = await new StreamReader(stream).ReadToEndAsync();
+
+            Assert.Equal("StreamDisposedAsync", contents);
+        }
+
+        [Fact]
+        public async Task ODataBatchWriteStreamDisposeAsyncShouldBeIdempotent()
+        {
+            var stream = new MemoryStream();
+            var batchWriteStream = ODataBatchUtils.CreateBatchOperationWriteStream(
+                new MemoryStream(),
+                new MockODataStreamListener(new StreamWriter(stream)));// `synchronous` argument becomes irrelevant since we'll directly call DisposeAsync
+
+            // 1st call to DisposeAsync
+            await batchWriteStream.DisposeAsync();
+            // 2nd call to DisposeAsync
+            await batchWriteStream.DisposeAsync();
+
+            stream.Position = 0;
+            var contents = await new StreamReader(stream).ReadToEndAsync();
+
+            Assert.Equal("StreamDisposedAsync", contents);
+        }
+#else
+        [Fact]
+        public async Task ODataBatchWriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
+        {
+            var stream = new MemoryStream();
+            using (var batchWriteStream = ODataBatchUtils.CreateBatchOperationWriteStream(
+                new MemoryStream(),
+                new MockODataStreamListener(new StreamWriter(stream)),
+                synchronous: false))
+            {
+            }
+
+            stream.Position = 0;
+            var contents = await new StreamReader(stream).ReadToEndAsync();
+
+            Assert.Equal("StreamDisposedAsync", contents);
+        }
+#endif
+
+        #endregion BatchOperationWriteStream
+
+        private void InitializeEdmModel()
+        {
+            this.model = new EdmModel();
+
+            var orderEntityType = new EdmEntityType("NS", "Order", /*baseType*/ null, /*isAbstract*/ false, /*isOpen*/ true);
+            var customerEntityType = new EdmEntityType("NS", "Customer");
+
+            var orderIdProperty = orderEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32);
+            orderEntityType.AddKeys(orderIdProperty);
+            orderEntityType.AddStructuralProperty("CustomerId", EdmPrimitiveTypeKind.Int32);
+            orderEntityType.AddStructuralProperty("Amount", EdmPrimitiveTypeKind.Decimal);
+            var customerNavProperty = orderEntityType.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Customer",
+                    Target = customerEntityType,
+                    TargetMultiplicity = EdmMultiplicity.ZeroOrOne
+                });
+            model.AddElement(orderEntityType);
+
+            var customerIdProperty = customerEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32);
+            customerEntityType.AddKeys(customerIdProperty);
+            customerEntityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            var ordersNavProperty = customerEntityType.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo
+                {
+                    Name = "Orders",
+                    Target = orderEntityType,
+                    TargetMultiplicity = EdmMultiplicity.Many
+                });
+            this.model.AddElement(customerEntityType);
+
+            var entityContainer = new EdmEntityContainer("NS", "Container");
+            this.model.AddElement(entityContainer);
+
+            var orderEntitySet = entityContainer.AddEntitySet("Orders", orderEntityType);
+            var customerEntitySet = entityContainer.AddEntitySet("Customers", customerEntityType);
+
+            orderEntitySet.AddNavigationTarget(customerNavProperty, customerEntitySet);
+            customerEntitySet.AddNavigationTarget(ordersNavProperty, orderEntitySet);
+        }
+
+        private ODataMultipartMixedBatchReaderStream CreateBatchReaderStream(string payload, bool synchronous = true, bool isRequest = true)
+        {
+            var multipartMixedBatchInputContext = CreateMultipartMixedBatchInputContext(
+                payload,
+                isRequest,
+                synchronous: synchronous);
+
+            return new ODataMultipartMixedBatchReaderStream(
+                multipartMixedBatchInputContext,
+                batchRequestBoundary,
+                MediaTypeUtils.EncodingUtf8NoPreamble);
+        }
+
+        /// <summary>
+        /// Sets up an ODataMultipartMixedBatchReader, then runs the given test code
+        /// </summary>
+        private void SetupMultipartMixedBatchReaderAndRunTest(
+            string payload,
+            Action<ODataMultipartMixedBatchReader> action,
+            string batchBoundary,
+            bool isRequest = true)
+        {
+            var multipartMixedBatchInputContext = CreateMultipartMixedBatchInputContext(
+                payload,
+                isRequest,
+                synchronous: true);
+            var multipartMixedBatchReader = new ODataMultipartMixedBatchReader(
+                multipartMixedBatchInputContext,
+                batchBoundary,
+                MediaTypeUtils.EncodingUtf8NoPreamble,
+                synchronous: true);
+
+            action(multipartMixedBatchReader);
+        }
+
+        /// <summary>
+        /// Sets up an ODataMultipartMixedBatchReader, then runs the given test code asynchronously
+        /// </summary>
+        private async Task SetupMultipartMixedBatchReaderAndRunTestAsync(
+            string payload,
+            Func<ODataMultipartMixedBatchReader, Task> func,
+            string batchBoundary,
+            bool isRequest = true)
+        {
+            var multipartMixedBatchInputContext = CreateMultipartMixedBatchInputContext(
+                payload,
+                isRequest,
+                synchronous: false);
+            var multipartMixedBatchReader = new ODataMultipartMixedBatchReader(
+                multipartMixedBatchInputContext,
+                batchBoundary,
+                MediaTypeUtils.EncodingUtf8NoPreamble,
+                synchronous: false);
+
+            await func(multipartMixedBatchReader);
+        }
+
+        private ODataMultipartMixedBatchInputContext CreateMultipartMixedBatchInputContext(
+            string payload,
+            bool isRequest = true,
+            bool synchronous = true)
+        {
+            var encoding = MediaTypeUtils.EncodingUtf8NoPreamble;
+            var messageInfo = new ODataMessageInfo
+            {
+                MessageStream = new MemoryStream(encoding.GetBytes(payload)),
+                MediaType = this.mediaType,
+                Encoding = encoding,
+                IsResponse = !isRequest,
+                IsAsync = !synchronous
+            };
+
+            return new ODataMultipartMixedBatchInputContext(ODataFormat.Batch, messageInfo, this.messageReaderSettings);
+        }
+
+        private class MockODataStreamListener : IODataStreamListener
+        {
+            private TextWriter writer;
+
+            public MockODataStreamListener(TextWriter writer)
+            {
+                this.writer = writer;
+            }
+
+            public void StreamDisposed()
+            {
+                writer.Write("StreamDisposed");
+                writer.Flush();
+            }
+
+            public async Task StreamDisposedAsync()
+            {
+                await writer.WriteAsync("StreamDisposedAsync").ConfigureAwait(false);
+                await writer.FlushAsync().ConfigureAwait(false);
+            }
+
+            public void StreamRequested()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task StreamRequestedAsync()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes https://github.com/OData/AspNetCoreOData/issues/624.*

### Description

Fix synchronous operations disallowed error when using Kestrel web server.

`AllowSynchronousIO` option is disabled by default from .NET Core 3.0.0-preview3 in (**Kestrel**, **HttpSys**, **IIS In-Process**, **TestServer**) web servers because these APIs are source of thread starvation and application hangs.
A call to `Dispose` method of `StreamWriter` from `RawValueWriter` was ultimately causing the `Flush` method of `Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseStream` to be triggered.
As a result, a _**System.InvalidOperationException: Synchronous operations are disallowed. Call ReadAsync or set AllowSynchronousIO to true instead**_ is thrown when using Kestrel web server.
What this change does is ensure that `DisposeAsync` method is trigged instead of Dispose from `RawValueWriter` class that is used when writing batch payloads.

#### Stack Trace

> Connection id "0HMJ5BJNH8K3F", Request id "0HMJ5BJNH8K3F:00000001": An unhandled exception was thrown by the application.
> System.AggregateException: One or more errors occurred. (Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.)
>  ---> System.InvalidOperationException: Synchronous operations are disallowed. Call WriteAsync or set AllowSynchronousIO to true instead.
>    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpResponseStream.Flush()
>    at Microsoft.OData.MessageStreamWrapper.MessageStreamWrappingStream.Flush() in C:\odata.net\src\Microsoft.OData.Core\MessageStreamWrapper.cs:line 161
>    at System.IO.BufferedStream.Flush()
>    at Microsoft.OData.MessageStreamWrapper.MessageStreamWrappingStream.Flush() in C:\odata.net\src\Microsoft.OData.Core\MessageStreamWrapper.cs:line 161
>    at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
>    at System.IO.StreamWriter.Dispose(Boolean disposing)
>    at System.IO.TextWriter.Dispose()
>    at Microsoft.OData.RawValueWriter.Dispose() in C:\odata.net\src\Microsoft.OData.Core\RawValueWriter.cs:line 85
>    at Microsoft.OData.ODataRawOutputContext.CloseWriter() in C:\odata.net\src\Microsoft.OData.Core\ODataRawOutputContext.cs:line 275
>    at Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchWriter.DisposeBatchWriterAndSetContentStreamRequestedState() in C:\odata.net\src\Microsoft.OData.Core\MultipartMixed\ODataMultipartMixedBatchWriter.cs:line 601
>    at Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchWriter.StreamRequestedAsync() in C:\odata.net\src\Microsoft.OData.Core\MultipartMixed\ODataMultipartMixedBatchWriter.cs:line 128
>    --- End of inner exception stack trace ---
>    at Microsoft.AspNetCore.OData.Batch.ODataBatchResponseItem.WriteMessageAsync(ODataBatchWriter writer, HttpContext context) in C:\Users\jogathog\Projects\AspNetCoreOData\src\Microsoft.AspNetCore.OData\Batch\ODataBatchResponseItem.cs:line 52
>    at Microsoft.AspNetCore.OData.Batch.ChangeSetResponseItem.WriteResponseAsync(ODataBatchWriter writer) in C:\Users\jogathog\Projects\AspNetCoreOData\src\Microsoft.AspNetCore.OData\Batch\ChangeSetResponseItem.cs:line 52
>    at Microsoft.AspNetCore.OData.Batch.ODataBatchContent.WriteToResponseMessageAsync(IODataResponseMessage responseMessage) in C:\Users\jogathog\Projects\AspNetCoreOData\src\Microsoft.AspNetCore.OData\Batch\ODataBatchContent.cs:line 107
>    at Microsoft.AspNetCore.OData.Batch.DefaultODataBatchHandler.ProcessBatchAsync(HttpContext context, RequestDelegate nextHandler) in C:\Users\jogathog\Projects\AspNetCoreOData\src\Microsoft.AspNetCore.OData\Batch\DefaultODataBatchHandler.cs:line 53
>    at Microsoft.AspNetCore.OData.Batch.ODataBatchMiddleware.Invoke(HttpContext context) in C:\Users\jogathog\Projects\AspNetCoreOData\src\Microsoft.AspNetCore.OData\Batch\ODataBatchMiddleware.cs:line 71
>    at Microsoft.AspNetCore.OData.Routing.ODataRouteDebugMiddleware.Invoke(HttpContext context) in C:\Users\jogathog\Projects\AspNetCoreOData\src\Microsoft.AspNetCore.OData\Routing\ODataRouteDebugMiddleware.cs:line 80
>    at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
