### PR TITLE
Add HasExplicitODataId to ODataResourceBase

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
@@ -861,6 +861,7 @@ namespace Microsoft.OData.JsonLight
                     else
                     {
                         resource.Id = (Uri)annotationValue;
+                        resource.HasExplicitODataId = true;
                     }
 
                     break;

--- a/src/Microsoft.OData.Core/ODataResource.cs
+++ b/src/Microsoft.OData.Core/ODataResource.cs
@@ -213,6 +213,14 @@ namespace Microsoft.OData
             set { this.SetInstanceAnnotations(value); }
         }
 
+        /// <summary>Gets or sets the value that shows if the resource has @odata.id or @id.</summary>
+        /// <returns>true if the resource has @odata.id or @id, false otherwise.</returns>
+        public bool HasExplicitODataId
+        {
+            get;
+            internal set;
+        }
+
         /// <summary>
         /// The metadata builder for this OData resource.
         /// </summary>

--- a/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.ODataResourceBase.HasExplicitODataId.get -> bool

--- a/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.ODataResourceBase.HasExplicitODataId.get -> bool

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.ODataResourceBase.HasExplicitODataId.get -> bool

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.ODataResourceBase.HasExplicitODataId.get -> bool

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceDeserializerTests.cs
@@ -206,6 +206,44 @@ namespace Microsoft.OData.Tests.JsonLight
         }
 
         [Fact]
+        public async Task ReadResourceContentWithODataId()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"@odata.id\":\"http://tempuri.org/Categories(1)\"," +
+                "\"Name\":\"Food\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    var resource = resourceState.Resource;
+                    Assert.Equal(new Uri("http://tempuri.org/Categories(1)"), resource.Id);
+                    Assert.True(resource.HasExplicitODataId);
+                });
+        }
+
+        [Fact]
+        public async Task ReadResourceContentWithIdProperty()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Food\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    var resource = resourceState.Resource;
+                    Assert.Null(resource.Id); // Null since Id is computed at ODataReaderState.ResourceEnd
+                    Assert.False(resource.HasExplicitODataId);
+                });
+        }
+
+        [Fact]
         public async Task ReadResourceContentWithODataAnnotationsAsync()
         {
             var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/JsonLight/ODataJsonLightSingletonReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/JsonLight/ODataJsonLightSingletonReaderTests.cs
@@ -70,10 +70,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader.JsonLight
             Assert.Equal(2, entry.Properties.Count());
             Assert.Equal(10, entry.Properties.Single(p => p.Name == "WebId").Value);
             Assert.Equal("SingletonWeb", entry.Properties.Single(p => p.Name == "Name").Value);
+            Assert.False(entry.HasExplicitODataId);
         }
 
         [Fact]
-        public void ReadSingletonWithIdSpecifiedTest()
+        public void ReadSingletonWithODataIdSpecifiedTest()
         {
             const string payload = "{" +
                 "\"@odata.context\":\"http://odata.org/test/$metadata#MySingleton\"," +
@@ -86,6 +87,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader.JsonLight
             Assert.Equal(new Uri("http://odata.org/test/Bla"), entry.Id);
             Assert.Equal(new Uri("http://odata.org/test/BlaBla"), entry.EditLink);
             Assert.Equal(new Uri("http://odata.org/test/BlaBlaBla"), entry.ReadLink);
+            Assert.True(entry.HasExplicitODataId);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

When deserializing a resource, we set the `Id` property in 2 ways:
- Getting it over the wire from `@odata.id`
- Computing it. e.g if we have a key property with `Id=1` and the resource is of type `Customer` we generate an Id `Customers(1)` using the `MetadataBuilder`.
Also, since the Id can be set publicly, we could do as follows:
```csharp
ODataResource resource = new ODataResource()
{
    Id = new Uri("Customers(1)")
}
```

Considering the above, it's not possible to determine if `resource.Id` was populated from `@odata.id` or not.
In bulk operation handlers, if `resource.Id` was populated from `@odata.id` we should call `TryAddRelatedObject` since we are linking an existing object.

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
