### PR TITLE
support reading relative context urls with bulk updates

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightDeserializer.cs
@@ -258,7 +258,8 @@ namespace Microsoft.OData.JsonLight
             ODataPayloadKind payloadKind,
             PropertyAndAnnotationCollector propertyAndAnnotationCollector,
             bool isReadingNestedPayload,
-            bool allowEmptyPayload)
+            bool allowEmptyPayload,
+            IEdmNavigationSource navigationSource = null)
         {
             this.JsonReader.AssertNotBuffering();
             Debug.Assert(isReadingNestedPayload || this.JsonReader.NodeType == JsonNodeType.None, "Pre-Condition: JSON reader must not have been used yet when not reading a nested payload.");
@@ -298,7 +299,9 @@ namespace Microsoft.OData.JsonLight
                     payloadKind,
                     this.MessageReaderSettings.ClientCustomTypeResolver,
                     this.JsonLightInputContext.ReadingResponse || payloadKind == ODataPayloadKind.Delta,
-                    this.JsonLightInputContext.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata);
+                    this.JsonLightInputContext.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata,
+                    this.BaseUri, 
+                    navigationSource);
             }
 
             this.contextUriParseResult = parseResult;
@@ -325,7 +328,8 @@ namespace Microsoft.OData.JsonLight
             ODataPayloadKind payloadKind,
             PropertyAndAnnotationCollector propertyAndAnnotationCollector,
             bool isReadingNestedPayload,
-            bool allowEmptyPayload)
+            bool allowEmptyPayload, 
+            IEdmNavigationSource navigationSource = null)
         {
             this.JsonReader.AssertNotBuffering();
             Debug.Assert(
@@ -349,7 +353,9 @@ namespace Microsoft.OData.JsonLight
                     payloadKind,
                     this.MessageReaderSettings.ClientCustomTypeResolver,
                     this.JsonLightInputContext.ReadingResponse || payloadKind == ODataPayloadKind.Delta,
-                    this.JsonLightInputContext.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata);
+                    this.JsonLightInputContext.MessageReaderSettings.ThrowIfTypeConflictsWithMetadata,
+                    this.BaseUri, 
+                    navigationSource);
             }
 
 #if DEBUG

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -211,7 +211,8 @@ namespace Microsoft.OData.JsonLight
                 payloadKind,
                 propertyAndAnnotationCollector,
                 this.IsReadingNestedPayload,
-                allowEmptyPayload: false).ConfigureAwait(false);
+                allowEmptyPayload: false,
+                this.CurrentNavigationSource).ConfigureAwait(false);
 
             ResolveScopeInfoFromContextUrl();
 
@@ -1231,7 +1232,10 @@ namespace Microsoft.OData.JsonLight
                     UriUtils.UriToString(nestedInfo.ContextUrl),
                     payloadKind,
                     this.jsonLightResourceDeserializer.MessageReaderSettings.ClientCustomTypeResolver,
-                    this.jsonLightResourceDeserializer.JsonLightInputContext.ReadingResponse).Path;
+                    this.jsonLightResourceDeserializer.JsonLightInputContext.ReadingResponse,
+                    true,
+                    this.jsonLightResourceDeserializer.MessageReaderSettings.BaseUri,
+                    this.CurrentNavigationSource).Path;
 
                 return new ODataUri() { Path = odataPath };
             }
@@ -1931,7 +1935,11 @@ namespace Microsoft.OData.JsonLight
                         contextUriStr,
                         this.ReadingDelta ? ODataPayloadKind.Delta : ODataPayloadKind.Resource,
                         this.jsonLightResourceDeserializer.MessageReaderSettings.ClientCustomTypeResolver,
-                        this.jsonLightInputContext.ReadingResponse || this.ReadingDelta);
+                        this.jsonLightInputContext.ReadingResponse || this.ReadingDelta,
+                        true,
+                        this.jsonLightResourceDeserializer.BaseUri, 
+                        this.CurrentNavigationSource);
+
                     if (parseResult != null)
                     {
                         // a top-level (deleted) resource in a delta response can come from any entity set
@@ -3459,7 +3467,10 @@ namespace Microsoft.OData.JsonLight
                         contextUriFromPayload: contextUriStr,
                         payloadKind: this.ReadingDelta ? ODataPayloadKind.Delta : ODataPayloadKind.Resource,
                         clientCustomTypeResolver: this.jsonLightResourceDeserializer.MessageReaderSettings.ClientCustomTypeResolver,
-                        needParseFragment: this.jsonLightInputContext.ReadingResponse || this.ReadingDelta);
+                        needParseFragment: this.jsonLightInputContext.ReadingResponse || this.ReadingDelta,
+                        true,
+                        this.jsonLightResourceDeserializer.BaseUri, 
+                        this.CurrentNavigationSource);
 
                     if (parseResult != null)
                     {

--- a/src/Microsoft.OData.Core/ODataConstants.cs
+++ b/src/Microsoft.OData.Core/ODataConstants.cs
@@ -147,6 +147,9 @@ namespace Microsoft.OData
         /// <summary>A segment name in a URI that indicates metadata is being requested.</summary>
         internal const string UriMetadataSegment = "$metadata";
 
+        /// <summary>A segment name in a URI that indicates metadata is being requested and that has a # suffix. Exa. $metadata#.</summary>
+        internal const string UriMetadataSegmentHash = UriMetadataSegment + TypeNamePrefix;
+
         /// <summary>The OData prefix</summary>
         internal const string ODataPrefix = "odata";
 
@@ -190,6 +193,9 @@ namespace Microsoft.OData
 
         /// <summary>The $delta token indicates delta resource set.</summary>
         internal const string ContextUriDeltaResourceSet = UriSegmentSeparator + DeltaResourceSet;
+
+        /// <summary>The $delta token indicates delta resource set.</summary>
+        internal const string HashDeltaResourceSet = TypeNamePrefix + DeltaResourceSet;
 
         /// <summary>The $deletedEntity token indicates deleted resource.</summary>
         internal const string DeletedEntry = "$deletedEntity";

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightContextUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightContextUriParserTests.cs
@@ -31,13 +31,29 @@ namespace Microsoft.OData.Tests.JsonLight
             return model;
         }
 
