### PR TITLE
fixes #2598, Composite key entities PUT,PATCH URIs generated by OData Client do not follow key order

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/QueryableResourceExpression.cs
+++ b/src/Microsoft.OData.Client/ALinq/QueryableResourceExpression.cs
@@ -507,9 +507,9 @@ namespace Microsoft.OData.Client
         /// Gets the key properties from KeyPredicateConjuncts
         /// </summary>
         /// <returns>The key properties.</returns>
-        internal Dictionary<PropertyInfo, ConstantExpression> GetKeyProperties()
+        internal IList<KeyValuePair<PropertyInfo, ConstantExpression>> GetKeyProperties()
         {
-            var keyValues = new Dictionary<PropertyInfo, ConstantExpression>(EqualityComparer<PropertyInfo>.Default);
+            var keyValues = new List<KeyValuePair<PropertyInfo, ConstantExpression>>();
             if (this.keyPredicateConjuncts.Count > 0)
             {
                 foreach (Expression predicate in this.keyPredicateConjuncts)
@@ -518,7 +518,7 @@ namespace Microsoft.OData.Client
                     ConstantExpression constantValue;
                     if (ResourceBinder.PatternRules.MatchKeyComparison(predicate, out property, out constantValue))
                     {
-                        keyValues.Add(property, constantValue);
+                        keyValues.Add(new KeyValuePair<PropertyInfo, ConstantExpression>(property, constantValue));
                     }
                 }
             }

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -333,6 +333,7 @@ namespace Microsoft.OData.Client
             Debug.Assert(predicates != null, "predicates != null");
 
             Dictionary<PropertyInfo, ConstantExpression> keyValuesFromPredicates = null;
+            Dictionary<Expression, string> expToPropertyNameMap = null;
             nonKeyPredicates = null;
             List<Expression> keyPredicates = null;
 
@@ -345,6 +346,7 @@ namespace Microsoft.OData.Client
                     if (keyValuesFromPredicates == null)
                     {
                         keyValuesFromPredicates = new Dictionary<PropertyInfo, ConstantExpression>(EqualityComparer<PropertyInfo>.Default);
+                        expToPropertyNameMap = new Dictionary<Expression, string>();
                         keyPredicates = new List<Expression>();
                     }
                     else if (keyValuesFromPredicates.ContainsKey(property))
@@ -356,6 +358,7 @@ namespace Microsoft.OData.Client
 
                     keyValuesFromPredicates.Add(property, constantValue);
                     keyPredicates.Add(predicate);
+                    expToPropertyNameMap.Add(predicate, ClientTypeUtil.GetServerDefinedName(property));
                 }
                 else
                 {
@@ -384,17 +387,77 @@ namespace Microsoft.OData.Client
 
                     Debug.Assert(schemaType != null, "SchemaType can not be null.");
 
+                    var keys = schemaType.Key().ToArray();
                     // Obtain the key properties from EdmEntityType, and compare them with keys obtained from predicates
                     // By this time we are sure that keyValuesFromPredicates has unique set (i.e. no duplicates), and has all the keys in it.
                     // So just comparing count with EDMModel's keys is enough for validation
-                    bool allKeysPresent = schemaType.Key().Count() == keyValuesFromPredicates.Keys.Count;
+                    bool allKeysPresent = keys.Length == keyValuesFromPredicates.Keys.Count;
 
                     if (!allKeysPresent)
                     {
                         keyValuesFromPredicates = null;
                         keyPredicates = null;
                     }
+
+                    if (allKeysPresent && keys.Length > 1)
+                    {
+                        // OData Client generates a request that should be the canonical URL, based on the order of keys in the CSDL.
+                        keyPredicates = AdjustKeyExpressionsBasedOnKeyOrders(keys, keyPredicates, expToPropertyNameMap);
+                    }
                 }
