### PR TITLE
Performance refactor - elide async and await

### DIFF
--- a/src/Microsoft.OData.Core/Batch/ODataBatchOperationMessage.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchOperationMessage.cs
@@ -141,13 +141,22 @@ namespace Microsoft.OData
         {
             this.VerifyNotCompleted();
 
-            // notify the listener that the stream has been requested
-            Task listenerTask = this.operationListener.StreamRequestedAsync();
+            return GetStreamInnerAsync();
 
-            // now remember that we are done processing the part header data (and only the payload is missing)
-            Stream contentStream = this.contentStreamCreatorFunc();
-            this.PartHeaderProcessingCompleted();
-            return listenerTask.FollowOnSuccessWith(task => { return (Stream)contentStream; });
+            async Task<Stream> GetStreamInnerAsync()
+            {
+                // notify the listener that the stream has been requested
+                Task listenerTask = this.operationListener.StreamRequestedAsync();
+
+                // now remember that we are done processing the part header data (and only the payload is missing)
+                Stream contentStream = this.contentStreamCreatorFunc();
+                this.PartHeaderProcessingCompleted();
+
+                await listenerTask
+                    .ConfigureAwait(false);
+
+                return contentStream;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -167,11 +167,10 @@ namespace Microsoft.OData
 
         /// <summary>Asynchronously starts a new batch; can be only called once and as first call.</summary>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public async Task WriteStartBatchAsync()
+        public Task WriteStartBatchAsync()
         {
             this.VerifyCanWriteStartBatch(false);
-            await this.WriteStartBatchImplementationAsync()
-                .ConfigureAwait(false);
+            return this.WriteStartBatchImplementationAsync();
         }
 
         /// <summary>Ends a batch; can only be called after WriteStartBatch has been called and if no other active changeset or operation exist.</summary>
@@ -340,12 +339,16 @@ namespace Microsoft.OData
         /// The format of operation Request-URI, which could be AbsoluteUri, AbsoluteResourcePathAndHost, or RelativeResourcePath.</param>
         /// <param name="dependsOnIds">The prerequisite request ids of this request.</param>
         /// <returns>A task that when completed returns the newly created operation request message.</returns>
-        public async Task<ODataBatchOperationRequestMessage> CreateOperationRequestMessageAsync(string method, Uri uri, string contentId,
-            BatchPayloadUriOption payloadUriOption, IList<string> dependsOnIds)
+        public Task<ODataBatchOperationRequestMessage> CreateOperationRequestMessageAsync(
+            string method,
+            Uri uri,
+            string contentId,
+            BatchPayloadUriOption payloadUriOption,
+            IList<string> dependsOnIds)
         {
             this.VerifyCanCreateOperationRequestMessage(false, method, uri, contentId);
-            return await this.CreateOperationRequestMessageInternalAsync(
-                method, uri, contentId, payloadUriOption, dependsOnIds).ConfigureAwait(false);
+            return this.CreateOperationRequestMessageInternalAsync(
+                method, uri, contentId, payloadUriOption, dependsOnIds);
         }
 
         /// <summary>Creates a message for writing an operation of a batch response.</summary>
@@ -360,11 +363,10 @@ namespace Microsoft.OData
         /// <summary>Asynchronously creates an <see cref="Microsoft.OData.ODataBatchOperationResponseMessage" /> for writing an operation of a batch response.</summary>
         /// <param name="contentId">The Content-ID value to write in ChangeSet head.</param>
         /// <returns>A task that when completed returns the newly created operation response message.</returns>
-        public async Task<ODataBatchOperationResponseMessage> CreateOperationResponseMessageAsync(string contentId)
+        public Task<ODataBatchOperationResponseMessage> CreateOperationResponseMessageAsync(string contentId)
         {
             this.VerifyCanCreateOperationResponseMessage(false);
-            return await this.CreateOperationResponseMessageImplementationAsync(contentId)
-                .ConfigureAwait(false);
+            return this.CreateOperationResponseMessageImplementationAsync(contentId);
         }
 
         /// <summary>Flushes the write buffer to the underlying stream.</summary>

--- a/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
+++ b/src/Microsoft.OData.Core/Batch/ODataBatchWriter.cs
@@ -592,7 +592,9 @@ namespace Microsoft.OData
         /// <returns>A task that represents the asynchronous write operation.</returns>
         protected virtual Task WriteStartBatchImplementationAsync()
         {
-            return TaskUtils.GetTaskForSynchronousOperation(this.WriteStartBatchImplementation);
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam) => thisParam.WriteStartBatchImplementation(),
+                this);
         }
 
         /// <summary>
@@ -601,7 +603,9 @@ namespace Microsoft.OData
         /// <returns>A task that represents the asynchronous write operation.</returns>
         protected virtual Task WriteEndBatchImplementationAsync()
         {
-            return TaskUtils.GetTaskForSynchronousOperation(this.WriteEndBatchImplementation);
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam) => thisParam.WriteEndBatchImplementation(),
+                this);
         }
 
         /// <summary>
@@ -612,7 +616,9 @@ namespace Microsoft.OData
         protected virtual Task WriteStartChangesetImplementationAsync(string groupOrChangesetId)
         {
             return TaskUtils.GetTaskForSynchronousOperation(
-                () => this.WriteStartChangesetImplementation(groupOrChangesetId));
+                (thisParam, groupOrChangesetIdParam) => thisParam.WriteStartChangesetImplementation(groupOrChangesetIdParam),
+                this,
+                groupOrChangesetId);
         }
 
         /// <summary>
@@ -621,7 +627,9 @@ namespace Microsoft.OData
         /// <returns>A task that represents the asynchronous write operation.</returns>
         protected virtual Task WriteEndChangesetImplementationAsync()
         {
-            return TaskUtils.GetTaskForSynchronousOperation(this.WriteEndChangesetImplementation);
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam) => thisParam.WriteEndChangesetImplementation(),
+                this);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -289,27 +289,45 @@ namespace Microsoft.OData
             // but foreach against an IEnumerable does due to boxing
             if (instanceAnnotations is List<ODataInstanceAnnotation> instanceAnnotationsList)
             {
-                return WriteInstanceAnnotationsListAsync();
+                return WriteInstanceAnnotationsListAsync(instanceAnnotationsList, tracker, instanceAnnotationNames, ignoreFilter, propertyName);
 
-                async Task WriteInstanceAnnotationsListAsync()
+                async Task WriteInstanceAnnotationsListAsync(
+                    List<ODataInstanceAnnotation> innerInstanceAnnotationsList,
+                    InstanceAnnotationWriteTracker innerInstanceAnnotationWriteTracker,
+                    HashSet<string> innerInstanceAnnotationNames,
+                    bool innerIgnoreFilter,
+                    string innerPropertyName)
                 {
-                    foreach (ODataInstanceAnnotation annotation in instanceAnnotationsList)
+                    foreach (ODataInstanceAnnotation annotation in innerInstanceAnnotationsList)
                     {
-                        await this.WriteAndTrackInstanceAnnotationAsync(annotation, tracker, instanceAnnotationNames, ignoreFilter, propertyName)
-                            .ConfigureAwait(false);
+                        await this.WriteAndTrackInstanceAnnotationAsync(
+                            annotation,
+                            innerInstanceAnnotationWriteTracker,
+                            innerInstanceAnnotationNames,
+                            innerIgnoreFilter,
+                            innerPropertyName).ConfigureAwait(false);
                     }
                 }
             }
             else
             {
-                return WriteInstanceAnnotationsInnerAsync();
+                return WriteInstanceAnnotationsInnerAsync(instanceAnnotations, tracker, instanceAnnotationNames, ignoreFilter, propertyName);
 
-                async Task WriteInstanceAnnotationsInnerAsync()
+                async Task WriteInstanceAnnotationsInnerAsync(
+                    ICollection<ODataInstanceAnnotation> innerInstanceAnnotations,
+                    InstanceAnnotationWriteTracker innerInstanceAnnotationWriteTracker,
+                    HashSet<string> innerInstanceAnnotationNames,
+                    bool innerIgnoreFilter,
+                    string innerPropertyName)
                 {
-                    foreach (ODataInstanceAnnotation annotation in instanceAnnotations)
+                    foreach (ODataInstanceAnnotation annotation in innerInstanceAnnotations)
                     {
-                        await this.WriteAndTrackInstanceAnnotationAsync(annotation, tracker, instanceAnnotationNames, ignoreFilter, propertyName)
-                            .ConfigureAwait(false);
+                        await this.WriteAndTrackInstanceAnnotationAsync(
+                            annotation,
+                            innerInstanceAnnotationWriteTracker,
+                            innerInstanceAnnotationNames,
+                            innerIgnoreFilter,
+                            innerPropertyName).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -2139,7 +2139,7 @@ namespace Microsoft.OData.Json
         /// The value of the TResult parameter contains true if a non-whitespace character was found,
         /// in which case the <see cref="tokenStartIndex"/> is pointing at that character;
         /// otherwise false if there are no non-whitespace characters left in the input.</returns>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private async ValueTask<bool> SkipWhitespacesAsync()
 #else
         private async Task<bool> SkipWhitespacesAsync()
@@ -2167,7 +2167,7 @@ namespace Microsoft.OData.Json
         /// <returns>A task that represents the asynchronous operation.
         /// The value of the TResult parameter contains true if at least the required number of characters is available; 
         /// otherwise false if end of input was reached.</returns>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private async ValueTask<bool> EnsureAvailableCharactersAsync(int characterCountAfterTokenStart)
 #else
         private async Task<bool> EnsureAvailableCharactersAsync(int characterCountAfterTokenStart)
@@ -2192,7 +2192,7 @@ namespace Microsoft.OData.Json
         /// otherwise false if end of input was reached.</returns>
         /// <remarks>This may move characters in the <see cref="characterBuffer"/>, so after this is called
         /// all indices to the <see cref="characterBuffer"/> are invalid except for <see cref="tokenStartIndex"/>.</remarks>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private async ValueTask<bool> ReadInputAsync()
 #else
         private async Task<bool> ReadInputAsync()

--- a/src/Microsoft.OData.Core/Json/JsonReaderExtensions.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReaderExtensions.cs
@@ -808,9 +808,10 @@ namespace Microsoft.OData.Json
 #if DEBUG
             bool result = await jsonReader.ReadAsync()
                 .ConfigureAwait(false);
-            Debug.Assert(result, "JsonReader.Read returned false in an unexpected place.");
+            Debug.Assert(result, "JsonReader.ReadAsync returned false in an unexpected place.");
 #else
-            await jsonReader.ReadAsync();
+            await jsonReader.ReadAsync()
+                .ConfigureAwait(false);
 #endif
             return jsonReader.NodeType;
         }

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -381,7 +381,7 @@ namespace Microsoft.OData.Json
         /// <param name="stringEscapeOption">The string escape option.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>
         /// <param name="bufferPool">Array pool for renting a buffer.</param>
-        internal static Task WriteEscapedJsonStringValueAsync(
+        internal static async Task WriteEscapedJsonStringValueAsync(
             this TextWriter writer,
             string inputString,
             ODataStringEscapeOption stringEscapeOption,
@@ -394,52 +394,45 @@ namespace Microsoft.OData.Json
             int firstIndex;
             if (!CheckIfStringHasSpecialChars(inputString, stringEscapeOption, out firstIndex))
             {
-                // This block is executed majority of the times
-                // Eliding async and await for better performance and memory usage metrics
-                return writer.WriteAsync(inputString);
+                await writer.WriteAsync(inputString).ConfigureAwait(false);
             }
             else
             {
-                return WriteEscapedJsonStringValueInnerAsync();
+                Debug.Assert(firstIndex < inputString.Length, "First index of the special character should be within the string");
+                buffer.Value = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer.Value);
+                int bufferLength = buffer.Value.Length;
+                int bufferIndex = 0;
+                int currentIndex = 0;
 
-                async Task WriteEscapedJsonStringValueInnerAsync()
+                // Let's copy and flush strings up to the first index of the special char
+                while (currentIndex < firstIndex)
                 {
-                    Debug.Assert(firstIndex < inputString.Length, "First index of the special character should be within the string");
-                    buffer.Value = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer.Value);
-                    int bufferLength = buffer.Value.Length;
-                    int bufferIndex = 0;
-                    int currentIndex = 0;
+                    int substrLength = firstIndex - currentIndex;
 
-                    // Let's copy and flush strings up to the first index of the special char
-                    while (currentIndex < firstIndex)
+                    Debug.Assert(substrLength > 0, "SubStrLength should be greater than 0 always");
+
+                    // If the first index of the special character is larger than the buffer length,
+                    // flush everything to the buffer first and reset the buffer to the next chunk.
+                    // Otherwise copy to the buffer and go on from there.
+                    if (substrLength >= bufferLength)
                     {
-                        int substrLength = firstIndex - currentIndex;
-
-                        Debug.Assert(substrLength > 0, "SubStrLength should be greater than 0 always");
-
-                        // If the first index of the special character is larger than the buffer length,
-                        // flush everything to the buffer first and reset the buffer to the next chunk.
-                        // Otherwise copy to the buffer and go on from there.
-                        if (substrLength >= bufferLength)
-                        {
-                            inputString.CopyTo(currentIndex, buffer.Value, 0, bufferLength);
-                            await writer.WriteAsync(buffer.Value, 0, bufferLength).ConfigureAwait(false);
-                            currentIndex += bufferLength;
-                        }
-                        else
-                        {
-                            WriteSubstringToBuffer(inputString, ref currentIndex, buffer.Value, ref bufferIndex, substrLength);
-                        }
+                        inputString.CopyTo(currentIndex, buffer.Value, 0, bufferLength);
+                        await writer.WriteAsync(buffer.Value, 0, bufferLength).ConfigureAwait(false);
+                        currentIndex += bufferLength;
                     }
-
-                    // Write escaped string to buffer
-                    WriteEscapedStringToBuffer(writer, inputString, ref currentIndex, buffer.Value, ref bufferIndex, stringEscapeOption);
-
-                    // write any remaining chars to the writer
-                    if (bufferIndex > 0)
+                    else
                     {
-                        await writer.WriteAsync(buffer.Value, 0, bufferIndex).ConfigureAwait(false);
+                        WriteSubstringToBuffer(inputString, ref currentIndex, buffer.Value, ref bufferIndex, substrLength);
                     }
+                }
+
+                // Write escaped string to buffer
+                WriteEscapedStringToBuffer(writer, inputString, ref currentIndex, buffer.Value, ref bufferIndex, stringEscapeOption);
+
+                // write any remaining chars to the writer
+                if (bufferIndex > 0)
+                {
+                    await writer.WriteAsync(buffer.Value, 0, bufferIndex).ConfigureAwait(false);
                 }
             }
         }

--- a/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
@@ -332,8 +332,6 @@ namespace Microsoft.OData.Json
                 {
                     return this.writer.WriteAsync(JsonConstants.ArrayElementSeparator);
                 }
-
-                
             }
 
             return TaskUtils.CompletedTask;

--- a/src/Microsoft.OData.Core/Json/JsonWriterAsyncExtensions.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterAsyncExtensions.cs
@@ -168,13 +168,13 @@ namespace Microsoft.OData.Json
 
             if (odataValue is ODataResourceValue resourceValue)
             {
-                return WriteODataResourceValueAsync();
+                return WriteODataResourceValueAsync(resourceValue);
 
-                async Task WriteODataResourceValueAsync()
+                async Task WriteODataResourceValueAsync(ODataResourceValue innerResourceValue)
                 {
                     await jsonWriter.StartObjectScopeAsync().ConfigureAwait(false);
 
-                    foreach (ODataProperty property in resourceValue.Properties)
+                    foreach (ODataProperty property in innerResourceValue.Properties)
                     {
                         await jsonWriter.WriteNameAsync(property.Name).ConfigureAwait(false);
                         await jsonWriter.WriteODataValueAsync(property.ODataValue).ConfigureAwait(false);
@@ -186,9 +186,9 @@ namespace Microsoft.OData.Json
 
             if (odataValue is ODataCollectionValue collectionValue)
             {
-                return WriteODataCollectionValueAsync();
+                return WriteODataCollectionValueAsync(collectionValue);
 
-                async Task WriteODataCollectionValueAsync()
+                async Task WriteODataCollectionValueAsync(ODataCollectionValue innerCollectionValue)
                 {
                     await jsonWriter.StartArrayScopeAsync().ConfigureAwait(false);
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonReaderCoreUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonReaderCoreUtils.cs
@@ -194,7 +194,7 @@ namespace Microsoft.OData.Json
         /// <returns>true if a null value could be read from the JSON reader; otherwise false.</returns>
         /// <remarks>If the method detects a null value it will read it (position the reader after the null value);
         /// otherwise the reader does not move.</remarks>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         internal static async ValueTask<bool> TryReadNullValueAsync(
 #else
         internal static async Task<bool> TryReadNullValueAsync(

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
@@ -171,15 +171,22 @@ namespace Microsoft.OData.Json
         /// <param name="jsonWriter">JsonWriter to write to.</param>
         /// <param name="settings">Writer settings.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        internal static async Task StartJsonPaddingIfRequiredAsync(IJsonWriterAsync jsonWriter, ODataMessageWriterSettings settings)
+        internal static Task StartJsonPaddingIfRequiredAsync(IJsonWriterAsync jsonWriter, ODataMessageWriterSettings settings)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter should not be null");
 
             if (settings.HasJsonPaddingFunction())
             {
-                await jsonWriter.WritePaddingFunctionNameAsync(settings.JsonPCallback).ConfigureAwait(false);
-                await jsonWriter.StartPaddingFunctionScopeAsync().ConfigureAwait(false);
+                return StartJsonPaddingIfRequiredInnerAsync();
+
+                async Task StartJsonPaddingIfRequiredInnerAsync()
+                {
+                    await jsonWriter.WritePaddingFunctionNameAsync(settings.JsonPCallback).ConfigureAwait(false);
+                    await jsonWriter.StartPaddingFunctionScopeAsync().ConfigureAwait(false);
+                }
             }
+
+            return TaskUtils.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
@@ -177,12 +177,12 @@ namespace Microsoft.OData.Json
 
             if (settings.HasJsonPaddingFunction())
             {
-                return StartJsonPaddingIfRequiredInnerAsync();
+                return StartJsonPaddingIfRequiredInnerAsync(jsonWriter, settings);
 
-                async Task StartJsonPaddingIfRequiredInnerAsync()
+                async Task StartJsonPaddingIfRequiredInnerAsync(IJsonWriterAsync innerJsonWriter, ODataMessageWriterSettings innerSettings)
                 {
-                    await jsonWriter.WritePaddingFunctionNameAsync(settings.JsonPCallback).ConfigureAwait(false);
-                    await jsonWriter.StartPaddingFunctionScopeAsync().ConfigureAwait(false);
+                    await innerJsonWriter.WritePaddingFunctionNameAsync(innerSettings.JsonPCallback).ConfigureAwait(false);
+                    await innerJsonWriter.StartPaddingFunctionScopeAsync().ConfigureAwait(false);
                 }
             }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightCollectionSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightCollectionSerializer.cs
@@ -107,8 +107,11 @@ namespace Microsoft.OData.JsonLight
                 // "@odata.context":...
                 await this.WriteContextUriPropertyAsync(
                     ODataPayloadKind.Collection,
-                    () => ODataContextUrlInfo.Create(collectionStart.SerializationInfo, itemTypeReference))
-                        .ConfigureAwait(false);
+                    (collectionStartSerializationInfoParam, itemTypeReferenceParam) => ODataContextUrlInfo.Create(
+                        collectionStartSerializationInfoParam,
+                        itemTypeReferenceParam),
+                    collectionStart.SerializationInfo,
+                    itemTypeReference).ConfigureAwait(false);
 
                 // "@odata.count":...
                 if (collectionStart.Count.HasValue)

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -1161,7 +1161,7 @@ namespace Microsoft.OData.JsonLight
         /// 1) true if the annotation name and value is skipped; otherwise false.
         /// 2) The annotation value that was read.
         /// </returns>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private async ValueTask<Tuple<bool, object>> SkipOverUnknownODataAnnotationAsync(
 #else
         private async Task<Tuple<bool, object>> SkipOverUnknownODataAnnotationAsync(

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightEntityReferenceLinkSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightEntityReferenceLinkSerializer.cs
@@ -62,7 +62,9 @@ namespace Microsoft.OData.JsonLight
             Debug.Assert(link != null, "link != null");
 
             return this.WriteTopLevelPayloadAsync(
-                () => this.WriteEntityReferenceLinkImplementationAsync(link, /* isTopLevel */ true));
+                (thisParam, linkParam) => thisParam.WriteEntityReferenceLinkImplementationAsync(linkParam, isTopLevel: true),
+                this,
+                link);
         }
 
         /// <summary>
@@ -73,8 +75,12 @@ namespace Microsoft.OData.JsonLight
         {
             Debug.Assert(entityReferenceLinks != null, "entityReferenceLinks != null");
 
-            return this.WriteTopLevelPayloadAsync(
-                () => this.WriteEntityReferenceLinksImplementationAsync(entityReferenceLinks));
+            return this.WriteTopLevelPayloadAsync((
+                thisParam,
+                entityReferenceLinksParam) => thisParam.WriteEntityReferenceLinksImplementationAsync(
+                    entityReferenceLinks),
+                this,
+                entityReferenceLinks);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -281,7 +281,17 @@ namespace Microsoft.OData.JsonLight
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateODataResourceSetWriterImplementation(entitySet, resourceType, false, false));
+            return TaskUtils.GetTaskForSynchronousOperation((
+                thisParam,
+                entitySetParam,
+                resourceTypeParam) => thisParam.CreateODataResourceSetWriterImplementation(
+                    entitySetParam,
+                    resourceTypeParam,
+                    writingParameter: false,
+                    writingDelta: false),
+                this,
+                entitySet,
+                resourceType);
         }
 
         /// <summary>
@@ -309,7 +319,17 @@ namespace Microsoft.OData.JsonLight
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateODataResourceSetWriterImplementation(entitySet, resourceType, false, true));
+            return TaskUtils.GetTaskForSynchronousOperation((
+                thisParam,
+                entitySetParam,
+                resourceTypeParam) => thisParam.CreateODataResourceSetWriterImplementation(
+                    entitySetParam,
+                    resourceTypeParam,
+                    writingParameter: false,
+                    writingDelta: true),
+                this,
+                entitySet,
+                resourceType);
         }
 
         /// <summary>
@@ -337,7 +357,15 @@ namespace Microsoft.OData.JsonLight
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateODataResourceWriterImplementation(navigationSource, resourceType));
+            return TaskUtils.GetTaskForSynchronousOperation((
+                thisParam,
+                navigationSourceParam,
+                resourceTypeParam) => thisParam.CreateODataResourceWriterImplementation(
+                    navigationSourceParam,
+                    resourceTypeParam),
+                this,
+                navigationSource,
+                resourceType);
         }
 
         /// <summary>
