### PR TITLE
Pass correct output stream to IStreamBasedJsonWriterFactory

### DIFF
--- a/src/Microsoft.OData.Core/Json/DefaultStreamBasedJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/DefaultStreamBasedJsonWriterFactory.cs
@@ -48,7 +48,7 @@ namespace Microsoft.OData.Json
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            return new ODataUtf8JsonWriter(stream, isIeee754Compatible, encoding, encoder: this.encoder);
+            return new ODataUtf8JsonWriter(stream, isIeee754Compatible, encoding, encoder: this.encoder, leaveStreamOpen: true);
         }
 
         public IJsonWriterAsync CreateAsynchronousJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding)
@@ -63,7 +63,7 @@ namespace Microsoft.OData.Json
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            return new ODataUtf8JsonWriter(stream, isIeee754Compatible, encoding, encoder: this.encoder);
+            return new ODataUtf8JsonWriter(stream, isIeee754Compatible, encoding, encoder: this.encoder, leaveStreamOpen: true);
         }
     }
 }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -114,7 +114,7 @@ namespace Microsoft.OData.JsonLight
                 {
                     this.asynchronousJsonWriter = CreateAsynchronousJsonWriter(
                         streamBasedJsonWriterFactory,
-                        this.messageOutputStream,
+                        outputStream,
                         isIeee754Compatible,
                         messageInfo.Encoding);
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/DefaultStreamBasedJsonWriterFactoryAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/DefaultStreamBasedJsonWriterFactoryAsyncTests.cs
@@ -123,6 +123,29 @@ namespace Microsoft.OData.Tests.Json
             string contents = await reader.ReadToEndAsync();
             Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":15.0,""Buzz"":""<\""\n""}", contents);
         }
+
+        [Fact]
+        public async Task CreatedAsyncJsonWriterShouldNotCloseOutputStream()
+        {
+            DefaultStreamBasedJsonWriterFactory factory = DefaultStreamBasedJsonWriterFactory.Default;
+            using TestStream stream = new TestStream();
+
+            IAsyncDisposable jsonWriter = factory.CreateAsynchronousJsonWriter(stream, false, Encoding.UTF8) as IAsyncDisposable;
+            await jsonWriter.DisposeAsync();
+
+            Assert.False(stream.Disposed);
+        }
+
+        private sealed class TestStream : MemoryStream
+        {
+            public bool Disposed { get; private set; }
+
+            public override ValueTask DisposeAsync()
+            {
+                Disposed = true;
+                return base.DisposeAsync();
+            }
+        }
     }
 }
 #endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/DefaultStreamBasedJsonWriterFactoryTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/DefaultStreamBasedJsonWriterFactoryTests.cs
@@ -122,6 +122,29 @@ namespace Microsoft.OData.Tests.Json
             string contents = reader.ReadToEnd();
             Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":15.0,""Buzz"":""<\""\n""}", contents);
         }
+
+
+        [Fact]
+        public void CreatedJsonWriterShouldNotCloseOutputStream()
+        {
+            DefaultStreamBasedJsonWriterFactory factory = DefaultStreamBasedJsonWriterFactory.Default;
+            using TestStream stream = new TestStream();
+
+            IDisposable jsonWriter = factory.CreateJsonWriter(stream, false, Encoding.UTF8) as IDisposable;
+            jsonWriter.Dispose();
+
+            Assert.False(stream.Disposed);
+        }
+
+        private sealed class TestStream : MemoryStream
+        {
+            public bool Disposed { get; private set; }
+            protected override void Dispose(bool disposing)
+            {
+                base.Dispose(disposing);
+                Disposed = true;
+            }
+        }
     }
 }
 #endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
@@ -418,7 +418,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     await jsonLightBatchWriter.WriteStartBatchAsync();
 
                     var customerOperationMessage = await jsonLightBatchWriter.CreateOperationResponseMessageAsync("1");
-                    customerOperationMessage.SetHeader("odata-version", "4.0");
+                    customerOperationMessage.SetHeader(ODataConstants.ODataVersionHeader, "4.0");
                     customerOperationMessage.SetHeader("Content-Type", "application/json");
 
                     // Copies operation's response body to the main batch response's stream
@@ -486,7 +486,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     }
 
                     var orderOperationMessage = await jsonLightBatchWriter.CreateOperationResponseMessageAsync("2");