+            }
+
+            return keyPredicates;
+        }
+
+        private static List<Expression> AdjustKeyExpressionsBasedOnKeyOrders(IEdmStructuralProperty[] edmKeys,
+            List<Expression> keyPredicates, Dictionary<Expression, string> expToPropertyNameMap)
+        {
+            bool needAdjust = false;
+            for (int i = 0; i < edmKeys.Length; ++i)
+            {
+                IEdmStructuralProperty edmKey = edmKeys[i];
+                Expression keyExpr = keyPredicates[i];
+
+                if (edmKey.Name != expToPropertyNameMap[keyExpr])
+                {
+                    needAdjust = true;
+                    break;
+                }
+            }
+
+            if (needAdjust)
+            {
+                List<Expression> orderedKeyPredicates = new List<Expression>();
+                foreach (var key in edmKeys)
+                {
+                    // find
+                    Expression foundExp = null;
+                    foreach (var exp in keyPredicates)
+                    {
+                        string propertyName = expToPropertyNameMap[exp];
+                        if (key.Name == propertyName)
+                        {
+                            foundExp = exp;
+                            break;
+                        }
+                    }
+
+                    // if found
+                    if (foundExp != null)
+                    {
+                        keyPredicates.Remove(foundExp);
+                        orderedKeyPredicates.Add(foundExp);
+                    }
+                }
+
+                // append the remainings
+                foreach (var exp in keyPredicates)
+                {
+                    orderedKeyPredicates.Add(exp);
+                }
+
+                keyPredicates = orderedKeyPredicates;
             }
 
             return keyPredicates;

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -387,7 +387,7 @@ namespace Microsoft.OData.Client
 
                     Debug.Assert(schemaType != null, "SchemaType can not be null.");
 
-                    var keys = schemaType.Key().ToArray();
+                    IEdmStructuralProperty[] keys = schemaType.Key().ToArray();
                     // Obtain the key properties from EdmEntityType, and compare them with keys obtained from predicates
                     // By this time we are sure that keyValuesFromPredicates has unique set (i.e. no duplicates), and has all the keys in it.
                     // So just comparing count with EDMModel's keys is enough for validation
@@ -414,6 +414,7 @@ namespace Microsoft.OData.Client
             List<Expression> keyPredicates, Dictionary<Expression, string> expToPropertyNameMap)
         {
             bool needAdjust = false;
+
             for (int i = 0; i < edmKeys.Length; ++i)
             {
                 IEdmStructuralProperty edmKey = edmKeys[i];
@@ -436,6 +437,7 @@ namespace Microsoft.OData.Client
                     foreach (var exp in keyPredicates)
                     {
                         string propertyName = expToPropertyNameMap[exp];
+
                         if (key.Name == propertyName)
                         {
                             foundExp = exp;

--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -478,7 +478,8 @@ namespace Microsoft.OData.Client
                             foreach (var orderedKey in keyProperties)
                             {
                                 string serverDefinedName = ClientTypeUtil.GetServerDefinedName(orderedKey);
-                                var keyProperty = loadedKeyProperties.FirstOrDefault(k => k.Name == serverDefinedName);
+                                IEdmStructuralProperty keyProperty = loadedKeyProperties.FirstOrDefault(k => k.Name == serverDefinedName);
+
                                 if (keyProperty != null)
                                 {
                                     orderedloadedKeyProperties.Add(keyProperty);

--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -473,7 +473,18 @@ namespace Microsoft.OData.Client
                                 entityType.AddProperty(property);
                             }
 
-                            entityType.AddKeys(loadedKeyProperties);
+                            // add keys in the same order of "keyProperties"
+                            List<IEdmStructuralProperty> orderedloadedKeyProperties = new List<IEdmStructuralProperty>();
+                            foreach (var orderedKey in keyProperties)
+                            {
+                                var keyProperty = loadedKeyProperties.FirstOrDefault(k => k.Name == orderedKey.Name);
+                                if (keyProperty != null)
+                                {
+                                    orderedloadedKeyProperties.Add(keyProperty);
+                                }
+                            }
+
+                            entityType.AddKeys(orderedloadedKeyProperties);
                         };
 
                         // Creating an entity type

--- a/src/Microsoft.OData.Client/ClientEdmModel.cs
+++ b/src/Microsoft.OData.Client/ClientEdmModel.cs
@@ -477,7 +477,8 @@ namespace Microsoft.OData.Client
                             List<IEdmStructuralProperty> orderedloadedKeyProperties = new List<IEdmStructuralProperty>();
                             foreach (var orderedKey in keyProperties)
                             {
-                                var keyProperty = loadedKeyProperties.FirstOrDefault(k => k.Name == orderedKey.Name);
+                                string serverDefinedName = ClientTypeUtil.GetServerDefinedName(orderedKey);
+                                var keyProperty = loadedKeyProperties.FirstOrDefault(k => k.Name == serverDefinedName);
                                 if (keyProperty != null)
                                 {
                                     orderedloadedKeyProperties.Add(keyProperty);

--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -362,6 +362,8 @@ namespace Microsoft.OData.Client.Metadata
                         // If the new order value is same as one item in the list , move to next.
                         break;
                     }
+
+                    ++index;
                 }
 
                 keys.Insert(index, newKeyWithOrder);

--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -271,7 +271,7 @@ namespace Microsoft.OData.Client.Metadata
         }
 
         private PropertyInfo[] GetKeyProperties()
-        {           
+        {
             if (CommonUtil.IsUnsupportedType(type))
             {
                 throw new InvalidOperationException(c.Strings.ClientType_UnsupportedType(type));
@@ -281,25 +281,32 @@ namespace Microsoft.OData.Client.Metadata
             IEnumerable<object> customAttributes = type.GetCustomAttributes(true);
             bool isEntity = customAttributes.OfType<EntityTypeAttribute>().Any();
             KeyAttribute dataServiceKeyAttribute = customAttributes.OfType<KeyAttribute>().FirstOrDefault();
-            List<PropertyInfo> keyProperties = new List<PropertyInfo>();
-            
+
+            List<KeyValuePair<PropertyInfo, int>> keyWithOrders = new List<KeyValuePair<PropertyInfo, int>>();
+
             KeyKind currentKeyKind = KeyKind.NotKey;
             KeyKind newKeyKind = KeyKind.NotKey;
             foreach (PropertyInfo propertyInfo in Properties)
             {
-                if ((newKeyKind = IsKeyProperty(propertyInfo, dataServiceKeyAttribute)) != KeyKind.NotKey)
+                if ((newKeyKind = IsKeyProperty(propertyInfo, dataServiceKeyAttribute, out int order)) != KeyKind.NotKey)
                 {
                     if (newKeyKind > currentKeyKind)
                     {
-                        keyProperties.Clear();
+                        keyWithOrders.Clear();
                         currentKeyKind = newKeyKind;
-                        keyProperties.Add(propertyInfo);
+                        InserKeyBasedOnOrder(keyWithOrders, propertyInfo, order);
                     }
                     else if (newKeyKind == currentKeyKind)
                     {
-                        keyProperties.Add(propertyInfo);
+                        InserKeyBasedOnOrder(keyWithOrders, propertyInfo, order);
                     }
                 }
+            }
+
+            List<PropertyInfo> keyProperties = new List<PropertyInfo>();
+            foreach (var item in keyWithOrders)
+            {
+                keyProperties.Add(item.Key);
             }
 
             Type keyPropertyDeclaringType = null;
@@ -336,26 +343,54 @@ namespace Microsoft.OData.Client.Metadata
             return keyProperties.Count > 0 ? keyProperties.ToArray() : (isEntity ? ClientTypeUtil.EmptyPropertyInfoArray : null);
         }
 
+        private static void InserKeyBasedOnOrder(List<KeyValuePair<PropertyInfo, int>> keys, PropertyInfo keyPi, int order)
+        {
+            var newKeyWithOrder = new KeyValuePair<PropertyInfo, int>(keyPi, order);
+            if (order < 0)
+            {
+                // order < 0 means there's no order value setting, append this key at the end of list.
+                keys.Add(newKeyWithOrder);
+            }
+            else
+            {
+                int index = 0;
+                foreach (var key in keys)
+                {
+                    if (key.Value < 0 || key.Value > order)
+                    {
+                        // Insert the new key before the first negative order or first order bigger than new order.
+                        // If the new order value is same as one item in the list , move to next.
+                        break;
+                    }
+                }
+
+                keys.Insert(index, newKeyWithOrder);
+            }
+        }
+
         /// <summary>
         /// Returns the KeyKind if <paramref name="propertyInfo"/> is declared as a key in <paramref name="dataServiceKeyAttribute"/> or it follows the key naming convention.
         /// </summary>
         /// <param name="propertyInfo">Property in question.</param>
         /// <param name="dataServiceKeyAttribute">DataServiceKeyAttribute instance.</param>
         /// <returns>Returns the KeyKind if <paramref name="propertyInfo"/> is declared as a key in <paramref name="dataServiceKeyAttribute"/> or it follows the key naming convention.</returns>
-        private static KeyKind IsKeyProperty(PropertyInfo propertyInfo, KeyAttribute dataServiceKeyAttribute)
+        private static KeyKind IsKeyProperty(PropertyInfo propertyInfo, KeyAttribute dataServiceKeyAttribute, out int order)
         {
             Debug.Assert(propertyInfo != null, "propertyInfo != null");
 
             string propertyName = ClientTypeUtil.GetServerDefinedName(propertyInfo);
 
+            order = -1;
             KeyKind keyKind = KeyKind.NotKey;
             if (dataServiceKeyAttribute != null && dataServiceKeyAttribute.KeyNames.Contains(propertyName))
             {
+                order = dataServiceKeyAttribute.KeyNames.IndexOf(propertyName);
                 keyKind = KeyKind.AttributedKey;
             }
-            else if (propertyInfo.GetCustomAttributes().OfType<System.ComponentModel.DataAnnotations.KeyAttribute>().Any())
+            else if (IsDataAnnotationsKeyProperty(propertyInfo, out KeyKind newKind, out int newOrder))
             {
-                keyKind = KeyKind.AttributedKey;
+                order = newOrder;
+                keyKind = newKind;
             }
             else if (propertyName.EndsWith("ID", StringComparison.Ordinal))
             {
@@ -373,6 +408,26 @@ namespace Microsoft.OData.Client.Metadata
             }
 
             return keyKind;
+        }
+
+        private static bool IsDataAnnotationsKeyProperty(PropertyInfo propertyInfo, out KeyKind kind, out int order)
+        {
+            order = -1;
+            kind = KeyKind.NotKey;
+            var attributes = propertyInfo.GetCustomAttributes();
+            if(!attributes.Any(a => a is System.ComponentModel.DataAnnotations.KeyAttribute))
+            {
+                return false;
+            }
+
+            var columnAttribute = attributes.OfType<System.ComponentModel.DataAnnotations.Schema.ColumnAttribute>().FirstOrDefault();
+            if (columnAttribute != null)
+            {
+                order = columnAttribute.Order;
+            }
+
+            kind = KeyKind.AttributedKey;
+            return true;
         }
     }
 }

--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -429,6 +429,7 @@ namespace Microsoft.OData.Client.Metadata
             }
 
             kind = KeyKind.AttributedKey;
+
             return true;
         }
     }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientEdmModelTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/ClientEdmModelTests.cs
