### PR TITLE
fix: ExpressionWriter only prepend slash to method call when we have …

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
@@ -413,7 +413,10 @@ namespace Microsoft.OData.Client
 
                     if (m.Method.Name != "GetValue" && m.Method.Name != "GetValueAsync")
                     {
-                        this.builder.Append(UriHelper.FORWARDSLASH);
+                        if (this.parent != null)
+                        {
+                            this.builder.Append(UriHelper.FORWARDSLASH);
+                        }
 
                         // writing functions in query options
                         writingFunctionsInQuery = true;


### PR DESCRIPTION
…a parent #2570

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2570 

### Description

Only prepend a slash to method name if it is non static (that is it is having a parent).

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
