### PR TITLE
Ensure service host is closed after each test

### DIFF
--- a/test/EndToEndTests/Tests/Client/Build.Desktop/AnnotationTests/InstanceAnnotationTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/AnnotationTests/InstanceAnnotationTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Test.OData.Tests.Client.AnnotationTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class InstanceAnnotationTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class InstanceAnnotationTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private const string TestModelNameSpace = "Microsoft.Test.OData.Services.ODataWCFService";
         private const string IncludeAnnotation = "odata.include-annotations";
@@ -201,5 +201,10 @@ namespace Microsoft.Test.OData.Tests.Client.AnnotationTests
             }
         }
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/AsyncRequestTests/AsyncRequestTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/AsyncRequestTests/AsyncRequestTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Test.OData.Tests.Client.AsyncRequestTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class AsyncRequestTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class AsyncRequestTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private static string NameSpacePrefix = "Microsoft.Test.OData.Services.ODataWCFService.";
 
@@ -414,6 +414,11 @@ namespace Microsoft.Test.OData.Tests.Client.AsyncRequestTests
             }
 
             #endregion
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/BatchRequestTests/BatchRequestWithRelativeUriTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/BatchRequestTests/BatchRequestWithRelativeUriTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Test.OData.Tests.Client.BatchRequestTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class BatchRequestWithRelativeUriTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class BatchRequestWithRelativeUriTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private static string NameSpacePrefix = "Microsoft.Test.OData.Services.ODataWCFService.";
 
@@ -202,6 +202,11 @@ namespace Microsoft.Test.OData.Tests.Client.BatchRequestTests
                 }
                 Assert.Equal(ODataBatchReaderState.Completed, batchReader.State);
             }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientDeleteTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientDeleteTests.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.Test.OData.Tests.Client
 {
+    using System;
     using System.Linq;
     using System.Net.Http;
     using Microsoft.OData.Client;
@@ -15,7 +16,7 @@ namespace Microsoft.Test.OData.Tests.Client
     /// <summary>
     /// Generic client delete test cases.
     /// </summary>
-    public class ClientDeleteTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class ClientDeleteTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         public ClientDeleteTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -31,5 +32,10 @@ namespace Microsoft.Test.OData.Tests.Client
             Assert.Equal(204, response.StatusCode);
         }
 #endif
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientEntityDescripterTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests/ClientEntityDescripterTests.cs
@@ -19,7 +19,7 @@ using Xunit;
 
 namespace Microsoft.Test.OData.Tests.Client.ClientTests
 {
-    public class ClientEntityDescripterTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class ClientEntityDescripterTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         public ClientEntityDescripterTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -346,6 +346,11 @@ namespace Microsoft.Test.OData.Tests.Client.ClientTests
             MethodInfo executeOfTMethod = typeof(DataServiceContext).GetMethod("Execute", new[] { typeof(Uri) }).MakeGenericMethod(clientType);
             var results = executeOfTMethod.Invoke(clientContext, new object[] { uriToExecute });
             return results as IEnumerable;
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/CollectionTests/CollectionNullableFacetTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/CollectionTests/CollectionNullableFacetTest.cs
@@ -18,7 +18,7 @@ using Microsoft.Test.OData.Tests.Client.Common;
     /// <summary>
     /// Tests for collection property nullable facet
     /// </summary>
-    public class CollectionNullableFacetTest : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class CollectionNullableFacetTest : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         private static string NameSpacePrefix = "Microsoft.Test.OData.Services.ODataWCFService.";
 
@@ -167,5 +167,10 @@ using Microsoft.Test.OData.Tests.Client.Common;
         }
 
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ComplexTypeTests/ComplexTypeTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ComplexTypeTests/ComplexTypeTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Test.OData.Tests.Client.ComplexTypeTests
     using Xunit;
     using ODataClient = Microsoft.OData.Client;
 
-    public class ComplexTypeTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class ComplexTypeTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         private const string NameSpacePrefix = "Microsoft.Test.OData.Services.ODataWCFService.";
 