-        // TODO: Support relative context uri and resolving other relative uris
         [Fact]
-        public void ParseRelativeContextUrlShouldThrowException()
+        public void ParseRelativeContextUrlShouldNotThrowException()
         {
-            string relativeUrl = "$metadata#R";
-            Action parseContextUri = () => ODataJsonLightContextUriParser.Parse(new EdmModel(), relativeUrl, ODataPayloadKind.Unsupported, null, true);
-            parseContextUri.Throws<ODataException>(ErrorStrings.ODataJsonLightContextUriParser_TopLevelContextUrlShouldBeAbsolute(relativeUrl));
+            string relativeUrl = "$metadata#People";
+            var parsedContextUrl = ODataJsonLightContextUriParser.Parse(this.GetModel(), relativeUrl, ODataPayloadKind.Unsupported, null, true, true, new Uri("https://www.example.com/api/"));
+            Assert.Equal(new Uri("https://www.example.com/api/$metadata#People"), parsedContextUrl.ContextUri);
+        }
+
+        [Fact]
+        public void ParseRelativeContextUrlWithoutMetadataShouldNotThrowException()
+        {
+            string relativeUrl = "People";
+            var parsedContextUrl = ODataJsonLightContextUriParser.Parse(this.GetModel(), relativeUrl, ODataPayloadKind.Unsupported, null, true, true, new Uri("https://www.example.com/api/"));
+            Assert.Equal(new Uri("https://www.example.com/api/$metadata#People"), parsedContextUrl.ContextUri);
+        }
+
+        [Fact]
+        public void ParseRelativeContextUrlWithOnlyDeltaSegmentShouldNotThrowException()
+        {
+            string relativeUrl = "#$delta";
+            IEdmNavigationSource navigationSource = this.GetModel().FindDeclaredEntitySet("People") as IEdmNavigationSource;
+            var parsedContextUrl = ODataJsonLightContextUriParser.Parse(this.GetModel(), relativeUrl, ODataPayloadKind.Unsupported, null, true, true, new Uri("https://www.example.com/api/"), navigationSource);
+            Assert.Equal(new Uri("https://www.example.com/api/$metadata#People"), parsedContextUrl.ContextUri);
         }
 
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/ContextUriParserJsonLightTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/ContextUriParserJsonLightTests.cs
@@ -88,17 +88,17 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 },
                 new ContextUriParserTestCase
                 {
-                    DebugDescription = "empty string is a relative URI; context URIs have to absolute",
+                    DebugDescription = "empty string is a relative URI; relative context URLs should not be null.",
                     ContextUri = string.Empty,
                     Model = this.testModel,
-                    ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightContextUriParser_TopLevelContextUrlShouldBeAbsolute", "")
+                    ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightContextUriParser_InvalidContextUrl")
                 },
                 new ContextUriParserTestCase
                 {
-                    DebugDescription = "another relative URI; context URIs have to absolute",
+                    DebugDescription = "another relative URI; context URIs should have null baseUri",
                     ContextUri = "relativeUri",
                     Model = this.testModel,
-                    ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightContextUriParser_TopLevelContextUrlShouldBeAbsolute", "relativeUri")
+                    ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightContextUriParser_InvalidContextUrl")
                 },
                 new ContextUriParserTestCase
                 {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This PR adds support for reading payloads with relative context URLs.  Currently we support `@context` with absolute URLS:  
EXA of a payload with a relative context URL that will be supported by these changes:
```json
{
    "@context": "#$delta",
    "value": [
        {
            "displayName": "Big cat",
            "percentageWeight": 100
        }
    ]
}
```

```json
{
    "@context": "Products",
    "value": [
        {
            "displayName": "Big cat",
            "percentageWeight": 100
        }
    ]
}
```
```json
{
    "@context": "$metadata#Products",
    "value": [
        {
            "displayName": "Big cat",
            "percentageWeight": 100
        }
    ]
}
```


### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
