### PR TITLE
Add support for writing JsonElement values in ODataWriter

### DIFF
--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -68,7 +68,7 @@ scenarios:
     application:
       job: components
       variables:
-        filter: "*ODataWriter*"
+        filter: "*Writer*"
   UriParser:
     application:
       job: components

--- a/src/Microsoft.OData.Core/Json/IJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriter.cs
@@ -8,6 +8,9 @@ namespace Microsoft.OData.Json
 {
     using System;
     using Microsoft.OData.Edm;
+#if NETCOREAPP3_1_OR_GREATER
+    using System.Text.Json;
+#endif
 
     /// <summary>
     /// Interface for a class that can write arbitrary JSON.
@@ -152,6 +155,15 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="value">TimeOfDay value to be written.</param>
         void WriteValue(TimeOfDay value);
+
+#if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>
+        /// Write a <see cref="JsonElement"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="JsonElement"/> value to be written.</param>
+        void WriteValue(JsonElement value);
+#endif
 
         /// <summary>
         /// Write a raw value.

--- a/src/Microsoft.OData.Core/Json/IJsonWriterAsync.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriterAsync.cs
@@ -9,6 +9,9 @@ namespace Microsoft.OData.Json
     using System;
     using System.Threading.Tasks;
     using Microsoft.OData.Edm;
+#if NETCOREAPP3_1_OR_GREATER
+    using System.Text.Json;
+#endif
 
     /// <summary>
     /// Interface for a class that can write arbitrary JSON asynchronously.
@@ -177,6 +180,16 @@ namespace Microsoft.OData.Json
         /// <param name="value">TimeOfDay value to be written.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         Task WriteValueAsync(TimeOfDay value);
+
+#if NETCOREAPP3_1_OR_GREATER
+
+        /// <summary>
+        /// Asynchronously writes a <see cref="JsonElement"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="JsonElement"/> value to be written.</param>
+        /// <returns>A task that represents the asynchronous write operation.</returns>
+        Task WriteValueAsync(JsonElement value);
+#endif
 
         /// <summary>
         /// Asynchronously writes a raw value.

--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -13,10 +13,11 @@ namespace Microsoft.OData.Json
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.IO;
-    using System.Text;
-    using System.Threading.Tasks;
     using Microsoft.OData.Buffers;
     using Microsoft.OData.Edm;
+#if NETCOREAPP3_1_OR_GREATER
+    using System.Text.Json;
+#endif
     #endregion Namespaces
 
     /// <summary>
@@ -407,6 +408,13 @@ namespace Microsoft.OData.Json
             this.WriteValueSeparator();
             JsonValueUtils.WriteValue(this.writer, value, this.wrappedBuffer, this.ArrayPool);
         }
+
+#if NETCOREAPP3_1_OR_GREATER
+        public void WriteValue(JsonElement value)
+        {
+            throw new NotImplementedException();
+        }
+#endif
 
         /// <summary>
         /// Write a raw value.

--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -412,7 +412,128 @@ namespace Microsoft.OData.Json
 #if NETCOREAPP3_1_OR_GREATER
         public void WriteValue(JsonElement value)
         {
-            throw new NotImplementedException();
+            switch (value.ValueKind)
+            {
+                case JsonValueKind.Null:
+                    this.WriteValue((string)null);
+                    break;
+                case JsonValueKind.False:
+                    this.WriteValue(false);
+                    break;
+                case JsonValueKind.True:
+                    this.WriteValue(true);
+                    break;
+                case JsonValueKind.String:
+                    this.WriteValue(value.GetString());
+                    break;
+                case JsonValueKind.Array:
+                    this.WriteJsonElementArray(value);
+                    break;
+                case JsonValueKind.Object:
+                    this.WriteJsonElementObject(value);
+                    break;
+                case JsonValueKind.Number:
+                    this.WriteJsonElementNumber(value);
+                    break;
+            }
+        }
+
+        private void WriteJsonElementArray(JsonElement value)
+        {
+            Debug.Assert(value.ValueKind == JsonValueKind.Array);
+
+            this.StartArrayScope();
+            foreach (JsonElement item in value.EnumerateArray())
+            {
+                this.WriteValue(item);
+            }
+
+            this.EndArrayScope();
+        }
+
+        private void WriteJsonElementObject(JsonElement value)
+        {
+            Debug.Assert(value.ValueKind == JsonValueKind.Object);
+
+            this.StartObjectScope();
+            foreach (JsonProperty property in value.EnumerateObject())
+            {
+                this.WriteName(property.Name);
+                this.WriteValue(property.Value);
+            }
+
+            this.EndObjectScope();
+        }
+
+        private void WriteJsonElementNumber(JsonElement value)
+        {
+            Debug.Assert(value.ValueKind == JsonValueKind.Number);
+
+            if (value.TryGetByte(out byte byteValue))
+            {
+                this.WriteValue(byteValue);
+                return;
+            }
+
+            if (value.TryGetDecimal(out decimal decimalValue))
+            {
+                this.WriteValue(decimalValue);
+                return;
+            }
+
+            if (value.TryGetDouble(out double doubleValue))
+            {
+                this.WriteValue(doubleValue);
+                return;
+            }
+
+            if (value.TryGetInt16(out short shortValue))
+            {
+                this.WriteValue(shortValue);
+                return;
+            }
+
+            if (value.TryGetInt32(out int intValue))
+            {
+                this.WriteValue(intValue);
+                return;
+            }
+
+            if (value.TryGetInt64(out long longValue))
+            {
+                this.WriteValue(longValue);
+                return;
+            }
+
+            if (value.TryGetSByte(out sbyte sbyteValue))
+            {
+                this.WriteValue(sbyteValue);
+                return;
+            }
+
+            if (value.TryGetSingle(out float floatValue))
+            {
+                this.WriteValue(floatValue);
+                return;
+            }
+
+            if (value.TryGetUInt16(out ushort ushortValue))
+            {
+                this.WriteValue(ushortValue);
+                return;
+            }
+
+            if (value.TryGetUInt32(out uint uintValue))
+            {
+                this.WriteValue(uintValue);
+                return;
+            }
+
+            if (value.TryGetUInt64(out ulong ulongValue))
+            {
+                this.WriteValue((decimal)ulongValue);
+                return;
+            }
         }
 #endif
 

--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -414,6 +414,9 @@ namespace Microsoft.OData.Json
         {
             switch (value.ValueKind)
             {
+                case JsonValueKind.String:
+                    this.WriteValue(value.GetString());
+                    break;
                 case JsonValueKind.Null:
                     this.WriteValue((string)null);
                     break;
@@ -423,8 +426,8 @@ namespace Microsoft.OData.Json
                 case JsonValueKind.True:
                     this.WriteValue(true);
                     break;
-                case JsonValueKind.String:
-                    this.WriteValue(value.GetString());
+                case JsonValueKind.Number:
+                    this.WriteJsonElementNumber(value);
                     break;
                 case JsonValueKind.Array:
                     this.WriteJsonElementArray(value);
@@ -432,9 +435,7 @@ namespace Microsoft.OData.Json
                 case JsonValueKind.Object:
                     this.WriteJsonElementObject(value);
                     break;
-                case JsonValueKind.Number:
-                    this.WriteJsonElementNumber(value);
-                    break;
+                
             }
         }
 
@@ -469,6 +470,18 @@ namespace Microsoft.OData.Json
         {
             Debug.Assert(value.ValueKind == JsonValueKind.Number);
 
+            if (value.TryGetInt32(out int intValue))
+            {
+                this.WriteValue(intValue);
+                return;
+            }
+
+            if (value.TryGetDouble(out double doubleValue))
+            {
+                this.WriteValue(doubleValue);
+                return;
+            }
+
             if (value.TryGetByte(out byte byteValue))
             {
                 this.WriteValue(byteValue);
@@ -481,21 +494,9 @@ namespace Microsoft.OData.Json
                 return;
             }
 
-            if (value.TryGetDouble(out double doubleValue))
-            {
-                this.WriteValue(doubleValue);
-                return;
-            }
-
             if (value.TryGetInt16(out short shortValue))
             {
                 this.WriteValue(shortValue);
-                return;
-            }
-
-            if (value.TryGetInt32(out int intValue))
-            {
-                this.WriteValue(intValue);
                 return;
             }
 

--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -435,7 +435,9 @@ namespace Microsoft.OData.Json
                 case JsonValueKind.Object:
                     this.WriteJsonElementObject(value);
                     break;
-                
+                default:
+                    // We have already exhausted all known JSON types. Treat this case undefined behaviour and do nothing.
+                    break;
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterAsync.cs
@@ -249,31 +249,29 @@ namespace Microsoft.OData.Json
         }
 
 #if NETCOREAPP3_1_OR_GREATER
-        public async Task WriteValueAsync(JsonElement value)
+        public Task WriteValueAsync(JsonElement value)
         {
             switch (value.ValueKind)
             {
                 case JsonValueKind.Null:
-                    await this.WriteValueAsync((string)null).ConfigureAwait(false);
-                    break;
+                    return this.WriteValueAsync((string)null);
                 case JsonValueKind.False:
-                    await this.WriteValueAsync(false).ConfigureAwait(false);
-                    break;
+                    return this.WriteValueAsync(false);
                 case JsonValueKind.True:
-                    await this.WriteValueAsync(true).ConfigureAwait(false);
-                    break;
+                    return this.WriteValueAsync(true);
                 case JsonValueKind.String:
-                    await this.WriteValueAsync(value.GetString()).ConfigureAwait(false);
-                    break;
+                    return this.WriteValueAsync(value.GetString());
                 case JsonValueKind.Array:
-                    await this.WriteJsonElementArrayAsync(value).ConfigureAwait(false);
-                    break;
+                    return this.WriteJsonElementArrayAsync(value);
                 case JsonValueKind.Object:
-                    await this.WriteJsonElementObjectAsync(value).ConfigureAwait(false);
-                    break;
+                    return this.WriteJsonElementObjectAsync(value);
                 case JsonValueKind.Number:
-                    await this.WriteJsonElementNumberAsync(value).ConfigureAwait(false);
-                    break;
+                    return this.WriteJsonElementNumberAsync(value);
+                default:
+                    // we've exhausted all known JSON types, if we get
+                    // to this point, then it's undefined behavior
+                    Debug.Fail($"Unexpected JSON ValueKind {value.ValueKind}");
+                    return Task.CompletedTask;
             }
         }
 
