### PR TITLE
ODataUriSlim struct

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
@@ -177,14 +177,14 @@ namespace Microsoft.OData.Evaluation
             {
                 // Compute ID from context URL rather than from parent.
                 uri = this.UriBuilder.BuildBaseUri();
-                ODataUri odataUri = this.ODataUri ?? this.MetadataContext.ODataUri;
+                ODataPath odataPath = this.ODataUri?.Path ?? this.MetadataContext.ODataUri.Path;
 
-                if (odataUri == null || odataUri.Path == null || odataUri.Path.Count == 0)
+                if (odataPath == null || odataPath.Count == 0)
                 {
                     throw new ODataException(Strings.ODataMetadataBuilder_MissingParentIdOrContextUrl);
                 }
 
-                uri = this.GetContainingEntitySetUri(uri, odataUri);
+                uri = this.GetContainingEntitySetUri(uri, odataPath);
             }
 
             // A path segment for the containment navigation property
@@ -270,9 +270,8 @@ namespace Microsoft.OData.Evaluation
         /// <param name="baseUri">The service root Uri.</param>
         /// <param name="odataUri">The request Uri.</param>
         /// <returns>The resource path.</returns>
-        private Uri GetContainingEntitySetUri(Uri baseUri, ODataUri odataUri)
+        private Uri GetContainingEntitySetUri(Uri baseUri, ODataPath path)
         {
-            ODataPath path = odataUri.Path;
             List<ODataPathSegment> segments = path.ToList();
             int lastIndex = segments.Count - 1;
             ODataPathSegment lastSegment = segments[lastIndex];

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
@@ -177,7 +177,7 @@ namespace Microsoft.OData.Evaluation
             {
                 // Compute ID from context URL rather than from parent.
                 uri = this.UriBuilder.BuildBaseUri();
-                ODataPath odataPath = this.ODataUri?.Path ?? this.MetadataContext.ODataUri.Path;
+                ODataPath odataPath = this.ODataUri?.Path ?? this.MetadataContext.ODataUri?.Path;
 
                 if (odataPath == null || odataPath.Count == 0)
                 {

--- a/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OData.Evaluation
         /// <summary>
         /// Gets the OData uri.
         /// </summary>
-        ODataUri ODataUri { get; }
+        ODataUriSlim ODataUri { get; }
 
         /// <summary>
         /// Gets an entity metadata builder for the given resource.
@@ -95,7 +95,7 @@ namespace Microsoft.OData.Evaluation
         /// <summary>
         /// The OData Uri.
         /// </summary>
-        private readonly ODataUri odataUri;
+        private readonly ODataUriSlim odataUri;
 
         /// <summary>
         /// The service base Uri.
@@ -115,8 +115,8 @@ namespace Microsoft.OData.Evaluation
         /// <param name="metadataDocumentUri">The metadata document uri.</param>
         /// <param name="odataUri">The request Uri.</param>
         /// <remarks>This overload should only be used by the writer.</remarks>
-        public ODataMetadataContext(bool isResponse, IEdmModel model, Uri metadataDocumentUri, ODataUri odataUri)
-            : this(isResponse, /*OperationsBoundToEntityTypeMustBeContainerQualified*/ null, EdmTypeWriterResolver.Instance, model, metadataDocumentUri, odataUri)
+        public ODataMetadataContext(bool isResponse, IEdmModel model, Uri metadataDocumentUri, in ODataUriSlim odataUri)
+            : this(isResponse, /*OperationsBoundToEntityTypeMustBeContainerQualified*/ null, EdmTypeWriterResolver.Instance, model, metadataDocumentUri, in odataUri)
         {
         }
 
@@ -136,7 +136,7 @@ namespace Microsoft.OData.Evaluation
             EdmTypeResolver edmTypeResolver,
             IEdmModel model,
             Uri metadataDocumentUri,
-            ODataUri odataUri)
+            in ODataUriSlim odataUri)
         {
             Debug.Assert(edmTypeResolver != null, "edmTypeResolver != null");
             Debug.Assert(model != null, "model != null");
@@ -166,9 +166,9 @@ namespace Microsoft.OData.Evaluation
             EdmTypeResolver edmTypeResolver,
             IEdmModel model,
             Uri metadataDocumentUri,
-            ODataUri odataUri,
+            in ODataUriSlim odataUri,
             JsonLightMetadataLevel metadataLevel)
-            : this(isResponse, operationsBoundToEntityTypeMustBeContainerQualified, edmTypeResolver, model, metadataDocumentUri, odataUri)
+            : this(isResponse, operationsBoundToEntityTypeMustBeContainerQualified, edmTypeResolver, model, metadataDocumentUri, in odataUri)
         {
             Debug.Assert(metadataLevel != null, "MetadataLevel != null");
 
@@ -215,7 +215,7 @@ namespace Microsoft.OData.Evaluation
         /// <summary>
         /// Gets the OData uri.
         /// </summary>
-        public ODataUri ODataUri
+        public ODataUriSlim ODataUri
         {
             get
             {

--- a/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OData.Evaluation
         /// <summary>
         /// Gets the OData uri.
         /// </summary>
-        ODataUriSlim ODataUri { get; }
+        ODataUriSlim? ODataUri { get; }
 
         /// <summary>
         /// Gets an entity metadata builder for the given resource.
@@ -95,7 +95,7 @@ namespace Microsoft.OData.Evaluation
         /// <summary>
         /// The OData Uri.
         /// </summary>
-        private readonly ODataUriSlim odataUri;
+        private readonly ODataUriSlim? odataUri;
 
         /// <summary>
         /// The service base Uri.
@@ -115,7 +115,7 @@ namespace Microsoft.OData.Evaluation
         /// <param name="metadataDocumentUri">The metadata document uri.</param>
         /// <param name="odataUri">The request Uri.</param>
         /// <remarks>This overload should only be used by the writer.</remarks>
-        public ODataMetadataContext(bool isResponse, IEdmModel model, Uri metadataDocumentUri, in ODataUriSlim odataUri)
+        public ODataMetadataContext(bool isResponse, IEdmModel model, Uri metadataDocumentUri, in ODataUriSlim? odataUri)
             : this(isResponse, /*OperationsBoundToEntityTypeMustBeContainerQualified*/ null, EdmTypeWriterResolver.Instance, model, metadataDocumentUri, in odataUri)
         {
         }
@@ -136,7 +136,7 @@ namespace Microsoft.OData.Evaluation
             EdmTypeResolver edmTypeResolver,
             IEdmModel model,
             Uri metadataDocumentUri,
-            in ODataUriSlim odataUri)
+            in ODataUriSlim? odataUri)
         {
             Debug.Assert(edmTypeResolver != null, "edmTypeResolver != null");
             Debug.Assert(model != null, "model != null");
@@ -166,7 +166,7 @@ namespace Microsoft.OData.Evaluation
             EdmTypeResolver edmTypeResolver,
             IEdmModel model,
             Uri metadataDocumentUri,
-            in ODataUriSlim odataUri,
+            in ODataUriSlim? odataUri,
             JsonLightMetadataLevel metadataLevel)
             : this(isResponse, operationsBoundToEntityTypeMustBeContainerQualified, edmTypeResolver, model, metadataDocumentUri, in odataUri)
         {
@@ -215,7 +215,7 @@ namespace Microsoft.OData.Evaluation
         /// <summary>
         /// Gets the OData uri.
         /// </summary>
-        public ODataUriSlim ODataUri
+        public ODataUriSlim? ODataUri
         {
             get
             {

--- a/src/Microsoft.OData.Core/JsonLight/JsonFullMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonFullMetadataLevel.cs
@@ -106,7 +106,7 @@ namespace Microsoft.OData.JsonLight
                 isResponse,
                 this.model,
                 this.NonNullMetadataDocumentUri,
-                in odataUri);
+                odataUri);
 
             ODataConventionalUriBuilder uriBuilder = new ODataConventionalUriBuilder(metadataContext.ServiceBaseUri,
                 keyAsSegment ? ODataUrlKeyDelimiter.Slash : ODataUrlKeyDelimiter.Parentheses);

--- a/src/Microsoft.OData.Core/JsonLight/JsonFullMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonFullMetadataLevel.cs
@@ -95,7 +95,7 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties,
             bool isResponse,
             bool keyAsSegment,
-            in ODataUriSlim odataUri,
+            in ODataUriSlim? odataUri,
             ODataMessageWriterSettings settings)
         {
             Debug.Assert(resource != null, "resource != null");

--- a/src/Microsoft.OData.Core/JsonLight/JsonFullMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonFullMetadataLevel.cs
@@ -95,7 +95,7 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties,
             bool isResponse,
             bool keyAsSegment,
-            ODataUri odataUri,
+            in ODataUriSlim odataUri,
             ODataMessageWriterSettings settings)
         {
             Debug.Assert(resource != null, "resource != null");
@@ -106,7 +106,7 @@ namespace Microsoft.OData.JsonLight
                 isResponse,
                 this.model,
                 this.NonNullMetadataDocumentUri,
-                odataUri);
+                in odataUri);
 
             ODataConventionalUriBuilder uriBuilder = new ODataConventionalUriBuilder(metadataContext.ServiceBaseUri,
                 keyAsSegment ? ODataUrlKeyDelimiter.Slash : ODataUrlKeyDelimiter.Parentheses);

--- a/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
@@ -114,7 +114,7 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties,
             bool isResponse,
             bool keyAsSegment,
-            in ODataUriSlim odataUri,
+            in ODataUriSlim? odataUri,
             ODataMessageWriterSettings settings);
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonLightMetadataLevel.cs
@@ -114,7 +114,7 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties,
             bool isResponse,
             bool keyAsSegment,
-            ODataUri odataUri,
+            in ODataUriSlim odataUri,
             ODataMessageWriterSettings settings);
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/JsonMinimalMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonMinimalMetadataLevel.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties,
             bool isResponse,
             bool keyAsSegment,
-            ODataUri odataUri,
+            in ODataUriSlim odataUri,
             ODataMessageWriterSettings settings)
         {
             // For minimal metadata we don't want to change the metadata builder that's currently on the resource because the resource might come from a JSON light

--- a/src/Microsoft.OData.Core/JsonLight/JsonMinimalMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonMinimalMetadataLevel.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties,
             bool isResponse,
             bool keyAsSegment,
-            in ODataUriSlim odataUri,
+            in ODataUriSlim? odataUri,
             ODataMessageWriterSettings settings)
         {
             // For minimal metadata we don't want to change the metadata builder that's currently on the resource because the resource might come from a JSON light

--- a/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
@@ -79,7 +79,7 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties,
             bool isResponse,
             bool keyAsSegment,
-            ODataUri odataUri,
+            in ODataUriSlim odataUri,
             ODataMessageWriterSettings settings)
         {
             return ODataResourceMetadataBuilder.Null;

--- a/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
+++ b/src/Microsoft.OData.Core/JsonLight/JsonNoMetadataLevel.cs
@@ -79,7 +79,7 @@ namespace Microsoft.OData.JsonLight
             SelectedPropertiesNode selectedProperties,
             bool isResponse,
             bool keyAsSegment,
-            in ODataUriSlim odataUri,
+            in ODataUriSlim? odataUri,
             ODataMessageWriterSettings settings)
         {
             return ODataResourceMetadataBuilder.Null;

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -124,7 +124,6 @@ namespace Microsoft.OData.JsonLight
                 // However, we need to answer this question for materializing operations which were left out of the payload.
                 // To get around this, the client sets a callback in the ReaderBehavior to answer the question.
 
-                // TODO: find ways to avoid creating a new ODataUriSlim here
                 ODataUriSlim? odataUri = null;
                 if (this.ODataUri != null)
                 {

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -123,9 +123,14 @@ namespace Microsoft.OData.JsonLight
                 // Under the client knob, the model we're given is really a facade, which doesn't flow open-type information into the combined types.
                 // However, we need to answer this question for materializing operations which were left out of the payload.
                 // To get around this, the client sets a callback in the ReaderBehavior to answer the question.
-                
+
                 // TODO: find ways to avoid creating a new ODataUriSlim here
-                ODataUriSlim odataUri = new ODataUriSlim(this.ODataUri);
+                ODataUriSlim? odataUri = null;
+                if (this.ODataUri != null)
+                {
+                    odataUri = new ODataUriSlim(this.ODataUri);
+                }
+
                 return this.metadataContext ?? (this.metadataContext = new ODataMetadataContext(
                     this.ReadingResponse,
                     null,

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -136,7 +136,7 @@ namespace Microsoft.OData.JsonLight
                     this.JsonLightInputContext.EdmTypeResolver,
                     this.Model,
                     this.MetadataDocumentUri,
-                    in odataUri,
+                    odataUri,
                     this.JsonLightInputContext.MetadataLevel));
             }
         }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -123,13 +123,16 @@ namespace Microsoft.OData.JsonLight
                 // Under the client knob, the model we're given is really a facade, which doesn't flow open-type information into the combined types.
                 // However, we need to answer this question for materializing operations which were left out of the payload.
                 // To get around this, the client sets a callback in the ReaderBehavior to answer the question.