@@ -200,6 +200,30 @@ namespace AstoriaUnitTests.Tests
             Assert.NotNull(enumType.FullName());
         }
 
+        [Fact]
+        public void GetOrCreateEdmTypeShouldWorkForTypesWithMultipleKeys()
+        {
+            var clientModel = new ClientEdmModel(ODataProtocolVersion.V4);
+            var edmType = clientModel.GetOrCreateEdmType(typeof(EntityWithThreeKeyProperties));
+            Assert.NotNull(edmType);
+            Assert.Equal(EdmTypeKind.Entity, edmType.TypeKind);
+            IEdmEntityType entityType = edmType as IEdmEntityType;
+            var keys = entityType.Key();
+            Assert.Collection(keys,
+                e => Assert.Equal("ID1", e.Name),
+                e => Assert.Equal("ID3", e.Name),
+                e => Assert.Equal("ID2", e.Name)
+                );
+        }
+
+        [Key("ID1", "ID3", "ID2")]
+        internal class EntityWithThreeKeyProperties
+        {
+            public int ID1 { get; set; }
+            public string ID2 { get; set; }
+            public DateTimeOffset ID3 { get; set; }
+        }
+
         private class TypeWithCollectionOfObjectProperty
         {
             public ICollection<object> Objects { get; set; }

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/LinqIntegrationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/LinqIntegrationTests.cs
@@ -202,10 +202,11 @@ namespace AstoriaUnitTests.Tests.Client
         public void TwoWhereClausesForKeysInDifferentOrderShouldReturnUrlForSingltonInCorrectOrder()
         {
             // Key properties provided in reverse order
+            // The request should be canonical URL (using key order in schema)
             query = context.CreateQuery<EntityWithTwoKeyProperties>("Test")
                             .Where(p => p.ID2 == 1).Where(p => p.ID1 == 2)
                             .ToString();
-            Assert.Equal(rootUrl + "Test(ID2=1,ID1=2)", query);
+            Assert.Equal(rootUrl + "Test(ID1=2,ID2=1)", query);
         }
 
         [Fact]
@@ -444,12 +445,13 @@ namespace AstoriaUnitTests.Tests.Client
         public void ThreeWhereClausesForKeysInDifferentOrderShouldReturnUrlForSingltonInCorrectOrder()
         {
             // Key properties provided in reverse order
+            // The request should be canonical URL (using key order in schema)
             query = context.CreateQuery<EntityWithThreeKeyProperties>("Test")
                             .Where(p => p.ID2 == "bar")
                             .Where(p => p.ID1 == 2)
                             .Where(p => p.ID3 == this.sampleDateTimeOffset)
                             .ToString();
-            Assert.Equal(rootUrl + "Test(ID2='bar',ID1=2,ID3=" + this.sampleDate + ")", query);
+            Assert.Equal(rootUrl + "Test(ID1=2,ID2='bar',ID3=" + this.sampleDate + ")", query);
         }
 
         [Fact]

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/LinqIntegrationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/LinqIntegrationTests.cs
@@ -147,6 +147,13 @@ namespace AstoriaUnitTests.Tests.Client
             public List<AnotherEntityWithTwoKeyProperties> NavPropertyCollection { get; set; }
         }
 