-                    orderOperationMessage.SetHeader("odata-version", "4.0");
+                    orderOperationMessage.SetHeader(ODataConstants.ODataVersionHeader, "4.0");
                     orderOperationMessage.SetHeader("Content-Type", "application/json");
 
                     using (var orderOperationStream = CreateOrderResponseStream(orderId: "1"))

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
@@ -421,6 +421,8 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     customerOperationMessage.SetHeader("odata-version", "4.0");
                     customerOperationMessage.SetHeader("Content-Type", "application/json");
 
+                    // Copies operation's response body to the main batch response's stream
+                    // This is similar to how the DefaultODataBatchHandler in WebApi writes batch responses.  
                     using (var customerResponseStream = CreateCustomerResponseStream(customerId: "1"))
                     using (var stream = await customerOperationMessage.GetStreamAsync())
                     {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
@@ -431,7 +431,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     }
 
                     var orderOperationMessage = await jsonLightBatchWriter.CreateOperationResponseMessageAsync("2");
-                    orderOperationMessage.SetHeader("odata-version", "4.0");
+                    orderOperationMessage.SetHeader(ODataConstants.ODataVersionHeader, "4.0");
                     orderOperationMessage.SetHeader("Content-Type", "application/json");
 
                     using (var orderOperationStream = CreateOrderResponseStream(orderId: "1"))
@@ -473,7 +473,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     await jsonLightBatchWriter.WriteStartBatchAsync();
 
                     var customerOperationMessage = await jsonLightBatchWriter.CreateOperationResponseMessageAsync("1");
-                    customerOperationMessage.SetHeader("odata-version", "4.0");
+                    customerOperationMessage.SetHeader(ODataConstants.ODataVersionHeader, "4.0");
                     customerOperationMessage.SetHeader("Content-Type", "application/json");
 
                     // Copies operation's response body to the main batch response's stream

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchWriterTests.cs
@@ -6,11 +6,15 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.OData.Edm;
+using Microsoft.OData.Json;
 using Microsoft.OData.JsonLight;
+using Microsoft.Test.OData.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.OData.Core.Tests.JsonLight
@@ -404,6 +408,110 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                 "\"body\" :{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\",\"Id\":1,\"Name\":\"Customer 1\",\"Type\":\"Retail\"}}]}",
                 result);
         }
