### PR TITLE
Update Validation Vocabulary

### DIFF
--- a/src/Microsoft.OData.Edm/Vocabularies/ValidationVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/ValidationVocabularies.xml
@@ -1,122 +1,174 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Org.OData.Validation.V1" Alias="Validation">
-  <Annotation Term="Core.Description">
-    <String>Terms describing validation rules</String>
-  </Annotation>
-  <Annotation Term="Core.Links">
-    <Collection>
-      <Record>
-        <PropertyValue Property="rel" String="latest-version" />
-        <PropertyValue Property="href"
-          String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Validation.V1.xml" />
-      </Record>
-      <Record>
-        <PropertyValue Property="rel" String="alternate" />
-        <PropertyValue Property="href"
-          String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Validation.V1.json" />
-      </Record>
-      <Record>
-        <PropertyValue Property="rel" String="describedby" />
-        <PropertyValue Property="href"
-          String="https://github.com/oasis-tcs/odata-vocabularies/blob/master/vocabularies/Org.OData.Validation.V1.md" />
-      </Record>
-    </Collection>
-  </Annotation>
+<!--
+  Technical Committee:
+  OASIS Open Data Protocol (OData) TC
+  https://www.oasis-open.org/committees/odata
+  Chairs:
+  - Ralf Handl (ralf.handl@sap.com), SAP SE
+  - Ram Jeyaraman (Ram.Jeyaraman@microsoft.com), Microsoft
+  Editors:
+  - Ralf Handl (ralf.handl@sap.com), SAP SE
+  - Ram Jeyaraman (Ram.Jeyaraman@microsoft.com), Microsoft
+  - Michael Pizzo (mikep@microsoft.com), Microsoft
+  Additional artifacts:
+  This vocabulary is one component of a Work Product that also includes the following vocabulary components:
+  - OData Core Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml.
+  - OData Measures Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml.
+  - OData Capabilities Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.xml.
+  - OData Validation Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Validation.V1.xml.
+  - OData Aggregation Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.xml.
+  - OData Authorization Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Authorization.V1.xml.
+  Related work:
+  This vocabulary replaces or supersedes:
+  - None.
+  This vocabulary is related to:
+  - OData Version 4.01 Part 1: Protocol. Latest version: http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html.
+  - OData Version 4.01 Part 2: URL Conventions. Latest version: http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html.
+  - OData Common Schema Definition Language (CSDL) JSON Representation Version 4.01. Latest version: http://docs.oasis-open.org/odata/odata-csdl-json/v4.01/odata-csdl-json-v4.01.html.
+  - OData Common Schema Definition Language (CSDL) XML Representation Version 4.01. Latest version: http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html.
+  - OData JSON Format Version 4.01. Latest version: http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html.
+  - OData Extension for Data Aggregation Version 4.0. Latest version: http://docs.oasis-open.org/odata/odata-data-aggregation-ext/v4.0/odata-data-aggregation-ext-v4.0.html.
+  Abstract:
+  This document contains terms describing validation rules.
+-->
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1" />
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Org.OData.Validation.V1" Alias="Validation">
+      <Annotation Term="Core.Description">
+        <String>Terms describing validation rules</String>
+      </Annotation>
+      <Annotation Term="Core.Links">
+        <Collection>
+          <Record>
+            <PropertyValue Property="rel" String="latest-version" />
+            <PropertyValue Property="href" String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Validation.V1.xml" />
+          </Record>
+          <Record>
+            <PropertyValue Property="rel" String="alternate" />
+            <PropertyValue Property="href" String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Validation.V1.json" />
+          </Record>
+          <Record>
+            <PropertyValue Property="rel" String="describedby" />
+            <PropertyValue Property="href" String="https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Validation.V1.md" />
+          </Record>
+        </Collection>
+      </Annotation>
 
-  <Term Name="Pattern" Type="Edm.String" AppliesTo="Property Parameter Term">
-    <Annotation Term="Core.Description" String="The pattern that a string property, parameter, or term must match. This SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect." />
-    <Annotation Term="Core.RequiresType" String="Edm.String" />
-  </Term>
+      <Term Name="Pattern" Type="Edm.String" Nullable="false" AppliesTo="Property Parameter Term">
+        <Annotation Term="Core.Description" String="The pattern that a string property, parameter, or term must match. This SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect." />
+        <Annotation Term="Core.RequiresType" String="Edm.String" />
+      </Term>
 