+                
+                // TODO: find ways to avoid creating a new ODataUriSlim here
+                ODataUriSlim odataUri = new ODataUriSlim(this.ODataUri);
                 return this.metadataContext ?? (this.metadataContext = new ODataMetadataContext(
                     this.ReadingResponse,
                     null,
                     this.JsonLightInputContext.EdmTypeResolver,
                     this.Model,
                     this.MetadataDocumentUri,
-                    this.ODataUri,
+                    in odataUri,
                     this.JsonLightInputContext.MetadataLevel));
             }
         }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
@@ -1029,12 +1029,11 @@ namespace Microsoft.OData.JsonLight
                     && this.messageWriterSettings.LibraryCompatibility < ODataLibraryCompatibility.Version7
                     && this.messageWriterSettings.Version < ODataVersion.V401)
                 {
-                    ODataUriSlim odataUri = this.CurrentScope.ODataUri;
                     ODataContextUrlInfo info = ODataContextUrlInfo.Create(
                                                 this.CurrentScope.NavigationSource,
                                                 this.CurrentScope.ResourceType.FullTypeName(),
                                                 containedEntitySet.NavigationProperty.Type.TypeKind() != EdmTypeKind.Collection,
-                                                in odataUri,
+                                                this.CurrentScope.ODataUri,
                                                 this.messageWriterSettings.Version ?? ODataVersion.V4);
 
                     this.jsonLightResourceSerializer.WriteNestedResourceInfoContextUrl(nestedResourceInfo, info);
@@ -1171,7 +1170,7 @@ namespace Microsoft.OData.JsonLight
             in ODataUriSlim odataUri,
             bool isUndeclared)
         {
-            return new JsonLightResourceSetScope(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, isUndeclared);
+            return new JsonLightResourceSetScope(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, odataUri, isUndeclared);
         }
 
         /// <summary>
@@ -1194,7 +1193,7 @@ namespace Microsoft.OData.JsonLight
             in ODataUriSlim odataUri,
             bool isUndeclared)
         {
-            return new JsonLightDeltaResourceSetScope(deltaResourceSet, navigationSource, resourceType, selectedProperties, in odataUri);
+            return new JsonLightDeltaResourceSetScope(deltaResourceSet, navigationSource, resourceType, selectedProperties, odataUri);
         }
 
         /// <summary>
@@ -1218,7 +1217,7 @@ namespace Microsoft.OData.JsonLight
                 skipWriting,
                 this.messageWriterSettings,
                 selectedProperties,
-                in odataUri,
+                odataUri,
                 isUndeclared);
         }
 
@@ -1233,7 +1232,7 @@ namespace Microsoft.OData.JsonLight
         /// <returns>The newly created property scope.</returns>
         protected override PropertyInfoScope CreatePropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
         {
-            return new JsonLightPropertyScope(property, navigationSource, resourceType, selectedProperties, in odataUri);
+            return new JsonLightPropertyScope(property, navigationSource, resourceType, selectedProperties, odataUri);
         }
 
         /// <summary>
@@ -1254,7 +1253,7 @@ namespace Microsoft.OData.JsonLight
                 navigationSource,
                 entityType,
                 selectedProperties,
-                in odataUri);
+                odataUri);
         }
 
         /// <summary>
@@ -1278,7 +1277,7 @@ namespace Microsoft.OData.JsonLight
                 skipWriting,
                 this.messageWriterSettings,
                 selectedProperties,
-                in odataUri,
+                odataUri,
                 isUndeclared);
         }
 
@@ -1296,7 +1295,7 @@ namespace Microsoft.OData.JsonLight
         protected override NestedResourceInfoScope CreateNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
         {
             Debug.Assert(this.CurrentScope != null, "Creating a nested resource info scope with a null parent scope.");
-            return new JsonLightNestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, this.CurrentScope);
+            return new JsonLightNestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, odataUri, this.CurrentScope);
         }
 
         /// <summary>
@@ -3081,7 +3080,7 @@ namespace Microsoft.OData.JsonLight
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="isUndeclared">true if the resource set is for an undeclared property</param>
             internal JsonLightResourceSetScope(ODataResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared)
-                : base(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, in odataUri)
+                : base(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, odataUri)
             {
                 this.isUndeclared = isUndeclared;
             }
@@ -3160,7 +3159,7 @@ namespace Microsoft.OData.JsonLight
                 SelectedPropertiesNode selectedProperties,
                 in ODataUriSlim odataUri,
                 bool isUndeclared)
-                : base(resource, serializationInfo, navigationSource, resourceType, writerSettings, selectedProperties, in odataUri)
+                : base(resource, serializationInfo, navigationSource, resourceType, writerSettings, selectedProperties, odataUri)
             {
                 this.isUndeclared = isUndeclared;
             }
@@ -3343,7 +3342,7 @@ namespace Microsoft.OData.JsonLight
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             internal JsonLightPropertyScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
-                : base(property, navigationSource, resourceType, selectedProperties, in odataUri)
+                : base(property, navigationSource, resourceType, selectedProperties, odataUri)
             {
             }
         }
@@ -3364,7 +3363,7 @@ namespace Microsoft.OData.JsonLight
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             public JsonLightDeltaLinkScope(WriterState state, ODataItem link, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
-                : base(state, link, serializationInfo, navigationSource, entityType, selectedProperties, in odataUri)
+                : base(state, link, serializationInfo, navigationSource, entityType, selectedProperties, odataUri)
             {
             }
         }
@@ -3389,7 +3388,7 @@ namespace Microsoft.OData.JsonLight
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             public JsonLightDeltaResourceSetScope(ODataDeltaResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
-                : base(resourceSet, navigationSource, resourceType, selectedProperties, in odataUri)
+                : base(resourceSet, navigationSource, resourceType, selectedProperties, odataUri)
             {
             }
 
@@ -3459,7 +3458,7 @@ namespace Microsoft.OData.JsonLight
                 SelectedPropertiesNode selectedProperties,
                 in ODataUriSlim odataUri,
                 bool isUndeclared)
-                : base(resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, in odataUri)
+                : base(resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, odataUri)
             {
                 this.isUndeclared = isUndeclared;
             }
@@ -3652,7 +3651,7 @@ namespace Microsoft.OData.JsonLight
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="parentScope">The scope of the parent.</param>
             internal JsonLightNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, Scope parentScope)
-                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, parentScope)
+                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, odataUri, parentScope)
             {
             }
 
@@ -3695,9 +3694,7 @@ namespace Microsoft.OData.JsonLight
             /// <returns>The cloned nested resource info scope with the specified writer state.</returns>
             internal override NestedResourceInfoScope Clone(WriterState newWriterState)
             {
-                ODataUriSlim odataUri = this.ODataUri;
-
-                return new JsonLightNestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, in odataUri, this.parentScope)
+                return new JsonLightNestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, this.ODataUri, this.parentScope)
                 {
                     EntityReferenceLinkWritten = this.entityReferenceLinkWritten,
                     ResourceSetWritten = this.resourceSetWritten,

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
@@ -1029,11 +1029,12 @@ namespace Microsoft.OData.JsonLight
                     && this.messageWriterSettings.LibraryCompatibility < ODataLibraryCompatibility.Version7
                     && this.messageWriterSettings.Version < ODataVersion.V401)
                 {
+                    ODataUriSlim odataUri = this.CurrentScope.ODataUri;
                     ODataContextUrlInfo info = ODataContextUrlInfo.Create(
                                                 this.CurrentScope.NavigationSource,
                                                 this.CurrentScope.ResourceType.FullTypeName(),
                                                 containedEntitySet.NavigationProperty.Type.TypeKind() != EdmTypeKind.Collection,
-                                                this.CurrentScope.ODataUri,
+                                                in odataUri,
                                                 this.messageWriterSettings.Version ?? ODataVersion.V4);
 
                     this.jsonLightResourceSerializer.WriteNestedResourceInfoContextUrl(nestedResourceInfo, info);
@@ -1167,10 +1168,10 @@ namespace Microsoft.OData.JsonLight
             IEdmType itemType,
             bool skipWriting,
             SelectedPropertiesNode selectedProperties,
-            ODataUri odataUri,
+            ref ODataUriSlim odataUri,
             bool isUndeclared)
         {
-            return new JsonLightResourceSetScope(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, odataUri, isUndeclared);
+            return new JsonLightResourceSetScope(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, isUndeclared);
         }
 
         /// <summary>
@@ -1190,10 +1191,10 @@ namespace Microsoft.OData.JsonLight
             IEdmStructuredType resourceType,
             bool skipWriting,
             SelectedPropertiesNode selectedProperties,
-            ODataUri odataUri,
+            ref ODataUriSlim odataUri,
             bool isUndeclared)
         {
-            return new JsonLightDeltaResourceSetScope(deltaResourceSet, navigationSource, resourceType, selectedProperties, odataUri);
+            return new JsonLightDeltaResourceSetScope(deltaResourceSet, navigationSource, resourceType, selectedProperties, ref odataUri);
         }
 
         /// <summary>
@@ -1207,7 +1208,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected override DeletedResourceScope CreateDeletedResourceScope(ODataDeletedResource deltaResource, IEdmNavigationSource navigationSource, IEdmEntityType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool isUndeclared)
+        protected override DeletedResourceScope CreateDeletedResourceScope(ODataDeletedResource deltaResource, IEdmNavigationSource navigationSource, IEdmEntityType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
         {
             return new JsonLightDeletedResourceScope(
                 deltaResource,
@@ -1217,7 +1218,7 @@ namespace Microsoft.OData.JsonLight
                 skipWriting,
                 this.messageWriterSettings,
                 selectedProperties,
-                odataUri,
+                ref odataUri,
                 isUndeclared);
         }
 
@@ -1230,9 +1231,9 @@ namespace Microsoft.OData.JsonLight
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly created property scope.</returns>
-        protected override PropertyInfoScope CreatePropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
+        protected override PropertyInfoScope CreatePropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
         {
-            return new JsonLightPropertyScope(property, navigationSource, resourceType, selectedProperties, odataUri);
+            return new JsonLightPropertyScope(property, navigationSource, resourceType, selectedProperties, ref odataUri);
         }
 
         /// <summary>
@@ -1244,7 +1245,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly create scope.</returns>
-        protected override DeltaLinkScope CreateDeltaLinkScope(ODataDeltaLinkBase link, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
+        protected override DeltaLinkScope CreateDeltaLinkScope(ODataDeltaLinkBase link, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
         {
             return new JsonLightDeltaLinkScope(
                 link is ODataDeltaLink ? WriterState.DeltaLink : WriterState.DeltaDeletedLink,
@@ -1253,7 +1254,7 @@ namespace Microsoft.OData.JsonLight
                 navigationSource,
                 entityType,
                 selectedProperties,
-                odataUri);
+                ref odataUri);
         }
 
         /// <summary>
@@ -1267,7 +1268,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected override ResourceScope CreateResourceScope(ODataResource resource, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool isUndeclared)
+        protected override ResourceScope CreateResourceScope(ODataResource resource, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
         {
             return new JsonLightResourceScope(
                 resource,
@@ -1277,7 +1278,7 @@ namespace Microsoft.OData.JsonLight
                 skipWriting,
                 this.messageWriterSettings,
                 selectedProperties,
-                odataUri,
+                ref odataUri,
                 isUndeclared);
         }
 
@@ -1292,10 +1293,10 @@ namespace Microsoft.OData.JsonLight
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly created JSON Light  nested resource info scope.</returns>
-        protected override NestedResourceInfoScope CreateNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
+        protected override NestedResourceInfoScope CreateNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
         {
             Debug.Assert(this.CurrentScope != null, "Creating a nested resource info scope with a null parent scope.");
-            return new JsonLightNestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, odataUri, this.CurrentScope);
+            return new JsonLightNestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, this.CurrentScope);
         }
 
         /// <summary>
@@ -2382,7 +2383,7 @@ namespace Microsoft.OData.JsonLight
         {
             ODataResourceSerializationInfo serializationInfo;
             IEdmStructuredType resourceType;
-            ODataUri uri;
+            ODataUriSlim uri;
 
             if (resource is ODataResource)
             {
@@ -3079,8 +3080,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="isUndeclared">true if the resource set is for an undeclared property</param>
-            internal JsonLightResourceSetScope(ODataResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool isUndeclared)
-                : base(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, odataUri)
+            internal JsonLightResourceSetScope(ODataResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
+                : base(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri)
             {
                 this.isUndeclared = isUndeclared;
             }
@@ -3157,9 +3158,9 @@ namespace Microsoft.OData.JsonLight
                 bool skipWriting,
                 ODataMessageWriterSettings writerSettings,
                 SelectedPropertiesNode selectedProperties,
-                ODataUri odataUri,
+                ref ODataUriSlim odataUri,
                 bool isUndeclared)
-                : base(resource, serializationInfo, navigationSource, resourceType, writerSettings, selectedProperties, odataUri)
+                : base(resource, serializationInfo, navigationSource, resourceType, writerSettings, selectedProperties, ref odataUri)
             {
                 this.isUndeclared = isUndeclared;
             }
@@ -3341,8 +3342,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="resourceType">The structured type for the resource containing the property to be written.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            internal JsonLightPropertyScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(property, navigationSource, resourceType, selectedProperties, odataUri)
+            internal JsonLightPropertyScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(property, navigationSource, resourceType, selectedProperties, ref odataUri)
             {
             }
         }
@@ -3362,8 +3363,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="entityType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            public JsonLightDeltaLinkScope(WriterState state, ODataItem link, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(state, link, serializationInfo, navigationSource, entityType, selectedProperties, odataUri)
+            public JsonLightDeltaLinkScope(WriterState state, ODataItem link, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(state, link, serializationInfo, navigationSource, entityType, selectedProperties, ref odataUri)
             {
             }
         }
@@ -3387,8 +3388,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="resourceType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            public JsonLightDeltaResourceSetScope(ODataDeltaResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(resourceSet, navigationSource, resourceType, selectedProperties, odataUri)
+            public JsonLightDeltaResourceSetScope(ODataDeltaResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(resourceSet, navigationSource, resourceType, selectedProperties, ref odataUri)
             {
             }
 
@@ -3456,9 +3457,9 @@ namespace Microsoft.OData.JsonLight
                 bool skipWriting,
                 ODataMessageWriterSettings writerSettings,
                 SelectedPropertiesNode selectedProperties,
-                ODataUri odataUri,
+                ref ODataUriSlim odataUri,
                 bool isUndeclared)
-                : base(resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, odataUri)
+                : base(resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, ref odataUri)
             {
                 this.isUndeclared = isUndeclared;
             }
@@ -3650,8 +3651,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="parentScope">The scope of the parent.</param>
-            internal JsonLightNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, Scope parentScope)
-                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, odataUri, parentScope)
+            internal JsonLightNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, Scope parentScope)
+                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, parentScope)
             {
             }
 
