### PR TITLE
Fix performance regression in DataServiceContext DefaultResolveType method

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -3279,7 +3279,12 @@ namespace Microsoft.OData.Client
 
                 if (!this.resolveTypesCache.TryGetValue(typeName, out matchedType))
                 {
-                    if (ClientTypeUtil.TryResolveType(typeName, fullNamespace, languageDependentNamespace, out matchedType))
+                    if (ClientTypeUtil.TryResolveType(
+                        this.GetType().GetAssembly(),
+                        typeName,
+                        fullNamespace,
+                        languageDependentNamespace,
+                        out matchedType))
                     {
                         this.resolveTypesCache.TryAdd(typeName, matchedType);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2557, fixes #2514*

### Description

Fix performance regression in `DataServiceContext` `DefaultResolveType` method.
- By searching for the materialization type from the assembly containing the data service context instance **first**
- By searching for the materialization type from the executing assembly **next** - where it's different from the assembly in the first step
- By searching for the materialization type from the other loaded assemblies while skipping framework and OData libraries where the type wouldn't be expected to be

Performance improvements stats

**Before this fix:**
| Run |      Method |     Mean |     Error |    StdDev |
|-----:|------------ |---------:|----------:|----------:|
| 1 | ResolveType | 9.559 ms | 0.2664 ms | 0.7771 ms |
| 2 | ResolveType | 10.82 ms | 0.187 ms | 0.511 ms |
| 3 | ResolveType | 10.15 ms | 0.218 ms | 0.644 ms |

**After this fix:**
| Run |      Method |     Mean |     Error |    StdDev |
|-----:|------------ |---------:|----------:|----------:|
| 1 | ResolveType | 3.173 ms | 0.0407 ms | 0.1153 ms |
| 2 | ResolveType | 4.023 ms | 0.0813 ms | 0.2254 ms |
| 3 | ResolveType | 3.161 ms | 0.0625 ms | 0.1772 ms |

**Before the change that introduced the performance regression:**
| Run |      Method |     Mean |     Error |    StdDev |
|-----|------------ |---------:|----------:|----------:|
| 1 | ResolveType | 4.901 ms | 0.3239 ms | 0.9396 ms |
| 2 | ResolveType | 3.148 ms | 0.0417 ms | 0.1195 ms |
| 3 | ResolveType | 5.302 ms | 0.2001 ms | 0.5511 ms |
| 4 | ResolveType | 3.965 ms | 0.2389 ms | 0.6855 ms |
| 5 | ResolveType | 3.495 ms | 0.1477 ms | 0.4354 ms |

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