-  <Term Name="Minimum" Type="Edm.Decimal" Scale="variable" AppliesTo="Property Parameter Term">
-    <Annotation Term="Core.Description" String="Minimum value that a property, parameter, or term can have." />
-    <Annotation Term="Validation.ApplicableTerms">
-      <Collection>
-        <String>Validation.Exclusive</String>
-      </Collection>
-    </Annotation>
-  </Term>
+      <Term Name="Minimum" Type="Edm.PrimitiveType" Nullable="false" AppliesTo="Property Parameter Term">
+        <Annotation Term="Core.Description" String="Minimum value that a property, parameter, or term can have." />
+        <Annotation Term="Validation.ApplicableTerms">
+          <Collection>
+            <String>Validation.Exclusive</String>
+          </Collection>
+        </Annotation>
+      </Term>
 
-  <Term Name="Maximum" Type="Edm.Decimal" Scale="variable" AppliesTo="Property Parameter Term">
-    <Annotation Term="Core.Description" String="Maximum value that a property, parameter, or term can have." />
-    <Annotation Term="Validation.ApplicableTerms">
-      <Collection>
-        <String>Validation.Exclusive</String>
-      </Collection>
-    </Annotation>
-  </Term>
+      <Term Name="Maximum" Type="Edm.PrimitiveType" Nullable="false" AppliesTo="Property Parameter Term">
+        <Annotation Term="Core.Description" String="Maximum value that a property, parameter, or term can have." />
+        <Annotation Term="Validation.ApplicableTerms">
+          <Collection>
+            <String>Validation.Exclusive</String>
+          </Collection>
+        </Annotation>
+      </Term>
 
-  <Term Name="Exclusive" Type="Core.Tag" DefaultValue="true" AppliesTo="Annotation">
-    <Annotation Term="Core.Description" String="Tags a Minimum or Maximum as exclusive, i.e. an open interval boundary." />
-  </Term>
+      <Term Name="Exclusive" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Annotation">
+        <Annotation Term="Core.Description" String="Tags a Minimum or Maximum as exclusive, i.e. an open interval boundary." />
+      </Term>
 
-  <Term Name="AllowedValues" Type="Collection(Validation.AllowedValue)" Nullable="false" AppliesTo="Property Parameter TypeDefinition" >
-    <Annotation Term="Core.Description" String="A collection of valid values for the annotated property, parameter, or type definition" />
-  </Term>
-  <ComplexType Name="AllowedValue">
-    <Property Name="Value" Type="Edm.PrimitiveType" Nullable="true">
-      <Annotation Term="Core.Description" String="An allowed value for the property, parameter, or type definition" />
-    </Property>
-  </ComplexType>
+      <Term Name="AllowedValues" Type="Collection(Validation.AllowedValue)" Nullable="false" AppliesTo="Property Parameter TypeDefinition">
+        <Annotation Term="Core.Description" String="A collection of valid values for the annotated property, parameter, or type definition" />
+      </Term>
+      <ComplexType Name="AllowedValue">
+        <Property Name="Value" Type="Edm.PrimitiveType" Nullable="true">
+          <Annotation Term="Core.Description" String="An allowed value for the property, parameter, or type definition" />
+        </Property>
+      </ComplexType>
 
-  <Term Name="MultipleOf" Type="Edm.Decimal" Scale="variable" AppliesTo="Property Parameter Term">
-    <Annotation Term="Core.Description" String="The value of the annotated property, parameter, or term must be an integer multiple of this positive value. For temporal types, the value is measured in seconds." />
-  </Term>
+      <Term Name="MultipleOf" Type="Edm.Decimal" Scale="variable" Nullable="false" AppliesTo="Property Parameter Term">
+        <Annotation Term="Core.Description" String="The value of the annotated property, parameter, or term must be an integer multiple of this positive value. For temporal types, the value is measured in seconds." />
+      </Term>
 