@@ -363,7 +391,12 @@ namespace Microsoft.OData.JsonLight
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateODataCollectionWriterImplementation(itemTypeReference));
+            return TaskUtils.GetTaskForSynchronousOperation((
+                thisParam,
+                itemTypeReferenceParam) => thisParam.CreateODataCollectionWriterImplementation(
+                    itemTypeReferenceParam),
+                this,
+                itemTypeReference);
         }
 
         /// <summary>
@@ -415,7 +448,17 @@ namespace Microsoft.OData.JsonLight
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateODataResourceSetWriterImplementation(entitySet, resourceType, true, false));
+            return TaskUtils.GetTaskForSynchronousOperation((
+                thisParam,
+                entitySetParam,
+                resourceTypeParam) => thisParam.CreateODataResourceSetWriterImplementation(
+                    entitySetParam,
+                    resourceTypeParam,
+                    writingParameter: true,
+                    writingDelta: false),
+                this,
+                entitySet,
+                resourceType);
         }
 
         /// <summary>
@@ -441,7 +484,12 @@ namespace Microsoft.OData.JsonLight
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateODataParameterWriterImplementation(operation));
+            return TaskUtils.GetTaskForSynchronousOperation((
+                thisParam,
+                operationParam) => thisParam.CreateODataParameterWriterImplementation(
+                    operationParam),
+                this,
+                operation);
         }
 
         /// <summary>
@@ -624,7 +672,9 @@ namespace Microsoft.OData.JsonLight
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateODataBatchWriterImplementation());
+            return TaskUtils.GetTaskForSynchronousOperation(
+                thisParam => thisParam.CreateODataBatchWriterImplementation(),
+                this);
         }
 
         /// <summary>
@@ -702,7 +752,15 @@ namespace Microsoft.OData.JsonLight
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateODataDeltaWriterImplementation(entitySet, entityType));
+            return TaskUtils.GetTaskForSynchronousOperation((
+                thisParam,
+                entitySetParam,
+                entityTypeParam) => thisParam.CreateODataDeltaWriterImplementation(
+                    entitySetParam,
+                    entityTypeParam),
+                this,
+                entitySet,
+                entityType);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -272,9 +272,10 @@ namespace Microsoft.OData.JsonLight
 
                     if (!(this.JsonLightOutputContext.MetadataLevel is JsonNoMetadataLevel))
                     {
-                        ODataContextUrlInfo contextInfo = GetContextUrlInfo(property);
-                        await this.WriteContextUriPropertyAsync(kind, () => contextInfo)
-                            .ConfigureAwait(false);
+                        ODataContextUrlInfo contextUrlInfo = GetContextUrlInfo(property);
+                        await this.WriteContextUriPropertyAsync(
+                            kind,
+                            (contextUrlInfoParam) => contextUrlInfoParam, contextUrlInfo).ConfigureAwait(false);
                     }
 
                     // Note we do not allow named stream properties to be written as top level property.

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -272,7 +272,7 @@ namespace Microsoft.OData.JsonLight
 
                     if (!(thisParam.JsonLightOutputContext.MetadataLevel is JsonNoMetadataLevel))
                     {
-                        ODataContextUrlInfo contextUrlInfo = thisParam.GetContextUrlInfo(property);
+                        ODataContextUrlInfo contextUrlInfo = thisParam.GetContextUrlInfo(propertyParam);
                         await thisParam.WriteContextUriPropertyAsync(
                             kind,
                             (contextUrlInfoParam) => contextUrlInfoParam, contextUrlInfo).ConfigureAwait(false);

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -265,34 +265,36 @@ namespace Microsoft.OData.JsonLight
             Debug.Assert(!(property.Value is ODataStreamReferenceValue), "!(property.Value is ODataStreamReferenceValue)");
 
             return this.WriteTopLevelPayloadAsync(
-                async () =>
+                async (thisParam, propertyParam) =>
                 {
-                    await this.AsynchronousJsonWriter.StartObjectScopeAsync().ConfigureAwait(false);
-                    ODataPayloadKind kind = GetPayloadKind();
+                    await thisParam.AsynchronousJsonWriter.StartObjectScopeAsync().ConfigureAwait(false);
+                    ODataPayloadKind kind = thisParam.GetPayloadKind();
 
-                    if (!(this.JsonLightOutputContext.MetadataLevel is JsonNoMetadataLevel))
+                    if (!(thisParam.JsonLightOutputContext.MetadataLevel is JsonNoMetadataLevel))
                     {
-                        ODataContextUrlInfo contextUrlInfo = GetContextUrlInfo(property);
-                        await this.WriteContextUriPropertyAsync(
+                        ODataContextUrlInfo contextUrlInfo = thisParam.GetContextUrlInfo(property);
+                        await thisParam.WriteContextUriPropertyAsync(
                             kind,
                             (contextUrlInfoParam) => contextUrlInfoParam, contextUrlInfo).ConfigureAwait(false);
                     }
 
                     // Note we do not allow named stream properties to be written as top level property.
-                    this.JsonLightValueSerializer.AssertRecursionDepthIsZero();
-                    IDuplicatePropertyNameChecker duplicatePropertyNameChecker = this.GetDuplicatePropertyNameChecker();
+                    thisParam.JsonLightValueSerializer.AssertRecursionDepthIsZero();
+                    IDuplicatePropertyNameChecker duplicatePropertyNameChecker = thisParam.GetDuplicatePropertyNameChecker();
 
-                    await this.WritePropertyAsync(
-                        property,
+                    await thisParam.WritePropertyAsync(
+                        property: propertyParam,
                         owningType : null,
                         isTopLevel : true,
                         duplicatePropertyNameChecker : duplicatePropertyNameChecker,
                         metadataBuilder : null).ConfigureAwait(false);
 
-                    this.JsonLightValueSerializer.AssertRecursionDepthIsZero();
-                    this.ReturnDuplicatePropertyNameChecker(duplicatePropertyNameChecker);
-                    await this.AsynchronousJsonWriter.EndObjectScopeAsync().ConfigureAwait(false);
-                });
+                    thisParam.JsonLightValueSerializer.AssertRecursionDepthIsZero();
+                    thisParam.ReturnDuplicatePropertyNameChecker(duplicatePropertyNameChecker);
+                    await thisParam.AsynchronousJsonWriter.EndObjectScopeAsync().ConfigureAwait(false);
+                },
+                this,
+                property);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceSerializer.cs
@@ -604,8 +604,9 @@ namespace Microsoft.OData.JsonLight
         {
             return this.WriteContextUriPropertyAsync(
                 ODataPayloadKind.Resource,
-                () => contextUrlInfo,
-                /* parentContextUrlInfo*/ null, nestedResourceInfo.Name);
+                (contextUrlInfoParam) => contextUrlInfoParam, contextUrlInfo,
+                parentContextUrlInfo: null,
+                propertyName: nestedResourceInfo.Name);
         }
 
         /// <summary>
@@ -649,7 +650,15 @@ namespace Microsoft.OData.JsonLight
 
             return this.WriteContextUriPropertyAsync(
                 ODataPayloadKind.Delta,
-                () => ODataContextUrlInfo.Create(typeContext, this.MessageWriterSettings.Version ?? ODataVersion.V4, kind, odataUri),
+                (typeContextParam, versionParam, kindParam, odataUriParam) => ODataContextUrlInfo.Create(
+                    typeContextParam,
+                    versionParam,
+                    kindParam,
+                    odataUriParam),
+                typeContext,
+                this.MessageWriterSettings.Version ?? ODataVersion.V4,
+                kind,
+                odataUri,
                 parentContextUrlInfo);
         }
 
@@ -666,7 +675,14 @@ namespace Microsoft.OData.JsonLight
 
             return this.WriteContextUriPropertyAsync(
                 ODataPayloadKind.Resource,
-                () => ODataContextUrlInfo.Create(typeContext, this.MessageWriterSettings.Version ?? ODataVersion.V4, /* isSingle */ true, odataUri),
+                (typeContextParam, versionParam, odataUriParam) => ODataContextUrlInfo.Create(
+                        typeContextParam,
+                        versionParam,
+                        isSingle: true,
+                        odataUri: odataUriParam),
+                typeContext,
+                this.MessageWriterSettings.Version ?? ODataVersion.V4,
+                odataUri,
                 parentContextUrlInfo);
         }
 
@@ -682,7 +698,14 @@ namespace Microsoft.OData.JsonLight
 
             return this.WriteContextUriPropertyAsync(
                 ODataPayloadKind.ResourceSet,
-                () => ODataContextUrlInfo.Create(typeContext, this.MessageWriterSettings.Version ?? ODataVersion.V4, /* isSingle */ false, odataUri));
+                (typeContextParam, versionParam, odataUriParam) => ODataContextUrlInfo.Create(
+                    typeContextParam,
+                    versionParam,
+                    isSingle: false,
+                    odataUri: odataUriParam),
+                typeContext,
+                this.MessageWriterSettings.Version ?? ODataVersion.V4,
+                odataUri);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
@@ -9,7 +9,7 @@ namespace Microsoft.OData.JsonLight
     #region Namespaces
     using System;
     using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using Microsoft.OData.Json;
     #endregion Namespaces
@@ -59,8 +59,10 @@ namespace Microsoft.OData.JsonLight
             Debug.Assert(jsonLightOutputContext != null, "jsonLightOutputContext != null");
 
             this.jsonLightOutputContext = jsonLightOutputContext;
-            this.instanceAnnotationWriter = new SimpleLazy<JsonLightInstanceAnnotationWriter>(() =>
-                new JsonLightInstanceAnnotationWriter(new ODataJsonLightValueSerializer(jsonLightOutputContext), jsonLightOutputContext.TypeNameOracle));
+            this.instanceAnnotationWriter = new SimpleLazy<JsonLightInstanceAnnotationWriter>(
+                () => new JsonLightInstanceAnnotationWriter(
+                    new ODataJsonLightValueSerializer(this.jsonLightOutputContext),
+                    this.jsonLightOutputContext.TypeNameOracle));
 
             // NOTE: Ideally, we should instantiate a JsonLightODataAnnotationWriter that supports EITHER synchronous OR asynchronous writing.
             // Based on the value of `jsonLightOutputContext.Synchronous`
@@ -69,13 +71,13 @@ namespace Microsoft.OData.JsonLight
             // the two separate instances when asynchronous API implementation is in progress
             this.odataAnnotationWriter = new SimpleLazy<JsonLightODataAnnotationWriter>(
                 () => new JsonLightODataAnnotationWriter(
-                    jsonLightOutputContext.JsonWriter,
-                    this.JsonLightOutputContext.OmitODataPrefix,
+                    this.jsonLightOutputContext.JsonWriter,
+                    this.jsonLightOutputContext.OmitODataPrefix,
                     this.MessageWriterSettings.Version));
             this.asynchronousODataAnnotationWriter = new SimpleLazy<JsonLightODataAnnotationWriter>(
                 () => new JsonLightODataAnnotationWriter(
-                    jsonLightOutputContext.AsynchronousJsonWriter,
-                    this.JsonLightOutputContext.OmitODataPrefix,
+                    this.jsonLightOutputContext.AsynchronousJsonWriter,
+                    this.jsonLightOutputContext.OmitODataPrefix,
                     this.MessageWriterSettings.Version));
 
             if (initContextUriBuilder)
@@ -282,7 +284,7 @@ namespace Microsoft.OData.JsonLight
             ODataContextUrlInfo parentContextUrlInfo = null,
             string propertyName = null)
         {
-            if (this.jsonLightOutputContext.MetadataLevel is JsonNoMetadataLevel)
+            if (IsJsonNoMetadataLevel())
             {
                 return null;
             }
@@ -294,34 +296,11 @@ namespace Microsoft.OData.JsonLight
                 contextUrlInfo = contextUrlInfoGen();
             }
 
-            if (contextUrlInfo != null && contextUrlInfo.IsHiddenBy(parentContextUrlInfo))
-            {
-                return null;
-            }
-
-            Uri contextUri = ContextUriBuilder.BuildContextUri(payloadKind, contextUrlInfo);
-
-            if (contextUri != null)
-            {
-                if (string.IsNullOrEmpty(propertyName))
-                {
-                    await this.AsynchronousODataAnnotationWriter.WriteInstanceAnnotationNameAsync(ODataAnnotationNames.ODataContext)
-                        .ConfigureAwait(false);
-                }
-                else
-                {
-                    await this.AsynchronousODataAnnotationWriter.WritePropertyAnnotationNameAsync(propertyName, ODataAnnotationNames.ODataContext)
-                        .ConfigureAwait(false);
-                }
-
-                await this.AsynchronousJsonWriter.WritePrimitiveValueAsync(contextUri.IsAbsoluteUri ? contextUri.AbsoluteUri : contextUri.OriginalString)
-                    .ConfigureAwait(false);
-                this.allowRelativeUri = true;
-
-                return contextUrlInfo;
-            }
-
-            return null;
+            return await WriteContextUriPropertyImplementationAsync(
+                payloadKind,
+                parentContextUrlInfo,
+                contextUrlInfo,
+                propertyName).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -406,6 +385,232 @@ namespace Microsoft.OData.JsonLight
             }
 
             return UriUtils.UriToString(resultUri);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the context URI property and the specified value into the payload.
