### PR TITLE
Content-Type Header changed to 'odata.metadata=minimal' when doing a SelectQuery

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceClientFormat.cs
+++ b/src/Microsoft.OData.Client/DataServiceClientFormat.cs
@@ -362,10 +362,10 @@ namespace Microsoft.OData.Client
         {
             if (hasSelectQueryOption)
             {
-                return MimeApplicationJsonODataLightWithAllMetadata;
+                return MimeApplicationJsonODataLight;
             }
 
-            return MimeApplicationJsonODataLight;
+            return MimeApplicationJsonODataLightWithAllMetadata;
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -2149,7 +2149,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
                 "} ] }";
 
             InMemoryMessage message = new InMemoryMessage();
-            message.SetHeader("Content-Type", "application/json;odata.metadata=mini");
+            message.SetHeader("Content-Type", "application/json;odata.metadata=minimal");
             message.Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
 
             ODataResource topLevelEntry = null;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2567.

### Description

When a SelectQuery is running, you want a subset of the entity, so the header should be set to "application/json; odata.metadata=minimal"

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