-  <Term Name="Constraint" Type="Validation.ConstraintType" AppliesTo="Property EntityType ComplexType">
-    <Annotation Term="Core.Description" String="Condition that the annotation target has to fulfill" />
-  </Term>
-  <ComplexType Name="ConstraintType">
-    <Property Name="FailureMessage" Type="Edm.String" Nullable="true">
-      <Annotation Term="Core.IsLanguageDependent" Bool="true" />
-      <Annotation Term="Core.Description" String="Human-readable message that can be shown to end users if the constraint is not fulfilled" />
-    </Property>
-    <Property Name="Condition" Type="Edm.Boolean" Nullable="false">
-      <Annotation Term="Core.Description" String="Value MUST be a dynamic expression that evaluates to true if and only if the constraint is fulfilled" />
-    </Property>
-  </ComplexType>
+      <Term Name="Constraint" Type="Validation.ConstraintType" Nullable="false" AppliesTo="Property EntityType ComplexType">
+        <Annotation Term="Core.Description" String="Condition that the annotation target has to fulfill" />
+      </Term>
+      <ComplexType Name="ConstraintType">
+        <Property Name="FailureMessage" Type="Edm.String" Nullable="true">
+          <Annotation Term="Core.IsLanguageDependent" />
+          <Annotation Term="Core.Description" String="Human-readable message that can be shown to end users if the constraint is not fulfilled" />
+        </Property>
+        <Property Name="Condition" Type="Edm.Boolean" Nullable="false">
+          <Annotation Term="Core.Description" String="Value MUST be a dynamic expression that evaluates to true if and only if the constraint is fulfilled" />
+        </Property>
+      </ComplexType>
 
-  <Term Name="ItemsOf" Type="Collection(Validation.ItemsOfType)" Nullable="false" AppliesTo="EntityType ComplexType">
-    <Annotation Term="Core.Description" String="A list of constraints describing that entities related via one navigation property MUST also be related via another, collection-valued navigation property. The same `path` value MUST NOT occur more than once." />
-    <Annotation Term="Core.LongDescription">
-      <String>Example: entity type `Customer` has navigation properties `AllOrders`, `OpenOrders`, and `ClosedOrders`. 
+      <Term Name="ItemsOf" Type="Collection(Validation.ItemsOfType)" Nullable="false" AppliesTo="EntityType ComplexType">
+        <Annotation Term="Core.Description" String="A list of constraints describing that entities related via one navigation property MUST also be related via another, collection-valued navigation property. The same `path` value MUST NOT occur more than once." />
+        <Annotation Term="Core.LongDescription">
+          <String>Example: entity type `Customer` has navigation properties `AllOrders`, `OpenOrders`, and `ClosedOrders`. 
 The term allows to express that items of `OpenOrders` and `ClosedOrders` are also items of the `AllOrders` navigation property,
 even though they are defined in an `Orders` entity set.</String>
-    </Annotation>
-  </Term>
-  <ComplexType Name="ItemsOfType">
-    <Annotation Term="Core.Description" String="Entities related via the single- or collection-valued navigation property identified by `path` are also related via the collection-valued navigation property identified by `target`." />
-    <Property Name="path" Type="Edm.NavigationPropertyPath" Nullable="false">
-      <Annotation Term="Core.Description" String="A path to a single- or collection-valued navigation property" />
-    </Property>
-    <Property Name="target" Type="Edm.NavigationPropertyPath" Nullable="false">
-      <Annotation Term="Core.Description" String="A path to a collection-valued navigation property" />
-    </Property>
-  </ComplexType>
+        </Annotation>
+      </Term>
+      <ComplexType Name="ItemsOfType">
+        <Annotation Term="Core.Description" String="Entities related via the single- or collection-valued navigation property identified by `path` are also related via the collection-valued navigation property identified by `target`." />
+        <Property Name="path" Type="Edm.NavigationPropertyPath" Nullable="false">
+          <Annotation Term="Core.Description" String="A path to a single- or collection-valued navigation property" />
+        </Property>
+        <Property Name="target" Type="Edm.NavigationPropertyPath" Nullable="false">
+          <Annotation Term="Core.Description" String="A path to a collection-valued navigation property" />
+        </Property>
+      </ComplexType>
 
-  <Term Name="OpenPropertyTypeConstraint" Type="Collection(Core.QualifiedTypeName)" Nullable="false" AppliesTo="ComplexType EntityType" >
-    <Annotation Term="Core.Description" String="Dynamic properties added to the annotated open structured type are restricted to the listed types" />
-  </Term>
+      <Term Name="OpenPropertyTypeConstraint" Type="Collection(Validation.SingleOrCollectionType)" Nullable="false" AppliesTo="ComplexType EntityType">
+        <Annotation Term="Core.Description" String="Dynamic properties added to the annotated open structured type are restricted to the listed types." />
+      </Term>
 