+        /// </summary>
+        /// <typeparam name="TArg">The <paramref name="contextUrlInfoGen"/> delegate argument type.</typeparam>
+        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
+        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
+        /// <param name="arg">The argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
+        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <returns>A task that represents the asynchronous read operation. 
+        /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/> instance 
+        /// if the context URI was successfully written.</returns>
+        protected async Task<ODataContextUrlInfo> WriteContextUriPropertyAsync<TArg>(
+            ODataPayloadKind payloadKind,
+            Func<TArg, ODataContextUrlInfo> contextUrlInfoGen,
+            TArg arg,
+            ODataContextUrlInfo parentContextUrlInfo = null,
+            string propertyName = null)
+        {
+            if (IsJsonNoMetadataLevel())
+            {
+                return null;
+            }
+
+            ODataContextUrlInfo contextUrlInfo = null;
+
+            if (contextUrlInfoGen != null)
+            {
+                contextUrlInfo = contextUrlInfoGen(arg);
+            }
+
+            return await WriteContextUriPropertyImplementationAsync(
+                payloadKind,
+                parentContextUrlInfo,
+                contextUrlInfo,
+                propertyName).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the context URI property and the specified value into the payload.
+        /// </summary>
+        /// <typeparam name="TArg1">The <paramref name="contextUrlInfoGen"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="contextUrlInfoGen"/> delegate second argument type.</typeparam>
+        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
+        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
+        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <returns>A task that represents the asynchronous read operation. 
+        /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/> instance 
+        /// if the context URI was successfully written.</returns>
+        protected async Task<ODataContextUrlInfo> WriteContextUriPropertyAsync<TArg1, TArg2>(
+            ODataPayloadKind payloadKind,
+            Func<TArg1, TArg2, ODataContextUrlInfo> contextUrlInfoGen,
+            TArg1 arg1,
+            TArg2 arg2,
+            ODataContextUrlInfo parentContextUrlInfo = null,
+            string propertyName = null)
+        {
+            if (IsJsonNoMetadataLevel())
+            {
+                return null;
+            }
+
+            ODataContextUrlInfo contextUrlInfo = null;
+
+            if (contextUrlInfoGen != null)
+            {
+                contextUrlInfo = contextUrlInfoGen(arg1, arg2);
+            }
+
+            return await WriteContextUriPropertyImplementationAsync(
+                payloadKind,
+                parentContextUrlInfo,
+                contextUrlInfo,
+                propertyName).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the context URI property and the specified value into the payload.
+        /// </summary>
+        /// <typeparam name="TArg1">The <paramref name="contextUrlInfoGen"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="contextUrlInfoGen"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="contextUrlInfoGen"/> delegate third argument type.</typeparam>
+        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
+        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
+        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <returns>A task that represents the asynchronous read operation. 
+        /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/> instance 
+        /// if the context URI was successfully written.</returns>
+        protected async Task<ODataContextUrlInfo> WriteContextUriPropertyAsync<TArg1, TArg2, TArg3>(
+            ODataPayloadKind payloadKind,
+            Func<TArg1, TArg2, TArg3, ODataContextUrlInfo> contextUrlInfoGen,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3,
+            ODataContextUrlInfo parentContextUrlInfo = null,
+            string propertyName = null)
+        {
+            if (IsJsonNoMetadataLevel())
+            {
+                return null;
+            }
+
+            ODataContextUrlInfo contextUrlInfo = null;
+
+            if (contextUrlInfoGen != null)
+            {
+                contextUrlInfo = contextUrlInfoGen(arg1, arg2, arg3);
+            }
+
+            return await WriteContextUriPropertyImplementationAsync(
+                payloadKind,
+                parentContextUrlInfo,
+                contextUrlInfo,
+                propertyName).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the context URI property and the specified value into the payload.
+        /// </summary>
+        /// <typeparam name="TArg1">The <paramref name="contextUrlInfoGen"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="contextUrlInfoGen"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="contextUrlInfoGen"/> delegate third argument type.</typeparam>
+        /// <typeparam name="TArg4">The <paramref name="contextUrlInfoGen"/> delegate fourth argument type.</typeparam>
+        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
+        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="arg4">The fourth argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
+        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
+        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <returns>A task that represents the asynchronous read operation. 
+        /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/> instance 
+        /// if the context URI was successfully written.</returns>
+        protected async Task<ODataContextUrlInfo> WriteContextUriPropertyAsync<TArg1, TArg2, TArg3, TArg4>(
+            ODataPayloadKind payloadKind,
+            Func<TArg1, TArg2, TArg3, TArg4, ODataContextUrlInfo> contextUrlInfoGen,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3,
+            TArg4 arg4,
+            ODataContextUrlInfo parentContextUrlInfo = null,
+            string propertyName = null)
+        {
+            if (IsJsonNoMetadataLevel())
+            {
+                return null;
+            }
+
+            ODataContextUrlInfo contextUrlInfo = null;
+
+            if (contextUrlInfoGen != null)
+            {
+                contextUrlInfo = contextUrlInfoGen(arg1, arg2, arg3, arg4);
+            }
+
+            return await WriteContextUriPropertyImplementationAsync(
+                payloadKind,
+                parentContextUrlInfo,
+                contextUrlInfo,
+                propertyName).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Checks whether JSON metadata level is <see cref="JsonNoMetadataLevel"/>.
+        /// </summary>
+        /// <returns>true if JSON metadata level is <see cref="JsonNoMetadataLevel"/>; otherwise false.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private bool IsJsonNoMetadataLevel()
+        {
+            return this.jsonLightOutputContext.MetadataLevel is JsonNoMetadataLevel;
+        }
+
+        /// <summary>
+        /// Asynchronously writes the context URI property and the specified value into the payload.
+        /// </summary>
+        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
+        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
+        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
+        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <returns>A task that represents the asynchronous read operation. 
+        /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/>, 
+        /// if the context URI was successfully written.</returns>
+        private async Task<ODataContextUrlInfo> WriteContextUriPropertyImplementationAsync(
+            ODataPayloadKind payloadKind,
+            ODataContextUrlInfo parentContextUrlInfo,
+            ODataContextUrlInfo contextUrlInfo,
+            string propertyName)
+        {
+            if (contextUrlInfo != null && contextUrlInfo.IsHiddenBy(parentContextUrlInfo))
+            {
+                return null;
+            }
+
+            Uri contextUri = ContextUriBuilder.BuildContextUri(payloadKind, contextUrlInfo);
+
+            if (contextUri != null)
+            {
+                if (string.IsNullOrEmpty(propertyName))
+                {
+                    await this.AsynchronousODataAnnotationWriter.WriteInstanceAnnotationNameAsync(ODataAnnotationNames.ODataContext)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await this.AsynchronousODataAnnotationWriter.WritePropertyAnnotationNameAsync(propertyName, ODataAnnotationNames.ODataContext)
+                        .ConfigureAwait(false);
+                }
+
+                await this.AsynchronousJsonWriter.WritePrimitiveValueAsync(contextUri.IsAbsoluteUri ? contextUri.AbsoluteUri : contextUri.OriginalString)
+                    .ConfigureAwait(false);
+                this.allowRelativeUri = true;
+
+                return contextUrlInfo;
+            }
+
+            return null;
         }
     }
 }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
@@ -393,11 +393,11 @@ namespace Microsoft.OData.JsonLight
         /// Asynchronously writes the context URI property and the specified value into the payload.
         /// </summary>
         /// <typeparam name="TArg">The <paramref name="contextUrlInfoGen"/> delegate argument type.</typeparam>
-        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
-        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
+        /// <param name="payloadKind">The <see cref="ODataPayloadKind"/> for the context URI.</param>
+        /// <param name="contextUrlInfoGen">The delegate to generate <see cref="ODataContextUrlInfo"/>.</param>
         /// <param name="arg">The argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
-        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
-        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <param name="parentContextUrlInfo">The parent <see cref="ODataContextUrlInfo"/> instance.</param>
+        /// <param name="propertyName">Name for the context URI property.</param>
         /// <returns>A task that represents the asynchronous read operation. 
         /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/> instance 
         /// if the context URI was successfully written.</returns>
@@ -432,12 +432,12 @@ namespace Microsoft.OData.JsonLight
         /// </summary>
         /// <typeparam name="TArg1">The <paramref name="contextUrlInfoGen"/> delegate first argument type.</typeparam>
         /// <typeparam name="TArg2">The <paramref name="contextUrlInfoGen"/> delegate second argument type.</typeparam>
-        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
-        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
+        /// <param name="payloadKind">The <see cref="ODataPayloadKind"/> for the context URI.</param>
+        /// <param name="contextUrlInfoGen">The delegate to generate <see cref="ODataContextUrlInfo"/>.</param>
         /// <param name="arg1">The first argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
         /// <param name="arg2">The second argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
-        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
-        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <param name="parentContextUrlInfo">The parent <see cref="ODataContextUrlInfo"/> instance.</param>
+        /// <param name="propertyName">Name for the context URI property.</param>
         /// <returns>A task that represents the asynchronous read operation. 
         /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/> instance 
         /// if the context URI was successfully written.</returns>
@@ -474,13 +474,13 @@ namespace Microsoft.OData.JsonLight
         /// <typeparam name="TArg1">The <paramref name="contextUrlInfoGen"/> delegate first argument type.</typeparam>
         /// <typeparam name="TArg2">The <paramref name="contextUrlInfoGen"/> delegate second argument type.</typeparam>
         /// <typeparam name="TArg3">The <paramref name="contextUrlInfoGen"/> delegate third argument type.</typeparam>
-        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
-        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
+        /// <param name="payloadKind">The <see cref="ODataPayloadKind"/> for the context URI.</param>
+        /// <param name="contextUrlInfoGen">The delegate to generate <see cref="ODataContextUrlInfo"/>.</param>
         /// <param name="arg1">The first argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
         /// <param name="arg2">The second argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
         /// <param name="arg3">The third argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
-        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
-        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <param name="parentContextUrlInfo">The parent <see cref="ODataContextUrlInfo"/> instance.</param>
+        /// <param name="propertyName">Name for the context URI property.</param>
         /// <returns>A task that represents the asynchronous read operation. 
         /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/> instance 
         /// if the context URI was successfully written.</returns>
@@ -519,14 +519,14 @@ namespace Microsoft.OData.JsonLight
         /// <typeparam name="TArg2">The <paramref name="contextUrlInfoGen"/> delegate second argument type.</typeparam>
         /// <typeparam name="TArg3">The <paramref name="contextUrlInfoGen"/> delegate third argument type.</typeparam>
         /// <typeparam name="TArg4">The <paramref name="contextUrlInfoGen"/> delegate fourth argument type.</typeparam>
-        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
-        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
+        /// <param name="payloadKind">The <see cref="ODataPayloadKind"/> for the context URI.</param>
+        /// <param name="contextUrlInfoGen">The delegate to generate <see cref="ODataContextUrlInfo"/>.</param>
         /// <param name="arg1">The first argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
         /// <param name="arg2">The second argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
         /// <param name="arg3">The third argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
         /// <param name="arg4">The fourth argument value provided to the <paramref name="contextUrlInfoGen"/> delegate.</param>
-        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
-        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <param name="parentContextUrlInfo">The parent <see cref="ODataContextUrlInfo"/> instance.</param>
+        /// <param name="propertyName">Name for the context URI property.</param>
         /// <returns>A task that represents the asynchronous read operation. 
         /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/> instance 
         /// if the context URI was successfully written.</returns>
@@ -563,14 +563,14 @@ namespace Microsoft.OData.JsonLight
         /// Asynchronously writes the data wrapper around a JSON payload.
         /// </summary>
         /// <typeparam name="TArg">The <paramref name="payloadWriterFunc"/> delegate argument type.</typeparam>
-        /// <param name="payloadWriterAction">The delegate that writes the actual JSON payload that is being wrapped.</param>
+        /// <param name="payloadWriterFunc">The delegate that writes the actual JSON payload that is being wrapped.</param>
         /// <param name="arg">The argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         protected async Task WriteTopLevelPayloadAsync<TArg>(
             Func<TArg, Task> payloadWriterFunc,
             TArg arg)
         {
-            Debug.Assert(payloadWriterFunc != null, "payloadWriterAction != null");
+            Debug.Assert(payloadWriterFunc != null, $"{nameof(payloadWriterFunc)} != null");
 
             await this.WritePayloadStartAsync().ConfigureAwait(false);
 
@@ -584,7 +584,7 @@ namespace Microsoft.OData.JsonLight
         /// </summary>
         /// <typeparam name="TArg1">The <paramref name="payloadWriterFunc"/> delegate first argument type.</typeparam>
         /// <typeparam name="TArg2">The <paramref name="payloadWriterFunc"/> delegate second argument type.</typeparam>
-        /// <param name="payloadWriterAction">The delegate that writes the actual JSON payload that is being wrapped.</param>
+        /// <param name="payloadWriterFunc">The delegate that writes the actual JSON payload that is being wrapped.</param>
         /// <param name="arg1">The first argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
         /// <param name="arg2">The second argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
@@ -593,7 +593,7 @@ namespace Microsoft.OData.JsonLight
             TArg1 arg1,
             TArg2 arg2)
         {
-            Debug.Assert(payloadWriterFunc != null, "payloadWriterAction != null");
+            Debug.Assert(payloadWriterFunc != null, $"{nameof(payloadWriterFunc)} != null");
 
             await this.WritePayloadStartAsync().ConfigureAwait(false);
 
@@ -608,7 +608,7 @@ namespace Microsoft.OData.JsonLight
         /// <typeparam name="TArg1">The <paramref name="payloadWriterFunc"/> delegate first argument type.</typeparam>
         /// <typeparam name="TArg2">The <paramref name="payloadWriterFunc"/> delegate second argument type.</typeparam>
         /// <typeparam name="TArg3">The <paramref name="payloadWriterFunc"/> delegate third argument type.</typeparam>
-        /// <param name="payloadWriterAction">The delegate that writes the actual JSON payload that is being wrapped.</param>
+        /// <param name="payloadWriterFunc">The delegate that writes the actual JSON payload that is being wrapped.</param>
         /// <param name="arg1">The first argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
         /// <param name="arg2">The second argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
         /// <param name="arg3">The third argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
@@ -619,7 +619,7 @@ namespace Microsoft.OData.JsonLight
             TArg2 arg2,
             TArg3 arg3)
         {
-            Debug.Assert(payloadWriterFunc != null, "payloadWriterAction != null");
+            Debug.Assert(payloadWriterFunc != null, $"{nameof(payloadWriterFunc)} != null");
 
             await this.WritePayloadStartAsync().ConfigureAwait(false);
 
@@ -641,12 +641,13 @@ namespace Microsoft.OData.JsonLight
         /// <summary>
         /// Asynchronously writes the context URI property and the specified value into the payload.
         /// </summary>
-        /// <param name="payloadKind">The ODataPayloadKind for the context URI.</param>
-        /// <param name="contextUrlInfoGen">Function to generate contextUrlInfo.</param>
-        /// <param name="parentContextUrlInfo">The parent contextUrlInfo.</param>
-        /// <param name="propertyName">Property name to write contextUri on.</param>
+        /// <param name="payloadKind">The <see cref="ODataPayloadKind"/> for the context URI.</param>
+        /// <param name="parentContextUrlInfo">The parent <see cref="ODataContextUrlInfo"/> instance.</param>
+        /// <param name="contextUrlInfo">The <see cref="ODataContextUrlInfo"/> instance
+        /// containing info for the context URI property.</param>
+        /// <param name="propertyName">Name for the context URI property.</param>
         /// <returns>A task that represents the asynchronous read operation. 
-        /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/>, 
+        /// The value of the TResult parameter contains the <see cref="ODataContextUrlInfo"/> instance 
         /// if the context URI was successfully written.</returns>
         private async Task<ODataContextUrlInfo> WriteContextUriPropertyImplementationAsync(
             ODataPayloadKind payloadKind,

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
@@ -306,7 +306,7 @@ namespace Microsoft.OData.JsonLight
         /// <summary>
         /// Asynchronously writes the data wrapper around a JSON payload.
         /// </summary>
-        /// <param name="payloadWriterAction">The action that writes the actual JSON payload that is being wrapped.</param>
+        /// <param name="payloadWriterFunc">The delegate that writes the actual JSON payload that is being wrapped.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         internal async Task WriteTopLevelPayloadAsync(Func<Task> payloadWriterFunc)
         {
@@ -329,16 +329,18 @@ namespace Microsoft.OData.JsonLight
         {
             Debug.Assert(error != null, "error != null");
 
-            return this.WriteTopLevelPayloadAsync(
-                () =>
-                {
-                    return ODataJsonWriterUtils.WriteErrorAsync(
-                        this.AsynchronousJsonWriter,
-                        this.InstanceAnnotationWriter.WriteInstanceAnnotationsForErrorAsync,
-                        error,
-                        includeDebugInformation,
-                        this.MessageWriterSettings.MessageQuotas.MaxNestingDepth);
-                });
+            return this.WriteTopLevelPayloadAsync((
+                thisParam,
+                errorParam,
+                includeDebugInformationParam) => ODataJsonWriterUtils.WriteErrorAsync(
+                    thisParam.AsynchronousJsonWriter,
+                    thisParam.InstanceAnnotationWriter.WriteInstanceAnnotationsForErrorAsync,
+                    errorParam,
+                    includeDebugInformationParam,
+                    thisParam.MessageWriterSettings.MessageQuotas.MaxNestingDepth),
+                this,
+                error,
+                includeDebugInformation);
         }
 
         /// <summary>
@@ -555,6 +557,75 @@ namespace Microsoft.OData.JsonLight
                 parentContextUrlInfo,
                 contextUrlInfo,
                 propertyName).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the data wrapper around a JSON payload.
+        /// </summary>
+        /// <typeparam name="TArg">The <paramref name="payloadWriterFunc"/> delegate argument type.</typeparam>
+        /// <param name="payloadWriterAction">The delegate that writes the actual JSON payload that is being wrapped.</param>
+        /// <param name="arg">The argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        protected async Task WriteTopLevelPayloadAsync<TArg>(
+            Func<TArg, Task> payloadWriterFunc,
+            TArg arg)
+        {
+            Debug.Assert(payloadWriterFunc != null, "payloadWriterAction != null");
+
+            await this.WritePayloadStartAsync().ConfigureAwait(false);
+
+            await payloadWriterFunc(arg).ConfigureAwait(false);
+
+            await this.WritePayloadEndAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the data wrapper around a JSON payload.
+        /// </summary>
+        /// <typeparam name="TArg1">The <paramref name="payloadWriterFunc"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="payloadWriterFunc"/> delegate second argument type.</typeparam>
+        /// <param name="payloadWriterAction">The delegate that writes the actual JSON payload that is being wrapped.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        protected async Task WriteTopLevelPayloadAsync<TArg1, TArg2>(
+            Func<TArg1, TArg2, Task> payloadWriterFunc,
+            TArg1 arg1,
+            TArg2 arg2)
+        {
+            Debug.Assert(payloadWriterFunc != null, "payloadWriterAction != null");
+
+            await this.WritePayloadStartAsync().ConfigureAwait(false);
+
+            await payloadWriterFunc(arg1, arg2).ConfigureAwait(false);
+
+            await this.WritePayloadEndAsync().ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asynchronously writes the data wrapper around a JSON payload.
+        /// </summary>
+        /// <typeparam name="TArg1">The <paramref name="payloadWriterFunc"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="payloadWriterFunc"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="payloadWriterFunc"/> delegate third argument type.</typeparam>
+        /// <param name="payloadWriterAction">The delegate that writes the actual JSON payload that is being wrapped.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="payloadWriterFunc"/> delegate.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        protected async Task WriteTopLevelPayloadAsync<TArg1, TArg2, TArg3>(
+            Func<TArg1, TArg2, TArg3, Task> payloadWriterFunc,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3)
+        {
+            Debug.Assert(payloadWriterFunc != null, "payloadWriterAction != null");
+
+            await this.WritePayloadStartAsync().ConfigureAwait(false);
+
+            await payloadWriterFunc(arg1, arg2, arg3).ConfigureAwait(false);
+
+            await this.WritePayloadEndAsync().ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightServiceDocumentSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightServiceDocumentSerializer.cs
@@ -143,47 +143,47 @@ namespace Microsoft.OData.JsonLight
             Debug.Assert(serviceDocument != null, "serviceDocument != null");
 
             return this.WriteTopLevelPayloadAsync(
-                async () =>
+                async (thisParam, serviceDocumentParam) =>
                 {
                     // "{"
-                    await this.AsynchronousJsonWriter.StartObjectScopeAsync()
+                    await thisParam.AsynchronousJsonWriter.StartObjectScopeAsync()
                         .ConfigureAwait(false);
 
                     // "@odata.context":...
-                    await this.WriteContextUriPropertyAsync(ODataPayloadKind.ServiceDocument)
+                    await thisParam.WriteContextUriPropertyAsync(ODataPayloadKind.ServiceDocument)
                         .ConfigureAwait(false);
 
                     // "value":
-                    await this.AsynchronousJsonWriter.WriteValuePropertyNameAsync()
+                    await thisParam.AsynchronousJsonWriter.WriteValuePropertyNameAsync()
                         .ConfigureAwait(false);
 
                     // "["
-                    await this.AsynchronousJsonWriter.StartArrayScopeAsync()
+                    await thisParam.AsynchronousJsonWriter.StartArrayScopeAsync()
                         .ConfigureAwait(false);
 
-                    if (serviceDocument.EntitySets != null)
+                    if (serviceDocumentParam.EntitySets != null)
                     {
-                        foreach (ODataEntitySetInfo collectionInfo in serviceDocument.EntitySets)
+                        foreach (ODataEntitySetInfo collectionInfo in serviceDocumentParam.EntitySets)
                         {
-                            await this.WriteServiceDocumentElementAsync(collectionInfo, JsonLightConstants.ServiceDocumentEntitySetKindName)
+                            await thisParam.WriteServiceDocumentElementAsync(collectionInfo, JsonLightConstants.ServiceDocumentEntitySetKindName)
                                 .ConfigureAwait(false);
                         }
                     }
 
-                    if (serviceDocument.Singletons != null)
+                    if (serviceDocumentParam.Singletons != null)
                     {
-                        foreach (ODataSingletonInfo singletonInfo in serviceDocument.Singletons)
+                        foreach (ODataSingletonInfo singletonInfo in serviceDocumentParam.Singletons)
                         {
-                            await this.WriteServiceDocumentElementAsync(singletonInfo, JsonLightConstants.ServiceDocumentSingletonKindName)
+                            await thisParam.WriteServiceDocumentElementAsync(singletonInfo, JsonLightConstants.ServiceDocumentSingletonKindName)
                                 .ConfigureAwait(false);
                         }
                     }
 
                     HashSet<string> functionImportsWritten = new HashSet<string>(StringComparer.Ordinal);
 
-                    if (serviceDocument.FunctionImports != null)
+                    if (serviceDocumentParam.FunctionImports != null)
                     {
-                        foreach (ODataFunctionImportInfo functionImportInfo in serviceDocument.FunctionImports)
+                        foreach (ODataFunctionImportInfo functionImportInfo in serviceDocumentParam.FunctionImports)
                         {
                             if (functionImportInfo == null)
                             {
@@ -193,20 +193,22 @@ namespace Microsoft.OData.JsonLight
                             if (!functionImportsWritten.Contains(functionImportInfo.Name))
                             {
                                 functionImportsWritten.Add(functionImportInfo.Name);
-                                await this.WriteServiceDocumentElementAsync(functionImportInfo, JsonLightConstants.ServiceDocumentFunctionImportKindName)
+                                await thisParam.WriteServiceDocumentElementAsync(functionImportInfo, JsonLightConstants.ServiceDocumentFunctionImportKindName)
                                     .ConfigureAwait(false);
                             }
                         }
                     }
 
                     // "]"
-                    await this.AsynchronousJsonWriter.EndArrayScopeAsync()
+                    await thisParam.AsynchronousJsonWriter.EndArrayScopeAsync()
                         .ConfigureAwait(false);
 
                     // "}"
-                    await this.AsynchronousJsonWriter.EndObjectScopeAsync()
+                    await thisParam.AsynchronousJsonWriter.EndObjectScopeAsync()
                         .ConfigureAwait(false);
-                });
+                },
+                this,
+                serviceDocument);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -679,10 +679,12 @@ namespace Microsoft.OData.JsonLight
             if (actualTypeReference != null && actualTypeReference.IsSpatial())
             {
                 // TODO: Implement asynchronous handling of spatial types in a separate PR
-                await TaskUtils.GetTaskForSynchronousOperation(() =>
-                {
-                    PrimitiveConverter.Instance.WriteJsonLight(value, this.JsonWriter);
-                }).ConfigureAwait(false);
+                await TaskUtils.GetTaskForSynchronousOperation(
+                    (thisParam, valueParam) => PrimitiveConverter.Instance.WriteJsonLight(
+                        valueParam,
+                        thisParam.JsonWriter),
+                    this,
+                    value).ConfigureAwait(false);
             }
             else
             {

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
@@ -2299,12 +2299,21 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties)
         {
             // Currently, no asynchronous operation is involved when preparing resource for writing
-            return TaskUtils.GetTaskForSynchronousOperation(
-                () => this.PrepareResourceForWriteStart(
-                    resourceScope,
-                    resource,
-                    writingResponse,
-                    selectedProperties));
+            return TaskUtils.GetTaskForSynchronousOperation((
+                thisParam,
+                resourceScopeParam,
+                resourceParam,
+                writingResponseParam,
+                selectedPropertiesParam) => thisParam.PrepareResourceForWriteStart(
+                    resourceScopeParam,
+                    resourceParam,
+                    writingResponseParam,
+                    selectedPropertiesParam),
+                this,
+                resourceScope,
+                resource,
+                writingResponse,
+                selectedProperties);
         }
 
         /// <summary>
@@ -2323,12 +2332,21 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties)
         {
             // Currently, no asynchronous operation is involved when preparing deleted resource for writing
-            return TaskUtils.GetTaskForSynchronousOperation(
-                () => this.PrepareDeletedResourceForWriteStart(
-                    resourceScope,
-                    deletedResource,
-                    writingResponse,
-                    selectedProperties));
+            return TaskUtils.GetTaskForSynchronousOperation((
+                thisParam,
+                resourceScopeParam,
+                deletedResourceParam,
+                writingResponseParam,
+                selectedPropertiesParam) => this.PrepareDeletedResourceForWriteStart(
+                    resourceScopeParam,
+                    deletedResourceParam,
+                    writingResponseParam,
+                    selectedPropertiesParam),
+                this,
+                resourceScope,
+                deletedResource,
+                writingResponse,
+                selectedProperties);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
@@ -1805,7 +1805,7 @@ namespace Microsoft.OData.JsonLight
                         this.CurrentDeltaResourceSetScope.InstanceAnnotationWriteTracker).ConfigureAwait(false);
 
                     // Write the next link if it's available.
-                    await this.WriteResourceSetNextLinkAsync(innerDeltaResourceSet.NextPageLink, /*propertynamne*/ null)
+                    await this.WriteResourceSetNextLinkAsync(innerDeltaResourceSet.NextPageLink, propertyName: null)
                         .ConfigureAwait(false);
 
                     // Write the delta link if it's available.

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchOutputContext.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchOutputContext.cs
@@ -60,7 +60,9 @@ namespace Microsoft.OData.MultipartMixed
         {
             this.AssertAsynchronous();
 
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateODataBatchWriterImplementation());
+            return TaskUtils.GetTaskForSynchronousOperation(
+                thisParam => thisParam.CreateODataBatchWriterImplementation(),
+                this);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -149,7 +149,8 @@ namespace Microsoft.OData.MultipartMixed
         public override Task StreamDisposedAsync()
         {
             return TaskUtils.GetTaskForSynchronousOperation(
-                () => this.StreamDisposed());
+                thisParam => thisParam.StreamDisposed(),
+                this);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataAsynchronousWriter.cs
+++ b/src/Microsoft.OData.Core/ODataAsynchronousWriter.cs
@@ -62,12 +62,11 @@ namespace Microsoft.OData
         /// Asynchronously creates a message for writing an async response.
         /// </summary>
         /// <returns>The message that can be used to write the async response.</returns>
-        public async Task<ODataAsynchronousResponseMessage> CreateResponseMessageAsync()
+        public Task<ODataAsynchronousResponseMessage> CreateResponseMessageAsync()
         {
             this.VerifyCanCreateResponseMessage(false);
 
-            return await this.CreateResponseMessageImplementationAsync()
-                .ConfigureAwait(false);
+            return this.CreateResponseMessageImplementationAsync();
         }
 
         /// <summary>
@@ -84,12 +83,11 @@ namespace Microsoft.OData
         /// Asynchronously flushes the write buffer to the underlying stream.
         /// </summary>
         /// <returns>A task instance that represents the asynchronous operation.</returns>
-        public async Task FlushAsync()
+        public Task FlushAsync()
         {
             this.VerifyCanFlush(false);
 
-            await this.rawOutputContext.FlushAsync()
-                .ConfigureAwait(false);
+            return this.rawOutputContext.FlushAsync();
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataBinaryStreamReader.cs
+++ b/src/Microsoft.OData.Core/ODataBinaryStreamReader.cs
@@ -47,7 +47,7 @@ namespace Microsoft.OData
 
 
         /// <summary>Buffer for reading the stream content.</summary>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private byte[] bytes = Array.Empty<byte>();
 #else
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1825:Avoid zero-length array allocations.", Justification = "<Pending>")]

--- a/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
+++ b/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OData
 
 
         /// <summary>Trailing bytes from a previous write to be prepended to the next write.</summary>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private byte[] trailingBytes = Array.Empty<byte>();
 #else
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1825:Avoid zero-length array allocations.", Justification = "<Pending>")]
@@ -47,7 +47,7 @@ namespace Microsoft.OData
 
 
         /// <summary>An empty byte[].</summary>
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private byte[] emptyByteArray = Array.Empty<byte>();
 #else
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1825:Avoid zero-length array allocations.", Justification = "<Pending>")]

--- a/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataCollectionWriterCore.cs
@@ -178,11 +178,10 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="collection">The <see cref="ODataCollectionStart"/> representing the collection.</param>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public sealed override async Task WriteStartAsync(ODataCollectionStart collection)
+        public sealed override Task WriteStartAsync(ODataCollectionStart collection)
         {
             this.VerifyCanWriteStart(false, collection);
-            await this.WriteStartImplementationAsync(collection)
-                .ConfigureAwait(false);
+            return this.WriteStartImplementationAsync(collection);
         }
 
         /// <summary>
@@ -200,11 +199,10 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="item">The collection item to write.</param>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public sealed override async Task WriteItemAsync(object item)
+        public sealed override Task WriteItemAsync(object item)
         {
             this.VerifyCanWriteItem(false);
-            await this.WriteItemImplementationAsync(item)
-                .ConfigureAwait(false);
+            return this.WriteItemImplementationAsync(item);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataMessage.cs
+++ b/src/Microsoft.OData.Core/ODataMessage.cs
@@ -194,17 +194,17 @@ namespace Microsoft.OData
                 }
             }
 
-            return GetMessageStreamAsync();
+            return GetMessageStreamAsync(streamFuncAsync, isRequest);
 
-            async Task<Stream> GetMessageStreamAsync()
+            async Task<Stream> GetMessageStreamAsync(Func<Task<Stream>> innerStreamFuncAsync, bool innerIsRequest)
             {
-                Task<Stream> messageStreamTask = streamFuncAsync();
-                ValidateMessageStreamTask(messageStreamTask, isRequest);
+                Task<Stream> messageStreamTask = innerStreamFuncAsync();
+                ValidateMessageStreamTask(messageStreamTask, innerIsRequest);
 
                 // Wrap it in a non-disposing stream if requested
                 Stream messageStream = await messageStreamTask
                     .ConfigureAwait(false);
-                ValidateMessageStream(messageStream, isRequest);
+                ValidateMessageStream(messageStream, innerIsRequest);
 
                 // When reading, wrap the stream in a byte counting stream if a max message size was specified.
                 // When requested, wrap the stream in a non-disposing stream.

--- a/src/Microsoft.OData.Core/ODataMessage.cs
+++ b/src/Microsoft.OData.Core/ODataMessage.cs
@@ -190,70 +190,55 @@ namespace Microsoft.OData
                 if (existingBufferingReadStream != null)
                 {
                     Debug.Assert(this.useBufferingReadStream.HasValue, "UseBufferingReadStream must have been set.");
-                    return TaskUtils.GetCompletedTask(existingBufferingReadStream);
+                    return Task.FromResult(existingBufferingReadStream);
                 }
             }
 
-            Task<Stream> task = streamFuncAsync();
-            ValidateMessageStreamTask(task, isRequest);
+            return GetMessageStreamAsync();
 
-            // Wrap it in a non-disposing stream if requested
-            task = task.FollowOnSuccessWith(
-                streamTask =>
-                {
-                    Stream messageStream = streamTask.Result;
-                    ValidateMessageStream(messageStream, isRequest);
-
-                    // When reading, wrap the stream in a byte counting stream if a max message size was specified.
-                    // When requested, wrap the stream in a non-disposing stream.
-                    bool needByteCountingStream = !this.writing && this.maxMessageSize > 0;
-                    if (!this.enableMessageStreamDisposal && needByteCountingStream)
-                    {
-                        messageStream = MessageStreamWrapper.CreateNonDisposingStreamWithMaxSize(messageStream, this.maxMessageSize);
-                    }
-                    else if (!this.enableMessageStreamDisposal)
-                    {
-                        messageStream = MessageStreamWrapper.CreateNonDisposingStream(messageStream);
-                    }
-                    else if (needByteCountingStream)
-                    {
-                        messageStream = MessageStreamWrapper.CreateStreamWithMaxSize(messageStream, this.maxMessageSize);
-                    }
-
-                    return messageStream;
-                });
-
-            // When we are reading, also buffer the input stream
-            if (!this.writing)
+            async Task<Stream> GetMessageStreamAsync()
             {
-                task = task
-                    .FollowOnSuccessWithTask(
-                        streamTask =>
-                        {
-                            return BufferedReadStream.BufferStreamAsync(streamTask.Result);
-                        })
-                    .FollowOnSuccessWith(
-                        streamTask =>
-                        {
-                            BufferedReadStream bufferedReadStream = streamTask.Result;
-                            return (Stream)bufferedReadStream;
-                        });
+                Task<Stream> messageStreamTask = streamFuncAsync();
+                ValidateMessageStreamTask(messageStreamTask, isRequest);
 
-                // If requested also create a buffering stream for payload kind detection
-                if (this.useBufferingReadStream == true)
+                // Wrap it in a non-disposing stream if requested
+                Stream messageStream = await messageStreamTask
+                    .ConfigureAwait(false);
+                ValidateMessageStream(messageStream, isRequest);
+
+                // When reading, wrap the stream in a byte counting stream if a max message size was specified.
+                // When requested, wrap the stream in a non-disposing stream.
+                bool needByteCountingStream = !this.writing && this.maxMessageSize > 0;
+                if (!this.enableMessageStreamDisposal && needByteCountingStream)
                 {
-                    task = task.FollowOnSuccessWith(
-                        streamTask =>
-                        {
-                            Stream messageStream = streamTask.Result;
-                            this.bufferingReadStream = new BufferingReadStream(messageStream);
-                            messageStream = this.bufferingReadStream;
-                            return messageStream;
-                        });
+                    messageStream = MessageStreamWrapper.CreateNonDisposingStreamWithMaxSize(messageStream, this.maxMessageSize);
                 }
-            }
+                else if (!this.enableMessageStreamDisposal)
+                {
+                    messageStream = MessageStreamWrapper.CreateNonDisposingStream(messageStream);
+                }
+                else if (needByteCountingStream)
+                {
+                    messageStream = MessageStreamWrapper.CreateStreamWithMaxSize(messageStream, this.maxMessageSize);
+                }
 
-            return task;
+                // When we are reading, also buffer the input stream
+                if (!this.writing)
+                {
+                    BufferedReadStream bufferedReadStream = await BufferedReadStream.BufferStreamAsync(messageStream)
+                        .ConfigureAwait(false);
+                    messageStream = (Stream)bufferedReadStream;
+
+                    // If requested also create a buffering stream for payload kind detection
+                    if (this.useBufferingReadStream == true)
+                    {
+                        this.bufferingReadStream = new BufferingReadStream(messageStream);
+                        messageStream = this.bufferingReadStream;
+                    }
+                }
+
+                return messageStream;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataMessageReader.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReader.cs
@@ -260,7 +260,7 @@ namespace Microsoft.OData
             IEnumerable<ODataPayloadKindDetectionResult> payloadKindsFromContentType;
             if (this.TryGetSinglePayloadKindResultFromContentType(out payloadKindsFromContentType))
             {
-                return TaskUtils.GetCompletedTask(payloadKindsFromContentType);
+                return Task.FromResult(payloadKindsFromContentType);
             }
 
             // Otherwise we have to do sniffing

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -1278,22 +1278,18 @@ namespace Microsoft.OData
         /// <param name="payloadKind">The payload kind to write.</param>
         /// <param name="writeAsyncAction">The write operation to invoke on the output.</param>
         /// <returns>Task which represents the pending write operation.</returns>
-        private Task WriteToOutputAsync(ODataPayloadKind payloadKind, Func<ODataOutputContext, Task> writeAsyncAction)
+        private async Task WriteToOutputAsync(ODataPayloadKind payloadKind, Func<ODataOutputContext, Task> writeAsyncAction)
         {
             // Set the content type header here since all headers have to be set before getting the stream
             this.SetOrVerifyHeaders(payloadKind);
             // Create the output context
-            return WriteToOutputInnerAsync(writeAsyncAction);
-
-            async Task WriteToOutputInnerAsync(Func<ODataOutputContext, Task> innerWriteAsyncAction)
-            {
-                Stream messageStream = await this.message.GetStreamAsync()
+            Stream messageStream = await this.message.GetStreamAsync()
                     .ConfigureAwait(false);
-                this.outputContext = await this.format.CreateOutputContextAsync(
-                        this.GetOrCreateMessageInfo(messageStream, true),
-                        this.settings).ConfigureAwait(false);
-                await innerWriteAsyncAction(this.outputContext).ConfigureAwait(false);
-            }
+            this.outputContext = await this.format.CreateOutputContextAsync(
+                    this.GetOrCreateMessageInfo(messageStream, true),
+                    this.settings).ConfigureAwait(false);
+
+            await writeAsyncAction(this.outputContext).ConfigureAwait(false);
         }
         /// <summary>
         /// Creates an output context and invokes a write operation on it.
@@ -1302,22 +1298,18 @@ namespace Microsoft.OData
         /// <param name="payloadKind">The payload kind to write.</param>
         /// <param name="writeFunc">The write operation to invoke on the output.</param>
         /// <returns>Task which represents the pending write operation.</returns>
-        private Task<TResult> WriteToOutputAsync<TResult>(ODataPayloadKind payloadKind, Func<ODataOutputContext, Task<TResult>> writeFunc)
+        private async Task<TResult> WriteToOutputAsync<TResult>(ODataPayloadKind payloadKind, Func<ODataOutputContext, Task<TResult>> writeFunc)
         {
             // Set the content type header here since all headers have to be set before getting the stream
             this.SetOrVerifyHeaders(payloadKind);
             // Create the output context
-            return WriteToOutputInnerAsync(writeFunc);
-
-            async Task<TResult> WriteToOutputInnerAsync(Func<ODataOutputContext, Task<TResult>> innerWriteFunc)
-            {
-                Stream messageStream = await this.message.GetStreamAsync()
+            Stream messageStream = await this.message.GetStreamAsync()
                     .ConfigureAwait(false);
-                this.outputContext = await this.format.CreateOutputContextAsync(
-                    this.GetOrCreateMessageInfo(messageStream, true),
-                    this.settings).ConfigureAwait(false);
-                return await innerWriteFunc(this.outputContext).ConfigureAwait(false);
-            }
+            this.outputContext = await this.format.CreateOutputContextAsync(
+                this.GetOrCreateMessageInfo(messageStream, true),
+                this.settings).ConfigureAwait(false);
+            
+            return await writeFunc(this.outputContext).ConfigureAwait(false);
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -1283,15 +1283,16 @@ namespace Microsoft.OData
             // Set the content type header here since all headers have to be set before getting the stream
             this.SetOrVerifyHeaders(payloadKind);
             // Create the output context
-            return WriteToOutputInnerAsync();
-            async Task WriteToOutputInnerAsync()
+            return WriteToOutputInnerAsync(writeAsyncAction);
+
+            async Task WriteToOutputInnerAsync(Func<ODataOutputContext, Task> innerWriteAsyncAction)
             {
                 Stream messageStream = await this.message.GetStreamAsync()
                     .ConfigureAwait(false);
                 this.outputContext = await this.format.CreateOutputContextAsync(
                         this.GetOrCreateMessageInfo(messageStream, true),
                         this.settings).ConfigureAwait(false);
-                await writeAsyncAction(this.outputContext).ConfigureAwait(false);
+                await innerWriteAsyncAction(this.outputContext).ConfigureAwait(false);
             }
         }
         /// <summary>
@@ -1306,15 +1307,16 @@ namespace Microsoft.OData
             // Set the content type header here since all headers have to be set before getting the stream
             this.SetOrVerifyHeaders(payloadKind);
             // Create the output context
-            return WriteToOutputInnerAsync();
-            async Task<TResult> WriteToOutputInnerAsync()
+            return WriteToOutputInnerAsync(writeFunc);
+
+            async Task<TResult> WriteToOutputInnerAsync(Func<ODataOutputContext, Task<TResult>> innerWriteFunc)
             {
                 Stream messageStream = await this.message.GetStreamAsync()
                     .ConfigureAwait(false);
                 this.outputContext = await this.format.CreateOutputContextAsync(
                     this.GetOrCreateMessageInfo(messageStream, true),
                     this.settings).ConfigureAwait(false);
-                return await writeFunc(this.outputContext).ConfigureAwait(false);
+                return await innerWriteFunc(this.outputContext).ConfigureAwait(false);
             }
         }
     }

