### PR TITLE
IncrementVersion.ps1 fixes

### DIFF
--- a/tools/IncrementVersion.ps1
+++ b/tools/IncrementVersion.ps1
@@ -54,7 +54,9 @@ ForEach ($line in $($changedFiles -split [System.Environment]::NewLine))
     $unshipped = Join-Path -Path $PSScriptRoot -ChildPath ..\$line
     $shipped = [System.IO.Path]::GetDirectoryName($unshipped) + "\PublicAPI.Shipped.txt"
 
-    Copy-Item $unshipped -Destination $shipped
+    $combined = Get-Content $unshipped,$shipped
+    $combined | Set-Content $shipped
+    Clear-Content $unshipped
 
     $apiChanges = $true
   }

--- a/tools/IncrementVersion.ps1
+++ b/tools/IncrementVersion.ps1
@@ -85,6 +85,7 @@ foreach ($propertyGroup in $versions.Project.PropertyGroup)
       Write-Host "Incrementing the VersionMinor in $versionPath to $currentVersion"
 
       $propertyGroup.VersionMinor.'#text' = [string] $currentVersion
+      $propertyGroup.VersionBuildNumber.'#text' = '0'
     }
 
     # if there are not api changes or the caller requested a revision version increment


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2439.*

### Description

Updated the `IncrementVersion.ps1` script to not duplicate the `PublicAPI.*.txt` files but instead concatenate them. Also updated the script to correctly increment minor versions (issue #2439, it currently will increment, for example, from 7.12.5 to 7.13.5 instead of 7.13.0). 

