### PR TITLE
Fix ArgumentException in ProjectPlanCompiler caused by missing materializerContext argument in dynamic calls

### DIFF
--- a/src/Microsoft.OData.Client/AtomMaterializerLog.cs
+++ b/src/Microsoft.OData.Client/AtomMaterializerLog.cs
@@ -49,7 +49,7 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// The materializer context.
         /// </summary>
-        private IODataMaterializerContext materializerContext;
+        private readonly IODataMaterializerContext materializerContext;
 
         #endregion Private fields
 
@@ -69,6 +69,7 @@ namespace Microsoft.OData.Client
         {
             Debug.Assert(model != null, "model != null");
             Debug.Assert(entityTracker != null, "entityTracker != null");
+            Debug.Assert(materializerContext != null, "materializerContext != null");
 
             this.appendOnlyEntries = new Dictionary<Uri, ODataResource>(EqualityComparer<Uri>.Default);
             this.mergeOption = mergeOption;

--- a/src/Microsoft.OData.Client/BaseAsyncResult.cs
+++ b/src/Microsoft.OData.Client/BaseAsyncResult.cs
@@ -28,11 +28,6 @@ namespace Microsoft.OData.Client
         protected PerRequest perRequest;
 
         /// <summary>
-        /// Cache used to store temporary metadata used for materialization of OData items.
-        /// </summary>
-        protected MaterializerCache materializerCache = new MaterializerCache();
-
-        /// <summary>
         /// The int equivalent for true.
         /// </summary>
         private const int True = 1;
@@ -93,6 +88,11 @@ namespace Microsoft.OData.Client
             this.userCallback = callback;
             this.userState = state;
         }
+
+        /// <summary>
+        /// Cache used to store temporary metadata used for materialization of OData items.
+        /// </summary>
+        protected MaterializerCache MaterializerCache { get; } = new MaterializerCache();
 
         /// <summary>
         /// This delegate exists to workaround limitations in the WP7 runtime.

--- a/src/Microsoft.OData.Client/BatchSaveResult.cs
+++ b/src/Microsoft.OData.Client/BatchSaveResult.cs
@@ -254,7 +254,7 @@ namespace Microsoft.OData.Client
                 /*projectionPlan*/ null,
                 this.currentOperationResponse.CreateResponseMessage(),
                 ODataPayloadKind.Resource,
-                this.materializerCache);
+                base.MaterializerCache);
         }
 
         /// <summary>
@@ -690,7 +690,7 @@ namespace Microsoft.OData.Client
                                             this.currentOperationResponse.Headers.GetHeader(XmlConstants.HttpContentType),
                                             this.currentOperationResponse.CreateResponseMessage(),
                                             query.PayloadKind,
-                                            this.materializerCache);
+                                            this.MaterializerCache);
                                         qresponse = QueryOperationResponse.GetInstance(query.ElementType, this.currentOperationResponse.Headers, query, materializer);
                                     }
                                 }

--- a/src/Microsoft.OData.Client/BatchSaveResult.cs
+++ b/src/Microsoft.OData.Client/BatchSaveResult.cs
@@ -690,7 +690,7 @@ namespace Microsoft.OData.Client
                                             this.currentOperationResponse.Headers.GetHeader(XmlConstants.HttpContentType),
                                             this.currentOperationResponse.CreateResponseMessage(),
                                             query.PayloadKind,
-                                            this.MaterializerCache);
+                                            base.MaterializerCache);
                                         qresponse = QueryOperationResponse.GetInstance(query.ElementType, this.currentOperationResponse.Headers, query, materializer);
                                     }
                                 }

--- a/src/Microsoft.OData.Client/GroupByProjectionPlanCompiler.cs
+++ b/src/Microsoft.OData.Client/GroupByProjectionPlanCompiler.cs
@@ -364,7 +364,12 @@ namespace Microsoft.OData.Client
             Debug.Assert(entry != null, "entry != null");
             Debug.Assert(path != null, "path != null");
 
-            Expression result = CallMaterializer("ProjectionValueForPath", this.materializerExpression, entry, entryType, Expression.Constant(path, typeof(object)));
+            Expression result = CallMaterializer(
+                nameof(ODataEntityMaterializerInvoker.ProjectionValueForPath),
+                this.materializerExpression,
+                entry, 
+                entryType,
+                Expression.Constant(path, typeof(object)));
             this.annotations.Add(result, new ExpressionAnnotation() { Segment = path[path.Count - 1] });
             return result;
         }
