### PR TITLE
Update version 7.12.4

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -37,7 +37,7 @@ jobs:
       ProductBinPath5: '$(Build.SourcesDirectory)\src\CodeGen\bin\$(BuildConfiguration)'
       mainDll5: 'Microsoft.OData.Service.Design.T4.dll'
       ProductBinPath: $(Build.SourcesDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\Product
-      NuGetArtifactsDir: 'Nuget-Debug'
+      NugetArtifactsDir: 'Nuget-Debug'
   steps:
     - template: nightly.yml
 
@@ -62,7 +62,7 @@ jobs:
       ProductBinPath5: '$(Build.SourcesDirectory)\src\CodeGen\bin\$(BuildConfiguration)'
       mainDll5: 'Microsoft.OData.Service.Design.T4.dll'
       ProductBinPath: $(Build.SourcesDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\Product
-      NuGetArtifactsDir: 'Nuget-Release'
+      NugetArtifactsDir: 'Nuget-Release'
   steps:
     - template: nightly.yml
 

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -37,6 +37,7 @@ jobs:
       ProductBinPath5: '$(Build.SourcesDirectory)\src\CodeGen\bin\$(BuildConfiguration)'
       mainDll5: 'Microsoft.OData.Service.Design.T4.dll'
       ProductBinPath: $(Build.SourcesDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\Product
+      NuGetArtifactsDir: 'Nuget-Debug'
   steps:
     - template: nightly.yml
 
@@ -61,6 +62,7 @@ jobs:
       ProductBinPath5: '$(Build.SourcesDirectory)\src\CodeGen\bin\$(BuildConfiguration)'
       mainDll5: 'Microsoft.OData.Service.Design.T4.dll'
       ProductBinPath: $(Build.SourcesDirectory)\bin\$(BuildPlatform)\$(BuildConfiguration)\Product
+      NuGetArtifactsDir: 'Nuget-Release'
   steps:
     - template: nightly.yml
 

--- a/nightly.yml
+++ b/nightly.yml
@@ -153,7 +153,7 @@
       displayName: 'ESRP CodeSigning Nuget Packages'
       inputs:
         ConnectedServiceName: 'ESRP CodeSigning - OData'
-        FolderPath: '$(Build.ArtifactStagingDirectory)\Nuget'
+        FolderPath: '$(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir)'
         Pattern: '*.nupkg'
         signConfigType: inlineSignParams
         inlineOperation: |

--- a/nightly.yml
+++ b/nightly.yml
@@ -2,18 +2,18 @@
     - template: buildandtest.yml
 
     - script: |
-        mkdir $(Build.ArtifactStagingDirectory)\sbom
+        mkdir $(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir)\sbom
       displayName: 'Create $(Build.ArtifactStagingDirectory)\sbom'
 
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: 'Manifest Generator '
       inputs:
-          BuildDropPath: '$(Build.ArtifactStagingDirectory)\sbom'
+          BuildDropPath: '$(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir)\sbom'
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish SBOM'
       inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)\sbom'
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir)\sbom'
 
     - template: credscan.yml
  
@@ -179,7 +179,7 @@
       displayName: 'Publish Artifact - Nuget Packages'
       inputs:
         PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir)'
-        ArtifactName: Nuget
+        ArtifactName: $(NugetArtifactsDir)
 
     - task: NuGetCommand@2
       displayName: 'NuGet push - Nightly packages to MyGet'

--- a/nightly.yml
+++ b/nightly.yml
@@ -98,56 +98,56 @@
       inputs:
         command: custom
         feedsToUse: config
-        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.Spatial\Build.NuGet\Microsoft.Spatial.Nightly.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath3)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
+        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.Spatial\Build.NuGet\Microsoft.Spatial.Nightly.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir) -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath3)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
     
     - task: NuGetCommand@2
       displayName: 'NuGet - pack Microsoft.Spatial.Release'
       inputs:
         command: custom
         feedsToUse: config
-        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.Spatial\Build.NuGet\Microsoft.Spatial.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath3)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
+        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.Spatial\Build.NuGet\Microsoft.Spatial.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir) -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath3)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
 
     - task: NuGetCommand@2
       displayName: 'NuGet - pack Microsoft.OData.Edm.Nightly.Release'
       inputs:
         command: custom
         feedsToUse: config
-        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Edm\Build.NuGet\Microsoft.OData.Edm.Nightly.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath1)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
+        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Edm\Build.NuGet\Microsoft.OData.Edm.Nightly.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir) -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath1)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
 
     - task: NuGetCommand@2
       displayName: 'NuGet - pack Microsoft.OData.Edm.Release'
       inputs:
         command: custom
         feedsToUse: config
-        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Edm\Build.NuGet\Microsoft.OData.Edm.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath1)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
+        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Edm\Build.NuGet\Microsoft.OData.Edm.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir) -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath1)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
     
     - task: NuGetCommand@2
       displayName: 'NuGet - pack Microsoft.OData.Core.Nightly.Release'
       inputs:
         command: custom
         feedsToUse: config
