### PR TITLE
Fix issue where CsdlWriter TryWriteCsdl does not trigger flushing of XmlWriter buffer

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/CsdlXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlXmlWriter.cs
@@ -66,6 +66,7 @@ namespace Microsoft.OData.Edm.Csdl
             this.WriteSchemas();
             this.EndElement(); // </DataServices>
             this.EndElement(); // </Edmx>
+            this.writer.Flush();
         }
 
         private void WriteEFCsdl()
@@ -77,6 +78,7 @@ namespace Microsoft.OData.Edm.Csdl
             this.EndElement(); // </ConceptualModels>
             this.EndElement(); // </Runtime>
             this.EndElement(); // </Edmx>
+            this.writer.Flush();
         }
 
         private void WriteEdmxElement()


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2522.*

### Description

Ensure `CsdlWriter` `TryWriteCsdl` method triggers flushing of `XmlWriter` buffer before exiting

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
