### PR TITLE
issue #2098: fix the issue ODataException: To compute an entity's metadata, its key and concurrency-token property values must be provided

### DIFF
--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -2828,7 +2828,7 @@ namespace Microsoft.OData
             ODataPath path = odataPath;
 
             KeyValuePair<string, object>[] keys = GetKeyProperties(throwIfFail);
-            if (keys == null || keys.Length == 0)
+            if (keys != null && keys.Length > 0)
             {
                 IEdmEntityType currentEntityType = this.CurrentScope.ResourceType as IEdmEntityType;
                 path = path.AddKeySegment(keys, currentEntityType, this.CurrentScope.NavigationSource);

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPathExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPathExtensions.cs
@@ -187,13 +187,18 @@ namespace Microsoft.OData.UriParser
         /// <returns>A new ODataPath with key segment added</returns>
         internal static ODataPath AddKeySegment(this ODataPath path, IEnumerable<KeyValuePair<string, object>> keys, IEdmEntityType edmType, IEdmNavigationSource navigationSource)
         {
+            KeySegment keySegment = new KeySegment(keys, edmType, navigationSource);
+            return path.AddKeySegment(keySegment);
+        }
+
+        internal static ODataPath AddKeySegment(this ODataPath path, KeySegment keySegment)
+        {
             var handler = new SplitEndingSegmentOfTypeHandler<TypeSegment>();
             path.WalkWith(handler);
-            KeySegment keySegment = new KeySegment(keys, edmType, navigationSource);
             ODataPath newPath = handler.FirstPart;
             newPath.Add(keySegment);
             AppendLastSegment(handler, newPath);
-          
+
             return newPath;
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -13,6 +13,10 @@ using Microsoft.OData.UriParser;
 using Microsoft.OData.Edm;
 using Microsoft.Test.OData.DependencyInjection;
 using Xunit;
+using System.Xml;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Csdl;
+using System.Threading.Tasks;
 
 namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
 {
@@ -510,6 +514,21 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             var function4 = new EdmFunction("Namespace", "Function4", new EdmEntityTypeReference(EntityType, false), true /*isBound*/, new EdmPathExpression("p/ExpandedNavLink"), true /*iscomposable*/);
             function4.AddParameter("p", new EdmEntityTypeReference(EntityType, isNullable: true));
             Model.AddElement(function4);
+        }
+
+        [Fact]
+        public void AATest()
+        {
+            StringBuilder stringBuilder = new StringBuilder();
+            StringWriter stringWriter = new StringWriter(stringBuilder);
+
+            using (var writer = XmlWriter.Create(stringWriter))
+            {
+                IEnumerable<EdmError> errors;
+                CsdlWriter.TryWriteCsdl(Model, writer, CsdlTarget.OData, out errors);
+            }
+
+            string modelAsString = stringBuilder.ToString();
         }
 
         public enum SerializationType
@@ -1232,7 +1251,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             ODataResource entityValue = new ODataResource
             {
                 TypeName = "NS.Customer",
-                Properties = new[] { new ODataProperty { Name = "Id", Value = 42 }}
+                Properties = new[] { new ODataProperty { Name = "Id", Value = 42 } }
             };
             resourceWriter.WriteStart(entityValue);
             resourceWriter.WriteEnd();
@@ -1356,6 +1375,172 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             return model;
         }
 
+        [Theory]
+        [InlineData("minimal")]
+        [InlineData("full")]
+        public void WritingContainedNavigationPropertyWithoutProvideKeyPropertyOnParentResourceWorks(string metadataLevel)
+        {
+            MemoryStream outputStream = new MemoryStream();
+            var container = ContainerBuilderHelper.BuildContainer(null);
+            IODataResponseMessage message = new InMemoryMessage() { Stream = outputStream, Container = container };
+
+            message.SetHeader("Content-Type", metadataLevel == "full" ? "application/json;odata.metadata=full" : "application/json");
+            ODataMessageWriterSettings settings = new ODataMessageWriterSettings();
+            var result = new ODataQueryOptionParser(Model, EntityType, EntitySet,
+                new Dictionary<string, string> { { "$select", "Name" }, { "$expand", "ContainedNavProp" } }).ParseSelectAndExpand();
+
+            ODataUri odataUri = new ODataUri()
+            {
+                ServiceRoot = new Uri("http://example.com"),
+                SelectAndExpand = result
+            };
+
+            Uri requestUri = new Uri("http://example.com/EntitySet(1)");
+            odataUri.RequestUri = requestUri;
+            odataUri.Path = new ODataUriParser(Model, new Uri("http://example.com"), requestUri).ParsePath();
+            settings.ODataUri = odataUri;
+
+            string output;
+            using (var messageWriter = new ODataMessageWriter(message, settings, Model))
+            {
+                ODataWriter writer = messageWriter.CreateODataResourceWriter(EntitySet, EntityType);
+
+                ODataResource resource = new ODataResource
+                {
+                    TypeName = "Namespace.EntityType",
+                    Properties = new[]
+                    {
+                        new ODataProperty { Name = "Name", Value = "SampleName" }
+                    }
+                };
+
+                if (metadataLevel == "full")
+                {
+                    resource.Id = new Uri("http://example.com/EntitySet(1)");
+                }
+
+                writer.WriteStart(resource);
+                ODataNestedResourceInfo nestedResourceInfo = new ODataNestedResourceInfo
+                {
+                    IsCollection = true,
+                    Name = "ContainedNavProp"
+                };
+                writer.WriteStart(nestedResourceInfo);
+                writer.WriteStart(new ODataResourceSet());
+                writer.WriteEnd(); // end of nested resource set
+                writer.WriteEnd(); // end of nested resource info
+                writer.WriteEnd(); // end of resource
+
+                outputStream.Seek(0, SeekOrigin.Begin);
+                output = new StreamReader(outputStream).ReadToEnd();
+            }
+
+            if (metadataLevel == "full")
+            {
+                Assert.Equal("{\"@odata.context\":\"http://example.com/$metadata#EntitySet(Name,ContainedNavProp())/$entity\"," +
+                  "\"@odata.type\":\"#Namespace.EntityType\"," +
+                  "\"@odata.id\":\"http://example.com/EntitySet(1)\"," +
+                  "\"@odata.etag\":\"W/\\\"'SampleName'\\\"\"," +
+                  "\"@odata.editLink\":\"EntitySet(1)\"," +
+                  "\"@odata.mediaEditLink\":\"EntitySet(1)/$value\"," +
+                  "\"Name\":\"SampleName\"," +
+                  "\"ContainedNavProp@odata.associationLink\":\"http://example.com/EntitySet(1)/ContainedNavProp/$ref\"," +
+                  "\"ContainedNavProp@odata.navigationLink\":\"http://example.com/EntitySet(1)/ContainedNavProp\"," +
+                  "\"ContainedNavProp\":[]}", output);
+            }
+            else
+            {
+                Assert.Equal("{\"@odata.context\":\"http://example.com/$metadata#EntitySet(Name,ContainedNavProp())/$entity\"," +
+                  "\"Name\":\"SampleName\"," +
+                  "\"ContainedNavProp\":[]}", output);
+            }
+        }
+
+        [Theory]
+        [InlineData("minimal")]
+        [InlineData("full")]
+        public async Task WritingContainedNavigationPropertyWithoutProvideKeyPropertyOnParentResourceSetWorks(string metadataLevel)
+        {
+            MemoryStream outputStream = new MemoryStream();
+            var container = ContainerBuilderHelper.BuildContainer(null);
+            IODataResponseMessage message = new InMemoryMessage() { Stream = outputStream, Container = container };
+
+            message.SetHeader("Content-Type", metadataLevel == "full" ? "application/json;odata.metadata=full" : "application/json");
+            ODataMessageWriterSettings settings = new ODataMessageWriterSettings();
+            var result = new ODataQueryOptionParser(Model, EntityType, EntitySet,
+                new Dictionary<string, string> { { "$select", "Name" }, { "$expand", "ContainedNavProp" } }).ParseSelectAndExpand();
+
+            ODataUri odataUri = new ODataUri()
+            {
+                ServiceRoot = new Uri("http://example.com"),
+                SelectAndExpand = result
+            };
+
+            Uri requestUri = new Uri("http://example.com/EntitySet");
+            odataUri.RequestUri = requestUri;
+            odataUri.Path = new ODataUriParser(Model, new Uri("http://example.com"), requestUri).ParsePath();
+            settings.ODataUri = odataUri;
+
+            string output;
+            using (var messageWriter = new ODataMessageWriter(message, settings, Model))
+            {
+                ODataWriter writer = await messageWriter.CreateODataResourceSetWriterAsync(EntitySet, EntityType);
+                await writer.WriteStartAsync(new ODataResourceSet());
+                ODataResource resource = new ODataResource
+                {
+                    TypeName = "Namespace.EntityType",
+                    Properties = new[]
+                    {
+                        new ODataProperty { Name = "Name", Value = "SampleName" }
+                    }
+                };
+
+                if (metadataLevel == "full")
+                {
+                    resource.Id = new Uri("http://example.com/EntitySet(1)");
+                }
+
+                await writer.WriteStartAsync(resource);
+                ODataNestedResourceInfo nestedResourceInfo = new ODataNestedResourceInfo
+                {
+                    IsCollection = true,
+                    Name = "ContainedNavProp"
+                };
+                await writer.WriteStartAsync(nestedResourceInfo);
+                await writer.WriteStartAsync(new ODataResourceSet());
+                await writer.WriteEndAsync(); // end of nested resource set
+                await writer.WriteEndAsync(); // end of nested resource info
+                await writer.WriteEndAsync(); // end of resource
+                await writer.WriteEndAsync(); // end of resourceset
+
+                outputStream.Seek(0, SeekOrigin.Begin);
+                output = new StreamReader(outputStream).ReadToEnd();
+            }
+
+            if (metadataLevel == "full")
+            {
+                Assert.Equal("{\"@odata.context\":\"http://example.com/$metadata#EntitySet(Name,ContainedNavProp())\"," +
+                    "\"value\":[" +
+                    "{" +
+                      "\"@odata.type\":\"#Namespace.EntityType\"," +
+                      "\"@odata.id\":\"http://example.com/EntitySet(1)\"," +
+                      "\"@odata.etag\":\"W/\\\"'SampleName'\\\"\"," +
+                      "\"@odata.editLink\":\"EntitySet(1)\"," +
+                      "\"@odata.mediaEditLink\":\"EntitySet(1)/$value\"," +
+                      "\"Name\":\"SampleName\"," +
+                      "\"ContainedNavProp@odata.associationLink\":\"http://example.com/EntitySet(1)/ContainedNavProp/$ref\"," +
+                      "\"ContainedNavProp@odata.navigationLink\":\"http://example.com/EntitySet(1)/ContainedNavProp\"," +
+                      "\"ContainedNavProp\":[]}]}", output);
+            }
+            else
+            {
+                Assert.Equal("{\"@odata.context\":\"http://example.com/$metadata#EntitySet(Name,ContainedNavProp())\"," +
+                    "\"value\":[" +
+                      "{\"Name\":\"SampleName\",\"ContainedNavProp\":[]}" +
+                    "]}", output);
+            }
+        }
+
         [Fact]
         public void WritingSimplifiedODataAnnotationsInFullMetadataMode()
         {
@@ -1429,7 +1614,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
                                            "\"UnknownNonCollectionNavProp@odata.navigationLink\":\"http://example.com/EntitySet(123)/UnknownNonCollectionNavProp\"," +
                                            "\"UnknownCollectionNavProp@odata.associationLink\":\"http://example.com/EntitySet(123)/UnknownCollectionNavProp/$ref\"," +
                                            "\"UnknownCollectionNavProp@odata.navigationLink\":\"http://example.com/EntitySet(123)/UnknownCollectionNavProp\"," +
-                                           "\"EnumAsKeyContainedNavProp@odata.associationLink\":\"http://example.com/EntitySet(123)/EnumAsKeyContainedNavProp/$ref\","+
+                                           "\"EnumAsKeyContainedNavProp@odata.associationLink\":\"http://example.com/EntitySet(123)/EnumAsKeyContainedNavProp/$ref\"," +
                                            "\"EnumAsKeyContainedNavProp@odata.navigationLink\":\"http://example.com/EntitySet(123)/EnumAsKeyContainedNavProp\"," +
                                            "\"StreamProp1@odata.mediaEditLink\":\"http://example.com/EntitySet(123)/StreamProp1\"," +
                                            "\"StreamProp1@odata.mediaReadLink\":\"http://example.com/EntitySet(123)/StreamProp1\"," +


### PR DESCRIPTION
…adata, its key and concurrency-token property values must be provided

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2098.*

### Description

*Basically, to generate a link for a contained resource we need the id of the containing resource. If the id value wasn’t included in a $select, we don’t have the id so we can’t create the link and throw an exception. We used to catch and silently ignore this exception, which resulted in creating an invalid URL, which was bad.  However, now we throw an exception in cases we didn’t before, which is breaking existing apps.

We could fix this at the webapi level by always making sure the key properties are included (similar to the workaround someone provided), but by the time it gets to ODL it’s too late if the key property isn’t available.  The best we can do is probably to not generate the link if we are missing this information, although even that is non-ideal.


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