@@ -304,75 +302,67 @@ namespace Microsoft.OData.Json
             await this.EndObjectScopeAsync().ConfigureAwait(false);
         }
 
-        private async Task WriteJsonElementNumberAsync(JsonElement value)
+        private Task WriteJsonElementNumberAsync(JsonElement value)
         {
             Debug.Assert(value.ValueKind == JsonValueKind.Number);
 
             if (value.TryGetByte(out byte byteValue))
             {
-                await this.WriteValueAsync(byteValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync(byteValue);
             }
 
             if (value.TryGetDecimal(out decimal decimalValue))
             {
-                await this.WriteValueAsync(decimalValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync(decimalValue);
             }
 
             if (value.TryGetDouble(out double doubleValue))
             {
-                await this.WriteValueAsync(doubleValue).ConfigureAwait(false);
-                return;
+                return WriteValueAsync(doubleValue);
             }
 
             if (value.TryGetInt16(out short shortValue))
             {
-                await this.WriteValueAsync(shortValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync(shortValue);
             }
 
             if (value.TryGetInt32(out int intValue))
             {
-                await this.WriteValueAsync(intValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync(intValue);
             }
 
             if (value.TryGetInt64(out long longValue))
             {
-                await this.WriteValueAsync(longValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync(longValue);
             }
 
             if (value.TryGetSByte(out sbyte sbyteValue))
             {
-                await this.WriteValueAsync(sbyteValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync(sbyteValue);
             }
 
             if (value.TryGetSingle(out float floatValue))
             {
-                await this.WriteValueAsync(floatValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync(floatValue);
             }
 
             if (value.TryGetUInt16(out ushort ushortValue))
             {
-                await this.WriteValueAsync(ushortValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync(ushortValue);
             }
 
             if (value.TryGetUInt32(out uint uintValue))
             {
-                await this.WriteValueAsync(uintValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync(uintValue);
             }
 
             if (value.TryGetUInt64(out ulong ulongValue))
             {
-                await this.WriteValueAsync((decimal)ulongValue).ConfigureAwait(false);
-                return;
+                return this.WriteValueAsync((decimal)ulongValue);
             }
+
+            Debug.Fail($"Exhausted all known JSON number types and did not find match.");
+            return Task.CompletedTask;
         }
 #endif
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -760,6 +760,13 @@ namespace Microsoft.OData.Json
             await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
         }
 
+        public async Task WriteValueAsync(JsonElement value)
+        {
+            this.WriteSeparatorIfNecessary();
+            value.WriteTo(utf8JsonWriter);
+            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+        }
+
         public async Task WriteRawValueAsync(string rawValue)
         {
             this.WriteRawValueCore(rawValue);

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -346,6 +346,7 @@ namespace Microsoft.OData.Json
 
         public void WriteValue(byte[] value)
         {
+            this.WriteSeparatorIfNecessary();
             if (value == null)
             {
                 this.utf8JsonWriter.WriteNullValue();
@@ -355,6 +356,13 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteBase64StringValue(value);
             }
             
+            this.FlushIfBufferThresholdReached();
+        }
+
+        public void WriteValue(JsonElement value)
+        {
+            this.WriteSeparatorIfNecessary();
+            value.WriteTo(this.utf8JsonWriter);
             this.FlushIfBufferThresholdReached();
         }
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -439,6 +439,15 @@ namespace Microsoft.OData.JsonLight
                     .ConfigureAwait(false);
                 return;
             }
+
+#if NETCOREAPP3_1_OR_GREATER
+            if (value is ODataJsonElementValue jsonElementValue)
+            {
+                await this.WriteJsonElementPropertyAsync(jsonElementValue)
+                    .ConfigureAwait(false);
+                return;
+            }
+#endif
         }
 
 
@@ -512,6 +521,19 @@ namespace Microsoft.OData.JsonLight
             this.jsonLightValueSerializer.WriteUntypedValue(untypedValue);
             return;
         }
+
+#if NETCOREAPP3_1_OR_GREATER
+        /// <summary>
+        /// Writes a <see cref="System.Text.Json.JsonElement"/> property.
+        /// </summary>
+        /// <param name="jsonElementvalue">The value to be written.</param>
+        private void WriteJsonElementProperty(ODataJsonElementValue jsonElementvalue)
+        {
+            this.JsonWriter.WriteName(this.currentPropertyInfo.WireName);
+            this.JsonWriter.WriteValue(jsonElementvalue.Value);
+        }
+
+#endif
 
         private void WriteStreamValue(IODataStreamReferenceInfo streamInfo, string propertyName, ODataResourceMetadataBuilder metadataBuilder)
         {
@@ -821,15 +843,6 @@ namespace Microsoft.OData.JsonLight
             }
         }
 
-#if NETCOREAPP3_1_OR_GREATER
-        private void WriteJsonElementProperty(ODataJsonElementValue jsonElementvalue)
-        {
-            this.JsonWriter.WriteName(this.currentPropertyInfo.WireName);
-            this.JsonWriter.WriteValue(jsonElementvalue.Value);
-        }
-
-#endif
-
         /// <summary>
         /// Writes the type name on the wire.
         /// </summary>
@@ -917,6 +930,21 @@ namespace Microsoft.OData.JsonLight
             await this.jsonLightValueSerializer.WriteUntypedValueAsync(untypedValue)
                 .ConfigureAwait(false);
         }
+
+#if NETCOREAPP3_1_OR_GREATER
+        /// <summary>
+        /// Asynchronously writes an <see cref="System.Text.Json.JsonElement"/> value.
+        /// </summary>
+        /// <param name="jsonElementvalue">The value to be written.</param>
+        private async Task WriteJsonElementPropertyAsync(ODataJsonElementValue jsonElementvalue)
+        {
+            await this.AsynchronousJsonWriter.WriteNameAsync(this.currentPropertyInfo.WireName)
+                .ConfigureAwait(false);
+            await this.AsynchronousJsonWriter.WriteValueAsync(jsonElementvalue.Value)
+                .ConfigureAwait(false);
+        }
+
+#endif
 
         /// <summary>
         /// Asynchronosly writes a stream reference value.

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -218,6 +218,14 @@ namespace Microsoft.OData.JsonLight
                 this.WriteStreamProperty(streamValue, isOpenPropertyType);
                 return;
             }
+
+#if NETCOREAPP3_1_OR_GREATER
+            if (value is ODataJsonElementValue jsonElementValue)
+            {
+                this.WriteJsonElementProperty(jsonElementValue);
+                return;
+            }
+#endif
         }
 
 
@@ -812,6 +820,15 @@ namespace Microsoft.OData.JsonLight
                 }
             }
         }
+
+#if NETCOREAPP3_1_OR_GREATER
+        private void WriteJsonElementProperty(ODataJsonElementValue jsonElementvalue)
+        {
+            this.JsonWriter.WriteName(this.currentPropertyInfo.WireName);
+            this.JsonWriter.WriteValue(jsonElementvalue.Value);
+        }
+
+#endif
 
         /// <summary>
         /// Writes the type name on the wire.

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -17,8 +17,11 @@ namespace Microsoft.OData.JsonLight
     using Microsoft.OData.Json;
     using Microsoft.OData.Metadata;
     using ODataErrorStrings = Microsoft.OData.Strings;
+#if NETCOREAPP3_0_OR_GREATER
+    using System.Text.Json;
+#endif
 
-    #endregion Namespaces
+#endregion Namespaces
 
     /// <summary>
     /// OData JsonLight serializer for value types.
@@ -356,6 +359,13 @@ namespace Microsoft.OData.JsonLight
                 this.JsonWriter.WritePrimitiveValue(value);
             }
         }
+
+#if NETCOREAPP3_1_OR_GREATER
+        public virtual void WriteJsonElementValue(JsonElement value)
+        {
+            this.JsonWriter.WriteValue(value);
+        }
+#endif
 
         /// <summary>
         /// Writes an untyped value.

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -17,9 +17,6 @@ namespace Microsoft.OData.JsonLight
     using Microsoft.OData.Json;
     using Microsoft.OData.Metadata;
     using ODataErrorStrings = Microsoft.OData.Strings;
-#if NETCOREAPP3_0_OR_GREATER
-    using System.Text.Json;
-#endif
 
 #endregion Namespaces
 

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightValueSerializer.cs
@@ -360,13 +360,6 @@ namespace Microsoft.OData.JsonLight
             }
         }
 
-#if NETCOREAPP3_1_OR_GREATER
-        public virtual void WriteJsonElementValue(JsonElement value)
-        {
-            this.JsonWriter.WriteValue(value);
-        }
-#endif
-
         /// <summary>
         /// Writes an untyped value.
         /// </summary>

--- a/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+Microsoft.OData.Json.IJsonWriter.WriteValue(System.Text.Json.JsonElement value) -> void
+Microsoft.OData.Json.IJsonWriterAsync.WriteValueAsync(System.Text.Json.JsonElement value) -> System.Threading.Tasks.Task
 Microsoft.OData.ODataJsonElementValue
 Microsoft.OData.ODataJsonElementValue.ODataJsonElementValue(System.Text.Json.JsonElement value) -> void
 Microsoft.OData.ODataJsonElementValue.Value.get -> System.Text.Json.JsonElement

--- a/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,3 @@
+Microsoft.OData.ODataJsonElementValue
+Microsoft.OData.ODataJsonElementValue.ODataJsonElementValue(System.Text.Json.JsonElement value) -> void
+Microsoft.OData.ODataJsonElementValue.Value.get -> System.Text.Json.JsonElement