@@ -1374,5 +1374,10 @@ namespace Microsoft.Test.OData.Tests.Client.ComplexTypeTests
         }
 
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ContainmentTest/ContainmentTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
     /// <summary>
     /// Send query and verify the results from the service implemented using ODataLib and EDMLib.
     /// </summary>
-    public class ContainmentTest : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class ContainmentTest : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private const string TestModelNameSpace = "Microsoft.Test.OData.Services.ODataWCFService";
 
@@ -1394,5 +1394,10 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
             return item;
         }
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/DeltaTests/DeltaTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/DeltaTests/DeltaTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Test.OData.Tests.Client.DeltaTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class DeltaTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class DeltaTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         public DeltaTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -235,6 +235,11 @@ namespace Microsoft.Test.OData.Tests.Client.DeltaTests
                     }
                 }
             }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
 
     }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/DisableAtomTests/DisableAtomTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/DisableAtomTests/DisableAtomTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Test.OData.Tests.Client.DisableAtomTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class DisableAtomTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class DisableAtomTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         private const string NameSpacePrefix = "Microsoft.Test.OData.Services.ODataWCFService.";
 
@@ -354,6 +354,11 @@ namespace Microsoft.Test.OData.Tests.Client.DisableAtomTests
                 Assert.Equal(typeof(Microsoft.OData.ODataError), error.GetType());
                 Assert.Equal("UnsupportedMediaType", error.ErrorCode);
             }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/EdmDateAndTimeOfDay/DateAndTimeOfDayCRUDTestings.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/EdmDateAndTimeOfDay/DateAndTimeOfDayCRUDTestings.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Test.OData.Tests.Client.EdmDateAndTimeOfDay
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class DateAndTimeOfDayCRUDTestings : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class DateAndTimeOfDayCRUDTestings : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         public DateAndTimeOfDayCRUDTestings()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -489,7 +489,12 @@ namespace Microsoft.Test.OData.Tests.Client.EdmDateAndTimeOfDay
         }
 #endif
 
-    #endregion
+        #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }
 

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/EnumerationTypeTests/EnumerationTypeQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/EnumerationTypeTests/EnumerationTypeQueryTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Test.OData.Tests.Client.EnumerationTypeTests
     /// <summary>
     /// Send query and verify the results from the service implemented using ODataLib and EDMLib.
     /// </summary>
-    public class EnumerationTypeQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class EnumerationTypeQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private static string NameSpacePrefix = "Microsoft.Test.OData.Services.ODataWCFService.";
 
@@ -598,5 +598,10 @@ namespace Microsoft.Test.OData.Tests.Client.EnumerationTypeTests
 #endif
 
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/EnumerationTypeTests/EnumerationTypeUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/EnumerationTypeTests/EnumerationTypeUpdateTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Test.OData.Tests.Client.EnumerationTypeTests
     /// Send query and verify the results from the service implemented using ODataLib and EDMLib.
     /// </summary>
 
-    public class EnumerationTypeUpdateTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class EnumerationTypeUpdateTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private static string NameSpacePrefix = "Microsoft.Test.OData.Services.ODataWCFService.";
 
@@ -258,5 +258,10 @@ namespace Microsoft.Test.OData.Tests.Client.EnumerationTypeTests
         }
 
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceCUDTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceCUDTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Test.OData.Tests.Client.ModelReferenceTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class ModelReferenceCUDTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class ModelReferenceCUDTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private const string TestModelNameSpace = "Microsoft.OData.SampleService.Models.ModelRefDemo";
 
