### PR TITLE
Fix ArgumentException regression in ProjectPlanCompiler

### DIFF
--- a/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
+++ b/src/Microsoft.OData.Client/ProjectionPlanCompiler.cs
@@ -811,7 +811,8 @@ namespace Microsoft.OData.Client
                 result = CallMaterializer(
                     nameof(ODataEntityMaterializerInvoker.ProjectionGetEntry),
                     result ?? this.pathBuilder.ParameterEntryInScope,
-                    Expression.Constant(((MemberExpression)path[pathIndex]).Member.Name, typeof(string)));
+                    Expression.Constant(((MemberExpression)path[pathIndex]).Member.Name, typeof(string)),
+                    Expression.Constant(this.materializerContext));
                 pathIndex++;
             }
             while (pathIndex < path.Length);

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
@@ -825,6 +825,22 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
             Assert.Equal(-10, computer.ComputerId);
         }
 
+        [Fact]
+        public async Task Linq_ProjectPropertiesFromNestedComplexTypeToADifferentTargetTypeFromTheSource()
+        {
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            var query = context.Customer.Where(c => c.CustomerId == -10)
+                .Select(c => new ContactDetails
+                {
+                    HomePhone = c.PrimaryContactInfo.HomePhone
+                }) as DataServiceQuery<ContactDetails>;
+
+            var result = await query.ExecuteAsync();
+
+            var contactDetails = result.First();
+            Assert.Equal("jqjklhnnkyhujailcedbguyectpuamgbghreatqvobbtj", contactDetails.HomePhone.Extension);
+        }
+
         /// <summary>
         /// LINQ query Project Name Stream Property
         /// </summary>

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
@@ -797,6 +797,8 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
                         .Select(c => new Computer
                          {
                              ComputerId = c.ComputerId,
+                             // this contrived expression is to get the plan compiler to perform
+                             // a null check against an expanded entity
                              ComputerDetail = c.ComputerDetail == null ? null : c.ComputerDetail,
                          }) as DataServiceQuery<Computer>;
 
@@ -805,6 +807,22 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
             var computer = result.First();
             Assert.Equal(-10, computer.ComputerId);
             Assert.Equal(-10, computer.ComputerDetail.ComputerDetailId);
+        }
+
+        [Fact]
+        public async Task Linq_ProjectPropertiesFromNestedExpandedEntityToADifferentTargetTypeFromTheSource()
+        {
+            var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            var query = context.ComputerDetail.Where(c => c.ComputerDetailId == -10)
+                .Select(c => new Computer
+                {
+                    ComputerId = c.Computer.ComputerId,
+                }) as DataServiceQuery<Computer>;
+
+            var result = await query.ExecuteAsync();
+
+            var computer = result.First();
+            Assert.Equal(-10, computer.ComputerId);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2617 .*



### Description

This was a regression caused by changes made in #2506, we fixed a similar issue in #2535.

In #2506 I added the `MaterializerContext` as a parameter to many existing methods, including methods in the `ProjectionPlanCompiler`. The problem is, the `ProjectionPlanCompiler` generates many method calls using reflection, and argument mismatch errors can only be caught at runtime. I went through all cases where the plan compiler generates method calls with reflection to ensure the materializer context argument is passed where needed. Hopefully I haven't missed any more cases this time.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