+
+        [Fact]
+        public async Task WriteBatchResponseAsync_WithStreamCopy()
+        {
+            var result = await SetupJsonLightBatchWriterAndRunTestAsync(
+                async (jsonLightBatchWriter) =>
+                {
+                    await jsonLightBatchWriter.WriteStartBatchAsync();
+
+                    var customerOperationMessage = await jsonLightBatchWriter.CreateOperationResponseMessageAsync("1");
+                    customerOperationMessage.SetHeader("odata-version", "4.0");
+                    customerOperationMessage.SetHeader("Content-Type", "application/json");
+
+                    using (var customerResponseStream = CreateCustomerResponseStream(customerId: "1"))
+                    using (var stream = await customerOperationMessage.GetStreamAsync())
+                    {
+                        customerResponseStream.Seek(0L, SeekOrigin.Begin);
+                        await customerResponseStream.CopyToAsync(stream);
+                    }
+
+                    var orderOperationMessage = await jsonLightBatchWriter.CreateOperationResponseMessageAsync("2");
+                    orderOperationMessage.SetHeader("odata-version", "4.0");
+                    orderOperationMessage.SetHeader("Content-Type", "application/json");
+
+                    using (var orderOperationStream = CreateOrderResponseStream(orderId: "1"))
+                    using (var stream = await orderOperationMessage.GetStreamAsync())
+                    {
+                        orderOperationStream.Seek(0L, SeekOrigin.Begin);
+                        await orderOperationStream.CopyToAsync(stream);
+                    }
+
+                    await jsonLightBatchWriter.WriteEndBatchAsync();
+                },
+                writingRequest: false);
+
+            Assert.Equal("{\"responses\":[" +
+                "{\"id\":\"1\"," +
+                "\"status\":0," +
+                "\"headers\":{\"odata-version\":\"4.0\",\"content-type\":\"application/json\"}, " +
+                "\"body\" :{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\",\"Id\":1,\"Name\":\"Customer 1\",\"Type\":\"Retail\"}}," +
+                "{\"id\":\"2\"," +
+                "\"status\":0," +
+                "\"headers\":{\"odata-version\":\"4.0\",\"content-type\":\"application/json\"}, " +
+                "\"body\" :{\"@odata.context\":\"http://tempuri.org/$metadata#Orders/$entity\",\"Id\":1,\"CustomerId\":1,\"Amount\":13}}" +
+                "]}",
+                result);
+        }
+
+#if NETCOREAPP3_1_OR_GREATER
+        [Fact]
+        public async Task WriteBatchResponseAsync_WithStreamCopy_UsingODataUtf8JsonWriter()
+        {
+            Action<IContainerBuilder> configureServices = (builder) =>
+            {
+                builder.AddService<IStreamBasedJsonWriterFactory>(ServiceLifetime.Singleton, _ =>DefaultStreamBasedJsonWriterFactory.Default);
+            };
+
+            var result = await SetupJsonLightBatchWriterAndRunTestAsync(
+                async (jsonLightBatchWriter) =>
+                {
+                    await jsonLightBatchWriter.WriteStartBatchAsync();
+
+                    var customerOperationMessage = await jsonLightBatchWriter.CreateOperationResponseMessageAsync("1");
+                    customerOperationMessage.SetHeader("odata-version", "4.0");
+                    customerOperationMessage.SetHeader("Content-Type", "application/json");
+
+                    // Copies operation's response body to the main batch response's stream
+                    // This is similar to how the DefaultODataBatchHandler in WebApi writes batch responses.  
+                    using (var customerResponseStream = CreateCustomerResponseStream(customerId: "1"))
+                    using (var stream = await customerOperationMessage.GetStreamAsync())
+                    {
+                        customerResponseStream.Seek(0L, SeekOrigin.Begin);
+                        await customerResponseStream.CopyToAsync(stream);
+                    }
+
+                    var orderOperationMessage = await jsonLightBatchWriter.CreateOperationResponseMessageAsync("2");
+                    orderOperationMessage.SetHeader("odata-version", "4.0");
+                    orderOperationMessage.SetHeader("Content-Type", "application/json");
+
+                    using (var orderOperationStream = CreateOrderResponseStream(orderId: "1"))
+                    using (var stream = await orderOperationMessage.GetStreamAsync())
+                    {
+                        orderOperationStream.Seek(0L, SeekOrigin.Begin);
+                        await orderOperationStream.CopyToAsync(stream);
+                    }
+
+                    await jsonLightBatchWriter.WriteEndBatchAsync();
+                },
+                writingRequest: false,
+                configureServices);
+
+            Assert.Equal("{\"responses\":[" +
+                "{\"id\":\"1\"," +
+                "\"status\":0," +
+                "\"headers\":{\"odata-version\":\"4.0\",\"content-type\":\"application/json\"}, " +
+                "\"body\" :{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\",\"Id\":1,\"Name\":\"Customer 1\",\"Type\":\"Retail\"}}," +
+                "{\"id\":\"2\"," +
+                "\"status\":0," +
+                "\"headers\":{\"odata-version\":\"4.0\",\"content-type\":\"application/json\"}, " +
+                "\"body\" :{\"@odata.context\":\"http://tempuri.org/$metadata#Orders/$entity\",\"Id\":1,\"CustomerId\":1,\"Amount\":13}}" +
+                "]}",
+                result);
+        }
+#endif
 
         [Fact]
         public async Task WriteBatchRequestWithAbsoluteUriUsingHostHeaderAsync()
@@ -853,9 +961,10 @@ namespace Microsoft.OData.Core.Tests.JsonLight
         /// </summary>
         private async Task<string> SetupJsonLightBatchWriterAndRunTestAsync(
             Func<ODataJsonLightBatchWriter, Task> func,
-            bool writingRequest = true)
+            bool writingRequest = true,
+            Action<IContainerBuilder> configureServices = null)
         {
-            var jsonLightOutputContext = CreateJsonLightOutputContext(writingRequest, /*asynchronous*/ true);
+            var jsonLightOutputContext = CreateJsonLightOutputContext(writingRequest, asynchronous: true, configureServices: configureServices);
             var jsonLightBatchWriter = new ODataJsonLightBatchWriter(jsonLightOutputContext);
 
             await func(jsonLightBatchWriter);
@@ -864,8 +973,10 @@ namespace Microsoft.OData.Core.Tests.JsonLight
             return await new StreamReader(this.stream).ReadToEndAsync();
         }
 
