### PR TITLE
Capability to close ODataBinaryStreamValue stream after serialization

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -733,13 +733,21 @@ namespace Microsoft.OData.JsonLight
                 Stream stream = await streamWriter.StartStreamValueScopeAsync().ConfigureAwait(false);
                 await streamValue.Stream.CopyToAsync(stream).ConfigureAwait(false);
                 await stream.FlushAsync().ConfigureAwait(false);
+#if NETCOREAPP3_1_OR_GREATER
+                await stream.DisposeAsync();
+#else
                 stream.Dispose();
+#endif
                 await streamWriter.EndStreamValueScopeAsync().ConfigureAwait(false);
             }
 
             if (!streamValue.LeaveOpen)
             {
+#if NETCOREAPP3_1_OR_GREATER
+                await streamValue.Stream.DisposeAsync();
+#else
                 streamValue.Stream.Dispose();
+#endif
             }
         }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -390,6 +390,11 @@ namespace Microsoft.OData.JsonLight
                 stream.Dispose();
                 streamWriter.EndStreamValueScope();
             }
+
+            if (!streamValue.LeaveOpen)
+            {
+                streamValue.Stream.Dispose();
+            }
         }
 
         /// <summary>
@@ -720,7 +725,6 @@ namespace Microsoft.OData.JsonLight
             IJsonStreamWriterAsync streamWriter = this.AsynchronousJsonWriter as IJsonStreamWriterAsync;
             if (streamWriter == null)
             {
-                // write as a string
                 byte[] value = await streamValue.Stream.ReadAllBytesAsync().ConfigureAwait(false);
                 await this.AsynchronousJsonWriter.WritePrimitiveValueAsync(value).ConfigureAwait(false);
             }
@@ -731,6 +735,11 @@ namespace Microsoft.OData.JsonLight
                 await stream.FlushAsync().ConfigureAwait(false);
                 stream.Dispose();
                 await streamWriter.EndStreamValueScopeAsync().ConfigureAwait(false);
+            }
+
+            if (!streamValue.LeaveOpen)
+            {
+                streamValue.Stream.Dispose();
             }
         }
 

--- a/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -373,6 +373,7 @@ Microsoft.OData.ODataBatchWriter.WriteStartChangesetAsync() -> System.Threading.
 Microsoft.OData.ODataBatchWriter.WriteStartChangesetAsync(string changesetId) -> System.Threading.Tasks.Task
 Microsoft.OData.ODataBinaryStreamValue
 Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream) -> void
+Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream, bool leaveOpen) -> void
 Microsoft.OData.ODataBinaryStreamValue.Stream.get -> System.IO.Stream
 Microsoft.OData.ODataCollectionReader
 Microsoft.OData.ODataCollectionReader.ODataCollectionReader() -> void

--- a/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -373,6 +373,7 @@ Microsoft.OData.ODataBatchWriter.WriteStartChangesetAsync() -> System.Threading.
 Microsoft.OData.ODataBatchWriter.WriteStartChangesetAsync(string changesetId) -> System.Threading.Tasks.Task
 Microsoft.OData.ODataBinaryStreamValue
 Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream) -> void
+Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream, bool leaveOpen) -> void
 Microsoft.OData.ODataBinaryStreamValue.Stream.get -> System.IO.Stream
 Microsoft.OData.ODataCollectionReader
 Microsoft.OData.ODataCollectionReader.ODataCollectionReader() -> void

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Shipped.txt
@@ -373,6 +373,7 @@ Microsoft.OData.ODataBatchWriter.WriteStartChangesetAsync() -> System.Threading.
 Microsoft.OData.ODataBatchWriter.WriteStartChangesetAsync(string changesetId) -> System.Threading.Tasks.Task
 Microsoft.OData.ODataBinaryStreamValue
 Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream) -> void
+Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream, bool leaveOpen) -> void
 Microsoft.OData.ODataBinaryStreamValue.Stream.get -> System.IO.Stream
 Microsoft.OData.ODataCollectionReader
 Microsoft.OData.ODataCollectionReader.ODataCollectionReader() -> void

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -373,6 +373,7 @@ Microsoft.OData.ODataBatchWriter.WriteStartChangesetAsync() -> System.Threading.
 Microsoft.OData.ODataBatchWriter.WriteStartChangesetAsync(string changesetId) -> System.Threading.Tasks.Task
 Microsoft.OData.ODataBinaryStreamValue
 Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream) -> void
+Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream, bool leaveOpen) -> void
 Microsoft.OData.ODataBinaryStreamValue.Stream.get -> System.IO.Stream
 Microsoft.OData.ODataCollectionReader
 Microsoft.OData.ODataCollectionReader.ODataCollectionReader() -> void

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream, bool leaveOpen) -> void
+﻿

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,1 @@
-﻿
+﻿Microsoft.OData.ODataBinaryStreamValue.ODataBinaryStreamValue(System.IO.Stream stream, bool leaveOpen) -> void

--- a/src/Microsoft.OData.Core/Value/ODataBinaryStreamValue.cs
+++ b/src/Microsoft.OData.Core/Value/ODataBinaryStreamValue.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="stream">Input stream</param>
         public ODataBinaryStreamValue(Stream stream) :
-            this(stream, true) // Leaves the stream open by default, for backward compability.
+            this(stream, true) // Leaves the stream open by default, for backward compatibility.
         {
         }
 

--- a/src/Microsoft.OData.Core/Value/ODataBinaryStreamValue.cs
+++ b/src/Microsoft.OData.Core/Value/ODataBinaryStreamValue.cs
@@ -19,16 +19,32 @@ namespace Microsoft.OData
         /// Constructor
         /// </summary>
         /// <param name="stream">Input stream</param>
-        public ODataBinaryStreamValue(Stream stream)
+        public ODataBinaryStreamValue(Stream stream) :
+            this(stream, true) // Leaves the stream open by default, for backward compability.
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="stream">Input stream</param>
+        /// <param name="leaveOpen">Whether the provided stream should be left open.</param>
+        public ODataBinaryStreamValue(Stream stream, bool leaveOpen)
         {
             ExceptionUtils.CheckArgumentNotNull(stream, "stream");
 
             this.Stream = stream;
+            this.LeaveOpen = leaveOpen;
         }
 
         /// <summary>
         /// The Stream wrapped by the ODataBinaryStreamValue
         /// </summary>
         public Stream Stream { get; private set; }
+
+        /// <summary>
+        /// Whether this instance's <see cref="Stream"/> should be left open.
+        /// </summary>
+        internal bool LeaveOpen { get; }
     }
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -5222,6 +5222,7 @@ public sealed class Microsoft.OData.ODataBatchOperationResponseMessage : IContai
 
 public sealed class Microsoft.OData.ODataBinaryStreamValue : Microsoft.OData.ODataValue {
     public ODataBinaryStreamValue (System.IO.Stream stream)
+    public ODataBinaryStreamValue (System.IO.Stream stream, bool leaveOpen)
 
     System.IO.Stream Stream  { public get; }
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -5222,6 +5222,7 @@ public sealed class Microsoft.OData.ODataBatchOperationResponseMessage : IContai
 
 public sealed class Microsoft.OData.ODataBinaryStreamValue : Microsoft.OData.ODataValue {
     public ODataBinaryStreamValue (System.IO.Stream stream)
+    public ODataBinaryStreamValue (System.IO.Stream stream, bool leaveOpen)
 
     System.IO.Stream Stream  { public get; }
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -5222,6 +5222,7 @@ public sealed class Microsoft.OData.ODataBatchOperationResponseMessage : IContai
 
 public sealed class Microsoft.OData.ODataBinaryStreamValue : Microsoft.OData.ODataValue {
     public ODataBinaryStreamValue (System.IO.Stream stream)
+    public ODataBinaryStreamValue (System.IO.Stream stream, bool leaveOpen)
 
     System.IO.Stream Stream  { public get; }
 }


### PR DESCRIPTION
### Issues

#2596 

### Description

Add a capability for an `ODataBinaryStreamValue` to have its `Stream` disposed by ODL.
- This behavior is optional and is disabled by default for backward compatibility.
- Implemented via an internal property (`bool LeaveOpen`) rather than making `ODataBinaryStreamValue` an `IDisposable` in order to avoid a breaking change to the public API.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*