### PR TITLE
Fix DisposeAsync implementation for .NET Core 3.1 and higher

### DIFF
--- a/src/Microsoft.OData.Core/ODataNotificationReader.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationReader.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData
     /// <summary>
     /// Wrapper for TextReader to listen for dispose.
     /// </summary>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
     internal sealed class ODataNotificationReader : TextReader, IAsyncDisposable
 #else
     internal sealed class ODataNotificationReader : TextReader
@@ -148,7 +148,7 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         public async ValueTask DisposeAsync()
         {
             if (!this.disposed)

--- a/src/Microsoft.OData.Core/ODataNotificationStream.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationStream.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData
     /// <summary>
     /// Wrapper to listen for dispose on a <see cref="Stream"/>.
     /// </summary>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_0
     internal sealed class ODataNotificationStream : Stream, IAsyncDisposable
 #else
     internal sealed class ODataNotificationStream : Stream
@@ -227,8 +227,29 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP
-        public async ValueTask DisposeAsync()
+#if NETCOREAPP3_1_OR_GREATER
+        /// <inheritdoc/>
+        public override ValueTask DisposeAsync()
+        {
+            return DisposeAsyncCore();
+        }
+#elif NETSTANDARD2_0
+        /// <summary>
+        /// Asynchronously releases all resources used by the <see cref="ODataNotificationStream"/> object.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
+        public ValueTask DisposeAsync()
+        {
+            return DisposeAsyncCore();
+        }
+#endif
+
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+        /// <summary>
+        /// Asynchronously releases all resources used by the <see cref="ODataNotificationStream"/> object.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
+        public async ValueTask DisposeAsyncCore()
         {
             if (!this.disposed && this.listener != null)
             {

--- a/src/Microsoft.OData.Core/ODataNotificationStream.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationStream.cs
@@ -249,7 +249,7 @@ namespace Microsoft.OData
         /// Asynchronously releases all resources used by the <see cref="ODataNotificationStream"/> object.
         /// </summary>
         /// <returns>A task that represents the asynchronous dispose operation.</returns>
-        public async ValueTask DisposeAsyncCore()
+        private async ValueTask DisposeAsyncCore()
         {
             if (!this.disposed && this.listener != null)
             {

--- a/src/Microsoft.OData.Core/ODataNotificationWriter.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationWriter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData
     /// <summary>
     /// Wrapper for TextWriter to listen for dispose.
     /// </summary>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_0
     internal sealed class ODataNotificationWriter : TextWriter, IAsyncDisposable
 #else
     internal sealed class ODataNotificationWriter : TextWriter
@@ -348,8 +348,29 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
+#if NETCOREAPP3_1_OR_GREATER
+        /// <inheritdoc/>
+        public override ValueTask DisposeAsync()
+        {
+            return DisposeAsyncCore();
+        }
+#elif NETSTANDARD2_0
+        /// <summary>
+        /// Asynchronously releases all resources used by the <see cref="ODataNotificationWriter"/> object.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
+        public ValueTask DisposeAsync()
+        {
+            return DisposeAsyncCore();
+        }
+#endif
+
 #if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
-        public async ValueTask DisposeAsync()
+        /// <summary>
+        /// Asynchronously releases all resources used by the <see cref="ODataNotificationWriter"/> object.
+        /// </summary>
+        /// <returns>A task that represents the asynchronous dispose operation.</returns>
+        private async ValueTask DisposeAsyncCore()
         {
             if (!this.disposed && this.listener != null)
             {

--- a/src/Microsoft.OData.Core/ODataStream.cs
+++ b/src/Microsoft.OData.Core/ODataStream.cs
@@ -18,7 +18,7 @@ namespace Microsoft.OData
     /// or representing a stream value.
     /// This stream communicates status changes to an IODataStreamListener instance.
     /// </summary>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETSTANDARD2_0
     internal abstract class ODataStream : Stream, IAsyncDisposable
 #else
     internal abstract class ODataStream : Stream
@@ -82,7 +82,17 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
+        public override async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore()
+                .ConfigureAwait(false);
+
+            // Dispose unmanaged resources
+            // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
+            this.Dispose(false);
+        }
+#elif NETSTANDARD2_0
         public async ValueTask DisposeAsync()
         {
             await DisposeAsyncCore()
@@ -92,7 +102,9 @@ namespace Microsoft.OData
             // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
             this.Dispose(false);
         }
+#endif
 
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         /// <summary>
         /// Encapsulates the common asynchronous cleanup operations.
         /// </summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationReaderTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public async Task NotificationReaderDisposeAsyncShouldInvokeStreamDisposedAsync()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationReaderTests.cs
@@ -67,9 +67,9 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETCOREAPP3_1
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         [Fact]
-        public async Task NotificationReaderDisposeShouldInvokeStreamDisposedAsync()
+        public async Task NotificationReaderDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
             await using (var notificationReader = new ODataNotificationReader(
                 this.reader,
@@ -83,7 +83,7 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
-        public async Task NotificationReaderDisposeAsyncShouldBeIdempotent()
+        public async Task NotificationReaderDisposeAsyncShouldBeIdempotentAsync()
         {
             var notificationReader = new ODataNotificationReader(
                 this.reader,
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Tests
 
 #else
         [Fact]
-        public async Task NotificationReaderDisposeShouldInvokeStreamDisposedAsync()
+        public async Task NotificationReaderDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
             using (var notificationReader = new ODataNotificationReader(
                 this.reader,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public async Task NotificationStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -99,7 +99,7 @@ namespace Microsoft.OData.Tests
 
 #else
         [Fact]
-        public async Task NotificationStreamDisposeShouldInvokeStreamDisposedAsync()
+        public async Task NotificationStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
             using (Stream notificationStream = new ODataNotificationStream(
                 this.stream,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OData.Tests
         {
             // We care about the notification stream being disposed
             // We don't care about the stream passed to the notification stream
-            using (var notificationStream = new ODataNotificationStream(
+            using (Stream notificationStream = new ODataNotificationStream(
                 this.stream,
                 this.streamListener,
                 synchronous))
@@ -48,7 +48,7 @@ namespace Microsoft.OData.Tests
         [InlineData(false, "StreamDisposedAsync")]
         public void NotificationStreamDisposeShouldBeIdempotent(bool synchronous, string expected)
         {
-            var notificationStream = new ODataNotificationStream(
+            Stream notificationStream = new ODataNotificationStream(
                 this.stream,
                 this.streamListener,
                 synchronous);
@@ -64,11 +64,11 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETCOREAPP3_1
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         [Fact]
-        public async Task NotificationStreamDisposeShouldInvokeStreamDisposedAsync()
+        public async Task NotificationStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
-            await using (var notificationStream = new ODataNotificationStream(
+            await using (Stream notificationStream = new ODataNotificationStream(
                 this.stream,
                 this.streamListener)) // `synchronous` argument becomes irrelevant
             {
@@ -80,9 +80,9 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
-        public async Task NotificationStreamDisposeAsyncShouldBeIdempotent()
+        public async Task NotificationStreamDisposeAsyncShouldBeIdempotentAsync()
         {
-            var notificationStream = new ODataNotificationStream(
+            Stream notificationStream = new ODataNotificationStream(
                 this.stream,
                 this.streamListener);
 
@@ -101,7 +101,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public async Task NotificationStreamDisposeShouldInvokeStreamDisposedAsync()
         {
-            using (var notificationStream = new ODataNotificationStream(
+            using (Stream notificationStream = new ODataNotificationStream(
                 this.stream,
                 this.streamListener,
                 /*synchronous*/ false))

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OData.Tests
         {
             // We care about the notification writer being disposed
             // We don't care about the writer passed to the notification writer
-            using (var notificationWriter = new ODataNotificationWriter(
+            using (TextWriter notificationWriter = new ODataNotificationWriter(
                 this.writer,
                 this.streamListener,
                 synchronous))
@@ -48,7 +48,7 @@ namespace Microsoft.OData.Tests
         [InlineData(false, "StreamDisposedAsync")]
         public void NotificationWriterDisposeShouldBeIdempotent(bool synchronous, string expected)
         {
-            var notificationWriter = new ODataNotificationWriter(
+            TextWriter notificationWriter = new ODataNotificationWriter(
                 this.writer,
                 this.streamListener,
                 synchronous);
@@ -64,11 +64,11 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETCOREAPP3_1
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         [Fact]
-        public async Task NotificationWriterDisposeShouldInvokeStreamDisposedAsync()
+        public async Task NotificationWriterDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
-            await using (var notificationWriter = new ODataNotificationWriter(
+            await using (TextWriter notificationWriter = new ODataNotificationWriter(
                 this.writer,
                 this.streamListener)) // `synchronous` argument becomes irrelevant since we'll directly call DisposeAsync
             {
@@ -80,9 +80,9 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
-        public async Task NotificationWriterDisposeAsyncShouldBeIdempotent()
+        public async Task NotificationWriterDisposeAsyncShouldBeIdempotentAsync()
         {
-            var notificationWriter = new ODataNotificationWriter(
+            TextWriter notificationWriter = new ODataNotificationWriter(
                 this.writer,
                 this.streamListener);
 
@@ -101,7 +101,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public async Task NotificationWriterDisposeShouldInvokeStreamDisposedAsync()
         {
-            using (var notificationWriter = new ODataNotificationWriter(
+            using (TextWriter notificationWriter = new ODataNotificationWriter(
                 this.writer,
                 this.streamListener,
                 /*synchronous*/ false))

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
@@ -64,7 +64,7 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public async Task NotificationWriterDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -99,7 +99,7 @@ namespace Microsoft.OData.Tests
 
 #else
         [Fact]
-        public async Task NotificationWriterDisposeShouldInvokeStreamDisposedAsync()
+        public async Task NotificationWriterDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
             using (TextWriter notificationWriter = new ODataNotificationWriter(
                 this.writer,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriteStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriteStreamTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.OData.Tests
         {
             // We care about the write stream being disposed
             // We don't care about the stream passed to the write stream
-            using (var writeStream = new ODataWriteStream(
+            using (Stream writeStream = new ODataWriteStream(
                 new MemoryStream(),
                 this.streamListener,
                 synchronous))
@@ -51,7 +51,7 @@ namespace Microsoft.OData.Tests
         [InlineData(false, "StreamDisposedAsync")]
         public void WriteStreamDisposeShouldBeIdempotent(bool synchronous, string expected)
         {
-            var writeStream = new ODataWriteStream(
+            Stream writeStream = new ODataWriteStream(
                 new MemoryStream(),
                 this.streamListener,
                 synchronous);
@@ -67,11 +67,11 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETCOREAPP3_1
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         [Fact]
-        public async Task WriteStreamDisposeShouldInvokeStreamDisposedAsync()
+        public async Task WriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
-            await using (var writeStream = new ODataWriteStream(
+            await using (Stream writeStream = new ODataWriteStream(
                 new MemoryStream(),
                 this.streamListener)) // `synchronous` argument becomes irrelevant
             {
@@ -83,9 +83,9 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
-        public async Task WriteStreamDisposeAsyncShouldBeIdempotent()
+        public async Task WriteStreamDisposeAsyncShouldBeIdempotentAsync()
         {
-            var writeStream = new ODataWriteStream(
+            Stream writeStream = new ODataWriteStream(
                 new MemoryStream(),
                 this.streamListener);
 
@@ -104,7 +104,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public async Task WriteStreamDisposeShouldInvokeStreamDisposedAsync()
         {
-            using (var writeStream = new ODataWriteStream(
+            using (Stream writeStream = new ODataWriteStream(
                 new MemoryStream(),
                 this.streamListener,
                 /*synchronous*/ false))

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriteStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriteStreamTests.cs
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public async Task WriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Tests
 
 #else
         [Fact]
-        public async Task WriteStreamDisposeShouldInvokeStreamDisposedAsync()
+        public async Task WriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
             using (Stream writeStream = new ODataWriteStream(
                 new MemoryStream(),


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Fixes `DisposeAsync` implementation by overriding base .NET Core 3.1 and higher

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