-        private ODataJsonLightOutputContext CreateJsonLightOutputContext(bool writingRequest = true, bool asynchronous = false)
+        private ODataJsonLightOutputContext CreateJsonLightOutputContext(bool writingRequest = true, bool asynchronous = false, Action<IContainerBuilder> configureServices = null)
         {
+            IServiceProvider container = configureServices == null ? null : CreateServiceProvider(configureServices);
+
             var messageInfo = new ODataMessageInfo
             {
                 MessageStream = this.stream,
@@ -873,7 +984,8 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                 Encoding = this.encoding,
                 IsResponse = !writingRequest,
                 IsAsync = asynchronous,
-                Model = this.model
+                Model = this.model,
+                Container = container,
             };
 
             return new ODataJsonLightOutputContext(messageInfo, this.settings);
@@ -931,6 +1043,42 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     NavigationSourceKind = EdmNavigationSourceKind.EntitySet
                 }
             };
+        }
+
+        private static Stream CreateCustomerResponseStream(string customerId)
+        {
+            string content = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\",\"Id\":{customerId},\"Name\":\"Customer 1\",\"Type\":\"Retail\"}}";
+            return CreateStreamWithContents(content);
+        }
+
+        private static Stream CreateOrderResponseStream(string orderId)
+        {
+            string content = $"{{\"@odata.context\":\"http://tempuri.org/$metadata#Orders/$entity\",\"Id\":{orderId},\"CustomerId\":1,\"Amount\":13}}";
+            return CreateStreamWithContents(content);
+        }
+
+        /// <summary>
+        /// Creates a stream that contains the specified content in the specified encoding.
+        /// </summary>
+        /// <param name="content">Content to fill the stream with.</param>
+        /// <returns>The stream with the specified content.</returns>
+        /// <remarks>The stream's cursor is positioned at the end.
+        /// You will need to seek or reposition the cursor if you want to read the stream from the beginning.
+        /// </remarks>
+        private static Stream CreateStreamWithContents(string content, Encoding encoding = null)
+        {
+            MemoryStream stream = new MemoryStream();
+            byte[] encoded = (encoding ?? Encoding.UTF8).GetBytes(content);
+            stream.Write(encoded, 0, encoded.Length);
+            return stream;
+        }
+
+        private static IServiceProvider CreateServiceProvider(Action<IContainerBuilder> configureServices)
+        {
+            TestContainerBuilder containerBuilder = new TestContainerBuilder();
+            containerBuilder.AddDefaultODataServices();
+            configureServices(containerBuilder);
+            return containerBuilder.BuildContainer();
         }
 
         #endregion Helper Methods


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes https://github.com/OData/AspNetCoreOData/issues/673

### Description

The `ODataJsonLightOutputContext` was passing the wrong stream to the `IStreamBasedJsonWriterFactory` when writing an async message. Normally, it [creates a `BufferedStream` that wraps the message stream](https://github.com/habbes/odata.net/blob/master/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs#L108), then uses the buffered stream as the output stream for the async writer. But it was passing the message stream directly to the `IStreamBasedJsonWriterFactory`, meaning that the `ODataUtf8JsonWriter` was bypassing the `BufferedStream` and flushing its output to the internal message stream.

The issue arises because in WebAPI, the `DefaultODataBatchHandler` [copies contents from sub-request responses to the message writer's stream](https://github.com/habbes/odata.net/blob/odataurislim-class-experiment/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs#L117), which in this case happens to be `BufferedStream`, but it uses the JSON writer to write the rest of the metadata in the batch response. This means that we have two writers who are not writing to the same stream. The result is that the bodies of the sub-requests get written out of order because the JSON writer gets flushed before the `BufferedStream`.

The existing batch test cases did not use the async writer. They also did not copy content directly to the stream, and instead used `ODataMessageWriter` instances to write the sub responses. For these reasons, the existing test cases would not detect this bug. I have added test cases to reproduce the issue and to validate more scenarios related to writing batch responses.

Another hidden bug was that the `ODataUtf8JsonWriter` was disposing the output stream when it was closed. This is an error because the writer does not own the stream in this case. The reason it was undetected is because the message stream passed by `ODataMessageWriter` is set to ignore disposals by default. However, `BufferedStream` throws an exception when used after disposal. I have fixed this issue by instructing `ODataUtf8JsonWriter` to leave the stream open when disposed.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
