### PR TITLE
Prevent multiple cast segments

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
@@ -406,7 +406,7 @@ namespace Microsoft.OData.Evaluation
             Uri uri = this.ResourceMetadataContext.Resource.HasNonComputedId ? this.ResourceMetadataContext.Resource.NonComputedId : this.ComputedId;
 
             Debug.Assert(this.ResourceMetadataContext != null && this.ResourceMetadataContext.TypeContext != null, "this.resourceMetadataContext != null && this.resourceMetadataContext.TypeContext != null");
-            if (this.ResourceMetadataContext.ActualResourceTypeName != this.ResourceMetadataContext.TypeContext.NavigationSourceEntityTypeName)
+            if (this.ResourceMetadataContext.ActualResourceTypeName != this.ResourceMetadataContext.TypeContext.NavigationSourceEntityTypeName && uri.Segments.Last() != this.ResourceMetadataContext.ActualResourceTypeName)
             {
                 uri = this.UriBuilder.AppendTypeSegment(uri, this.ResourceMetadataContext.ActualResourceTypeName);
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataConventionalEntityMetadataBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataConventionalEntityMetadataBuilderTests.cs
@@ -247,9 +247,10 @@ namespace Microsoft.OData.Tests.Evaluation
         }
 
         [Fact]
-        public void EditLinkShouldContainTypeSegmentIfInstanceTypeIsMoreDerviedThanSet()
+        public void EditLinkShouldContainTypeSegmentIfInstanceTypeIsMoreDerviedThanSet() 
         {
             // Verify that the last segment of the edit link is the expected type segment.
+            _ = this.derivedMultiKeyMultiEtagMleConventionalEntityMetadataBuilder.GetReadLink();
             string[] uriSegments = this.derivedMultiKeyMultiEtagMleConventionalEntityMetadataBuilder.GetEditLink().Segments;
             Assert.Equal("TestModel.DerivedMleProduct", uriSegments[uriSegments.Length - 1]);
         }
@@ -270,6 +271,14 @@ namespace Microsoft.OData.Tests.Evaluation
             this.derivedMultiKeyMultiEtagMleEntry.Id = id;
             Uri expectedEditLink = this.uriBuilder.AppendTypeSegment(id, DerivedMleEntityTypeName);
             Assert.Equal(this.derivedMultiKeyMultiEtagMleConventionalEntityMetadataBuilder.GetEditLink(), expectedEditLink);
+        }
+
+        [Fact]
+        public void GetEditLinkShoulReturnNonComputedIdUriWithoutDoubleTypeCastForDerivedEntityWhenNonComputedIdIsSet()
+        {
+            var id = new Uri($"http://anotherodata.org/serviceBase/SomeType('xyz')/{DerivedMleEntityTypeName}");
+            this.derivedMultiKeyMultiEtagMleEntry.Id = id;
+            Assert.Equal(this.derivedMultiKeyMultiEtagMleConventionalEntityMetadataBuilder.GetEditLink(), id);
         }
 
         [Fact]
@@ -574,6 +583,14 @@ namespace Microsoft.OData.Tests.Evaluation
             var readLinkUri = new Uri("http://anotherodata.org/serviceBaseRead/SomeType('xyz')");
             this.productEntry.ReadLink = readLinkUri;
             Assert.Equal(this.productConventionalEntityMetadataBuilder.GetReadLink(), readLinkUri);
+        }
+
+        [Fact]
+        public void GetReadLinkShoulReturnNonComputedIdUriWithoutDoubleTypeCastForDerivedEntityWhenNonComputedIdIsSet()
+        {
+            var id = new Uri($"http://anotherodata.org/serviceBase/SomeType('xyz')/{DerivedMleEntityTypeName}");
+            this.derivedMultiKeyMultiEtagMleEntry.Id = id;
+            Assert.Equal(this.derivedMultiKeyMultiEtagMleConventionalEntityMetadataBuilder.GetReadLink(), id);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2444 *

### Description

When a resource is a derived type, by default the id link doesn't contains a cast. The AspNetCoreOData library does add this cast, but then the edit link will contain a double cast. This library prevents this.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