--- a/src/Microsoft.OData.Core/ODataMetadataFormat.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataFormat.cs
@@ -125,7 +125,7 @@ namespace Microsoft.OData
             ExceptionUtils.CheckArgumentNotNull(messageInfo, "messageInfo");
             return messageInfo.IsResponse
                 ? Task.FromResult(DetectPayloadKindImplementation(messageInfo, settings))
-                : TaskUtils.GetCompletedTask(Enumerable.Empty<ODataPayloadKind>());
+                : Task.FromResult(Enumerable.Empty<ODataPayloadKind>());
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataParameterReaderCoreAsync.cs
+++ b/src/Microsoft.OData.Core/ODataParameterReaderCoreAsync.cs
@@ -42,7 +42,7 @@ namespace Microsoft.OData
         /// When the state is ODataParameterReaderState.Resource, the Name property of the <see cref="ODataParameterReader"/> returns the name of the parameter
         /// and the Value property of the <see cref="ODataParameterReader"/> returns null. Calling this method in any other state will cause an ODataException to be thrown.
         /// </remarks>
-        public override async Task<ODataReader> CreateResourceReaderAsync()
+        public override Task<ODataReader> CreateResourceReaderAsync()
         {
             this.VerifyCanCreateSubReader(ODataParameterReaderState.Resource);
             this.subReaderState = SubReaderState.Active;
@@ -50,8 +50,7 @@ namespace Microsoft.OData
             Debug.Assert(this.Value == null, "this.Value == null");
             IEdmStructuredType expectedResourceType = (IEdmStructuredType)this.GetParameterTypeReference(this.Name).Definition;
 
-            return await this.CreateResourceReaderAsync(expectedResourceType)
-                .ConfigureAwait(false);
+            return this.CreateResourceReaderAsync(expectedResourceType);
         }
 
         /// <summary>
@@ -65,7 +64,7 @@ namespace Microsoft.OData
         /// When the state is ODataParameterReaderState.ResourceSet, the Name property of the <see cref="ODataParameterReader"/> returns the name of the parameter
         /// and the Value property of the <see cref="ODataParameterReader"/> returns null. Calling this method in any other state will cause an ODataException to be thrown.
         /// </remarks>
-        public override async Task<ODataReader> CreateResourceSetReaderAsync()
+        public override Task<ODataReader> CreateResourceSetReaderAsync()
         {
             this.VerifyCanCreateSubReader(ODataParameterReaderState.ResourceSet);
             this.subReaderState = SubReaderState.Active;
@@ -73,8 +72,7 @@ namespace Microsoft.OData
             Debug.Assert(this.Value == null, "this.Value == null");
             IEdmStructuredType expectedResourceType = (IEdmStructuredType)((IEdmCollectionType)this.GetParameterTypeReference(this.Name).Definition).ElementType.Definition;
 
-            return await this.CreateResourceSetReaderAsync(expectedResourceType)
-                .ConfigureAwait(false);
+            return this.CreateResourceSetReaderAsync(expectedResourceType);
         }
 
         /// <summary>
@@ -88,7 +86,7 @@ namespace Microsoft.OData
         /// When the state is ODataParameterReaderState.Collection, the Name property of the <see cref="ODataParameterReader"/> returns the name of the parameter
         /// and the Value property of the <see cref="ODataParameterReader"/> returns null. Calling this method in any other state will cause an ODataException to be thrown.
         /// </remarks>