@@ -523,7 +528,7 @@ namespace Microsoft.OData.Client
             annotation.Segment.StartPath.Add(memberSegment);
 
             Expression value = CallMaterializer(
-                "ProjectionDynamicValueForPath",
+                nameof(ODataEntityMaterializerInvoker.ProjectionDynamicValueForPath),
                 this.materializerExpression,
                 annotation.Segment.StartPath.RootEntry,
                 Expression.Constant(targetType, typeof(Type)),

--- a/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
+++ b/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
@@ -504,7 +504,12 @@ namespace Microsoft.OData.Client
         /// <returns>A new expression with the call instance.</returns>
         private Expression CallCheckValueForPathIsNull(Expression entry, Expression entryType, ProjectionPath path)
         {
-            Expression result = CallMaterializer("ProjectionCheckValueForPathIsNull", entry, entryType, Expression.Constant(path, typeof(object)));
+            Expression result = CallMaterializer(
+                "ProjectionCheckValueForPathIsNull",
+                entry,
+                entryType,
+                Expression.Constant(path, typeof(object)),
+                Expression.Constant(this.materializerContext));
             this.annotations.Add(result, new ExpressionAnnotation() { Segment = path[path.Count - 1] });
             return result;
         }

--- a/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
+++ b/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
@@ -505,7 +505,7 @@ namespace Microsoft.OData.Client
         private Expression CallCheckValueForPathIsNull(Expression entry, Expression entryType, ProjectionPath path)
         {
             Expression result = CallMaterializer(
-                "ProjectionCheckValueForPathIsNull",
+                nameof(ODataEntityMaterializerInvoker.ProjectionCheckValueForPathIsNull),
                 entry,
                 entryType,
                 Expression.Constant(path, typeof(object)),
@@ -524,7 +524,12 @@ namespace Microsoft.OData.Client
             Debug.Assert(entry != null, "entry != null");
             Debug.Assert(path != null, "path != null");
 
-            Expression result = CallMaterializer("ProjectionValueForPath", this.materializerExpression, entry, entryType, Expression.Constant(path, typeof(object)));
+            Expression result = CallMaterializer(
+                nameof(ODataEntityMaterializerInvoker.ProjectionValueForPath),
+                this.materializerExpression,
+                entry,
+                entryType,
+                Expression.Constant(path, typeof(object)));
             this.annotations.Add(result, new ExpressionAnnotation() { Segment = path[path.Count - 1] });
             return result;
         }
@@ -676,7 +681,7 @@ namespace Microsoft.OData.Client
                      assignment.Expression.NodeType == ExpressionType.MemberInit))
                 {
                     Expression nestedEntry = CallMaterializer(
-                        "ProjectionGetEntry",
+                        nameof(ODataEntityMaterializerInvoker.ProjectionGetEntry),
                         entryParameterAtMemberInit,
                         Expression.Constant(assignment.Member.Name, typeof(string)),
                         Expression.Constant(this.materializerContext));
@@ -776,7 +781,7 @@ namespace Microsoft.OData.Client
             }
 
             Expression reboundExpression = CallMaterializer(
-                "ProjectionInitializeEntity",
+                nameof(ODataEntityMaterializerInvoker.ProjectionInitializeEntity),
                 this.materializerExpression,
                 entryToInitValue,
                 expectedParamValue,
@@ -802,7 +807,7 @@ namespace Microsoft.OData.Client
             do
             {
                 result = CallMaterializer(
-                    "ProjectionGetEntry",
+                    nameof(ODataEntityMaterializerInvoker.ProjectionGetEntry),
                     result ?? this.pathBuilder.ParameterEntryInScope,
                     Expression.Constant(((MemberExpression)path[pathIndex]).Member.Name, typeof(string)));
                 pathIndex++;
@@ -1056,7 +1061,7 @@ namespace Microsoft.OData.Client
                     // helpers, eg to preserve paging information.
                     Type returnElementType = call.Method.ReturnType.GetGenericArguments()[0];
                     result = CallMaterializer(
-                        "ProjectionSelect",
+                        nameof(ODataEntityMaterializerInvoker.ProjectionSelect),
                         this.materializerExpression,
                         this.pathBuilder.ParameterEntryInScope,
                         this.pathBuilder.ExpectedParamTypeInScope,
@@ -1065,7 +1070,7 @@ namespace Microsoft.OData.Client
                         selectorExpression);
                     this.annotations.Add(result, annotation);
                     result = CallMaterializerWithType(
-                        "EnumerateAsElementType",
+                        nameof(ODataEntityMaterializerInvoker.EnumerateAsElementType),
                         new Type[] { returnElementType },
                         result);
                     this.annotations.Add(result, annotation);
@@ -1155,7 +1160,7 @@ namespace Microsoft.OData.Client
                         // {(mat, entry1, type1) => Convert(ProjectionValueForPath(mat, entry1, type1, p->*.FirstName))}
                         Type returnElementType = call.Method.ReturnType.GetGenericArguments()[0];
                         result = CallMaterializer(
-                            "ProjectionSelect",
+                            nameof(ODataEntityMaterializerInvoker.ProjectionSelect),
                             this.materializerExpression,
                             this.pathBuilder.ParameterEntryInScope,
                             this.pathBuilder.ExpectedParamTypeInScope,
@@ -1164,7 +1169,7 @@ namespace Microsoft.OData.Client
                             selectorExpression);
                         this.annotations.Add(result, annotation);
                         result = CallMaterializerWithType(
-                            "EnumerateAsElementType",
+                            nameof(ODataEntityMaterializerInvoker.EnumerateAsElementType),
                             new Type[] { returnElementType },
                             result);
                         this.annotations.Add(result, annotation);
@@ -1214,7 +1219,7 @@ namespace Microsoft.OData.Client
 
             // Return the annotated expression.
             Expression result = CallMaterializerWithType(
-                "ListAsElementType",
+                nameof(ODataEntityMaterializer.ListAsElementType),
                 new Type[] { enumeratedType, listElementType },
                 this.materializerExpression,
                 source);

--- a/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
+++ b/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
@@ -67,6 +67,8 @@ namespace Microsoft.OData.Client
         /// <param name="materializerContext">The materializer context.</param>
         private ProjectionPlanCompiler(Dictionary<Expression, Expression> normalizerRewrites, IODataMaterializerContext materializerContext)
         {
+            Debug.Assert(materializerContext != null, "materializerContext != null");
+
             this.annotations = new Dictionary<Expression, ExpressionAnnotation>(ReferenceEqualityComparer<Expression>.Instance);
             this.materializerExpression = Expression.Parameter(typeof(object), "mat");
             this.normalizerRewrites = normalizerRewrites;

--- a/src/Microsoft.OData.Client/QueryResult.cs
+++ b/src/Microsoft.OData.Client/QueryResult.cs
@@ -708,7 +708,7 @@ namespace Microsoft.OData.Client
                 this.ContentType,
                 responseMessageWrapper,
                 payloadKind,
-                this.materializerCache);
+                base.MaterializerCache);
         }
     }
 }

