### PR TITLE
odata.id annotation property should be written for transient complex resource

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceSerializer.cs
@@ -95,7 +95,7 @@ namespace Microsoft.OData.JsonLight
 
             // Write the "@odata.id": "Entity Id"
             Uri id;
-            if (resource.MetadataBuilder.TryGetIdForSerialization(out id))
+            if (resourceState?.ResourceType?.TypeKind != EdmTypeKind.Complex && resource.MetadataBuilder.TryGetIdForSerialization(out id))
             {
                 this.ODataAnnotationWriter.WriteInstanceAnnotationName(ODataAnnotationNames.ODataId);
                 if (id != null && !resource.HasNonComputedId)
@@ -397,7 +397,7 @@ namespace Microsoft.OData.JsonLight
 
             // Write the "@odata.id": "Entity Id"
             Uri id;
-            if (resource.MetadataBuilder.TryGetIdForSerialization(out id))
+            if (resourceState?.ResourceType?.TypeKind != EdmTypeKind.Complex && resource.MetadataBuilder.TryGetIdForSerialization(out id))
             {
                 await this.AsynchronousODataAnnotationWriter.WriteInstanceAnnotationNameAsync(ODataAnnotationNames.ODataId)
                     .ConfigureAwait(false);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2565.*

### Description

`odata.id` annotation property should not be written for transient complex resource

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
