### PR TITLE
allow configuring alternate key vocabulary and address performance co…

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -730,6 +730,7 @@ namespace Microsoft.OData
         internal const string UriParser_ExpandDepthExceeded = "UriParser_ExpandDepthExceeded";
         internal const string UriParser_TypeInvalidForSelectExpand = "UriParser_TypeInvalidForSelectExpand";
         internal const string UriParser_ContextHandlerCanNotBeNull = "UriParser_ContextHandlerCanNotBeNull";
+        internal const string UriParser_NullAlternateKeyTerm = "UriParser_NullAlternateKeyTerm";
         internal const string UriParserMetadata_MultipleMatchingPropertiesFound = "UriParserMetadata_MultipleMatchingPropertiesFound";
         internal const string UriParserMetadata_MultipleMatchingNavigationSourcesFound = "UriParserMetadata_MultipleMatchingNavigationSourcesFound";
         internal const string UriParserMetadata_MultipleMatchingTypesFound = "UriParserMetadata_MultipleMatchingTypesFound";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -840,6 +840,7 @@ UriParser_ExpandCountExceeded=The result of parsing $expand contained at least {
 UriParser_ExpandDepthExceeded=The result of parsing $expand was at least {0} items deep, but the maximum allowed is {1}.
 UriParser_TypeInvalidForSelectExpand=The type '{0}' is not valid for $select or $expand, only structured types are allowed.
 UriParser_ContextHandlerCanNotBeNull=The handler property for context '{0}' should not return null.
+UriParser_NullAlternateKeyTerm=A null term was provided in the '{0}' parameter
 UriParserMetadata_MultipleMatchingPropertiesFound=More than one properties match the name '{0}' were found in type '{1}'.
 UriParserMetadata_MultipleMatchingNavigationSourcesFound=More than one navigation sources match the name '{0}' were found in model.
 UriParserMetadata_MultipleMatchingTypesFound=More than one types match the name '{0}' were found in model.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -6373,6 +6373,14 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "A null term was provided in the '{0}' parameter"
+        /// </summary>
+        internal static string UriParser_NullAlternateKeyTerm(object p0)
+        {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.UriParser_NullAlternateKeyTerm, p0);
+        }
+
+        /// <summary>
         /// A string like "More than one properties match the name '{0}' were found in type '{1}'."
         /// </summary>
         internal static string UriParserMetadata_MultipleMatchingPropertiesFound(object p0, object p1)

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
@@ -40,6 +40,7 @@ namespace Microsoft.OData.Edm
         internal const string EdmType_UnexpectedEdmType = "EdmType_UnexpectedEdmType";
         internal const string NavigationPropertyBinding_PathIsNotValid = "NavigationPropertyBinding_PathIsNotValid";
         internal const string MultipleMatchingPropertiesFound = "MultipleMatchingPropertiesFound";
+        internal const string NullTermForAlternateKey = "NullTermForAlternateKey";
         internal const string Edm_Evaluator_NoTermTypeAnnotationOnType = "Edm_Evaluator_NoTermTypeAnnotationOnType";
         internal const string Edm_Evaluator_NoValueAnnotationOnType = "Edm_Evaluator_NoValueAnnotationOnType";
         internal const string Edm_Evaluator_NoValueAnnotationOnElement = "Edm_Evaluator_NoValueAnnotationOnElement";

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -20,6 +20,7 @@ Constructable_DependentPropertyCountMustMatchNumberOfPropertiesOnPrincipalType=T
 EdmType_UnexpectedEdmType=Unexpected Edm type.
 NavigationPropertyBinding_PathIsNotValid=The navigation property binding path is not valid.
 MultipleMatchingPropertiesFound=More than one properties match the name '{0}' were found in type '{1}'.
+NullTermForAlternateKey=A null term was provided in the '{0}' parameter when enumerating alternate keys on a type
 
 ; Evaluation messages
 Edm_Evaluator_NoTermTypeAnnotationOnType=Type '{0}' must have a single type annotation with term type '{1}'.

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -187,6 +187,14 @@ namespace Microsoft.OData.Edm {
         }
 
         /// <summary>
+        /// A string like "A null term was provided in the '{0}' parameter when enumerating alternate keys on a type"
+        /// </summary>
+        internal static string NullTermForAlternateKey(object p0)
+        {
+            return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.NullTermForAlternateKey, p0);
+        }
+
+        /// <summary>
         /// A string like "Type '{0}' must have a single type annotation with term type '{1}'."
         /// </summary>
         internal static string Edm_Evaluator_NoTermTypeAnnotationOnType(object p0, object p1)

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -11,6 +11,7 @@ using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Csdl.CsdlSemantics;
 using Microsoft.OData.Edm.Csdl.Parsing.Ast;
 using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OData.Edm.Vocabularies.V1;
 using Microsoft.OData.Edm.Tests.Validation;
 using Microsoft.OData.Edm.Validation;
 using Xunit;