--- a/src/Microsoft.OData.Client/SaveResult.cs
+++ b/src/Microsoft.OData.Client/SaveResult.cs
@@ -360,7 +360,7 @@ namespace Microsoft.OData.Client
         {
             Debug.Assert(this.cachedResponse.Exception == null && this.cachedResponse.MaterializerEntry != null, "this.cachedResponse.Exception == null && this.cachedResponse.Entry != null");
             ODataResource entry = this.cachedResponse.MaterializerEntry == null ? null : this.cachedResponse.MaterializerEntry.Entry;
-            return new MaterializeAtom(responseInfo, new[] { entry }, entityDescriptor.Entity.GetType(), this.cachedResponse.MaterializerEntry.Format, this.materializerCache);
+            return new MaterializeAtom(responseInfo, new[] { entry }, entityDescriptor.Entity.GetType(), this.cachedResponse.MaterializerEntry.Format, this.MaterializerCache);
         }
 
         /// <summary>
@@ -865,7 +865,7 @@ namespace Microsoft.OData.Client
                             responseMsg.StatusCode,
                             () => responseStream);
 
-                        ODataMaterializerContext materializerContext = new ODataMaterializerContext(responseInfo, this.materializerCache);
+                        ODataMaterializerContext materializerContext = new ODataMaterializerContext(responseInfo, base.MaterializerCache);
                         entry = ODataReaderEntityMaterializer.ParseSingleEntityPayload(responseMessageWrapper, responseInfo, entityDescriptor.Entity.GetType(), materializerContext);
                         entityDescriptor.TransientEntityDescriptor = entry.EntityDescriptor;
                     }