-  <Term Name="DerivedTypeConstraint" Type="Collection(Core.QualifiedTypeName)" Nullable="false" AppliesTo="EntitySet Singleton NavigationProperty Property TypeDefinition Parameter ReturnType">
-    <Annotation Term="Core.Description" String="Values are restricted to types that are both identical to or derived from the declared type and a type listed in this collection." />
-    <Annotation Term="Core.LongDescription" String="This allows restricting values to certain sub-trees of an inheritance hierarchy. Types listed in this collection that are not derived from the declared type of the annotated model element are ignored." />
-  </Term>
+      <Term Name="DerivedTypeConstraint" Type="Collection(Validation.SingleOrCollectionType)" Nullable="false" AppliesTo="EntitySet Singleton NavigationProperty Property TypeDefinition Parameter ReturnType">
+        <Annotation Term="Core.Description" String="Values are restricted to types that are both identical to or derived from the declared type and a type listed in this collection." />
+        <Annotation Term="Core.LongDescription">
+          <String>This allows restricting values to certain sub-trees of an inheritance hierarchy,
+          including hierarchies starting at the [Built-In Abstract Types](https://docs.oasis-open.org/odata/odata-csdl-json/v4.01/odata-csdl-json-v4.01.html#sec_BuiltInAbstractTypes).
+          Types listed in this collection are ignored if they are not derived from the declared type of the annotated model element
+          or would not be allowed as declared type of the annotated model element.
 
-  <Term Name="AllowedTerms" Type="Collection(Core.QualifiedTermName)" AppliesTo="Term Property">
-    <Annotation Term="Core.Description" String="Annotate a term of type Edm.AnnotationPath, or a property of type Edm.AnnotationPath that is used within a structured term, to restrict the terms that can be targeted by the path." />
-    <Annotation Term="Core.LongDescription" String="The annotation path expression is intended to end in a path segment with one of the listed terms. For forward compatibility, clients should be prepared for the annotation to reference terms besides those listed." />
-    <Annotation Term="Core.RequiresType" String="Edm.AnnotationPath" />
-  </Term>
-  <Term Name="ApplicableTerms" Type="Collection(Core.QualifiedTermName)">
-    <Annotation Term="Core.Description" String="Names of specific terms that are applicable and may be applied in the current context. This annotation does not restrict the use of other terms." />
-  </Term>
+          When applied to a collection-valued element, this annotation specifies the types allowed for members
+          of the collection without mentioning the `Collection()` wrapper.
+          The SingleOrCollectionType may only include the `Collection()` wrapper
+          if the annotation is applied to an element with declared type `Edm.Untyped`.</String>
+        </Annotation>
+      </Term>
 
-  <Term Name="MaxItems" Type="Edm.Int64" Nullable="false" AppliesTo="Collection">
-    <Annotation Term="Core.Description" String="The annotated collection must have at most the specified number of items." />
-  </Term>
+      <TypeDefinition Name="SingleOrCollectionType" UnderlyingType="Edm.String">
+        <Annotation Term="Core.Description" String="The qualified name of a type in scope, optionally wrapped in `Collection()` to denote a collection of instances of the type" />
+      </TypeDefinition>
 
-  <Term Name="MinItems" Type="Edm.Int64" Nullable="false" AppliesTo="Collection">
-    <Annotation Term="Core.Description" String="The annotated collection must have at least the specified number of items." />
-  </Term>
-</Schema>
+      <Term Name="AllowedTerms" Type="Collection(Core.QualifiedTermName)" Nullable="false" AppliesTo="Term Property">
+        <Annotation Term="Core.Description" String="Annotate a term of type Edm.AnnotationPath, or a property of type Edm.AnnotationPath that is used within a structured term, to restrict the terms that can be targeted by the path." />
+        <Annotation Term="Core.LongDescription" String="The annotation path expression is intended to end in a path segment with one of the listed terms. For forward compatibility, clients should be prepared for the annotation to reference terms besides those listed." />
+        <Annotation Term="Core.RequiresType" String="Edm.AnnotationPath" />
+      </Term>
+
+      <Term Name="ApplicableTerms" Type="Collection(Core.QualifiedTermName)" Nullable="false">
+        <Annotation Term="Core.Description" String="Names of specific terms that are applicable and may be applied in the current context. This annotation does not restrict the use of other terms." />
+      </Term>
+
+      <Term Name="MaxItems" Type="Edm.Int64" Nullable="false" AppliesTo="Collection">
+        <Annotation Term="Core.Description" String="The annotated collection must have at most the specified number of items." />
+      </Term>
+
+      <Term Name="MinItems" Type="Edm.Int64" Nullable="false" AppliesTo="Collection">
+        <Annotation Term="Core.Description" String="The annotated collection must have at least the specified number of items." />
+      </Term>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/src/Microsoft.OData.Edm/Vocabularies/VocabularyModelProvider.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/VocabularyModelProvider.cs
@@ -77,7 +77,7 @@ namespace Microsoft.OData.Edm.Vocabularies.V1
             // Validation
             string validationVocabularies = allResources.Where(x => x.Contains("ValidationVocabularies.xml")).FirstOrDefault();
             Debug.Assert(validationVocabularies != null, "ValidationVocabularies.xml: not found.");
-            ValidationModel = LoadSchemaEdmModel(assembly, validationVocabularies, new[] { CoreModel }); // validation relies on core
+            ValidationModel = LoadCsdlEdmModel(assembly, validationVocabularies, new[] { CoreModel }); // validation relies on core
 
             // capabilities
             string capabilitiesVocabularies = allResources.FirstOrDefault(x => x.Contains("CapabilitiesVocabularies.xml"));

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.cs
@@ -27,6 +27,9 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
         {
             const string expectedText = @"<?xml version=""1.0"" encoding=""utf-16""?>
 <Schema Namespace=""Org.OData.Validation.V1"" Alias=""Validation"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+  <TypeDefinition Name=""SingleOrCollectionType"" UnderlyingType=""Edm.String"">
+    <Annotation Term=""Core.Description"" String=""The qualified name of a type in scope, optionally wrapped in `Collection()` to denote a collection of instances of the type"" />
+  </TypeDefinition>
   <ComplexType Name=""AllowedValue"">
     <Property Name=""Value"" Type=""Edm.PrimitiveType"">
       <Annotation Term=""Core.Description"" String=""An allowed value for the property, parameter, or type definition"" />
@@ -34,7 +37,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   </ComplexType>
   <ComplexType Name=""ConstraintType"">
     <Property Name=""FailureMessage"" Type=""Edm.String"">
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
       <Annotation Term=""Core.Description"" String=""Human-readable message that can be shown to end users if the constraint is not fulfilled"" />
     </Property>
     <Property Name=""Condition"" Type=""Edm.Boolean"" Nullable=""false"">
@@ -50,11 +53,11 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Annotation Term=""Core.Description"" String=""Entities related via the single- or collection-valued navigation property identified by `path` are also related via the collection-valued navigation property identified by `target`."" />
   </ComplexType>
-  <Term Name=""Pattern"" Type=""Edm.String"" AppliesTo=""Property Parameter Term"">
+  <Term Name=""Pattern"" Type=""Edm.String"" AppliesTo=""Property Parameter Term"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""The pattern that a string property, parameter, or term must match. This SHOULD be a valid regular expression, according to the ECMA 262 regular expression dialect."" />
     <Annotation Term=""Core.RequiresType"" String=""Edm.String"" />
   </Term>
-  <Term Name=""Minimum"" Type=""Edm.Decimal"" AppliesTo=""Property Parameter Term"" Scale=""Variable"">
+  <Term Name=""Minimum"" Type=""Edm.PrimitiveType"" AppliesTo=""Property Parameter Term"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Minimum value that a property, parameter, or term can have."" />
     <Annotation Term=""Validation.ApplicableTerms"">
       <Collection>
@@ -62,7 +65,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       </Collection>
     </Annotation>
   </Term>
-  <Term Name=""Maximum"" Type=""Edm.Decimal"" AppliesTo=""Property Parameter Term"" Scale=""Variable"">
+  <Term Name=""Maximum"" Type=""Edm.PrimitiveType"" AppliesTo=""Property Parameter Term"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Maximum value that a property, parameter, or term can have."" />
     <Annotation Term=""Validation.ApplicableTerms"">
       <Collection>
@@ -70,35 +73,35 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       </Collection>
     </Annotation>
   </Term>
-  <Term Name=""Exclusive"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Annotation"">
+  <Term Name=""Exclusive"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Annotation"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Tags a Minimum or Maximum as exclusive, i.e. an open interval boundary."" />
   </Term>
   <Term Name=""AllowedValues"" Type=""Collection(Validation.AllowedValue)"" AppliesTo=""Property Parameter TypeDefinition"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""A collection of valid values for the annotated property, parameter, or type definition"" />
   </Term>
-  <Term Name=""MultipleOf"" Type=""Edm.Decimal"" AppliesTo=""Property Parameter Term"" Scale=""Variable"">
+  <Term Name=""MultipleOf"" Type=""Edm.Decimal"" AppliesTo=""Property Parameter Term"" Nullable=""false"" Scale=""Variable"">
     <Annotation Term=""Core.Description"" String=""The value of the annotated property, parameter, or term must be an integer multiple of this positive value. For temporal types, the value is measured in seconds."" />
   </Term>
-  <Term Name=""Constraint"" Type=""Validation.ConstraintType"" AppliesTo=""Property EntityType ComplexType"">
+  <Term Name=""Constraint"" Type=""Validation.ConstraintType"" AppliesTo=""Property EntityType ComplexType"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Condition that the annotation target has to fulfill"" />
   </Term>
   <Term Name=""ItemsOf"" Type=""Collection(Validation.ItemsOfType)"" AppliesTo=""EntityType ComplexType"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""A list of constraints describing that entities related via one navigation property MUST also be related via another, collection-valued navigation property. The same `path` value MUST NOT occur more than once."" />
     <Annotation Term=""Core.LongDescription"" String=""Example: entity type `Customer` has navigation properties `AllOrders`, `OpenOrders`, and `ClosedOrders`. &#xA;The term allows to express that items of `OpenOrders` and `ClosedOrders` are also items of the `AllOrders` navigation property,&#xA;even though they are defined in an `Orders` entity set."" />
   </Term>
-  <Term Name=""OpenPropertyTypeConstraint"" Type=""Collection(Core.QualifiedTypeName)"" AppliesTo=""ComplexType EntityType"" Nullable=""false"">
-    <Annotation Term=""Core.Description"" String=""Dynamic properties added to the annotated open structured type are restricted to the listed types"" />
+  <Term Name=""OpenPropertyTypeConstraint"" Type=""Collection(Validation.SingleOrCollectionType)"" AppliesTo=""ComplexType EntityType"" Nullable=""false"">
+    <Annotation Term=""Core.Description"" String=""Dynamic properties added to the annotated open structured type are restricted to the listed types."" />
   </Term>
-  <Term Name=""DerivedTypeConstraint"" Type=""Collection(Core.QualifiedTypeName)"" AppliesTo=""EntitySet Singleton NavigationProperty Property TypeDefinition Parameter ReturnType"" Nullable=""false"">
+  <Term Name=""DerivedTypeConstraint"" Type=""Collection(Validation.SingleOrCollectionType)"" AppliesTo=""EntitySet Singleton NavigationProperty Property TypeDefinition Parameter ReturnType"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Values are restricted to types that are both identical to or derived from the declared type and a type listed in this collection."" />
-    <Annotation Term=""Core.LongDescription"" String=""This allows restricting values to certain sub-trees of an inheritance hierarchy. Types listed in this collection that are not derived from the declared type of the annotated model element are ignored."" />
+    <Annotation Term=""Core.LongDescription"" String=""This allows restricting values to certain sub-trees of an inheritance hierarchy,&#xA;          including hierarchies starting at the [Built-In Abstract Types](https://docs.oasis-open.org/odata/odata-csdl-json/v4.01/odata-csdl-json-v4.01.html#sec_BuiltInAbstractTypes).&#xA;          Types listed in this collection are ignored if they are not derived from the declared type of the annotated model element&#xA;          or would not be allowed as declared type of the annotated model element.&#xA;&#xA;          When applied to a collection-valued element, this annotation specifies the types allowed for members&#xA;          of the collection without mentioning the `Collection()` wrapper.&#xA;          The SingleOrCollectionType may only include the `Collection()` wrapper&#xA;          if the annotation is applied to an element with declared type `Edm.Untyped`."" />
   </Term>
-  <Term Name=""AllowedTerms"" Type=""Collection(Core.QualifiedTermName)"" AppliesTo=""Term Property"">
+  <Term Name=""AllowedTerms"" Type=""Collection(Core.QualifiedTermName)"" AppliesTo=""Term Property"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Annotate a term of type Edm.AnnotationPath, or a property of type Edm.AnnotationPath that is used within a structured term, to restrict the terms that can be targeted by the path."" />
     <Annotation Term=""Core.LongDescription"" String=""The annotation path expression is intended to end in a path segment with one of the listed terms. For forward compatibility, clients should be prepared for the annotation to reference terms besides those listed."" />
     <Annotation Term=""Core.RequiresType"" String=""Edm.AnnotationPath"" />
   </Term>
-  <Term Name=""ApplicableTerms"" Type=""Collection(Core.QualifiedTermName)"">
+  <Term Name=""ApplicableTerms"" Type=""Collection(Core.QualifiedTermName)"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Names of specific terms that are applicable and may be applied in the current context. This annotation does not restrict the use of other terms."" />
   </Term>
   <Term Name=""MaxItems"" Type=""Edm.Int64"" AppliesTo=""Collection"" Nullable=""false"">
@@ -131,20 +134,20 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
 
         [Theory]
         [InlineData("Pattern", "Edm.String", "Property Parameter Term")]
-        [InlineData("Minimum", "Edm.Decimal", "Property Parameter Term")]
-        [InlineData("Maximum", "Edm.Decimal", "Property Parameter Term")]
-        [InlineData("Exclusive", "Core.Tag", "Annotation")]
+        [InlineData("Minimum", "Edm.PrimitiveType", "Property Parameter Term")]
+        [InlineData("Maximum", "Edm.PrimitiveType", "Property Parameter Term")]
+        [InlineData("Exclusive", "Org.OData.Core.V1.Tag", "Annotation")]
         [InlineData("AllowedValues", "Collection(Org.OData.Validation.V1.AllowedValue)", "Property Parameter TypeDefinition")]
         [InlineData("MultipleOf", "Edm.Decimal", "Property Parameter Term")]
         [InlineData("Constraint", "Org.OData.Validation.V1.ConstraintType", "Property EntityType ComplexType")]
         [InlineData("ItemsOf", "Collection(Org.OData.Validation.V1.ItemsOfType)", "EntityType ComplexType")]
-        [InlineData("OpenPropertyTypeConstraint", "Collection(Core.QualifiedTypeName)", "ComplexType EntityType")]
-        [InlineData("DerivedTypeConstraint", "Collection(Core.QualifiedTypeName)",
+        [InlineData("OpenPropertyTypeConstraint", "Collection(Org.OData.Validation.V1.SingleOrCollectionType)", "ComplexType EntityType")]
+        [InlineData("DerivedTypeConstraint", "Collection(Org.OData.Validation.V1.SingleOrCollectionType)",
             "EntitySet Singleton NavigationProperty Property TypeDefinition Parameter ReturnType")]
-        [InlineData("AllowedTerms", "Collection(Core.QualifiedTermName)", "Term Property")]
+        [InlineData("AllowedTerms", "Collection(Org.OData.Core.V1.QualifiedTermName)", "Term Property")]
         [InlineData("MaxItems", "Edm.Int64", "Collection")]
         [InlineData("MinItems", "Edm.Int64", "Collection")]
-        [InlineData("ApplicableTerms", "Collection(Core.QualifiedTermName)", null)]
+        [InlineData("ApplicableTerms", "Collection(Org.OData.Core.V1.QualifiedTermName)", null)]
         public void TestValidationVocabularyTermType(string termName, string typeName, string appliesTo)
         {
             var termType = this._validationModel.FindDeclaredTerm("Org.OData.Validation.V1." + termName);


### PR DESCRIPTION
Update to latest OASIS Validation vocabulary
Fixes references to Core vocabulary

<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fixes an issue where references to Core.* elements failed because the Core vocabulary was not referenced and Core was not defined as an alias.

### Description

Updates to the latest OASIS vocabulary.
Includes the edmx wrapper in order to provide references to other schemas.
Changes how the vocabulary is loaded to read as csdl and not just the schema element.
Updates tests

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
-should add a test for application of the OpenTypePropertyConstraint, that was broken prior to this fix.
-I removed an annotation for allowed values that is defined in the OASIS vocabulary because it references a type definition that is not defined in our core vocabulary.