-        public override async Task<ODataCollectionReader> CreateCollectionReaderAsync()
+        public override Task<ODataCollectionReader> CreateCollectionReaderAsync()
         {
             this.VerifyCanCreateSubReader(ODataParameterReaderState.Collection);
             this.subReaderState = SubReaderState.Active;
@@ -96,8 +94,7 @@ namespace Microsoft.OData
             Debug.Assert(this.Value == null, "this.Value == null");
             IEdmTypeReference expectedItemTypeReference = ((IEdmCollectionType)this.GetParameterTypeReference(this.Name).Definition).ElementType;
 
-            return await this.CreateCollectionReaderAsync(expectedItemTypeReference)
-                .ConfigureAwait(false);
+            return this.CreateCollectionReaderAsync(expectedItemTypeReference);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -964,23 +964,27 @@ namespace Microsoft.OData
         /// Asynchronously catch any exception thrown by the action passed in; in the exception case move the writer into
         /// state Error and then rethrow the exception.
         /// </summary>
-        /// <typeparam name="TArg0">The delegate first argument type.</typeparam>
-        /// <typeparam name="TArg1">The delegate second argument type.</typeparam>
-        /// <typeparam name="TArg2">The delegate third argument type.</typeparam>
+        /// <typeparam name="TArg1">The <paramref name="func"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="func"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="func"/> delegate third argument type.</typeparam>
         /// <param name="func">The delegate to execute asynchronously.</param>
-        /// <param name="arg0">The first argument value provided to the action.</param>
-        /// <param name="arg1">The second argument value provided to the action.</param>
-        /// <param name="arg2">The third argument value provided to the action.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="func"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="func"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="func"/> delegate.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
         /// <remarks>
         /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
         /// so the compiler optimizes the code to avoid delegate and closure allocations on every call to this method.
         /// </remarks>
-        private async Task InterceptExceptionAsync<TArg0, TArg1, TArg2>(Func<ODataParameterWriterCore, TArg0, TArg1, TArg2, Task> func, TArg0 arg0, TArg1 arg1, TArg2 arg2)
+        private async Task InterceptExceptionAsync<TArg1, TArg2, TArg3>(
+            Func<ODataParameterWriterCore, TArg1, TArg2, TArg3, Task> func,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3)
         {
             try
             {
-                await func(this, arg0, arg1, arg2).ConfigureAwait(false);
+                await func(this, arg1, arg2, arg3).ConfigureAwait(false);
             }
             catch
             {
@@ -994,23 +998,27 @@ namespace Microsoft.OData
         /// Asynchronously catch any exception thrown by the action passed in; in the exception case move the writer into
         /// state Error and then rethrow the exception.
         /// </summary>
-        /// <typeparam name="T">The delegate first argument type.</typeparam>
-        /// <typeparam name="TArg0">The delegate second argument type.</typeparam>
-        /// <typeparam name="TArg1">The delegate third argument type.</typeparam>
+        /// <typeparam name="T">The type of the result returned by the delegate.</typeparam>
+        /// <typeparam name="TArg1">The <paramref name="func"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="func"/> delegate second argument type.</typeparam>
         /// <param name="func">The delegate to execute asynchronously.</param>
-        /// <param name="arg0">The first argument value provided to the action.</param>
-        /// <param name="arg1">The second argument value provided to the action.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="func"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="func"/> delegate.</param>
         /// <returns>A task that represents the asynchronous operation. 
         /// The value of the TResult parameter contains a T instance.</returns>
         /// <remarks>
         /// Make sure to only use anonymous functions that don't capture state from the enclosing context, 
         /// so the compiler optimizes the code to avoid delegate and closure allocations on every call to this method.
         /// </remarks>
-        private async Task<T> InterceptExceptionAsync<T, TArg0, TArg1>(Func<ODataParameterWriterCore, TArg0, TArg1, Task<T>> func, TArg0 arg0, TArg1 arg1)
+        private async Task<T> InterceptExceptionAsync<T, TArg1, TArg2>(
+            Func<ODataParameterWriterCore, TArg1, TArg2, Task<T>>
+            func,
+            TArg1 arg1,
+            TArg2 arg2)
         {
             try
             {
-                return await func(this, arg0, arg1).ConfigureAwait(false);
+                return await func(this, arg1, arg2).ConfigureAwait(false);
             }
             catch
             {
@@ -1068,7 +1076,17 @@ namespace Microsoft.OData
         {
             Debug.Assert(this.State == ParameterWriterState.CanWriteParameter, "this.State == ParameterWriterState.CanWriteParameter");
 
-            return this.InterceptExceptionAsync((thisParam) => thisParam.WriteValueParameterAsync(parameterName, parameterValue, expectedTypeReference));
+            return this.InterceptExceptionAsync((
+                thisParam,
+                parameterNameParam,
+                parameterValueParam,
+                expectedTypeReferenceParam) => thisParam.WriteValueParameterAsync(
+                    parameterNameParam,
+                    parameterValueParam,
+                    expectedTypeReferenceParam),
+                parameterName,
+                parameterValue,
+                expectedTypeReference);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -998,7 +998,7 @@ namespace Microsoft.OData
         /// Asynchronously catch any exception thrown by the action passed in; in the exception case move the writer into
         /// state Error and then rethrow the exception.
         /// </summary>
-        /// <typeparam name="T">The type of the result returned by the delegate.</typeparam>
+        /// <typeparam name="T">The type of the result returned by the <paramref name="func"/> delegate.</typeparam>
         /// <typeparam name="TArg1">The <paramref name="func"/> delegate first argument type.</typeparam>
         /// <typeparam name="TArg2">The <paramref name="func"/> delegate second argument type.</typeparam>
         /// <param name="func">The delegate to execute asynchronously.</param>
@@ -1011,8 +1011,7 @@ namespace Microsoft.OData
         /// so the compiler optimizes the code to avoid delegate and closure allocations on every call to this method.
         /// </remarks>
         private async Task<T> InterceptExceptionAsync<T, TArg1, TArg2>(
-            Func<ODataParameterWriterCore, TArg1, TArg2, Task<T>>
-            func,
+            Func<ODataParameterWriterCore, TArg1, TArg2, Task<T>> func,
             TArg1 arg1,
             TArg2 arg2)
         {

--- a/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataParameterWriterCore.cs
@@ -134,11 +134,11 @@ namespace Microsoft.OData
         /// Asynchronously start writing a parameter payload.
         /// </summary>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public sealed override async Task WriteStartAsync()
+        public sealed override Task WriteStartAsync()
         {
             this.VerifyCanWriteStart(false /*synchronousCall*/);
-            await this.InterceptExceptionAsync(
-                (thisParam) => thisParam.WriteStartImplementationAsync()).ConfigureAwait(false);
+            return this.InterceptExceptionAsync(
+                (thisParam) => thisParam.WriteStartImplementationAsync());
         }
 
         /// <summary>
@@ -163,14 +163,14 @@ namespace Microsoft.OData
         /// <param name="parameterName">The name of the parameter to write.</param>
         /// <param name="parameterValue">The value of the parameter to write.</param>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public sealed override async Task WriteValueAsync(string parameterName, object parameterValue)
+        public sealed override Task WriteValueAsync(string parameterName, object parameterValue)
         {
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference expectedTypeReference = this.VerifyCanWriteValueParameter(false /*synchronousCall*/, parameterName, parameterValue);
-            await this.InterceptExceptionAsync(
+            return this.InterceptExceptionAsync(
                 (thisParam, parameterNameParam, parameterValueParam, expectedTypeReferenceParam) => 
                     thisParam.WriteValueImplementationAsync(parameterNameParam, parameterValueParam, expectedTypeReferenceParam),
-                parameterName, parameterValue, expectedTypeReference).ConfigureAwait(false);
+                parameterName, parameterValue, expectedTypeReference);
         }
 
         /// <summary>
@@ -194,18 +194,15 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="parameterName">The name of the collection parameter to write.</param>
         /// <returns>A running task for the created writer.</returns>
-        public sealed override async Task<ODataCollectionWriter> CreateCollectionWriterAsync(string parameterName)
+        public sealed override Task<ODataCollectionWriter> CreateCollectionWriterAsync(string parameterName)
         {
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateCollectionWriter(false /*synchronousCall*/, parameterName);
 
-            ODataCollectionWriter collectionWriter = await this.InterceptExceptionAsync(
+            return this.InterceptExceptionAsync(
                 (thisParam, parameterNameParam, itemTypeReferenceParam) =>
                     thisParam.CreateCollectionWriterImplementationAsync(parameterNameParam, itemTypeReferenceParam),
-                parameterName, itemTypeReference).ConfigureAwait(false);
-
-            Debug.Assert(collectionWriter != null, "collectionWriter != null");
-            return collectionWriter;
+                parameterName, itemTypeReference);
         }
 
         /// <summary> Creates an <see cref="Microsoft.OData.ODataWriter" /> to write a resource. </summary>
@@ -225,18 +222,15 @@ namespace Microsoft.OData
         /// <summary>Asynchronously creates an <see cref="ODataWriter" /> to  write a resource.</summary>
         /// <param name="parameterName">The name of the parameter to write.</param>
         /// <returns>The asynchronously created <see cref="ODataWriter" />.</returns>
-        public sealed override async Task<ODataWriter> CreateResourceWriterAsync(string parameterName)
+        public sealed override Task<ODataWriter> CreateResourceWriterAsync(string parameterName)
         {
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceWriter(false /*synchronousCall*/, parameterName);
 
-            ODataWriter resourceWriter = await this.InterceptExceptionAsync(
+            return this.InterceptExceptionAsync(
                 (thisParam, parameterNameParam, itemTypeReferenceParam) =>
                     thisParam.CreateResourceWriterImplementationAsync(parameterNameParam, itemTypeReferenceParam),
-                parameterName, itemTypeReference).ConfigureAwait(false);
-
-            Debug.Assert(resourceWriter != null, "resourceWriter != null");
-            return resourceWriter;
+                parameterName, itemTypeReference);
         }
 
         /// <summary> Creates an <see cref="Microsoft.OData.ODataWriter" /> to write a resource set. </summary>
@@ -256,18 +250,15 @@ namespace Microsoft.OData
         /// <summary>Asynchronously creates an <see cref="ODataWriter" /> to  write a resource set.</summary>
         /// <param name="parameterName">The name of the parameter to write.</param>
         /// <returns>The asynchronously created <see cref="ODataWriter" />.</returns>
-        public sealed override async Task<ODataWriter> CreateResourceSetWriterAsync(string parameterName)
+        public sealed override Task<ODataWriter> CreateResourceSetWriterAsync(string parameterName)
         {
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(parameterName, "parameterName");
             IEdmTypeReference itemTypeReference = this.VerifyCanCreateResourceSetWriter(false /*synchronousCall*/, parameterName);
 
-            ODataWriter resourceSetWriter = await this.InterceptExceptionAsync(
+            return this.InterceptExceptionAsync(
                 (thisParam, parameterNameParam, itemTypeReferenceParam) =>
                     thisParam.CreateResourceSetWriterImplementationAsync(parameterNameParam, itemTypeReferenceParam),
-                parameterName, itemTypeReference).ConfigureAwait(false);
-
-            Debug.Assert(resourceSetWriter != null, "resourceSetWriter != null");
-            return resourceSetWriter;
+                parameterName, itemTypeReference);
         }
 
         /// <summary>
@@ -288,10 +279,10 @@ namespace Microsoft.OData
         /// Asynchronously finish writing a parameter payload.
         /// </summary>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public sealed override async Task WriteEndAsync()
+        public sealed override Task WriteEndAsync()
         {
             this.VerifyCanWriteEnd(false /*synchronousCall*/);
-            await this.InterceptExceptionAsync(
+            return this.InterceptExceptionAsync(
                 async (thisParam) =>
                 {
                     await thisParam.WriteEndImplementationAsync()
@@ -303,7 +294,7 @@ namespace Microsoft.OData
                         await thisParam.FlushAsync()
                             .ConfigureAwait(false);
                     }
-                }).ConfigureAwait(false);
+                });
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataReaderCore.cs
+++ b/src/Microsoft.OData.Core/ODataReaderCore.cs
@@ -459,7 +459,9 @@ namespace Microsoft.OData
         /// <returns>A task for method called when a stream is requested.</returns>
         Task IODataStreamListener.StreamRequestedAsync()
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => ((IODataStreamListener)this).StreamRequested());
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam) => ((IODataStreamListener)thisParam).StreamRequested(),
+                this);
         }
 
         /// <summary>
@@ -480,7 +482,9 @@ namespace Microsoft.OData
         /// <returns>A task that represents the asynchronous operation.</returns>
         Task IODataStreamListener.StreamDisposedAsync()
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => ((IODataStreamListener)this).StreamDisposed());
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam) => ((IODataStreamListener)thisParam).StreamDisposed(),
+                this);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataUtils.cs
+++ b/src/Microsoft.OData.Core/ODataUtils.cs
@@ -192,7 +192,7 @@ namespace Microsoft.OData
 
         public static T[] GetEmptyArray<T>()
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
             return Array.Empty<T>();
 #else
             return new T[0];

--- a/src/Microsoft.OData.Core/ODataWriter.cs
+++ b/src/Microsoft.OData.Core/ODataWriter.cs
@@ -51,7 +51,10 @@ namespace Microsoft.OData
         /// <param name="resourceSet">The resource set or collection to write.</param>
         public virtual Task WriteStartAsync(ODataResourceSet resourceSet)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteStart(resourceSet));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, resourceSetParam) => thisParam.WriteStart(resourceSetParam),
+                this,
+                resourceSet);
         }
 
         /// <summary>Starts the writing of a delta resource set.</summary>
@@ -89,7 +92,10 @@ namespace Microsoft.OData
         /// <param name="deltaResourceSet">The resource set or collection to write.</param>
         public virtual Task WriteStartAsync(ODataDeltaResourceSet deltaResourceSet)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteStart(deltaResourceSet));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, deltaResourceSetParam) => thisParam.WriteStart(deltaResourceSetParam),
+                this,
+                deltaResourceSet);
         }
 
         /// <summary>Starts the writing of a resource.</summary>
@@ -164,7 +170,10 @@ namespace Microsoft.OData
         /// <param name="resource">The resource or item to write.</param>
         public virtual Task WriteStartAsync(ODataResource resource)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteStart(resource));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, resourceParam) => thisParam.WriteStart(resourceParam),
+                this,
+                resource);
         }
 
 
@@ -183,7 +192,10 @@ namespace Microsoft.OData
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
         public virtual Task WriteStartAsync(ODataDeletedResource deletedResource)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteStart(deletedResource));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, deletedResourceParam) => thisParam.WriteStart(deletedResourceParam),
+                this,
+                deletedResource);
         }
 
 
@@ -204,7 +216,10 @@ namespace Microsoft.OData
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
         public virtual Task WriteDeltaLinkAsync(ODataDeltaLink deltaLink)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteDeltaLink(deltaLink));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, deltaLinkParam) => thisParam.WriteDeltaLink(deltaLinkParam),
+                this,
+                deltaLink);
         }
 
 
@@ -225,7 +240,10 @@ namespace Microsoft.OData
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
         public virtual Task WriteDeltaDeletedLinkAsync(ODataDeltaDeletedLink deltaDeletedLink)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteDeltaDeletedLink(deltaDeletedLink));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, deltaDeletedLinkParam) => thisParam.WriteDeltaDeletedLink(deltaDeletedLinkParam),
+                this,
+                deltaDeletedLink);
         }
 
 
@@ -261,7 +279,10 @@ namespace Microsoft.OData
         /// <param name="nestedResourceInfo">The nested resource info to writer.</param>
         public virtual Task WriteStartAsync(ODataNestedResourceInfo nestedResourceInfo)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteStart(nestedResourceInfo));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, nestedResourceInfoParam) => thisParam.WriteStart(nestedResourceInfoParam),
+                this,
+                nestedResourceInfo);
         }
 
         /// <summary>Writes a primitive value within an untyped collection.</summary>
@@ -286,7 +307,10 @@ namespace Microsoft.OData
         /// <param name="primitiveValue">The primitive value to write.</param>
         public virtual Task WritePrimitiveAsync(ODataPrimitiveValue primitiveValue)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WritePrimitive(primitiveValue));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, primitiveValueParam) => thisParam.WritePrimitive(primitiveValueParam),
+                this,
+                primitiveValue);
         }
 
         /// <summary>Writes a primitive property within a resource.</summary>
@@ -326,7 +350,10 @@ namespace Microsoft.OData
         /// <param name="primitiveProperty">The primitive property to write.</param>
         public virtual Task WriteStartAsync(ODataPropertyInfo primitiveProperty)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteStart(primitiveProperty));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, primitivePropertyParam) => thisParam.WriteStart(primitivePropertyParam),
+                this,
+                primitiveProperty);
         }
 
         /// <summary>Creates a stream for writing a binary value.</summary>
@@ -353,7 +380,9 @@ namespace Microsoft.OData
         /// <returns>A stream to write a binary value to.</returns>
         public virtual Task<Stream> CreateBinaryWriteStreamAsync()
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateBinaryWriteStream());
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam) => thisParam.CreateBinaryWriteStream(),
+                this);
         }
 
         /// <summary>Creates a TextWriter for writing a string value.</summary>
@@ -368,7 +397,9 @@ namespace Microsoft.OData
         /// <returns>A TextWriter to write a string value.</returns>
         public virtual Task<TextWriter> CreateTextWriterAsync()
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.CreateTextWriter());
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam) => thisParam.CreateTextWriter(),
+                this);
         }
 
         /// <summary>Finishes the writing of a resource set, a resource, or a nested resource info.</summary>
@@ -379,7 +410,9 @@ namespace Microsoft.OData
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
         public virtual Task WriteEndAsync()
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteEnd());
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam) => thisParam.WriteEnd(),
+                this);
         }
 
         /// <summary> Writes an entity reference link, which is used to represent binding to an existing resource in a request payload. </summary>
@@ -404,7 +437,10 @@ namespace Microsoft.OData
         /// </remarks>
         public virtual Task WriteEntityReferenceLinkAsync(ODataEntityReferenceLink entityReferenceLink)
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.WriteEntityReferenceLink(entityReferenceLink));
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam, entityReferenceLinkParam) => thisParam.WriteEntityReferenceLink(entityReferenceLinkParam),
+                this,
+                entityReferenceLink);
         }
 
         /// <summary>Flushes the write buffer to the underlying stream.</summary>
@@ -415,7 +451,9 @@ namespace Microsoft.OData
         /// <returns>A task instance that represents the asynchronous operation.</returns>
         public virtual Task FlushAsync()
         {
-            return TaskUtils.GetTaskForSynchronousOperation(() => this.Flush());
+            return TaskUtils.GetTaskForSynchronousOperation(
+                (thisParam) => thisParam.Flush(),
+                this);
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -655,7 +655,10 @@ namespace Microsoft.OData
             this.VerifyCanWriteStartNestedResourceInfo(false, nestedResourceInfo);
             // Currently, no asynchronous operation is involved when commencing with writing a nested resource info
             return TaskUtils.GetTaskForSynchronousOperation(
-                () => this.WriteStartNestedResourceInfoImplementation(nestedResourceInfo));
+                (thisParam, nestedResourceInfoParam) => thisParam.WriteStartNestedResourceInfoImplementation(
+                    nestedResourceInfoParam),
+                this,
+                nestedResourceInfo);
         }
 
         /// <summary>
@@ -3286,14 +3289,14 @@ namespace Microsoft.OData
                 async (thisParam, resourceParam) =>
                 {
                     DeletedResourceScope resourceScope = thisParam.CurrentScope as DeletedResourceScope;
-                    this.ValidateResourceForResourceSet(resourceParam, resourceScope);
+                    thisParam.ValidateResourceForResourceSet(resourceParam, resourceScope);
 
-                    await this.PrepareDeletedResourceForWriteStartAsync(
+                    await thisParam.PrepareDeletedResourceForWriteStartAsync(
                         resourceScope,
                         resourceParam,
                         thisParam.outputContext.WritingResponse,
                         resourceScope.SelectedProperties).ConfigureAwait(false);
-                    await thisParam.StartDeletedResourceAsync(resource)
+                    await thisParam.StartDeletedResourceAsync(resourceParam)
                         .ConfigureAwait(false);
                 }, resource).ConfigureAwait(false);
         }

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -493,11 +493,10 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="resource">Resource/item to write.</param>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public sealed override async Task WriteStartAsync(ODataResource resource)
+        public sealed override Task WriteStartAsync(ODataResource resource)
         {
             this.VerifyCanWriteStartResource(false, resource);
-            await this.WriteStartResourceImplementationAsync(resource)
-                .ConfigureAwait(false);
+            return this.WriteStartResourceImplementationAsync(resource);
         }
 
         /// <summary>
@@ -515,11 +514,10 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="deletedResource">The delta deleted resource to write.</param>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public sealed override async Task WriteStartAsync(ODataDeletedResource deletedResource)
+        public sealed override Task WriteStartAsync(ODataDeletedResource deletedResource)
         {
             this.VerifyCanWriteStartDeletedResource(false, deletedResource);
-            await this.WriteStartDeletedResourceImplementationAsync(deletedResource)
-                .ConfigureAwait(false);
+            return this.WriteStartDeletedResourceImplementationAsync(deletedResource);
         }
 
         /// <summary>
@@ -537,11 +535,10 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="deltaLink">The delta link to write.</param>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public override async Task WriteDeltaLinkAsync(ODataDeltaLink deltaLink)
+        public override Task WriteDeltaLinkAsync(ODataDeltaLink deltaLink)
         {
             this.VerifyCanWriteLink(false, deltaLink);
-            await this.WriteDeltaLinkImplementationAsync(deltaLink)
-                .ConfigureAwait(false);
+            return this.WriteDeltaLinkImplementationAsync(deltaLink);
         }
 
         /// <summary>
@@ -559,11 +556,10 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="deltaLink">The delta link to write.</param>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public override async Task WriteDeltaDeletedLinkAsync(ODataDeltaDeletedLink deltaLink)
+        public override Task WriteDeltaDeletedLinkAsync(ODataDeltaDeletedLink deltaLink)
         {
             this.VerifyCanWriteLink(false, deltaLink);
-            await this.WriteDeltaLinkImplementationAsync(deltaLink)
-                .ConfigureAwait(false);
+            return this.WriteDeltaLinkImplementationAsync(deltaLink);
         }
 
         /// <summary>
@@ -581,11 +577,10 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="primitiveValue"> Primitive value to write.</param>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public sealed override async Task WritePrimitiveAsync(ODataPrimitiveValue primitiveValue)
+        public sealed override Task WritePrimitiveAsync(ODataPrimitiveValue primitiveValue)
         {
             this.VerifyCanWritePrimitive(false, primitiveValue);
-            await this.WritePrimitiveValueImplementationAsync(primitiveValue)
-                .ConfigureAwait(false);
+            return this.WritePrimitiveValueImplementationAsync(primitiveValue);
         }
 
         /// <summary>Writes a primitive property within a resource.</summary>
@@ -599,11 +594,10 @@ namespace Microsoft.OData
         /// <summary> Asynchronously write a primitive property within a resource. </summary>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
         /// <param name="primitiveProperty">The primitive property to write.</param>
-        public sealed override async Task WriteStartAsync(ODataPropertyInfo primitiveProperty)
+        public sealed override Task WriteStartAsync(ODataPropertyInfo primitiveProperty)
         {
             this.VerifyCanWriteProperty(false, primitiveProperty);
-            await this.WriteStartPropertyImplementationAsync(primitiveProperty)
-                .ConfigureAwait(false);
+            return this.WriteStartPropertyImplementationAsync(primitiveProperty);
         }
 
         /// <summary>Creates a stream for writing a binary value.</summary>