--- a/src/Microsoft.OData.Client/SaveResult.cs
+++ b/src/Microsoft.OData.Client/SaveResult.cs
@@ -360,7 +360,7 @@ namespace Microsoft.OData.Client
         {
             Debug.Assert(this.cachedResponse.Exception == null && this.cachedResponse.MaterializerEntry != null, "this.cachedResponse.Exception == null && this.cachedResponse.Entry != null");
             ODataResource entry = this.cachedResponse.MaterializerEntry == null ? null : this.cachedResponse.MaterializerEntry.Entry;
-            return new MaterializeAtom(responseInfo, new[] { entry }, entityDescriptor.Entity.GetType(), this.cachedResponse.MaterializerEntry.Format, this.MaterializerCache);
+            return new MaterializeAtom(responseInfo, new[] { entry }, entityDescriptor.Entity.GetType(), this.cachedResponse.MaterializerEntry.Format, base.MaterializerCache);
         }
 
         /// <summary>

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
     using System.Linq;
     using System.Net;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Microsoft.OData.Client;
     using Microsoft.Test.OData.Services.TestServices;
     using Microsoft.Test.OData.Services.TestServices.AstoriaDefaultServiceReference;
@@ -786,6 +787,24 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
             Assert.Equal(-10, c1.ComputerDetail.ComputerDetailId);
 
             this.EnqueueTestComplete();
