### PR TITLE
Implement ODataUtf8JsonWriter async API

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -71,7 +71,7 @@ scenarios:
         filter: "*ODataWriter*"
   UriParser:
     application:
-      job: component
+      job: components
       variables:
         filter: "*UriParser*"
   Components:

--- a/src/Microsoft.OData.Core/Json/DefaultStreamBasedJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/DefaultStreamBasedJsonWriterFactory.cs
@@ -53,7 +53,17 @@ namespace Microsoft.OData.Json
 
         public IJsonWriterAsync CreateAsynchronousJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding)
         {
-            throw new NotImplementedException();
+            if (stream == null)
+            {
+                throw new ArgumentNullException(nameof(stream));
+            }
+
+            if (encoding == null)
+            {
+                throw new ArgumentNullException(nameof(encoding));
+            }
+
+            return new ODataUtf8JsonWriter(stream, isIeee754Compatible, encoding, encoder: this.encoder);
         }
     }
 }

--- a/src/Microsoft.OData.Core/Json/IStreamBasedJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/IStreamBasedJsonWriterFactory.cs
@@ -11,7 +11,7 @@ using System.Text;
 namespace Microsoft.OData.Json
 {
     /// <summary>
-    /// The interface of factories that create <see cref="IJsonWriter"/> instances
+    /// The interface of factories that create <see cref="IJsonWriterAsync"/> and <see cref="IJsonWriter"/> instances
     /// that write directly to a <see cref="Stream"/> rather than a <see cref="TextWriter"/>.
     /// </summary>
     [CLSCompliant(false)]

--- a/src/Microsoft.OData.Core/Json/IStreamBasedJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/IStreamBasedJsonWriterFactory.cs
@@ -11,7 +11,7 @@ using System.Text;
 namespace Microsoft.OData.Json
 {
     /// <summary>
-    /// The interface of factories that create <see cref="IJsonWriterAsync"/> and <see cref="IJsonWriter"/> instances
+    /// The interface of factories that create <see cref="IJsonWriter"/> and <see cref="IJsonWriterAsync"/> instances
     /// that write directly to a <see cref="Stream"/> rather than a <see cref="TextWriter"/>.
     /// </summary>
     [CLSCompliant(false)]

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData.Json
     {
         private const int DefaultBufferSize = 16 * 1024;
         private readonly float bufferFlushThreshold;
-        private readonly static ReadOnlyMemory<byte> Parentheses = new byte[] { (byte)'(', (byte)')' };
+        private readonly static ReadOnlyMemory<byte> parentheses = new byte[] { (byte)'(', (byte)')' };
 
         private readonly Stream outputStream;
         private readonly Stream writeStream;
@@ -319,7 +319,7 @@ namespace Microsoft.OData.Json
         public async Task StartPaddingFunctionScopeAsync()
         {
             await this.FlushAsync().ConfigureAwait(false);
-            await this.writeStream.WriteAsync(Parentheses[..1]).ConfigureAwait(false);
+            await this.writeStream.WriteAsync(parentheses[..1]).ConfigureAwait(false);
         }
 
         public async Task WritePaddingFunctionNameAsync(string functionName)
@@ -331,7 +331,7 @@ namespace Microsoft.OData.Json
         public async Task EndPaddingFunctionScopeAsync()
         {
             await this.FlushAsync().ConfigureAwait(false);
-            await this.writeStream.WriteAsync(Parentheses[1..2]).ConfigureAwait(false);
+            await this.writeStream.WriteAsync(parentheses[1..2]).ConfigureAwait(false);
         }
 
         public async Task StartObjectScopeAsync()
@@ -364,7 +364,6 @@ namespace Microsoft.OData.Json
             await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
         }
 
-        
         public async Task WriteValueAsync(bool value)
         {
             this.writer.WriteBooleanValue(value);

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -319,8 +319,7 @@ namespace Microsoft.OData.Json
         public async Task StartPaddingFunctionScopeAsync()
         {
             await this.FlushAsync().ConfigureAwait(false);
-            // writes '('
-            await this.writeStream.WriteAsync(Parantheses[..1]).ConfigureAwait(false);
+            await this.writeStream.WriteAsync(stackalloc byte[] { '(' }.ConfigureAwait(false);
         }
 
         public async Task WritePaddingFunctionNameAsync(string functionName)
@@ -332,8 +331,7 @@ namespace Microsoft.OData.Json
         public async Task EndPaddingFunctionScopeAsync()
         {
             await this.FlushAsync().ConfigureAwait(false);
-            // writes ')'
-            await this.writeStream.WriteAsync(Parantheses[1..2]).ConfigureAwait(false);
+            await this.writeStream.WriteAsync(stackalloc byte[] {  ')' }]).ConfigureAwait(false);
         }
 
         public async Task StartObjectScopeAsync()

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData.Json
     {
         private const int DefaultBufferSize = 16 * 1024;
         private readonly float bufferFlushThreshold;
-        private readonly static ReadOnlyMemory<byte> Parantheses = new byte[] { (byte)'(', (byte)')' };
+        private readonly static ReadOnlyMemory<byte> Parentheses = new byte[] { (byte)'(', (byte)')' };
 
         private readonly Stream outputStream;
         private readonly Stream writeStream;
@@ -319,7 +319,7 @@ namespace Microsoft.OData.Json
         public async Task StartPaddingFunctionScopeAsync()
         {
             await this.FlushAsync().ConfigureAwait(false);
-            await this.writeStream.WriteAsync(stackalloc byte[] { '(' }.ConfigureAwait(false);
+            await this.writeStream.WriteAsync(Parentheses[..1]).ConfigureAwait(false);
         }
 
         public async Task WritePaddingFunctionNameAsync(string functionName)
@@ -331,7 +331,7 @@ namespace Microsoft.OData.Json
         public async Task EndPaddingFunctionScopeAsync()
         {
             await this.FlushAsync().ConfigureAwait(false);
-            await this.writeStream.WriteAsync(stackalloc byte[] {  ')' }]).ConfigureAwait(false);
+            await this.writeStream.WriteAsync(Parentheses[1..2]).ConfigureAwait(false);
         }
 
         public async Task StartObjectScopeAsync()

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -117,11 +117,9 @@ namespace Microsoft.OData.JsonLight
                         this.messageOutputStream,
                         isIeee754Compatible,
                         messageInfo.Encoding);
-                }
 
-                if (this.asynchronousJsonWriter == null && streamBasedJsonWriterFactory != null)
-                {
-                    this.jsonWriter = CreateJsonWriter(streamBasedJsonWriterFactory, this.messageOutputStream, isIeee754Compatible, messageInfo.Encoding);
+                    // the IStreamBasedJsonWriterFactory expects that the async writer also implements
+                    // the synchronous interface. The EnsureJsonWritersAreTheSame() method verifies this.
                 }
 
                 // Then fallback to the TextWriter-based approach

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -72,14 +72,6 @@ namespace Microsoft.OData.JsonLight
         private PropertyCacheHandler propertyCacheHandler;
 
         /// <summary>
-        /// The concrete <see cref="JsonWriter"/> instance initialized when
-        /// creating either synchronous or asynchronous writer.
-        /// Used to guarantee that the synchronous and asynchronous writers share the same scope(s) specifically
-        /// because the synchronous writer is used to write spatial data in both synchronous and asynchronous scenarios.
-        /// </summary>
-        //private JsonWriter concreteJsonWriter;
-
-        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="messageInfo">The context information for the message.</param>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -876,7 +876,7 @@ namespace Microsoft.OData.JsonLight
         /// when the JSON writer factory is DefaultJsonWriterFactory - since both CreateJsonWriter and
         /// CreateAsynchronousJsonWriter methods of that factory return an instance of JsonWriter.
         /// Merging IJsonWriter and IJsonWriterAsync interface in a major release will simplify this.</remarks>
-        private IJsonWriter CreateJsonWriter(
+        private static IJsonWriter CreateJsonWriter(
             IServiceProvider container,
             TextWriter textWriter,
             bool isIeee754Compatible,
@@ -936,7 +936,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="isIeee754Compatible">true if the writer should write large integers as strings.</param>
         /// <param name="writerSettings">Configuration settings for the OData writer.</param>
         /// <returns>An asynchronous JSON writer.</returns>
-        private IJsonWriterAsync CreateAsynchronousJsonWriter(
+        private static IJsonWriterAsync CreateAsynchronousJsonWriter(
             IServiceProvider container,
             TextWriter textWriter,
             bool isIeee754Compatible,
@@ -961,7 +961,7 @@ namespace Microsoft.OData.JsonLight
             return asynchronousJsonWriter;
         }
 
-        private IJsonWriterAsync CreateAsynchronousJsonWriter(
+        private static IJsonWriterAsync CreateAsynchronousJsonWriter(
             IStreamBasedJsonWriterFactory factory,
             Stream outputStream,
             bool isIeee754Compatible,
@@ -994,21 +994,21 @@ namespace Microsoft.OData.JsonLight
             if (this.jsonWriter != null && this.asynchronousJsonWriter == null && this.jsonWriter is IJsonWriterAsync jsonWriterAsync)
             {
                 this.asynchronousJsonWriter = jsonWriterAsync;
+                return;
             }
 
             if (this.asynchronousJsonWriter != null && this.jsonWriter == null)
             {
-                if (this.asynchronousJsonWriter is IJsonWriter jsonWriter)
+                if (this.asynchronousJsonWriter is IJsonWriter syncJsonWriter)
                 {
-                    this.jsonWriter = jsonWriter;
+                    this.jsonWriter = syncJsonWriter;
+                    return;
                 }
-                else
-                {
-                    throw new ODataException(Strings.ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter);
-                }
+
+                throw new ODataException(Strings.ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter);
             }
 
-            if (this.asynchronousJsonWriter != null && !this.asynchronousJsonWriter.Equals(this.jsonWriter))
+            if (this.asynchronousJsonWriter != null && !object.ReferenceEquals(this.asynchronousJsonWriter, this.jsonWriter))
             {
                 throw new ODataException(Strings.ODataMessageWriter_IJsonWriter_And_IJsonWriterAsync_Are_Different_Instances);
             }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -139,7 +139,7 @@ namespace Microsoft.OData.JsonLight
                     }
                 }
 
-                this.VerifyJsonWriter();
+                this.EnsureJsonWritersAreTheSame();
             }
             catch (Exception e)
             {
@@ -183,7 +183,7 @@ namespace Microsoft.OData.JsonLight
                 this.jsonWriter = CreateJsonWriter(messageInfo.Container, textWriter, ieee754CompatibleSetToTrue, messageWriterSettings);
             }
             
-            this.VerifyJsonWriter();
+            this.EnsureJsonWritersAreTheSame();
             this.metadataLevel = new JsonMinimalMetadataLevel();
             this.propertyCacheHandler = new PropertyCacheHandler();
         }
@@ -977,7 +977,13 @@ namespace Microsoft.OData.JsonLight
             return jsonWriter;
         }
 
-        private void VerifyJsonWriter()
+        /// <summary>
+        /// Ensures that both <see cref="jsonWriter"/> and <see cref="asynchronousJsonWriter"/>
+        /// members are set and they refer to the same instance, otherwise it throws
+        /// an exception.
+        /// </summary>
+        /// <exception cref="ODataException"></exception>
+        private void EnsureJsonWritersAreTheSame()
         {
             // Asynchronous support is not implemented in Microsoft.Spatial library.
             // To write spatial data, we rely on the synchronous PrimitiveConverter.Instance.WriteJsonLight(object, IJsonWriter) method.
@@ -991,7 +997,9 @@ namespace Microsoft.OData.JsonLight
             // can be reused for spatial data. If we somehow end up with 2 separate instances, then we fail early with an exception.
             // Merging IJsonWriter and IJsonWriterAsync interface in a major release will simplify this.
 
-            if (this.jsonWriter != null && this.asynchronousJsonWriter == null && this.jsonWriter is IJsonWriterAsync jsonWriterAsync)
+            if (this.jsonWriter != null
+                && this.asynchronousJsonWriter == null
+                && this.jsonWriter is IJsonWriterAsync jsonWriterAsync)
             {
                 this.asynchronousJsonWriter = jsonWriterAsync;
                 return;

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -100,6 +100,8 @@ namespace Microsoft.OData
         internal const string ODataMessageWriter_NonCollectionType = "ODataMessageWriter_NonCollectionType";
         internal const string ODataMessageWriter_NotAllowedWriteTopLevelPropertyWithResourceValue = "ODataMessageWriter_NotAllowedWriteTopLevelPropertyWithResourceValue";
         internal const string ODataMessageWriter_StreamBasedJsonWriterFactory_ReturnedNull = "ODataMessageWriter_StreamBasedJsonWriterFactory_ReturnedNull";
+        internal const string ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter = "ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter";
+        internal const string ODataMessageWriter_IJsonWriter_And_IJsonWriterAsync_Are_Different_Instances = "ODataMessageWriter_IJsonWriter_And_IJsonWriterAsync_Are_Different_Instances";
         internal const string ODataMessageWriterSettings_MessageWriterSettingsXmlCustomizationCallbacksMustBeSpecifiedBoth = "ODataMessageWriterSettings_MessageWriterSettingsXmlCustomizationCallbacksMustBeSpecifiedBoth";
         internal const string ODataCollectionWriterCore_InvalidTransitionFromStart = "ODataCollectionWriterCore_InvalidTransitionFromStart";
         internal const string ODataCollectionWriterCore_InvalidTransitionFromCollection = "ODataCollectionWriterCore_InvalidTransitionFromCollection";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -103,8 +103,4 @@
       <Version>6.0.3</Version>
     </PackageReference>
   </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-  </ItemGroup>
 </Project>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -103,4 +103,8 @@
       <Version>6.0.3</Version>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -98,6 +98,8 @@ ODataMessageWriter_JsonPaddingOnInvalidContentType=A JsonPaddingFunctionName was
 ODataMessageWriter_NonCollectionType=The type '{0}' specified as the collection's item type is not primitive, enum or complex. An ODataCollectionWriter can only write collections of primitive, enum or complex values.
 ODataMessageWriter_NotAllowedWriteTopLevelPropertyWithResourceValue=Not allowed to write top level property '{0}' with 'ODataResourceValue' or collection of resource value.
 ODataMessageWriter_StreamBasedJsonWriterFactory_ReturnedNull=The provided implementation of IStreamBasedJsonWriterFactory returned null for arguments: isIeee754Compatible '{0}', encoding '{1}'. The factory should return a concrete IJsonWriter implementation.
+ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter=The provided IJsonWriterAsync instance must also implement IJsonWriter.
+ODataMessageWriter_IJsonWriter_And_IJsonWriterAsync_Are_Different_Instances=Detected different instances of IJsonWriter and IJsonWriterAsync. The writer instance returned by the factory should implement both IJsonWriter and IJsonWriterAsync.
 
 ODataMessageWriterSettings_MessageWriterSettingsXmlCustomizationCallbacksMustBeSpecifiedBoth=Both startResourceXmlCustomizationCallback and endResourceXmlCustomizationCallback must be either null or non-null.
 

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -763,6 +763,28 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The provided IJsonWriterAsync instance must also implement IJsonWriter."
+        /// </summary>
+        internal static string ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter
+        {
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter);
+            }
+        }
+
+        /// <summary>
+        /// A string like "Detected different instances of IJsonWriter and IJsonWriterAsync. The writer instance returned by the factory should implement both IJsonWriter and IJsonWriterAsync."
+        /// </summary>
+        internal static string ODataMessageWriter_IJsonWriter_And_IJsonWriterAsync_Are_Different_Instances
+        {
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataMessageWriter_IJsonWriter_And_IJsonWriterAsync_Are_Different_Instances);
+            }
+        }
+
+        /// <summary>
         /// A string like "Both startResourceXmlCustomizationCallback and endResourceXmlCustomizationCallback must be either null or non-null."
         /// </summary>
         internal static string ODataMessageWriterSettings_MessageWriterSettingsXmlCustomizationCallbacksMustBeSpecifiedBoth

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/AssertExtensions.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/AssertExtensions.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.OData.Tests
@@ -35,6 +36,18 @@ namespace Microsoft.OData.Tests
         public static void Throws<T>(this Action testCode, string errorMessage) where T : Exception
         {
             T exception = Assert.Throws<T>(testCode);
+            Assert.Equal(errorMessage, exception.Message);
+        }
+
+        /// <summary>
+        /// Verifies that the exact exception calling the async test code is thrown.
+        /// </summary>
+        /// <typeparam name="T">The type of the exception expected to be thrown</typeparam>
+        /// <param name="testCode">An async delegate to the code to be tested</param>
+        /// <param name="errorMessage">The expected error message.</param>
+        public static async Task ThrowsAsync<T>(this Func<Task> testCode, string errorMessage) where T : Exception
+        {
+            T exception = await Assert.ThrowsAsync<T>(testCode);
             Assert.Equal(errorMessage, exception.Message);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/DefaultStreamBasedJsonWriterFactoryAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/DefaultStreamBasedJsonWriterFactoryAsyncTests.cs
@@ -1,0 +1,128 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DefaultStreamBasedJsonWriterFactoryAsyncTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETCOREAPP3_1_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.OData.Json;
+using Xunit;
+
+namespace Microsoft.OData.Tests.Json
+{
+    public sealed class DefaultStreamBasedJsonWriterFactoryAsyncTests
+    {
+
+        #region Argument validation
+
+        [Fact]
+        public void CreateAsynchronousJsonWriter_ThrowsIfStreamIsNull()
+        {
+            DefaultStreamBasedJsonWriterFactory factory = DefaultStreamBasedJsonWriterFactory.Default;
+
+            Assert.Throws<ArgumentNullException>("stream", () => factory.CreateAsynchronousJsonWriter(null, false, Encoding.UTF8));
+        }
+
+        [Fact]
+        public void CreateAsynchronousJsonWriter_ThrowsIfEncodingIsNull()
+        {
+            DefaultStreamBasedJsonWriterFactory factory = DefaultStreamBasedJsonWriterFactory.Default;
+            using MemoryStream stream = new MemoryStream();
+
+            Assert.Throws<ArgumentNullException>("encoding", () => factory.CreateAsynchronousJsonWriter(stream, false, null));
+        }
+
+        #endregion
+
+        public static IEnumerable<object[]> Encodings { get; } =
+           new object[][]
+           {
+                new object[] { Encoding.UTF8 },
+                new object[] { Encoding.Unicode },
+                new object[] { Encoding.UTF32 },
+                new object[] { Encoding.BigEndianUnicode },
+                new object[] { Encoding.ASCII }
+           };
+
+        [Theory]
+        [MemberData(nameof(Encodings))]
+        public async Task CreateAsynchronousJsonWriterWithSpecifiedEncoding(Encoding encoding)
+        {
+            DefaultStreamBasedJsonWriterFactory factory = DefaultStreamBasedJsonWriterFactory.Default;
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriterAsync jsonWriter = factory.CreateAsynchronousJsonWriter(stream, isIeee754Compatible: false, encoding);
+
+            await jsonWriter.StartObjectScopeAsync();
+            await jsonWriter.WriteNameAsync("Foo");
+            await jsonWriter.WriteValueAsync("Bar");
+            await jsonWriter.WriteNameAsync("Fizz");
+            await jsonWriter.WriteValueAsync(15.0m);
+            await jsonWriter.WriteNameAsync("Buzz");
+            await jsonWriter.WriteValueAsync("<\"\n");
+            await jsonWriter.EndObjectScopeAsync();
+
+            await jsonWriter.FlushAsync();
+            using StreamReader reader = new StreamReader(stream, encoding);
+            stream.Seek(0, SeekOrigin.Begin);
+            string contents = await reader.ReadToEndAsync();
+            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":15.0,""Buzz"":""\u003C\u0022\n""}", contents);
+        }
+
+        [Theory]
+        [MemberData(nameof(Encodings))]
+        public async Task CreateAsynchronousJsonWriterWithIeee754Compatibility(Encoding encoding)
+        {
+            DefaultStreamBasedJsonWriterFactory factory = DefaultStreamBasedJsonWriterFactory.Default;
+            using MemoryStream stream = new MemoryStream();
+
+            IJsonWriterAsync jsonWriter = factory.CreateAsynchronousJsonWriter(stream, isIeee754Compatible: true, encoding: encoding);
+
+            await jsonWriter.StartObjectScopeAsync();
+            await jsonWriter.WriteNameAsync("Foo");
+            await jsonWriter.WriteValueAsync("Bar");
+            await jsonWriter.WriteNameAsync("Fizz");
+            await jsonWriter.WriteValueAsync(15.0m);
+            await jsonWriter.WriteNameAsync("Buzz");
+            await jsonWriter.WriteValueAsync("<\"\n");
+            await jsonWriter.EndObjectScopeAsync();
+
+            await jsonWriter.FlushAsync();
+            using StreamReader reader = new StreamReader(stream, encoding);
+            stream.Seek(0, SeekOrigin.Begin);
+            string contents = await reader.ReadToEndAsync();
+            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":""15.0"",""Buzz"":""\u003C\u0022\n""}", contents);
+        }
+
+        [Theory]
+        [MemberData(nameof(Encodings))]
+        public async Task CreateAsynchronousJsonWriterWithCustomEncoder(Encoding encoding)
+        {
+            DefaultStreamBasedJsonWriterFactory factory = new DefaultStreamBasedJsonWriterFactory(JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+            using MemoryStream stream = new MemoryStream();
+
+            IJsonWriterAsync jsonWriter = factory.CreateAsynchronousJsonWriter(stream, isIeee754Compatible: false, encoding: encoding);
+
+            await jsonWriter.StartObjectScopeAsync();
+            await jsonWriter.WriteNameAsync("Foo");
+            await jsonWriter.WriteValueAsync("Bar");
+            await jsonWriter.WriteNameAsync("Fizz");
+            await jsonWriter.WriteValueAsync(15.0m);
+            await jsonWriter.WriteNameAsync("Buzz");
+            await jsonWriter.WriteValueAsync("<\"\n");
+            await jsonWriter.EndObjectScopeAsync();
+
+            await jsonWriter.FlushAsync();
+            using StreamReader reader = new StreamReader(stream, encoding);
+            stream.Seek(0, SeekOrigin.Begin);
+            string contents = await reader.ReadToEndAsync();
+            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":15.0,""Buzz"":""<\""\n""}", contents);
+        }
+    }
+}
+#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockAsyncOnlyJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockAsyncOnlyJsonWriter.cs
@@ -18,134 +18,56 @@ namespace Microsoft.OData.Tests.Json
     /// </summary>
     internal class MockAsyncOnlyJsonWriter : IJsonWriterAsync
     {
-        public Task EndArrayScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task EndArrayScopeAsync() => throw new NotImplementedException();
 
-        public Task EndObjectScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task EndObjectScopeAsync() => throw new NotImplementedException();
 
-        public Task EndPaddingFunctionScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task EndPaddingFunctionScopeAsync() => throw new NotImplementedException();
 
-        public Task FlushAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task FlushAsync() => throw new NotImplementedException();
 
-        public Task StartArrayScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task StartArrayScopeAsync() => throw new NotImplementedException();
 
-        public Task StartObjectScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task StartObjectScopeAsync() => throw new NotImplementedException();
 
-        public Task StartPaddingFunctionScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task StartPaddingFunctionScopeAsync() => throw new NotImplementedException();
 
-        public Task WriteNameAsync(string name)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteNameAsync(string name) => throw new NotImplementedException();
 
-        public Task WritePaddingFunctionNameAsync(string functionName)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WritePaddingFunctionNameAsync(string functionName) => throw new NotImplementedException();
 
-        public Task WriteRawValueAsync(string rawValue)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteRawValueAsync(string rawValue) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(bool value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(bool value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(int value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(int value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(float value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(float value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(short value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(short value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(long value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(long value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(double value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(double value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(Guid value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(Guid value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(decimal value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(decimal value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(DateTimeOffset value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(DateTimeOffset value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(TimeSpan value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(TimeSpan value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(byte value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(byte value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(sbyte value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(sbyte value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(string value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(string value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(byte[] value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(byte[] value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(Date value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(Date value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(TimeOfDay value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(TimeOfDay value) => throw new NotImplementedException();
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockAsyncOnlyJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockAsyncOnlyJsonWriter.cs
@@ -1,0 +1,151 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="MockAsyncOnlyJsonWriter.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Json;
+
+namespace Microsoft.OData.Tests.Json
+{
+    /// <summary>
+    /// A mock implementation of <see cref="IJsonWriterAsync"/> that
+    /// does not implement the synchronous interface <see cref="IJsonWriter"/>.
+    /// This is used for testing purposes. Most of the methods have not been implemented.
+    /// </summary>
+    internal class MockAsyncOnlyJsonWriter : IJsonWriterAsync
+    {
+        public Task EndArrayScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task EndObjectScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task EndPaddingFunctionScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task FlushAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task StartArrayScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task StartObjectScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task StartPaddingFunctionScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteNameAsync(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WritePaddingFunctionNameAsync(string functionName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteRawValueAsync(string rawValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(bool value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(int value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(float value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(short value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(double value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(Guid value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(decimal value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(DateTimeOffset value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(TimeSpan value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(byte value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(sbyte value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(byte[] value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(Date value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(TimeOfDay value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
@@ -22,35 +22,17 @@ namespace Microsoft.OData.Tests.Json
         public Action<string> WriteNameVerifier;
         public Action<string> WriteValueVerifier;
 
-        public void StartPaddingFunctionScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void StartPaddingFunctionScope() => throw new NotImplementedException();
 
-        public void EndPaddingFunctionScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void EndPaddingFunctionScope() => throw new NotImplementedException();
 
-        public void StartObjectScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void StartObjectScope() => throw new NotImplementedException();
 
-        public void EndObjectScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void EndObjectScope() => throw new NotImplementedException();
 
-        public void StartArrayScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void StartArrayScope() => throw new NotImplementedException();
 
-        public void EndArrayScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void EndArrayScope() => throw new NotImplementedException();
 
         public void WriteName(string name)
         {
@@ -58,80 +40,35 @@ namespace Microsoft.OData.Tests.Json
             this.WriteNameVerifier(name);
         }
 
-        public void WritePaddingFunctionName(string functionName)
-        {
-            throw new NotImplementedException();
-        }
+        public void WritePaddingFunctionName(string functionName) => throw new NotImplementedException();
 
-        public void WriteValue(bool value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(bool value) => throw new NotImplementedException();
 
-        public void WriteValue(int value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(int value) => throw new NotImplementedException();
 
-        public void WriteValue(float value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(float value) => throw new NotImplementedException();
 
-        public void WriteValue(short value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(short value) => throw new NotImplementedException();
 
-        public void WriteValue(long value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(long value) => throw new NotImplementedException();
 
-        public void WriteValue(double value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(double value) => throw new NotImplementedException();
 
-        public void WriteValue(Guid value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(Guid value) => throw new NotImplementedException();
 
-        public void WriteValue(decimal value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(decimal value) => throw new NotImplementedException();
 
-        public void WriteValue(Date value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(Date value) => throw new NotImplementedException();
 
-        public void WriteValue(DateTimeOffset value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(DateTimeOffset value) => throw new NotImplementedException();
 
-        public void WriteValue(TimeSpan value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(TimeSpan value) => throw new NotImplementedException();
 
-        public void WriteValue(TimeOfDay value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(TimeOfDay value) => throw new NotImplementedException();
 
-        public void WriteValue(byte value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(byte value) => throw new NotImplementedException();
 
-        public void WriteValue(sbyte value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(sbyte value) => throw new NotImplementedException();
 
         public void WriteValue(string value)
         {
@@ -151,40 +88,19 @@ namespace Microsoft.OData.Tests.Json
             this.WriteValueVerifier(rawValue);
         }
 
-        public void Flush()
-        {
-            throw new NotImplementedException();
-        }
+        public void Flush() => throw new NotImplementedException();
 
-        public Task StartPaddingFunctionScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task StartPaddingFunctionScopeAsync() => throw new NotImplementedException();
 
-        public Task EndPaddingFunctionScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task EndPaddingFunctionScopeAsync() => throw new NotImplementedException();
 
-        public Task StartObjectScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task StartObjectScopeAsync() => throw new NotImplementedException();
 
-        public Task EndObjectScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task EndObjectScopeAsync() => throw new NotImplementedException();
 
-        public Task StartArrayScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task StartArrayScopeAsync() => throw new NotImplementedException();
 
-        public Task EndArrayScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task EndArrayScopeAsync() => throw new NotImplementedException();
 
         public Task WriteNameAsync(string name)
         {
@@ -193,70 +109,31 @@ namespace Microsoft.OData.Tests.Json
             return TaskUtils.CompletedTask;
         }
 
-        public Task WritePaddingFunctionNameAsync(string functionName)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WritePaddingFunctionNameAsync(string functionName) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(bool value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(bool value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(int value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(int value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(float value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(float value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(short value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(short value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(long value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(long value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(double value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(double value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(Guid value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(Guid value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(decimal value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(decimal value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(DateTimeOffset value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(DateTimeOffset value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(TimeSpan value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(TimeSpan value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(byte value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(byte value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(sbyte value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(sbyte value) => throw new NotImplementedException();
 
         public Task WriteValueAsync(string value)
         {
@@ -272,15 +149,9 @@ namespace Microsoft.OData.Tests.Json
             return TaskUtils.CompletedTask;
         }
 
-        public Task WriteValueAsync(Date value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(Date value) => throw new NotImplementedException();
 
-        public Task WriteValueAsync(TimeOfDay value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(TimeOfDay value) => throw new NotImplementedException();
 
         public Task WriteRawValueAsync(string rawValue)
         {
@@ -289,9 +160,6 @@ namespace Microsoft.OData.Tests.Json
             return TaskUtils.CompletedTask;
         }
 
-        public Task FlushAsync()
-        {
-            throw new NotImplementedException();
-        }
+        public Task FlushAsync() => throw new NotImplementedException();
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
@@ -8,6 +8,7 @@ using System;
 using Microsoft.OData.Json;
 using Microsoft.OData.Edm;
 using Xunit;
+using System.Threading.Tasks;
 
 namespace Microsoft.OData.Tests.Json
 {
@@ -16,7 +17,7 @@ namespace Microsoft.OData.Tests.Json
     /// 
     /// So far only a a few things have been implemented.
     /// </summary>
-    internal class MockJsonWriter : IJsonWriter
+    internal class MockJsonWriter : IJsonWriter, IJsonWriterAsync
     {
         public Action<string> WriteNameVerifier;
         public Action<string> WriteValueVerifier;
@@ -151,6 +152,144 @@ namespace Microsoft.OData.Tests.Json
         }
 
         public void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task StartPaddingFunctionScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task EndPaddingFunctionScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task StartObjectScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task EndObjectScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task StartArrayScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task EndArrayScopeAsync()
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteNameAsync(string name)
+        {
+            Assert.NotNull(this.WriteNameVerifier);
+            this.WriteNameVerifier(name);
+            return TaskUtils.CompletedTask;
+        }
+
+        public Task WritePaddingFunctionNameAsync(string functionName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(bool value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(int value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(float value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(short value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(double value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(Guid value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(decimal value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(DateTimeOffset value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(TimeSpan value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(byte value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(sbyte value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(string value)
+        {
+            Assert.NotNull(this.WriteValueVerifier);
+            this.WriteValueVerifier(value);
+            return TaskUtils.CompletedTask;
+        }
+
+        public Task WriteValueAsync(byte[] value)
+        {
+            Assert.NotNull(this.WriteValueVerifier);
+            this.WriteValueVerifier(Convert.ToBase64String(value));
+            return TaskUtils.CompletedTask;
+        }
+
+        public Task WriteValueAsync(Date value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteValueAsync(TimeOfDay value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task WriteRawValueAsync(string rawValue)
+        {
+            Assert.NotNull(this.WriteValueVerifier);
+            this.WriteValueVerifier(rawValue);
+            return TaskUtils.CompletedTask;
+        }
+
+        public Task FlushAsync()
         {
             throw new NotImplementedException();
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriterFactoryAsync.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriterFactoryAsync.cs
@@ -1,0 +1,25 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="MokeJsonWriterFactoryAsync.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.IO;
+using Microsoft.OData.Json;
+
+namespace Microsoft.OData.Tests.Json
+{
+    internal sealed class MockJsonWriterFactoryAsync : IJsonWriterFactoryAsync
+    {
+        private IJsonWriterAsync jsonWriter;
+
+        public MockJsonWriterFactoryAsync(IJsonWriterAsync jsonWriter)
+        {
+            this.jsonWriter = jsonWriter;
+        }
+        public IJsonWriterAsync CreateAsynchronousJsonWriter(TextWriter textWriter, bool isIeee754Compatible)
+        {
+            return jsonWriter;
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriterFactoryAsync.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriterFactoryAsync.cs
@@ -17,6 +17,7 @@ namespace Microsoft.OData.Tests.Json
         {
             this.jsonWriter = jsonWriter;
         }
+
         public IJsonWriterAsync CreateAsynchronousJsonWriter(TextWriter textWriter, bool isIeee754Compatible)
         {
             return jsonWriter;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockStreamBasedJsonWriterFactory.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockStreamBasedJsonWriterFactory.cs
@@ -14,10 +14,12 @@ namespace Microsoft.OData.Tests.Json
     internal sealed class MockStreamBasedJsonWriterFactory : IStreamBasedJsonWriterFactory
     {
         private readonly IJsonWriter jsonWriter;
+        private readonly IJsonWriterAsync asyncJsonWriter;
 
-        public MockStreamBasedJsonWriterFactory(IJsonWriter jsonWriter)
+        public MockStreamBasedJsonWriterFactory(IJsonWriter jsonWriter, IJsonWriterAsync asyncJsonWriter)
         {
             this.jsonWriter = jsonWriter;
+            this.asyncJsonWriter = asyncJsonWriter;
         }
 
         public IJsonWriter CreateJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding)
@@ -27,7 +29,7 @@ namespace Microsoft.OData.Tests.Json
 
         public IJsonWriterAsync CreateAsynchronousJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding)
         {
-            throw new System.NotImplementedException();
+            return this.asyncJsonWriter;
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockStreamBasedJsonWriterFactoryWrapper.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockStreamBasedJsonWriterFactoryWrapper.cs
@@ -43,22 +43,33 @@ namespace Microsoft.OData.Tests.Json
 
         public IJsonWriterAsync CreateAsynchronousJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding)
         {
-            throw new NotImplementedException();
+            this.NumCalls++;
+            this.Encoding = encoding;
+            IJsonWriterAsync writer = innerFactory.CreateAsynchronousJsonWriter(stream, isIeee754Compatible, encoding);
+            this.CreatedAsyncWriter = writer;
+
+            return writer;
         }
 
         /// <summary>
         /// The <see cref="IJsonWriter"/> that was last created by the wrapped <see cref="IStreamBasedJsonWriterFactory"/>.
         /// </summary>
         public IJsonWriter CreatedWriter { get; private set; }
+
+        /// <summary>
+        /// The <see cref="IJsonWriterAsync" that was last created by the wrapped <see cref="IStreamBasedJsonWriterFactory"/>.
+        /// </summary>
+        public IJsonWriterAsync CreatedAsyncWriter { get; private set; }
+
         /// <summary>
         /// The encoding used when creating the <see cref="IJsonWriter"/>.
         /// </summary>
         public Encoding Encoding { get; private set; }
+
         /// <summary>
         /// Number of times the <see cref="CreateJsonWriter(Stream, bool, Encoding)"/> method was called.
         /// </summary>
         public int NumCalls { get; private set; }
     }
 }
-
 #endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockSyncOnlyJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockSyncOnlyJsonWriter.cs
@@ -19,134 +19,56 @@ namespace Microsoft.OData.Tests.Json
     /// </summary>
     internal class MockSyncOnlyJsonWriter : IJsonWriter
     {
-        public void EndArrayScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void EndArrayScope() => throw new NotImplementedException();
 
-        public void EndObjectScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void EndObjectScope() => throw new NotImplementedException();
 
-        public void EndPaddingFunctionScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void EndPaddingFunctionScope() => throw new NotImplementedException();
 
-        public void Flush()
-        {
-            throw new NotImplementedException();
-        }
+        public void Flush() => throw new NotImplementedException();
 
-        public void StartArrayScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void StartArrayScope() => throw new NotImplementedException();
 
-        public void StartObjectScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void StartObjectScope() => throw new NotImplementedException();
 
-        public void StartPaddingFunctionScope()
-        {
-            throw new NotImplementedException();
-        }
+        public void StartPaddingFunctionScope() => throw new NotImplementedException();
 
-        public void WriteName(string name)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteName(string name) => throw new NotImplementedException();
 
-        public void WritePaddingFunctionName(string functionName)
-        {
-            throw new NotImplementedException();
-        }
+        public void WritePaddingFunctionName(string functionName) => throw new NotImplementedException();
 
-        public void WriteRawValue(string rawValue)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteRawValue(string rawValue) => throw new NotImplementedException();
 
-        public void WriteValue(bool value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(bool value) => throw new NotImplementedException();
 
-        public void WriteValue(int value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(int value) => throw new NotImplementedException();
 
-        public void WriteValue(float value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(float value) => throw new NotImplementedException();
 
-        public void WriteValue(short value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(short value) => throw new NotImplementedException();
 
-        public void WriteValue(long value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(long value) => throw new NotImplementedException();
 
-        public void WriteValue(double value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(double value) => throw new NotImplementedException();
 
-        public void WriteValue(Guid value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(Guid value) => throw new NotImplementedException();
 
-        public void WriteValue(decimal value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(decimal value) => throw new NotImplementedException();
 
-        public void WriteValue(DateTimeOffset value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(DateTimeOffset value) => throw new NotImplementedException();
 
-        public void WriteValue(TimeSpan value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(TimeSpan value) => throw new NotImplementedException();
 
-        public void WriteValue(byte value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(byte value) => throw new NotImplementedException();
 
-        public void WriteValue(sbyte value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(sbyte value) => throw new NotImplementedException();
 
-        public void WriteValue(string value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(string value) => throw new NotImplementedException();
 
-        public void WriteValue(byte[] value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(byte[] value) => throw new NotImplementedException();
 
-        public void WriteValue(Date value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(Date value) => throw new NotImplementedException();
 
-        public void WriteValue(TimeOfDay value)
-        {
-            throw new NotImplementedException();
-        }
+        public void WriteValue(TimeOfDay value) => throw new NotImplementedException();
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockSyncOnlyJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockSyncOnlyJsonWriter.cs
@@ -1,0 +1,152 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="MockSyncOnlyJsonWriter.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Json;
+
+namespace Microsoft.OData.Tests.Json
+{
+    /// <summary>
+    /// A mock implementation of <see cref="IJsonWriter"/>
+    /// that does not implement the async interface <see cref="IJsonWriterAsync"/>
+    /// use for testing purposes.
+    /// 
+    /// Note: most methods are not actually implemented.
+    /// </summary>
+    internal class MockSyncOnlyJsonWriter : IJsonWriter
+    {
+        public void EndArrayScope()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void EndObjectScope()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void EndPaddingFunctionScope()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void StartArrayScope()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void StartObjectScope()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void StartPaddingFunctionScope()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteName(string name)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WritePaddingFunctionName(string functionName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteRawValue(string rawValue)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(bool value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(int value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(float value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(short value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(double value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(Guid value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(decimal value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(DateTimeOffset value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(TimeSpan value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(byte value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(sbyte value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(byte[] value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(Date value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void WriteValue(TimeOfDay value)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -433,7 +433,6 @@ namespace Microsoft.OData.Tests.Json
 
         #endregion Custom JavaScriptEncoder
 
-
         private Task<string> ReadStreamAsync()
         {
             return this.ReadStreamAsync(Encoding.UTF8);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -1,0 +1,454 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataUtf8JsonWriterAsyncTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETCOREAPP3_1_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Json;
+using Xunit;
+
+namespace Microsoft.OData.Tests.Json
+{
+    /// <summary>
+    /// Unit tests for the ODataUtf8JsonWriter class
+    /// </summary>
+    public sealed class ODataUtf8JsonWriterAsyncTests: IDisposable
+    {
+        private IJsonWriterAsync writer;
+        private MemoryStream stream;
+        private bool disposed;
+
+        public ODataUtf8JsonWriterAsyncTests()
+        {
+            this.stream = new MemoryStream();
+
+            try
+            {
+                this.writer = new ODataUtf8JsonWriter(stream, isIeee754Compatible: true, encoding: Encoding.UTF8, leaveStreamOpen: true);
+            }
+            catch
+            {
+                this.stream.Dispose();
+                throw;
+            }
+
+            this.disposed = false;
+        }
+
+        public void Dispose()
+        {
+            if (this.disposed)
+            {
+                return;
+            }
+
+            this.stream.Dispose();
+            (this.writer as ODataUtf8JsonWriter).Dispose();
+
+            this.disposed = true;
+        }
+
+        [Fact]
+        public async Task StartPaddingFunctionScopeAsync_WritesParenthesis()
+        {
+            await this.writer.StartPaddingFunctionScopeAsync();
+            Assert.Equal("(", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task EndPaddingFunctionScopeAsync_WritesParenthesis()
+        {
+            await this.writer.StartPaddingFunctionScopeAsync();
+            await this.writer.EndPaddingFunctionScopeAsync();
+            Assert.Equal("()", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WritePaddingFunctionNameAsync_WritesName()
+        {
+            await this.writer.WritePaddingFunctionNameAsync("example");
+            Assert.Equal("example", await this.ReadStreamAsync());
+        }
+
+        #region WritePrimitiveValue
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_Boolean()
+        {
+            await this.VerifyWritePrimitiveValueAsync(false, "false");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_Byte()
+        {
+            await this.VerifyWritePrimitiveValueAsync((byte)4, "4");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_DecimalWithIeee754CompatibleTrue()
+        {
+            await this.VerifyWriterPrimitiveValueWithIeee754CompatibleAsync(42.2m, "\"42.2\"", isIeee754Compatible: true);
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_DecimalWithIeee754CompatibleFalse()
+        {
+            await this.VerifyWriterPrimitiveValueWithIeee754CompatibleAsync(42.2m, "42.2", isIeee754Compatible: false);
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_Double()
+        {
+            await this.VerifyWritePrimitiveValueAsync(42.2d, "42.2");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_Int16()
+        {
+            await this.VerifyWritePrimitiveValueAsync((short)876, "876");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_Int32()
+        {
+            await this.VerifyWritePrimitiveValueAsync((int)876, "876");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_Int64WithIeee754CompatibleTrue()
+        {
+            await this.VerifyWriterPrimitiveValueWithIeee754CompatibleAsync((long)876, "\"876\"", isIeee754Compatible: true);
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_WithIeee754CompatibleFalse()
+        {
+            await this.VerifyWriterPrimitiveValueWithIeee754CompatibleAsync((long)876, "876", isIeee754Compatible: false);
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_SByte()
+        {
+            await this.VerifyWritePrimitiveValueAsync((sbyte)4, "4");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_Single()
+        {
+            await this.VerifyWritePrimitiveValueAsync((Single)876, "876");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_String()
+        {
+            await this.VerifyWritePrimitiveValueAsync("string", "\"string\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_String_WritesNullIfArgumentIsNull()
+        {
+            await this.writer.WriteValueAsync((string)null);
+            Assert.Equal("null", await this.ReadStreamAsync());
+        }
+
+        [Theory]
+        // Utf8JsonWriter uses uppercase character in unicode literals, i.e. uD800 instead of ud800
+        [InlineData("Foo \uD800\udc05 \u00e4", "\"Foo \\uD800\\uDC05 \\u00E4\"")]
+        // Utf8JsonWriter escapes double-quotes using \u0022
+        [InlineData("Foo \nBar\t\"Baz\"", "\"Foo \\nBar\\t\\u0022Baz\\u0022\"")]
+        [InlineData("Foo ия", "\"Foo \\u0438\\u044F\"")]
+        [InlineData("<script>", "\"\\u003Cscript\\u003E\"")]
+        public async Task WritePrimitiveValueAsync_String_EscapesStrings(string input, string expectedOutput)
+        {
+            await this.VerifyWritePrimitiveValueAsync(input, expectedOutput);
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_EmptyByteArray()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new byte[] { 0 }, "\"" + Convert.ToBase64String(new byte[] { 0 }) + "\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_ByteArray_WritesNullIfArgumentIsNull()
+        {
+            await this.writer.WriteValueAsync((byte[])null);
+            Assert.Equal("null", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_DateTimeOffset()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new DateTimeOffset(1, 2, 3, 4, 5, 6, 7, new TimeSpan(1, 2, 0)), "\"0001-02-03T04:05:06.007+01:02\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_Guid()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new Guid("00000012-0000-0000-0000-012345678900"), "\"00000012-0000-0000-0000-012345678900\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_TimeSpan()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new TimeSpan(1, 2, 3, 4, 5), "\"P1DT2H3M4.005S\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_Date()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new Date(2014, 12, 31), "\"2014-12-31\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsync_TimeOfDay()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new TimeOfDay(12, 30, 5, 10), "\"12:30:05.0100000\"");
+        }
+
+        private async Task VerifyWritePrimitiveValueAsync<T>(T parameter, string expected)
+        {
+            await this.writer.WritePrimitiveValueAsync(parameter);
+            Assert.Equal(expected, await this.ReadStreamAsync());
+        }
+
+        private async Task VerifyWriterPrimitiveValueWithIeee754CompatibleAsync<T>(T parameter, string expected, bool isIeee754Compatible)
+        {
+            this.writer = new ODataUtf8JsonWriter(this.stream, isIeee754Compatible, Encoding.UTF8);
+            await this.writer.WritePrimitiveValueAsync(parameter);
+            Assert.Equal(expected, await this.ReadStreamAsync());
+        }
+
+        #endregion
+
+        [Fact]
+        public async Task WriteRawValueAsync_WritesValue()
+        {
+            await this.writer.WriteRawValueAsync("Raw\t\"Value ия");
+            Assert.Equal("Raw\t\"Value ия", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WriteRawValueAsync_WritesNothingWhenNull()
+        {
+            await this.writer.WriteRawValueAsync(null);
+            Assert.Equal("", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WriteNameAsync_WritesName()
+        {
+            await this.writer.StartObjectScopeAsync();
+            await this.writer.WriteNameAsync("Name");
+            Assert.Equal("{\"Name\":", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WriteNameAsync_WritesNameWithObjectMemberSeparator()
+        {
+            await this.writer.StartObjectScopeAsync();
+            await this.writer.WriteNameAsync("Name");
+            await this.writer.WritePrimitiveValueAsync("Sue");
+            await this.writer.WriteNameAsync("Age");
+            Assert.Equal("{\"Name\":\"Sue\",\"Age\":", await this.ReadStreamAsync());
+        }
+
+        #region JsonWriter Extension Methods
+
+        [Fact]
+        public async Task WriteJsonObjectValueAsync_WritesJsonObject()
+        {
+            var properties = new Dictionary<string, object>
+            {
+                { "Name", "Sue" },
+                { "Attributes",
+                    new Dictionary<string, object>
+                    {
+                        { "Height", 1.77 },
+                        { "Weight", 80.7 }
+                    }
+                }
+            };
+
+            await this.writer.WriteJsonObjectValueAsync(properties, null);
+            Assert.Equal("{\"Name\":\"Sue\",\"Attributes\":{\"Height\":1.77,\"Weight\":80.7}}", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WriteJsonObjectValueAsync_CallsInjectedPropertyAction()
+        {
+            var properties = new Dictionary<string, object> { { "Name", "Sue" } };
+            Func<IJsonWriterAsync, Task> injectPropertyDelegate = async (IJsonWriterAsync actionWriter) =>
+            {
+                await actionWriter.WriteNameAsync("Id");
+                await actionWriter.WriteValueAsync(7);
+            };
+
+            await this.writer.WriteJsonObjectValueAsync(properties, injectPropertyDelegate);
+            Assert.Equal("{\"Id\":7,\"Name\":\"Sue\"}", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WriteJsonObjectValueAsync_WritesPrimitiveCollection()
+        {
+            var properties = new Dictionary<string, object>
+            {
+                { "Names", new string[] { "Sue", "Joe", null } }
+            };
+
+            await this.writer.WriteJsonObjectValueAsync(properties, null);
+            Assert.Equal("{\"Names\":[\"Sue\",\"Joe\",null]}", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WriteODataValueAsync_WritesODataValue()
+        {
+            var value = new ODataPrimitiveValue(3.14);
+            await this.writer.WriteODataValueAsync(value);
+            Assert.Equal("3.14", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WriteODataValueAsync_WritesNullValue()
+        {
+            var value = new ODataNullValue();
+            await this.writer.WriteODataValueAsync(value);
+            Assert.Equal("null", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WriteODataValueAsync_WritesODataResourceValue()
+        {
+            var resourceValue = new ODataResourceValue
+            {
+                Properties = new List<ODataProperty>
+                {
+                    new ODataProperty { Name = "Name", Value = "Sue" },
+                    new ODataProperty { Name = "Age", Value = 19 }
+                }
+            };
+
+            await this.writer.WriteODataValueAsync(resourceValue);
+            Assert.Equal("{\"Name\":\"Sue\",\"Age\":19}", await this.ReadStreamAsync());
+        }
+
+        [Fact]
+        public async Task WriteODataValueAsync_WritesODataCollectionValue()
+        {
+            var collectionValue = new ODataCollectionValue
+            {
+                Items = new List<ODataResourceValue>
+                {
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Sue" },
+                            new ODataProperty { Name = "Age", Value = 19 }
+                        }
+                    },
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Joe" },
+                            new ODataProperty { Name = "Age", Value = 23 }
+                        }
+                    }
+                }
+            };
+
+            await this.writer.WriteODataValueAsync(collectionValue);
+            Assert.Equal("[{\"Name\":\"Sue\",\"Age\":19},{\"Name\":\"Joe\",\"Age\":23}]", await this.ReadStreamAsync());
+        }
+
+        #endregion JsonWriter Extension Methods
+
+        #region Support for other encodings
+
+        public static IEnumerable<object[]> Encodings { get; } = new object[][]
+           {
+                new object[] { Encoding.UTF8 },
+                new object[] { Encoding.Unicode },
+                new object[] { Encoding.UTF32 },
+                new object[] { Encoding.BigEndianUnicode },
+                new object[] { Encoding.ASCII }
+           };
+
+        [Theory]
+        [MemberData(nameof(Encodings))]
+        public async Task SupportsOtherEncodings(Encoding encoding)
+        {
+            var collectionValue = new ODataCollectionValue
+            {
+                Items = new List<ODataResourceValue>
+                {
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Sue\uD800\udc05 \u00e4" },
+                            new ODataProperty { Name = "Age", Value = 19 }
+                        }
+                    },
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Joe" },
+                            new ODataProperty { Name = "Age", Value = 23 }
+                        }
+                    }
+                }
+            };
+
+            this.writer = new ODataUtf8JsonWriter(this.stream, false, encoding);
+            await this.writer.WriteODataValueAsync(collectionValue);
+            Assert.Equal("[{\"Name\":\"Sue\\uD800\\uDC05 \\u00E4\",\"Age\":19},{\"Name\":\"Joe\",\"Age\":23}]", await this.ReadStreamAsync(encoding));
+        }
+
+        #endregion Support for other Encodings
+
+        #region Custom JavaScriptEncoder
+
+        [Fact]
+        public async Task AllowsCustomJavaScriptEncoder()
+        {
+            string input = "test<>\"ия\n\t";
+            string expected = "\"test<>\\\"ия\\n\\t\"";
+
+            this.writer = new ODataUtf8JsonWriter(this.stream, false, Encoding.UTF8, encoder: JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+            await this.writer.WritePrimitiveValueAsync(input);
+
+            Assert.Equal(expected, await this.ReadStreamAsync());
+        }
+
+        #endregion Custom JavaScriptEncoder
+
+
+        private Task<string> ReadStreamAsync()
+        {
+            return this.ReadStreamAsync(Encoding.UTF8);
+        }
+
+        private async Task<string> ReadStreamAsync(Encoding encoding)
+        {
+            await this.writer.FlushAsync();
+            this.stream.Seek(0, SeekOrigin.Begin);
+            // leave open since the this.stream is disposed separately
+            using StreamReader reader = new StreamReader(this.stream, encoding, leaveOpen: true);
+            string result = await reader.ReadToEndAsync();
+            return result;
+        }
+    }
+}
+
+#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -13,6 +13,7 @@ using Xunit;
 using System.Threading.Tasks;
 using Microsoft.OData.Tests.Json;
 using System.Text;
+using Microsoft.Test.OData.DependencyInjection;
 
 namespace Microsoft.OData.Tests
 {
@@ -197,15 +198,17 @@ namespace Microsoft.OData.Tests
             {
                 InMemoryMessage request = new InMemoryMessage() { Stream = stream };
 
-                IContainerBuilder containerBuilder = new Test.OData.DependencyInjection.TestContainerBuilder();
-                containerBuilder.AddDefaultODataServices();
-                containerBuilder.AddService<IJsonWriterFactory>(
+                IServiceProvider container = CreateTestServiceContainer(containerBuilder =>
+                {
+                    containerBuilder.AddService<IJsonWriterFactory>(
                     ServiceLifetime.Singleton, sp => new MockJsonWriterFactory(new MockSyncOnlyJsonWriter()));
-                containerBuilder.AddService<IJsonWriterFactoryAsync>(
-                    ServiceLifetime.Singleton, _ => new MockJsonWriterFactoryAsync(new MockAsyncOnlyJsonWriter()));
-                request.Container = containerBuilder.BuildContainer();
+                    containerBuilder.AddService<IJsonWriterFactoryAsync>(
+                        ServiceLifetime.Singleton, _ => new MockJsonWriterFactoryAsync(new MockAsyncOnlyJsonWriter()));
+                });
 
-                settings.ODataUri.ServiceRoot = new Uri("http://host/service");
+                request.Container = container;
+
+                settings.ODataUri.ServiceRoot = new Uri("http://www.example.com");
                 settings.SetContentType(ODataFormat.Json);
                 EdmModel model = new EdmModel();
                 using (ODataMessageWriter writer = new ODataMessageWriter((IODataRequestMessage)request, settings, model))
@@ -230,13 +233,15 @@ namespace Microsoft.OData.Tests
             {
                 InMemoryMessage request = new InMemoryMessage() { Stream = stream };
 
-                IContainerBuilder containerBuilder = new Test.OData.DependencyInjection.TestContainerBuilder();
-                containerBuilder.AddDefaultODataServices();
-                containerBuilder.AddService<IJsonWriterFactory>(
+                IServiceProvider container = CreateTestServiceContainer(containerBuilder =>
+                {
+                    containerBuilder.AddService<IJsonWriterFactory>(
                     ServiceLifetime.Singleton, _ => new MockJsonWriterFactory(new MockSyncOnlyJsonWriter()));
-                request.Container = containerBuilder.BuildContainer();
+                });
 
-                settings.ODataUri.ServiceRoot = new Uri("http://host/service");
+                request.Container = container;
+
+                settings.ODataUri.ServiceRoot = new Uri("http://www.example.com");
                 settings.SetContentType(ODataFormat.Json);
                 EdmModel model = new EdmModel();
                 using (ODataMessageWriter writer = new ODataMessageWriter((IODataRequestMessage)request, settings, model))
@@ -257,79 +262,63 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void SupportsStreamBasedJsonWriter()
         {
-            ODataMessageWriterSettings settings = new ODataMessageWriterSettings();
-
             using MemoryStream stream = new MemoryStream();
             InMemoryMessage request = new InMemoryMessage() { Stream = stream };
 
-            IContainerBuilder containerBuilder = new Test.OData.DependencyInjection.TestContainerBuilder();
-            containerBuilder.AddDefaultODataServices();
-            containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
-                ServiceLifetime.Singleton, sp => DefaultStreamBasedJsonWriterFactory.Default);
-            request.Container = containerBuilder.BuildContainer();
-
-            IStreamBasedJsonWriterFactory factory = request.Container.GetService<IStreamBasedJsonWriterFactory>();
-            Assert.IsType<DefaultStreamBasedJsonWriterFactory>(factory);
-
-            settings.ODataUri.ServiceRoot = new Uri("http://host/service");
-            settings.SetContentType(ODataFormat.Json);
             EdmModel model = new EdmModel();
-            using ODataMessageWriter writer = new ODataMessageWriter((IODataRequestMessage)request, settings, model);
-            Action writePropertyAction = () => writer.WriteProperty(new ODataProperty()
+            Action<ODataMessageWriter> writePropertyAction = (writer) => writer.WriteProperty(new ODataProperty()
             {
                 Name = "Name",
                 Value = "This is a test ия"
             });
 
-            writePropertyAction.DoesNotThrow();
-            request.GetStream().Position = 0;
-            using StreamReader reader = new StreamReader(request.GetStream());
-            string output = reader.ReadToEnd();
-            Assert.Equal("{\"@odata.context\":\"http://host/service/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
+            string output = WriteAndGetPayload(
+                model,
+                "application/json",
+                writePropertyAction,
+                message: request,
+                configureServices: (containerBuilder) =>
+                {
+                    containerBuilder.AddDefaultODataServices();
+                    containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
+                        ServiceLifetime.Singleton, sp => DefaultStreamBasedJsonWriterFactory.Default);
+                });
+
+            IStreamBasedJsonWriterFactory factory = request.Container.GetService<IStreamBasedJsonWriterFactory>();
+            Assert.IsType<DefaultStreamBasedJsonWriterFactory>(factory);
+            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
         }
 
         [Fact]
         public void WhenInjectingStreamBasedJsonWriterFactory_DoesNotCreateSynchronousWriter_IfAsyncWriterImplementsSynchronousInterface()
         {
             // Arrange
-            ODataMessageWriterSettings settings = new ODataMessageWriterSettings();
             MockStreamBasedJsonWriterFactoryWrapper writerFactory =
                 new MockStreamBasedJsonWriterFactoryWrapper(DefaultStreamBasedJsonWriterFactory.Default);
-
-            using MemoryStream stream = new MemoryStream();
-            InMemoryMessage request = new InMemoryMessage() { Stream = stream };
-
-            IContainerBuilder containerBuilder = new Test.OData.DependencyInjection.TestContainerBuilder();
-            containerBuilder.AddDefaultODataServices();
-
-            containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
-                ServiceLifetime.Singleton, sp => writerFactory);
-            request.Container = containerBuilder.BuildContainer();
-
-            IStreamBasedJsonWriterFactory factory = request.Container.GetService<IStreamBasedJsonWriterFactory>();
-            Assert.IsType<MockStreamBasedJsonWriterFactoryWrapper>(factory);
-
-            settings.ODataUri.ServiceRoot = new Uri("http://host/service");
             EdmModel model = new EdmModel();
-            using ODataMessageWriter writer = new ODataMessageWriter((IODataRequestMessage)request, settings, model);
 
             // Act
-            Action writePropertyAction = () => writer.WriteProperty(new ODataProperty()
+            Action<ODataMessageWriter> writePropertyAction = (writer) => writer.WriteProperty(new ODataProperty()
             {
                 Name = "Name",
                 Value = "This is a test ия"
             });
 
-            writePropertyAction.DoesNotThrow();
-            request.GetStream().Position = 0;
-            using StreamReader reader = new StreamReader(request.GetStream(), Encoding.UTF8);
-            string output = reader.ReadToEnd();
+            string output = WriteAndGetPayload(
+                model,
+                "application/json",
+                writePropertyAction,
+                configureServices: (containerBuilder) =>
+                {
+                    containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
+                        ServiceLifetime.Singleton, _ => writerFactory);
+                });
 
             // Assert
             Assert.IsType<ODataUtf8JsonWriter>(writerFactory.CreatedAsyncWriter);
             Assert.Null(writerFactory.CreatedWriter);
             Assert.Equal(1, writerFactory.NumCalls);
-            Assert.Equal("{\"@odata.context\":\"http://host/service/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
+            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
         }
 
         [Fact]
@@ -343,17 +332,18 @@ namespace Microsoft.OData.Tests
             using MemoryStream stream = new MemoryStream();
             InMemoryMessage request = new InMemoryMessage() { Stream = stream };
 
-            IContainerBuilder containerBuilder = new Test.OData.DependencyInjection.TestContainerBuilder();
-            containerBuilder.AddDefaultODataServices();
-
-            containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
+            IServiceProvider container = CreateTestServiceContainer(containerBuilder =>
+            {
+                containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
                 ServiceLifetime.Singleton, sp => writerFactory);
-            request.Container = containerBuilder.BuildContainer();
+            });
+
+            request.Container = container;
 
             IStreamBasedJsonWriterFactory factory = request.Container.GetService<IStreamBasedJsonWriterFactory>();
             Assert.IsType<MockStreamBasedJsonWriterFactory>(factory);
 
-            settings.ODataUri.ServiceRoot = new Uri("http://host/service");
+            settings.ODataUri.ServiceRoot = new Uri("http://www.example.com");
             EdmModel model = new EdmModel();
             using ODataMessageWriter writer = new ODataMessageWriter((IODataRequestMessage)request, settings, model);
 
@@ -375,45 +365,33 @@ namespace Microsoft.OData.Tests
         public void WhenInjectingStreamBasedJsonWriterFactory_CreatesWriterUsingConfiguredEncoding(string encodingCharset)
         {
             // Arrange
-            ODataMessageWriterSettings settings = new ODataMessageWriterSettings();
             MockStreamBasedJsonWriterFactoryWrapper writerFactory =
                 new MockStreamBasedJsonWriterFactoryWrapper(DefaultStreamBasedJsonWriterFactory.Default);
-
-            using MemoryStream stream = new MemoryStream();
-            InMemoryMessage request = new InMemoryMessage() { Stream = stream };
-
-            IContainerBuilder containerBuilder = new Test.OData.DependencyInjection.TestContainerBuilder();
-            containerBuilder.AddDefaultODataServices();
-
-            containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
-                ServiceLifetime.Singleton, sp => writerFactory);
-            request.Container = containerBuilder.BuildContainer();
-
-            IStreamBasedJsonWriterFactory factory = request.Container.GetService<IStreamBasedJsonWriterFactory>();
-            Assert.IsType<MockStreamBasedJsonWriterFactoryWrapper>(factory);
-
-            settings.ODataUri.ServiceRoot = new Uri("http://host/service");
-            settings.SetContentType("application/json", encodingCharset);
             EdmModel model = new EdmModel();
-            using ODataMessageWriter writer = new ODataMessageWriter((IODataRequestMessage)request, settings, model);
 
             // Act
-            Action writePropertyAction = () => writer.WriteProperty(new ODataProperty()
+            Action<ODataMessageWriter> writePropertyAction = (writer) => writer.WriteProperty(new ODataProperty()
             {
                 Name = "Name",
                 Value = "This is a test ия"
             });
 
-            writePropertyAction.DoesNotThrow();
-            request.GetStream().Position = 0;
-            using StreamReader reader = new StreamReader(request.GetStream(), Encoding.GetEncoding(encodingCharset));
-            string output = reader.ReadToEnd();
+            string output = WriteAndGetPayload(
+                model,
+                $"application/json; charset={encodingCharset}",
+                writePropertyAction,
+                encoding: Encoding.GetEncoding(encodingCharset),
+                configureServices: (containerBuilder) =>
+                {
+                    containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
+                        ServiceLifetime.Singleton, sp => writerFactory);
+                });
 
             // Assert
             Assert.IsType<ODataUtf8JsonWriter>(writerFactory.CreatedAsyncWriter);
             Assert.Equal(encodingCharset, writerFactory.Encoding.WebName);
             Assert.Equal(1, writerFactory.NumCalls);
-            Assert.Equal("{\"@odata.context\":\"http://host/service/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
+            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
         }
 
         [Fact]
@@ -424,16 +402,18 @@ namespace Microsoft.OData.Tests
             using MemoryStream stream = new MemoryStream();
             InMemoryMessage request = new InMemoryMessage() { Stream = stream };
 
-            IContainerBuilder containerBuilder = new Test.OData.DependencyInjection.TestContainerBuilder();
-            containerBuilder.AddDefaultODataServices();
-            containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
-                ServiceLifetime.Singleton, sp => new MockStreamBasedJsonWriterFactory(null, null));
-            request.Container = containerBuilder.BuildContainer();
+            IServiceProvider container = CreateTestServiceContainer(containerBuilder =>
+            {
+                containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
+                    ServiceLifetime.Singleton, sp => new MockStreamBasedJsonWriterFactory(null, null));
+            });
+
+            request.Container = container;
 
             IStreamBasedJsonWriterFactory factory = request.Container.GetService<IStreamBasedJsonWriterFactory>();
             Assert.IsType<MockStreamBasedJsonWriterFactory>(factory);
 
-            settings.ODataUri.ServiceRoot = new Uri("http://host/service");
+            settings.ODataUri.ServiceRoot = new Uri("http://www.example.com");
             settings.SetContentType(ODataFormat.Json);
             EdmModel model = new EdmModel();
             using ODataMessageWriter writer = new ODataMessageWriter((IODataRequestMessage)request, settings, model);
@@ -449,34 +429,22 @@ namespace Microsoft.OData.Tests
         [Fact]
         public async Task SupportsStreamBasedJsonWriterAsync()
         {
-            ODataMessageWriterSettings settings = new ODataMessageWriterSettings();
-
-            using MemoryStream stream = new MemoryStream();
-            InMemoryMessage request = new InMemoryMessage() { Stream = stream };
-
-            IContainerBuilder containerBuilder = new Test.OData.DependencyInjection.TestContainerBuilder();
-            containerBuilder.AddDefaultODataServices();
-            containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
-                ServiceLifetime.Singleton, sp => DefaultStreamBasedJsonWriterFactory.Default);
-            request.Container = containerBuilder.BuildContainer();
-
-            IStreamBasedJsonWriterFactory factory = request.Container.GetService<IStreamBasedJsonWriterFactory>();
-            Assert.IsType<DefaultStreamBasedJsonWriterFactory>(factory);
-
-            settings.ODataUri.ServiceRoot = new Uri("http://host/service");
-            settings.SetContentType(ODataFormat.Json);
             EdmModel model = new EdmModel();
-            using ODataMessageWriter writer = new ODataMessageWriter((IODataRequestMessage)request, settings, model);
-            await writer.WritePropertyAsync(new ODataProperty()
-            {
-                Name = "Name",
-                Value = "This is a test ия"
-            });
+            string output = await WriteAndGetPayloadAsync(
+                model,
+                "application/json",
+                (writer) => writer.WritePropertyAsync(new ODataProperty()
+                {
+                    Name = "Name",
+                    Value = "This is a test ия"
+                }),
+                configureServices: (containerBuilder) =>
+                {
+                    containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
+                        ServiceLifetime.Singleton, sp => DefaultStreamBasedJsonWriterFactory.Default);
+                });
 
-            request.GetStream().Position = 0;
-            using StreamReader reader = new StreamReader(request.GetStream());
-            string output = await reader.ReadToEndAsync();
-            Assert.Equal("{\"@odata.context\":\"http://host/service/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
+            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
         }
 
         [Theory]
@@ -487,44 +455,33 @@ namespace Microsoft.OData.Tests
         public async Task WhenInjectingStreamBasedJsonWriterFactoryAsync_CreatesWriterUsingConfiguredEncoding(string encodingCharset)
         {
             // Arrange
-            ODataMessageWriterSettings settings = new ODataMessageWriterSettings();
             MockStreamBasedJsonWriterFactoryWrapper writerFactory =
                 new MockStreamBasedJsonWriterFactoryWrapper(DefaultStreamBasedJsonWriterFactory.Default);
-
-            using MemoryStream stream = new MemoryStream();
-            InMemoryMessage request = new InMemoryMessage() { Stream = stream };
-
-            IContainerBuilder containerBuilder = new Test.OData.DependencyInjection.TestContainerBuilder();
-            containerBuilder.AddDefaultODataServices();
-
-            containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
-                ServiceLifetime.Singleton, sp => writerFactory);
-            request.Container = containerBuilder.BuildContainer();
-
-            IStreamBasedJsonWriterFactory factory = request.Container.GetService<IStreamBasedJsonWriterFactory>();
-            Assert.IsType<MockStreamBasedJsonWriterFactoryWrapper>(factory);
-
-            settings.ODataUri.ServiceRoot = new Uri("http://host/service");
-            settings.SetContentType("application/json", encodingCharset);
             EdmModel model = new EdmModel();
-            using ODataMessageWriter writer = new ODataMessageWriter((IODataRequestMessage)request, settings, model);
 
             // Act
-            await writer.WritePropertyAsync(new ODataProperty()
+            Func<ODataMessageWriter, Task> writePropertyAsync = (writer) => writer.WritePropertyAsync(new ODataProperty()
             {
                 Name = "Name",
                 Value = "This is a test ия"
             });
 
-            request.GetStream().Position = 0;
-            using StreamReader reader = new StreamReader(request.GetStream(), Encoding.GetEncoding(encodingCharset));
-            string output = await reader.ReadToEndAsync();
+            string output = await WriteAndGetPayloadAsync(
+                model,
+                $"application/json; charset={encodingCharset}",
+                writePropertyAsync,
+                encoding: Encoding.GetEncoding(encodingCharset),
+                configureServices: (containerBuilder) =>
+                {
+                    containerBuilder.AddService<IStreamBasedJsonWriterFactory>(
+                        ServiceLifetime.Singleton, sp => writerFactory);
+                });
 
             // Assert
             Assert.IsType<ODataUtf8JsonWriter>(writerFactory.CreatedAsyncWriter);
             Assert.Equal(encodingCharset, writerFactory.Encoding.WebName);
             Assert.Equal(1, writerFactory.NumCalls);
-            Assert.Equal("{\"@odata.context\":\"http://host/service/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
+            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
         }
 
         #endregion "ODataUtf8JsonWriter support"
@@ -680,12 +637,46 @@ namespace Microsoft.OData.Tests
             return edmModel;
         }
 
-        private string WriteAndGetPayload(IEdmModel edmModel, string contentType, Action<ODataMessageWriter> test)
+        /// <summary>
+        /// Write a message using an <see cref="ODataMessageWriter"/> instance
+        /// and returns the written payload as a string.
+        /// </summary>
+        /// <param name="edmModel">The <see cref="IEdmModel"/> used to initialize the writer.</param>
+        /// <param name="contentType">The value of the message's Content-Type header.</param>
+        /// <param name="test">The action that writes the payload.</param>
+        /// <param name="message">
+        /// The message instance that encapsulate the request.
+        /// If none is provided, a new instance of <see cref="InMemoryMessage"/>.
+        /// The provided instance might be modified by this method.
+        /// </param>
+        /// <param name="encoding">
+        /// The encoding to use when reading from the request stream. This defaults to UTF8.
+        /// If you set a custom <paramref name="contentType"/>, you should specify a matching encoding.
+        /// </param>
+        /// <param name="configureServices">
+        /// Action to inject services to the dependency-injection container.
+        /// If this is set, then the generated <see cref="IServiceProvider"/> will be added to the <paramref name="message"/>.Container property.
+        /// </param>
+        /// <returns>The written output.</returns>
+        private string WriteAndGetPayload(
+            IEdmModel edmModel,
+            string contentType,
+            Action<ODataMessageWriter> test,
+            InMemoryMessage message = null,
+            Encoding encoding = null,
+            Action<IContainerBuilder> configureServices = null)
         {
-            var message = new InMemoryMessage() { Stream = new MemoryStream() };
+            message = message ?? new InMemoryMessage() { Stream = new MemoryStream() };
+
             if (contentType != null)
             {
                 message.SetHeader("Content-Type", contentType);
+            }
+
+            if (configureServices != null)
+            {
+                IServiceProvider container = CreateTestServiceContainer(configureServices);
+                message.Container = container;
             }
 
             ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings();
@@ -699,18 +690,46 @@ namespace Microsoft.OData.Tests
             }
 
             message.Stream.Seek(0, SeekOrigin.Begin);
-            using (StreamReader reader = new StreamReader(message.Stream))
+            using (StreamReader reader = new StreamReader(message.Stream, encoding: encoding ?? Encoding.UTF8))
             {
                 return reader.ReadToEnd();
             }
         }
 
-        private async Task<string> WriteAndGetPayloadAsync(IEdmModel edmModel, string contentType, Func<ODataMessageWriter, Task> test)
+        /// <summary>
+        /// Asynchronously writes a message using an <see cref="ODataMessageWriter"/> instance
+        /// and returns the written payload as a string.
+        /// </summary>
+        /// <param name="edmModel">The <see cref="IEdmModel"/> used to initialize the writer.</param>
+        /// <param name="contentType">The value of the message's Content-Type header.</param>
+        /// <param name="test">The action that writes the payload.</param>
+        /// <param name="message">
+        /// The message instance that encapsulate the request.
+        /// If none is provided, a new instance of <see cref="InMemoryMessage"/>.
+        /// The provided instance might be modified by this method.
+        /// </param>
+        /// <param name="encoding">
+        /// The encoding to use when reading from the request stream. This defaults to UTF8.
+        /// If you set a custom <paramref name="contentType"/>, you should specify a matching encoding.
+        /// </param>
+        /// <param name="configureServices">
+        /// Action to inject services to the dependency-injection container.
+        /// If this is set, then the generated <see cref="IServiceProvider"/> will be added to the <paramref name="message"/>.Container property.
+        /// </param>
+        /// <returns>A task representing the asynchrnous operation. The result of the task will be the written output.</returns>
+        private async Task<string> WriteAndGetPayloadAsync(IEdmModel edmModel, string contentType, Func<ODataMessageWriter, Task> test, InMemoryMessage message = null, Encoding encoding = null, Action<IContainerBuilder> configureServices = null)
         {
-            var message = new InMemoryMessage() { Stream = new MemoryStream() };
+            message = message ?? new InMemoryMessage() { Stream = new MemoryStream() };
+
             if (contentType != null)
             {
                 message.SetHeader("Content-Type", contentType);
+            }
+
+            if (configureServices != null)
+            {
+                IServiceProvider container = CreateTestServiceContainer(configureServices);
+                message.Container = container;
             }
 
             ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings();
@@ -724,10 +743,21 @@ namespace Microsoft.OData.Tests
             }
 
             message.Stream.Seek(0, SeekOrigin.Begin);
-            using (StreamReader reader = new StreamReader(message.Stream))
+            using (StreamReader reader = new StreamReader(message.Stream, encoding: encoding ?? Encoding.UTF8))
             {
-                return reader.ReadToEnd();
+                string contents = await reader.ReadToEndAsync();
+                return contents;
             }
+        }
+
+        private static IServiceProvider CreateTestServiceContainer(Action<IContainerBuilder> configureServices)
+        {
+            IContainerBuilder builder = new TestContainerBuilder();
+            builder.AddDefaultODataServices();
+
+            configureServices.Invoke(builder);
+
+            return builder.BuildContainer();
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -746,6 +746,7 @@ namespace Microsoft.OData.Tests
             using (StreamReader reader = new StreamReader(message.Stream, encoding: encoding ?? Encoding.UTF8))
             {
                 string contents = await reader.ReadToEndAsync();
+
                 return contents;
             }
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/SingletonBatchRoundtripJsonLightTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/SingletonBatchRoundtripJsonLightTests.cs
@@ -986,7 +986,7 @@ Content-Type: application/json;odata.metadata=none
         }
 
         [Fact]
-        public void BatchJsonLightTest()
+        public void BatchJsonLightTestUsingMultipartMixed()
         {
             BatchJsonLightTestUsingBatchFormat(BatchFormat.MultipartMIME, 0);
         }
@@ -999,7 +999,7 @@ Content-Type: application/json;odata.metadata=none
 
 #if NETCOREAPP3_1_OR_GREATER
         [Fact]
-        public void BatchJsonLightTest_WithODataUtf8JsonWriter()
+        public void BatchJsonLightTestUsingMultipartMixed_WithODataUtf8JsonWriter()
         {
             Action<IContainerBuilder> configure = (IContainerBuilder builder) =>
             {
@@ -1022,7 +1022,7 @@ Content-Type: application/json;odata.metadata=none
 #endif
 
         [Fact]
-        public void BatchJsonLightTestChangesetsFollowedByQuery()
+        public void BatchJsonLightTestChangesetsFollowedByQueryUsingMultipartMixed()
         {
             BatchJsonLightTestUsingBatchFormat(BatchFormat.MultipartMIME, 1);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Json;
@@ -381,15 +380,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                 this.textWriter = textWriter;
             }
 
-            public void StartPaddingFunctionScope()
-            {
-                throw new NotImplementedException();
-            }
+            public void StartPaddingFunctionScope() => throw new NotImplementedException();
 
-            public void EndPaddingFunctionScope()
-            {
-                throw new NotImplementedException();
-            }
+            public void EndPaddingFunctionScope() => throw new NotImplementedException();
 
             public void StartObjectScope()
             {
@@ -401,15 +394,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                 this.textWriter.Write('>');
             }
 
-            public void StartArrayScope()
-            {
-                throw new NotImplementedException();
-            }
+            public void StartArrayScope() => throw new NotImplementedException();
 
-            public void EndArrayScope()
-            {
-                throw new NotImplementedException();
-            }
+            public void EndArrayScope() => throw new NotImplementedException();
 
             public void WriteName(string name)
             {
@@ -421,110 +408,56 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                 this.textWriter.Write("\"{0}\":", name);
             }
 
-            public void WritePaddingFunctionName(string functionName)
-            {
-                throw new NotImplementedException();
-            }
+            public void WritePaddingFunctionName(string functionName) => throw new NotImplementedException();
 
-            public void WriteValue(bool value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(bool value) => throw new NotImplementedException();
 
             public void WriteValue(int value)
             {
                 this.textWriter.Write("{0},", value);
             }
 
-            public void WriteValue(float value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(float value) => throw new NotImplementedException();
 
-            public void WriteValue(short value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(short value) => throw new NotImplementedException();
 
-            public void WriteValue(long value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(long value) => throw new NotImplementedException();
 
-            public void WriteValue(double value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(double value) => throw new NotImplementedException();
 
-            public void WriteValue(Guid value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(Guid value) => throw new NotImplementedException();
 
-            public void WriteValue(decimal value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(decimal value) => throw new NotImplementedException();
 
-            public void WriteValue(DateTimeOffset value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(DateTimeOffset value) => throw new NotImplementedException();
 
-            public void WriteValue(TimeSpan value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(TimeSpan value) => throw new NotImplementedException();
 
-            public void WriteValue(byte value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(byte value) => throw new NotImplementedException();
 
-            public void WriteValue(sbyte value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(sbyte value) => throw new NotImplementedException();
 
             public void WriteValue(string value)
             {
                 this.textWriter.Write("\"{0}\",", value);
             }
 
-            public void WriteValue(byte[] value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(byte[] value) => throw new NotImplementedException();
 
-            public void WriteValue(Date value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(Date value) => throw new NotImplementedException();
 
-            public void WriteValue(TimeOfDay value)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteValue(TimeOfDay value) => throw new NotImplementedException();
 
-            public void WriteRawValue(string rawValue)
-            {
-                throw new NotImplementedException();
-            }
+            public void WriteRawValue(string rawValue) => throw new NotImplementedException();
 
             public void Flush()
             {
                 this.textWriter.Flush();
             }
 
-            public Task StartPaddingFunctionScopeAsync()
-            {
-                throw new NotImplementedException();
-            }
+            public Task StartPaddingFunctionScopeAsync() => throw new NotImplementedException();
 
-            public Task EndPaddingFunctionScopeAsync()
-            {
-                throw new NotImplementedException();
-            }
+            public Task EndPaddingFunctionScopeAsync() => throw new NotImplementedException();
 
             public async Task StartObjectScopeAsync()
             {
@@ -536,15 +469,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                 await this.textWriter.WriteAsync('>');
             }
 
-            public Task StartArrayScopeAsync()
-            {
-                throw new NotImplementedException();
-            }
+            public Task StartArrayScopeAsync() => throw new NotImplementedException();
 
-            public Task EndArrayScopeAsync()
-            {
-                throw new NotImplementedException();
-            }
+            public Task EndArrayScopeAsync() => throw new NotImplementedException();
 
             public async Task WriteNameAsync(string name)
             {
@@ -556,95 +483,47 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                 await this.textWriter.WriteAsync(string.Format("\"{0}\":", name));
             }
 
-            public Task WritePaddingFunctionNameAsync(string functionName)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WritePaddingFunctionNameAsync(string functionName) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(bool value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(bool value) => throw new NotImplementedException();
 
             public async Task WriteValueAsync(int value)
             {
                 await this.textWriter.WriteAsync(string.Format("{0},", value));
             }
 
-            public Task WriteValueAsync(float value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(float value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(short value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(short value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(long value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(long value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(double value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(double value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(Guid value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(Guid value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(decimal value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(decimal value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(DateTimeOffset value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(DateTimeOffset value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(TimeSpan value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(TimeSpan value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(byte value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(byte value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(sbyte value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(sbyte value) => throw new NotImplementedException();
 
             public Task WriteValueAsync(string value)
             {
                 return this.textWriter.WriteAsync(string.Format("\"{0}\",", value));
             }
 
-            public Task WriteValueAsync(byte[] value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(byte[] value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(Date value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(Date value) => throw new NotImplementedException();
 
-            public Task WriteValueAsync(TimeOfDay value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(TimeOfDay value) => throw new NotImplementedException();
 
-            public Task WriteRawValueAsync(string rawValue)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteRawValueAsync(string rawValue) => throw new NotImplementedException();
 
             public Task FlushAsync()
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
@@ -459,14 +459,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
 
             public Task EndPaddingFunctionScopeAsync() => throw new NotImplementedException();
 
-            public async Task StartObjectScopeAsync()
+            public Task StartObjectScopeAsync()
             {
-                await this.textWriter.WriteAsync('<');
+                return this.textWriter.WriteAsync('<');
             }
 
-            public async Task EndObjectScopeAsync()
+            public Task EndObjectScopeAsync()
             {
-                await this.textWriter.WriteAsync('>');
+                return this.textWriter.WriteAsync('>');
             }
 
             public Task StartArrayScopeAsync() => throw new NotImplementedException();
@@ -487,9 +487,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
 
             public Task WriteValueAsync(bool value) => throw new NotImplementedException();
 
-            public async Task WriteValueAsync(int value)
+            public Task WriteValueAsync(int value)
             {
-                await this.textWriter.WriteAsync(string.Format("{0},", value));
+                return this.textWriter.WriteAsync(string.Format("{0},", value));
             }
 
             public Task WriteValueAsync(float value) => throw new NotImplementedException();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Json;
 using Microsoft.Test.OData.DependencyInjection;
@@ -371,7 +372,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
             }
         }
 
-        private class TestJsonWriter : IJsonWriter
+        private class TestJsonWriter : IJsonWriter, IJsonWriterAsync
         {
             private readonly TextWriter textWriter;
 
@@ -513,6 +514,141 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
             public void Flush()
             {
                 this.textWriter.Flush();
+            }
+
+            public Task StartPaddingFunctionScopeAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task EndPaddingFunctionScopeAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public async Task StartObjectScopeAsync()
+            {
+                await this.textWriter.WriteAsync('<');
+            }
+
+            public async Task EndObjectScopeAsync()
+            {
+                await this.textWriter.WriteAsync('>');
+            }
+
+            public Task StartArrayScopeAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task EndArrayScopeAsync()
+            {
+                throw new NotImplementedException();
+            }
+
+            public async Task WriteNameAsync(string name)
+            {
+                if (name.StartsWith("@odata."))
+                {
+                    name = '@' + name.Substring(7);
+                }
+
+                await this.textWriter.WriteAsync(string.Format("\"{0}\":", name));
+            }
+
+            public Task WritePaddingFunctionNameAsync(string functionName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(bool value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public async Task WriteValueAsync(int value)
+            {
+                await this.textWriter.WriteAsync(string.Format("{0},", value));
+            }
+
+            public Task WriteValueAsync(float value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(short value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(long value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(double value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(Guid value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(decimal value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(DateTimeOffset value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(TimeSpan value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(byte value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(sbyte value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(string value)
+            {
+                return this.textWriter.WriteAsync(string.Format("\"{0}\",", value));
+            }
+
+            public Task WriteValueAsync(byte[] value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(Date value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteValueAsync(TimeOfDay value)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task WriteRawValueAsync(string rawValue)
+            {
+                throw new NotImplementedException();
+            }
+
+            public Task FlushAsync()
+            {
+                return this.textWriter.FlushAsync();
             }
         }
 

--- a/test/PerformanceTests/SerializationComparisonsTests/Lib/DefaultWriterCollection.cs
+++ b/test/PerformanceTests/SerializationComparisonsTests/Lib/DefaultWriterCollection.cs
@@ -36,6 +36,8 @@ namespace ExperimentsLib
 
                 ("ODataUtf8JsonWriter-Direct", new ODataJsonWriterDirectPayloadWriter(
                     stream => stream.CreateODataUtf8JsonWriter())),
+                ("ODataUtf8JsonWriter-Direct-Async", new ODataJsonWriterAsyncDirectPayloadWriter(
+                    stream => stream.CreateODataUtf8JsonWriterAsync())),
 
                 ("ODataJsonWriter-Direct", new ODataJsonWriterDirectPayloadWriter(
                     stream => stream.CreateODataJsonWriter())),
@@ -47,14 +49,24 @@ namespace ExperimentsLib
                 ("ODataMessageWriter-NoValidation", new ODataMessageWriterPayloadWriter(model, stream => stream.CreateJsonWriterMessage(), enableValidation: false)),
                 ("ODataMessageWriter-NoOp", new ODataMessageWriterPayloadWriter(model, stream => stream.CreateNoopMessage())),
 
-                ("ODataMessageWriter-Utf8JsonWriter", new ODataMessageWriterPayloadWriter(model, stream => stream.CreateUtf8JsonWriterMessage())),
-                ("ODataMessageWriter-Utf8JsonWriter-Utf16", new ODataMessageWriterPayloadWriter(model, stream => stream.CreateUtf8JsonWriterMessage("UTF-16"))),
-                ("ODataMessageWriter-Utf8JsonWriter-NoValidation", new ODataMessageWriterPayloadWriter(model, stream => stream.CreateUtf8JsonWriterMessage(), enableValidation: false)),
+                ("ODataMessageWriter-Utf8JsonWriter", new ODataMessageWriterPayloadWriter(model,
+                    stream => stream.CreateUtf8JsonWriterMessage())),
+                ("ODataMessageWriter-Utf8JsonWriter-Utf16", new ODataMessageWriterPayloadWriter(model,
+                    stream => stream.CreateUtf8JsonWriterMessage("UTF-16"))),
+                ("ODataMessageWriter-Utf8JsonWriter-NoValidation", new ODataMessageWriterPayloadWriter(model,
+                    stream => stream.CreateUtf8JsonWriterMessage(), enableValidation: false)),
 
-                ("ODataMessageWriter-Async", new ODataMessageWriterAsyncPayloadWriter(model, stream => stream.CreateJsonWriterMessage())),
-                ("ODataMessageWriter-NoValidation-Async", new ODataMessageWriterAsyncPayloadWriter(model, stream => stream.CreateJsonWriterMessage(), enableValidation: false)),
-                ("ODataMessageWriter-NoOp-Async", new ODataMessageWriterAsyncPayloadWriter(model, stream => stream.CreateNoopMessage()))
-                );
+                ("ODataMessageWriter-Async", new ODataMessageWriterAsyncPayloadWriter(model,
+                    stream => stream.CreateJsonWriterMessage())),
+                ("ODataMessageWriter-NoValidation-Async", new ODataMessageWriterAsyncPayloadWriter(model,
+                    stream => stream.CreateJsonWriterMessage(), enableValidation: false)),
+                ("ODataMessageWriter-NoOp-Async", new ODataMessageWriterAsyncPayloadWriter(model,
+                    stream => stream.CreateNoopMessage())),
+
+                ("ODataMessageWriter-Utf8JsonWriter-Async", new ODataMessageWriterAsyncPayloadWriter(model,
+                    stream => stream.CreateUtf8JsonWriterMessage())),
+                ("ODataMessageWriter-Utf8JsonWriter-NoValidation-Async", new ODataMessageWriterAsyncPayloadWriter(model,
+                    stream => stream.CreateUtf8JsonWriterMessage(), enableValidation: false)));
 
             return writers;
         }

--- a/test/PerformanceTests/SerializationComparisonsTests/Lib/ODataJsonWriterDirectPayloadWriter.cs
+++ b/test/PerformanceTests/SerializationComparisonsTests/Lib/ODataJsonWriterDirectPayloadWriter.cs
@@ -47,12 +47,10 @@ namespace ExperimentsLib
                 jsonWriter.WriteValue(customer.Name);
                 jsonWriter.WriteName("Emails");
                 jsonWriter.StartArrayScope();
-
                 foreach (var email in customer.Emails)
                 {
                     jsonWriter.WriteValue(email);
                 }
-
                 jsonWriter.EndArrayScope();
 
 

--- a/test/PerformanceTests/SerializationComparisonsTests/Lib/Utf8JsonWriterDirectPayloadWriter.cs
+++ b/test/PerformanceTests/SerializationComparisonsTests/Lib/Utf8JsonWriterDirectPayloadWriter.cs
@@ -29,16 +29,12 @@ namespace ExperimentsLib
         /// <inheritdoc/>
         public async Task WritePayloadAsync(IEnumerable<Customer> payload, Stream stream)
         {
-            Uri serviceRoot = new Uri("https://services.odata.org/V4/OData/OData.svc/");
-
-            using Utf8JsonWriter jsonWriter = this.writerFactory(stream);
 
             jsonWriter.WriteStartObject();
             jsonWriter.WriteString("@odata.context", $"{serviceRoot}$metadata#Customers");
             jsonWriter.WriteStartArray("value");
 
             int count = 0;
-
             foreach (var _customer in payload)
             {
                 Customer customer = _customer;
@@ -47,12 +43,10 @@ namespace ExperimentsLib
                 jsonWriter.WriteNumber("Id", customer.Id);
                 jsonWriter.WriteString("Name", customer.Name);
                 jsonWriter.WriteStartArray("Emails");
-
                 foreach (var email in customer.Emails)
                 {
                     jsonWriter.WriteStringValue(email);
                 }
-
                 jsonWriter.WriteEndArray();
 
 
@@ -94,7 +88,6 @@ namespace ExperimentsLib
                     await jsonWriter.FlushAsync();
                 }
             }
-
             jsonWriter.WriteEndArray();
             jsonWriter.WriteEndObject();
             await jsonWriter.FlushAsync();

--- a/test/PerformanceTests/SerializationComparisonsTests/Lib/Utf8JsonWriterDirectPayloadWriter.cs
+++ b/test/PerformanceTests/SerializationComparisonsTests/Lib/Utf8JsonWriterDirectPayloadWriter.cs
@@ -21,7 +21,7 @@ namespace ExperimentsLib
     {
         private readonly Func<Stream, Utf8JsonWriter> writerFactory;
 
-        public Utf8JsonWriterDirectPayloadWriter(Func<Stream, Utf8JsonWriter> writerFactory, bool simulateResourceGeneration = false)
+        public Utf8JsonWriterDirectPayloadWriter(Func<Stream, Utf8JsonWriter> writerFactory)
         {
             this.writerFactory = writerFactory;
         }
@@ -29,6 +29,9 @@ namespace ExperimentsLib
         /// <inheritdoc/>
         public async Task WritePayloadAsync(IEnumerable<Customer> payload, Stream stream)
         {
+            Uri serviceRoot = new Uri("https://services.odata.org/V4/OData/OData.svc/");
+
+            using Utf8JsonWriter jsonWriter = this.writerFactory(stream);
 
             jsonWriter.WriteStartObject();
             jsonWriter.WriteString("@odata.context", $"{serviceRoot}$metadata#Customers");
@@ -43,10 +46,12 @@ namespace ExperimentsLib
                 jsonWriter.WriteNumber("Id", customer.Id);
                 jsonWriter.WriteString("Name", customer.Name);
                 jsonWriter.WriteStartArray("Emails");
+
                 foreach (var email in customer.Emails)
                 {
                     jsonWriter.WriteStringValue(email);
                 }
+
                 jsonWriter.WriteEndArray();
 
 
@@ -88,6 +93,7 @@ namespace ExperimentsLib
                     await jsonWriter.FlushAsync();
                 }
             }
+
             jsonWriter.WriteEndArray();
             jsonWriter.WriteEndObject();
             await jsonWriter.FlushAsync();

--- a/test/PerformanceTests/SerializationComparisonsTests/Lib/Utf8JsonWriterDirectPayloadWriter.cs
+++ b/test/PerformanceTests/SerializationComparisonsTests/Lib/Utf8JsonWriterDirectPayloadWriter.cs
@@ -38,10 +38,9 @@ namespace ExperimentsLib
             jsonWriter.WriteStartArray("value");
 
             int count = 0;
-            foreach (var _customer in payload)
-            {
-                Customer customer = _customer;
 
+            foreach (Customer customer in payload)
+            {
                 jsonWriter.WriteStartObject();
                 jsonWriter.WriteNumber("Id", customer.Id);
                 jsonWriter.WriteString("Name", customer.Name);

--- a/test/PerformanceTests/SerializationComparisonsTests/Lib/Utf8JsonWriterDirectPayloadWriterWithArrayPool.cs
+++ b/test/PerformanceTests/SerializationComparisonsTests/Lib/Utf8JsonWriterDirectPayloadWriterWithArrayPool.cs
@@ -23,7 +23,7 @@ namespace ExperimentsLib
         private Func<IBufferWriter<byte>, Utf8JsonWriter> writerFactory;
         const int BufferSize = 16 * 1024;
 
-        public Utf8JsonWriterDirectPayloadWriterWithArrayPool(Func<IBufferWriter<byte>, Utf8JsonWriter> writerFactory, bool simulateResourceGeneration = false)
+        public Utf8JsonWriterDirectPayloadWriterWithArrayPool(Func<IBufferWriter<byte>, Utf8JsonWriter> writerFactory)
         {
             this.writerFactory = writerFactory;
         }
@@ -42,16 +42,19 @@ namespace ExperimentsLib
             jsonWriter.WriteStartArray("value");
 
             int count = 0;
+
             foreach (Customer customer in payload)
             {
                 jsonWriter.WriteStartObject();
                 jsonWriter.WriteNumber("Id", customer.Id);
                 jsonWriter.WriteString("Name", customer.Name);
                 jsonWriter.WriteStartArray("Emails");
+
                 foreach (var email in customer.Emails)
                 {
                     jsonWriter.WriteStringValue(email);
                 }
+
                 jsonWriter.WriteEndArray();
 
 

--- a/test/PerformanceTests/SerializationComparisonsTests/Lib/WriterHelpers.cs
+++ b/test/PerformanceTests/SerializationComparisonsTests/Lib/WriterHelpers.cs
@@ -34,6 +34,12 @@ namespace ExperimentsLib
             return factory.CreateJsonWriter(stream, false, encoding ?? Encoding.UTF8);
         }
 
+        public static IJsonWriterAsync CreateODataUtf8JsonWriterAsync(this Stream stream, Encoding encoding = null)
+        {
+            DefaultStreamBasedJsonWriterFactory factory = DefaultStreamBasedJsonWriterFactory.Default;
+            return factory.CreateAsynchronousJsonWriter(stream, false, encoding ?? Encoding.UTF8);
+        }
+
         public static IODataResponseMessage CreateJsonWriterMessage(this Stream stream, string charset = "UTF-8")
         {
             return stream.CreateODataMessage(null, charset);

--- a/test/PerformanceTests/SerializationComparisonsTests/README.md
+++ b/test/PerformanceTests/SerializationComparisonsTests/README.md
@@ -33,24 +33,27 @@ Intel Xeon E-2336 CPU 2.90GHz, 1 CPU, 12 logical and 6 physical cores
 
 Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1
 
-|          Method |                                     WriterName |       Mean |     Error |    StdDev |      Gen 0 |     Gen 1 |  Allocated |
------------------ |----------------------------------------------- |-----------:|----------:|----------:|-----------:|----------:|-----------:|
- WriteToFileAsync |                                 JsonSerializer |  30.849 ms | 0.2615 ms | 0.2446 ms |          - |         - |      28 KB |
- WriteToFileAsync |                              NoOpWriter-Direct |   1.252 ms | 0.0054 ms | 0.0042 ms |          - |         - |       3 KB |
- WriteToFileAsync |                         ODataJsonWriter-Direct |  34.918 ms | 0.0741 ms | 0.0657 ms |  1000.0000 |         - |   6,675 KB |
- WriteToFileAsync |                   ODataJsonWriter-Direct-Async | 190.807 ms | 0.7046 ms | 0.6590 ms |  8000.0000 |         - |  48,698 KB |
- WriteToFileAsync |                             ODataMessageWriter | 293.411 ms | 0.5442 ms | 0.5091 ms | 41000.0000 |         - | 254,694 KB |
- WriteToFileAsync |                       ODataMessageWriter-Async | 900.943 ms | 2.9349 ms | 2.2914 ms | 66000.0000 | 1000.0000 | 406,565 KB |
- WriteToFileAsync |                        ODataMessageWriter-NoOp | 242.911 ms | 0.6638 ms | 0.6210 ms | 40000.0000 |         - | 248,036 KB |
- WriteToFileAsync |                  ODataMessageWriter-NoOp-Async | 373.211 ms | 0.4660 ms | 0.4131 ms | 44000.0000 |         - | 272,274 KB |
- WriteToFileAsync |                ODataMessageWriter-NoValidation | 258.008 ms | 0.4445 ms | 0.4158 ms | 37000.0000 |         - | 231,254 KB |
- WriteToFileAsync |          ODataMessageWriter-NoValidation-Async | 853.044 ms | 2.1455 ms | 1.9020 ms | 62000.0000 | 1000.0000 | 382,928 KB |
- WriteToFileAsync |                       ODataMessageWriter-Utf16 | 304.285 ms | 0.7415 ms | 0.6936 ms | 41000.0000 |         - | 254,689 KB |
- WriteToFileAsync |              ODataMessageWriter-Utf8JsonWriter | 284.935 ms | 0.5261 ms | 0.4921 ms | 40000.0000 | 1000.0000 | 248,271 KB |
- WriteToFileAsync | ODataMessageWriter-Utf8JsonWriter-NoValidation | 245.019 ms | 0.6755 ms | 0.6319 ms | 36000.0000 | 1000.0000 | 224,831 KB |
- WriteToFileAsync |        ODataMessageWriter-Utf8JsonWriter-Utf16 | 288.879 ms | 0.4336 ms | 0.3844 ms | 40000.0000 | 1000.0000 | 248,272 KB |
- WriteToFileAsync |                     ODataUtf8JsonWriter-Direct |  21.080 ms | 0.0378 ms | 0.0354 ms |          - |         - |     241 KB |
- WriteToFileAsync |   Utf8JsonWriter-Direct-ArrayPool-NoValidation |  18.246 ms | 0.0396 ms | 0.0370 ms |          - |         - |      29 KB |
+|           Method |                                           WriterName |       Mean |     Error |    StdDev |     Median |      Gen 0 |     Gen 1 |  Allocated |
+----------------- |----------------------------------------------------- |-----------:|----------:|----------:|-----------:|-----------:|----------:|-----------:|
+ WriteToFileAsync |                                       JsonSerializer |  31.501 ms | 0.6233 ms | 1.0916 ms |  30.733 ms |          - |         - |      12 KB |
+ WriteToFileAsync |                                    NoOpWriter-Direct |   1.248 ms | 0.0125 ms | 0.0117 ms |   1.250 ms |          - |         - |       3 KB |
+ WriteToFileAsync |                               ODataJsonWriter-Direct |  34.767 ms | 0.2421 ms | 0.2146 ms |  34.753 ms |  1000.0000 |         - |   6,676 KB |
+ WriteToFileAsync |                         ODataJsonWriter-Direct-Async | 185.872 ms | 0.8463 ms | 0.7502 ms | 185.852 ms |  8000.0000 |         - |  48,697 KB |
+ WriteToFileAsync |                                   ODataMessageWriter | 281.088 ms | 0.5729 ms | 0.5078 ms | 280.970 ms | 41000.0000 |         - | 254,692 KB |
+ WriteToFileAsync |                             ODataMessageWriter-Async | 907.453 ms | 4.1577 ms | 3.4718 ms | 906.944 ms | 66000.0000 | 1000.0000 | 406,552 KB |
+ WriteToFileAsync |                              ODataMessageWriter-NoOp | 229.170 ms | 0.5146 ms | 0.4814 ms | 229.286 ms | 40000.0000 |         - | 248,033 KB |
+ WriteToFileAsync |                        ODataMessageWriter-NoOp-Async | 368.397 ms | 0.7569 ms | 0.7080 ms | 368.138 ms | 44000.0000 |         - | 272,260 KB |
+ WriteToFileAsync |                      ODataMessageWriter-NoValidation | 245.621 ms | 0.5507 ms | 0.4881 ms | 245.605 ms | 37000.0000 |         - | 231,252 KB |
+ WriteToFileAsync |                ODataMessageWriter-NoValidation-Async | 860.340 ms | 2.2663 ms | 2.1199 ms | 860.096 ms | 62000.0000 | 1000.0000 | 382,899 KB |
+ WriteToFileAsync |                             ODataMessageWriter-Utf16 | 290.900 ms | 0.3936 ms | 0.3681 ms | 290.847 ms | 41000.0000 |         - | 254,686 KB |
+ WriteToFileAsync |                    ODataMessageWriter-Utf8JsonWriter | 268.592 ms | 0.5407 ms | 0.5058 ms | 268.590 ms | 40000.0000 | 1000.0000 | 248,268 KB |
+ WriteToFileAsync |              ODataMessageWriter-Utf8JsonWriter-Async | 480.797 ms | 0.7170 ms | 0.6707 ms | 480.779 ms | 44000.0000 | 1000.0000 | 273,436 KB |
+ WriteToFileAsync |       ODataMessageWriter-Utf8JsonWriter-NoValidation | 232.998 ms | 0.2320 ms | 0.2057 ms | 232.957 ms | 36000.0000 | 1000.0000 | 224,828 KB |
+ WriteToFileAsync | ODataMessageWriter-Utf8JsonWriter-NoValidation-Async | 434.364 ms | 0.4606 ms | 0.4309 ms | 434.374 ms | 40000.0000 | 1000.0000 | 249,996 KB |
+ WriteToFileAsync |              ODataMessageWriter-Utf8JsonWriter-Utf16 | 273.423 ms | 0.3096 ms | 0.2896 ms | 273.425 ms | 40000.0000 | 1000.0000 | 248,269 KB |
+ WriteToFileAsync |                           ODataUtf8JsonWriter-Direct |  21.348 ms | 0.0488 ms | 0.0433 ms |  21.350 ms |          - |         - |     241 KB |
+ WriteToFileAsync |                     ODataUtf8JsonWriter-Direct-Async |  44.466 ms | 0.3865 ms | 0.3426 ms |  44.554 ms |          - |         - |     520 KB |
+ WriteToFileAsync |         Utf8JsonWriter-Direct-ArrayPool-NoValidation |  18.642 ms | 0.0550 ms | 0.0514 ms |  18.639 ms |          - |         - |      29 KB |
 
 By default, there's a filter applied that only runs the "ToFile" tests. If you want to run the in-memory tests, or apply a different filter, you can pass the `filter` variable manually to the `crank` command:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2421 

### Description

This PR adds an implementation of the `IJsonWriterAsync` API to `ODataUtf8JsonWriter`. At the basic level, it adds `Write***Async` methods to the `ODataUtf8JsonWriter` class.

I also had to make some changes to the `ODataJsonLightOutputContext`. This class was tightly coupled to the `JsonWriter` implementation. @gathogojr explained to me the rationale behind this: When writing spatial data we use a class that's part of Microsoft.Spatial library, that library expects an `IJsonWriter` (not the async version) as input. In the async methods we have an `IJsonWriterAsync`. So now we had to make sure that this `IJsonWriterAsync` is actually a JSON writer that implements both `IJsonWriterAsync` and `IJsonWriter`. We had to ensure that it's the same instance of the writer that does all of the writing, and not one writer for the async methods and another writer for the synchronous methods since the writer needs to keep track of internal state about the current scope being written.

Here are the changes I made: instead of relying on `JsonWriter`. I added some checks to ensure that when the user supplies an `IJsonWriter` implementation, that it also implements `IJsonWriterAsync` and vice-versa, otherwise an exception to be thrown.

In 8.x these two interfaces will be unified and that will do away with all these workarounds aimed to prevent potential breaking changes.

#### Perf

According to the following benchmark results, using `ODataMessageWriter` async API with `ODataUtf8JsonWriter` is up to 2x faster and uses significantly less memory.

![Benchmakrs](https://user-images.githubusercontent.com/8460169/180695085-71043a58-6cc4-4914-b6d6-924eb6097756.png)


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