@@ -3694,7 +3695,9 @@ namespace Microsoft.OData.JsonLight
             /// <returns>The cloned nested resource info scope with the specified writer state.</returns>
             internal override NestedResourceInfoScope Clone(WriterState newWriterState)
             {
-                return new JsonLightNestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, this.ODataUri, this.parentScope)
+                ODataUriSlim odataUri = this.ODataUri;
+
+                return new JsonLightNestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, ref odataUri, this.parentScope)
                 {
                     EntityReferenceLinkWritten = this.entityReferenceLinkWritten,
                     ResourceSetWritten = this.resourceSetWritten,

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
@@ -1168,10 +1168,10 @@ namespace Microsoft.OData.JsonLight
             IEdmType itemType,
             bool skipWriting,
             SelectedPropertiesNode selectedProperties,
-            ref ODataUriSlim odataUri,
+            in ODataUriSlim odataUri,
             bool isUndeclared)
         {
-            return new JsonLightResourceSetScope(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, isUndeclared);
+            return new JsonLightResourceSetScope(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, isUndeclared);
         }
 
         /// <summary>
@@ -1191,10 +1191,10 @@ namespace Microsoft.OData.JsonLight
             IEdmStructuredType resourceType,
             bool skipWriting,
             SelectedPropertiesNode selectedProperties,
-            ref ODataUriSlim odataUri,
+            in ODataUriSlim odataUri,
             bool isUndeclared)
         {
-            return new JsonLightDeltaResourceSetScope(deltaResourceSet, navigationSource, resourceType, selectedProperties, ref odataUri);
+            return new JsonLightDeltaResourceSetScope(deltaResourceSet, navigationSource, resourceType, selectedProperties, in odataUri);
         }
 
         /// <summary>
@@ -1208,7 +1208,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected override DeletedResourceScope CreateDeletedResourceScope(ODataDeletedResource deltaResource, IEdmNavigationSource navigationSource, IEdmEntityType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
+        protected override DeletedResourceScope CreateDeletedResourceScope(ODataDeletedResource deltaResource, IEdmNavigationSource navigationSource, IEdmEntityType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared)
         {
             return new JsonLightDeletedResourceScope(
                 deltaResource,
@@ -1218,7 +1218,7 @@ namespace Microsoft.OData.JsonLight
                 skipWriting,
                 this.messageWriterSettings,
                 selectedProperties,
-                ref odataUri,
+                in odataUri,
                 isUndeclared);
         }
 
@@ -1231,9 +1231,9 @@ namespace Microsoft.OData.JsonLight
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly created property scope.</returns>
-        protected override PropertyInfoScope CreatePropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+        protected override PropertyInfoScope CreatePropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
         {
-            return new JsonLightPropertyScope(property, navigationSource, resourceType, selectedProperties, ref odataUri);
+            return new JsonLightPropertyScope(property, navigationSource, resourceType, selectedProperties, in odataUri);
         }
 
         /// <summary>
@@ -1245,7 +1245,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly create scope.</returns>
-        protected override DeltaLinkScope CreateDeltaLinkScope(ODataDeltaLinkBase link, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+        protected override DeltaLinkScope CreateDeltaLinkScope(ODataDeltaLinkBase link, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
         {
             return new JsonLightDeltaLinkScope(
                 link is ODataDeltaLink ? WriterState.DeltaLink : WriterState.DeltaDeletedLink,
@@ -1254,7 +1254,7 @@ namespace Microsoft.OData.JsonLight
                 navigationSource,
                 entityType,
                 selectedProperties,
-                ref odataUri);
+                in odataUri);
         }
 
         /// <summary>
@@ -1268,7 +1268,7 @@ namespace Microsoft.OData.JsonLight
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected override ResourceScope CreateResourceScope(ODataResource resource, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
+        protected override ResourceScope CreateResourceScope(ODataResource resource, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared)
         {
             return new JsonLightResourceScope(
                 resource,
@@ -1278,7 +1278,7 @@ namespace Microsoft.OData.JsonLight
                 skipWriting,
                 this.messageWriterSettings,
                 selectedProperties,
-                ref odataUri,
+                in odataUri,
                 isUndeclared);
         }
 
@@ -1293,10 +1293,10 @@ namespace Microsoft.OData.JsonLight
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly created JSON Light  nested resource info scope.</returns>
-        protected override NestedResourceInfoScope CreateNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+        protected override NestedResourceInfoScope CreateNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
         {
             Debug.Assert(this.CurrentScope != null, "Creating a nested resource info scope with a null parent scope.");
-            return new JsonLightNestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, this.CurrentScope);
+            return new JsonLightNestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, this.CurrentScope);
         }
 
         /// <summary>
@@ -3080,8 +3080,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="isUndeclared">true if the resource set is for an undeclared property</param>
-            internal JsonLightResourceSetScope(ODataResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
-                : base(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri)
+            internal JsonLightResourceSetScope(ODataResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared)
+                : base(resourceSet, navigationSource, itemType, skipWriting, selectedProperties, in odataUri)
             {
                 this.isUndeclared = isUndeclared;
             }
@@ -3158,9 +3158,9 @@ namespace Microsoft.OData.JsonLight
                 bool skipWriting,
                 ODataMessageWriterSettings writerSettings,
                 SelectedPropertiesNode selectedProperties,
-                ref ODataUriSlim odataUri,
+                in ODataUriSlim odataUri,
                 bool isUndeclared)
-                : base(resource, serializationInfo, navigationSource, resourceType, writerSettings, selectedProperties, ref odataUri)
+                : base(resource, serializationInfo, navigationSource, resourceType, writerSettings, selectedProperties, in odataUri)
             {
                 this.isUndeclared = isUndeclared;
             }
@@ -3342,8 +3342,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="resourceType">The structured type for the resource containing the property to be written.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            internal JsonLightPropertyScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(property, navigationSource, resourceType, selectedProperties, ref odataUri)
+            internal JsonLightPropertyScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(property, navigationSource, resourceType, selectedProperties, in odataUri)
             {
             }
         }
@@ -3363,8 +3363,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="entityType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            public JsonLightDeltaLinkScope(WriterState state, ODataItem link, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(state, link, serializationInfo, navigationSource, entityType, selectedProperties, ref odataUri)
+            public JsonLightDeltaLinkScope(WriterState state, ODataItem link, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(state, link, serializationInfo, navigationSource, entityType, selectedProperties, in odataUri)
             {
             }
         }
@@ -3388,8 +3388,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="resourceType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            public JsonLightDeltaResourceSetScope(ODataDeltaResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(resourceSet, navigationSource, resourceType, selectedProperties, ref odataUri)
+            public JsonLightDeltaResourceSetScope(ODataDeltaResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(resourceSet, navigationSource, resourceType, selectedProperties, in odataUri)
             {
             }
 
@@ -3457,9 +3457,9 @@ namespace Microsoft.OData.JsonLight
                 bool skipWriting,
                 ODataMessageWriterSettings writerSettings,
                 SelectedPropertiesNode selectedProperties,
-                ref ODataUriSlim odataUri,
+                in ODataUriSlim odataUri,
                 bool isUndeclared)
-                : base(resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, ref odataUri)
+                : base(resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, in odataUri)
             {
                 this.isUndeclared = isUndeclared;
             }
@@ -3651,8 +3651,8 @@ namespace Microsoft.OData.JsonLight
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="parentScope">The scope of the parent.</param>
-            internal JsonLightNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, Scope parentScope)
-                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, parentScope)
+            internal JsonLightNestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, Scope parentScope)
+                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, parentScope)
             {
             }
 
@@ -3697,7 +3697,7 @@ namespace Microsoft.OData.JsonLight
             {
                 ODataUriSlim odataUri = this.ODataUri;
 
-                return new JsonLightNestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, ref odataUri, this.parentScope)
+                return new JsonLightNestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, in odataUri, this.parentScope)
                 {
                     EntityReferenceLinkWritten = this.entityReferenceLinkWritten,
                     ResourceSetWritten = this.resourceSetWritten,

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -92,7 +92,7 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="value">The ODataValue to be used.</param>
         /// <param name="version">OData Version.</param>
-        /// <param name="odataUriSlim">The odata uri info for current query.</param>
+        /// <param name="odataUri">The odata uri info for current query.</param>
         /// <param name="model">The model used to handle unsigned int conversions.</param>
         /// <returns>The generated ODataContextUrlInfo.</returns>
         internal static ODataContextUrlInfo Create(ODataValue value, ODataVersion version, in ODataUriSlim odataUri, IEdmModel model = null)

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -88,6 +88,25 @@ namespace Microsoft.OData
         }
 
         /// <summary>
+        /// Create ODataContextUrlInfo for OdataValue.
+        /// </summary>
+        /// <param name="value">The ODataValue to be used.</param>
+        /// <param name="version">OData Version.</param>
+        /// <param name="odataUriSlim">The odata uri info for current query.</param>
+        /// <param name="model">The model used to handle unsigned int conversions.</param>
+        /// <returns>The generated ODataContextUrlInfo.</returns>
+        internal static ODataContextUrlInfo Create(ODataValue value, ODataVersion version, in ODataUriSlim odataUri, IEdmModel model = null)
+        {
+            return new ODataContextUrlInfo()
+            {
+                TypeName = GetTypeNameForValue(value, model),
+                ResourcePath = ComputeResourcePath(odataUri),
+                QueryClause = ComputeQueryClause(odataUri, version),
+                IsUndeclared = ComputeIfIsUndeclared(odataUri)
+            };
+        }
+
+        /// <summary>
         /// Create ODataContextUrlInfo from ODataCollectionStartSerializationInfo
         /// </summary>
         /// <param name="info">The ODataCollectionStartSerializationInfo to be used.</param>
@@ -121,6 +140,33 @@ namespace Microsoft.OData
         /// <param name="version">The OData Version of the response.</param>
         /// <returns>The generated ODataContextUrlInfo.</returns>
         internal static ODataContextUrlInfo Create(IEdmNavigationSource navigationSource, string expectedEntityTypeName, bool isSingle, ODataUri odataUri, ODataVersion version)