+        }
+
+        [Fact]
+        public async Task Linq_ProjectPropertiesFromEntityWithConditionalNullCheckOnExpandedEntity()
+        {
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            var query = context.Computer.Where(c => c.ComputerId == -10)
+                        .Select(c => new Computer
+                         {
+                             ComputerId = c.ComputerId,
+                             ComputerDetail = c.ComputerDetail == null ? null : c.ComputerDetail,
+                         }) as DataServiceQuery<Computer>;
+
+            var result = await query.ExecuteAsync();
+
+            var computer = result.First();
+            Assert.Equal(-10, computer.ComputerId);
+            Assert.Equal(-10, computer.ComputerDetail.ComputerDetailId);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/CollectionValueMaterializationPolicyTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/CollectionValueMaterializationPolicyTests.cs
@@ -130,7 +130,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void DataServicCollectionOfTAsCollectionTypeShouldFailForPrimitiveOrComplexCollections()
         {
-            var testContext = new TestMaterializerContext(new MaterializerCache());
+            var testContext = new TestMaterializerContext();
             var edmType = testContext.Model.GetOrCreateEdmType(typeof(MyInfo));
             var clientTypeAnnotation = new ClientTypeAnnotation(edmType, typeof(MyInfo), "MyInfo", testContext.Model);
 
@@ -141,7 +141,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void CreateCollectionInstanceShouldFailOnTypeWithNoParametersLessConstructors()
         {
-            var testContext = new TestMaterializerContext(new MaterializerCache());
+            var testContext = new TestMaterializerContext();
             var edmType = testContext.Model.GetOrCreateEdmType(typeof(ListWithNoEmptyConstructors));
             var clientTypeAnnotation = new ClientTypeAnnotation(edmType, typeof(ListWithNoEmptyConstructors), "Points", testContext.Model);
 
@@ -153,7 +153,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         public void CreateCollectionPropertyInstanceShouldFailOnTypeWithNoParametersLessConstructors()
         {
             var odataProperty = new ODataProperty() { Name = "foo", Value = new ODataCollectionValue() { TypeName = "Points" } };
-            var testContext = new TestMaterializerContext(new MaterializerCache());
+            var testContext = new TestMaterializerContext();
             testContext.ResolveTypeForMaterializationOverrideFunc = (Type type, string name) =>
             {
                 var edmType = testContext.Model.GetOrCreateEdmType(typeof(ListWithNoEmptyConstructors));
@@ -167,7 +167,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void NonMissingMethodExceptionOnCreateInstanceShouldNotBeCaught()
         {
-            var testContext = new TestMaterializerContext(new MaterializerCache());
+            var testContext = new TestMaterializerContext();
             var edmType = testContext.Model.GetOrCreateEdmType(typeof(ListWithNoEmptyConstructors));
             var clientTypeAnnotation = new ClientTypeAnnotation(edmType, typeof(ErrorThrowingList), "Points", testContext.Model);
 
@@ -181,7 +181,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
 
         internal CollectionValueMaterializationPolicy CreateCollectionValueMaterializationPolicy()
         {
-            return CreateCollectionValueMaterializationPolicy(new TestMaterializerContext(new MaterializerCache()));
+            return CreateCollectionValueMaterializationPolicy(new TestMaterializerContext());
         }
 
         internal CollectionValueMaterializationPolicy CreateCollectionValueMaterializationPolicy(IODataMaterializerContext materializerContext)

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/EntryMaterializationPolicyForComplexResourceTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/EntryMaterializationPolicyForComplexResourceTests.cs
@@ -50,7 +50,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void ApplyNonExistantPropertyWithIgnoreMissingPropertiesShouldNotError()
         {
-            TestMaterializerContext  materializerContext = new TestMaterializerContext(new MaterializerCache()) { UndeclaredPropertyBehavior = DSClient.UndeclaredPropertyBehavior.Support };
+            TestMaterializerContext  materializerContext = new TestMaterializerContext() { UndeclaredPropertyBehavior = DSClient.UndeclaredPropertyBehavior.Support };
             CollectionValueMaterializationPolicyTests.Point point = new CollectionValueMaterializationPolicyTests.Point();
             ODataProperty property = new ODataProperty() { Name = "Z", Value = 10 };
             this.CreateEntryMaterializationPolicy(materializerContext)
@@ -60,7 +60,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void ApplyNullOnCollectionPropertyShouldError()
         {
-            TestMaterializerContext  materializerContext = new TestMaterializerContext(new MaterializerCache());
+            TestMaterializerContext  materializerContext = new TestMaterializerContext();
             ComplexTypeWithPrimitiveCollection complexInstance = new ComplexTypeWithPrimitiveCollection();
             ODataProperty property = new ODataProperty() { Name = "Strings", Value = null };
 
@@ -71,7 +71,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void ApplyStringValueForCollectionPropertyShouldError()
         {
-            TestMaterializerContext  materializerContext = new TestMaterializerContext(new MaterializerCache());
+            TestMaterializerContext  materializerContext = new TestMaterializerContext();
             ComplexTypeWithPrimitiveCollection complexInstance = new ComplexTypeWithPrimitiveCollection();
             ODataProperty property = new ODataProperty() { Name = "Strings", Value = "foo" };
 
@@ -82,8 +82,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void MaterializeDerivedComplexForBaseComplexTypeProperty()
         {
-            var materializerCache = new MaterializerCache();
-            TestMaterializerContext  materializerContext = new TestMaterializerContext(materializerCache);
+            TestMaterializerContext  materializerContext = new TestMaterializerContext();
 
             //In a true client, a TypeResolver will be used to resolve derived property type.
             materializerContext.ResolveTypeForMaterializationOverrideFunc = (Type type, string name) =>
@@ -110,7 +109,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void ApplyDerivedComplexForBaseComplexTypeProperty()
         {
-            TestMaterializerContext  materializerContext = new TestMaterializerContext(new MaterializerCache());
+            TestMaterializerContext  materializerContext = new TestMaterializerContext();
 
             materializerContext.ResolveTypeForMaterializationOverrideFunc = (Type type, string name) =>
             {
@@ -141,7 +140,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void ApplyODataCollectionValueToNonNullExistingCollectionProperty()
         {
-            TestMaterializerContext  materializerContext = new TestMaterializerContext(new MaterializerCache());
+            TestMaterializerContext  materializerContext = new TestMaterializerContext();
 
             ComplexTypeWithPrimitiveCollection complexInstance = new ComplexTypeWithPrimitiveCollection();
             complexInstance.Strings.Add("ShouldBeCleared");
@@ -157,7 +156,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void ApplyODataCollectionValueToNullCollectionProperty()
         {
-            TestMaterializerContext  materializerContext = new TestMaterializerContext(new MaterializerCache());
+            TestMaterializerContext  materializerContext = new TestMaterializerContext();
             ComplexTypeWithPrimitiveCollection complexInstance = new ComplexTypeWithPrimitiveCollection();
             complexInstance.Strings = null;
             ODataProperty property = new ODataProperty() { Name = "Strings", Value = new ODataCollectionValue() { Items = new string[] { "foo" }, TypeName = typeof(ComplexTypeWithPrimitiveCollection).FullName } };
@@ -172,7 +171,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         {
             foreach (var startingPropertyState in new ChildComplexType[] { null, new ChildComplexType() })
             {
-                TestMaterializerContext  materializerContext = new TestMaterializerContext(new MaterializerCache());
+                TestMaterializerContext  materializerContext = new TestMaterializerContext();
                 ComplexTypeWithChildComplexType complexInstance = new ComplexTypeWithChildComplexType();
                 complexInstance.InnerComplexProperty = startingPropertyState;
                 var innerEntry = new ODataResource() { Properties = new ODataProperty[] { new ODataProperty() { Name = "Prop", Value = 1 } } };
@@ -184,7 +183,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         [Fact]
         public void NullValueShouldBeAppliedToSubComplexValueProperty()
         {
-            TestMaterializerContext  materializerContext = new TestMaterializerContext(new MaterializerCache());
+            TestMaterializerContext  materializerContext = new TestMaterializerContext();
             ComplexTypeWithChildComplexType complexInstance = new ComplexTypeWithChildComplexType();
             complexInstance.InnerComplexProperty = new ChildComplexType();
 
@@ -194,7 +193,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
 
         private void ApplyInnerProperty(ODataResource innerResource, ComplexTypeWithChildComplexType parentInstance, TestMaterializerContext  materializerContext = null)
         {
-            materializerContext = materializerContext ?? new TestMaterializerContext(new MaterializerCache());
+            materializerContext = materializerContext ?? new TestMaterializerContext();
             var resource = new ODataResource() { TypeName = "ComplexTypeWithChildComplexType", Properties = new ODataProperty[0] };
 
             var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
@@ -224,7 +223,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         {
             var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
             var context = new DataServiceContext();
-            materializerContext = materializerContext ?? new TestMaterializerContext(new MaterializerCache()) { Model = clientEdmModel, Context = context };
+            materializerContext = materializerContext ?? new TestMaterializerContext() { Model = clientEdmModel, Context = context };
             var adapter = new EntityTrackingAdapter(new TestEntityTracker(), MergeOption.OverwriteChanges, clientEdmModel, context, materializerContext);
             var lazyPrimitivePropertyConverter = new DSClient.SimpleLazy<PrimitivePropertyConverter>(() => new PrimitivePropertyConverter());
             var primitiveValueMaterializerPolicy = new PrimitiveValueMaterializationPolicy(materializerContext, lazyPrimitivePropertyConverter);
@@ -274,7 +273,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
                 new ODataResource(){Properties = new ODataProperty[]{ new ODataProperty(){Name="Points", Value = 0}, new ODataProperty(){Name="Diameter", Value = 18} }},
             });
 
-            var testContext = new TestMaterializerContext(new MaterializerCache());
+            var testContext = new TestMaterializerContext();
             testContext.ResolveTypeForMaterializationOverrideFunc = (Type type, string name) =>
             {
                 var edmType = testContext.Model.GetOrCreateEdmType(typeof(CollectionValueMaterializationPolicyTests.Circle));
@@ -328,7 +327,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
         {
             var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
             var context = new DataServiceContext();
-            materializerContext = materializerContext ?? new TestMaterializerContext(new MaterializerCache()) { Model = clientEdmModel, Context = context };
+            materializerContext = materializerContext ?? new TestMaterializerContext() { Model = clientEdmModel, Context = context };
 
             var resourceSet = new ODataResourceSet();
             MaterializerFeed.CreateFeed(resourceSet, resources, materializerContext);

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/EntryValueMaterializationPolicyUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/EntryValueMaterializationPolicyUnitTests.cs
@@ -41,7 +41,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
             this.clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
             this.clientEdmModel.GetOrCreateEdmType(typeof(TestCustomer));
             this.clientEdmModel.GetOrCreateEdmType(typeof(TestOrder));
-            this.materializerContext = new TestMaterializerContext(new MaterializerCache()) { Model = this.clientEdmModel };
+            this.materializerContext = new TestMaterializerContext() { Model = this.clientEdmModel };
             this.ordersProperty = this.clientEdmModel.GetClientTypeAnnotation(typeof(TestCustomer)).GetProperty("Orders", UndeclaredPropertyBehavior.ThrowException);
         }
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/FeedAndEntryMaterializerAdapterUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/FeedAndEntryMaterializerAdapterUnitTests.cs
@@ -52,7 +52,7 @@ namespace AstoriaUnitTests.Tests
 
             var responsePipeline = new DataServiceClientResponsePipelineConfiguration(new DataServiceContext());
             var odataReaderWrapper = ODataReaderWrapper.CreateForTest(testODataReader, responsePipeline);
-            var materializerContext = new TestMaterializerContext(new MaterializerCache());
+            var materializerContext = new TestMaterializerContext();
             FeedAndEntryMaterializerAdapter reader = new FeedAndEntryMaterializerAdapter(ODataFormat.Json, odataReaderWrapper, clientEdmModel, MergeOption.OverwriteChanges, materializerContext);
 
             int readCounter = 0;

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/MaterializerEntryTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/MaterializerEntryTests.cs
@@ -64,7 +64,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
                 modifyEntry(entry);
             }
 
-            var materializerContext = new TestMaterializerContext(new MaterializerCache());
+            var materializerContext = new TestMaterializerContext();
             return MaterializerEntry.CreateEntry(entry, format, true, this.clientModel, materializerContext);
         }
     }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/ODataEntityMaterializerUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/ODataEntityMaterializerUnitTests.cs
@@ -31,7 +31,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         [Fact]
         public void AfterEntryMaterializedShouldOccur()
         {
-            var materializerContext = new TestMaterializerContext(new MaterializerCache());
+            var materializerContext = new TestMaterializerContext();
 
             foreach (ODataFormat format in new ODataFormat[] { ODataFormat.Json })
             {

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/ODataEntriesEntityMaterializerUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/ODataEntriesEntityMaterializerUnitTests.cs
@@ -30,7 +30,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
 
             var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
             var context = new DataServiceContext();
-            var materializerContext = new TestMaterializerContext(new MaterializerCache()) { Model = clientEdmModel, Context = context };
+            var materializerContext = new TestMaterializerContext() { Model = clientEdmModel, Context = context };
             MaterializerEntry.CreateEntry(odataEntry, ODataFormat.Json, true, clientEdmModel, materializerContext);
             
             var adapter = new EntityTrackingAdapter(new TestEntityTracker(), MergeOption.OverwriteChanges, clientEdmModel, context, materializerContext);

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/PrimitiveValueMaterializationPolicyTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/PrimitiveValueMaterializationPolicyTests.cs
@@ -63,7 +63,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client.Materialization
 
         internal PrimitiveValueMaterializationPolicy CreatePrimitiveValueMaterializationPolicy()
         {
-            return new PrimitiveValueMaterializationPolicy(new TestMaterializerContext(new MaterializerCache()), new SimpleLazy<PrimitivePropertyConverter>(() => new PrimitivePropertyConverter()));
+            return new PrimitiveValueMaterializationPolicy(new TestMaterializerContext(), new SimpleLazy<PrimitivePropertyConverter>(() => new PrimitivePropertyConverter()));
         }
 
         public class UnknownPoint

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/TestMaterializerContext.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/TestMaterializerContext.cs
@@ -17,13 +17,13 @@ namespace AstoriaUnitTests.Tests
     /// </summary>
     internal class TestMaterializerContext : IODataMaterializerContext
     {
-        public TestMaterializerContext(MaterializerCache materializerCache)
+        public TestMaterializerContext()
         {
             this.UndeclaredPropertyBehavior = UndeclaredPropertyBehavior.ThrowException;
             this.ResponsePipeline = new DataServiceClientResponsePipelineConfiguration(this);
             this.Model = new ClientEdmModel(ODataProtocolVersion.V4);
             this.Context = new DataServiceContext();
-            this.MaterializerCache = materializerCache;
+            this.MaterializerCache = new MaterializerCache();
         }
 
         public Func<Type, string, ClientTypeAnnotation> ResolveTypeForMaterializationOverrideFunc { get; set; }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/T4/ODataT4CamelCaseTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/T4/ODataT4CamelCaseTests.cs
@@ -322,7 +322,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
 
             var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
             var context = new DataServiceContext();
-            var materializerContext = new TestMaterializerContext(new MaterializerCache()) { Model = clientEdmModel, Context = context };
+            var materializerContext = new TestMaterializerContext() { Model = clientEdmModel, Context = context };
             var materializerEntry = MaterializerEntry.CreateEntry(odataEntry, OData.ODataFormat.Json, true, clientEdmModel, materializerContext);
 
             MaterializerNavigationLink.CreateLink(complexP, MaterializerEntry.CreateEntry(complexResource, OData.ODataFormat.Json, true, clientEdmModel, materializerContext), materializerContext);
@@ -382,7 +382,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
                 }
             };
 
-            var materializerContext = new TestMaterializerContext(new MaterializerCache());
+            var materializerContext = new TestMaterializerContext();
             var materializerEntry = MaterializerEntry.CreateEntry(complexValue, OData.ODataFormat.Json, false, new ClientEdmModel(ODataProtocolVersion.V4), materializerContext);
             this.CreateEntryMaterializationPolicy().Materialize(materializerEntry, typeof(ComplexType), false);
             var complex = materializerEntry.ResolvedObject as ComplexType;
@@ -398,7 +398,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         {
             OData.ODataEnumValue enumValue = new OData.ODataEnumValue("blue");
             OData.ODataProperty property = new OData.ODataProperty { Name = "enumProperty", Value = enumValue };
-            var materializerContext = new TestMaterializerContext(new MaterializerCache());
+            var materializerContext = new TestMaterializerContext();
             var enumPolicy = new EnumValueMaterializationPolicy(materializerContext);
             var result = enumPolicy.MaterializeEnumTypeProperty(typeof(Color), property);
             property.GetMaterializedValue(materializerContext).Should().Be(Color.Blue);
@@ -473,7 +473,7 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         {
             var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
             var context = new DataServiceContext().ReConfigureForNetworkLoadingTests();
-            materializerContext = materializerContext ?? new TestMaterializerContext(new MaterializerCache()) { Model = clientEdmModel, Context = context };
+            materializerContext = materializerContext ?? new TestMaterializerContext() { Model = clientEdmModel, Context = context };
             var adapter = new EntityTrackingAdapter(new TestEntityTracker(), MergeOption.OverwriteChanges, clientEdmModel, context, materializerContext);
             var lazyPrimitivePropertyConverter = new Microsoft.OData.Client.SimpleLazy<PrimitivePropertyConverter>(() => new PrimitivePropertyConverter());
             var primitiveValueMaterializerPolicy = new PrimitiveValueMaterializationPolicy(materializerContext, lazyPrimitivePropertyConverter);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2531 

### Description

The `ProjectionPlanCompiler` and `GroupByProjectionCompiler` class call methods of the `ODataEntityMaterializerInvoker` dynamically using reflection/dynamic IL generation. Since the [PR that refactored the `MaterializerCache`](https://github.com/OData/odata.net/pull/2506), many materializer static methods needed to adjusted to accept an `IODataMaterializerContext` as input. 2 methods in `ProjectionPlanCompiler` expect a materializer context as the last argument: `ProjectionCheckValueForPathIsNull` and `ProjectionDynamicValueForPath`. `ProjectionPlanCompiler` calls both methods, but did not pass the materializer context to the `ProjectionCheckValueForPathIsNull`. There was not test covering this method, so we didn't notice. This method is called when there's a conditional check against a nested navigation property in the LINQ query. I've added a test and fixed it.

I've also done some additional refactoring (replacing string literals of method names with `nameof`) and implementing suggestions @corranrogue9 added to [this PR](https://github.com/OData/odata.net/pull/2506)

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