+        [Key("ID2", "ID1")]
+        internal class EntityWithTwoDiffOrderKeyProperties
+        {
+            public int ID1 { get; set; }
+            public int ID2 { get; set; }
+        }
+
         [Key("Key1", "Key2")]
         internal class AnotherEntityWithTwoKeyProperties
         {
@@ -164,6 +171,24 @@ namespace AstoriaUnitTests.Tests.Client
 
         [Fact]
         public void TwoWhereClausesForKeysShouldReturnUrlForSingleton()
+        {
+            // Simple case, only two key properties provided
+            string query1 = context.CreateQuery<EntityWithTwoDiffOrderKeyProperties>("Test")
+                .Where(p => p.ID1 == 1)
+                .Where(p => p.ID2 == 2)
+                .ToString();
+
+            string query2 = context.CreateQuery<EntityWithTwoDiffOrderKeyProperties>("Test")
+                .Where(p => p.ID2 == 2)
+                .Where(p => p.ID1 == 1)
+                .ToString();
+
+            Assert.Equal(query1, query2);
+            Assert.Equal(rootUrl + "Test(ID2=2,ID1=1)", query1);
+        }
+
+        [Fact]
+        public void TwoWhereClausesForDiffOrderKeysShouldReturnUrlForSingleton()
         {
             // Simple case, only two key properties provided
             string query = context.CreateQuery<EntityWithTwoKeyProperties>("Test")

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/TemplatingIntegrationTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/TemplatingIntegrationTests.cs
@@ -62,19 +62,19 @@ namespace AstoriaUnitTests.TDD.Tests.Client
         public void AttachPinningTest()
         {
             const string expectedOutput = @"http://test.org/test/EntityS%C3%A9t1('foo%2B%2Fbar')
-http://test.org/test/EntityS%C3%A9t2(Property1='fo%2Bo',Property2='b%2Far')
+http://test.org/test/EntityS%C3%A9t2(Property2='b%2Far',Property1='fo%2Bo')
 http://test.org/test/EntitySet1('foo')
-http://test.org/test/EntitySet2(Property1='foo',Property2='bar')
+http://test.org/test/EntitySet2(Property2='bar',Property1='foo')
 http://test.org/test/EntitySet1('foo')
-http://test.org/test/EntitySet2(Property1='foo',Property2='bar')
+http://test.org/test/EntitySet2(Property2='bar',Property1='foo')
 http://test.org/test/EntitySet1/Fake(1)('foo')
 http://test.org/test/EntitySet1/Fake(1)('foo')
 http://test.org/test/EntitySet1/Fake(1)('foo')
 http://test.org/test/EntitySet1/Fake(1)('foo')
-http://test.org/test/EntitySet2/Fake(1)/Navigation(Property1='foo',Property2='bar')
-http://test.org/test/EntitySet2/Fake(1)/Navigation(Property1='foo',Property2='bar')
-http://test.org/test/EntitySet2/Fake(1)/Navigation(Property1='foo',Property2='bar')
-http://test.org/test/EntitySet2/Fake(1)/Navigation(Property1='foo',Property2='bar')
+http://test.org/test/EntitySet2/Fake(1)/Navigation(Property2='bar',Property1='foo')
+http://test.org/test/EntitySet2/Fake(1)/Navigation(Property2='bar',Property1='foo')
+http://test.org/test/EntitySet2/Fake(1)/Navigation(Property2='bar',Property1='foo')
+http://test.org/test/EntitySet2/Fake(1)/Navigation(Property2='bar',Property1='foo')
 ";
             var ctx = new DataServiceContext(new Uri("http://test.org/test"));
             RunAttachPinningTest(ctx, expectedOutput);
@@ -87,19 +87,19 @@ http://test.org/test/EntitySet2/Fake(1)/Navigation(Property1='foo',Property2='ba
         public void AttachPinningTestWithEntitySetResolver()
         {
             const string expectedOutput = @"http://resolved.org/EntityS%C3%A9t1('foo%2B%2Fbar')
-http://resolved.org/EntityS%C3%A9t2(Property1='fo%2Bo',Property2='b%2Far')
+http://resolved.org/EntityS%C3%A9t2(Property2='b%2Far',Property1='fo%2Bo')
 http://resolved.org/EntitySet1('foo')
-http://resolved.org/EntitySet2(Property1='foo',Property2='bar')
+http://resolved.org/EntitySet2(Property2='bar',Property1='foo')
 http://resolved.org/EntitySet1('foo')
-http://resolved.org/EntitySet2(Property1='foo',Property2='bar')
+http://resolved.org/EntitySet2(Property2='bar',Property1='foo')
 http://resolved.org/EntitySet1/Fake(1)('foo')
 http://resolved.org/EntitySet1/Fake(1)('foo')
 http://resolved.org/EntitySet1/Fake(1)('foo')
 http://resolved.org/EntitySet1/Fake(1)('foo')
-http://resolved.org/EntitySet2/Fake(1)/Navigation(Property1='foo',Property2='bar')
-http://resolved.org/EntitySet2/Fake(1)/Navigation(Property1='foo',Property2='bar')
-http://resolved.org/EntitySet2/Fake(1)/Navigation(Property1='foo',Property2='bar')
-http://resolved.org/EntitySet2/Fake(1)/Navigation(Property1='foo',Property2='bar')
+http://resolved.org/EntitySet2/Fake(1)/Navigation(Property2='bar',Property1='foo')
+http://resolved.org/EntitySet2/Fake(1)/Navigation(Property2='bar',Property1='foo')
+http://resolved.org/EntitySet2/Fake(1)/Navigation(Property2='bar',Property1='foo')
+http://resolved.org/EntitySet2/Fake(1)/Navigation(Property2='bar',Property1='foo')
 ";
             var ctx = new TestClientContext { ResolveEntitySet = s => new Uri("http://resolved.org/" + s) };
             RunAttachPinningTest(ctx, expectedOutput);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2598.*

### Description

* Fix
*1) DeclareKey on EntityType should be ordered based on the schema
  2) Generate the request URL is canonical URL

with these changes:

```C#
var aEntities = container.AEntities.Where(a => a.CId == 8 && a.AId == "a" && a.BId == "b");
var aEntities = container.AEntities.Where(a => a.AId == "a" && a.BId == "b" && a.CId == 8);
var aEntities = container.AEntities.Where(a => a.BId == "b" && a.CId == 8 && a.AId == "a" );
```

Will output the same request URL as:

` ..../odata/AEntities(CId=8,BId='b',AId='a')`

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