+        {
+            EdmNavigationSourceKind kind = navigationSource.NavigationSourceKind();
+            string navigationSourceEntityType = navigationSource.EntityType().FullName();
+            return new ODataContextUrlInfo()
+            {
+                IsUnknownEntitySet = kind == EdmNavigationSourceKind.UnknownEntitySet,
+                NavigationSource = navigationSource.Name,
+                TypeCast = navigationSourceEntityType == expectedEntityTypeName ? null : expectedEntityTypeName,
+                TypeName = navigationSourceEntityType,
+                IncludeFragmentItemSelector = isSingle && kind != EdmNavigationSourceKind.Singleton,
+                NavigationPath = ComputeNavigationPath(kind, odataUri, navigationSource.Name),
+                ResourcePath = ComputeResourcePath(odataUri),
+                QueryClause = ComputeQueryClause(odataUri, version),
+                IsUndeclared = ComputeIfIsUndeclared(odataUri)
+            };
+        }
+
+        /// <summary>
+        /// Create ODataContextUrlInfo from basic information
+        /// </summary>
+        /// <param name="navigationSource">Navigation source for current element.</param>\
+        /// <param name="expectedEntityTypeName">The expectedEntity for current element.</param>
+        /// <param name="isSingle">Whether target is single item.</param>
+        /// <param name="odataUri">The odata uri info for current query.</param>
+        /// <param name="version">The OData Version of the response.</param>
+        /// <returns>The generated ODataContextUrlInfo.</returns>
+        internal static ODataContextUrlInfo Create(IEdmNavigationSource navigationSource, string expectedEntityTypeName, bool isSingle, in ODataUriSlim odataUri, ODataVersion version)
         {
             EdmNavigationSourceKind kind = navigationSource.NavigationSourceKind();
             string navigationSourceEntityType = navigationSource.EntityType().FullName();
@@ -263,9 +309,44 @@ namespace Microsoft.OData
             return navigationPath ?? navigationSource;
         }
 
+        private static string ComputeNavigationPath(EdmNavigationSourceKind kind, in ODataUriSlim odataUri, string navigationSource)
+        {
+            if (kind == EdmNavigationSourceKind.UnknownEntitySet)
+            {
+                // If the navigation target is not specified, i.e., UnknownEntitySet,
+                // the navigation path should be null so that type name will be used
+                // to build the context Url.
+                return null;
+            }
+
+            string navigationPath = null;
+            if (kind == EdmNavigationSourceKind.ContainedEntitySet && odataUri.Path != null)
+            {
+                ODataPath odataPath = odataUri.Path.TrimEndingTypeSegment().TrimEndingKeySegment();
+                if (!(odataPath.LastSegment is NavigationPropertySegment) && !(odataPath.LastSegment is OperationSegment))
+                {
+                    throw new ODataException(Strings.ODataContextUriBuilder_ODataPathInvalidForContainedElement(odataPath.ToContextUrlPathString()));
+                }
+
+                navigationPath = odataPath.ToContextUrlPathString();
+            }
+
+            return navigationPath ?? navigationSource;
+        }
+
         private static string ComputeResourcePath(ODataUri odataUri)
         {
             if (odataUri != null && odataUri.Path != null && odataUri.Path.IsIndividualProperty())
+            {
+                return odataUri.Path.ToContextUrlPathString();
+            }
+
+            return string.Empty;
+        }
+
+        private static string ComputeResourcePath(in ODataUriSlim odataUri)
+        {
+            if (odataUri.Path != null && odataUri.Path.IsIndividualProperty())
             {
                 return odataUri.Path.ToContextUrlPathString();
             }
@@ -290,9 +371,33 @@ namespace Microsoft.OData
             return null;
         }
 
+        private static string ComputeQueryClause(in ODataUriSlim odataUri, ODataVersion version)
+        {
+            if (odataUri.SelectAndExpand != null)
+            {
+                return CreateSelectExpandContextUriSegment(odataUri.SelectAndExpand);
+            }
+            else if (odataUri.Apply != null)
+            {
+                return CreateApplyUriSegment(odataUri.Apply);
+            }
+
+            return null;
+        }
+
         private static bool? ComputeIfIsUndeclared(ODataUri odataUri)
         {
             if (odataUri != null && odataUri.Path != null)
+            {
+                return odataUri.Path.IsUndeclared();
+            }
+
+            return null;
+        }
+
+        private static bool? ComputeIfIsUndeclared(in ODataUriSlim odataUri)
+        {
+            if (odataUri.Path != null)
             {
                 return odataUri.Path.IsUndeclared();
             }

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -70,17 +70,17 @@ namespace Microsoft.OData
                 resourceType = this.outputContext.EdmTypeResolver.GetElementType(navigationSource);
             }
 
-            ODataUri odataUri = outputContext.MessageWriterSettings.ODataUri.Clone();
+            ODataUriSlim odataUri = new ODataUriSlim(outputContext.MessageWriterSettings.ODataUri);
 
             // Remove key for top level resource
-            if (!writingResourceSet && odataUri != null && odataUri.Path != null)
+            if (!writingResourceSet && odataUri.Path != null)
             {
                 odataUri.Path = odataUri.Path.TrimEndingKeySegment();
             }
 
             this.listener = listener;
 
-            this.scopeStack.Push(new Scope(WriterState.Start, /*item*/null, navigationSource, resourceType, /*skipWriting*/false, outputContext.MessageWriterSettings.SelectedProperties, odataUri, /*enableDelta*/ true));
+            this.scopeStack.Push(new Scope(WriterState.Start, /*item*/null, navigationSource, resourceType, /*skipWriting*/false, outputContext.MessageWriterSettings.SelectedProperties, ref odataUri, /*enableDelta*/ true));
             this.CurrentScope.DerivedTypeConstraints = this.outputContext.Model.GetDerivedTypeConstraints(navigationSource)?.ToList();
         }
 
@@ -1070,7 +1070,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource set is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected abstract ResourceSetScope CreateResourceSetScope(ODataResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool isUndeclared);
+        protected abstract ResourceSetScope CreateResourceSetScope(ODataResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared);
 
         /// <summary>
         /// Create a new delta resource set scope.
@@ -1083,7 +1083,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource set is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected virtual DeltaResourceSetScope CreateDeltaResourceSetScope(ODataDeltaResourceSet deltaResourceSet, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool isUndeclared)
+        protected virtual DeltaResourceSetScope CreateDeltaResourceSetScope(ODataDeltaResourceSet deltaResourceSet, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
         {
             throw new NotImplementedException();
         }
@@ -1099,7 +1099,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected abstract ResourceScope CreateResourceScope(ODataResource resource, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool isUndeclared);
+        protected abstract ResourceScope CreateResourceScope(ODataResource resource, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared);
 
         /// <summary>
         /// Create a new resource scope.
@@ -1112,7 +1112,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected virtual DeletedResourceScope CreateDeletedResourceScope(ODataDeletedResource resource, IEdmNavigationSource navigationSource, IEdmEntityType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool isUndeclared)
+        protected virtual DeletedResourceScope CreateDeletedResourceScope(ODataDeletedResource resource, IEdmNavigationSource navigationSource, IEdmEntityType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
         {
             throw new NotImplementedException();
         }
@@ -1126,7 +1126,7 @@ namespace Microsoft.OData
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly created property scope.</returns>
-        protected virtual PropertyInfoScope CreatePropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
+        protected virtual PropertyInfoScope CreatePropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
         {
             throw new NotImplementedException();
         }
@@ -1140,7 +1140,7 @@ namespace Microsoft.OData
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly create scope.</returns>
-        protected virtual DeltaLinkScope CreateDeltaLinkScope(ODataDeltaLinkBase link, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
+        protected virtual DeltaLinkScope CreateDeltaLinkScope(ODataDeltaLinkBase link, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
         {
             throw new NotImplementedException();
         }
@@ -1239,10 +1239,10 @@ namespace Microsoft.OData
             IEdmType itemType,
             bool skipWriting,
             SelectedPropertiesNode selectedProperties,
-            ODataUri odataUri)
+            ref ODataUriSlim odataUri)
         {
             Debug.Assert(this.CurrentScope != null, "Creating a nested resource info scope with a null parent scope.");
-            return new NestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, odataUri, this.CurrentScope);
+            return new NestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, this.CurrentScope);
         }
 
         /// <summary>
@@ -2555,10 +2555,10 @@ namespace Microsoft.OData
             IEdmNavigationSource navigationSource = null;
             IEdmType itemType = null;
             SelectedPropertiesNode selectedProperties = currentScope.SelectedProperties;
-            ODataUri odataUri = currentScope.ODataUri.Clone();
-            if (odataUri.Path == null)
+            ODataUriSlim odataUriSlim = new ODataUriSlim(currentScope.ODataUri);
+            if (odataUriSlim.Path == null)
             {
-                odataUri.Path = new ODataPath();
+                odataUriSlim.Path = new ODataPath();
             }
 
             IEnumerable<string> derivedTypeConstraints = null;
@@ -2595,8 +2595,9 @@ namespace Microsoft.OData
                                 if (serializationInfo.NavigationSourceName != null)
                                 {
                                     ODataUriParser uriParser = new ODataUriParser(model, new Uri(serializationInfo.NavigationSourceName, UriKind.Relative), this.outputContext.Container);
-                                    odataUri = uriParser.ParseUri();
-                                    navigationSource = odataUri.Path.NavigationSource();
+                                    ODataUri odataUri = uriParser.ParseUri();
+                                    odataUriSlim = new ODataUriSlim(odataUri);
+                                    navigationSource = odataUriSlim.Path.NavigationSource();
                                     itemType = itemType ?? navigationSource.EntityType();
                                 }
 
@@ -2679,7 +2680,7 @@ namespace Microsoft.OData
                 {
                     selectedProperties = currentScope.SelectedProperties.GetSelectedPropertiesForNavigationProperty(currentScope.ResourceType, nestedResourceInfo.Name);
 
-                    ODataPath odataPath = odataUri.Path;
+                    ODataPath odataPath = odataUriSlim.Path;
                     IEdmStructuredType currentResourceType = currentScope.ResourceType;
 
                     ResourceBaseScope resourceScope = currentScope as ResourceBaseScope;
@@ -2734,13 +2735,13 @@ namespace Microsoft.OData
                                 ? null
                                 : currentNavigationSource.FindNavigationTarget(navigationProperty, BindingPathHelper.MatchBindingPath, odataPath.Segments, out bindingPath);
 
-                            SelectExpandClause clause = odataUri.SelectAndExpand;
+                            SelectExpandClause clause = odataUriSlim.SelectAndExpand;
                             TypeSegment typeCastFromExpand = null;
                             if (clause != null)
                             {
                                 SelectExpandClause subClause;
                                 clause.GetSubSelectExpandClause(nestedResourceInfo.Name, out subClause, out typeCastFromExpand);
-                                odataUri.SelectAndExpand = subClause;
+                                odataUriSlim.SelectAndExpand = subClause;
                             }
 
                             switch (navigationSource.NavigationSourceKind())
@@ -2776,7 +2777,7 @@ namespace Microsoft.OData
                         }
                     }
 
-                    odataUri.Path = odataPath;
+                    odataUriSlim.Path = odataPath;
                 }
             }
             else if ((currentState == WriterState.ResourceSet || currentState == WriterState.DeltaResourceSet) && (newState == WriterState.Resource || newState == WriterState.Primitive || newState == WriterState.ResourceSet || newState == WriterState.DeletedResource))
@@ -2790,10 +2791,10 @@ namespace Microsoft.OData
 
             if (navigationSource == null)
             {
-                navigationSource = this.CurrentScope.NavigationSource ?? odataUri.Path.TargetNavigationSource();
+                navigationSource = this.CurrentScope.NavigationSource ?? odataUriSlim.Path.TargetNavigationSource();
             }
 
-            this.PushScope(newState, item, navigationSource, itemType, skipWriting, selectedProperties, odataUri, derivedTypeConstraints);
+            this.PushScope(newState, item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUriSlim, derivedTypeConstraints);
 
             this.NotifyListener(newState);
         }
@@ -2842,7 +2843,8 @@ namespace Microsoft.OData
             {
                 Scope startScope = this.scopeStack.Pop();
                 Debug.Assert(startScope.State == WriterState.Start, "startScope.State == WriterState.Start");
-                this.PushScope(WriterState.Completed, /*item*/null, startScope.NavigationSource, startScope.ResourceType, /*skipWriting*/false, startScope.SelectedProperties, startScope.ODataUri, null);
+                ODataUriSlim odataUri = startScope.ODataUri;
+                this.PushScope(WriterState.Completed, /*item*/null, startScope.NavigationSource, startScope.ResourceType, /*skipWriting*/false, startScope.SelectedProperties, ref odataUri, null);
                 this.InterceptException((thisParam) => thisParam.EndPayload());
                 this.NotifyListener(WriterState.Completed);
             }
@@ -3030,7 +3032,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The OdataUri info of this scope.</param>
         /// <param name="derivedTypeConstraints">The derived type constraints.</param>
         [SuppressMessage("Microsoft.Performance", "CA1800:DoNotCastUnnecessarily", Justification = "Debug.Assert check only.")]