@@ -617,11 +611,10 @@ namespace Microsoft.OData
         /// <summary>Asynchronously creates a stream for writing a binary value.</summary>
         /// <returns>A task that represents the asynchronous operation.
         /// The value of the TResult parameter contains a <see cref="Stream"/> to write a binary value to.</returns>
-        public sealed override async Task<Stream> CreateBinaryWriteStreamAsync()
+        public sealed override Task<Stream> CreateBinaryWriteStreamAsync()
         {
             this.VerifyCanCreateWriteStream(false);
-            return await this.CreateWriteStreamImplementationAsync()
-                .ConfigureAwait(false);
+            return this.CreateWriteStreamImplementationAsync();
         }
 
         /// <summary>Creates a TextWriter for writing a string value.</summary>
@@ -635,11 +628,10 @@ namespace Microsoft.OData
         /// <summary>Asynchronously creates a <see cref="TextWriter"/> for writing a string value.</summary>
         /// <returns>A task that represents the asynchronous operation.
         /// The value of the TResult parameter contains a <see cref="TextWriter"/> to write a string value to.</returns>
-        public sealed override async Task<TextWriter> CreateTextWriterAsync()
+        public sealed override Task<TextWriter> CreateTextWriterAsync()
         {
             this.VerifyCanCreateWriteStream(false);
-            return await this.CreateTextWriterImplementationAsync()
-                .ConfigureAwait(false);
+            return this.CreateTextWriterImplementationAsync();
         }
 
         /// <summary>
@@ -658,12 +650,12 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="nestedResourceInfo">Navigation link to writer.</param>
         /// <returns>A task instance that represents the asynchronous write operation.</returns>
-        public sealed override async Task WriteStartAsync(ODataNestedResourceInfo nestedResourceInfo)
+        public sealed override Task WriteStartAsync(ODataNestedResourceInfo nestedResourceInfo)
         {
             this.VerifyCanWriteStartNestedResourceInfo(false, nestedResourceInfo);
             // Currently, no asynchronous operation is involved when commencing with writing a nested resource info
-            await TaskUtils.GetTaskForSynchronousOperation(
-                () => this.WriteStartNestedResourceInfoImplementation(nestedResourceInfo)).ConfigureAwait(false);
+            return TaskUtils.GetTaskForSynchronousOperation(
+                () => this.WriteStartNestedResourceInfoImplementation(nestedResourceInfo));
         }
 
         /// <summary>
@@ -726,11 +718,10 @@ namespace Microsoft.OData
         /// The <see cref="ODataNestedResourceInfo.Url"/> will be ignored in that case and the Uri from the <see cref="ODataEntityReferenceLink.Url"/> will be used
         /// as the binding URL to be written.
         /// </remarks>
-        public sealed override async Task WriteEntityReferenceLinkAsync(ODataEntityReferenceLink entityReferenceLink)
+        public sealed override Task WriteEntityReferenceLinkAsync(ODataEntityReferenceLink entityReferenceLink)
         {
             this.VerifyCanWriteEntityReferenceLink(entityReferenceLink, false);
-            await this.WriteEntityReferenceLinkImplementationAsync(entityReferenceLink)
-                .ConfigureAwait(false);
+            return this.WriteEntityReferenceLinkImplementationAsync(entityReferenceLink);
         }
 
         /// <summary>
@@ -1857,11 +1848,11 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="primitiveValue">Primitive value to write.</param>
         /// <returns>The task.</returns>
-        private async Task WritePrimitiveValueImplementationAsync(ODataPrimitiveValue primitiveValue)
+        private Task WritePrimitiveValueImplementationAsync(ODataPrimitiveValue primitiveValue)
         {
             EnterScope(WriterState.Primitive, primitiveValue);
 
-            await InterceptExceptionAsync(
+            return InterceptExceptionAsync(
                 async (thisParam, primiteValueParam) =>
                 {
                     if (!(CurrentResourceSetValidator == null) && primiteValueParam != null)
@@ -1875,7 +1866,7 @@ namespace Microsoft.OData
                         .ConfigureAwait(false);
                     await thisParam.WriteEndAsync()
                         .ConfigureAwait(false);
-                }, primitiveValue).ConfigureAwait(false);
+                }, primitiveValue);
         }
 
         /// <summary>
@@ -3149,15 +3140,14 @@ namespace Microsoft.OData
         /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
         /// <param name="resourceSet">The resource set/collection to write.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        private async Task VerifyCanWriteStartResourceSetAsync(bool synchronousCall, ODataResourceSet resourceSet)
+        private Task VerifyCanWriteStartResourceSetAsync(bool synchronousCall, ODataResourceSet resourceSet)
         {
             ExceptionUtils.CheckArgumentNotNull(resourceSet, "resourceSet");
 
             this.VerifyNotDisposed();
             this.VerifyCallAllowed(synchronousCall);
 
-            await this.StartPayloadInStartStateAsync()
-                .ConfigureAwait(false);
+            return this.StartPayloadInStartStateAsync();
         }
 
         /// <summary>
@@ -3198,14 +3188,13 @@ namespace Microsoft.OData
         /// <param name="synchronousCall">true if the call is to be synchronous; false otherwise.</param>
         /// <param name="deltaResourceSet">The delta resource set/collection to write.</param>
         /// <returns>A task that represents the asynchronous operation.</returns>
-        private async Task VerifyCanWriteStartDeltaResourceSetAsync(bool synchronousCall, ODataDeltaResourceSet deltaResourceSet)
+        private Task VerifyCanWriteStartDeltaResourceSetAsync(bool synchronousCall, ODataDeltaResourceSet deltaResourceSet)
         {
             ExceptionUtils.CheckArgumentNotNull(deltaResourceSet, "deltaResourceSet");
             this.VerifyNotDisposed();
             this.VerifyCallAllowed(synchronousCall);
 
-            await this.StartPayloadInStartStateAsync()
-                .ConfigureAwait(false);
+            return this.StartPayloadInStartStateAsync();
         }
 
         /// <summary>
@@ -3314,13 +3303,13 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="property">Property to write.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private async Task WriteStartPropertyImplementationAsync(ODataPropertyInfo property)
+        private Task WriteStartPropertyImplementationAsync(ODataPropertyInfo property)
         {
             this.EnterScope(WriterState.Property, property);
 
             if (!this.SkipWriting)
             {
-                await this.InterceptExceptionAsync(
+                return this.InterceptExceptionAsync(
                     async (thisParam, propertyParam) =>
                     {
                         await thisParam.StartPropertyAsync(propertyParam)
@@ -3332,8 +3321,10 @@ namespace Microsoft.OData
                             Debug.Assert(scope != null, "Scope for ODataPropertyInfo is not ODataPropertyInfoScope");
                             scope.ValueWritten = true;
                         }
-                    }, property).ConfigureAwait(false);
+                    }, property);
             }
+
+            return TaskUtils.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/RawValueWriter.cs
+++ b/src/Microsoft.OData.Core/RawValueWriter.cs
@@ -235,8 +235,13 @@ namespace Microsoft.OData
 
             if (value is Geometry || value is Geography)
             {
-                return TaskUtils.GetTaskForSynchronousOperation(
-                    () => PrimitiveConverter.Instance.WriteJsonLight(value, jsonWriter));
+                return TaskUtils.GetTaskForSynchronousOperation((
+                    valueParam,
+                    jsonWriterParam) => PrimitiveConverter.Instance.WriteJsonLight(
+                        valueParam,
+                        jsonWriterParam),
+                    value,
+                    jsonWriter);
             }
 
             if (ODataRawValueUtils.TryConvertPrimitiveToString(value, out string valueAsString))

--- a/src/Microsoft.OData.Core/RawValueWriter.cs
+++ b/src/Microsoft.OData.Core/RawValueWriter.cs
@@ -184,15 +184,22 @@ namespace Microsoft.OData
         /// Asynchronously start writing a raw output. This should only be called once.
         /// </summary>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        internal async Task StartAsync()
+        internal Task StartAsync()
         {
             if (this.settings.HasJsonPaddingFunction())
             {
-                await this.textWriter.WriteAsync(this.settings.JsonPCallback)
+                return StartInnerAsync();
+
+                async Task StartInnerAsync()
+                {
+                    await this.textWriter.WriteAsync(this.settings.JsonPCallback)
                     .ConfigureAwait(false);
-                await this.textWriter.WriteAsync(JsonConstants.StartPaddingFunctionScope)
-                    .ConfigureAwait(false);
+                    await this.textWriter.WriteAsync(JsonConstants.StartPaddingFunctionScope)
+                        .ConfigureAwait(false);
+                }
             }
+
+            return TaskUtils.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/TaskUtils.cs
+++ b/src/Microsoft.OData.Core/TaskUtils.cs
@@ -108,7 +108,7 @@ namespace Microsoft.OData.Client
         /// <returns>An already completed task. If the <paramref name="synchronousOperation"/> succeeded this will be a successfully completed task,
         /// otherwise it will be a faulted task holding the exception thrown.</returns>
         /// <remarks>The advantage of this method over CompletedTask property is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.</remarks>
+        /// this method returns a faulted task, instead of throwing an exception.</remarks>
         internal static Task GetTaskForSynchronousOperation(Action synchronousOperation)
         {
             Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
@@ -143,7 +143,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property 
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task GetTaskForSynchronousOperation<TArg>(
             Action<TArg> synchronousOperation,
@@ -183,7 +183,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property 
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task GetTaskForSynchronousOperation<TArg1, TArg2>(
             Action<TArg1, TArg2> synchronousOperation,
@@ -226,7 +226,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property 
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task GetTaskForSynchronousOperation<TArg1, TArg2, TArg3>(
             Action<TArg1, TArg2, TArg3> synchronousOperation,
@@ -272,7 +272,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property 
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task GetTaskForSynchronousOperation<TArg1, TArg2, TArg3, TArg4>(
             Action<TArg1, TArg2, TArg3, TArg4> synchronousOperation,
@@ -321,7 +321,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property 
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task GetTaskForSynchronousOperation<TArg1, TArg2, TArg3, TArg4, TArg5>(
             Action<TArg1, TArg2, TArg3, TArg4, TArg5> synchronousOperation,
@@ -357,7 +357,7 @@ namespace Microsoft.OData.Client
         /// <returns>An already completed task. If the <paramref name="synchronousOperation"/> succeeded this will be a successfully completed task,
         /// otherwise it will be a faulted task holding the exception thrown.</returns>
         /// <remarks>The advantage of this method over GetCompletedTask property is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.</remarks>
+        /// this method returns a faulted task, instead of throwing an exception.</remarks>
         internal static Task<T> GetTaskForSynchronousOperation<T>(Func<T> synchronousOperation)
         {
             Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
@@ -395,7 +395,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg>(
             Func<TArg, TResult> synchronousOperation,
@@ -438,7 +438,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg1, TArg2>(
             Func<TArg1, TArg2, TResult> synchronousOperation,
@@ -484,7 +484,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg1, TArg2, TArg3>(
             Func<TArg1, TArg2, TArg3, TResult> synchronousOperation,
@@ -533,7 +533,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg1, TArg2, TArg3, TArg4>(
             Func<TArg1, TArg2, TArg3, TArg4, TResult> synchronousOperation,
@@ -585,7 +585,7 @@ namespace Microsoft.OData.Client
         /// <remarks>
         /// The advantage of this method over <see cref="CompletedTask"/> property
         /// is that if the <paramref name="synchronousOperation"/> fails
-        /// this method returns a faulted task, instead of throwing exception.
+        /// this method returns a faulted task, instead of throwing an exception.
         /// </remarks>
         internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg1, TArg2, TArg3, TArg4, TArg5>(
             Func<TArg1, TArg2, TArg3, TArg4, TArg5, TResult> synchronousOperation,

--- a/src/Microsoft.OData.Core/TaskUtils.cs
+++ b/src/Microsoft.OData.Core/TaskUtils.cs
@@ -90,11 +90,15 @@ namespace Microsoft.OData.Client
         /// <returns>An already completed task with the specified exception.</returns>
         internal static Task<T> GetFaultedTask<T>(Exception exception)
         {
+#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
+            return Task.FromException<T>(exception);
+#else
             TaskCompletionSource<T> taskCompletionSource = new TaskCompletionSource<T>();
             taskCompletionSource.SetException(exception);
             return taskCompletionSource.Task;
+#endif
         }
-        #endregion
+#endregion
 
 #region GetTaskForSynchronousOperation
         /// <summary>
@@ -121,7 +125,7 @@ namespace Microsoft.OData.Client
                     throw;
                 }
 
-                return TaskUtils.GetFaultedTask(e);
+                return GetFaultedTask(e);
             }
         }
 
@@ -142,7 +146,7 @@ namespace Microsoft.OData.Client
             try
             {
                 T result = synchronousOperation();
-                return TaskUtils.GetCompletedTask<T>(result);
+                return Task.FromResult(result);
             }
             catch (Exception e)
             {
@@ -151,7 +155,7 @@ namespace Microsoft.OData.Client
                     throw;
                 }
 
-                return TaskUtils.GetFaultedTask<T>(e);
+                return GetFaultedTask<T>(e);
             }
         }
 
@@ -175,7 +179,7 @@ namespace Microsoft.OData.Client
                     throw;
                 }
 
-                return TaskUtils.GetFaultedTask(exception);
+                return GetFaultedTask(exception);
             }
         }
 
@@ -200,10 +204,10 @@ namespace Microsoft.OData.Client
                     throw;
                 }
 
-                return TaskUtils.GetFaultedTask<TResult>(exception);
+                return GetFaultedTask<TResult>(exception);
             }
         }
-        #endregion
+#endregion
 
 #region FollowOnSuccessWith
         /// <summary>
@@ -267,9 +271,9 @@ namespace Microsoft.OData.Client
         {
             return FollowOnSuccessWithImplementation(antecedentTask, t => operation((Task<TAntecedentTaskResult>)t));
         }
-        #endregion
+#endregion
 
-        #region FollowOnSuccessWithTask
+#region FollowOnSuccessWithTask
         /// <summary>
         /// Returns a new task which will consist of the <paramref name="antecedentTask"/> followed by a call to the <paramref name="operation"/>
         /// which will only be invoked if the antecedent task succeeded.
@@ -369,7 +373,7 @@ namespace Microsoft.OData.Client
                 TaskContinuationOptions.ExecuteSynchronously);
             return taskCompletionSource.Task.Unwrap();
         }
-        #endregion
+#endregion
 
 #region FollowOnFaultWith
         /// <summary>
@@ -398,7 +402,7 @@ namespace Microsoft.OData.Client
         {
             return FollowOnFaultWithImplementation(antecedentTask, t => ((Task<TResult>)t).Result, t => operation((Task<TResult>)t));
         }
-        #endregion
+#endregion
 
 #region FollowOnFaultAndCatchExceptionWith
         /// <summary>
@@ -419,7 +423,7 @@ namespace Microsoft.OData.Client
         {
             return FollowOnFaultAndCatchExceptionWithImplementation<TResult, TExceptionType>(antecedentTask, t => ((Task<TResult>)t).Result, catchBlock);
         }
-        #endregion
+#endregion
 
 #region FollowAlwaysWith
         /// <summary>
@@ -454,7 +458,7 @@ namespace Microsoft.OData.Client
         {
             return FollowAlwaysWithImplementation(antecedentTask, t => ((Task<TResult>)t).Result, t => operation((Task<TResult>)t));
         }
-        #endregion
+#endregion
 
 #region Task.IgnoreExceptions - copied from Samples for Parallel Programming
         /// <summary>Suppresses default exception handling of a Task that would otherwise reraise the exception on the finalizer thread.</summary>
@@ -470,7 +474,7 @@ namespace Microsoft.OData.Client
                 TaskScheduler.Default);
             return task;
         }
-        #endregion Task.IgnoreExceptions - copied from Samples for Parallel Programming
+#endregion Task.IgnoreExceptions - copied from Samples for Parallel Programming
 
 #region TaskFactory.GetTargetScheduler - copied from Samples for Parallel Programming
         /// <summary>Gets the TaskScheduler instance that should be used to schedule tasks.</summary>
@@ -481,7 +485,7 @@ namespace Microsoft.OData.Client
             Debug.Assert(factory != null, "factory != null");
             return factory.Scheduler ?? TaskScheduler.Current;
         }
-        #endregion TaskFactory.GetTargetScheduler - copied from Samples for Parallel Programming
+#endregion TaskFactory.GetTargetScheduler - copied from Samples for Parallel Programming
 
 #region TaskFactory.Iterate - copied from Samples for Parallel Programming
         //// Note that if we would migrate to .NET 4.5 and could get dependency on the "await" keyword, all of this is not needed
@@ -573,7 +577,7 @@ namespace Microsoft.OData.Client
             // Return the representative task to the user
             return trc.Task;
         }
-        #endregion TaskFactory.Iterate - copied from Samples for Parallel Programming
+#endregion TaskFactory.Iterate - copied from Samples for Parallel Programming
 
 #region FollowOnSuccess helpers
         /// <summary>
@@ -636,7 +640,7 @@ namespace Microsoft.OData.Client
                 .IgnoreExceptions();
             return taskCompletionSource.Task;
         }
-        #endregion
+#endregion
 
 #region FollowOnFault helpers
         /// <summary>
@@ -690,7 +694,7 @@ namespace Microsoft.OData.Client
                 .IgnoreExceptions();
             return taskCompletionSource.Task;
         }
-        #endregion
+#endregion
 
 #region FollowOnFaultAndCatchException helpers
         /// <summary>
@@ -766,7 +770,7 @@ namespace Microsoft.OData.Client
                 .IgnoreExceptions();
             return taskCompletionSource.Task;
         }
-        #endregion
+#endregion
 
 #region FollowAlways helpers
         /// <summary>
@@ -847,6 +851,6 @@ namespace Microsoft.OData.Client
                 .IgnoreExceptions();
             return taskCompletionSource.Task;
         }
-        #endregion
+#endregion
     }
 }

