### PR TITLE
Make ODataPath.Segments property read-only

### DIFF
--- a/src/Microsoft.OData.Core/BindingPathHelper.cs
+++ b/src/Microsoft.OData.Core/BindingPathHelper.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.OData.Edm;
@@ -21,7 +20,7 @@ namespace Microsoft.OData
         /// <param name="bindingPath">The binding path.</param>
         /// <param name="parsedSegments">The list of segments in Uri path.</param>
         /// <returns>True if the path of navigation property in current scope is matching the <paramref name="bindingPath"/>.</returns>
-        public static bool MatchBindingPath(IEdmPathExpression bindingPath, IList<ODataPathSegment> parsedSegments)
+        public static bool MatchBindingPath(IEdmPathExpression bindingPath, IReadOnlyList<ODataPathSegment> parsedSegments)
         {
             List<string> paths = bindingPath.PathSegments.ToList();
 

--- a/src/Microsoft.OData.Core/EdmExtensionMethods.cs
+++ b/src/Microsoft.OData.Core/EdmExtensionMethods.cs
@@ -58,7 +58,7 @@ namespace Microsoft.OData
         /// <param name="parsedSegments">The parsed segments in path, which is used to match binding path.</param>
         /// <param name="bindingPath">The output binding path of the navigation property which matches the <paramref name="parsedSegments"/></param>
         /// <returns>The navigation target which matches the binding path.</returns>
-        public static IEdmNavigationSource FindNavigationTarget(this IEdmNavigationSource navigationSource, IEdmNavigationProperty navigationProperty, Func<IEdmPathExpression, IList<ODataPathSegment>, bool> matchBindingPath, IList<ODataPathSegment> parsedSegments, out IEdmPathExpression bindingPath)
+        public static IEdmNavigationSource FindNavigationTarget(this IEdmNavigationSource navigationSource, IEdmNavigationProperty navigationProperty, Func<IEdmPathExpression, IReadOnlyList<ODataPathSegment>, bool> matchBindingPath, IReadOnlyList<ODataPathSegment> parsedSegments, out IEdmPathExpression bindingPath)
         {
             Debug.Assert(navigationSource != null);
             Debug.Assert(navigationProperty != null);

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
@@ -85,7 +85,7 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// Get the List of ODataPathSegments.
         /// </summary>
-        internal IList<ODataPathSegment> Segments
+        internal IReadOnlyList<ODataPathSegment> Segments
         {
             get { return this.segments; }
         }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

This changes the type of the internal `ODataPath.Segments` property from `IList<ODataPathSegments>` to `IReadOnlyList<ODataPathSegments>` to prevent accidental modifications to the list. This property is really only passed to a single method: `BindingPathHelper.MatchBindingPath`, and it does not modify the list. `ODataPath` is intended to be immutable.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