@@ -178,6 +179,24 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         {
             var enumType = new EdmEnumTypeReference(new EdmEnumType("n", "enumtype"), false);
             Assert.Equal(enumType.Definition.FullTypeName(), enumType.FullName());
+        }
+
+        [Fact]
+        public void GetAlternateKeyAnnotationsWithNullTerms()
+        {
+            Assert.Throws<ArgumentNullException>(() => EdmCoreModel.Instance.GetAlternateKeysAnnotation(EdmCoreModelEntityType.Instance, null));
+        }
+
+        [Fact]
+        public void GetAlternateKeyAnnotationsWithNullTerm()
+        {
+            Assert.Throws<ArgumentException>(() => EdmCoreModel.Instance.GetAlternateKeysAnnotation(
+                EdmCoreModelEntityType.Instance, 
+                new IEdmTerm[]
+                {
+                    CoreVocabularyModel.AlternateKeysTerm,
+                    null,
+                }));
         }
 
         #region IEdmType FullName tests

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -1978,6 +1978,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.IDictionary`2[[System.String],[Microsoft.OData.Edm.IEdmProperty]]]] GetAlternateKeysAnnotation (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmEntityType type, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmTerm]] alternateKeyTerms)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static T GetAnnotationValue (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmElement element)
 
     [
@@ -6621,6 +6626,7 @@ public sealed class Microsoft.OData.UriParser.AllToken : Microsoft.OData.UriPars
 
 public sealed class Microsoft.OData.UriParser.AlternateKeysODataUriResolver : Microsoft.OData.UriParser.ODataUriResolver {
     public AlternateKeysODataUriResolver (Microsoft.OData.Edm.IEdmModel model)
+    public AlternateKeysODataUriResolver (Microsoft.OData.Edm.IEdmModel model, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmTerm]] alternateKeyTerms)
 
     public virtual System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.KeyValuePair`2[[System.String],[System.Object]]]] ResolveKeys (Microsoft.OData.Edm.IEdmEntityType type, System.Collections.Generic.IDictionary`2[[System.String],[System.String]] namedValues, System.Func`3[[Microsoft.OData.Edm.IEdmTypeReference],[System.String],[System.Object]] convertFunc)
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -1978,6 +1978,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.IDictionary`2[[System.String],[Microsoft.OData.Edm.IEdmProperty]]]] GetAlternateKeysAnnotation (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmEntityType type, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmTerm]] alternateKeyTerms)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static T GetAnnotationValue (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmElement element)
 
     [
@@ -6621,6 +6626,7 @@ public sealed class Microsoft.OData.UriParser.AllToken : Microsoft.OData.UriPars
 
 public sealed class Microsoft.OData.UriParser.AlternateKeysODataUriResolver : Microsoft.OData.UriParser.ODataUriResolver {
     public AlternateKeysODataUriResolver (Microsoft.OData.Edm.IEdmModel model)
+    public AlternateKeysODataUriResolver (Microsoft.OData.Edm.IEdmModel model, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmTerm]] alternateKeyTerms)
 
     public virtual System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.KeyValuePair`2[[System.String],[System.Object]]]] ResolveKeys (Microsoft.OData.Edm.IEdmEntityType type, System.Collections.Generic.IDictionary`2[[System.String],[System.String]] namedValues, System.Func`3[[Microsoft.OData.Edm.IEdmTypeReference],[System.String],[System.Object]] convertFunc)
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -1978,6 +1978,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.IDictionary`2[[System.String],[Microsoft.OData.Edm.IEdmProperty]]]] GetAlternateKeysAnnotation (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmEntityType type, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmTerm]] alternateKeyTerms)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static T GetAnnotationValue (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmElement element)
 
     [
@@ -6621,6 +6626,7 @@ public sealed class Microsoft.OData.UriParser.AllToken : Microsoft.OData.UriPars
 
 public sealed class Microsoft.OData.UriParser.AlternateKeysODataUriResolver : Microsoft.OData.UriParser.ODataUriResolver {
     public AlternateKeysODataUriResolver (Microsoft.OData.Edm.IEdmModel model)
+    public AlternateKeysODataUriResolver (Microsoft.OData.Edm.IEdmModel model, System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmTerm]] alternateKeyTerms)
 
     public virtual System.Collections.Generic.IEnumerable`1[[System.Collections.Generic.KeyValuePair`2[[System.String],[System.Object]]]] ResolveKeys (Microsoft.OData.Edm.IEdmEntityType type, System.Collections.Generic.IDictionary`2[[System.String],[System.String]] namedValues, System.Func`3[[Microsoft.OData.Edm.IEdmTypeReference],[System.String],[System.Object]] convertFunc)
 }


### PR DESCRIPTION
…ncerns

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2490.*

### Description

Updated the `AlternateKeyODataUriResolver` to be able to configure which alternate key vocabularies are used and removed the use of a lambda which presented a memory leak concern. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