--- a/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
+++ b/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OData
 {
     /// <summary>
     /// Represents a <see cref="JsonElement"/> value.
-    /// Useful for writingparsed  JSON inputs directly without reading them first, which would result in double allocations.
+    /// Useful for writing parsed  JSON inputs directly without reading them first, which would result in double allocations.
     /// </summary>
     public sealed class ODataJsonElementValue : ODataValue
     {

--- a/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
+++ b/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData
     public sealed class ODataJsonElementValue : ODataValue
     {
         /// <summary>
-        /// Creates an intsance of <see cref="ODataJsonElementValue"/> based
+        /// Creates an instance of <see cref="ODataJsonElementValue"/> based
         /// on the specified <see cref="JsonElement"/> value.
         /// </summary>
         /// <param name="value">The <see cref="JsonElement"/> to wrap.</param>

--- a/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
+++ b/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
@@ -1,0 +1,38 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataJsonElementValue.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETCOREAPP3_1_OR_GREATER
+using System.Text.Json;
+
+namespace Microsoft.OData
+{
+    /// <summary>
+    /// Represents a <see cref="JsonElement"/> value.
+    /// Useful for writingparsed  JSON inputs directly without reading them first, which would result in double allocations.
+    /// </summary>
+    public sealed class ODataJsonElementValue : ODataValue
+    {
+        /// <summary>
+        /// Creates an intsance of <see cref="ODataJsonElementValue"/> based
+        /// on the specified <see cref="JsonElement"/> value.
+        /// </summary>
+        /// <param name="value">The <see cref="JsonElement"/> to wrap.</param>
+        /// <remarks>
+        /// The caller is responsible for ensuring the contents of the <see cref="JsonElement"/> are valid.
+        /// </remarks>
+        public ODataJsonElementValue(JsonElement value)
+        {
+            this.Value = value;
+        }
+
+        /// <summary>
+        /// Gets the underlying <see cref="JsonElement"/> wrapped by this
+        /// <see cref="ODataJsonElementValue"/>.
+        /// </summary>
+        public JsonElement Value { get; private set; }
+    }
+}
+#endif

--- a/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
+++ b/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
@@ -21,7 +21,8 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="value">The <see cref="JsonElement"/> to wrap.</param>
         /// <remarks>
-        /// The caller is responsible for ensuring the contents of the <see cref="JsonElement"/> are valid.
+        /// The caller is responsible for ensuring the contents of the <see cref="JsonElement"/> are valid
+        /// and contain any necessary annotations. The contents are not be inspected by the <see cref="ODataWriter"/>.
         /// </remarks>
         public ODataJsonElementValue(JsonElement value)
         {

--- a/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
+++ b/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
@@ -82,13 +82,6 @@ namespace Microsoft.OData
                 return primitiveValue.Value;
             }
 
-#if NETCOREAPP3_1_OR_GREATER
-            if (odataValue is ODataJsonElementValue jsonElementValue)
-            {
-                return jsonElementValue.Value;
-            }
-#endif
-
             return odataValue;
         }
     }

--- a/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
+++ b/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
@@ -7,6 +7,10 @@
 #if ODATA_SERVICE
 namespace Microsoft.OData.Service
 #else
+#if NETCOREAPP3_1_OR_GREATER
+using System.Text.Json;
+#endif
+
 namespace Microsoft.OData
 #endif
 {
@@ -45,6 +49,13 @@ namespace Microsoft.OData
                 return new ODataEnumValue(objectToConvert.ToString().Replace(", ", ","));
             }
 
+#if NETCOREAPP3_1_OR_GREATER
+            if (objectToConvert is JsonElement jsonElement)
+            {
+                return new ODataJsonElementValue(jsonElement);
+            }
+#endif
+
             // Otherwise treat it as a primitive and wrap in an ODataPrimitiveValue. This includes spatial types.
             return new ODataPrimitiveValue(objectToConvert);
         }
@@ -67,6 +78,13 @@ namespace Microsoft.OData
             {
                 return primitiveValue.Value;
             }
+
+#if NETCOREAPP3_1_OR_GREATER
+            if (odataValue is ODataJsonElementValue jsonElementValue)
+            {
+                return jsonElementValue.Value;
+            }
+#endif
 
             return odataValue;
         }

--- a/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
+++ b/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
@@ -50,6 +50,9 @@ namespace Microsoft.OData
             }
 
 #if NETCOREAPP3_1_OR_GREATER
