### PR TITLE
Add CreateAsynchronousJsonWriter to IStreamBasedJsonWriterFactoryAsync

### DIFF
--- a/src/Microsoft.OData.Core/Json/DefaultStreamBasedJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/DefaultStreamBasedJsonWriterFactory.cs
@@ -50,6 +50,11 @@ namespace Microsoft.OData.Json
 
             return new ODataUtf8JsonWriter(stream, isIeee754Compatible, encoding, encoder: this.encoder);
         }
+
+        public IJsonWriterAsync CreateAsynchronousJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding)
+        {
+            throw new NotImplementedException();
+        }
     }
 }
 #endif

--- a/src/Microsoft.OData.Core/Json/IStreamBasedJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/IStreamBasedJsonWriterFactory.cs
@@ -25,5 +25,16 @@ namespace Microsoft.OData.Json
         /// <param name="encoding">The text encoding of the output data.</param>
         /// <returns>The JSON writer created.</returns>
         IJsonWriter CreateJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding);
+
+        /// <summary>
+        /// Creates an asynchronous JSON writer of <see cref="IJsonWriterAsync"/>.
+        /// The returned instance should also implement the synchronous <see cref="IJsonWriter"/>
+        /// interface.
+        /// </summary>
+        /// <param name="stream">Output stream to which the resulting <see cref="IJsonWriterAsync"/> should write data.</param>
+        /// <param name="isIeee754Compatible">True if it is IEEE754Compatible.</param>
+        /// <param name="encoding">The text encoding of the output data.</param>
+        /// <returns>The JSON writer created.</returns>
+        IJsonWriterAsync CreateAsynchronousJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding);
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockStreamBasedJsonWriterFactory.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockStreamBasedJsonWriterFactory.cs
@@ -24,6 +24,11 @@ namespace Microsoft.OData.Tests.Json
         {
             return this.jsonWriter;
         }
+
+        public IJsonWriterAsync CreateAsynchronousJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }
 #endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockStreamBasedJsonWriterFactoryWrapper.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockStreamBasedJsonWriterFactoryWrapper.cs
@@ -41,6 +41,11 @@ namespace Microsoft.OData.Tests.Json
             return writer;
         }
 
+        public IJsonWriterAsync CreateAsynchronousJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding)
+        {
+            throw new NotImplementedException();
+        }
+
         /// <summary>
         /// The <see cref="IJsonWriter"/> that was last created by the wrapped <see cref="IStreamBasedJsonWriterFactory"/>.
         /// </summary>

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -5975,6 +5975,7 @@ public interface Microsoft.OData.Json.IJsonWriterFactoryAsync {
 CLSCompliantAttribute(),
 ]
 public interface Microsoft.OData.Json.IStreamBasedJsonWriterFactory {
+    Microsoft.OData.Json.IJsonWriterAsync CreateAsynchronousJsonWriter (System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding)
     Microsoft.OData.Json.IJsonWriter CreateJsonWriter (System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding)
 }
 

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -5975,6 +5975,7 @@ public interface Microsoft.OData.Json.IJsonWriterFactoryAsync {
 CLSCompliantAttribute(),
 ]
 public interface Microsoft.OData.Json.IStreamBasedJsonWriterFactory {
+    Microsoft.OData.Json.IJsonWriterAsync CreateAsynchronousJsonWriter (System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding)
     Microsoft.OData.Json.IJsonWriter CreateJsonWriter (System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding)
 }
 

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -5975,6 +5975,7 @@ public interface Microsoft.OData.Json.IJsonWriterFactoryAsync {
 CLSCompliantAttribute(),
 ]
 public interface Microsoft.OData.Json.IStreamBasedJsonWriterFactory {
+    Microsoft.OData.Json.IJsonWriterAsync CreateAsynchronousJsonWriter (System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding)
     Microsoft.OData.Json.IJsonWriter CreateJsonWriter (System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding)
 }
 


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

Related to #2421 

### Description

This PR adds the `CreateAsynchronousJsonWriter` method to the `IStreamBasedJsonWriter` interface that was introduced as part of the `ODataUtf8JsonWriter` work (https://github.com/OData/odata.net/pull/2416).

This method will allow the same interface to also be used to create `IJsonWriterAsync`. This is a change that is being back-ported from the currently pending PR that's implementing the async API for `ODataUtf8JsonWriter` (https://github.com/OData/odata.net/pull/2460).

The goal is to merge this PR before the next release so that when we release the async API for `ODataUtf8JsonWriter`, it will not be a breaking change.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
