### PR TITLE
fixes #2601: AddDefaultODataServices should pass OData version to low layer

### DIFF
--- a/src/Microsoft.OData.Core/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.OData.Core/ContainerBuilderExtensions.cs
@@ -136,7 +136,7 @@ namespace Microsoft.OData
             builder.AddService<IJsonWriterFactoryAsync>(ServiceLifetime.Singleton, sp => new DefaultJsonWriterFactory());
             builder.AddService(ServiceLifetime.Singleton, sp => ODataMediaTypeResolver.GetMediaTypeResolver(null));
             builder.AddService<ODataMessageInfo>(ServiceLifetime.Scoped);
-            builder.AddServicePrototype(new ODataMessageReaderSettings());
+            builder.AddServicePrototype(new ODataMessageReaderSettings(odataVersion));
             builder.AddService(ServiceLifetime.Scoped, sp => sp.GetServicePrototype<ODataMessageReaderSettings>().Clone());
             builder.AddServicePrototype(new ODataMessageWriterSettings());
             builder.AddService(ServiceLifetime.Scoped, sp => sp.GetServicePrototype<ODataMessageWriterSettings>().Clone());

--- a/src/Microsoft.OData.Core/ContainerBuilderExtensions.cs
+++ b/src/Microsoft.OData.Core/ContainerBuilderExtensions.cs
@@ -138,7 +138,7 @@ namespace Microsoft.OData
             builder.AddService<ODataMessageInfo>(ServiceLifetime.Scoped);
             builder.AddServicePrototype(new ODataMessageReaderSettings(odataVersion));
             builder.AddService(ServiceLifetime.Scoped, sp => sp.GetServicePrototype<ODataMessageReaderSettings>().Clone());
-            builder.AddServicePrototype(new ODataMessageWriterSettings());
+            builder.AddServicePrototype(new ODataMessageWriterSettings { Version = odataVersion });
             builder.AddService(ServiceLifetime.Scoped, sp => sp.GetServicePrototype<ODataMessageWriterSettings>().Clone());
             builder.AddService(ServiceLifetime.Singleton, sp => ODataPayloadValueConverter.GetPayloadValueConverter(null));
             builder.AddService<IEdmModel>(ServiceLifetime.Singleton, sp => EdmCoreModel.Instance);


### PR DESCRIPTION
…er layer

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2601 .*

### Description

* Pass OData version to lower layer in AddDefaultODataServices

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
