### PR TITLE
Change the tojson function of ODataErrorDetail to deal with escaped strings

### DIFF
--- a/src/Microsoft.OData.Core/ODataErrorDetail.cs
+++ b/src/Microsoft.OData.Core/ODataErrorDetail.cs
@@ -7,6 +7,7 @@
 
 namespace Microsoft.OData
 {
+    using Microsoft.OData.Json;
     #region
     using System.Globalization;
     #endregion
@@ -36,7 +37,9 @@ namespace Microsoft.OData
         {
             return string.Format(CultureInfo.InvariantCulture,
                 "{{ \"errorcode\": \"{0}\", \"message\": \"{1}\", \"target\": \"{2}\" }}",
-                this.ErrorCode ?? "", this.Message ?? "", this.Target ?? "");
+                this.ErrorCode == null ? "" : JsonValueUtils.GetEscapedJsonString(this.ErrorCode), 
+                this.Message == null ? "" : JsonValueUtils.GetEscapedJsonString(this.Message), 
+                this.Target == null ? "" : JsonValueUtils.GetEscapedJsonString(this.Target));
         }
-}
+    }
 }

--- a/src/Microsoft.OData.Core/ODataErrorDetail.cs
+++ b/src/Microsoft.OData.Core/ODataErrorDetail.cs
@@ -7,10 +7,10 @@
 
 namespace Microsoft.OData
 {
-    using Microsoft.OData.Json;
-    #region
+    #region Namespaces
     using System.Globalization;
-    #endregion
+    using Microsoft.OData.Json;
+    #endregion Namespaces
 
     /// <summary>
     /// Class representing an error detail.

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
@@ -97,6 +97,30 @@ namespace Microsoft.OData.Tests.Json
             "}}", result);
         }
 
+        [Fact]
+        public async Task WriteErrorAsync_WritesTargetAndDetailsWithEscapedCharacters()
+        {
+            var error = new ODataError
+            {
+                Target = "any target",
+                Details = new[] { new ODataErrorDetail { ErrorCode = "500", Target = "any target", Message = "any msg with \"escaped characters\"" } }
+            };
+
+            await ODataJsonWriterUtils.WriteErrorAsync(
+                this.jsonWriter,
+                this.writeInstanceAnnotationsDelegate,
+                error,
+                includeDebugInformation: false,
+                maxInnerErrorDepth: 0);
+            var result = stringWriter.GetStringBuilder().ToString();
+            Assert.Equal("{\"error\":{" +
+                "\"code\":\"\"," +
+                "\"message\":\"\"," +
+                "\"target\":\"any target\"," +
+                "\"details\":[{\"code\":\"500\",\"target\":\"any target\",\"message\":\"any msg with \\\"escaped characters\\\"\"}]" +
+            "}}", result);
+        }
+
 
         [Fact]
         public async Task WriteErrorAsync_InnerErrorWithNestedNullValue()


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes the ToJson function of ODataErrorDetail to escape characters that require it in JSON serialization. The calling function in ODataError already uses the GetEscapedJsonString function but the ODataErrorDetail currently does not. (See https://github.com/OData/odata.net/blob/master/src/Microsoft.OData.Core/ODataError.cs#L84)

### Description

The ToJson function of ODataErrorDetail does not properly escape characters that require it

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

N/A