-        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Core\Build.NuGet\Microsoft.OData.Core.Nightly.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath2)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
+        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Core\Build.NuGet\Microsoft.OData.Core.Nightly.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir) -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath2)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
 
     - task: NuGetCommand@2
       displayName: 'NuGet - pack Microsoft.OData.Core.Release'
       inputs:
         command: custom
         feedsToUse: config
-        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Core\Build.NuGet\Microsoft.OData.Core.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath2)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
+        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Core\Build.NuGet\Microsoft.OData.Core.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir) -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath2)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
 
     - task: NuGetCommand@2
       displayName: 'NuGet - pack Microsoft.OData.Client.Nightly.Release'
       inputs:
         command: custom
         feedsToUse: config
-        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Client\Build.NuGet\Microsoft.OData.Client.Nightly.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath4)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
+        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Client\Build.NuGet\Microsoft.OData.Client.Nightly.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir) -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath4)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);NightlyBuildVersion=$(VersionNugetNightlyBuild);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
     
     - task: NuGetCommand@2
       displayName: 'NuGet - pack Microsoft.OData.Client.Release'
       inputs:
         command: custom
         feedsToUse: config
-        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Client\Build.NuGet\Microsoft.OData.Client.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\Nuget -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath4)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
+        arguments: 'pack $(Build.SourcesDirectory)\src\Microsoft.OData.Client\Build.NuGet\Microsoft.OData.Client.Release.nuspec -NonInteractive -OutputDirectory $(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir) -Properties Configuration=$(BuildConfiguration);ProductRoot=$(ProductBinPath4)\**;SourcesRoot=$(Build.SourcesDirectory);VersionFullSemantic=$(VersionFullSemantic);VersionNuGetSemantic=$(VersionNuGetSemantic) -Verbosity Detailed -Symbols -SymbolPackageFormat snupkg'
 
     - task: EsrpCodeSigning@1
       displayName: 'ESRP CodeSigning Nuget Packages'
@@ -178,14 +178,14 @@
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact - Nuget Packages'
       inputs:
-        PathtoPublish: '$(Build.ArtifactStagingDirectory)\Nuget'
+        PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir)'
         ArtifactName: Nuget
 
     - task: NuGetCommand@2
       displayName: 'NuGet push - Nightly packages to MyGet'
       inputs:
         command: push
-        packagesToPush: '$(Build.ArtifactStagingDirectory)\Nuget\*Nightly*.nupkg'
+        packagesToPush: '$(Build.ArtifactStagingDirectory)\$(NugetArtifactsDir)\*Nightly*.nupkg'
         nuGetFeedType: external
         publishFeedCredentials: 'MyGet.org - OData.net Nightly Feed'
       enabled: true

--- a/tools/CustomMSBuild/Versioning.props
+++ b/tools/CustomMSBuild/Versioning.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">7</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">12</VersionMinor>
-    <VersionBuildNumber Condition="'$(VersionBuildNumber)' == ''">3</VersionBuildNumber>
+    <VersionBuildNumber Condition="'$(VersionBuildNumber)' == ''">4</VersionBuildNumber>
     <VersionRelease Condition="'$(VersionRelease)' == ''"></VersionRelease>
   </PropertyGroup>
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2510 *

### Description

Updates the version to 7.12.4. Also fixes the build pipeline so that the debug and release builds are copied to different directories, `Nuget-Debug` and `Nuget-Release` respectively. This avoids the confusion or the builds overwriting each other.

To verify that the write builds were stored in the right folder I ran a nighly pipeline and download the artifacts. The I unzipped the `.nupkg` and opened the the dlls in `ildasm` and followed the [instructions post here](https://www.codeproject.com/articles/1073360/how-to-tell-if-an-assembly-is-debug-or-release#:~:text=Here%27s%20how%20to%20do%20it%3A%201%20Open%20the,JIT%20Optimized%20-%20anything%20else%2C%20it%20is%20not%3A) to tell whether the build is JIT optimized or not:

- Open the `ildasm` (an easy way to find is to open the Developer Command Prompt for Visual Studio and enter the `ildasm` command)
- Open the dll file
- Open `MANIFEST`
- Find the `DebuggableAttribute` in the manifest.
- Look at the 4th byte of the value, if it's 0 then the assembly is JIT-optimized, otherwise it's not.

Here's what it looked like for a sample dll in the `Nuget-Release` folder. You can see the 4th byte is `00`

![image](https://user-images.githubusercontent.com/8460169/195515698-19e886af-e4c0-45f2-843f-77cc12c4854a.png)

Here's what it looked like for a sample dll in the `Nuget-Debug` folder. You can see the 4th byte is `01`

![image](https://user-images.githubusercontent.com/8460169/195516459-643a7730-143e-43d7-92ec-84d786a961a2.png)



### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