+            // Ideally, the JsonElement should be wrapped inside an ODataJsonElementValue
+            // when being assigned to an ODataProperty, that will avoid
+            // this conversion and avoid boxing the JsonElement.
             if (objectToConvert is JsonElement jsonElement)
             {
                 return new ODataJsonElementValue(jsonElement);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncBaseTests.cs
@@ -5,6 +5,9 @@ using System.Threading.Tasks;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Json;
 using Xunit;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Text.Json;
+#endif
 
 namespace Microsoft.OData.Tests.Json
 {
@@ -13,7 +16,10 @@ namespace Microsoft.OData.Tests.Json
     /// </summary>
     public abstract class JsonWriterAsyncBaseTests
     {
-        const string MixedObjectJson = "{\"StringProp\":\"John\",\"IntProp\":10,\"BoolPropFalse\":false,\"DateProp\":\"2014-12-31\",\"RawStringProp\":\"foobar\",\"BoolPropTrue\":false,\"RawArrayProp\":[1, 2, 3, 4, 5],\"DateTimeOffsetProp\":\"2014-12-31T12:42:30+01:20\",\"DateProp\":\"2014-12-31\",\"TimeSpanProp\":\"PT12H42M30S\",\"TimeOfDayProp\":\"12:42:30.1000000\",\"ObjectProp\":{\"FloatProp\":3.1,\"NestedRawValue\":\"test\",\"ShortProp\":1124,\"ByteProp\":10,\"LongProp\":234234,\"SignedByteProp\":-10,\"GuidProp\":\"00000012-0000-0000-0000-012345678900\",\"ArrayPropWithEveryOtherValueRaw\":[\"test\",\"raw\",10,\"raw\",true,\"raw\",\"2014-12-31\",\"raw\",\"2014-12-31T12:42:30+01:20\",\"raw\",[1,2,3],1124,\"raw\",10,\"raw\",-10,\"raw\",25253,\"raw\",\"00000012-0000-0000-0000-012345678900\",\"raw\",\"foo\",\"raw\",12.3,\"raw\",2.6,\"raw\",{},\"raw\",[\"rawAtArrayStartBeforeString\",\"test\"],[\"rawAtArrayStartBeforeBool\",false],[\"rawAtArrayStartBeforeByte\",10],[\"rawAtArrayStartBeforeSignedByte\",-10],[\"rawAtArrayStartBeforeShort\",10],[\"rawAtArrayStartBeforeInt\",10],[\"rawAtArrayStartBeforeLong\",10],[\"rawAtArrayStartBeforeDouble\",10.2],[\"rawAtArrayStartBeforeFloat\",10.2],[\"rawAtArrayStartBeforeDecimal\",10.2],[\"rawAtArrayStartBeforeGuid\",\"00000012-0000-0000-0000-012345678900\"],[\"rawAtArrayStartBeforeObject\",{}],[\"rawAtArrayStartBeforeDateTimeOffset\",\"2014-12-31T12:42:30+01:20\"],[\"rawAtArrayStartBeforeDate\",\"2014-12-31\"],[\"rawAtArrayStartBeforeTimeOfDay\",\"12:42:30.1000000\"],[\"rawAtArrayStartBeforeTimeSpan\",\"PT12H42M30S\"],[\"rawAtArrayStartBeforeArray\",[]],[\"rawAtArrayStartBeforeRaw\",\"raw\",\"test\",\"raw\"],\"raw\",\"raw\",\"raw\"]},\"ArrayProp\":[10,\"baz\",20,12.3,2.6,{\"RawObjectInArray\": true }],\"UntypedObjectProp\":{\"foo\":\"bar\"}}";
+        const string MixedObjectJson = "{\"StringProp\":\"John\",\"IntProp\":10,\"BoolPropFalse\":false,\"DateProp\":\"2014-12-31\",\"RawStringProp\":\"foobar\",\"BoolPropTrue\":false,\"RawArrayProp\":[1,2,3,4,5],\"DateTimeOffsetProp\":\"2014-12-31T12:42:30+01:20\",\"DateProp\":\"2014-12-31\",\"TimeSpanProp\":\"PT12H42M30S\",\"TimeOfDayProp\":\"12:42:30.1000000\",\"ObjectProp\":{\"FloatProp\":3.1,\"NestedRawValue\":\"test\",\"ShortProp\":1124,\"ByteProp\":10,\"LongProp\":234234,\"SignedByteProp\":-10,\"GuidProp\":\"00000012-0000-0000-0000-012345678900\",\"ArrayPropWithEveryOtherValueRaw\":[\"test\",\"raw\",10,\"raw\",true,\"raw\",\"2014-12-31\",\"raw\",\"2014-12-31T12:42:30+01:20\",\"raw\",[1,2,3],1124,\"raw\",10,\"raw\",-10,\"raw\",25253,\"raw\",\"00000012-0000-0000-0000-012345678900\",\"raw\",\"foo\",\"raw\",12.3,\"raw\",2.6,\"raw\",{},\"raw\",[\"rawAtArrayStartBeforeString\",\"test\"],[\"rawAtArrayStartBeforeBool\",false],[\"rawAtArrayStartBeforeByte\",10],[\"rawAtArrayStartBeforeSignedByte\",-10],[\"rawAtArrayStartBeforeShort\",10],[\"rawAtArrayStartBeforeInt\",10],[\"rawAtArrayStartBeforeLong\",10],[\"rawAtArrayStartBeforeDouble\",10.2],[\"rawAtArrayStartBeforeFloat\",10.2],[\"rawAtArrayStartBeforeDecimal\",10.2],[\"rawAtArrayStartBeforeGuid\",\"00000012-0000-0000-0000-012345678900\"],[\"rawAtArrayStartBeforeObject\",{}],[\"rawAtArrayStartBeforeDateTimeOffset\",\"2014-12-31T12:42:30+01:20\"],[\"rawAtArrayStartBeforeDate\",\"2014-12-31\"],[\"rawAtArrayStartBeforeTimeOfDay\",\"12:42:30.1000000\"],[\"rawAtArrayStartBeforeTimeSpan\",\"PT12H42M30S\"],[\"rawAtArrayStartBeforeArray\",[]],[\"rawAtArrayStartBeforeNull\",null],[\"rawAtArrayStartBeforeByteArray\",\"TWFu\"],[\"rawAtArrayStartBeforeRaw\",\"raw\",\"test\",\"raw\"],\"raw\",\"raw\",\"raw\"]},\"ArrayProp\":[10,\"baz\",20,12.3,2.6,{\"RawObjectInArray\":true}],\"UntypedObjectProp\":{\"foo\":\"bar\"}}";
+        const string SampleJsonInput = "{\"jsonInput\":{\"foo\":\"bar\"}}";
+        const string MixedJsonInputAndRawValue = "{\"StringProp\":\"John\",\"JsonInputProp\":{\"jsonInput\":{\"foo\":\"bar\"}},\"RawStringProp\":\"foobar\",\"JsonInputAfterRawValue\":{\"jsonInput\":{\"foo\":\"bar\"}},\"ArrayProp\":[\"raw\",{\"jsonInput\":{\"foo\":\"bar\"}},\"foobar\",{\"jsonInput\":{\"foo\":\"bar\"}},\"raw\"]}";
+
         protected abstract IJsonWriterAsync CreateJsonWriterAsync(Stream stream, bool isIeee754Compatible, Encoding encoding);
 
         [Fact]
@@ -43,7 +49,7 @@ namespace Microsoft.OData.Tests.Json
                 await jsonWriter.WriteValueAsync(false);
 
                 await jsonWriter.WriteNameAsync("RawArrayProp");
-                await jsonWriter.WriteRawValueAsync("[1, 2, 3, 4, 5]");
+                await jsonWriter.WriteRawValueAsync("[1,2,3,4,5]");
 
                 await jsonWriter.WriteNameAsync("DateTimeOffsetProp");
                 await jsonWriter.WriteValueAsync(new DateTimeOffset(2014, 12, 31, 12, 42, 30, new TimeSpan(1, 20, 0)));
@@ -177,6 +183,14 @@ namespace Microsoft.OData.Tests.Json
                 await jsonWriter.EndArrayScopeAsync();
                 await jsonWriter.EndArrayScopeAsync();
                 await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteRawValueAsync(@"""rawAtArrayStartBeforeNull""");
+                await jsonWriter.WriteValueAsync((string)null);
+                await jsonWriter.EndArrayScopeAsync();
+                await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteRawValueAsync(@"""rawAtArrayStartBeforeByteArray""");
+                await jsonWriter.WriteValueAsync(new byte[] { 77, 97, 110 });
+                await jsonWriter.EndArrayScopeAsync();
+                await jsonWriter.StartArrayScopeAsync();
                 await jsonWriter.WriteRawValueAsync(@"""rawAtArrayStartBeforeRaw""");
                 await jsonWriter.WriteRawValueAsync(@"""raw""");
                 await jsonWriter.WriteValueAsync("test");
@@ -196,7 +210,7 @@ namespace Microsoft.OData.Tests.Json
                 await jsonWriter.WriteRawValueAsync("20");
                 await jsonWriter.WriteValueAsync(12.3m);
                 await jsonWriter.WriteValueAsync(2.6f);
-                await jsonWriter.WriteRawValueAsync(@"{""RawObjectInArray"": true }");
+                await jsonWriter.WriteRawValueAsync(@"{""RawObjectInArray"":true}");
                 await jsonWriter.EndArrayScopeAsync();
 
                 await jsonWriter.WriteNameAsync("UntypedObjectProp");
@@ -216,6 +230,71 @@ namespace Microsoft.OData.Tests.Json
             }
         }
 
+#if NETCOREAPP3_1_OR_GREATER
+        [Fact]
+        public async Task WritesJsonElementCorrectly()
+        {
+            using (JsonDocument jsonDoc = JsonDocument.Parse(MixedObjectJson))
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriterAsync jsonWriter = CreateJsonWriterAsync(stream, false, Encoding.UTF8);
+                await jsonWriter.WriteValueAsync(jsonDoc.RootElement);
+
+                await jsonWriter.FlushAsync();
+                stream.Seek(0, SeekOrigin.Begin);
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    string normalizedOutput = NormalizeJsonText(rawOutput);
+                    string normalizedExpectedOutput = NormalizeJsonText(MixedObjectJson);
+                    Assert.Equal(normalizedExpectedOutput, normalizedOutput);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task WriteObjectWithJsonInputAndRawValuesCorrectly()
+        {
+            using (JsonDocument jsonInput = JsonDocument.Parse(SampleJsonInput))
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriterAsync jsonWriter = CreateJsonWriterAsync(stream, false, Encoding.UTF8);
+                await jsonWriter.StartObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("StringProp");
+                await jsonWriter.WriteValueAsync("John");
+                await jsonWriter.WriteNameAsync("JsonInputProp");
+                
+                await jsonWriter.WriteValueAsync (jsonInput.RootElement);
+                await jsonWriter.WriteNameAsync("RawStringProp");
+                await jsonWriter.WriteRawValueAsync(@"""foobar""");
+                await jsonWriter.WriteNameAsync("JsonInputAfterRawValue");
+                await jsonWriter.WriteValueAsync(jsonInput.RootElement);
+
+                await jsonWriter.WriteNameAsync("ArrayProp");
+                await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteRawValueAsync(@"""raw""");
+                await jsonWriter.WriteValueAsync(jsonInput.RootElement);
+                await jsonWriter.WriteValueAsync("foobar");
+                await jsonWriter.WriteValueAsync(jsonInput.RootElement);
+                await jsonWriter.WriteRawValueAsync(@"""raw""");
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.FlushAsync();
+                stream.Seek(0, SeekOrigin.Begin);
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    string normalizedOutput = NormalizeJsonText(rawOutput);
+                    string normalizedExpectedOutput = NormalizeJsonText(MixedJsonInputAndRawValue);
+                    Assert.Equal(normalizedExpectedOutput, normalizedOutput);
+                }
+            }
+        }
+#endif
+
         /// <summary>
         /// Normalizes the differences between JSON text encoded
         /// by Utf8JsonWriter and OData's JsonWriter, to make
@@ -231,7 +310,9 @@ namespace Microsoft.OData.Tests.Json
                 .ToLowerInvariant()
                 // Utf8JsonWrites escapes double-quotes using \u0022
                 // OData JsonWrtier uses \"