-        private void PushScope(WriterState state, ODataItem item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri,
+        private void PushScope(WriterState state, ODataItem item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri,
             IEnumerable<string> derivedTypeConstraints)
         {
             IEdmStructuredType resourceType = itemType as IEdmStructuredType;
@@ -3064,17 +3066,17 @@ namespace Microsoft.OData
             switch (state)
             {
                 case WriterState.Resource:
-                    scope = this.CreateResourceScope((ODataResource)item, navigationSource, resourceType, skipWriting, selectedProperties, odataUri, isUndeclaredResourceOrResourceSet);
+                    scope = this.CreateResourceScope((ODataResource)item, navigationSource, resourceType, skipWriting, selectedProperties, ref odataUri, isUndeclaredResourceOrResourceSet);
                     break;
                 case WriterState.DeletedResource:
-                    scope = this.CreateDeletedResourceScope((ODataDeletedResource)item, navigationSource, (IEdmEntityType)itemType, skipWriting, selectedProperties, odataUri, isUndeclaredResourceOrResourceSet);
+                    scope = this.CreateDeletedResourceScope((ODataDeletedResource)item, navigationSource, (IEdmEntityType)itemType, skipWriting, selectedProperties, ref odataUri, isUndeclaredResourceOrResourceSet);
                     break;
                 case WriterState.DeltaLink:
                 case WriterState.DeltaDeletedLink:
-                    scope = this.CreateDeltaLinkScope((ODataDeltaLinkBase)item, navigationSource, (IEdmEntityType)itemType, selectedProperties, odataUri);
+                    scope = this.CreateDeltaLinkScope((ODataDeltaLinkBase)item, navigationSource, (IEdmEntityType)itemType, selectedProperties, ref odataUri);
                     break;
                 case WriterState.ResourceSet:
-                    scope = this.CreateResourceSetScope((ODataResourceSet)item, navigationSource, itemType, skipWriting, selectedProperties, odataUri, isUndeclaredResourceOrResourceSet);
+                    scope = this.CreateResourceSetScope((ODataResourceSet)item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, isUndeclaredResourceOrResourceSet);
                     if (this.outputContext.Model.IsUserModel())
                     {
                         Debug.Assert(scope is ResourceSetBaseScope, "Create a scope for a resource set that is not a ResourceSetBaseScope");
@@ -3083,7 +3085,7 @@ namespace Microsoft.OData
 
                     break;
                 case WriterState.DeltaResourceSet:
-                    scope = this.CreateDeltaResourceSetScope((ODataDeltaResourceSet)item, navigationSource, resourceType, skipWriting, selectedProperties, odataUri, isUndeclaredResourceOrResourceSet);
+                    scope = this.CreateDeltaResourceSetScope((ODataDeltaResourceSet)item, navigationSource, resourceType, skipWriting, selectedProperties, ref odataUri, isUndeclaredResourceOrResourceSet);
                     if (this.outputContext.Model.IsUserModel())
                     {
                         Debug.Assert(scope is ResourceSetBaseScope, "Create a scope for a delta resource set that is not a ResourceSetBaseScope");
@@ -3092,21 +3094,21 @@ namespace Microsoft.OData
 
                     break;
                 case WriterState.Property:
-                    scope = this.CreatePropertyInfoScope((ODataPropertyInfo)item, navigationSource, resourceType, selectedProperties, odataUri);
+                    scope = this.CreatePropertyInfoScope((ODataPropertyInfo)item, navigationSource, resourceType, selectedProperties, ref odataUri);
                     break;
                 case WriterState.NestedResourceInfo:            // fall through
                 case WriterState.NestedResourceInfoWithContent:
-                    scope = this.CreateNestedResourceInfoScope(state, (ODataNestedResourceInfo)item, navigationSource, itemType, skipWriting, selectedProperties, odataUri);
+                    scope = this.CreateNestedResourceInfoScope(state, (ODataNestedResourceInfo)item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri);
                     break;
                 case WriterState.Start:
-                    scope = new Scope(state, item, navigationSource, itemType, skipWriting, selectedProperties, odataUri, /*enableDelta*/ true);
+                    scope = new Scope(state, item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, /*enableDelta*/ true);
                     break;
                 case WriterState.Primitive:                 // fall through
                 case WriterState.Stream:                    // fall through
                 case WriterState.String:                    // fall through
                 case WriterState.Completed:                 // fall through
                 case WriterState.Error:
-                    scope = new Scope(state, item, navigationSource, itemType, skipWriting, selectedProperties, odataUri, /*enableDelta*/ false);
+                    scope = new Scope(state, item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, /*enableDelta*/ false);
                     break;
                 default:
                     string errorMessage = Strings.General_InternalError(InternalErrorCodes.ODataWriterCore_Scope_Create_UnreachableCodePath);
@@ -3646,6 +3648,7 @@ namespace Microsoft.OData
             {
                 Scope startScope = this.scopeStack.Pop();
                 Debug.Assert(startScope.State == WriterState.Start, "startScope.State == WriterState.Start");
+                ODataUriSlim odataUri = startScope.ODataUri;
                 this.PushScope(
                     WriterState.Completed,
                     /*item*/ null,
@@ -3653,7 +3656,7 @@ namespace Microsoft.OData
                     startScope.ResourceType,
                     /*skipWriting*/ false,
                     startScope.SelectedProperties,
-                    startScope.ODataUri,
+                    ref odataUri,
                     /*derivedTypeConstraints*/ null);
                 await this.InterceptExceptionAsync((thisParam) => thisParam.EndPayloadAsync(), this.CurrentScope.Item)
                     .ConfigureAwait(false);
@@ -3786,7 +3789,7 @@ namespace Microsoft.OData
             private IEdmType itemType;
 
             /// <summary>The odata uri info for current scope.</summary>
-            private ODataUri odataUri;
+            private ODataUriSlim odataUri;
 
             /// <summary>Whether we are in the context of writing a delta collection.</summary>
             private bool enableDelta;
@@ -3802,7 +3805,7 @@ namespace Microsoft.OData
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="enableDelta">Whether we are in the context of writing a delta collection.</param>
-            internal Scope(WriterState state, ODataItem item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool enableDelta)
+            internal Scope(WriterState state, ODataItem item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool enableDelta)
             {
                 this.state = state;
                 this.item = item;
@@ -3895,11 +3898,10 @@ namespace Microsoft.OData
             }
 
             /// <summary>The odata Uri for the current scope.</summary>
-            internal ODataUri ODataUri
+            internal ODataUriSlim ODataUri
             {
                 get
                 {
-                    Debug.Assert(this.odataUri != null, "this.odataUri != null");
                     return this.odataUri;
                 }
             }
@@ -3967,8 +3969,8 @@ namespace Microsoft.OData
             /// <param name="skipWriting">true if the content of the scope to create should not be written.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            internal ResourceSetBaseScope(WriterState writerState, ODataResourceSetBase resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(writerState, resourceSet, navigationSource, itemType, skipWriting, selectedProperties, odataUri, writerState == WriterState.DeltaResourceSet)
+            internal ResourceSetBaseScope(WriterState writerState, ODataResourceSetBase resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(writerState, resourceSet, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, writerState == WriterState.DeltaResourceSet)
             {
                 this.serializationInfo = resourceSet.SerializationInfo;
             }
@@ -4061,8 +4063,8 @@ namespace Microsoft.OData
             /// <param name="skipWriting">true if the content of the scope to create should not be written.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected ResourceSetScope(ODataResourceSet item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(WriterState.ResourceSet, item, navigationSource, itemType, skipWriting, selectedProperties, odataUri)
+            protected ResourceSetScope(ODataResourceSet item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(WriterState.ResourceSet, item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri)
             {
             }
         }
@@ -4080,8 +4082,8 @@ namespace Microsoft.OData
             /// <param name="resourceType">The structured type of the items in the resource set to be written (or null if the entity set base type should be used).</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected DeltaResourceSetScope(ODataDeltaResourceSet item, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(WriterState.DeltaResourceSet, item, navigationSource, resourceType, false /*skip writing*/, selectedProperties, odataUri)
+            protected DeltaResourceSetScope(ODataDeltaResourceSet item, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(WriterState.DeltaResourceSet, item, navigationSource, resourceType, false /*skip writing*/, selectedProperties, ref odataUri)
             {
             }
 
@@ -4123,8 +4125,8 @@ namespace Microsoft.OData
             /// <param name="writerSettings">The <see cref="ODataMessageWriterSettings"/> The settings of the writer.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            internal ResourceBaseScope(WriterState state, ODataResourceBase resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(state, resource, navigationSource, itemType, skipWriting, selectedProperties, odataUri, /*enableDelta*/ true)
+            internal ResourceBaseScope(WriterState state, ODataResourceBase resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(state, resource, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, /*enableDelta*/ true)
             {
                 Debug.Assert(writerSettings != null, "writerBehavior != null");
 
@@ -4230,8 +4232,8 @@ namespace Microsoft.OData
             /// <param name="writerSettings">The <see cref="ODataMessageWriterSettings"/> The settings of the writer.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected ResourceScope(ODataResource resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(WriterState.Resource, resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, odataUri)
+            protected ResourceScope(ODataResource resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(WriterState.Resource, resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, ref odataUri)
             {
             }
         }
@@ -4251,8 +4253,8 @@ namespace Microsoft.OData
             /// <param name="writerSettings">The <see cref="ODataMessageWriterSettings"/> The settings of the writer.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected DeletedResourceScope(ODataDeletedResource resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(WriterState.DeletedResource, resource, serializationInfo, navigationSource, entityType, false /*skipWriting*/, writerSettings, selectedProperties, odataUri)
+            protected DeletedResourceScope(ODataDeletedResource resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(WriterState.DeletedResource, resource, serializationInfo, navigationSource, entityType, false /*skipWriting*/, writerSettings, selectedProperties, ref odataUri)
             {
             }
         }
@@ -4283,8 +4285,8 @@ namespace Microsoft.OData
             /// <param name="entityType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected DeltaLinkScope(WriterState state, ODataItem link, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(state, link, navigationSource, entityType, /*skipWriting*/false, selectedProperties, odataUri, /*enableDelta*/ false)
+            protected DeltaLinkScope(WriterState state, ODataItem link, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(state, link, navigationSource, entityType, /*skipWriting*/false, selectedProperties, ref odataUri, /*enableDelta*/ false)
             {
                 Debug.Assert(link != null, "link != null");
                 Debug.Assert(
@@ -4329,8 +4331,8 @@ namespace Microsoft.OData
             /// <param name="resourceType">The structured type for the resource containing the property to be written.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            internal PropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ODataUri odataUri)
-                : base(WriterState.Property, property, navigationSource, resourceType, /*skipWriting*/ false, selectedProperties, odataUri, /*enableDelta*/ true)
+            internal PropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+                : base(WriterState.Property, property, navigationSource, resourceType, /*skipWriting*/ false, selectedProperties, ref odataUri, /*enableDelta*/ true)
             {
                 ValueWritten = false;
             }
@@ -4363,8 +4365,8 @@ namespace Microsoft.OData
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="parentScope">The scope of the parent.</param>
-            internal NestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, Scope parentScope)
-                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, odataUri, parentScope.EnableDelta)
+            internal NestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, Scope parentScope)
+                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, parentScope.EnableDelta)
             {
                 this.parentScope = parentScope;
             }
@@ -4379,7 +4381,9 @@ namespace Microsoft.OData
             /// <returns>The cloned nested resource info scope with the specified writer state.</returns>
             internal virtual NestedResourceInfoScope Clone(WriterState newWriterState)
             {
-                return new NestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, this.ODataUri, parentScope)
+                ODataUriSlim odataUri = this.ODataUri;
+
+                return new NestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, ref odataUri, parentScope)
                 {
                     DerivedTypeConstraints = this.DerivedTypeConstraints,
                 };

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -80,7 +80,7 @@ namespace Microsoft.OData
 
             this.listener = listener;
 
-            this.scopeStack.Push(new Scope(WriterState.Start, /*item*/null, navigationSource, resourceType, /*skipWriting*/false, outputContext.MessageWriterSettings.SelectedProperties, ref odataUri, /*enableDelta*/ true));
+            this.scopeStack.Push(new Scope(WriterState.Start, /*item*/null, navigationSource, resourceType, /*skipWriting*/false, outputContext.MessageWriterSettings.SelectedProperties, in odataUri, /*enableDelta*/ true));
             this.CurrentScope.DerivedTypeConstraints = this.outputContext.Model.GetDerivedTypeConstraints(navigationSource)?.ToList();
         }
 
@@ -1070,7 +1070,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource set is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected abstract ResourceSetScope CreateResourceSetScope(ODataResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared);
+        protected abstract ResourceSetScope CreateResourceSetScope(ODataResourceSet resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared);
 
         /// <summary>
         /// Create a new delta resource set scope.
@@ -1083,7 +1083,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource set is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected virtual DeltaResourceSetScope CreateDeltaResourceSetScope(ODataDeltaResourceSet deltaResourceSet, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
+        protected virtual DeltaResourceSetScope CreateDeltaResourceSetScope(ODataDeltaResourceSet deltaResourceSet, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared)
         {
             throw new NotImplementedException();
         }
@@ -1099,7 +1099,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected abstract ResourceScope CreateResourceScope(ODataResource resource, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared);
+        protected abstract ResourceScope CreateResourceScope(ODataResource resource, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared);
 
         /// <summary>
         /// Create a new resource scope.
@@ -1112,7 +1112,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <param name="isUndeclared">true if the resource is for an undeclared property</param>
         /// <returns>The newly create scope.</returns>
-        protected virtual DeletedResourceScope CreateDeletedResourceScope(ODataDeletedResource resource, IEdmNavigationSource navigationSource, IEdmEntityType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool isUndeclared)
+        protected virtual DeletedResourceScope CreateDeletedResourceScope(ODataDeletedResource resource, IEdmNavigationSource navigationSource, IEdmEntityType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared)
         {
             throw new NotImplementedException();
         }
@@ -1126,7 +1126,7 @@ namespace Microsoft.OData
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly created property scope.</returns>
-        protected virtual PropertyInfoScope CreatePropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+        protected virtual PropertyInfoScope CreatePropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
         {
             throw new NotImplementedException();
         }
@@ -1140,7 +1140,7 @@ namespace Microsoft.OData
         /// <param name="selectedProperties">The selected properties of this scope.</param>
         /// <param name="odataUri">The ODataUri info of this scope.</param>
         /// <returns>The newly create scope.</returns>
-        protected virtual DeltaLinkScope CreateDeltaLinkScope(ODataDeltaLinkBase link, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
+        protected virtual DeltaLinkScope CreateDeltaLinkScope(ODataDeltaLinkBase link, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
         {
             throw new NotImplementedException();
         }
@@ -1239,10 +1239,10 @@ namespace Microsoft.OData
             IEdmType itemType,
             bool skipWriting,
             SelectedPropertiesNode selectedProperties,
-            ref ODataUriSlim odataUri)
+            in ODataUriSlim odataUri)
         {
             Debug.Assert(this.CurrentScope != null, "Creating a nested resource info scope with a null parent scope.");
-            return new NestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, this.CurrentScope);
+            return new NestedResourceInfoScope(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, this.CurrentScope);
         }
 
         /// <summary>
@@ -2794,7 +2794,7 @@ namespace Microsoft.OData
                 navigationSource = this.CurrentScope.NavigationSource ?? odataUriSlim.Path.TargetNavigationSource();
             }
 
-            this.PushScope(newState, item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUriSlim, derivedTypeConstraints);
+            this.PushScope(newState, item, navigationSource, itemType, skipWriting, selectedProperties, in odataUriSlim, derivedTypeConstraints);
 
             this.NotifyListener(newState);
         }
@@ -2844,7 +2844,7 @@ namespace Microsoft.OData
                 Scope startScope = this.scopeStack.Pop();
                 Debug.Assert(startScope.State == WriterState.Start, "startScope.State == WriterState.Start");
                 ODataUriSlim odataUri = startScope.ODataUri;
-                this.PushScope(WriterState.Completed, /*item*/null, startScope.NavigationSource, startScope.ResourceType, /*skipWriting*/false, startScope.SelectedProperties, ref odataUri, null);
+                this.PushScope(WriterState.Completed, /*item*/null, startScope.NavigationSource, startScope.ResourceType, /*skipWriting*/false, startScope.SelectedProperties, in odataUri, null);
                 this.InterceptException((thisParam) => thisParam.EndPayload());
                 this.NotifyListener(WriterState.Completed);
             }
@@ -3032,7 +3032,7 @@ namespace Microsoft.OData
         /// <param name="odataUri">The OdataUri info of this scope.</param>
         /// <param name="derivedTypeConstraints">The derived type constraints.</param>
         [SuppressMessage("Microsoft.Performance", "CA1800:DoNotCastUnnecessarily", Justification = "Debug.Assert check only.")]
-        private void PushScope(WriterState state, ODataItem item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri,
+        private void PushScope(WriterState state, ODataItem item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri,
             IEnumerable<string> derivedTypeConstraints)
         {
             IEdmStructuredType resourceType = itemType as IEdmStructuredType;
@@ -3066,17 +3066,17 @@ namespace Microsoft.OData
             switch (state)
             {
                 case WriterState.Resource:
-                    scope = this.CreateResourceScope((ODataResource)item, navigationSource, resourceType, skipWriting, selectedProperties, ref odataUri, isUndeclaredResourceOrResourceSet);
+                    scope = this.CreateResourceScope((ODataResource)item, navigationSource, resourceType, skipWriting, selectedProperties, in odataUri, isUndeclaredResourceOrResourceSet);
                     break;
                 case WriterState.DeletedResource:
-                    scope = this.CreateDeletedResourceScope((ODataDeletedResource)item, navigationSource, (IEdmEntityType)itemType, skipWriting, selectedProperties, ref odataUri, isUndeclaredResourceOrResourceSet);
+                    scope = this.CreateDeletedResourceScope((ODataDeletedResource)item, navigationSource, (IEdmEntityType)itemType, skipWriting, selectedProperties, in odataUri, isUndeclaredResourceOrResourceSet);
                     break;
                 case WriterState.DeltaLink:
                 case WriterState.DeltaDeletedLink:
-                    scope = this.CreateDeltaLinkScope((ODataDeltaLinkBase)item, navigationSource, (IEdmEntityType)itemType, selectedProperties, ref odataUri);
+                    scope = this.CreateDeltaLinkScope((ODataDeltaLinkBase)item, navigationSource, (IEdmEntityType)itemType, selectedProperties, in odataUri);
                     break;
                 case WriterState.ResourceSet:
-                    scope = this.CreateResourceSetScope((ODataResourceSet)item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, isUndeclaredResourceOrResourceSet);
+                    scope = this.CreateResourceSetScope((ODataResourceSet)item, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, isUndeclaredResourceOrResourceSet);
                     if (this.outputContext.Model.IsUserModel())
                     {
                         Debug.Assert(scope is ResourceSetBaseScope, "Create a scope for a resource set that is not a ResourceSetBaseScope");
@@ -3085,7 +3085,7 @@ namespace Microsoft.OData
 
                     break;
                 case WriterState.DeltaResourceSet:
-                    scope = this.CreateDeltaResourceSetScope((ODataDeltaResourceSet)item, navigationSource, resourceType, skipWriting, selectedProperties, ref odataUri, isUndeclaredResourceOrResourceSet);
+                    scope = this.CreateDeltaResourceSetScope((ODataDeltaResourceSet)item, navigationSource, resourceType, skipWriting, selectedProperties, in odataUri, isUndeclaredResourceOrResourceSet);
                     if (this.outputContext.Model.IsUserModel())
                     {
                         Debug.Assert(scope is ResourceSetBaseScope, "Create a scope for a delta resource set that is not a ResourceSetBaseScope");
@@ -3094,21 +3094,21 @@ namespace Microsoft.OData
 
                     break;
                 case WriterState.Property:
-                    scope = this.CreatePropertyInfoScope((ODataPropertyInfo)item, navigationSource, resourceType, selectedProperties, ref odataUri);
+                    scope = this.CreatePropertyInfoScope((ODataPropertyInfo)item, navigationSource, resourceType, selectedProperties, in odataUri);
                     break;
                 case WriterState.NestedResourceInfo:            // fall through
                 case WriterState.NestedResourceInfoWithContent:
-                    scope = this.CreateNestedResourceInfoScope(state, (ODataNestedResourceInfo)item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri);
+                    scope = this.CreateNestedResourceInfoScope(state, (ODataNestedResourceInfo)item, navigationSource, itemType, skipWriting, selectedProperties, in odataUri);
                     break;
                 case WriterState.Start:
-                    scope = new Scope(state, item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, /*enableDelta*/ true);
+                    scope = new Scope(state, item, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, /*enableDelta*/ true);
                     break;
                 case WriterState.Primitive:                 // fall through
                 case WriterState.Stream:                    // fall through
                 case WriterState.String:                    // fall through
                 case WriterState.Completed:                 // fall through
                 case WriterState.Error:
-                    scope = new Scope(state, item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, /*enableDelta*/ false);
+                    scope = new Scope(state, item, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, /*enableDelta*/ false);
                     break;
                 default:
                     string errorMessage = Strings.General_InternalError(InternalErrorCodes.ODataWriterCore_Scope_Create_UnreachableCodePath);
@@ -3656,7 +3656,7 @@ namespace Microsoft.OData
                     startScope.ResourceType,
                     /*skipWriting*/ false,
                     startScope.SelectedProperties,
-                    ref odataUri,
+                    in odataUri,
                     /*derivedTypeConstraints*/ null);
                 await this.InterceptExceptionAsync((thisParam) => thisParam.EndPayloadAsync(), this.CurrentScope.Item)
                     .ConfigureAwait(false);
@@ -3805,7 +3805,7 @@ namespace Microsoft.OData
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="enableDelta">Whether we are in the context of writing a delta collection.</param>
-            internal Scope(WriterState state, ODataItem item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, bool enableDelta)
+            internal Scope(WriterState state, ODataItem item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool enableDelta)
             {
                 this.state = state;
                 this.item = item;
@@ -3969,8 +3969,8 @@ namespace Microsoft.OData
             /// <param name="skipWriting">true if the content of the scope to create should not be written.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            internal ResourceSetBaseScope(WriterState writerState, ODataResourceSetBase resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(writerState, resourceSet, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, writerState == WriterState.DeltaResourceSet)
+            internal ResourceSetBaseScope(WriterState writerState, ODataResourceSetBase resourceSet, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(writerState, resourceSet, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, writerState == WriterState.DeltaResourceSet)
             {
                 this.serializationInfo = resourceSet.SerializationInfo;
             }
@@ -4063,8 +4063,8 @@ namespace Microsoft.OData
             /// <param name="skipWriting">true if the content of the scope to create should not be written.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected ResourceSetScope(ODataResourceSet item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(WriterState.ResourceSet, item, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri)
+            protected ResourceSetScope(ODataResourceSet item, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(WriterState.ResourceSet, item, navigationSource, itemType, skipWriting, selectedProperties, in odataUri)
             {
             }
         }
@@ -4082,8 +4082,8 @@ namespace Microsoft.OData
             /// <param name="resourceType">The structured type of the items in the resource set to be written (or null if the entity set base type should be used).</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected DeltaResourceSetScope(ODataDeltaResourceSet item, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(WriterState.DeltaResourceSet, item, navigationSource, resourceType, false /*skip writing*/, selectedProperties, ref odataUri)
+            protected DeltaResourceSetScope(ODataDeltaResourceSet item, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(WriterState.DeltaResourceSet, item, navigationSource, resourceType, false /*skip writing*/, selectedProperties, in odataUri)
             {
             }
 
@@ -4125,8 +4125,8 @@ namespace Microsoft.OData
             /// <param name="writerSettings">The <see cref="ODataMessageWriterSettings"/> The settings of the writer.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            internal ResourceBaseScope(WriterState state, ODataResourceBase resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(state, resource, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, /*enableDelta*/ true)
+            internal ResourceBaseScope(WriterState state, ODataResourceBase resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(state, resource, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, /*enableDelta*/ true)
             {
                 Debug.Assert(writerSettings != null, "writerBehavior != null");
 
@@ -4232,8 +4232,8 @@ namespace Microsoft.OData
             /// <param name="writerSettings">The <see cref="ODataMessageWriterSettings"/> The settings of the writer.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected ResourceScope(ODataResource resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(WriterState.Resource, resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, ref odataUri)
+            protected ResourceScope(ODataResource resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(WriterState.Resource, resource, serializationInfo, navigationSource, resourceType, skipWriting, writerSettings, selectedProperties, in odataUri)
             {
             }
         }
@@ -4253,8 +4253,8 @@ namespace Microsoft.OData
             /// <param name="writerSettings">The <see cref="ODataMessageWriterSettings"/> The settings of the writer.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected DeletedResourceScope(ODataDeletedResource resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(WriterState.DeletedResource, resource, serializationInfo, navigationSource, entityType, false /*skipWriting*/, writerSettings, selectedProperties, ref odataUri)
+            protected DeletedResourceScope(ODataDeletedResource resource, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, ODataMessageWriterSettings writerSettings, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(WriterState.DeletedResource, resource, serializationInfo, navigationSource, entityType, false /*skipWriting*/, writerSettings, selectedProperties, in odataUri)
             {
             }
         }
@@ -4285,8 +4285,8 @@ namespace Microsoft.OData
             /// <param name="entityType">The entity type for the entries in the resource set to be written (or null if the entity set base type should be used).</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            protected DeltaLinkScope(WriterState state, ODataItem link, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(state, link, navigationSource, entityType, /*skipWriting*/false, selectedProperties, ref odataUri, /*enableDelta*/ false)
+            protected DeltaLinkScope(WriterState state, ODataItem link, ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType entityType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(state, link, navigationSource, entityType, /*skipWriting*/false, selectedProperties, in odataUri, /*enableDelta*/ false)
             {
                 Debug.Assert(link != null, "link != null");
                 Debug.Assert(
@@ -4331,8 +4331,8 @@ namespace Microsoft.OData
             /// <param name="resourceType">The structured type for the resource containing the property to be written.</param>
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
-            internal PropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri)
-                : base(WriterState.Property, property, navigationSource, resourceType, /*skipWriting*/ false, selectedProperties, ref odataUri, /*enableDelta*/ true)
+            internal PropertyInfoScope(ODataPropertyInfo property, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri)
+                : base(WriterState.Property, property, navigationSource, resourceType, /*skipWriting*/ false, selectedProperties, in odataUri, /*enableDelta*/ true)
             {
                 ValueWritten = false;
             }
@@ -4365,8 +4365,8 @@ namespace Microsoft.OData
             /// <param name="selectedProperties">The selected properties of this scope.</param>
             /// <param name="odataUri">The ODataUri info of this scope.</param>
             /// <param name="parentScope">The scope of the parent.</param>
-            internal NestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ref ODataUriSlim odataUri, Scope parentScope)
-                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, ref odataUri, parentScope.EnableDelta)
+            internal NestedResourceInfoScope(WriterState writerState, ODataNestedResourceInfo navLink, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, Scope parentScope)
+                : base(writerState, navLink, navigationSource, itemType, skipWriting, selectedProperties, in odataUri, parentScope.EnableDelta)
             {
                 this.parentScope = parentScope;
             }
@@ -4383,7 +4383,7 @@ namespace Microsoft.OData
             {
                 ODataUriSlim odataUri = this.ODataUri;
 
-                return new NestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, ref odataUri, parentScope)
+                return new NestedResourceInfoScope(newWriterState, (ODataNestedResourceInfo)this.Item, this.NavigationSource, this.ItemType, this.SkipWriting, this.SelectedProperties, in odataUri, parentScope)
                 {
                     DerivedTypeConstraints = this.DerivedTypeConstraints,
                 };

--- a/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
@@ -4,6 +4,7 @@
 //---------------------------------------------------------------------
 
 using System;
+using System.Diagnostics;
 using System.Collections.Generic;
 using Microsoft.OData.UriParser.Aggregation;
 using Microsoft.OData.UriParser;
@@ -16,6 +17,7 @@ namespace Microsoft.OData
 
         public ODataUriSlim(ODataUri odataUri)
         {
+            Debug.Assert(odataUri != null, "odataUri != null");
             this.odataUri = odataUri;
             this.SelectAndExpand = odataUri.SelectAndExpand;
             this.Path = odataUri.Path;

--- a/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
@@ -1,0 +1,121 @@
+﻿// <copyright file="ODataUriSlim.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.OData.UriParser.Aggregation;
+using Microsoft.OData.UriParser;
+
+namespace Microsoft.OData
+{
+    internal struct ODataUriSlim
+    {
+        private readonly ODataUri odataUri;
+
+        public ODataUriSlim(ODataUri odataUri)
+        {
+            this.odataUri = odataUri;
+            this.SelectAndExpand = odataUri.SelectAndExpand;
+            this.Path = odataUri.Path;
+        }
+
+        public ODataUriSlim(ODataUriSlim odataUriSlim)
+        {
+            this.odataUri = odataUriSlim.odataUri;
+            this.SelectAndExpand = odataUriSlim.SelectAndExpand;
+            this.Path = odataUriSlim.Path;
+        }
+
+        /// <summary>
+        /// Gets or sets the top level path for this uri.
+        /// </summary>
+        public ODataPath Path { get; set; }
+
+        /// <summary>
+        /// Gets or sets any $select or $expand option for this uri.
+        /// </summary>
+        public SelectExpandClause SelectAndExpand { get; set; }
+
+        /// <summary>
+        /// Gets or sets the request Uri.
+        /// </summary>
+        public Uri RequestUri => this.odataUri.RequestUri;
+
+        /// <summary>
+        /// Gets or sets the service root Uri.
+        /// </summary>
+        public Uri ServiceRoot => this.odataUri.ServiceRoot;
+
+        /// <summary>
+        /// Get the parameter alias nodes info.
+        /// </summary>
+        public IDictionary<string, SingleValueNode> ParameterAliasNodes => this.odataUri.ParameterAliasNodes;
+
+        /// <summary>
+        /// Gets or sets any custom query options for this uri.
+        /// </summary>
+        public IEnumerable<QueryNode> CustomQueryOptions => this.odataUri.CustomQueryOptions;
+
+        /// <summary>
+        /// Gets or sets any $filter option for this uri.
+        /// </summary>
+        public FilterClause Filter => this.odataUri.Filter;
+
+        /// <summary>
+        /// Gets or sets any $orderby option for this uri.
+        /// </summary>
+        public OrderByClause OrderBy => this.odataUri.OrderBy;
+
+        /// <summary>
+        /// Gets or sets any $search option for this uri.
+        /// </summary>
+        public SearchClause Search => this.odataUri.Search;
+
+        /// <summary>
+        /// Gets or sets any $apply option for this uri.
+        /// </summary>
+        public ApplyClause Apply => this.odataUri.Apply;
+
+        /// <summary>
+        /// Gets or sets any $compute option for this uri.
+        /// </summary>
+        public ComputeClause Compute => this.odataUri.Compute;
+
+        /// <summary>
+        /// Gets or sets any $skip option for this uri.
+        /// </summary>
+        public long? Skip => this.odataUri.Skip;
+
+        /// <summary>
+        /// Gets or sets any $top option for this uri.
+        /// </summary>
+        public long? Top => this.odataUri.Top;
+
+        /// <summary>
+        /// Gets or sets any $index option for this uri.
+        /// </summary>
+        public long? Index => this.odataUri.Index;
+
+        /// <summary>
+        /// Get or sets any query $count option for this uri.
+        /// </summary>
+        public bool? QueryCount => this.odataUri.QueryCount;
+
+        /// <summary>
+        /// Gets or sets any $skiptoken option for this uri.
+        /// </summary>
+        public string SkipToken => this.odataUri.SkipToken;
+
+        /// <summary>
+        /// Gets or sets any $deltatoken option for this uri.
+        /// </summary>
+        public string DeltaToken => this.odataUri.DeltaToken;
+
+        /// <summary>
+        /// Get or sets the MetadataDocumentUri, which is always ServiceRoot + $metadata
+        /// </summary>
+        internal Uri MetadataDocumentUri => this.odataUri.MetadataDocumentUri;
+    }
+}

--- a/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
@@ -57,12 +57,12 @@ namespace Microsoft.OData
         public SelectExpandClause SelectAndExpand { get; set; }
 
         /// <summary>
-        /// Gets or sets the request Uri.
+        /// Gets the request Uri.
         /// </summary>
         public Uri RequestUri => this.odataUri.RequestUri;
 
         /// <summary>
-        /// Gets or sets the service root Uri.
+        /// Gets the service root Uri.
         /// </summary>
         public Uri ServiceRoot => this.odataUri.ServiceRoot;
 
@@ -72,47 +72,47 @@ namespace Microsoft.OData
         public IDictionary<string, SingleValueNode> ParameterAliasNodes => this.odataUri.ParameterAliasNodes;
 
         /// <summary>
-        /// Gets or sets any custom query options for this uri.
+        /// Gets any custom query options for this uri.
         /// </summary>
         public IEnumerable<QueryNode> CustomQueryOptions => this.odataUri.CustomQueryOptions;
 
         /// <summary>
-        /// Gets or sets any $filter option for this uri.
+        /// Gets any $filter option for this uri.
         /// </summary>
         public FilterClause Filter => this.odataUri.Filter;
 
         /// <summary>
-        /// Gets or sets any $orderby option for this uri.
+        /// Gets any $orderby option for this uri.
         /// </summary>
         public OrderByClause OrderBy => this.odataUri.OrderBy;
 
         /// <summary>
-        /// Gets or sets any $search option for this uri.
+        /// Gets any $search option for this uri.
         /// </summary>
         public SearchClause Search => this.odataUri.Search;
 
         /// <summary>
-        /// Gets or sets any $apply option for this uri.
+        /// Gets any $apply option for this uri.
         /// </summary>
         public ApplyClause Apply => this.odataUri.Apply;
 
         /// <summary>
-        /// Gets or sets any $compute option for this uri.
+        /// Gets any $compute option for this uri.
         /// </summary>
         public ComputeClause Compute => this.odataUri.Compute;
 
         /// <summary>
-        /// Gets or sets any $skip option for this uri.
+        /// Gets any $skip option for this uri.
         /// </summary>
         public long? Skip => this.odataUri.Skip;
 
         /// <summary>
-        /// Gets or sets any $top option for this uri.
+        /// Gets any $top option for this uri.
         /// </summary>
         public long? Top => this.odataUri.Top;
 
         /// <summary>
-        /// Gets or sets any $index option for this uri.
+        /// Gets any $index option for this uri.
         /// </summary>
         public long? Index => this.odataUri.Index;
 
@@ -122,12 +122,12 @@ namespace Microsoft.OData
         public bool? QueryCount => this.odataUri.QueryCount;
 
         /// <summary>
-        /// Gets or sets any $skiptoken option for this uri.
+        /// Gets any $skiptoken option for this uri.
         /// </summary>
         public string SkipToken => this.odataUri.SkipToken;
 
         /// <summary>
-        /// Gets or sets any $deltatoken option for this uri.
+        /// Gets any $deltatoken option for this uri.
         /// </summary>
         public string DeltaToken => this.odataUri.DeltaToken;
 

--- a/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs
@@ -11,10 +11,21 @@ using Microsoft.OData.UriParser;
 
 namespace Microsoft.OData
 {
+    /// <summary>
+    /// A lightweight version of <see cref="ODataUri"/> that is
+    /// used by the writer to efficiently create a copy of the URI when entering
+    /// each scope. This is used to avoid cloning <see cref="ODataUri"/>
+    /// excessively.
+    /// </summary>
     internal struct ODataUriSlim
     {
         private readonly ODataUri odataUri;
 
+        /// <summary>
+        /// Creates an instance of <see cref="ODataUriSlim"/>
+        /// by copying the provided <see cref="ODataUri"/> instance.
+        /// </summary>
+        /// <param name="odataUri">The URI to copy.</param>
         public ODataUriSlim(ODataUri odataUri)
         {
             Debug.Assert(odataUri != null, "odataUri != null");
@@ -23,6 +34,11 @@ namespace Microsoft.OData
             this.Path = odataUri.Path;
         }
 
+        /// <summary>
+        /// Creates an instance of <see cref="ODataUriSlim"/> by
+        /// cloning the provided <see cref="ODataUriSlim"/>.
+        /// </summary>
+        /// <param name="odataUriSlim">The URI to copy.</param>
         public ODataUriSlim(ODataUriSlim odataUriSlim)
         {
             this.odataUri = odataUriSlim.odataUri;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMissingOperationGeneratorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMissingOperationGeneratorTests.cs
@@ -211,7 +211,7 @@ namespace Microsoft.OData.Tests.Evaluation
             throw new NotImplementedException();
         }
 
-        public ODataUri ODataUri { get; set; }
+        public ODataUriSlim? ODataUri { get; set; }
     }
 
     public class AllPropertiesComparer<T> : IEqualityComparer<T>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriterCoreTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriterCoreTests.cs
@@ -269,12 +269,12 @@ namespace Microsoft.OData.Tests
                 throw new NotImplementedException();
             }
 
-            protected override ODataWriterCore.ResourceSetScope CreateResourceSetScope(ODataResourceSet resourceCollection, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool isUndeclared)
+            protected override ODataWriterCore.ResourceSetScope CreateResourceSetScope(ODataResourceSet resourceCollection, IEdmNavigationSource navigationSource, IEdmType itemType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared)
             {
                 throw new NotImplementedException();
             }
 
-            protected override ODataWriterCore.ResourceScope CreateResourceScope(ODataResource entry, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, ODataUri odataUri, bool isUndeclared)
+            protected override ODataWriterCore.ResourceScope CreateResourceScope(ODataResource entry, IEdmNavigationSource navigationSource, IEdmStructuredType resourceType, bool skipWriting, SelectedPropertiesNode selectedProperties, in ODataUriSlim odataUri, bool isUndeclared)
             {
                 throw new NotImplementedException();
             }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2163 

### Description

This PR introduces a new internal struct called `ODataUriSlim` to be used by `ODataWriterCore` instead of cloning `ODataUri` each time it enters a new scope. Now the scope stores a `ODataUriSlim` struct instead of a reference to the cloned `ODataUri`.

Making the type a struct avoids allocating instances to the heap. I have tried to keep the struct small by only storing properties that can be modified from one writer scope to another, namely the `SelectAndExpand` and `Path` properties. The other properties are never changed by the writer, and therefore do not need to be cloned.

To avoid excessive copies of the struct, I passed it by reference to all methods using the `in` keyword. Some copies were inevitable. For example, a copy will be made when assigning the struct value to a property of a class instance. Also, storing the struct in a class makes instance of that class larger because the memory of struct is embedded in the class, instead of a reference to a different memory location. Another case of inevitable copy is when retrieving the value from a property. You cannot pass property value by reference. For example, the following snippet will not compile:
```c#
SomeMethodThatAcceptsAStructByReference(in someObject.ODataUri); // someObject.ODataUri is a struct
```
In such cases I ended doing something like the following:
```c#
ODataUriSlim odataUri = someObject.ODataUri
SomeMethodThatAcceptsAStructByReference(in odataUri);
```

For ease of use, I have added a reference to the `ODataUri` to the `ODataUriSlim` and made the properties of `ODataUri` accessible through `ODataUriSlim`. Technically, this makes the ODataUriSlim slightly bigger by adding a reference, but this might prevent bugs. If these properties were not accessible through `ODataUriSlim`, then I would have had to pass `ODataUri` and `ODataUriSlim` to some methods which need to access the other properties. Using both `ODataUri` and `ODataUriSlim` can lead to bugs because someone can accidentally access the `ODataUri.Path` property, which would be different from the `ODataUriSlim.Path` property.

I have had to refactor a few other methods and classes that the writer passes the `ODataUri` to. In some cases I have changed the input or property type to `ODataUriSlim?` from `ODataUri`. In other cases I have created new method overloads that use `ODataUriSlim` as input instead of `ODataUri`. Luckily, there were not many places where I needed to do this. I avoided adding both `ODataUri` and `ODataUriSlim` properties to the same class because that would introduce a lot more complexity and maintainability issues than is necessary. I also avoided changing classes and methods beyond what the writer needs, because that's beyond the scope of this PR.

I also experimented with making `ODataUriSlim` a class instead of a struct (see: https://github.com/habbes/odata.net/blob/odataurislim-class-experiment/src/Microsoft.OData.Core/Uri/ODataUriSlim.cs). This would still lead to heap allocations, but the objects allocated would be smaller in size. This avoids the inevitable copies of the struct. We can also avoid code duplication by creating a common interface between `ODataUriSlim` and `ODataUri`, say `IODataUri` which we use as the argument for methods that can accept either type. We could have done the same with the struct, but passing a struct to a method that accepts an interface would lead to boxing, which implies heap allocations, which would have defeated my purpose for using a struct. `ODataUriSlim` class experiment ended up allocating slightly more memory than `ODataUriSlim` struct, but the benchmark results were pretty close.

### Benchmark comparisons

According to the [SerializationComparisonTests](https://github.com/OData/odata.net/tree/master/test/PerformanceTests/SerializationComparisonsTests) benchmarks in our repo, use of `ODataUriSlim` struct has resulted in an 11% reduction in allocated memory when using `ODataMessageWriter` synchronous API.  When using the async API, the reduction was 7% when using the default `JsonWriter` and 10% when using `ODataUtf8JsonWriter` (more impact because it has a much smaller memory footprint compared to `JsonWriter` async). I did not observe significant improvement in speed, the figures in the time column fluctuated between different runs of the benchmarks, in some cases they were almost the same.

### Full benchmark results

#### Baseline (before the PR)

**[SerializationComparisons](https://github.com/OData/odata.net/tree/master/test/PerformanceTests/SerializationComparisonsTests)** benchmarks

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.20348
Intel Xeon E-2336 CPU 2.90GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=        5.0.404 [C:\Program Files\dotnet\sdk]
  [Host] : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT

Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1

|           Method |                                           WriterName |       Mean |     Error |    StdDev |      Gen 0 |     Gen 1 |  Allocated |
----------------- |----------------------------------------------------- |-----------:|----------:|----------:|-----------:|----------:|-----------:|
 WriteToFileAsync |                                   ODataMessageWriter | 294.143 ms | 0.7563 ms | 0.7075 ms | 41000.0000 |         - | 251,958 KB |
 WriteToFileAsync |                             ODataMessageWriter-Async | 897.045 ms | 2.4466 ms | 2.1689 ms | 66000.0000 | 1000.0000 | 403,831 KB |
 WriteToFileAsync |                    ODataMessageWriter-Utf8JsonWriter | 276.190 ms | 0.5155 ms | 0.4822 ms | 40000.0000 | 1000.0000 | 245,533 KB |
 WriteToFileAsync |              ODataMessageWriter-Utf8JsonWriter-Async | 466.277 ms | 0.7230 ms | 0.6409 ms | 44000.0000 | 1000.0000 | 270,701 KB |

**[ODataWriterFeedTests](https://github.com/OData/odata.net/tree/master/test/PerformanceTests/ComponentTests)** benchmarks

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.20348
Intel Xeon E-2336 CPU 2.90GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=        5.0.404 [C:\Program Files\dotnet\sdk]

Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1

|                                             Method | isModelImmutable |      Mean |    Error |   StdDev |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|--------------------------------------------------- |----------------- |----------:|---------:|---------:|-----------:|----------:|------:|----------:|
|                                          WriteFeed |             True |  83.66 ms | 0.533 ms | 0.498 ms |  9000.0000 |         - |     - |  57.68 MB |
|                            WriteFeedIncludeSpatial |             True | 263.05 ms | 0.353 ms | 0.313 ms | 51000.0000 | 2000.0000 |     - | 308.71 MB |
|                            WriteFeedWithExpansions |             True |  91.39 ms | 0.062 ms | 0.058 ms | 10000.0000 |         - |     - |  63.11 MB |
|              WriteFeedIncludeSpatialWithExpansions |             True | 109.92 ms | 0.073 ms | 0.068 ms | 14000.0000 |         - |     - |  88.23 MB |
|                             WriteFeed_NoValidation |             True |  73.14 ms | 0.073 ms | 0.064 ms |  8000.0000 |         - |     - |  53.47 MB |
|               WriteFeedIncludeSpatial_NoValidation |             True | 244.18 ms | 0.290 ms | 0.271 ms | 50000.0000 | 1000.0000 |     - | 304.04 MB |
|               WriteFeedWithExpansions_NoValidation |             True |  75.56 ms | 0.060 ms | 0.053 ms |  8000.0000 |         - |     - |  52.61 MB |
| WriteFeedIncludeSpatialWithExpansions_NoValidation |             True |  94.08 ms | 0.292 ms | 0.273 ms | 12000.0000 |         - |     - |  77.68 MB |


#### With `ODataUriSlim` struct

**[SerializationComparisons](https://github.com/OData/odata.net/tree/master/test/PerformanceTests/SerializationComparisonsTests)** benchmarks

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.20348
Intel Xeon E-2336 CPU 2.90GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=        5.0.404 [C:\Program Files\dotnet\sdk]
  [Host] : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT

Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1

|           Method |                                           WriterName |       Mean |     Error |    StdDev |     Median |      Gen 0 |     Gen 1 |  Allocated |
----------------- |----------------------------------------------------- |-----------:|----------:|----------:|-----------:|-----------:|----------:|-----------:|
 WriteToFileAsync |                                   ODataMessageWriter | 277.459 ms | 0.6373 ms | 0.5961 ms | 277.459 ms | 36000.0000 |         - | 224,025 KB |
 WriteToFileAsync |                             ODataMessageWriter-Async | 877.478 ms | 4.2997 ms | 3.8116 ms | 877.849 ms | 61000.0000 | 1000.0000 | 375,895 KB |
 WriteToFileAsync |                    ODataMessageWriter-Utf8JsonWriter | 255.648 ms | 0.2981 ms | 0.2788 ms | 255.745 ms | 35000.0000 | 1000.0000 | 217,600 KB |
 WriteToFileAsync |              ODataMessageWriter-Utf8JsonWriter-Async | 470.307 ms | 0.6589 ms | 0.6163 ms | 470.346 ms | 39000.0000 | 1000.0000 | 242,768 KB |

**[ODataWriterFeedTests](https://github.com/OData/odata.net/tree/master/test/PerformanceTests/ComponentTests)** benchmarks

 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.20348
Intel Xeon E-2336 CPU 2.90GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=        5.0.404 [C:\Program Files\dotnet\sdk]
  [Host] : .NET Core 3.1.28 (CoreCLR 4.700.22.36202, CoreFX 4.700.22.36301), X64 RyuJIT

Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1

|                                             Method | isModelImmutable |      Mean |    Error |   StdDev |    Median |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|--------------------------------------------------- |----------------- |----------:|---------:|---------:|----------:|-----------:|----------:|------:|----------:|
|                                          WriteFeed |             True |  83.77 ms | 0.142 ms | 0.119 ms |  83.77 ms |  9000.0000 |         - |     - |  55.61 MB |
|                            WriteFeedIncludeSpatial |             True | 266.62 ms | 0.362 ms | 0.339 ms | 266.68 ms | 51000.0000 | 2000.0000 |     - | 306.34 MB |
|                            WriteFeedWithExpansions |             True |  92.23 ms | 0.109 ms | 0.102 ms |  92.19 ms | 10000.0000 |         - |     - |  60.11 MB |
|              WriteFeedIncludeSpatialWithExpansions |             True | 110.49 ms | 0.078 ms | 0.073 ms | 110.50 ms | 14000.0000 |         - |     - |   85.2 MB |
|                             WriteFeed_NoValidation |             True |  73.12 ms | 0.315 ms | 0.280 ms |  73.13 ms |  8000.0000 |         - |     - |   51.4 MB |
|               WriteFeedIncludeSpatial_NoValidation |             True | 246.96 ms | 0.387 ms | 0.362 ms | 246.92 ms | 50000.0000 | 1000.0000 |     - | 301.67 MB |
|               WriteFeedWithExpansions_NoValidation |             True |  75.21 ms | 0.312 ms | 0.292 ms |  75.01 ms |  8000.0000 |         - |     - |  49.61 MB |
| WriteFeedIncludeSpatialWithExpansions_NoValidation |             True |  93.38 ms | 0.108 ms | 0.090 ms |  93.36 ms | 12000.0000 |         - |     - |  74.65 MB |

#### With `ODataUriSlim` class

**SerializationComparisons** benchmarks

 BenchmarkDotNet=v0.13.1, OS=Windows 10.0.20348
Intel Xeon E-2336 CPU 2.90GHz, 1 CPU, 12 logical and 6 physical cores
.NET SDK=        5.0.404 [C:\Program Files\dotnet\sdk]
  [Host] : .NET 6.0.8 (6.0.822.36306), X64 RyuJIT

Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1

|           Method |                                           WriterName |       Mean |     Error |    StdDev |      Gen 0 |     Gen 1 |  Allocated |
----------------- |----------------------------------------------------- |-----------:|----------:|----------:|-----------:|----------:|-----------:|
 WriteToFileAsync |                                   ODataMessageWriter | 284.516 ms | 0.7395 ms | 0.6918 ms | 37000.0000 |         - | 227,321 KB |
 WriteToFileAsync |                             ODataMessageWriter-Async | 890.175 ms | 7.5653 ms | 6.7064 ms | 62000.0000 | 1000.0000 | 379,179 KB |
 WriteToFileAsync |                    ODataMessageWriter-Utf8JsonWriter | 265.688 ms | 0.4744 ms | 0.4438 ms | 36000.0000 | 1000.0000 | 220,905 KB |
 WriteToFileAsync |              ODataMessageWriter-Utf8JsonWriter-Async | 479.593 ms | 0.2380 ms | 0.1987 ms | 40000.0000 | 1000.0000 | 246,073 KB |

**ODataWriterFeedTests** benchmarks

 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.20348
Intel Xeon E-2336 CPU 2.90GHz, 1 CPU, 12 logical and 6 physical cores
.NET Core SDK=        5.0.404 [C:\Program Files\dotnet\sdk]
  [Host] : .NET Core 3.1.28 (CoreCLR 4.700.22.36202, CoreFX 4.700.22.36301), X64 RyuJIT

Toolchain=InProcessEmitToolchain  InvocationCount=1  UnrollFactor=1

|                                             Method | isModelImmutable |      Mean |    Error |   StdDev |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|--------------------------------------------------- |----------------- |----------:|---------:|---------:|-----------:|----------:|------:|----------:|
|                                          WriteFeed |             True |  84.19 ms | 0.425 ms | 0.398 ms |  9000.0000 |         - |     - |  55.89 MB |
|                            WriteFeedIncludeSpatial |             True | 264.23 ms | 0.259 ms | 0.229 ms | 51000.0000 | 2000.0000 |     - | 306.65 MB |
|                            WriteFeedWithExpansions |             True |  92.59 ms | 0.116 ms | 0.097 ms | 10000.0000 |         - |     - |  60.51 MB |
|              WriteFeedIncludeSpatialWithExpansions |             True | 110.50 ms | 0.105 ms | 0.093 ms | 14000.0000 |         - |     - |   85.6 MB |
|                             WriteFeed_NoValidation |             True |  72.41 ms | 0.192 ms | 0.180 ms |  8000.0000 |         - |     - |  51.68 MB |
|               WriteFeedIncludeSpatial_NoValidation |             True | 243.16 ms | 0.200 ms | 0.178 ms | 50000.0000 | 1000.0000 |     - | 301.98 MB |
|               WriteFeedWithExpansions_NoValidation |             True |  75.64 ms | 0.075 ms | 0.067 ms |  8000.0000 |         - |     - |  50.01 MB |
| WriteFeedIncludeSpatialWithExpansions_NoValidation |             True |  93.07 ms | 0.129 ms | 0.107 ms | 12000.0000 |         - |     - |  75.05 MB |


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
