### PR TITLE
Add vocabulary terms to Require Explicit Binding

### DIFF
--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
@@ -391,6 +391,17 @@
     <Annotation Term="Core.Description" String="The qualified name of a type in scope." />
   </TypeDefinition>
 
+  <TypeDefinition Name="QualifiedBoundOperationName" UnderlyingType="Edm.String">
+    <Annotation Term="Core.Description" String="The qualified name of a bound action or function in scope." />
+    <Annotation Term="Core.LongDescription">
+      <String>Either
+- the qualified name of an action, to indicate the single bound overload with the specified binding parameter type,
+- the qualified name of a function, to indicate all bound overloads with the specified binding parameter type, or
+- the qualified name of a function followed by parentheses containing a comma-separated list of parameter types, in the order of their definition, to identify a single function overload with the first (binding) parameter matching the specified parameter type.
+      </String>
+    </Annotation>
+  </TypeDefinition>
+
   <Term Name="Ordered" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Property NavigationProperty EntitySet ReturnType">
     <Annotation Term="Core.Description" String="Collection has a stable order. Ordered collections of primitive or complex types can be indexed by ordinal." />
   </Term>

--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
@@ -398,7 +398,7 @@
 - the qualified name of an action, to indicate the single bound overload with the specified binding parameter type,
 - the qualified name of a function, to indicate all bound overloads with the specified binding parameter type, or
 - the qualified name of a function followed by parentheses containing a comma-separated list of parameter types, in the order of their definition, to identify a single function overload with the first (binding) parameter matching the specified parameter type.
-      </String>
+</String>
     </Annotation>
   </TypeDefinition>
 