-                .Replace(@"\u0022", @"\""");
+                .Replace(@"\u0022", @"\""")
+                // Utf8JsonWriter writes + as \u002b when writing JsonElement
+                .Replace(@"\u002b", "+"); ;
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -233,10 +233,9 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public void WritesJsonElementCorrectly()
         {
+            using (JsonDocument jsonDoc = JsonDocument.Parse(MixedObjectJson))
             using (MemoryStream stream = new MemoryStream())
             {
-                JsonDocument jsonDoc = JsonDocument.Parse(MixedObjectJson);
-
                 IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
                 jsonWriter.WriteValue(jsonDoc.RootElement);
 
@@ -255,6 +254,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public void WriteObjectWithJsonInputAndRawValuesCorrectly()
         {
+            using (JsonDocument jsonInput = JsonDocument.Parse(SampleJsonInput))
             using (MemoryStream stream = new MemoryStream())
             {
                 IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
@@ -263,7 +263,6 @@ namespace Microsoft.OData.Tests.Json
                 jsonWriter.WriteName("StringProp");
                 jsonWriter.WriteValue("John");
                 jsonWriter.WriteName("JsonInputProp");
-                JsonDocument jsonInput = JsonDocument.Parse(SampleJsonInput);
                 jsonWriter.WriteValue(jsonInput.RootElement);
                 jsonWriter.WriteName("RawStringProp");
                 jsonWriter.WriteRawValue(@"""foobar""");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -294,7 +294,6 @@ namespace Microsoft.OData.Tests.Json
         }
 #endif
 
-
         /// <summary>
         /// Normalizes the differences between JSON text encoded
         /// by Utf8JsonWriter and OData's JsonWriter, to make

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -15,9 +15,10 @@ namespace Microsoft.OData.Tests.Json
     /// </summary>
     public abstract class JsonWriterBaseTests
     {
-        const string MixedObjectJson = "{\"StringProp\":\"John\",\"IntProp\":10,\"BoolPropFalse\":false,\"DateProp\":\"2014-12-31\",\"RawStringProp\":\"foobar\",\"BoolPropTrue\":false,\"RawArrayProp\":[1, 2, 3, 4, 5],\"DateTimeOffsetProp\":\"2014-12-31T12:42:30+01:20\",\"DateProp\":\"2014-12-31\",\"TimeSpanProp\":\"PT12H42M30S\",\"TimeOfDayProp\":\"12:42:30.1000000\",\"ObjectProp\":{\"FloatProp\":3.1,\"NestedRawValue\":\"test\",\"ShortProp\":1124,\"ByteProp\":10,\"LongProp\":234234,\"SignedByteProp\":-10,\"GuidProp\":\"00000012-0000-0000-0000-012345678900\",\"ArrayPropWithEveryOtherValueRaw\":[\"test\",\"raw\",10,\"raw\",true,\"raw\",\"2014-12-31\",\"raw\",\"2014-12-31T12:42:30+01:20\",\"raw\",[1,2,3],1124,\"raw\",10,\"raw\",-10,\"raw\",25253,\"raw\",\"00000012-0000-0000-0000-012345678900\",\"raw\",\"foo\",\"raw\",12.3,\"raw\",2.6,\"raw\",{},\"raw\",[\"rawAtArrayStartBeforeString\",\"test\"],[\"rawAtArrayStartBeforeBool\",false],[\"rawAtArrayStartBeforeByte\",10],[\"rawAtArrayStartBeforeSignedByte\",-10],[\"rawAtArrayStartBeforeShort\",10],[\"rawAtArrayStartBeforeInt\",10],[\"rawAtArrayStartBeforeLong\",10],[\"rawAtArrayStartBeforeDouble\",10.2],[\"rawAtArrayStartBeforeFloat\",10.2],[\"rawAtArrayStartBeforeDecimal\",10.2],[\"rawAtArrayStartBeforeGuid\",\"00000012-0000-0000-0000-012345678900\"],[\"rawAtArrayStartBeforeObject\",{}],[\"rawAtArrayStartBeforeDateTimeOffset\",\"2014-12-31T12:42:30+01:20\"],[\"rawAtArrayStartBeforeDate\",\"2014-12-31\"],[\"rawAtArrayStartBeforeTimeOfDay\",\"12:42:30.1000000\"],[\"rawAtArrayStartBeforeTimeSpan\",\"PT12H42M30S\"],[\"rawAtArrayStartBeforeArray\",[]],[\"rawAtArrayStartBeforeNull\",null],[\"rawAtArrayStartBeforeByteArray\",\"TWFu\"],[\"rawAtArrayStartBeforeRaw\",\"raw\",\"test\",\"raw\"],\"raw\",\"raw\",\"raw\"]},\"ArrayProp\":[10,\"baz\",20,12.3,2.6,{\"RawObjectInArray\": true }],\"UntypedObjectProp\":{\"foo\":\"bar\"}}";
+        const string MixedObjectJson = "{\"StringProp\":\"John\",\"IntProp\":10,\"BoolPropFalse\":false,\"DateProp\":\"2014-12-31\",\"RawStringProp\":\"foobar\",\"BoolPropTrue\":false,\"RawArrayProp\":[1,2,3,4,5],\"DateTimeOffsetProp\":\"2014-12-31T12:42:30+01:20\",\"DateProp\":\"2014-12-31\",\"TimeSpanProp\":\"PT12H42M30S\",\"TimeOfDayProp\":\"12:42:30.1000000\",\"ObjectProp\":{\"FloatProp\":3.1,\"NestedRawValue\":\"test\",\"ShortProp\":1124,\"ByteProp\":10,\"LongProp\":234234,\"SignedByteProp\":-10,\"GuidProp\":\"00000012-0000-0000-0000-012345678900\",\"ArrayPropWithEveryOtherValueRaw\":[\"test\",\"raw\",10,\"raw\",true,\"raw\",\"2014-12-31\",\"raw\",\"2014-12-31T12:42:30+01:20\",\"raw\",[1,2,3],1124,\"raw\",10,\"raw\",-10,\"raw\",25253,\"raw\",\"00000012-0000-0000-0000-012345678900\",\"raw\",\"foo\",\"raw\",12.3,\"raw\",2.6,\"raw\",{},\"raw\",[\"rawAtArrayStartBeforeString\",\"test\"],[\"rawAtArrayStartBeforeBool\",false],[\"rawAtArrayStartBeforeByte\",10],[\"rawAtArrayStartBeforeSignedByte\",-10],[\"rawAtArrayStartBeforeShort\",10],[\"rawAtArrayStartBeforeInt\",10],[\"rawAtArrayStartBeforeLong\",10],[\"rawAtArrayStartBeforeDouble\",10.2],[\"rawAtArrayStartBeforeFloat\",10.2],[\"rawAtArrayStartBeforeDecimal\",10.2],[\"rawAtArrayStartBeforeGuid\",\"00000012-0000-0000-0000-012345678900\"],[\"rawAtArrayStartBeforeObject\",{}],[\"rawAtArrayStartBeforeDateTimeOffset\",\"2014-12-31T12:42:30+01:20\"],[\"rawAtArrayStartBeforeDate\",\"2014-12-31\"],[\"rawAtArrayStartBeforeTimeOfDay\",\"12:42:30.1000000\"],[\"rawAtArrayStartBeforeTimeSpan\",\"PT12H42M30S\"],[\"rawAtArrayStartBeforeArray\",[]],[\"rawAtArrayStartBeforeNull\",null],[\"rawAtArrayStartBeforeByteArray\",\"TWFu\"],[\"rawAtArrayStartBeforeRaw\",\"raw\",\"test\",\"raw\"],\"raw\",\"raw\",\"raw\"]},\"ArrayProp\":[10,\"baz\",20,12.3,2.6,{\"RawObjectInArray\":true}],\"UntypedObjectProp\":{\"foo\":\"bar\"}}";
         const string SampleJsonInput = "{\"jsonInput\":{\"foo\":\"bar\"}}";
         const string MixedJsonInputAndRawValue = "{\"StringProp\":\"John\",\"JsonInputProp\":{\"jsonInput\":{\"foo\":\"bar\"}},\"RawStringProp\":\"foobar\",\"JsonInputAfterRawValue\":{\"jsonInput\":{\"foo\":\"bar\"}},\"ArrayProp\":[\"raw\",{\"jsonInput\":{\"foo\":\"bar\"}},\"foobar\",{\"jsonInput\":{\"foo\":\"bar\"}},\"raw\"]}";
+        
         protected abstract IJsonWriter CreateJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding);
 
         [Fact]
@@ -47,7 +48,7 @@ namespace Microsoft.OData.Tests.Json
                 jsonWriter.WriteValue(false);
 
                 jsonWriter.WriteName("RawArrayProp");
-                jsonWriter.WriteRawValue("[1, 2, 3, 4, 5]");
+                jsonWriter.WriteRawValue("[1,2,3,4,5]");
 
                 jsonWriter.WriteName("DateTimeOffsetProp");
                 jsonWriter.WriteValue(new DateTimeOffset(2014, 12, 31, 12, 42, 30, new TimeSpan(1, 20, 0)));
@@ -208,7 +209,7 @@ namespace Microsoft.OData.Tests.Json
                 jsonWriter.WriteRawValue("20");
                 jsonWriter.WriteValue(12.3m);
                 jsonWriter.WriteValue(2.6f);
-                jsonWriter.WriteRawValue(@"{""RawObjectInArray"": true }");
+                jsonWriter.WriteRawValue(@"{""RawObjectInArray"":true}");
                 jsonWriter.EndArrayScope();
 
                 jsonWriter.WriteName("UntypedObjectProp");
@@ -229,6 +230,28 @@ namespace Microsoft.OData.Tests.Json
         }
 
 #if NETCOREAPP3_1_OR_GREATER
+        [Fact]
+        public void WritesJsonElementCorrectly()
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                JsonDocument jsonDoc = JsonDocument.Parse(MixedObjectJson);
+
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
+                jsonWriter.WriteValue(jsonDoc.RootElement);
+
+                jsonWriter.Flush();
+                stream.Seek(0, SeekOrigin.Begin);
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    string normalizedOutput = NormalizeJsonText(rawOutput);
+                    string normalizedExpectedOutput = NormalizeJsonText(MixedObjectJson);
+                    Assert.Equal(normalizedExpectedOutput, normalizedOutput);
+                }
+            }
+        }
+
         [Fact]
         public void WriteObjectWithJsonInputAndRawValuesCorrectly()
         {
@@ -285,9 +308,11 @@ namespace Microsoft.OData.Tests.Json
                 // Utf8JsonWriter uses uppercase letters when encoding unicode characters e.g. \uDC05
                 // OData's JsonWriter uses lowercase letters: \udc05
                 .ToLowerInvariant()
-                // Utf8JsonWrites escapes double-quotes using \u0022
+                // Utf8JsonWriter escapes double-quotes using \u0022
                 // OData JsonWrtier uses \"
-                .Replace(@"\u0022", @"\""");
+                .Replace(@"\u0022", @"\""")
+                // Utf8JsonWriter writes + as \u002b when writing JsonElement
+                .Replace(@"\u002b", "+");
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockAsyncOnlyJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockAsyncOnlyJsonWriter.cs
@@ -8,6 +8,9 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Json;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Text.Json;
+#endif
 
 namespace Microsoft.OData.Tests.Json
 {
@@ -69,5 +72,12 @@ namespace Microsoft.OData.Tests.Json
         public Task WriteValueAsync(Date value) => throw new NotImplementedException();
 
         public Task WriteValueAsync(TimeOfDay value) => throw new NotImplementedException();
+
+#if NETCOREAPP3_1_OR_GREATER
+        public Task WriteValueAsync(JsonElement value)
+        {
+            throw new NotImplementedException();
+        }
+#endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
@@ -9,6 +9,9 @@ using Microsoft.OData.Json;
 using Microsoft.OData.Edm;
 using Xunit;
 using System.Threading.Tasks;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Text.Json;
+#endif
 
 namespace Microsoft.OData.Tests.Json
 {
@@ -165,5 +168,12 @@ namespace Microsoft.OData.Tests.Json
         }
 
         public Task FlushAsync() => throw new NotImplementedException();
+
+#if NETCOREAPP3_1_OR_GREATER
+        public Task WriteValueAsync(JsonElement value)
+        {
+            throw new NotImplementedException();
+        }
+#endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
@@ -82,6 +82,10 @@ namespace Microsoft.OData.Tests.Json
             this.WriteValueVerifier(Convert.ToBase64String(value));
         }
 
+#if NETCOREAPP3_1_OR_GREATER
+        public void WriteValue(System.Text.Json.JsonElement value) => throw new NotImplementedException();
+#endif
+
         public void WriteRawValue(string rawValue)
         {
             Assert.NotNull(this.WriteValueVerifier);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
@@ -170,10 +170,7 @@ namespace Microsoft.OData.Tests.Json
         public Task FlushAsync() => throw new NotImplementedException();
 
 #if NETCOREAPP3_1_OR_GREATER
-        public Task WriteValueAsync(JsonElement value)
-        {
-            throw new NotImplementedException();
-        }
+        public Task WriteValueAsync(JsonElement value) => throw new NotImplementedException();
 #endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockSyncOnlyJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockSyncOnlyJsonWriter.cs
@@ -70,5 +70,9 @@ namespace Microsoft.OData.Tests.Json
         public void WriteValue(Date value) => throw new NotImplementedException();
 
         public void WriteValue(TimeOfDay value) => throw new NotImplementedException();
+
+#if NETCOREAPP3_1_OR_GREATER
+        public void WriteValue(System.Text.Json.JsonElement value) => throw new NotImplementedException();
+#endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
@@ -13,8 +13,10 @@ using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OData.Edm.Vocabularies.V1;
+using Microsoft.OData.Json;
 using Microsoft.OData.JsonLight;
 using Microsoft.Spatial;
+using Microsoft.Test.OData.DependencyInjection;
 using Xunit;
 
 namespace Microsoft.OData.Tests.JsonLight
@@ -577,15 +579,39 @@ namespace Microsoft.OData.Tests.JsonLight
                 result);
         }
 
+#if NETCOREAPP3_1_OR_GREATER
+        [Fact]
+        public void WritingJsonElementPropertiesShouldSerializeJsonInputAsIs()
+        {
+            string jsonInputString = "{\"foo\":\"bar\"}";
+            var jsonDocument = System.Text.Json.JsonDocument.Parse(jsonInputString);
+
+            var property = new ODataProperty()
+            {
+                Name = "JsonProp",
+                Value = new ODataJsonElementValue(jsonDocument.RootElement)
+            };
+
+            Action<IContainerBuilder> configureServices = (IContainerBuilder builder) =>
+            {
+                builder.AddService<IStreamBasedJsonWriterFactory>(ServiceLifetime.Singleton, _ => DefaultStreamBasedJsonWriterFactory.Default);
+            };
+
+            var result = SerializeProperty(null, property, configureServices);
+            Assert.Equal("{\"JsonProp\":{\"foo\":\"bar\"}}", result);
+        }
+#endif
+
         /// <summary>
         /// Serialize the given property as a non-top-level property in JSON Light.
         /// </summary>
         /// <param name="odataProperty">The property to serialize.</param>
+        /// <param name="configureServices">Action to add custom services to the service provider.</param>
         /// <returns>A string of JSON text, where the given ODataProperty has been serialized and wrapped in a JSON object.</returns>
-        private string SerializeProperty(IEdmStructuredType owningType, ODataProperty odataProperty)
+        private string SerializeProperty(IEdmStructuredType owningType, ODataProperty odataProperty, Action<IContainerBuilder> configureServices = null)
         {
             MemoryStream outputStream = new MemoryStream();
-            ODataJsonLightOutputContext jsonLightOutputContext = this.CreateJsonLightOutputContext(outputStream);
+            ODataJsonLightOutputContext jsonLightOutputContext = this.CreateJsonLightOutputContext(outputStream, configureServices);
             var serializer = new ODataJsonLightPropertySerializer(jsonLightOutputContext);
 
             jsonLightOutputContext.JsonWriter.StartObjectScope();
@@ -604,7 +630,7 @@ namespace Microsoft.OData.Tests.JsonLight
             return result;
         }
 
-        private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream)
+        private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream, Action<IContainerBuilder> configureServices = null)
         {
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
             settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
@@ -619,6 +645,14 @@ namespace Microsoft.OData.Tests.JsonLight
                 IsAsync = false,
                 Model = this.model
             };
+
+            if (configureServices != null)
+            {
+                TestContainerBuilder containerBuilder = new TestContainerBuilder();
+                containerBuilder.AddDefaultODataServices();
+                configureServices(containerBuilder);
+                messageInfo.Container = containerBuilder.BuildContainer();
+            }
 
             return new ODataJsonLightOutputContext(messageInfo, settings);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
@@ -581,7 +581,23 @@ namespace Microsoft.OData.Tests.JsonLight
 
 #if NETCOREAPP3_1_OR_GREATER
         [Fact]
-        public void WritingJsonElementPropertiesShouldSerializeJsonInputAsIs()
+        public void WritingJsonElementProperties_ShouldSerializeJsonInput()
+        {
+            string jsonInputString = "{\"foo\":\"bar\"}";
+            var jsonDocument = System.Text.Json.JsonDocument.Parse(jsonInputString);
+
+            var property = new ODataProperty()
+            {
+                Name = "JsonProp",
+                Value = new ODataJsonElementValue(jsonDocument.RootElement)
+            };
+
+            var result = SerializeProperty(null, property);
+            Assert.Equal("{\"JsonProp\":{\"foo\":\"bar\"}}", result);
+        }
+
+        [Fact]
+        public void WritingJsonElementProperties_ShouldSerializeJsonInput_WithODataUtf8JsonWriter()
         {
             string jsonInputString = "{\"foo\":\"bar\"}";
             var jsonDocument = System.Text.Json.JsonDocument.Parse(jsonInputString);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
@@ -18,6 +18,9 @@ using Microsoft.OData.JsonLight;
 using Microsoft.Spatial;
 using Microsoft.Test.OData.DependencyInjection;
 using Xunit;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Text.Json;
+#endif
 
 namespace Microsoft.OData.Tests.JsonLight
 {
@@ -584,7 +587,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void WritingJsonElementProperties_ShouldSerializeJsonInput()
         {
             string jsonInputString = "{\"foo\":\"bar\"}";
-            var jsonDocument = System.Text.Json.JsonDocument.Parse(jsonInputString);
+            var jsonDocument = JsonDocument.Parse(jsonInputString);
 
             var property = new ODataProperty()
             {
@@ -600,7 +603,7 @@ namespace Microsoft.OData.Tests.JsonLight
         public void WritingJsonElementProperties_ShouldSerializeJsonInput_WithODataUtf8JsonWriter()
         {
             string jsonInputString = "{\"foo\":\"bar\"}";
-            var jsonDocument = System.Text.Json.JsonDocument.Parse(jsonInputString);
+            var jsonDocument = JsonDocument.Parse(jsonInputString);
 
             var property = new ODataProperty()
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -19,6 +19,10 @@
     <OutputPath>..\..\..\bin\AnyCPU\Release\Test\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <DefineConstants>$(DefineConstants);NETCOREAPP3_1_OR_GREATER;NETCOREAPP;NETCOREAPP3_1</DefineConstants>
+  </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataValueUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataValueUtilsTests.cs
@@ -6,6 +6,10 @@
 
 using System;
 using Xunit;
+using System.IO;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Text.Json;
+#endif
 
 namespace Microsoft.OData.Tests
 {
@@ -49,5 +53,27 @@ namespace Microsoft.OData.Tests
             Feature3 = 4,
             Feature4 = 8,
         }
+
+#if NETCOREAPP3_1_OR_GREATER
+        [Fact]
+        public void ConvertsJsonElementToODataValue()
+        {
+            string jsonString = "{\"foo\":\"bar\"}";
+            JsonDocument jsonDoc = JsonDocument.Parse(jsonString);
+            ODataValue odataValue = jsonDoc.RootElement.ToODataValue();
+
+            ODataJsonElementValue odataJsonValue = odataValue as ODataJsonElementValue;
+            Assert.NotNull(odataJsonValue);
+
+            var stream = new MemoryStream();
+            var jsonWriter = new Utf8JsonWriter(stream);
+            odataJsonValue.Value.WriteTo(jsonWriter);
+            jsonWriter.Flush();
+            stream.Position = 0;
+            var output = new StreamReader(stream).ReadToEnd();
+
+            Assert.Equal(jsonString, output);
+        }
+#endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
@@ -538,10 +538,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
             }
 
 #if NETCOREAPP3_1_OR_GREATER
-            public Task WriteValueAsync(JsonElement value)
-            {
-                throw new NotImplementedException();
-            }
+            public Task WriteValueAsync(JsonElement value) => throw new NotImplementedException();
 #endif
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
@@ -448,6 +448,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
 
             public void WriteValue(TimeOfDay value) => throw new NotImplementedException();
 
+#if NETCOREAPP3_1_OR_GREATER
+            public void WriteValue(System.Text.Json.JsonElement value) => throw new NotImplementedException();
+#endif
+
             public void WriteRawValue(string rawValue) => throw new NotImplementedException();
 
             public void Flush()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
@@ -14,6 +14,9 @@ using Microsoft.OData.Json;
 using Microsoft.Test.OData.DependencyInjection;
 using Microsoft.Test.OData.Utils.ODataLibTest;
 using Xunit;
+#if NETCOREAPP3_1_OR_GREATER
+using System.Text.Json;
+#endif
 
 namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
 {
@@ -533,6 +536,13 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
             {
                 return this.textWriter.FlushAsync();
             }
+
+#if NETCOREAPP3_1_OR_GREATER
+            public Task WriteValueAsync(JsonElement value)
+            {
+                throw new NotImplementedException();
+            }
+#endif
         }
 
         private class TestJsonReader : IJsonReader

--- a/test/PerformanceTests/ComponentTests/Common/ODataMessageHelper.cs
+++ b/test/PerformanceTests/ComponentTests/Common/ODataMessageHelper.cs
@@ -32,13 +32,19 @@ namespace Microsoft.OData.Performance
         /// <summary>
         /// Gets the shared DI container
         /// </summary>
+        /// <param name="configureServices">Action callback to configure DI services.</param>
         /// <returns>Instance of the DI container</returns>
-        private static IServiceProvider GetSharedContainer()
+        private static IServiceProvider GetSharedContainer(Action<IContainerBuilder> configureServices = null)
         {
             if (container == null)
             {
                 var builder = new TestContainerBuilder();
                 builder.AddDefaultODataServices();
+                if (configureServices != null)
+                {
+                    configureServices(builder);
+                }
+
                 container = builder.BuildContainer();
             }
 
@@ -154,17 +160,18 @@ namespace Microsoft.OData.Performance
         /// <param name="model">Edm model</param>
         /// <param name="messageKind">Is request or response</param>
         /// <param name="isFullValidation">Whether turn on FullValidation</param>
+        /// <param name="configureServices">Action callback to configure DI services.</param>
         /// <returns>Instance of ODataMessageWriter</returns>
-        public static ODataMessageWriter CreateMessageWriter(Stream stream, IEdmModel model, ODataMessageKind messageKind, bool isFullValidation)
+        public static ODataMessageWriter CreateMessageWriter(Stream stream, IEdmModel model, ODataMessageKind messageKind, bool isFullValidation, Action<IContainerBuilder> configureServices = null)
         {
             var settings = CreateMessageWriterSettings(isFullValidation);
 
             if (messageKind == ODataMessageKind.Request)
             {
-                return new ODataMessageWriter(new StreamBasedRequestMessage(stream) { Container = GetSharedContainer() }, settings, model);
+                return new ODataMessageWriter(new StreamBasedRequestMessage(stream) { Container = GetSharedContainer(configureServices) }, settings, model);
             }
 
-            return new ODataMessageWriter(new StreamBasedResponseMessage(stream) { Container = GetSharedContainer() }, settings, model);
+            return new ODataMessageWriter(new StreamBasedResponseMessage(stream) { Container = GetSharedContainer(configureServices) }, settings, model);
         }
 
         /// <summary>
@@ -172,11 +179,12 @@ namespace Microsoft.OData.Performance
         /// </summary>
         /// <param name="stream">Message stream</param>
         /// <param name="model">Edm model</param>
+        /// <param name="configureServices">Action callback to configure DI services.</param>
         /// <returns>Instance of ODataMessageWriter</returns>
-        public static ODataMessageWriter CreateMessageWriter(Stream stream, IEdmModel model)
+        public static ODataMessageWriter CreateMessageWriter(Stream stream, IEdmModel model, Action<IContainerBuilder> configureServices = null)
         {
             var settings = CreateMessageWriterSettings(true);
-            return new ODataMessageWriter(new StreamBasedRequestMessage(stream) { Container = GetSharedContainer() }, settings, model);
+            return new ODataMessageWriter(new StreamBasedRequestMessage(stream) { Container = GetSharedContainer(configureServices) }, settings, model);
         }
         #endregion
     }

--- a/test/PerformanceTests/ComponentTests/ODataWriter/JsonElementPropertyTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataWriter/JsonElementPropertyTests.cs
@@ -1,0 +1,233 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="JsonElementPropertyTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.IO;
+using BenchmarkDotNet.Attributes;
+using Microsoft.OData.Edm;
+using System.Text.Json;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml;
+using Microsoft.OData.Json;
+
+namespace Microsoft.OData.Performance
+{
+    [MemoryDiagnoser]
+    public class JsonElementPropertyTests
+    {
+        private static readonly IEdmModel Model = TestUtils.GetAdventureWorksModel();
+        private static readonly byte[] JsonPayload = TestUtils.ReadTestResource("EntryWithExpansions.json");
+        private static readonly IEdmEntitySet entitySet = Model.FindDeclaredEntitySet("Product");
+        private const int MaxStreamSize = 220000000;
+        private const int NumEntries = 100;
+        private JsonDocument ParsedPayload;
+
+        private static readonly Stream WriteStream = new MemoryStream(MaxStreamSize);
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            ParsedPayload = JsonDocument.Parse(JsonPayload);
+        }
+
+        [GlobalCleanup]
+        public void Teardown()
+        {
+            ParsedPayload.Dispose();
+        }
+
+        [IterationSetup]
+        public void ResetStream()
+        {
+            WriteStream.Seek(0, SeekOrigin.Begin);
+        }
+
+        [Benchmark]
+        public void WriteParsedJsonWithJsonElementValues_DefaultWriter()
+        {
+            WriteParsedJsonWithJsonElementValues();
+        }
+
+        [Benchmark]
+        public void WriteParsedJsonWithJsonElementValues_Utf8JsonWriter()
+        {
+            WriteParsedJsonWithJsonElementValues(builder =>
+            {
+                builder.AddService<IStreamBasedJsonWriterFactory>(ServiceLifetime.Singleton, _ => DefaultStreamBasedJsonWriterFactory.Default);
+            });
+        }
+
+        [Benchmark]
+        public void WriteParsedJsonWithoutJsonElementValues_DefaultWriter()
+        {
+            WriteParsedJsonWithoutJsonElementValues();
+        }
+
+        [Benchmark]
+        public void WriteParsedJsonWithoutJsonElementValues_Utf8JsonWriter()
+        {
+            WriteParsedJsonWithoutJsonElementValues(builder =>
+            {
+                builder.AddService<IStreamBasedJsonWriterFactory>(ServiceLifetime.Singleton, _ => DefaultStreamBasedJsonWriterFactory.Default);
+            });
+        }
+
+        private void WriteParsedJsonWithJsonElementValues(Action<IContainerBuilder> configureServices = null)
+        {
+            using (var messageWriter = ODataMessageHelper.CreateMessageWriter(WriteStream, Model, ODataMessageKind.Response, isFullValidation: true, configureServices: configureServices))
+            {
+                ODataWriter writer = messageWriter.CreateODataResourceSetWriter(entitySet, entitySet.EntityType());
+                writer.WriteStart(new ODataResourceSet { Id = new Uri("http://www.odata.org/Perf.svc") });
+
+                for (int i = 0; i < NumEntries; i++)
+                {
+                    List<ODataProperty> properties = new List<ODataProperty>();
+                    foreach (var property in ParsedPayload.RootElement.EnumerateObject())
+                    {
+                        if (property.Name.Contains('@'))
+                        {
+                            continue;
+                        }
+                        properties.Add(new ODataProperty
+                        {
+                            Name = property.Name,
+                            Value = new ODataJsonElementValue(property.Value)
+                        });
+                    }
+
+                    ODataResource entry = new ODataResource { Properties = properties };
+                    writer.WriteStart(entry);
+                    writer.WriteEnd();
+                }
+
+                writer.WriteEnd();
+                writer.Flush();
+            }
+        }
+
+        private void WriteParsedJsonWithoutJsonElementValues(Action<IContainerBuilder> configureServices = null)
+        {
+            using (var messageWriter = ODataMessageHelper.CreateMessageWriter(WriteStream, Model, ODataMessageKind.Response, isFullValidation: true, configureServices: configureServices))
+            {
+                ODataWriter writer = messageWriter.CreateODataResourceSetWriter(entitySet, entitySet.EntityType());
+                writer.WriteStart(new ODataResourceSet { Id = new Uri("http://www.odata.org/Perf.svc") });
+
+                for (int i = 0; i < NumEntries; i++)
+                {
+                    var root = ParsedPayload.RootElement;
+
+                    ODataResource entry = new ODataResource
+                    {
+                        Properties = new[]
+                        {
+                            CreateIntProperty("ProductID", root),
+                            CreateStringProperty("Name", root),
+                            CreateStringProperty("ProductNumber", root),
+                            CreateBoolProperty("MakeFlag", root),
+                            CreateBoolProperty("FinishedGoodsFlag", root),
+                            CreateStringProperty("Color", root),
+                            CreateShortProperty("SafetyStockLevel", root),
+                            CreateShortProperty("ReorderPoint", root),
+                            CreateDecimalProperty("StandardCost", root),
+                            CreateDecimalProperty("ListPrice", root),
+                            CreateNullableIntProperty("Size", root),
+                            CreateStringProperty("SizeUnitMeasureCode", root),
+                            CreateStringProperty("WeightUnitMeasureCode", root),
+                            CreateDecimalProperty("Weight", root),
+                            CreateIntProperty("DaysToManufacture", root),
+                            CreateStringProperty("ProductLine", root),
+                            CreateStringProperty("Class", root),
+                            CreateStringProperty("Style", root),
+                            CreateIntProperty("ProductSubcategoryID", root),
+                            CreateStringProperty("ProductModelID", root),
+                            CreateDateProperty("SellStartDate", root),
+                            CreateStringProperty("SellEndDate", root),
+                            CreateDateProperty("DiscontinuedDate", root),
+                            CreateGuidProperty("rowguid", root),
+                            CreateDateProperty("ModifiedDate", root),
+                            CreateIntProperty("OpenProperty0", root),
+                            CreateIntProperty("OpenProperty1", root),
+                            CreateDecimalProperty("OpenProperty2", root),
+                            CreateIntProperty("OpenProperty4", root),
+                            CreateProperty("LuckyNumbers",
+                                new ODataCollectionValue {
+                                    TypeName = "Collection(Edm.Int64)",
+                                    Items = root.GetProperty("LuckyNumbers").EnumerateArray().Select(value => (object)value.GetInt64())
+                                }
+                            )
+                        }
+                    };
+
+                    writer.WriteStart(entry);
+
+                    JsonElement timeZones = root.GetProperty("TimeZones");
+                    writer.WriteStart(new ODataNestedResourceInfo { Name = "TimeZones", IsCollection = true, });
+                    writer.WriteStart(new ODataResourceSet { });
+
+                    foreach (JsonElement timeZone in root.GetProperty("TimeZones").EnumerateArray())
+                    {
+                        var timeZoneResource = new ODataResource
+                        {
+                            TypeName = "PerformanceServices.Edm.AdventureWorks.TimeZone",
+                            Properties = new[]
+                            {
+                                CreateDateProperty("Offset", timeZone),
+                                CreateTimeSpanProperty("StartTime", timeZone)
+                            }
+                        };
+
+                        writer.WriteStart(timeZoneResource);
+                        writer.WriteEnd();
+                    }
+
+                    writer.WriteEnd(); // Timezones resource set
+                    writer.WriteEnd(); // TimeZones nested resource info
+
+                    writer.WriteEnd(); // entry
+                }
+
+                writer.WriteEnd();
+                writer.Flush();
+            }
+        }
+
+        private static ODataProperty CreateStringProperty(string name, JsonElement json) =>
+            CreateProperty(name, json.GetProperty(name).GetString());
+
+        private static ODataProperty CreateGuidProperty(string name, JsonElement json) =>
+           CreateProperty(name, json.GetProperty(name).GetGuid());
+
+        private static ODataProperty CreateBoolProperty(string name, JsonElement json) =>
+            CreateProperty(name, json.GetProperty(name).GetBoolean());
+
+        private static ODataProperty CreateIntProperty(string name, JsonElement json) =>
+            CreateProperty(name, json.GetProperty(name).GetInt32());
+        private static ODataProperty CreateShortProperty(string name, JsonElement json) =>
+            CreateProperty(name, json.GetProperty(name).GetInt16());
+
+        private static ODataProperty CreateNullableIntProperty(string name, JsonElement json)
+        {
+            var property = json.GetProperty(name);
+            int? value = property.ValueKind == JsonValueKind.Null ? null : (int?)property.GetInt32();
+            return CreateProperty(name, value);
+        }
+
+        private static ODataProperty CreateDoubleProperty(string name, JsonElement json) =>
+            CreateProperty(name, json.GetProperty(name).GetDouble());
+
+        private static ODataProperty CreateDecimalProperty(string name, JsonElement json) =>
+            CreateProperty(name, json.GetProperty(name).GetDecimal());
+
+        private static ODataProperty CreateDateProperty(string name, JsonElement json) =>
+            CreateProperty(name, DateTimeOffset.Parse(json.GetProperty(name).GetString()));
+
+        private static ODataProperty CreateTimeSpanProperty(string name, JsonElement json) =>
+            CreateProperty(name, XmlConvert.ToTimeSpan(json.GetProperty(name).GetString()));
+
+        private static ODataProperty CreateProperty(string name, object value) => new ODataProperty { Name = name, Value = value };
+    }
+}

--- a/test/PerformanceTests/ComponentTests/ODataWriter/JsonElementPropertyTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataWriter/JsonElementPropertyTests.cs
@@ -22,10 +22,13 @@ namespace Microsoft.OData.Performance.Writer
         private static readonly byte[] JsonPayload = TestUtils.ReadTestResource("Entry.json");
         private static readonly IEdmEntitySet entitySet = Model.FindDeclaredEntitySet("Product");
         private const int MaxStreamSize = 220000000;
-        private const int NumEntries = 500;
+        private const int NumEntries = 300;
         private JsonDocument ParsedPayload;
 
         private static readonly Stream WriteStream = new MemoryStream(MaxStreamSize);
+
+        [Params(true, false)]
+        public bool enableValidation;
 
         [GlobalSetup]
         public void Setup()
@@ -75,7 +78,7 @@ namespace Microsoft.OData.Performance.Writer
 
         private void WriteParsedJsonWithJsonElementValues(Action<IContainerBuilder> configureServices = null)
         {
-            using (var messageWriter = ODataMessageHelper.CreateMessageWriter(WriteStream, Model, ODataMessageKind.Response, isFullValidation: true, configureServices: configureServices))
+            using (var messageWriter = ODataMessageHelper.CreateMessageWriter(WriteStream, Model, ODataMessageKind.Response, enableValidation, configureServices))
             {
                 ODataWriter writer = messageWriter.CreateODataResourceSetWriter(entitySet, entitySet.EntityType());
                 writer.WriteStart(new ODataResourceSet { Id = new Uri("http://www.odata.org/Perf.svc") });
@@ -128,7 +131,7 @@ namespace Microsoft.OData.Performance.Writer
 
         private void WriteParsedJsonWithoutJsonElementValues(Action<IContainerBuilder> configureServices = null)
         {
-            using (var messageWriter = ODataMessageHelper.CreateMessageWriter(WriteStream, Model, ODataMessageKind.Response, isFullValidation: true, configureServices: configureServices))
+            using (var messageWriter = ODataMessageHelper.CreateMessageWriter(WriteStream, Model, ODataMessageKind.Response, enableValidation, configureServices))
             {
                 ODataWriter writer = messageWriter.CreateODataResourceSetWriter(entitySet, entitySet.EntityType());
                 writer.WriteStart(new ODataResourceSet { Id = new Uri("http://www.odata.org/Perf.svc") });

--- a/test/PerformanceTests/ComponentTests/ODataWriter/ODataWriterFeedTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataWriter/ODataWriterFeedTests.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-namespace Microsoft.OData.Performance
+namespace Microsoft.OData.Performance.Writer
 {
     using System;
     using System.IO;

--- a/test/PerformanceTests/ComponentTests/ODataWriter/WriteFeedPropertyTypeTests.cs
+++ b/test/PerformanceTests/ComponentTests/ODataWriter/WriteFeedPropertyTypeTests.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-namespace Microsoft.OData.Performance
+namespace Microsoft.OData.Performance.Writer
 {
     using System;
     using System.Collections.Generic;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This PR allows `ODataWriter` to write `JsonElement` values directly. This is useful in cases where then input payload is already in OData JSON format. In such cases you may want to adjust some of the input but keep most of it intact. The problem is that if you parse JSON input, then convert it to `ODataProperty/ODataValue` items, then write them out using `ODataMessageWriter`, you'd end up allocating JSON content multiple times, which can be costly.

Here's what the scenario that this feature enables:

- Assume workload response as a stream of size X bytes. 
- Stream is parsed to `JsonDocument` in `System.Text.Json` lib. 
- This new object is an index on top of memory stream. So extra X bytes are not allocated. 
- From this `JsonDocument`, `ODataEntry`/`ODataProperty` is created and sent to `ODataWriter`. 

### Description

This PR implements the following changes:
- Introduces new `ODataJsonElementValue` subclass of `ODataValue` that wraps a `JsonElement`
- Introduces a new `WriteValue(JsonElement` overload in `IJsonWriter` (as well as the async version)
  - The `ODataUtf8JsonWriter` implementation uses `JsonElement.WriteTo(Utf8JsonWriter)` method to write the payload effeiciently
  - The `JsonWriter` implementation reads the `JsonElement` and writes using the existing `WriteValue()` methods based on the data type. This is less efficient and results in double allocation, so this feature should ideally only be used with the `ODataUtf8JsonWriter`
  - Updated `ODataJsonLightPropertySerializer` to properly handle `ODataJsonElementValue`.

Here's how the feature looks like in action:

```c#
string jsonString = @"{""Name"": ""John Doe"", ""Address"": { ""Foo"": ""Bar"" } }";
var jsonDoc = JsonDocument.Parse(jsonString);

List<ODataProperty> properties = new List<ODataProperty>();

foreach (var property in jsonDoc.RootElement.EnumerateObject())
{
    properties.Add(new ODataProperty()
    {
        Name = property.Name,
        Value = new ODataJsonElementValue(property.Value)
    });
}

var resource = new ODataResource { Properties = properties };

messageWriter.WriteStart(resource);
messageWriter.WriteEnd();
messageWriter.Flush();
```

It's important that we set the property value as

```c#
new ODataProperty { ..., Value = new ODataJsonElementValue(property.Value); 
```

instead of

```c#
new ODataProperty { Value = property.Value };
```

While the two will result have the same functional result, the latter will try to convert the `JsonElement` into an `ODataValue` and cause the `JsonElement` struct to be boxed in the process.

Note that at the moment support for `ODataJsonElementValue` is limited to only property values, this PR doesn't support using `JsonElement` as a top-level resource.

#### Benchmarks

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19045
Intel Xeon W-2123 CPU 3.60GHz, 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=7.0.102
  [Host]     : .NET Core 3.1.32 (CoreCLR 4.700.22.55902, CoreFX 4.700.22.56512), X64 RyuJIT
  Job-CXDUTP : .NET Core 3.1.32 (CoreCLR 4.700.22.55902, CoreFX 4.700.22.56512), X64 RyuJIT

InvocationCount=1  UnrollFactor=1

|                                                 Method | enableValidation |      Mean |     Error |    StdDev |    Median |     Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------------------------------------- |----------------- |----------:|----------:|----------:|----------:|----------:|------:|------:|----------:|
|     WriteParsedJsonWithJsonElementValues_DefaultWriter |            False |  8.555 ms | 0.1786 ms | 0.4704 ms |  8.498 ms |         - |     - |     - |   3.07 MB |
|    WriteParsedJsonWithJsonElementValues_Utf8JsonWriter |            False |  6.628 ms | 0.2292 ms | 0.6077 ms |  6.535 ms |         - |     - |     - |   1.94 MB |
|  WriteParsedJsonWithoutJsonElementValues_DefaultWriter |            False | 30.176 ms | 1.2152 ms | 3.3060 ms | 28.855 ms | 2000.0000 |     - |     - |    9.6 MB |
| WriteParsedJsonWithoutJsonElementValues_Utf8JsonWriter |            False | 32.233 ms | 2.7839 ms | 8.1647 ms | 28.296 ms | 1000.0000 |     - |     - |   7.73 MB |
|     WriteParsedJsonWithJsonElementValues_DefaultWriter |             True |  9.749 ms | 0.4113 ms | 1.1259 ms |  9.341 ms |         - |     - |     - |   3.67 MB |
|    WriteParsedJsonWithJsonElementValues_Utf8JsonWriter |             True |  7.689 ms | 0.4516 ms | 1.2053 ms |  7.279 ms |         - |     - |     - |   2.54 MB |
|  WriteParsedJsonWithoutJsonElementValues_DefaultWriter |             True | 36.798 ms | 2.2392 ms | 6.5673 ms | 32.988 ms | 2000.0000 |     - |     - |  10.87 MB |
| WriteParsedJsonWithoutJsonElementValues_Utf8JsonWriter |             True | 37.780 ms | 2.6307 ms | 7.2895 ms | 34.741 ms | 2000.0000 |     - |     - |   8.99 MB |

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