--- a/src/Microsoft.OData.Core/TaskUtils.cs
+++ b/src/Microsoft.OData.Core/TaskUtils.cs
@@ -116,7 +116,227 @@ namespace Microsoft.OData.Client
             try
             {
                 synchronousOperation();
-                return TaskUtils.CompletedTask;
+                return CompletedTask;
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TArg">The <paramref name="synchronousOperation"/> delegate argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg">The argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property 
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task GetTaskForSynchronousOperation<TArg>(
+            Action<TArg> synchronousOperation,
+            TArg arg)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+
+            try
+            {
+                synchronousOperation(arg);
+                return CompletedTask;
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TArg1">The <paramref name="synchronousOperation"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="synchronousOperation"/> delegate second argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property 
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task GetTaskForSynchronousOperation<TArg1, TArg2>(
+            Action<TArg1, TArg2> synchronousOperation,
+            TArg1 arg1,
+            TArg2 arg2)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+
+            try
+            {
+                synchronousOperation(arg1, arg2);
+                return CompletedTask;
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TArg1">The <paramref name="synchronousOperation"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="synchronousOperation"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="synchronousOperation"/> delegate third argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property 
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task GetTaskForSynchronousOperation<TArg1, TArg2, TArg3>(
+            Action<TArg1, TArg2, TArg3> synchronousOperation,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+
+            try
+            {
+                synchronousOperation(arg1, arg2, arg3);
+                return CompletedTask;
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TArg1">The <paramref name="synchronousOperation"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="synchronousOperation"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="synchronousOperation"/> delegate third argument type.</typeparam>
+        /// <typeparam name="TArg4">The <paramref name="synchronousOperation"/> delegate fourth argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg4">The fourth argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property 
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task GetTaskForSynchronousOperation<TArg1, TArg2, TArg3, TArg4>(
+            Action<TArg1, TArg2, TArg3, TArg4> synchronousOperation,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3,
+            TArg4 arg4)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+
+            try
+            {
+                synchronousOperation(arg1, arg2, arg3, arg4);
+                return CompletedTask;
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TArg1">The <paramref name="synchronousOperation"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="synchronousOperation"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="synchronousOperation"/> delegate third argument type.</typeparam>
+        /// <typeparam name="TArg4">The <paramref name="synchronousOperation"/> delegate fourth argument type.</typeparam>
+        /// <typeparam name="TArg5">The <paramref name="synchronousOperation"/> delegate fifth argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg4">The fourth argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg5">The fifth argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property 
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task GetTaskForSynchronousOperation<TArg1, TArg2, TArg3, TArg4, TArg5>(
+            Action<TArg1, TArg2, TArg3, TArg4, TArg5> synchronousOperation,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3,
+            TArg4 arg4,
+            TArg5 arg5)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+
+            try
+            {
+                synchronousOperation(arg1, arg2, arg3, arg4, arg5);
+                return CompletedTask;
             }
             catch (Exception e)
             {
@@ -141,7 +361,8 @@ namespace Microsoft.OData.Client
         internal static Task<T> GetTaskForSynchronousOperation<T>(Func<T> synchronousOperation)
         {
             Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
-            Debug.Assert(!(typeof(Task).IsAssignableFrom(typeof(T))), "This method doesn't support operations returning Task instances.");
+            Debug.Assert(!(typeof(Task).IsAssignableFrom(typeof(T))),
+                "This method doesn't support operations returning Task instances.");
 
             try
             {
@@ -156,6 +377,241 @@ namespace Microsoft.OData.Client
                 }
 
                 return GetFaultedTask<T>(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the operation. This MUST NOT be a Task type.</typeparam>
+        /// <typeparam name="TArg">The <paramref name="synchronousOperation"/> delegate first argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg">The first argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg>(
+            Func<TArg, TResult> synchronousOperation,
+            TArg arg)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+            Debug.Assert(!typeof(Task).IsAssignableFrom(typeof(TResult)),
+                "This method doesn't support operations returning Task instances.");
+
+            try
+            {
+                TResult result = synchronousOperation(arg);
+                return Task.FromResult(result);
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask<TResult>(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the operation. This MUST NOT be a Task type.</typeparam>
+        /// <typeparam name="TArg1">The <paramref name="synchronousOperation"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="synchronousOperation"/> delegate second argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg1, TArg2>(
+            Func<TArg1, TArg2, TResult> synchronousOperation,
+            TArg1 arg1,
+            TArg2 arg2)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+            Debug.Assert(!typeof(Task).IsAssignableFrom(typeof(TResult)),
+                "This method doesn't support operations returning Task instances.");
+
+            try
+            {
+                TResult result = synchronousOperation(arg1, arg2);
+                return Task.FromResult(result);
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask<TResult>(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the operation. This MUST NOT be a Task type.</typeparam>
+        /// <typeparam name="TArg1">The <paramref name="synchronousOperation"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="synchronousOperation"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="synchronousOperation"/> delegate third argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg1, TArg2, TArg3>(
+            Func<TArg1, TArg2, TArg3, TResult> synchronousOperation,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+            Debug.Assert(!typeof(Task).IsAssignableFrom(typeof(TResult)),
+                "This method doesn't support operations returning Task instances.");
+
+            try
+            {
+                TResult result = synchronousOperation(arg1, arg2, arg3);
+                return Task.FromResult(result);
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask<TResult>(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the operation. This MUST NOT be a Task type.</typeparam>
+        /// <typeparam name="TArg1">The <paramref name="synchronousOperation"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="synchronousOperation"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="synchronousOperation"/> delegate third argument type.</typeparam>
+        /// <typeparam name="TArg4">The <paramref name="synchronousOperation"/> delegate fourth argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg4">The fourth argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg1, TArg2, TArg3, TArg4>(
+            Func<TArg1, TArg2, TArg3, TArg4, TResult> synchronousOperation,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3,
+            TArg4 arg4)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+            Debug.Assert(!typeof(Task).IsAssignableFrom(typeof(TResult)),
+                "This method doesn't support operations returning Task instances.");
+
+            try
+            {
+                TResult result = synchronousOperation(arg1, arg2, arg3, arg4);
+                return Task.FromResult(result);
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask<TResult>(e);
+            }
+        }
+
+        /// <summary>
+        /// Returns an already completed task for the specified synchronous operation.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the operation. This MUST NOT be a Task type.</typeparam>
+        /// <typeparam name="TArg1">The <paramref name="synchronousOperation"/> delegate first argument type.</typeparam>
+        /// <typeparam name="TArg2">The <paramref name="synchronousOperation"/> delegate second argument type.</typeparam>
+        /// <typeparam name="TArg3">The <paramref name="synchronousOperation"/> delegate third argument type.</typeparam>
+        /// <typeparam name="TArg4">The <paramref name="synchronousOperation"/> delegate fourth argument type.</typeparam>
+        /// <typeparam name="TArg5">The <paramref name="synchronousOperation"/> delegate fifth argument type.</typeparam>
+        /// <param name="synchronousOperation">The synchronous operation to perform.</param>
+        /// <param name="arg1">The first argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg2">The second argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg3">The third argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg4">The fourth argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <param name="arg5">The fifth argument value provided to the <paramref name="synchronousOperation"/> delegate.</param>
+        /// <returns>
+        /// An already completed task. If the <paramref name="synchronousOperation"/>
+        /// succeeded this will be a successfully completed task,
+        /// otherwise it will be a faulted task holding the exception thrown.
+        /// </returns>
+        /// <remarks>
+        /// The advantage of this method over <see cref="CompletedTask"/> property
+        /// is that if the <paramref name="synchronousOperation"/> fails
+        /// this method returns a faulted task, instead of throwing exception.
+        /// </remarks>
+        internal static Task<TResult> GetTaskForSynchronousOperation<TResult, TArg1, TArg2, TArg3, TArg4, TArg5>(
+            Func<TArg1, TArg2, TArg3, TArg4, TArg5, TResult> synchronousOperation,
+            TArg1 arg1,
+            TArg2 arg2,
+            TArg3 arg3,
+            TArg4 arg4,
+            TArg5 arg5)
+        {
+            Debug.Assert(synchronousOperation != null, "synchronousOperation != null");
+            Debug.Assert(!typeof(Task).IsAssignableFrom(typeof(TResult)),
+                "This method doesn't support operations returning Task instances.");
+
+            try
+            {
+                TResult result = synchronousOperation(arg1, arg2, arg3, arg4, arg5);
+                return Task.FromResult(result);
+            }
+            catch (Exception e)
+            {
+                if (!ExceptionUtils.IsCatchableExceptionType(e))
+                {
+                    throw;
+                }
+
+                return GetFaultedTask<TResult>(e);
             }
         }
 

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -4504,19 +4504,11 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataOutputInStreamErr
     public Microsoft.OData.ODataBatchOperationRequestMessage CreateOperationRequestMessage (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId)
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption)
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IList`1[[System.String]] dependsOnIds)
-
     protected abstract Microsoft.OData.ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)
     protected virtual System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageImplementationAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)
     public Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessage (string contentId)
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageAsync (string contentId)
-
     protected abstract Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation (string contentId)
     protected virtual System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageImplementationAsync (string contentId)
     public void Flush ()
@@ -4550,11 +4542,7 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataOutputInStreamErr
     protected abstract void WriteEndChangesetImplementation ()
     protected virtual System.Threading.Tasks.Task WriteEndChangesetImplementationAsync ()
     public void WriteStartBatch ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task WriteStartBatchAsync ()
-
     protected abstract void WriteStartBatchImplementation ()
     protected virtual System.Threading.Tasks.Task WriteStartBatchImplementationAsync ()
     public void WriteStartChangeset ()
@@ -5180,15 +5168,8 @@ public sealed class Microsoft.OData.ODataAsynchronousResponseMessage : IContaine
 
 public sealed class Microsoft.OData.ODataAsynchronousWriter : IODataOutputInStreamErrorListener {
     public Microsoft.OData.ODataAsynchronousResponseMessage CreateResponseMessage ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataAsynchronousResponseMessage]] CreateResponseMessageAsync ()
-
     public void Flush ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task FlushAsync ()
 }
 

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -4504,19 +4504,11 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataOutputInStreamErr
     public Microsoft.OData.ODataBatchOperationRequestMessage CreateOperationRequestMessage (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId)
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption)
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IList`1[[System.String]] dependsOnIds)
-
     protected abstract Microsoft.OData.ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)
     protected virtual System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageImplementationAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)
     public Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessage (string contentId)
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageAsync (string contentId)
-
     protected abstract Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation (string contentId)
     protected virtual System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageImplementationAsync (string contentId)
     public void Flush ()
@@ -4550,11 +4542,7 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataOutputInStreamErr
     protected abstract void WriteEndChangesetImplementation ()
     protected virtual System.Threading.Tasks.Task WriteEndChangesetImplementationAsync ()
     public void WriteStartBatch ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task WriteStartBatchAsync ()
-
     protected abstract void WriteStartBatchImplementation ()
     protected virtual System.Threading.Tasks.Task WriteStartBatchImplementationAsync ()
     public void WriteStartChangeset ()
@@ -5180,15 +5168,8 @@ public sealed class Microsoft.OData.ODataAsynchronousResponseMessage : IContaine
 
 public sealed class Microsoft.OData.ODataAsynchronousWriter : IODataOutputInStreamErrorListener {
     public Microsoft.OData.ODataAsynchronousResponseMessage CreateResponseMessage ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataAsynchronousResponseMessage]] CreateResponseMessageAsync ()
-
     public void Flush ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task FlushAsync ()
 }
 

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -4504,19 +4504,11 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataOutputInStreamErr
     public Microsoft.OData.ODataBatchOperationRequestMessage CreateOperationRequestMessage (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId)
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption)
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IList`1[[System.String]] dependsOnIds)
-
     protected abstract Microsoft.OData.ODataBatchOperationRequestMessage CreateOperationRequestMessageImplementation (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)
     protected virtual System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationRequestMessage]] CreateOperationRequestMessageImplementationAsync (string method, System.Uri uri, string contentId, Microsoft.OData.BatchPayloadUriOption payloadUriOption, System.Collections.Generic.IEnumerable`1[[System.String]] dependsOnIds)
     public Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessage (string contentId)
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageAsync (string contentId)
-
     protected abstract Microsoft.OData.ODataBatchOperationResponseMessage CreateOperationResponseMessageImplementation (string contentId)
     protected virtual System.Threading.Tasks.Task`1[[Microsoft.OData.ODataBatchOperationResponseMessage]] CreateOperationResponseMessageImplementationAsync (string contentId)
     public void Flush ()
@@ -4550,11 +4542,7 @@ public abstract class Microsoft.OData.ODataBatchWriter : IODataOutputInStreamErr
     protected abstract void WriteEndChangesetImplementation ()
     protected virtual System.Threading.Tasks.Task WriteEndChangesetImplementationAsync ()
     public void WriteStartBatch ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task WriteStartBatchAsync ()
-
     protected abstract void WriteStartBatchImplementation ()
     protected virtual System.Threading.Tasks.Task WriteStartBatchImplementationAsync ()
     public void WriteStartChangeset ()
@@ -5180,15 +5168,8 @@ public sealed class Microsoft.OData.ODataAsynchronousResponseMessage : IContaine
 
 public sealed class Microsoft.OData.ODataAsynchronousWriter : IODataOutputInStreamErrorListener {
     public Microsoft.OData.ODataAsynchronousResponseMessage CreateResponseMessage ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task`1[[Microsoft.OData.ODataAsynchronousResponseMessage]] CreateResponseMessageAsync ()
-
     public void Flush ()
-    [
-    AsyncStateMachineAttribute(),
-    ]
     public System.Threading.Tasks.Task FlushAsync ()
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description
The following sections describe the nature of changes made to improve performance and memory usage

#### 1. Trade off pure asynchronous semantics (where it makes sense) to circumvent the async state machine overhead
When implementing asynchronous support, there are methods that I changed to `async` such that even [bonehead exceptions](https://ericlippert.com/2008/09/10/vexing-exceptions/) would be caught by the state machine for async methods and placed on the returned task.
Those category of methods take the following form:
```csharp
async Task MethodAsync()
{
    VerifyYadaYada(); // Throws exception if expected conditions are not met
    await MethodAnotherAsync();
}
```
The `VerifyYadaYada` methods verifies for example that the stream is not disposed, or that a delta link is being written within a delta resource set, etc.
Without the `async` keyword, the exception would be raised directly rather than get placed on the returned task.
In this PR, I have dropped the `async` modifier from such methods for the following reasons:
- Unless there's a bug in our code, bonehead exceptions resulting from verification failures _should_ never happen.
- On the strength of the above point, we trade off pure asynchronous semantics - _exception being placed on the task returned from the method_ - for performance. There's little sense in incurring a performance cost (construction of state machine, instantiation of `Task` objects, etc.) for a condition that will almost never occur. If it occurred, the exception will still be caught by a method with the `async` modifier higher up in the call stack.

#### 2. Use of local functions to circumvent the async state machine overhead
Another category of methods where I dropped the `async` modifier are those where the asynchronous logic is run conditionally. By placing the asynchronous logic in a local function, it becomes possible to elide `async` and `await`. We get a performance benefit especially where the asynchronous logic is almost never executed. Such methods take the following form:
```csharp
async Task MethodAsync()
{
    if (true) // Check condition
    {
        // Asynchronous methods
    }
}
```
To avoid paying a higher cost when the condition is false, the rewritten method looks as follows:
```csharp
Task MethodAsync()
{
    if (true) // Check condition
    {
        return MethodInnerAsync();

        async Task MethodInnerAsync()
        {
            // Asynchronous methods
        }
    }

    return TaskUtils.CompletedTask; // Static property that returns a completed task instance
}
```
#### 3. Elide async/await where different branches of logic in a method makes it possible
This PR also elides `async` and `await` where each branch of logic in the asynchronous method consist of a single asynchronous method call. For example;
```csharp
async Task MethodAsync()
{
    if (true) // Condition check
    {
        await MethodAnotherAsync();
    }
    else if (true) // Another condition check
    {
        await MethodYetAnotherAsync();
    }

    throw new ODataException("Houston, we have a problem");
}
```
We rewrite these category of methods as follows:
```csharp
Task MethodAsync()
{
    if (true) // Condition check
    {
        return MethodAnotherAsync();
    }
    else if (true) // Another condition check
    {
        return MethodYetAnotherAsync();
    }

    return TaskUtils.GetFaultedTask(new ODataException("Houston, we have a problem"));
}
```

#### 4. Dropped use of expensive methods defined in `TaskUtils`
This PR also drops use of expensive methods defined in `TaskUtils` class - `FollowOnSuccessWithTask`, `FollowOnSuccessWith`, etc. Local functions that achieve the same purpose are introduced.

#### 5. Performance and memory usage improvements to particular methods defined in `TaskUtils`
There are asynchronous methods that we support but the logic in such methods do not currently perform any asynchronous operations.
For example, `CreateODataResourceWriterAsync` currently only initializes the writer to use for writing OData resources (same logic as `CreateODataResourceWriter`). It makes use of a method [`GetTaskForSynchronousOperation`](https://github.com/OData/odata.net/blob/7dcad74478debcfe54e93c63f47b7cb57f2d2e67/src/Microsoft.OData.Core/TaskUtils.cs#L108) defined in `TaskUtils` class. That method is used as follows:
```csharp
return TaskUtils.GetTaskForSynchronousOperation(
    () => this.CreateODataResourceWriterImplementation(navigationSource, resourceType));
```
Where `CreateODataResourceWriterImplementation` is a synchronous method.

I considered replacing all instances of `GetTaskForAsynchronousOperation` with `Task.FromResult` but held back since the `GetTaskForAsynchronousOperation` method does some exception handling and returns a faulted task for all exceptions except `OutOfMemoryException`.
The `GetTaskForAsynchronousOperation` method makes use of 2 helper methods (`GetCompletedTask` and `GetFaultedTask`).
I did some benchmarking to see whether using `Task.FromResult` and `Task.FromException` in the 2 helper methods would result into better performance and memory usage metrics.
```csharp
[MemoryDiagnoser]
public class CompletedTaskBenchmark
{
    private static readonly Type OutOfMemoryExceptionType = typeof(OutOfMemoryException);

    [Benchmark]
    public Task CompletedTaskUsingFromResultAsync()
    {
        return Task.FromResult("Task completed");
    }

    [Benchmark]
    public Task CompletedTaskUsingTaskCompletionSourceAsync()
    {
        return GetCompletedTask("Task completed");
    }

    [Benchmark]
    public Task CompletedTaskUsingGetTaskForSynchronousOperationAsync()
    {
        return GetTaskForSynchronousOperation(() => "Task completed");
    }

    [Benchmark]
    public Task CompletedTaskUsingGetTaskForSynchronousOperationRevisedAsync()
    {
        return GetTaskForSynchronousOperationRevised(() => "Task completed");
    }

    static Task<T> GetCompletedTask<T>(T value)
    {
        TaskCompletionSource<T> taskCompletionSource = new TaskCompletionSource<T>();
        taskCompletionSource.SetResult(value);
        return taskCompletionSource.Task;
    }

    internal static Task<T> GetFaultedTask<T>(Exception exception)
    {
        TaskCompletionSource<T> taskCompletionSource = new TaskCompletionSource<T>();
        taskCompletionSource.SetException(exception);
        return taskCompletionSource.Task;
    }

    static Task<T> GetTaskForSynchronousOperation<T>(Func<T> synchronousOperation)
    {
        try
        {
            T result = synchronousOperation();
            return GetCompletedTask(result);
        }
        catch (Exception ex)
        {
            Type type = ex.GetType();

            if (type == OutOfMemoryExceptionType)
            {
                throw;
            }

            return GetFaultedTask<T>(ex);
        }
    }

    static Task<T> GetTaskForSynchronousOperationRevised<T>(Func<T> synchronousOperation)
    {
        try
        {
            T result = synchronousOperation();
            return Task.FromResult(result);
        }
        catch (Exception ex)
        {
            Type type = ex.GetType();

            if (type == OutOfMemoryExceptionType)
            {
                throw;
            }

            return Task.FromException<T>(ex);
        }
    }
}
```
Below were the results:
```
|                                                       Method |      Mean |     Error |    StdDev |  Gen 0 | Allocated |
|------------------------------------------------------------- |----------:|----------:|----------:|-------:|----------:|
|                            CompletedTaskUsingFromResultAsync |  8.071 ns | 0.1713 ns | 0.2344 ns | 0.0172 |      72 B |
|                   CompletedTaskUsingTaskCompletedSourceAsync | 37.606 ns | 0.6161 ns | 0.5763 ns | 0.0229 |      96 B |
|        CompletedTaskUsingGetTaskForSynchronousOperationAsync | 40.309 ns | 0.4737 ns | 0.4431 ns | 0.0229 |      96 B |
| CompletedTaskUsingGetTaskForSynchronousOperationRevisedAsync | 13.357 ns | 0.2933 ns | 0.3709 ns | 0.0172 |      72 B |
```

From the above results, it's clear that the `GetCompletedTask` and `GetFaultedTask` as currently implemented are expensive. Using `TaskCompletionSource` to create a task instance has a higher cost than calling `Task.FromResult`.
I have refactored the `GetTaskForSynchronousOperation` to make use of both `Task.FromResult` and `Task.FromException` (where possible - `Task.FromException` is not supported across all frameworks that OData supports)

#### 6. Introduction of overloads of particular methods that accept delegates as parameters to prevent capturing of state from the enclosing context
The following 4 methods accept delegates as a parameter. In a lot of cases where they are used, they capture state from the enclosing context and as a consequence the C# compiler automatically generates a private "display class" that results into inadvertent allocations.
```csharp
Task WriteTopLevelPayloadAsync(Func<Task>) { /*...*/ } // ODataJsonLightSerializer

ODataContextUrlInfo WriteContextUriPropertyAsync(
    ODataPayloadKind,
    Func<ODataContextUrlInfo>,
    ODataContextUrlInfo,
    string) { /*...*/ } // ODataJsonLightSerializer

Task GetTaskForSynchronousOperation(Action) { /*...*/ } // TaskUtils

Task<T> GetTaskForSynchronousOperation(Func<T>) { /*...*/ } // TaskUtils
```

Below are examples of scenarios where "display classes" are created:
![image](https://user-images.githubusercontent.com/28291332/191093040-a12f6174-7ea0-4777-94a1-87e3ee7923d1.png)

![image](https://user-images.githubusercontent.com/28291332/191092805-c222871b-2983-46d5-a4ab-1d0cc141072f.png)

Since the above methods are quite heavily used, I introduced `protected` overloads that help prevent capturing state from the enclosing context. For `WriteTopLevelPayloadAsync` method for example, I introduced the following overloads:

```csharp
Task WriteTopLevelPayloadAsync<TArg>(Func<TArg, Task>, TArg) { /*...*/ }

Task WriteTopLevelPayloadAsync<TArg1, TArg2>(Func<TArg1, TArg2>, TArg1, TArg2) { /*...*/ }

Task WriteTopLevelPayloadAsync<TArg1, TArg2, TArg3>(Func<TArg1, TArg2, TArg3>, TArg1, TArg2, TArg3) { /*...*/ }
```
By making use of the overloads, the "display classes" are eliminated together with the associated allocation overheads
![image](https://user-images.githubusercontent.com/28291332/191092048-dc62ff86-1e90-46df-ba12-bc0e78f74eed.png)

No self-allocations in `ODataJsonLightResourceSerializer.WriteResourceSetContextUriAsync`
![image](https://user-images.githubusercontent.com/28291332/191094127-cfa50bb6-1c94-4d45-a930-cd79cfeef8d7.png)

#### Objects Allocations Report: Base vs Diff
```
summary:
better: 10, geomean: 1.199
worse: 11, geomean: 1.196
new (results in the diff that are not in the base): 12
missing (results in the base that are not in the diff): 32
total diff: 65

| Worse                                                    |          diff/base | Base Allocations | Diff Allocations | Modality|
| -------------------------------------------------------- | ------------------:| ----------------:| ----------------:| --------:|
| System.Func<,,,,>                                        |                  3 |             1.00 |             3.00 |         |
| System.Threading.ThreadPoolWorkQueueThreadLocals         |               1.25 |             4.00 |             5.00 |         |
| System.Threading.ThreadPoolWorkQueue.WorkStealingQueue   |               1.25 |             4.00 |             5.00 |         |
| System.Threading.Thread                                  |                1.2 |             5.00 |             6.00 |         |
| System.Threading.ThreadPoolWorkQueue.WorkStealingQueue[] |                1.2 |             5.00 |             6.00 |         |
| System.Action<,>                                         | 1.0263157894736843 |           114.00 |           117.00 |         |
| System.Threading.Tasks.Task<>                            | 1.0180722891566265 |           166.00 |           169.00 |         |
| System.Text.StringBuilder                                | 1.0081967213114753 |           244.00 |           246.00 |         |
| System.Func<,,>                                          | 1.0036231884057971 |          1656.00 |          1662.00 |         |
| System.Object[]                                          | 1.0033444816053512 |           598.00 |           600.00 |         |
| System.Char[]                                            |       1.0029296875 |          1024.00 |          1027.00 |         |

| Better                                                                          |          base/diff | Base Allocations | Diff Allocations | Modality|
| ------------------------------------------------------------------------------- | ------------------:| ----------------:| ----------------:| --------:|
| System.Threading.Tasks.TaskCompletionSource<>                                   |  3.176470588235294 |            54.00 |            17.00 |         |
| System.Action                                                                   | 1.1612903225806452 |           288.00 |           248.00 |         |
| System.Func<>                                                                   | 1.1336206896551724 |           263.00 |           232.00 |         |
| System.Runtime.CompilerServices.AsyncTaskMethodBuilder<>.AsyncStateMachineBox<> | 1.1290322580645162 |            35.00 |            31.00 |         |
| System.Threading.ContextCallback                                                | 1.1111111111111112 |            20.00 |            18.00 |         |
| System.Action<>                                                                 |  1.110655737704918 |           271.00 |           244.00 |         |
| System.Func<,>                                                                  | 1.0348178137651822 |          1278.00 |          1235.00 |         |
| System.Byte[]                                                                   | 1.0165289256198347 |           123.00 |           121.00 |         |
| System.SByte[]                                                                  | 1.0055137844611528 |          8024.00 |          7980.00 |         |
| System.String                                                                   |  1.000027430703186 |         72913.00 |         72911.00 |         |

| New                                                                      | diff/base | Base Allocations | Diff Allocations | Modality|
| ------------------------------------------------------------------------ | --------- | ----------------:| ----------------:| -------- |
| System.Func<,,,>                                                         | N/A       |                  |             6.00 | N/A     |
| System.Action<,,,,>                                                      | N/A       |                  |             2.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightCollectionSerializer.<>c         | N/A       |                  |             1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.<>c                | N/A       |                  |             1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightPropertySerializer.<>c           | N/A       |                  |             1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.<>c           | N/A       |                  |             1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightServiceDocumentSerializer.<>c    | N/A       |                  |             1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightValueSerializer.<>c              | N/A       |                  |             1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.<>c                       | N/A       |                  |             1.00 | N/A     |
| Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchOutputContext.<>c | N/A       |                  |             1.00 | N/A     |
| Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchWriter.<>c        | N/A       |                  |             1.00 | N/A     |
| Microsoft.OData.RawValueWriter.<>c                                       | N/A       |                  |             1.00 | N/A     |

| Missing                                                                          | diff/base | Base Allocations | Diff Allocations | Modality|
| -------------------------------------------------------------------------------- | --------- | ----------------:| ----------------:| -------- |
| System.Threading.Tasks.ContinuationTaskFromTask                                  | N/A       |            48.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightValueSerializer.<>c__DisplayClass19_0    | N/A       |           102.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer.<>c__DisplayClass6_0          | N/A       |            62.00 |                  | N/A     |
| System.Threading.Tasks.Task.ContingentProperties                                 | N/A       |            24.00 |                  | N/A     |
| System.Threading.Tasks.StandardTaskContinuation                                  | N/A       |            48.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.<>c__DisplayClass82_0             | N/A       |            19.00 |                  | N/A     |
| Microsoft.OData.TaskUtils.<>c__DisplayClass27_0<>                                | N/A       |            24.00 |                  | N/A     |
| Microsoft.OData.ODataMessage.<>c__DisplayClass19_0                               | N/A       |            20.00 |                  | N/A     |
| Microsoft.OData.TaskUtils.<>c__DisplayClass13_0<,>                               | N/A       |            20.00 |                  | N/A     |
| Microsoft.OData.ODataMessageWriter.<>c__DisplayClass102_0<>                      | N/A       |            13.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.<>c__DisplayClass20_0 | N/A       |             6.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.<>c__DisplayClass30_0      | N/A       |             6.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.<>c__DisplayClass21_0 | N/A       |             6.00 |                  | N/A     |
| Microsoft.OData.ODataMessageWriter.<>c__DisplayClass101_0                        | N/A       |             7.00 |                  | N/A     |
| Microsoft.OData.ODataWriterCore.<>c__DisplayClass64_0                            | N/A       |             6.00 |                  | N/A     |
| Microsoft.OData.ODataBatchOperationMessage.<>c__DisplayClass10_0                 | N/A       |             4.00 |                  | N/A     |
| Microsoft.OData.ODataBatchWriter.<>c__DisplayClass71_0                           | N/A       |             4.00 |                  | N/A     |
| Microsoft.OData.RawValueWriter.<>c__DisplayClass18_0                             | N/A       |             3.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.<>c__DisplayClass83_0             | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.<>c__DisplayClass26_0      | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.<>c__DisplayClass28_0      | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.<>c__DisplayClass36_0      | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.<>c__DisplayClass22_0 | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.ODataParameterWriterCore.<>c__DisplayClass75_0                   | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightCollectionSerializer.<>c__DisplayClass4_ | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.<>c__DisplayClass32_0      | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.<>c__DisplayClass38_0      | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightPropertySerializer.<>c__DisplayClass9_0  | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightServiceDocumentSerializer.<>c__DisplayCl | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.ODataWriterCore.<>c__DisplayClass195_0                           | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightPropertySerializer.<>c__DisplayClass9_1  | N/A       |             1.00 |                  | N/A     |
| Microsoft.OData.TaskUtils.<>c                                                    | N/A       |             1.00 |                  | N/A     |
```

#### Functions Allocations Report: Base vs Diff
```
summary:
better: 14, geomean: 1.686
worse: 17, geomean: 1.412
new (results in the diff that are not in the base): 40
missing (results in the base that are not in the diff): 42
total diff: 113

| Worse                                                                            |          diff/base | Base Self Allocations | Diff Self Allocations | Modality|
| -------------------------------------------------------------------------------- | ------------------:| ---------------------:| ---------------------:| --------:|
| Microsoft.OData.ODataWriterCore.InterceptExceptionAsync()                        |                  6 |                  3.00 |                 18.00 |         |
| Microsoft.OData.Json.JsonWriter.StartStreamValueScopeAsync()                     |                  3 |                  1.00 |                  3.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.StartResourceSetAsync()           |              2.125 |                 16.00 |                 34.00 |         |
| Microsoft.OData.ODataWriterCore.WriteStartAsync()                                |              1.625 |                  8.00 |                 13.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.WriteEntityReferenceLinkImplement | 1.3333333333333333 |                  6.00 |                  8.00 |         |
| Microsoft.OData.ODataResponseMessage.GetStreamAsync()                            |                1.3 |                 10.00 |                 13.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightPropertySerializer.WritePropertyAsync()  | 1.2857142857142858 |                  7.00 |                  9.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightValueSerializer.WriteResourceValueAsync( | 1.2857142857142858 |                  7.00 |                  9.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteOperationMetadat |                1.2 |                  5.00 |                  6.00 |         |
| Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchOutputContext.CreateOData |                1.2 |                  5.00 |                  6.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightPropertySerializer.WritePropertyInfoAsyn |  1.105263157894737 |                 19.00 |                 21.00 |         |
| Microsoft.OData.UriParser.ODataPathExtensions.AddKeySegment(Microsoft.OData.UriP | 1.0588235294117647 |                 17.00 |                 18.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightPropertySerializer.WritePrimitivePropert | 1.0588235294117647 |                 17.00 |                 18.00 |         |
| Microsoft.OData.ODataSimplifiedOptions.GetODataSimplifiedOptions(System.IService | 1.0416666666666667 |                 24.00 |                 25.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.StartResourceAsync()              | 1.0263157894736843 |                 38.00 |                 39.00 |         |
| Microsoft.OData.ODataWriterCore.WriteStartResourceSetImplementationAsync()       | 1.0204081632653061 |                 49.00 |                 50.00 |         |
| Microsoft.OData.ODataWriterCore.PushScope(WriterState, Microsoft.OData.ODataItem | 1.0192307692307692 |                 52.00 |                 53.00 |         |

| Better                                                                           |          base/diff | Base Self Allocations | Diff Self Allocations | Modality|
| -------------------------------------------------------------------------------- | ------------------:| ---------------------:| ---------------------:| --------:|
| Microsoft.OData.JsonLight.ODataJsonLightValueSerializer.WritePrimitiveValueAsync |                 28 |                112.00 |                  4.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer.WriteContextUriPropertyAsync( |                4.2 |                 21.00 |                  5.00 |         |
| Microsoft.OData.ODataBatchWriter.CreateOperationRequestMessageInternalAsync()    | 1.7777777777777777 |                 16.00 |                  9.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.WritePropertyImplementatio |                1.5 |                  3.00 |                  2.00 |         |
| Microsoft.OData.ODataWriterCore.CreateTextWriterImplementationAsync()            | 1.3333333333333333 |                  4.00 |                  3.00 |         |
| Microsoft.OData.ODataBatchWriter.InterceptException(System.Action<Microsoft.ODat |               1.25 |                  5.00 |                  4.00 |         |
| Microsoft.OData.ODataWriterCore.WriteStartResourceImplementationAsync.AnonymousM | 1.2352941176470589 |                 21.00 |                 17.00 |         |
| Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchFormat.CreateOutputContex | 1.1818181818181819 |                 13.00 |                 11.00 |         |
| Microsoft.OData.SimpleLazy<T>.CreateValue()                                      | 1.1818181818181819 |                 13.00 |                 11.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer.ctor(Microsoft.OData.JsonLigh | 1.1653333333333333 |                437.00 |                375.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightPropertySerializer.WriteCollectionProper | 1.1428571428571428 |                  8.00 |                  7.00 |         |
| Microsoft.OData.Json.JsonWriter.StartScopeAsync()                                | 1.1126760563380282 |                 79.00 |                 71.00 |         |
| Microsoft.OData.RawValueWriter.WriteRawValueAsync(object)                        | 1.1071428571428572 |                 31.00 |                 28.00 |         |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.ctor(Microsoft.OData.JsonLight.OD | 1.0149253731343284 |                 68.00 |                 67.00 |         |

| New                                                                              | diff/base | Base Self Allocations | Diff Self Allocations | Modality|
| -------------------------------------------------------------------------------- | --------- | ---------------------:| ---------------------:| -------- |
| Microsoft.OData.ODataMessage.GetStreamAsync.__GetMessageStreamAsync19_0()        | N/A       |                       |                 52.00 | N/A     |
| Microsoft.OData.ODataBatchOperationMessage.GetStreamAsync.__GetStreamInnerAsync1 | N/A       |                       |                 11.00 | N/A     |
| Microsoft.OData.TaskUtils.GetTaskForSynchronousOperation<T1, T2, T3, T4, T5>(Sys | N/A       |                       |                 32.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer..ctor.AnonymousMethod__6_0()  | N/A       |                       |                 30.00 | N/A     |
| Microsoft.OData.ODataCollectionWriterCore.WriteItemImplementationAsync.Anonymous | N/A       |                       |                  1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteResourceSetStart | N/A       |                       |                  1.00 | N/A     |
| Microsoft.OData.ODataCollectionWriterCore.InterceptExceptionAsync()              | N/A       |                       |                  1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer.WriteContextUriPropertyImplem | N/A       |                       |                 20.00 | N/A     |
| Microsoft.OData.ODataMessageWriter.WriteToOutputAsync()                          | N/A       |                       |                  4.00 | N/A     |
| Microsoft.OData.Json.JsonWriterAsyncExtensions.WritePrimitiveValueAsync(Microsof | N/A       |                       |                  1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer..ctor.AnonymousMethod__6_2()  | N/A       |                       |                 26.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataResourceWriterA | N/A       |                       |                  6.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer..ctor.AnonymousMethod__6_1()  | N/A       |                       |                 23.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightPropertySerializer.WriteTopLevelProperty | N/A       |                       |                  5.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataResourceSetWrit | N/A       |                       |                 13.00 | N/A     |
| Microsoft.OData.ODataWriterCore.InterceptExceptionAsync(System.Func<Microsoft.OD | N/A       |                       |                  1.00 | N/A     |
| Microsoft.OData.TaskUtils.GetTaskForSynchronousOperation<T1, T2>(System.Action<T | N/A       |                       |                  8.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataParameterWriter | N/A       |                       |                  5.00 | N/A     |
| Microsoft.OData.TaskUtils.GetTaskForSynchronousOperation<T1, T2, T3>(System.Func | N/A       |                       |                  8.00 | N/A     |
| Microsoft.OData.TaskUtils.GetTaskForSynchronousOperation<T1, T2, T3, T4>(System. | N/A       |                       |                  6.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataCollectionWrite | N/A       |                       |                  5.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteOperationAsync() | N/A       |                       |                  1.00 | N/A     |
| Microsoft.OData.ODataWriterCore.WriteStartResourceSetImplementationAsync.Anonymo | N/A       |                       |                  3.00 | N/A     |
| Microsoft.OData.JsonLightInstanceAnnotationWriter.WriteInstanceAnnotationsAsync( | N/A       |                       |                  4.00 | N/A     |
| Microsoft.OData.ODataWriterCore.VerifyCanWriteStartResourceSetAsync(bool, Micros | N/A       |                       |                  5.00 | N/A     |
| Microsoft.OData.ODataCollectionWriterCore.WriteStartAsync(Microsoft.OData.ODataC | N/A       |                       |                  4.00 | N/A     |
| Microsoft.OData.WriterValidator.ValidateTypeKind(Microsoft.OData.Edm.EdmTypeKind | N/A       |                       |                  2.00 | N/A     |
| Microsoft.OData.HttpUtils.ReadMediaTypeParameter(string, ref int, System.Collect | N/A       |                       |                  5.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightValueSerializer.get_PropertySerializer() | N/A       |                       |                  2.00 | N/A     |
| Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchWriter.WriteStartChangese | N/A       |                       |                  3.00 | N/A     |
| Microsoft.OData.ODataMessageWriter.WriteServiceDocumentAsync(Microsoft.OData.ODa | N/A       |                       |                  4.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteResourceEndMetad | N/A       |                       |                  4.00 | N/A     |
| Microsoft.OData.EdmExtensionMethods.FindNavigationTarget(Microsoft.OData.Edm.IEd | N/A       |                       |                  3.00 | N/A     |
| Microsoft.OData.ODataParameterWriterCore.WriteEndAsync()                         | N/A       |                       |                  3.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataUriParameterRes | N/A       |                       |                  1.00 | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataDeltaResourceSe | N/A       |                       |                  1.00 | N/A     |
| Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchWriterUtils.WriteStartBou | N/A       |                       |                  2.00 | N/A     |
| Microsoft.OData.UriParser.ODataPathInfo.ctor(Microsoft.OData.UriParser.ODataPath | N/A       |                       |                  2.00 | N/A     |
| Microsoft.OData.ODataMessageWriter.CreateODataParameterWriterAsync(Microsoft.ODa | N/A       |                       |                  4.00 | N/A     |
| Microsoft.OData.ODataParameterWriterCore.VerifyCanWriteStart(bool)               | N/A       |                       |                  3.00 | N/A     |

| Missing                                                                          | diff/base | Base Self Allocations | Diff Self Allocations | Modality|
| -------------------------------------------------------------------------------- | --------- | ---------------------:| ---------------------:| -------- |
| Microsoft.OData.ODataMessage.GetStreamAsync(System.Func<System.Threading.Tasks.T | N/A       |                 57.00 |                       | N/A     |
| Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchWriterUtils.WriteRequestP | N/A       |                  2.00 |                       | N/A     |
| Microsoft.OData.TaskUtils.FollowOnSuccessWithImplementation<T>(System.Threading. | N/A       |                 79.00 |                       | N/A     |
| Microsoft.OData.ODataBatchOperationMessage.GetStreamAsync()                      | N/A       |                 15.00 |                       | N/A     |
| Microsoft.OData.Json.JsonWriterAsyncExtensions.WritePrimitiveValueAsync()        | N/A       |                  3.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.PrepareResourceForWriteStartAsync | N/A       |                 38.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer..ctor.AnonymousMethod__0()    | N/A       |                 30.00 |                       | N/A     |
| Microsoft.OData.ODataWriterCore.WriteStartDeletedResourceImplementationAsync.Ano | N/A       |                  2.00 |                       | N/A     |
| Microsoft.OData.Json.JsonValueUtils.WriteValueAsync()                            | N/A       |                  2.00 |                       | N/A     |
| Microsoft.OData.TaskUtils.FollowOnSuccessWith<T1, T2>(System.Threading.Tasks.Tas | N/A       |                 40.00 |                       | N/A     |
| Microsoft.OData.ODataMessageWriter<T>.MoveNext()                                 | N/A       |                 30.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.PrepareDeletedResourceForWriteSta | N/A       |                 18.00 |                       | N/A     |
| Microsoft.OData.ODataMessage.GetStreamAsync.AnonymousMethod__0(System.Threading. | N/A       |                 21.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.PrepareResourceForWriteStartAsync | N/A       |                 16.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightWriter.StartResourceAsync(Microsoft.ODat | N/A       |                  1.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer..ctor.AnonymousMethod__2()    | N/A       |                 26.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataResourceWriterA | N/A       |                  6.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightSerializer..ctor.AnonymousMethod__1()    | N/A       |                 23.00 |                       | N/A     |
| Microsoft.OData.ODataBatchWriter.CreateOperationRequestMessageAsync()            | N/A       |                 12.00 |                       | N/A     |
| Microsoft.OData.TaskUtils.GetTaskForSynchronousOperation<T>(System.Func<T>)      | N/A       |                 15.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteDeltaContextUriA | N/A       |                 12.00 |                       | N/A     |
| Microsoft.OData.ODataWriterCore.VerifyCanWriteStartResourceSetAsync()            | N/A       |                 13.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataResourceSetWrit | N/A       |                 13.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteResourceContextU | N/A       |                 12.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataResourceWriterA | N/A       |                 12.00 |                       | N/A     |
| Microsoft.OData.TaskUtils.GetTaskForSynchronousOperation(System.Action)          | N/A       |                 10.00 |                       | N/A     |
| Microsoft.OData.ODataWriterCore.WriteStartAsync(Microsoft.OData.ODataResourceSet | N/A       |                  1.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteDeltaContextUriA | N/A       |                 11.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteResourceSetConte | N/A       |                 12.00 |                       | N/A     |
| Microsoft.OData.ODataMessageWriter.WriteToOutputAsync<T>(Microsoft.OData.ODataPa | N/A       |                 14.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightPropertySerializer.WriteTopLevelProperty | N/A       |                  5.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataParameterWriter | N/A       |                  5.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightOutputContext.CreateODataCollectionWrite | N/A       |                  5.00 |                       | N/A     |
| Microsoft.OData.TaskUtils.GetCompletedTask<T>(T)                                 | N/A       |                 13.00 |                       | N/A     |
| Microsoft.OData.TaskUtils.FollowOnSuccessWithContinuation<T>(System.Threading.Ta | N/A       |                  6.00 |                       | N/A     |
| Microsoft.OData.ODataWriterCore.CreateTextWriterAsync()                          | N/A       |                  3.00 |                       | N/A     |
| Microsoft.OData.JsonLightInstanceAnnotationWriter.WriteInstanceAnnotationsAsync( | N/A       |                  4.00 |                       | N/A     |
| Microsoft.OData.MultipartMixed.ODataMultipartMixedBatchWriter.StreamDisposedAsyn | N/A       |                  4.00 |                       | N/A     |
| Microsoft.OData.ODataMessageWriter.WriteToOutputAsync.__WriteToOutputInnerAsync0 | N/A       |                  4.00 |                       | N/A     |
| Microsoft.OData.JsonLight.ODataJsonLightResourceSerializer.WriteResourceSetConte | N/A       |                  4.00 |                       | N/A     |
| Microsoft.OData.ODataMessageWriter.WriteToOutputAsync(Microsoft.OData.ODataPaylo | N/A       |                  7.00 |                       | N/A     |
| Microsoft.OData.ODataCollectionWriterCore.WriteStartAsync()                      | N/A       |                  4.00 |                       | N/A     |
```

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