--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
@@ -443,6 +443,14 @@ Any simple identifier | Any type listed in `Validation.OpenPropertyTypeConstrain
     <Annotation Term="Core.LongDescription" String="The annotation value will usually be an expression, e.g. using properties of the binding parameter type for instance-dependent availability, or using properties of a singleton for global availability. The static value `null` means that availability cannot be determined upfront and is instead expressed as an operation advertisement." />
   </Term>
 
+  <Term Name="RequiresExplicitBinding" Type="Core.Tag" DefaultValue="true" AppliesTo="Action Function">
+	<Annotation Term="Core.Description" String="This bound action or function is only available on model elements annotated with the ExplicitOperationBindings term." />
+  </Term>
+
+  <Term Name="ExplicitOperationBindings" Type="Collection(Core.QualifiedBoundOperationName)">
+    <Annotation Term="Core.Description" String="The qualified names of explicitly bound operations that are supported on the target model element. These operations are in addition to any operations not annotated with RequiresExplicitBinding that are bound to the type of the target model element." />
+  </Term>
+
   <TypeDefinition Name="LocalDateTime" UnderlyingType="Edm.String">
     <Annotation Term="Core.Description" String="A string representing a Local Date-Time value with no offset." />
     <Annotation Term="Validation.Pattern" String="^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9](\\.[0-9]+)?)?$" />

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
@@ -349,6 +349,12 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Annotation Term=""Core.Description"" String=""Action or function is available"" />
     <Annotation Term=""Core.LongDescription"" String=""The annotation value will usually be an expression, e.g. using properties of the binding parameter type for instance-dependent availability, or using properties of a singleton for global availability. The static value `null` means that availability cannot be determined upfront and is instead expressed as an operation advertisement."" />
   </Term>
+  <Term Name=""RequiresExplicitBinding"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Action Function"">
+    <Annotation Term=""Core.Description"" String=""This bound action or function is only available on model elements annotated with the ExplicitOperationBindings term."" />
+  </Term>
+  <Term Name=""ExplicitOperationBindings"" Type=""Collection(Core.QualifiedBoundOperationName)"">
+    <Annotation Term=""Core.Description"" String=""The qualified names of explicitly bound operations that are supported on the target model element. These operations are in addition to any operations not annotated with RequiresExplicitBinding that are bound to the type of the target model element."" />
+  </Term>
 </Schema>";
 
             var s = coreVocModel.FindDeclaredTerm("Org.OData.Core.V1.OptimisticConcurrency");
@@ -377,6 +383,19 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             var isLanguageDependentType = isLanguageDependentTerm.Type.Definition as IEdmTypeDefinition;
             Assert.NotNull(isLanguageDependentType);
             Assert.Equal(EdmPrimitiveTypeKind.Boolean, isLanguageDependentType.UnderlyingType.PrimitiveKind);
+
+            var requiresExplicitBindingTerm = coreVocModel.FindTerm("Org.OData.Core.V1.RequiresExplicitBinding");
+            Assert.NotNull(requiresExplicitBindingTerm);
+            var requiresExplicitBindingType = requiresExplicitBindingTerm.Type.Definition as IEdmTypeDefinition;
+            Assert.NotNull(requiresExplicitBindingType);
+            Assert.Equal(EdmPrimitiveTypeKind.Boolean, requiresExplicitBindingType.UnderlyingType.PrimitiveKind);
+
+            var explicitOperationBindingsTerm = coreVocModel.FindTerm("Org.OData.Core.V1.ExplicitOperationBindings");
+            Assert.NotNull(explicitOperationBindingsTerm);
+            var explicitOperationBindingsType = explicitOperationBindingsTerm.Type.Definition;
+            Assert.NotNull(explicitOperationBindingsType);
+            Assert.Equal("Collection(Org.OData.Core.V1.QualifiedBoundOperationName)", explicitOperationBindingsType.FullTypeName());
+            Assert.Equal(EdmTypeKind.Collection, explicitOperationBindingsType.TypeKind);
 
             StringWriter sw = new StringWriter();
             XmlWriterSettings settings = new XmlWriterSettings();

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
@@ -54,6 +54,10 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <TypeDefinition Name=""QualifiedTypeName"" UnderlyingType=""Edm.String"">
     <Annotation Term=""Core.Description"" String=""The qualified name of a type in scope."" />
   </TypeDefinition>
+  <TypeDefinition Name=""QualifiedBoundOperationName"" UnderlyingType=""Edm.String"">
+    <Annotation Term=""Core.Description"" String=""The qualified name of a bound action or function in scope."" />
+    <Annotation Term=""Core.LongDescription"" String=""Either&#xA;- the qualified name of an action, to indicate the single bound overload with the specified binding parameter type,&#xA;- the qualified name of a function, to indicate all bound overloads with the specified binding parameter type, or&#xA;- the qualified name of a function followed by parentheses containing a comma-separated list of parameter types, in the order of their definition, to identify a single function overload with the first (binding) parameter matching the specified parameter type.&#xA;      "" />
+  </TypeDefinition>
   <TypeDefinition Name=""LocalDateTime"" UnderlyingType=""Edm.String"">
     <Annotation Term=""Core.Description"" String=""A string representing a Local Date-Time value with no offset."" />
     <Annotation Term=""Validation.Pattern"" String=""^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9](\\.[0-9]+)?)?$"" />
@@ -397,6 +401,10 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             Assert.Equal("Collection(Org.OData.Core.V1.QualifiedBoundOperationName)", explicitOperationBindingsType.FullTypeName());
             Assert.Equal(EdmTypeKind.Collection, explicitOperationBindingsType.TypeKind);
 
+            var qualifiedBoundOperationNameType = coreVocModel.FindType("Org.OData.Core.V1.QualifiedBoundOperationName");
+            Assert.NotNull(qualifiedBoundOperationNameType);
+            Assert.Equal(qualifiedBoundOperationNameType, explicitOperationBindingsType.AsElementType());
+
             StringWriter sw = new StringWriter();
             XmlWriterSettings settings = new XmlWriterSettings();
             settings.Indent = true;
@@ -478,6 +486,8 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
         }
 
         [Theory]
+        [InlineData("ExplicitOperationBindings", "Collection(Org.OData.Core.V1.QualifiedBoundOperationName)", null)]
+        [InlineData("RequiresExplicitBinding", "Org.OData.Core.V1.Tag", "Action Function")]
         [InlineData("OperationAvailable", "Edm.Boolean", "Action Function")]
         [InlineData("OptionalParameter", "Org.OData.Core.V1.OptionalParameterType", "Parameter")]
         [InlineData("AlternateKeys", "Collection(Org.OData.Core.V1.AlternateKey)", "EntityType EntitySet NavigationProperty")]
@@ -529,6 +539,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
         }
 
         [Theory]
+        [InlineData("QualifiedBoundOperationName", "Edm.String")]
         [InlineData("MessageSeverity", "Edm.String")]
         [InlineData("Tag", "Edm.Boolean")]
         [InlineData("QualifiedTermName", "Edm.String")]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   </TypeDefinition>
   <TypeDefinition Name=""QualifiedBoundOperationName"" UnderlyingType=""Edm.String"">
     <Annotation Term=""Core.Description"" String=""The qualified name of a bound action or function in scope."" />
-    <Annotation Term=""Core.LongDescription"" String=""Either&#xA;- the qualified name of an action, to indicate the single bound overload with the specified binding parameter type,&#xA;- the qualified name of a function, to indicate all bound overloads with the specified binding parameter type, or&#xA;- the qualified name of a function followed by parentheses containing a comma-separated list of parameter types, in the order of their definition, to identify a single function overload with the first (binding) parameter matching the specified parameter type.&#xA;      "" />
+    <Annotation Term=""Core.LongDescription"" String=""Either&#xA;- the qualified name of an action, to indicate the single bound overload with the specified binding parameter type,&#xA;- the qualified name of a function, to indicate all bound overloads with the specified binding parameter type, or&#xA;- the qualified name of a function followed by parentheses containing a comma-separated list of parameter types, in the order of their definition, to identify a single function overload with the first (binding) parameter matching the specified parameter type.&#xA;"" />
   </TypeDefinition>
   <TypeDefinition Name=""LocalDateTime"" UnderlyingType=""Edm.String"">
     <Annotation Term=""Core.Description"" String=""A string representing a Local Date-Time value with no offset."" />


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2611.

### Description

Adds two new vocabulary annotation terms: RequiresExplicitBinding and ExplicitOperationBindings.

### Checklist

- [x] Test cases added
- [x] Build and test with one-click build and test script passed