### PR TITLE
Fix #1529 by first checking that a property was found

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/EndPathBinder.cs
@@ -6,7 +6,6 @@
 
 namespace Microsoft.OData.UriParser
 {
-    using System.Linq;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Metadata;
     using ODataErrorStrings = Microsoft.OData.Strings;
@@ -140,8 +139,7 @@ namespace Microsoft.OData.UriParser
 
             QueryNode boundFunction;
 
-            SingleValueNode singleValueParent = parent as SingleValueNode;
-            if (singleValueParent != null)
+            if (parent is SingleValueNode singleValueParent)
             {
                 if (endPathToken.Identifier == ExpressionConstants.QueryOptionCount)
                 {
@@ -155,7 +153,7 @@ namespace Microsoft.OData.UriParser
 
                 // Now that we have the parent type, can find its corresponding EDM type
                 IEdmStructuredTypeReference structuredParentType =
-                    singleValueParent.TypeReference == null ? null : singleValueParent.TypeReference.AsStructuredOrNull();
+                    singleValueParent.TypeReference?.AsStructuredOrNull();
 
                 IEdmProperty property =
                     structuredParentType == null ? null : this.Resolver.ResolveProperty(structuredParentType.StructuredDefinition(), endPathToken.Identifier);
@@ -175,20 +173,19 @@ namespace Microsoft.OData.UriParser
 
             // Collection with any or all expression is already supported and handled separately.
             // Add support of collection with $count segment.
-            CollectionNode colNode = parent as CollectionNode;
-            if (colNode != null && endPathToken.Identifier.Equals(UriQueryConstants.CountSegment, System.StringComparison.Ordinal))
+            if (parent is CollectionNode colNode
+                && endPathToken.Identifier.Equals(UriQueryConstants.CountSegment, System.StringComparison.Ordinal))
             {
                 // create a collection count node for collection node property.
                 return new CountNode(colNode);
             }
 
-            CollectionNavigationNode collectionParent = parent as CollectionNavigationNode;
-            if (collectionParent != null)
+            if (parent is CollectionNavigationNode collectionParent)
             {
                 IEdmEntityTypeReference parentType = collectionParent.EntityItemType;
                 IEdmProperty property = this.Resolver.ResolveProperty(parentType.StructuredDefinition(), endPathToken.Identifier);
 
-                if (property.PropertyKind == EdmPropertyKind.Structural
+                if (property?.PropertyKind == EdmPropertyKind.Structural
                     && !property.Type.IsCollection()
                     && this.state.InEntitySetAggregation)
                 {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/EndPathBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/EndPathBinderTests.cs
@@ -259,6 +259,40 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             propertyNode.ShouldBeSingleValueOpenPropertyAccessQueryNode("Color");
         }
 
+        [Fact]
+        public void ShouldThrowIfSingleValueNodeOfCollectionNavigationNodeIsUsedOutsideAggregation()
+        {
+            var state = new BindingState(this.configuration);
+            var metadataBinder = new MetadataBinder(state);
+            var endPathBinder = new EndPathBinder(metadataBinder.Bind, state);
+
+            var token = new EndPathToken("FastestOwner",
+                new EndPathToken("MyFriendsDogs", new RangeVariableToken("a")));
+            CollectionResourceNode entityCollectionNode = new EntitySetNode(HardCodedTestModel.GetPeopleSet());
+            state.RangeVariables.Push(new ResourceRangeVariable("a", HardCodedTestModel.GetPersonTypeReference(), entityCollectionNode));
+
+            Action bind = () => endPathBinder.BindEndPath(token);
+
+            bind.Throws<ODataException>(Strings.MetadataBinder_PropertyAccessSourceNotSingleValue("FastestOwner"));
+        }
+
+        [Fact]
+        public void ShouldThrowIfUnknownPropertyOfCollectionNavigationNodeIsUsed()
+        {
+            var state = new BindingState(this.configuration);
+            var metadataBinder = new MetadataBinder(state);
+            var endPathBinder = new EndPathBinder(metadataBinder.Bind, state);
+
+            var token = new EndPathToken("MissingProperty",
+                new EndPathToken("MyFriendsDogs", new RangeVariableToken("a")));
+            CollectionResourceNode entityCollectionNode = new EntitySetNode(HardCodedTestModel.GetPeopleSet());
+            state.RangeVariables.Push(new ResourceRangeVariable("a", HardCodedTestModel.GetPersonTypeReference(), entityCollectionNode));
+
+            Action bind = () => endPathBinder.BindEndPath(token);
+
+            bind.Throws<ODataException>(Strings.MetadataBinder_PropertyAccessSourceNotSingleValue("MissingProperty"));
+        }
+
         /// <summary>
         /// We substitute this method for the MetadataBinder.Bind method to keep the tests from growing too large in scope.
         /// In practice this does the same thing.


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #1529.

### Description

In EndPathFinder validate, that a property was resolved, before checking if it is selected and suitable for aggregation.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