@@ -365,5 +365,10 @@ namespace Microsoft.Test.OData.Tests.Client.ModelReferenceTests
             return item;
         }
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceClientTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceClientTests.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.Test.OData.Tests.Client.ModelReferenceTests
 {
+    using System;
     using System.Linq;
     using Microsoft.OData.Client;
     using Microsoft.Test.OData.Services.TestServices;
@@ -15,7 +16,7 @@ namespace Microsoft.Test.OData.Tests.Client.ModelReferenceTests
     using Microsoft.Test.OData.Services.TestServices.ModelReferenceServiceReference.Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo;
     using Xunit;
 
-    public class ModelReferenceClientTests : ODataWCFServiceTestsBase<TruckDemoService>
+    public class ModelReferenceClientTests : ODataWCFServiceTestsBase<TruckDemoService>, IDisposable
     {
         public ModelReferenceClientTests()
             : base(ServiceDescriptors.ModelRefServiceDescriptor)
@@ -367,6 +368,11 @@ namespace Microsoft.Test.OData.Tests.Client.ModelReferenceTests
             var querable3 = TestClientContext.VehicleGPSSet.Where(v => v.Key == "VehicleKey6").OfType<DerivedVehicleGPSType>();
             var test = querable3 as DataServiceQuery;
             Assert.True(test.RequestUri.OriginalString.EndsWith("VehicleGPSSet/Microsoft.OData.SampleService.Models.ModelRefDemo.TruckDemo.DerivedVehicleGPSType('VehicleKey6')"));
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ModelReferenceTests/ModelReferenceQueryTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Test.OData.Tests.Client.ModelReferenceTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class ModelReferenceQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class ModelReferenceQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private const string TestModelNameSpace = "Microsoft.OData.SampleService.Models.ModelRefDemo";
 
@@ -671,5 +671,10 @@ namespace Microsoft.Test.OData.Tests.Client.ModelReferenceTests
             return item;
         }
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataSimplifiedServiceTests/ODataSimplifiedServiceTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataSimplifiedServiceTests/ODataSimplifiedServiceTests.cs
@@ -6,11 +6,12 @@
 
 namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
-    using Microsoft.Test.OData.Services.TestServices.ODataSimplifiedServiceReference;
     using Microsoft.Test.OData.Services.TestServices;
+    using Microsoft.Test.OData.Services.TestServices.ODataSimplifiedServiceReference;
     using Xunit;
 
     /// <summary>
@@ -19,7 +20,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
     // [Ignore] // Issues: #623
     // [TestClass] // github issuse: #896
     //The whole of this class was ignored in MsTest tests that is why am skipping all the tests in this class. 
-    public class ODataSimplifiedServiceQueryTests : ODataWCFServiceTestsBase<ODataSimplifiedService>
+    public class ODataSimplifiedServiceQueryTests : ODataWCFServiceTestsBase<ODataSimplifiedService>, IDisposable
     {
         public ODataSimplifiedServiceQueryTests()
             : base(ServiceDescriptors.ODataSimplifiedServiceDescriptor)
@@ -79,6 +80,11 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
             TestClientContext.Detach(person);
             var personReturned = TestClientContext.People.ByKey(new Dictionary<string, object> { { "PersonId", person.PersonId } }).GetValue();
             Assert.Equal(person.PersonId, personReturned.PersonId);
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/AbstractEntityTypeTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/AbstractEntityTypeTests.cs
@@ -6,12 +6,13 @@
 
 namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
 {
+    using System;
     using System.Linq;
     using Microsoft.Test.OData.Services.TestServices;
     using Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference;
     using Xunit;
 
-    public class AbstractEntityTypeTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class AbstractEntityTypeTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         public AbstractEntityTypeTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -31,6 +32,11 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
 
             //var details = customer.getOrderAndOrderDetails().OfType<OrderDetail>().ToList();
             //Assert.Equal(1, details.Count);
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/IDReadLinkEditLinkTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/IDReadLinkEditLinkTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class IdReadLinkEditLinkTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class IdReadLinkEditLinkTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private const string TestHeader = "Test_ODataEntryFieldToModify";
 
@@ -226,6 +226,11 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
             var intOrderCountAfterDeleteLink = detailsInAProdct.Count();
             //The added link is deleted
             Assert.Equal(intOriginalOrderCount, intOrderCountAfterDeleteLink);
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/ODataWCFServiceQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/ODataWCFServiceQueryTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
     /// <summary>
     /// Send query and verify the results from the service implemented using ODataLib and EDMLib.
     /// </summary>
-    public class ODataWCFServiceQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class ODataWCFServiceQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         public ODataWCFServiceQueryTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -754,6 +754,11 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
             responseMessage = requestMessage.GetResponse();
             Assert.Equal(200, responseMessage.StatusCode);
             #endregion
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/ODataWCFServiceUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTests/ODataWCFServiceUpdateTests.cs
@@ -6,20 +6,19 @@
 
 namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
 {
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Linq;
     using Microsoft.OData;
-    using Microsoft.OData.UriParser;
     using Microsoft.OData.Edm;
     using Microsoft.Test.OData.Services.TestServices;
     using Microsoft.Test.OData.Tests.Client.Common;
-    using System;
-    using System.Linq;
-    using System.Collections.ObjectModel;
     using Xunit;
 
     /// <summary>
     /// CUD tests for the ODL service.
     /// </summary>
-    public class ODataWCFServiceUpdateTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class ODataWCFServiceUpdateTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         private static string NameSpacePrefix = "Microsoft.Test.OData.Services.ODataWCFService.";
 
@@ -201,6 +200,11 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
             }
 
             return item;
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTestsBase.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/ODataWCFServiceTestsBase.cs
@@ -69,10 +69,11 @@ namespace Microsoft.Test.OData.Tests.Client
             ar.AsyncWaitHandle.WaitOne();
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             TestServiceWrapper.StopService();
         }
+
         private Stream GetStreamFromUrl(string absoluteUri)
         {
             HttpWebRequestMessage message = new HttpWebRequestMessage(new Uri(absoluteUri, UriKind.Absolute));

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/OperationTests/OperationClientTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/OperationTests/OperationClientTests.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Microsoft.Test.OData.Tests.Client.OperationTests
 {
-    public class OperationClientTests : ODataWCFServiceTestsBase<OperationService>
+    public class OperationClientTests : ODataWCFServiceTestsBase<OperationService>, IDisposable
     {
 
         public OperationClientTests()
@@ -199,6 +199,11 @@ namespace Microsoft.Test.OData.Tests.Client.OperationTests
             var orders = this.TestClientContext.Orders.GetOrdersByNote("1111").Where(o => o.ID < 1).ToList();
             Assert.Equal(1, orders.Count);
             Assert.Null(orders[0].Customer);
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/OperationTests/OperationT4Tests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/OperationTests/OperationT4Tests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.Test.OData.Services.TestServices.OperationServiceReference;
@@ -11,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.Test.OData.Tests.Client.OperationTests
 {
-    public class OperationT4Tests : ODataWCFServiceTestsBase<OperationService>
+    public class OperationT4Tests : ODataWCFServiceTestsBase<OperationService>, IDisposable
     {
         public OperationT4Tests()
             : base(Microsoft.Test.OData.Services.TestServices.ServiceDescriptors.OperationServiceDescriptor)
@@ -190,6 +191,11 @@ namespace Microsoft.Test.OData.Tests.Client.OperationTests
 
             Assert.NotNull(customer);
             Assert.Equal(2, customer.ID);
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
 
     }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/PayloadValueConverterTests/PayloadValueConverterTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/PayloadValueConverterTests/PayloadValueConverterTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
     /// <summary>
     /// Tests for pluggable format service
     /// </summary>
-    public class PayloadValueConverterTests : ODataWCFServiceTestsBase<PluggableFormatService>
+    public class PayloadValueConverterTests : ODataWCFServiceTestsBase<PluggableFormatService>, IDisposable
     {
         public PayloadValueConverterTests()
             : base(ServiceDescriptors.PayloadValueConverterServiceDescriptor)
@@ -39,6 +39,11 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
             Assert.Equal(200, responseMessage.StatusCode);
             var dat = new StreamReader(responseMessage.GetStream()).ReadToEnd();
             Assert.True(dat.Contains("\"value\":\"3-1-4\""));
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/PluggableFormatServiceTests/PluggableFormatServiceTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/PluggableFormatServiceTests/PluggableFormatServiceTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
     /// <summary>
     /// Tests for pluggable format service
     /// </summary>
-    public class PluggableFormatQueryTests : ODataWCFServiceTestsBase<PluggableFormatService>
+    public class PluggableFormatQueryTests : ODataWCFServiceTestsBase<PluggableFormatService>, IDisposable
     {
         public PluggableFormatQueryTests()
             : base(ServiceDescriptors.PluggableFormatServiceDescriptor)
@@ -313,5 +313,10 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
             return settings;
         }
 #endif
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/PrimitiveTypesTests/DurationTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/PrimitiveTypesTests/DurationTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Test.OData.Tests.Client.PrimitiveTypes
     /// Tests for Edm.Duration primitive type
     /// Send query and verify the results from the service implemented using ODataLib and EDMLib.
     /// </summary>
-    public class DurationTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class DurationTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         public DurationTests() : base(ServiceDescriptors.ODataWCFServiceDescriptor)
         {
@@ -235,5 +235,10 @@ namespace Microsoft.Test.OData.Tests.Client.PrimitiveTypes
             Assert.True(queryable4.Count() == 0);
         }
 #endif
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/PropertyTrackingTests/PostPropertyTrackingTest.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/PropertyTrackingTests/PostPropertyTrackingTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Test.OData.Tests.Client.PropertyTrackingTests
     using Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReferencePlus;
     using Xunit;
 
-    public class PostPropertyTrackingTest : ODataWCFServiceTestsBase<InMemoryEntitiesPlus>
+    public class PostPropertyTrackingTest : ODataWCFServiceTestsBase<InMemoryEntitiesPlus>, IDisposable
     {
         public PostPropertyTrackingTest()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -406,6 +406,11 @@ namespace Microsoft.Test.OData.Tests.Client.PropertyTrackingTests
 
             OrderPlus orderCreated = customer.PlaceOrderPlus(order).GetValue();
             Assert.Equal(orderId, orderCreated.OrderIDPlus);
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/EntityReferenceLinkTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/EntityReferenceLinkTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
     using HttpWebRequestMessage = Microsoft.Test.OData.Tests.Client.Common.HttpWebRequestMessage;
     using Xunit;
 
-    public class EntityReferenceLinkTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class EntityReferenceLinkTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         public EntityReferenceLinkTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -110,6 +110,11 @@ namespace Microsoft.Test.OData.Tests.Client.ContainmentTest
             Assert.NotNull(primitiveValue1);
             Assert.NotNull(primitiveValue2);
             Assert.Equal(primitiveValue1.Value, primitiveValue2.Value);
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/ExpandQueryOptionTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/ExpandQueryOptionTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class ExpandQueryOptionTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class ExpandQueryOptionTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         public ExpandQueryOptionTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -151,6 +151,9 @@ namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
 
         #endregion
 
-        
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/FilterQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/FilterQueryTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class FilterQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class FilterQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         public FilterQueryTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -70,6 +70,11 @@ namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
                     Assert.Equal(1, details.Count);
                 }
             }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/OrderbyQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/OrderbyQueryTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class OrderbyQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class OrderbyQueryTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         public OrderbyQueryTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -78,6 +78,11 @@ namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
                     Assert.Equal("Bob", details.First().Properties.Single(p => p.Name == "FirstName").Value);
                 }
             }
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/QueryOptionOnCollectionTypePropertyTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/QueryOptionOnCollectionTypePropertyTests.cs
@@ -6,15 +6,16 @@
 
 namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
 {
+    using System;
     using System.Linq;
-    using Microsoft.OData.Client;
     using Microsoft.OData;
+    using Microsoft.OData.Client;
     using Microsoft.Test.OData.Services.TestServices;
     using Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference;
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class QueryOptionOnCollectionTypePropertyTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class QueryOptionOnCollectionTypePropertyTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
 
         public QueryOptionOnCollectionTypePropertyTests()
@@ -144,5 +145,10 @@ namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
         }
 
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/SearchQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/QueryOptionTests/SearchQueryTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class SearchQueryTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class SearchQueryTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         public SearchQueryTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -102,5 +102,10 @@ namespace Microsoft.Test.OData.Tests.Client.QueryOptionTests
         }
 
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/SingletonTests/SingletonClientTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/SingletonTests/SingletonClientTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Test.OData.Tests.Client.SingletonTests
     using Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference;
     using Xunit;
 
-    public class SingletonClientTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class SingletonClientTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         public SingletonClientTests() : base(ServiceDescriptors.ODataWCFServiceDescriptor)
         {
@@ -302,5 +302,10 @@ namespace Microsoft.Test.OData.Tests.Client.SingletonTests
         }
 
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/SingletonTests/SingletonQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/SingletonTests/SingletonQueryTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Test.OData.Tests.Client.SingletonTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class SingletonQueryTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class SingletonQueryTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         public SingletonQueryTests()
             : base(ServiceDescriptors.ODataWCFServiceDescriptor)
@@ -584,5 +584,10 @@ namespace Microsoft.Test.OData.Tests.Client.SingletonTests
         }
 
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/SingletonTests/SingletonUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/SingletonTests/SingletonUpdateTests.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Test.OData.Tests.Client.SingletonTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class SingletonUpdateTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class SingletonUpdateTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         private const string NameSpacePrefix = "Microsoft.Test.OData.Services.ODataWCFService.";
 
@@ -189,5 +189,10 @@ namespace Microsoft.Test.OData.Tests.Client.SingletonTests
         }
 
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TripPinServiceTests/TripPinFilterTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TripPinServiceTests/TripPinFilterTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
     using Microsoft.Test.OData.Tests.Client.Common;
     using Xunit;
 
-    public class TripPinFilterTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>
+    public class TripPinFilterTests : ODataWCFServiceTestsBase<Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference.InMemoryEntities>, IDisposable
     {
         private const string NameSpacePrefix = "Microsoft.OData.SampleService.Models.TripPin.";
 
@@ -409,5 +409,10 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
             return entries;
         }
         #endregion
+
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TripPinServiceTests/TripPinServiceTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TripPinServiceTests/TripPinServiceTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
     using Microsoft.Test.OData.Services.TestServices.TrippinServiceReference;
     using Xunit;
 
-    public class TripPinServiceTests : ODataWCFServiceTestsBase<DefaultContainer>
+    public class TripPinServiceTests : ODataWCFServiceTestsBase<DefaultContainer>, IDisposable
     {
         private const string NameSpacePrefix = "Microsoft.OData.SampleService.Models.TripPin.";
         private int lastResponseStatusCode;
@@ -3113,6 +3113,11 @@ namespace Microsoft.Test.OData.Tests.Client.ODataWCFServiceTests
             Assert.NotNull(context);
 
             return context;
+        }
+
+        public override void Dispose()
+        {
+            base.Dispose();
         }
     }
 }

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TypeDefinitionTests/TypeDefinitionTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TypeDefinitionTests/TypeDefinitionTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Test.OData.Tests.Client.TypeDefinitionTests
     using System.Linq;
     using Xunit;
 
-    public class TypeDefinitionTests : ODataWCFServiceTestsBase<InMemoryEntities>
+    public class TypeDefinitionTests : ODataWCFServiceTestsBase<InMemoryEntities>, IDisposable
     {
         private const string NameSpacePrefix = "microsoft.odata.sampleService.models.typedefinition.";
 
@@ -652,7 +652,10 @@ namespace Microsoft.Test.OData.Tests.Client.TypeDefinitionTests
 
         #endregion
 
-
+        public override void Dispose()
+        {
+            base.Dispose();
+        }
     }
 
     public class UInt32ValueConverter : IPrimitiveValueConverter


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

This pull request fixes an issue causing tests to fail across multiple PR builds by ensuring that the service host/port is closed after each test by implementing `Dispose` method in each child class that inherits from `ODataWCFServiceTestsBase`

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
