### PR TITLE
Fixed the "NormalizeStringCollectionItems" method  …

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -158,7 +158,8 @@ namespace Microsoft.OData.UriParser
         {
             // a comma-separated list of primitive values, enclosed in parentheses,
             // or a single expression that resolves to a collection
-            StringBuilder sb = new StringBuilder();
+            if (literalText == null) return NullLiteral;
+            StringBuilder sb = new StringBuilder(literalText.Length);
             char? openStringChar = null;
             char previousChar = '\0';
             int closeIndex = 0;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/InBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/InBinderTests.cs
@@ -34,6 +34,8 @@ namespace Microsoft.OData.Core.Tests.UriParser.Binders
             Assert.Equal("[\"\\\"\\\"\\\"\"]", InBinder.NormalizeStringCollectionItems("[\"\\\"\\\"\\\"\"]"));
             Assert.Equal("", InBinder.NormalizeStringCollectionItems(""));
             Assert.Equal("\"ABC\"", InBinder.NormalizeStringCollectionItems("\"ABC\""));
+            Assert.Equal("", InBinder.NormalizeStringCollectionItems(""));
+            Assert.Equal("null", InBinder.NormalizeStringCollectionItems(null));
         }
 
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/InBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/InBinderTests.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.OData.UriParser;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.OData.Core.Tests.UriParser.Binders
+{
+    public class InBinderTests
+    {
+
+        [Fact]
+        public void NormalizeStringCollectionItems()
+        {
+            Assert.Equal("[\"ABC\"]", InBinder.NormalizeStringCollectionItems("(\"ABC\")"));
+            Assert.Equal("[null,null]", InBinder.NormalizeStringCollectionItems("[null,null]"));
+            Assert.Equal("[]", InBinder.NormalizeStringCollectionItems("[]"));
+            Assert.Equal("[\"\\\"\\\"\"]", InBinder.NormalizeStringCollectionItems("['']"));
+            Assert.Equal("[\"\\\"\\\"\"]", InBinder.NormalizeStringCollectionItems("[\"\"]"));
+            Assert.Equal("[\"\\\"\\\"\",\"\\\"\\\"\"]", InBinder.NormalizeStringCollectionItems("['','']"));
+            Assert.Equal("[\"\\\"\\\"\",\"\\\"\\\"\"]", InBinder.NormalizeStringCollectionItems("[\"\", \"\"]"));
+            Assert.Equal("[\"'\"]", InBinder.NormalizeStringCollectionItems("['''']"));
+            Assert.Equal("[\"\\\"\"]", InBinder.NormalizeStringCollectionItems("['\"']"));
+            Assert.Equal("[\"'\"]", InBinder.NormalizeStringCollectionItems("[\"'\"]"));
+            Assert.Equal("[\"'''\"]", InBinder.NormalizeStringCollectionItems("['''''''']"));
+            Assert.Equal("[\"A\",,,,\"B\",\"C\"]", InBinder.NormalizeStringCollectionItems("['A',,,,'B','C']"));
+            Assert.Equal("[\"[AB'''CD\",\"(EF)GH&IJ\",null]", InBinder.NormalizeStringCollectionItems("[\"[AB'''CD\",'(EF)GH&IJ', null]"));
+            Assert.Equal("[\"ABC\",\"DEF\"]", InBinder.NormalizeStringCollectionItems("['ABC',   'DEF]"));
+            Assert.Equal("[\"ABC\",\"DEF\"]", InBinder.NormalizeStringCollectionItems("[\"ABC\",   \"DEF]"));
+            // The following tests failed in the previous version of the "NormalizeStringCollectionItems" method 
+            Assert.Equal("[\"[AB)'\",\"(CD)EF&GH\"]", InBinder.NormalizeStringCollectionItems("['[AB)''','(CD)EF&GH']"));
+            Assert.Equal("[\"\\\"\\\"\\\"\"]", InBinder.NormalizeStringCollectionItems("[\"\\\"\\\"\\\"\"]"));
+            Assert.Equal("", InBinder.NormalizeStringCollectionItems(""));
+            Assert.Equal("\"ABC\"", InBinder.NormalizeStringCollectionItems("\"ABC\""));
+        }
+
+    }
+}


### PR DESCRIPTION
…which triggered an exception when a string ended with a quote.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

No issues was created.

### Description

The previous "NormalizeStringCollectionItems" method throw an exception if the input string, surrounded by simple quote contains a single quote as last character :
```
OLD: ['[AB)''','(CD)EF&GH'] -> FAILED ! ERROR
NEW: ['[AB)''','(CD)EF&GH'] -> ["[AB)'","(CD)EF&GH"]
```

An another strange result is fixed :
```
OLD: ["\"\"\""] -> ["\"\"\"\"\""]
NEW: ["\"\"\""] -> ["\"\"\""]
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
