### PR TITLE
Feature/read bulk updates

### DIFF
--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -811,12 +811,19 @@ namespace Microsoft.OData.Client
 
         /// <summary>flag results as being processed</summary>
         /// <param name="descriptor">result descriptor being processed</param>
+        /// <param name="failedOperationInBulkOps">true if processing a failed operation in a bulk operation, otherwise false.</param>
         /// <returns>count of related links that were also processed</returns>
-        protected int SaveResultProcessed(Descriptor descriptor)
+        protected int SaveResultProcessed(Descriptor descriptor, bool failedOperationInBulkOps = false)
         {
             // media links will be processed twice
+            // If we get a failed operation in a bulk operation then we don't make updates to the descriptor.
             descriptor.SaveResultWasProcessed = descriptor.State;
 
+            if (failedOperationInBulkOps)
+            {
+                descriptor.SaveResultWasProcessed = EntityStates.Unchanged;
+            }
+            
             int count = 0;
             if (descriptor.DescriptorKind == DescriptorKind.Entity && (EntityStates.Added == descriptor.State))
             {

--- a/src/Microsoft.OData.Client/BulkUpdateGraph.cs
+++ b/src/Microsoft.OData.Client/BulkUpdateGraph.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData.Client
     internal sealed class BulkUpdateGraph
     {
         /// <summary>Set of related descriptors.</summary>
-        private readonly Dictionary<Descriptor, HashSet<Descriptor>> descriptorGraph;
+        private readonly Dictionary<Descriptor, List<Descriptor>> descriptorGraph;
 
         /// <summary>Set of top level descriptors.</summary>
         private readonly List<EntityDescriptor> topLevelDescriptors;
@@ -30,7 +30,7 @@ namespace Microsoft.OData.Client
 
         public BulkUpdateGraph(RequestInfo requestInfo)
         { 
-            this.descriptorGraph = new Dictionary<Descriptor, HashSet<Descriptor>>(); 
+            this.descriptorGraph = new Dictionary<Descriptor, List<Descriptor>>(); 
             this.topLevelDescriptors = new List<EntityDescriptor>();
             this.requestInfo = requestInfo;
         }
@@ -105,7 +105,7 @@ namespace Microsoft.OData.Client
         /// <param name="relatedDescriptor">The related descriptor to the parent descriptor.</param>
         public void AddRelatedDescriptor(Descriptor parent, Descriptor relatedDescriptor)
         {
-            HashSet<Descriptor> childrenDescriptors = this.GetRelatedDescriptors(parent);
+            List<Descriptor> childrenDescriptors = this.GetRelatedDescriptors(parent);
             childrenDescriptors.Add(relatedDescriptor);
         }
 
@@ -123,14 +123,14 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <param name="descriptor">The descriptor.</param>
         /// <returns>All the related descriptors to a given key descriptor.</returns>
-        public HashSet<Descriptor> GetRelatedDescriptors(Descriptor descriptor)
+        public List<Descriptor> GetRelatedDescriptors(Descriptor descriptor)
         {
-            if (this.descriptorGraph.TryGetValue(descriptor, out HashSet<Descriptor> relatedDescriptors))
+            if (this.descriptorGraph.TryGetValue(descriptor, out List<Descriptor> relatedDescriptors))
             {
                 return relatedDescriptors;
             }
 
-            relatedDescriptors = new HashSet<Descriptor>();
+            relatedDescriptors = new List<Descriptor>();
             this.descriptorGraph[descriptor] = relatedDescriptors;
 
             return relatedDescriptors;

--- a/src/Microsoft.OData.Client/BulkUpdateSaveResult.cs
+++ b/src/Microsoft.OData.Client/BulkUpdateSaveResult.cs
@@ -9,6 +9,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Net;
+using Microsoft.OData.Client.Materialization;
 
 namespace Microsoft.OData.Client
 {
@@ -28,6 +31,33 @@ namespace Microsoft.OData.Client
         /// </summary>
         private readonly BulkUpdateGraph bulkUpdateGraph;
 
+        /// <summary> 
+        /// Link descriptors associated with entity descriptors that were added to the entity tracker during an $expand operation.
+        /// </summary>
+        /// <remarks>
+        /// If we expand the related resources to some resources when we are fetching data from an OData endpoint, 
+        /// OData client creates descriptors for the retrieved descriptors and creates links for 
+        /// the related descriptors. If we want to update the related objects' we'll get the related resources
+        /// make changes to them then call the `UpdateObject` to update the descriptors then save the changes.
+        /// The updated descriptors do not have any information that routes them to the parent descriptors but 
+        /// we can get that information from the Links object in the entitytracker.
+        /// </remarks>
+        private readonly Dictionary<Descriptor, List<LinkDescriptor>> linkDescriptors;
+
+        /// <summary>The bulk update response cache.</summary>
+        private CachedResponse cachedResponse;
+
+        /// <summary>The descriptor associated with a materializer state.</summary>
+        private readonly Dictionary<Descriptor, IMaterializerState> materializerStateForDescriptor;
+
+        /// <summary>A list of all the operation responses for a bulk update response.</summary>
+        private readonly List<OperationResponse> operationResponses;
+
+        /// <summary>
+        /// We cache the current response and then parse it. We need to do this for the async case only.
+        /// </summary>
+        private Stream responseStream;
+
         #endregion
 
         /// <summary>
@@ -43,6 +73,9 @@ namespace Microsoft.OData.Client
         {
             Debug.Assert(Util.IsBulkUpdate(options), "the options must have bulk update flag set");
             this.bulkUpdateGraph = new BulkUpdateGraph(this.RequestInfo);
+            this.linkDescriptors = new Dictionary<Descriptor, List<LinkDescriptor>>();
+            this.materializerStateForDescriptor = new Dictionary<Descriptor, IMaterializerState>();
+            this.operationResponses = new List<OperationResponse>();
         }
 
         /// <summary>
@@ -53,15 +86,31 @@ namespace Microsoft.OData.Client
             get { return this.bulkUpdateGraph; }
         }
 
-        protected override Stream ResponseStream => throw new NotImplementedException();
+        /// <summary>
+        /// Returns an instance of the link descriptors.
+        /// </summary>
+        internal Dictionary<Descriptor, List<LinkDescriptor>> LinkDescriptors
+        {
+            get { return this.linkDescriptors; }
+        }
+
+        protected override Stream ResponseStream
+        {
+            get { return this.responseStream; }
+        }
 
         /// <summary>
-        /// Syncronous bulk update request.
+        /// Synchronous bulk update request.
         /// </summary>
         /// <typeparam name="T"> The type of the top-level objects to be deep-updated.</typeparam>
         /// <param name="objects"> The top-level objects of the type to be deep updated.</param>
         internal void BulkUpdateRequest<T>(params T[] objects)
         {
+            if (objects == null || objects.Length == 0)
+            {
+                throw Error.Argument(Strings.Util_EmptyArray, nameof(objects));
+            }
+
             BuildDescriptorGraph(this.ChangedEntries, true, objects);
 
             ODataRequestMessageWrapper bulkUpdateRequestMessage = this.GenerateBulkUpdateRequest();
@@ -76,6 +125,8 @@ namespace Microsoft.OData.Client
             try
             {
                 this.batchResponseMessage = this.RequestInfo.GetSynchronousResponse(bulkUpdateRequestMessage, false);
+                this.responseStream = this.batchResponseMessage.GetStream();
+                this.HandleBulkUpdateResponse(this.batchResponseMessage, responseStream);
             }
             catch (DataServiceTransportException ex)
             {
@@ -119,12 +170,26 @@ namespace Microsoft.OData.Client
                 {
                     if (descriptor is EntityDescriptor entityDescriptor)
                     {
-                        if (entityDescriptor.ParentEntity != null && 
-                            entityDescriptor.ParentEntity.Equals(topLevelDescriptor.Entity) && 
+                        if (entityDescriptor.ParentEntity != null &&
+                            entityDescriptor.ParentEntity.Equals(topLevelDescriptor.Entity) &&
                             !bulkUpdateGraph.Contains(entityDescriptor))
                         {
                             bulkUpdateGraph.AddRelatedDescriptor(topLevelDescriptor, entityDescriptor);
                             this.BuildDescriptorGraph(descriptors, false, entityDescriptor.Entity);
+                        }
+                        else
+                        {
+                            // We check if the link representation of the descriptor exists in the entity tracker and it is unchanged. 
+                            LinkDescriptor linkDescriptor = this.RequestInfo.EntityTracker.Links.Where(
+                                a => a.Source == topLevelDescriptor.Entity && 
+                                this.RequestInfo.EntityTracker.GetEntityDescriptor(a.Target) == entityDescriptor &&
+                                a.State == EntityStates.Unchanged).FirstOrDefault();
+                            if (linkDescriptor != null)
+                            {
+                                bulkUpdateGraph.AddRelatedDescriptor(topLevelDescriptor, entityDescriptor);
+                                this.GetLinkDescriptors(entityDescriptor).Add(linkDescriptor);
+                                this.BuildDescriptorGraph(descriptors, false, entityDescriptor.Entity);
+                            }         
                         }
                     }
                     else if (descriptor is LinkDescriptor link)
@@ -137,6 +202,24 @@ namespace Microsoft.OData.Client
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets the link descriptor representations for the provided descriptor.
+        /// </summary>
+        /// <param name="descriptor">The descriptor.</param>
+        /// <returns>All the link descriptors to a given key descriptor.</returns>
+        public List<LinkDescriptor> GetLinkDescriptors(Descriptor descriptor)
+        {
+            if (this.linkDescriptors.TryGetValue(descriptor, out List<LinkDescriptor> relatedLinkDescriptors))
+            {
+                return relatedLinkDescriptors;
+            }
+
+            relatedLinkDescriptors = new List<LinkDescriptor>();
+            this.linkDescriptors[descriptor] = relatedLinkDescriptors;
+
+            return relatedLinkDescriptors;
         }
 
         /// <summary>
@@ -156,8 +239,8 @@ namespace Microsoft.OData.Client
 
             ApplyPreferences(headers, httpMethod, this.RequestInfo.AddAndUpdateResponsePreference, ref requestVersion);
 
-            headers.SetHeader("OData-Version", ODataVersion.V401.ToString());
-            headers.SetHeader("OData-MaxVersion", ODataVersion.V401.ToString());
+            headers.SetHeader(XmlConstants.HttpODataVersion, XmlConstants.ODataVersion401);
+            headers.SetHeader(XmlConstants.HttpODataMaxVersion, XmlConstants.ODataVersion401);
 
             this.RequestInfo.Format.SetRequestAcceptHeader(headers);
 
@@ -184,13 +267,23 @@ namespace Microsoft.OData.Client
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(bulkUpdateRequestMessage, this.RequestInfo, isParameterPayload: false))
             {
                 this.writer = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, this.bulkUpdateGraph.EntitySetName, this.RequestInfo.Configurations.RequestPipeline, bulkUpdateRequestMessage, this.RequestInfo);
-                this.SerializerInstance.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, writer);
+                this.SerializerInstance.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, this.bulkUpdateGraph, writer);
             }
 
             return bulkUpdateRequestMessage;
         }
 
-        protected override bool ProcessResponsePayload => throw new NotImplementedException();
+        /// <summary>
+        /// Returns true if the response payload needs to be processed.
+        /// </summary>
+        protected override bool ProcessResponsePayload
+        {
+            get
+            {
+                Debug.Assert(this.cachedResponse.Exception == null, "no exception should have been encountered");
+                return this.cachedResponse.DeltaFeed != null;
+            }
+        }
 
         internal override bool IsBatchRequest
         {
@@ -202,19 +295,367 @@ namespace Microsoft.OData.Client
             return this.CreateTopLevelRequest(method, requestUri, headers, httpStack, descriptor);
         }
 
+        /// <summary>
+        /// Gets the materializer state to process the response.
+        /// </summary>
+        /// <param name="entityDescriptor">The entity descriptor whose response is getting materialized.</param>
+        /// <param name="responseInfo">Information about the response to be materialized.</param>
+        /// <returns>An instance of <see cref="MaterializeAtom"/> that can be used to materialize the response.</returns>
         protected override MaterializeAtom GetMaterializer(EntityDescriptor entityDescriptor, ResponseInfo responseInfo)
         {
-            throw new NotImplementedException();
-        }
+            Debug.Assert(this.cachedResponse.Exception == null && this.materializerStateForDescriptor != null, "this.cachedResponse.Exception == null && this.descriptorForMaterializer != null");
 
+            if (this.materializerStateForDescriptor.TryGetValue(entityDescriptor, out IMaterializerState materializerState) && materializerState is MaterializerEntry materializerEntry)
+            {
+                return new MaterializeAtom(responseInfo, new[] { materializerEntry.Entry }, entityDescriptor.Entity.GetType(), materializerEntry.Format, base.MaterializerCache);
+            }
+
+            return null;
+        }
+        
+        /// <summary>
+        /// Handles the <see cref="IODataResponseMessage"/> for the bulk update operation.
+        /// </summary>
+        /// <param name="responseMessage">An instance of <see cref="IODataResponseMessage"/>.</param>
         protected override void HandleOperationResponse(IODataResponseMessage responseMessage)
         {
-            throw new NotImplementedException();
+            this.batchResponseMessage = responseMessage;
         }
 
+        /// <summary>
+        /// Handles the bulk update response.
+        /// </summary>
+        /// <returns>An instance of the DataServiceResponse, containing responses for all the operations in a bulk update.</returns>
         protected override DataServiceResponse HandleResponse()
         {
-            throw new NotImplementedException();
+            DataServiceResponse dataServiceResponse = new DataServiceResponse(headers: null, statusCode: -1, this.operationResponses, batchResponse: false);
+
+            if (this.cachedResponse.Exception != null)
+            {
+                throw new DataServiceRequestException(Strings.DataServiceException_GeneralError, this.cachedResponse.Exception, dataServiceResponse);
+            }
+                
+            Stack<(int LastVisited, IReadOnlyList<Descriptor> Descriptors)> adjacentDescriptors = new Stack<(int LastVisited, IReadOnlyList<Descriptor> Descriptors)>();
+            Stack<List<OperationResponse>> operationResponseTracker = new Stack<List<OperationResponse>>();
+            List<IMaterializerState> entries = this.cachedResponse.DeltaFeed.Entries;
+
+            HandleInnerBulkUpdateResponse(entries, true, adjacentDescriptors, operationResponseTracker);
+
+            return dataServiceResponse;
+        }
+
+        /// <summary>
+        /// Loops through the materializer list entries and creates an operation response for each entry.
+        /// </summary>
+        /// <param name="entries">The materializer entries for the bulk update response.</param>
+        /// <param name="isTopLevelResponse">true if the materializer entry is for a top-level response, otherwise false.</param>
+        /// <param name="adjacentDescriptors">Tracks the descriptors adjacent to a descriptor that has been visited.</param>
+        /// <param name="operationResponseTracker">Tracks the operation responses for the operations that have been performed.</param>
+        private void HandleInnerBulkUpdateResponse(
+            List<IMaterializerState> entries, 
+            bool isTopLevelResponse, 
+            Stack<(int LastVisited, IReadOnlyList<Descriptor> Descriptors)> adjacentDescriptors,
+            Stack<List<OperationResponse>> operationResponseTracker) 
+        {  
+            foreach (IMaterializerState entry in entries)
+            {
+                if (entry is MaterializerEntry materializerEntry)
+                {
+                    CreateOperationResponse(materializerEntry, isTopLevelResponse, adjacentDescriptors, operationResponseTracker);
+                   
+                    foreach (IMaterializerState nestedItem in materializerEntry?.NestedItems)
+                    {
+                        if (nestedItem is MaterializerNestedEntry materializerNestedEntry)
+                        {
+                            foreach (IMaterializerState nestedEntries in materializerNestedEntry?.NestedItems)
+                            {
+                                if (nestedEntries is MaterializerDeltaFeed feed)
+                                {
+                                    this.HandleInnerBulkUpdateResponse(feed.Entries, false, adjacentDescriptors, operationResponseTracker);
+                                }
+                            }
+                        }
+                    }
+                }
+                else if (entry is MaterializerDeletedEntry deletedEntry)
+                {
+                    CreateOperationResponse(deletedEntry, isTopLevelResponse, adjacentDescriptors, operationResponseTracker);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Processes the bulk update <see cref="IODataResponseMessage"/> response and caches the result.
+        /// </summary>
+        /// <param name="response">An instance of the <see cref="IODataResponseMessage"/> for the bulk update response.</param>
+        /// <param name="responseStream">The response stream.</param>
+        private void HandleBulkUpdateResponse(IODataResponseMessage response, Stream responseStream)
+        {
+            EntityDescriptor entityDescriptor = this.bulkUpdateGraph.TopLevelDescriptors[0];
+            MaterializerDeltaFeed deltaFeed = default;
+
+            // We are setting the MaxProtocolVersion to v4.01 when reading bulk update responses.
+            this.RequestInfo.Context.MaxProtocolVersion = ODataProtocolVersion.V401;
+            Exception exception = HandleResponse(
+                this.RequestInfo, 
+                (HttpStatusCode)response.StatusCode, 
+                response.GetHeader(XmlConstants.HttpODataVersion), 
+                () => this.ResponseStream,
+                throwOnFailure: false, 
+                out Version responseVersion);
+
+            HeaderCollection headers = new HeaderCollection(response);
+           
+            if (responseStream != null && entityDescriptor.DescriptorKind == DescriptorKind.Entity && exception == null)
+            {
+                try
+                {
+                    ResponseInfo responseInfo = this.CreateResponseInfo(entityDescriptor);
+                    HttpWebResponseMessage responseMessageWrapper = new HttpWebResponseMessage(
+                        headers,
+                        response.StatusCode,
+                        () => this.ResponseStream);
+
+                    ODataMaterializerContext materializerContext = new ODataMaterializerContext(responseInfo, base.MaterializerCache);
+                    deltaFeed = ODataReaderEntityMaterializer.ParseDeltaResourceSetPayload(responseMessageWrapper, responseInfo, entityDescriptor.Entity.GetType(), materializerContext);
+                }
+                catch (Exception ex)
+                {
+                    exception = ex;
+
+                    if (!CommonUtil.IsCatchableExceptionType(ex))
+                    {
+                        throw;
+                    }
+                }
+            }
+
+            // Cache the response.
+            this.cachedResponse = new CachedResponse(
+                this.bulkUpdateGraph,
+                headers,
+                (HttpStatusCode)response.StatusCode,
+                responseVersion,
+                deltaFeed,
+                exception);
+        }
+
+        /// <summary>
+        /// Gets the last descriptor that was processed or visited. 
+        /// </summary>
+        /// <param name="adjacentDescriptors">Tracks the descriptors adjacent to a descriptor that has been visited.</param>
+        /// <returns>The descriptor for the particular operation being processed.</returns>
+        private static Descriptor GetLastVisitedDescriptor(Stack<(int LastVisited, IReadOnlyList<Descriptor> Descriptors)> adjacentDescriptors)
+        {
+            Descriptor lastVisitedDescriptor = null;
+
+            if (adjacentDescriptors.Count > 0)
+            {
+                int index = adjacentDescriptors.Peek().LastVisited;
+
+                IReadOnlyList<Descriptor> descriptors = adjacentDescriptors.Peek().Descriptors;
+
+                if (index < descriptors.Count)
+                {
+                    lastVisitedDescriptor = descriptors[index];
+                }
+            }
+           
+            return lastVisitedDescriptor;
+        }
+
+        /// <summary>
+        /// Checks whether an entry has a data modification exception instance annotation.
+        /// </summary>
+        /// <param name="materializerState">The materializer state entry to check for the data modification exception instance annotation.</param>
+        /// <returns>true if the entry has the data modification exception, otherwise false.</returns>
+        private static bool HasFailedOperation(IMaterializerState materializerState)
+        {
+            if (materializerState is MaterializerDeletedEntry deltaEntry)
+            {
+                return deltaEntry.DeletedResource.InstanceAnnotations.Any(a => a.Name == XmlConstants.DataModificationException);
+            }
+            else if (materializerState is MaterializerEntry entry)
+            {
+                return entry.Entry.InstanceAnnotations.Any(a => a.Name == XmlConstants.DataModificationException);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Creates an operation response for each operation.
+        /// </summary>
+        /// <param name="materializerState">An instance of the <see cref="IMaterializerState"/> entry associated with an operation response.</param>
+        /// <param name="isTopLevelResponse">true for a top-level response otherwise false.</param>
+        /// <param name="adjacentDescriptors">Tracks the descriptors adjacent to a descriptor that has been visited.</param>
+        /// <param name="operationResponseTracker">Tracks the operation responses for the operations that have been performed.</param>
+        /// <exception cref="DataServiceRequestException"></exception>
+        private void CreateOperationResponse(
+            IMaterializerState materializerState, 
+            bool isTopLevelResponse, 
+            Stack<(int LastVisited, IReadOnlyList<Descriptor> Descriptors)> adjacentDescriptors,
+            Stack<List<OperationResponse>> operationResponseTracker)
+        {
+            Exception ex = null;
+            OperationResponse operationResponse = null;
+            DataServiceResponse dataServiceResponse = new DataServiceResponse(
+                headers: null, 
+                statusCode: -1, 
+                this.operationResponses, 
+                batchResponse: false);
+            Descriptor descriptor = null;
+
+            try
+            {
+                if (adjacentDescriptors.Count == 0)
+                {
+                    descriptor = this.bulkUpdateGraph.TopLevelDescriptors[0];
+                    // If the adjacentDescriptors is empty then we push a tuple with index 0 and 
+                    // the list of top-level descriptors to the stack.  
+                    adjacentDescriptors.Push((0, this.bulkUpdateGraph.TopLevelDescriptors));
+                }
+                else
+                {
+                    Descriptor lastVisitedDescriptor = GetLastVisitedDescriptor(adjacentDescriptors);
+
+                    if (lastVisitedDescriptor != null)
+                    {
+                        IReadOnlyList<Descriptor> relatedDescriptors = this.bulkUpdateGraph.GetRelatedDescriptors(lastVisitedDescriptor);
+
+                        if (relatedDescriptors.Count == 0)
+                        {
+                            // Check the index of the last visited descriptor in the descriptors list.
+                            // If the index is the same value as the length of the descriptors list then
+                            // all the descriptors in the descriptors list have been traversed and we pop the items from the stack. 
+                            if (adjacentDescriptors.Peek().LastVisited == adjacentDescriptors.Peek().Descriptors.Count - 1)
+                            {
+                                adjacentDescriptors.Pop();
+                            }
+
+                            int index = adjacentDescriptors.Peek().LastVisited;
+                            IReadOnlyList<Descriptor> descriptors = adjacentDescriptors.Peek().Descriptors;
+
+                            if (index == descriptors.Count - 1)
+                            {
+                                adjacentDescriptors.Pop();
+                            }
+                            else
+                            {
+                                // To get the next descriptor to be visited, we take the last visited index and increment it by one.
+                                // Then we get the descriptor at the new index from the descriptors list. 
+                                // We then update the index to the new index value. 
+                                descriptor = descriptors[index + 1];
+                                adjacentDescriptors.Pop();
+                                adjacentDescriptors.Push((index + 1, descriptors));
+                            }
+                        }
+                        else 
+                        {
+                            // If we find the last visited descriptors had related descriptors then we start traversing the related descriptors list and
+                            // we start with the descriptor at index 0 and keep updating the index as we traverse the list. 
+                            descriptor = relatedDescriptors[0];
+                            adjacentDescriptors.Push((0, relatedDescriptors));
+                        }
+                    }          
+                }
+                 
+                if (descriptor != null) 
+                {
+                    this.SaveResultProcessed(descriptor, HasFailedOperation(materializerState));
+
+                    operationResponse = new ChangeOperationResponse(this.cachedResponse.Headers, descriptor)
+                    {
+                        StatusCode = (int)this.cachedResponse.StatusCode
+                    };
+
+                    this.materializerStateForDescriptor.Add(descriptor, materializerState);
+
+#if DEBUG
+                    this.HandleOperationResponse(descriptor, this.cachedResponse.Headers, this.cachedResponse.StatusCode);
+#else
+                    this.HandleOperationResponse(descriptor, this.cachedResponse.Headers);
+#endif
+
+                    if (isTopLevelResponse)
+                    {
+                        this.operationResponses.Add(operationResponse);
+                        operationResponseTracker.Push(operationResponses);
+                    }
+                    else
+                    {
+                        List<OperationResponse> lastOperationResponses = operationResponseTracker.Peek();
+                        lastOperationResponses[lastOperationResponses.Count-1].NestedResponses.Add(operationResponse);
+
+                        if (this.bulkUpdateGraph.GetRelatedDescriptors(descriptor).Count == 0)
+                        {
+                            operationResponseTracker.Pop();
+                            operationResponseTracker.Push(lastOperationResponses);
+                        }
+                        else
+                        {
+                            operationResponseTracker.Pop();
+                            operationResponseTracker.Push(lastOperationResponses[lastOperationResponses.Count-1].NestedResponses);
+                        }
+                    }
+                }  
+            }
+            catch (InvalidOperationException e)
+            {
+                ex = e;
+            }
+
+            if (ex != null)
+            {
+                throw new DataServiceRequestException(Strings.DataServiceException_GeneralError, ex, dataServiceResponse);
+            }
+        }
+        
+        /// <summary>
+        /// The cached response of a bulk update response.
+        /// </summary>
+        private readonly struct CachedResponse
+        {
+            /// <summary>The response headers</summary>
+            public readonly HeaderCollection Headers;
+
+            /// <summary>The response status code</summary>
+            public readonly HttpStatusCode StatusCode;
+
+            /// <summary>The parsed response OData-Version header.</summary>
+            public readonly Version Version;
+
+            /// <summary>The <see cref="MaterializerDeltaFeed"/> of the <see cref="ODataDeltaResourceSet"/> entry being parsed.</summary>
+            public readonly MaterializerDeltaFeed DeltaFeed;
+
+            /// <summary>Exception if encountered.</summary>
+            public readonly Exception Exception;
+
+            /// <summary>The descriptor graph that was used when writing the request and whose response is being parsed.</summary>
+            public readonly BulkUpdateGraph DescriptorGraph;
+
+            /// <summary>
+            /// Creates an instance of <see cref="CachedResponse"/>.
+            /// </summary>
+            /// <param name="descriptorGraph">The descriptor graph used in writing the request whose response is getting processed.</param>
+            /// <param name="headers">The headers.</param>
+            /// <param name="statusCode">The status code.</param>
+            /// <param name="responseVersion">The parsed response OData-Version header.</param>
+            /// <param name="deltaFeed">The <see cref="MaterializerDeltaFeed"/> of the <see cref="ODataDeltaResourceSet"/> of the response payload.</param>
+            /// <param name="exception">The exception, if the request threw an exception.</param>
+            internal CachedResponse(BulkUpdateGraph descriptorGraph, HeaderCollection headers, HttpStatusCode statusCode, Version responseVersion, MaterializerDeltaFeed deltaFeed, Exception exception)
+            {
+                Debug.Assert(descriptorGraph != null, "descriptorGraph != null");
+                Debug.Assert(headers != null, "headers != null");
+                Debug.Assert(deltaFeed == null || (exception == null), "if deltaFeed is specified, exception cannot be specified");
+
+                this.DescriptorGraph = descriptorGraph;
+                this.DeltaFeed = deltaFeed;
+                this.Exception = exception;
+                this.Headers = headers;
+                this.StatusCode = statusCode;
+                this.Version = responseVersion;
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -2790,15 +2790,17 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <typeparam name="T">The type of top-level objects to be deep updated.</typeparam>
         /// <param name="objects">The top-level objects of the type to be deep updated.</param>
-        internal virtual void BulkUpdate<T>(params T[] objects)
+        public virtual DataServiceResponse BulkUpdate<T>(params T[] objects)
         {
-            if (objects.Length == 0)
+            if (objects == null || objects.Length == 0)
             {
-                throw Error.Argument(Strings.Util_EmptyArray, "top-level objects");
+                throw Error.Argument(Strings.Util_EmptyArray, nameof(objects));
             }
 
             BulkUpdateSaveResult result = new BulkUpdateSaveResult(this, Util.SaveChangesMethodName, SaveChangesOptions.BulkUpdate, callback: null, state: null);
             result.BulkUpdateRequest(objects);
+
+            return result.EndRequest();
         }
 
         #endregion

--- a/src/Microsoft.OData.Client/Materialization/FeedAndEntryMaterializerAdapter.cs
+++ b/src/Microsoft.OData.Client/Materialization/FeedAndEntryMaterializerAdapter.cs
@@ -36,8 +36,14 @@ namespace Microsoft.OData.Client.Materialization
         /// <summary>The current feed.</summary>
         private ODataResourceSet currentFeed;
 
+        /// <summary>The current feed.</summary>
+        private ODataDeltaResourceSet currentDeltaFeed;
+
         /// <summary>The current entry.</summary>
         private ODataResource currentEntry;
+
+        /// <summary>The stack of read <see cref="IMaterializerState"/> items.</summary>
+        private readonly Stack<IMaterializerState> materializerStateItems;
 
         /// <summary>
         /// The materializer context.
@@ -52,8 +58,8 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="model">The model.</param>
         /// <param name="mergeOption">The mergeOption.</param>
         /// <param name="materializerContext">The materializer context.</param>
-        internal FeedAndEntryMaterializerAdapter(ODataMessageReader messageReader, ODataReaderWrapper reader, ClientEdmModel model, MergeOption mergeOption, IODataMaterializerContext materializerContext)
-            : this(ODataUtils.GetReadFormat(messageReader), reader, model, mergeOption, materializerContext)
+        internal FeedAndEntryMaterializerAdapter(ODataMessageReader messageReader, ODataReaderWrapper reader, ClientEdmModel model, MergeOption mergeOption, IODataMaterializerContext materializerContext, bool isDeltaPayload = false)
+            : this(ODataUtils.GetReadFormat(messageReader), reader, model, mergeOption, materializerContext, isDeltaPayload)
         {
         }
 
@@ -65,7 +71,7 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="model">The model.</param>
         /// <param name="mergeOption">The mergeOption.</param>
         /// <param name="materializerContext">The materializer context.</param>
-        internal FeedAndEntryMaterializerAdapter(ODataFormat odataFormat, ODataReaderWrapper reader, ClientEdmModel model, MergeOption mergeOption, IODataMaterializerContext materializerContext)
+        internal FeedAndEntryMaterializerAdapter(ODataFormat odataFormat, ODataReaderWrapper reader, ClientEdmModel model, MergeOption mergeOption, IODataMaterializerContext materializerContext, bool isDeltaPayload = false)
         {
             this.readODataFormat = odataFormat;
             this.clientEdmModel = model;
@@ -74,7 +80,14 @@ namespace Microsoft.OData.Client.Materialization
             this.currentEntry = null;
             this.currentFeed = null;
             this.feedEntries = null;
+            this.currentDeltaFeed = null;
             this.materializerContext = materializerContext;
+
+            if (isDeltaPayload)
+            {
+                // If we have a delta payload, we need the stack data structure to keep track of the read items.
+                this.materializerStateItems = new Stack<IMaterializerState>();
+            }    
         }
 
         /// <summary>
@@ -83,6 +96,14 @@ namespace Microsoft.OData.Client.Materialization
         public ODataResourceSet CurrentFeed
         {
             get { return this.currentFeed; }
+        }
+
+        /// <summary>
+        /// Gets the current delta resource set feed.
+        /// </summary>
+        public ODataDeltaResourceSet CurrentDeltaFeed
+        {
+            get { return this.currentDeltaFeed; }
         }
 
         /// <summary>
@@ -153,11 +174,14 @@ namespace Microsoft.OData.Client.Materialization
                 case ODataReaderState.Start:
                     {
                         ODataResourceSet feed;
+                        MaterializerDeltaFeed deltaEntry;
                         MaterializerEntry entryAndState;
-                        if (this.TryReadFeedOrEntry(true, out feed, out entryAndState))
+                        if (this.TryReadFeedOrEntry(true, out feed, out deltaEntry, out entryAndState))
                         {
                             this.currentEntry = entryAndState != null ? entryAndState.Entry : null;
                             this.currentFeed = feed;
+                            this.currentDeltaFeed = deltaEntry?.DeltaFeed;
+
                             if (this.currentFeed != null)
                             {
                                 this.feedEntries = MaterializerFeed.GetFeed(this.currentFeed, this.materializerContext).Entries.GetEnumerator();
@@ -182,8 +206,8 @@ namespace Microsoft.OData.Client.Materialization
                             throw new NotImplementedException();
                         }
                     }
-
-                case ODataReaderState.ResourceSetEnd:
+                case ODataReaderState.ResourceSetEnd: 
+                case ODataReaderState.DeltaResourceSetEnd:
                 case ODataReaderState.ResourceEnd:
                     if (this.TryRead() || this.reader.State != ODataReaderState.Completed)
                     {
@@ -191,6 +215,7 @@ namespace Microsoft.OData.Client.Materialization
                     }
 
                     this.currentEntry = null;
+                    this.currentDeltaFeed = null;
                     return false;
                 default:
                     throw DSClient.Error.InternalError(InternalError.UnexpectedReadState);
@@ -214,31 +239,33 @@ namespace Microsoft.OData.Client.Materialization
         /// </summary>
         /// <param name="lazy">if set to <c>true</c> [lazy].</param>
         /// <param name="feed">The feed.</param>
+        /// <param name="deltaFeed">The delta feed.</param>
         /// <param name="entry">The entry.</param>
         /// <returns>true if a value was read, otherwise false</returns>
-        private bool TryReadFeedOrEntry(bool lazy, out ODataResourceSet feed, out MaterializerEntry entry)
+        private bool TryReadFeedOrEntry(bool lazy, out ODataResourceSet feed, out MaterializerDeltaFeed deltaFeed, out MaterializerEntry entry)
         {
+            entry = null;
+            feed = null;
+            deltaFeed = null;
+
             if (this.TryStartReadFeedOrEntry())
             {
                 if (this.reader.State == ODataReaderState.ResourceStart)
                 {
                     entry = this.ReadEntryCore();
-                    feed = null;
+                }
+                else if (this.reader.State == ODataReaderState.DeltaResourceSetStart)
+                {
+                    deltaFeed = this.ReadDeltaFeedCore();
                 }
                 else
                 {
-                    entry = null;
                     feed = this.ReadFeedCore(lazy);
                 }
             }
-            else
-            {
-                feed = null;
-                entry = null;
-            }
 
-            Debug.Assert(feed == null || entry == null, "feed == null || entry == null");
-            return feed != null || entry != null;
+            Debug.Assert(feed == null || entry == null || deltaFeed == null, "feed == null || entry == null || deltaFeed == null");
+            return feed != null || entry != null || deltaFeed != null;
         }
 
         /// <summary>
@@ -247,7 +274,7 @@ namespace Microsoft.OData.Client.Materialization
         /// <returns>true if a value was read, otherwise false</returns>
         private bool TryStartReadFeedOrEntry()
         {
-            return this.TryRead() && (this.reader.State == ODataReaderState.ResourceSetStart || this.reader.State == ODataReaderState.ResourceStart);
+            return this.TryRead() && (this.reader.State == ODataReaderState.ResourceSetStart || this.reader.State == ODataReaderState.ResourceStart || this.reader.State == ODataReaderState.DeltaResourceSetStart);
         }
 
         /// <summary>
@@ -297,6 +324,72 @@ namespace Microsoft.OData.Client.Materialization
         }
 
         /// <summary>
+        /// Reads an <see cref="ODataDeltaResourceSet"/>.
+        /// </summary>
+        /// <returns>The <see cref="MaterializerDeltaFeed"/> of the read <see cref="ODataDeltaResourceSet"/>.</returns>
+        private MaterializerDeltaFeed ReadDeltaFeedCore()
+        {
+            this.ExpectState(ODataReaderState.DeltaResourceSetStart);
+
+            ODataDeltaResourceSet result = (ODataDeltaResourceSet)this.reader.Item;
+            MaterializerDeltaFeed feed = null;
+
+            Debug.Assert(this.materializerStateItems != null, "this.materializerStateItems should not be null");
+
+            feed = MaterializerDeltaFeed.CreateDeltaFeed(
+                    result,
+                    new List<IMaterializerState>(),
+                    this.materializerContext);
+
+            this.materializerStateItems.Push(feed);
+
+            do
+            {
+                this.AssertRead();
+
+                switch (this.reader.State)
+                {
+                    case ODataReaderState.ResourceStart:
+                        MaterializerEntry entry = this.ReadEntryCore();
+                        feed.AddEntry(entry);
+                        break;
+                    case ODataReaderState.DeletedResourceStart:
+                        MaterializerDeletedEntry deletedMaterializerEntry = this.ReadDeletedResource();
+                        feed.AddEntry(deletedMaterializerEntry);
+                        break;
+                    case ODataReaderState.DeletedResourceEnd:
+                    case ODataReaderState.ResourceEnd:
+                    case ODataReaderState.DeltaResourceSetEnd:
+                        this.materializerStateItems?.Pop();
+                        break;
+                    default:
+                        throw DSClient.Error.InternalError(InternalError.UnexpectedReadState);
+                }
+            }
+            while (this.reader.State != ODataReaderState.DeltaResourceSetEnd);
+
+            return feed;
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IMaterializerState"/> entry to a parent entry.
+        /// </summary>
+        /// <param name="materializerState">The <see cref="IMaterializerState"/> entry being added to the parent item.</param>
+        private void AddResourceToParent(IMaterializerState materializerState)
+        {
+            IMaterializerState topItem = this.materializerStateItems.Peek();
+
+            if (topItem is MaterializerDeltaFeed delta)
+            {
+                delta.AddEntry(materializerState);
+            }
+            else if (topItem is MaterializerEntry entry)
+            {
+                entry.AddNestedItem(materializerState);
+            }
+        }
+
+        /// <summary>
         /// Lazily reads entries.
         /// </summary>
         /// <returns>An enumerable that will lazily read entries when enumerated.</returns>
@@ -341,6 +434,7 @@ namespace Microsoft.OData.Client.Materialization
 
             MaterializerEntry entry;
             List<ODataNestedResourceInfo> navigationLinks = new List<ODataNestedResourceInfo>();
+
             if (result != null)
             {
                 entry = MaterializerEntry.CreateEntry(
@@ -349,6 +443,13 @@ namespace Microsoft.OData.Client.Materialization
                     this.mergeOption != MergeOption.NoTracking,
                     this.clientEdmModel,
                     this.materializerContext);
+
+                // A resource cannot be a top-level item in a bulk-update. 
+                // The resource has to be contained in a delta resource set. 
+                if (this.materializerStateItems?.Count > 0)
+                {
+                    this.materializerStateItems.Push(entry);
+                }
 
                 do
                 {
@@ -359,8 +460,13 @@ namespace Microsoft.OData.Client.Materialization
                         case ODataReaderState.NestedResourceInfoStart:
                             // Cache the list of navigation links here but don't add them to the entry because all of the key properties may not be available yet.
                             navigationLinks.Add(this.ReadNestedResourceInfo());
+                            
                             break;
                         case ODataReaderState.ResourceEnd:
+                            if (this.materializerStateItems?.Count > 0)
+                            {
+                                this.materializerStateItems.Pop();
+                            }    
                             break;
                         default:
                             throw DSClient.Error.InternalError(InternalError.UnexpectedReadState);
@@ -398,13 +504,29 @@ namespace Microsoft.OData.Client.Materialization
 
             ODataNestedResourceInfo link = (ODataNestedResourceInfo)this.reader.Item;
 
-            MaterializerEntry entry;
-            ODataResourceSet feed;
-            if (this.TryReadFeedOrEntry(false, out feed, out entry))
+            MaterializerNestedEntry nestedEntry;
+
+            if (this.TryReadFeedOrEntry(false, out ODataResourceSet feed, out MaterializerDeltaFeed deltaFeed, out MaterializerEntry entry))
             {
                 if (feed != null)
                 {
                     MaterializerNavigationLink.CreateLink(link, feed, this.materializerContext);
+                }
+                else if (deltaFeed != null)
+                {
+                    nestedEntry = MaterializerNestedEntry.CreateNestedResourceInfo(
+                        link, 
+                        new List<IMaterializerState>(), 
+                        this.materializerContext);
+
+                    nestedEntry.AddNestedItem(deltaFeed);
+
+                    Debug.Assert(this.materializerStateItems != null, "this.materializerStateItems should not be null");
+
+                    if (this.materializerStateItems.Count > 0)
+                    {
+                        AddResourceToParent(nestedEntry);    
+                    }                     
                 }
                 else
                 {
@@ -418,6 +540,46 @@ namespace Microsoft.OData.Client.Materialization
             this.ExpectState(ODataReaderState.NestedResourceInfoEnd);
 
             return link;
+        }
+
+        /// <summary>
+        /// Reads an <see cref="ODataDeletedResource"/>
+        /// </summary>
+        /// <returns>An <see cref="MaterializerDeletedEntry"/> of the read <see cref="ODataDeletedResource"/>.</returns>
+        private MaterializerDeletedEntry ReadDeletedResource()
+        {
+            this.ExpectState(ODataReaderState.DeletedResourceStart);
+
+            ODataDeletedResource result = (ODataDeletedResource)this.reader.Item;
+            MaterializerDeletedEntry entry;
+
+            Debug.Assert(this.materializerStateItems != null, "this.materializerStateItems should not be null");
+
+            entry = MaterializerDeletedEntry.CreateDeletedEntry(
+                    result,
+                    this.materializerContext);
+
+            this.materializerStateItems.Push(entry);
+
+            do
+            {
+                this.AssertRead();
+
+                switch (this.reader.State)
+                {
+                    case ODataReaderState.DeletedResourceEnd:
+                        if (this.materializerStateItems.Count > 0)
+                        {
+                            this.materializerStateItems.Pop();
+                        }
+                        break;
+                    default:
+                        throw DSClient.Error.InternalError(InternalError.UnexpectedReadState);
+                }
+            }
+            while (this.reader.State != ODataReaderState.DeletedResourceEnd);
+
+            return entry;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/Materialization/IMaterializerState.cs
+++ b/src/Microsoft.OData.Client/Materialization/IMaterializerState.cs
@@ -1,0 +1,15 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="IMaterializerState.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.Materialization
+{
+    /// <summary>
+    /// This is a marker interface to group the different materializer states together.
+    /// </summary>
+    internal interface IMaterializerState
+    {
+    }
+}

--- a/src/Microsoft.OData.Client/Materialization/MaterializerDeletedEntry.cs
+++ b/src/Microsoft.OData.Client/Materialization/MaterializerDeletedEntry.cs
@@ -1,0 +1,52 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="MaterializerDeletedEntry.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Diagnostics;
+
+namespace Microsoft.OData.Client.Materialization
+{
+    /// <summary>
+    /// Materializer state for a given <see cref="ODataDeletedResource"/>.
+    /// </summary>
+    internal class MaterializerDeletedEntry : IMaterializerState
+    {
+        /// <summary>The <see cref="ODataDeletedResource"/> entry.</summary>
+        private readonly ODataDeletedResource deletedEntry;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="MaterializerDeletedEntry"/>.
+        /// </summary>
+        /// <param name="deletedEntry">The <see cref="ODataDeletedResource"/> of the deleted entry.</param>
+        private MaterializerDeletedEntry(ODataDeletedResource deletedEntry)
+        {
+            this.deletedEntry = deletedEntry;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ODataDeletedResource"/>.
+        /// </summary>
+        public ODataDeletedResource DeletedResource
+        {
+            get { return this.deletedEntry; }
+        }
+
+        /// <summary>
+        /// Creates the <see cref="MaterializerDeletedEntry"/> of the <see cref="ODataDeletedResource"/> entry.
+        /// </summary>
+        /// <param name="deletedEntry">The <see cref="ODataDeletedResource"/> entry.</param>
+        /// <param name="materializerContext">The current materializer context.</param>
+        /// <returns>The <see cref="MaterializerDeletedEntry"/> of the <see cref="ODataDeletedResource"/> entry.</returns>
+        public static MaterializerDeletedEntry CreateDeletedEntry(ODataDeletedResource deletedEntry, IODataMaterializerContext materializerContext)
+        {
+            Debug.Assert(materializerContext.GetAnnotation<ODataDeletedResource>(deletedEntry) == null, "MaterializerDeletedEntry state has already been created.");
+
+            MaterializerDeletedEntry materializerDeletedEntry = new MaterializerDeletedEntry(deletedEntry);
+            materializerContext.SetAnnotation<MaterializerDeletedEntry>(deletedEntry, materializerDeletedEntry);
+
+            return materializerDeletedEntry;
+        }
+    }
+}

--- a/src/Microsoft.OData.Client/Materialization/MaterializerDeltaFeed.cs
+++ b/src/Microsoft.OData.Client/Materialization/MaterializerDeltaFeed.cs
@@ -1,0 +1,97 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="MaterializerDeltaFeed.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.OData.Client.Materialization
+{
+    /// <summary>
+    /// Materializer state for a given <see cref="ODataDeltaResourceSet"/>.
+    /// </summary>
+    internal class MaterializerDeltaFeed : IMaterializerState
+    {
+        /// <summary>The delta feed.</summary>
+        private readonly ODataDeltaResourceSet deltaFeed;
+
+        /// <summary>The entries.</summary>
+        private readonly List<IMaterializerState> entries;
+
+        /// <summary>
+        /// Creates an instance of the <see cref="MaterializerDeltaFeed"/>.
+        /// </summary>
+        /// <param name="deltaFeed">The delta feed.</param>
+        /// <param name="entries">The entries.</param>
+        private MaterializerDeltaFeed(ODataDeltaResourceSet deltaFeed, List<IMaterializerState> entries)
+        {
+            Debug.Assert(deltaFeed != null, "deltaFeed != null");
+            Debug.Assert(entries != null, "entries != null");
+
+            this.deltaFeed = deltaFeed;
+            this.entries = entries;
+        }
+
+        /// <summary>
+        /// Gets the delta feed.
+        /// </summary>
+        public ODataDeltaResourceSet DeltaFeed
+        {
+            get { return this.deltaFeed; }
+        }
+
+        /// <summary>
+        /// Gets the entries.
+        /// </summary>
+        public List<IMaterializerState> Entries
+        {
+            get { return this.entries; }
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IMaterializerState"/> entry to the entries collection.
+        /// </summary>
+        /// <param name="entry">The <see cref="IMaterializerState"/> entry to be added.</param>
+        public void AddEntry(IMaterializerState entry)
+        {
+            this.entries.Add(entry);
+        }
+
+        /// <summary>
+        /// Creates the <see cref="MaterializerDeltaFeed"/>.
+        /// </summary>
+        /// <param name="deltaFeed">The delta feed to be created.</param>
+        /// <param name="entries">The entries.</param>
+        /// <param name="materializerContext">The current materializer context.</param>
+        /// <returns>The materializer delta feed.</returns>
+        public static MaterializerDeltaFeed CreateDeltaFeed(ODataDeltaResourceSet deltaFeed, List<IMaterializerState> entries, IODataMaterializerContext materializerContext)
+        {
+            Debug.Assert(materializerContext.GetAnnotation<List<IMaterializerState>>(deltaFeed) == null, "Delta feed state has already been created.");
+            
+            if (entries == null)
+            {
+                entries = new List<IMaterializerState>();
+            }
+            else
+            {
+                materializerContext.SetAnnotation(deltaFeed, entries);
+            }
+
+            return new MaterializerDeltaFeed(deltaFeed, entries);
+        }
+
+        /// <summary>
+        /// Gets the delta feed.
+        /// </summary>
+        /// <param name="deltaFeed">The delta feed.</param>
+        /// <param name="materializerContext">The current materializer context.</param>
+        /// <returns>The materializer delta feed.</returns>
+        public static MaterializerDeltaFeed GetDeltaFeed(ODataDeltaResourceSet deltaFeed, IODataMaterializerContext materializerContext)
+        {
+            List<IMaterializerState> entries = materializerContext.GetAnnotation<List<IMaterializerState>>(deltaFeed);
+            return new MaterializerDeltaFeed(deltaFeed, entries);
+        }
+    }
+}

--- a/src/Microsoft.OData.Client/Materialization/MaterializerEntry.cs
+++ b/src/Microsoft.OData.Client/Materialization/MaterializerEntry.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.Client.Materialization
     /// <summary>
     /// Materializer state for a given ODataResource
     /// </summary>
-    internal class MaterializerEntry
+    internal class MaterializerEntry : IMaterializerState
     {
         /// <summary>The entry.</summary>
         private readonly ODataResource entry;
@@ -32,6 +32,9 @@ namespace Microsoft.OData.Client.Materialization
 
         /// <summary>List of navigation links for this entry.</summary>
         private ICollection<ODataNestedResourceInfo> navigationLinks = ODataMaterializer.EmptyLinks;
+
+        /// <summary>List of navigation links for this entry.</summary>
+        private List<IMaterializerState> nestedItems = new List<IMaterializerState>();    
 
         /// <summary>
         /// Creates a new instance of MaterializerEntry.
@@ -113,6 +116,14 @@ namespace Microsoft.OData.Client.Materialization
         public ODataResource Entry
         {
             get { return this.entry; }
+        }
+
+        /// <summary>
+        /// Gets the nested <see cref="IMaterializerState"/> items.
+        /// </summary>
+        internal List<IMaterializerState> NestedItems
+        {
+            get { return this.nestedItems; }
         }
 
         /// <summary>
@@ -366,6 +377,15 @@ namespace Microsoft.OData.Client.Materialization
 
                 this.EntityDescriptorUpdated = true;
             }
+        }
+
+        /// <summary>
+        /// Adds a <see cref="IMaterializerState"/> item to the entry's nested items.
+        /// </summary>
+        /// <param name="nestedItem">The <see cref="IMaterializerState"/> item to add to the entry's nested items.</param>
+        internal void AddNestedItem(IMaterializerState nestedItem)
+        {
+            this.nestedItems.Add(nestedItem);
         }
 
         #region Private methods.

--- a/src/Microsoft.OData.Client/Materialization/MaterializerNestedEntry.cs
+++ b/src/Microsoft.OData.Client/Materialization/MaterializerNestedEntry.cs
@@ -1,0 +1,86 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="MaterializerNestedEntry.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.OData.Client.Materialization
+{
+    /// <summary>
+    /// Materializer state for a given <see cref="ODataNestedResourceInfo"/>
+    /// </summary>
+    internal class MaterializerNestedEntry : IMaterializerState
+    {
+        /// <summary>The <see cref="ODataNestedResourceInfo"/> entry.</summary>
+        private readonly ODataNestedResourceInfo nestedResourceInfo;
+
+        /// <summary>The <see cref="IMaterializerState"/> entries.</summary>
+        private readonly List<IMaterializerState> nestedItems;
+
+        /// <summary>
+        /// Creates a new instance of MaterializerNestedEntry.
+        /// </summary>
+        /// <param name="nestedResourceInfo">The <see cref="ODataNestedResourceInfo"/>.</param>
+        /// <param name="nestedItems">The <see cref="IMaterializerState"/> entries.</param>
+        private MaterializerNestedEntry(ODataNestedResourceInfo nestedResourceInfo, List<IMaterializerState> nestedItems)
+        {
+            Debug.Assert(nestedResourceInfo != null, "nestedResourceInfo != null");
+            Debug.Assert(nestedItems != null, "nestedItems != null");
+
+            this.nestedResourceInfo = nestedResourceInfo;
+            this.nestedItems = nestedItems;
+        }
+
+        /// <summary>
+        /// Gets the nested resource info.
+        /// </summary>
+        public ODataNestedResourceInfo NestedResourceInfo
+        {
+            get { return this.nestedResourceInfo; }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IMaterializerState"/> items nested within the <see cref="ODataNestedResourceInfo"/>.
+        /// </summary>
+        public List<IMaterializerState> NestedItems
+        {
+            get { return this.nestedItems; }
+        }
+
+        /// <summary>
+        /// Adds an <see cref="IMaterializerState"/> item to the <see cref="ODataNestedResourceInfo"/>'s nested entries.
+        /// </summary>
+        /// <param name="nestedItem">The <see cref="IMaterializerState"/> entry to be added to the <see cref="ODataNestedResourceInfo"/>'s nested items.</param>
+        public void AddNestedItem(IMaterializerState nestedItem)
+        {
+            this.nestedItems.Add(nestedItem);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="MaterializerNestedEntry"/> for the nested resource info.
+        /// </summary>
+        /// <param name="nestedResourceInfo">The nested resource info instance.</param>
+        /// <param name="nestedItems">The items nested within the <see cref="ODataNestedResourceInfo"/>.</param>
+        /// <param name="materializerContext">The current materializer context.</param>
+        /// <returns>The <see cref="MaterializerNestedEntry"/> of the created <see cref="ODataNestedResourceInfo"/>.</returns>
+        public static MaterializerNestedEntry CreateNestedResourceInfo(ODataNestedResourceInfo nestedResourceInfo, List<IMaterializerState> nestedItems, IODataMaterializerContext materializerContext)
+        {
+            Debug.Assert(materializerContext.GetAnnotation<List<IMaterializerState>>(nestedResourceInfo) == null, "nestedResourceInfo state has already been created.");
+            
+            if (nestedItems == null)
+            {
+                nestedItems = new List<IMaterializerState>();
+            }
+            else
+            {
+                materializerContext.SetAnnotation<List<IMaterializerState>>(nestedResourceInfo, nestedItems);
+            }
+
+            return new MaterializerNestedEntry(nestedResourceInfo, nestedItems);
+        }
+    }
+}
+

--- a/src/Microsoft.OData.Client/Materialization/ODataEntriesEntityMaterializer.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataEntriesEntityMaterializer.cs
@@ -59,6 +59,14 @@ namespace Microsoft.OData.Client.Materialization
         }
 
         /// <summary>
+        /// OData delta resource set being materialized; possibly null.
+        /// </summary>
+        internal override ODataDeltaResourceSet CurrentDeltaFeed
+        {
+            get { return null; }
+        }
+
+        /// <summary>
         /// Entry being materialized; possibly null.
         /// </summary>
         internal override ODataResource CurrentEntry

--- a/src/Microsoft.OData.Client/Materialization/ODataMaterializer.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataMaterializer.cs
@@ -10,12 +10,11 @@ namespace Microsoft.OData.Client.Materialization
     using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using DSClient = Microsoft.OData.Client;
     using Microsoft.OData;
     using Microsoft.OData.Client;
     using Microsoft.OData.Edm;
-    using DSClient = Microsoft.OData.Client;
 
     /// <summary>
     /// Use this class to materialize objects provided from an <see cref="ODataMessageReader"/>.
@@ -77,6 +76,9 @@ namespace Microsoft.OData.Client.Materialization
 
         /// <summary>Feed being materialized; possibly null.</summary>
         internal abstract ODataResourceSet CurrentFeed { get; }
+
+        /// <summary>OData delta resource set being materialized; possibly null.</summary>
+        internal abstract ODataDeltaResourceSet CurrentDeltaFeed { get; }
 
         /// <summary>Entry being materialized; possibly null.</summary>
         internal abstract ODataResource CurrentEntry { get; }
@@ -350,6 +352,16 @@ namespace Microsoft.OData.Client.Materialization
         {
             ODataMessageReaderSettings settings = responseInfo.ReadHelper.CreateSettings();
 
+            // We use v401 to read delta payloads.
+            if (payloadKind == ODataPayloadKind.Delta)
+            {
+                settings.Version = ODataVersion.V401;
+                settings.ShouldIncludeAnnotation = (annotation) =>
+                {
+                    return true;
+                };
+            }
+            
             ODataMessageReader odataMessageReader = responseInfo.ReadHelper.CreateReader(responseMessage, settings);
 
             if (payloadKind == ODataPayloadKind.Unsupported)

--- a/src/Microsoft.OData.Client/Materialization/ODataMessageReaderMaterializer.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataMessageReaderMaterializer.cs
@@ -51,6 +51,14 @@ namespace Microsoft.OData.Client.Materialization
         }
 
         /// <summary>
+        /// Delta resource set being materialized; possibly null.
+        /// </summary>
+        internal sealed override ODataDeltaResourceSet CurrentDeltaFeed
+        {
+            get { return null; }
+        }
+
+        /// <summary>
         /// Entry being materialized; possibly null.
         /// </summary>
         internal sealed override ODataResource CurrentEntry

--- a/src/Microsoft.OData.Client/Materialization/ODataReaderWrapper.cs
+++ b/src/Microsoft.OData.Client/Materialization/ODataReaderWrapper.cs
@@ -82,6 +82,12 @@ namespace Microsoft.OData.Client.Materialization
                     case ODataReaderState.ResourceSetEnd:
                         this.responsePipeline.ExecuteOnFeedEndActions((ODataResourceSet)this.reader.Item);
                         break;
+                    case ODataReaderState.DeltaResourceSetStart:
+                        this.responsePipeline.ExecuteOnDeltaFeedStartActions((ODataDeltaResourceSet)this.reader.Item);
+                        break;
+                    case ODataReaderState.DeltaResourceSetEnd:
+                        this.responsePipeline.ExecuteOnDeltaFeedEndActions((ODataDeltaResourceSet)this.reader.Item);
+                        break;
                     case ODataReaderState.NestedResourceInfoStart:
                         this.responsePipeline.ExecuteOnNavigationStartActions((ODataNestedResourceInfo)this.reader.Item);
                         break;
@@ -108,6 +114,10 @@ namespace Microsoft.OData.Client.Materialization
             if (messageType == ODataPayloadKind.Resource)
             {
                 return new ODataReaderWrapper(messageReader.CreateODataResourceReader(entityType), responsePipeline);
+            }
+            else if (messageType == ODataPayloadKind.Delta)
+            {
+                return new ODataReaderWrapper(messageReader.CreateODataDeltaResourceSetReader(entityType), responsePipeline);
             }
 
             return new ODataReaderWrapper(messageReader.CreateODataResourceSetReader(entityType), responsePipeline);

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -166,6 +166,7 @@
     <PackageReference Include="System.ComponentModel" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Microsoft.OData.Client.tt">

--- a/src/Microsoft.OData.Client/OperationResponse.cs
+++ b/src/Microsoft.OData.Client/OperationResponse.cs
@@ -24,6 +24,9 @@ namespace Microsoft.OData.Client
         /// <summary>exception to throw during get results</summary>
         private Exception innerException;
 
+        /// <summary>The nested operation response for nested operations in a bulk update.</summary>
+        private List<OperationResponse> nestedResponses;
+
         /// <summary>
         /// constructor
         /// </summary>
@@ -68,6 +71,24 @@ namespace Microsoft.OData.Client
         internal HeaderCollection HeaderCollection
         {
             get { return this.headers; }
+        }
+
+        /// <summary>Nested operation responses for nested operations in bulk update.</summary>
+        internal List<OperationResponse> NestedResponses 
+        { 
+            get 
+            {
+                if (this.nestedResponses == null)
+                {
+                    this.nestedResponses = new List<OperationResponse>();
+                }
+
+                return this.nestedResponses; 
+            }
+            set 
+            { 
+                this.nestedResponses = value; 
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Client/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,2 +1,8 @@
+Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration.OnDeltaFeedEnded(System.Action<Microsoft.OData.Client.ReadingDeltaFeedArgs> action) -> Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration
+Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration.OnDeltaFeedStarted(System.Action<Microsoft.OData.Client.ReadingDeltaFeedArgs> action) -> Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration
+Microsoft.OData.Client.ReadingDeltaFeedArgs
+Microsoft.OData.Client.ReadingDeltaFeedArgs.DeltaFeed.get -> Microsoft.OData.ODataDeltaResourceSet
+Microsoft.OData.Client.ReadingDeltaFeedArgs.ReadingDeltaFeedArgs(Microsoft.OData.ODataDeltaResourceSet deltaFeed) -> void
 Microsoft.OData.Client.SaveChangesOptions.BulkUpdate = 128 -> Microsoft.OData.Client.SaveChangesOptions
 Microsoft.OData.Client.SendingRequest2EventArgs.IsBulkUpdate.get -> bool
+virtual Microsoft.OData.Client.DataServiceContext.BulkUpdate<T>(params T[] objects) -> Microsoft.OData.Client.DataServiceResponse

--- a/src/Microsoft.OData.Client/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,8 @@
+Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration.OnDeltaFeedEnded(System.Action<Microsoft.OData.Client.ReadingDeltaFeedArgs> action) -> Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration
+Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration.OnDeltaFeedStarted(System.Action<Microsoft.OData.Client.ReadingDeltaFeedArgs> action) -> Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration
+Microsoft.OData.Client.ReadingDeltaFeedArgs
+Microsoft.OData.Client.ReadingDeltaFeedArgs.DeltaFeed.get -> Microsoft.OData.ODataDeltaResourceSet
+Microsoft.OData.Client.ReadingDeltaFeedArgs.ReadingDeltaFeedArgs(Microsoft.OData.ODataDeltaResourceSet deltaFeed) -> void
 Microsoft.OData.Client.SaveChangesOptions.BulkUpdate = 128 -> Microsoft.OData.Client.SaveChangesOptions
 Microsoft.OData.Client.SendingRequest2EventArgs.IsBulkUpdate.get -> bool
+virtual Microsoft.OData.Client.DataServiceContext.BulkUpdate<T>(params T[] objects) -> Microsoft.OData.Client.DataServiceResponse

--- a/src/Microsoft.OData.Client/ReadingDeltaFeedArgs.cs
+++ b/src/Microsoft.OData.Client/ReadingDeltaFeedArgs.cs
@@ -1,0 +1,33 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ReadingDeltaFeedArgs.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+
+namespace Microsoft.OData.Client
+{
+    /// <summary>
+    /// The reading delta feed arguments
+    /// </summary>
+    public sealed class ReadingDeltaFeedArgs
+    {
+        /// <summary>
+        /// Creates an instance of the <see cref="ReadingDeltaFeedArgs"/>
+        /// </summary>
+        /// <param name="deltaFeed">The delta dfeed.</param>
+        public ReadingDeltaFeedArgs(ODataDeltaResourceSet deltaFeed)
+        {
+            Util.CheckArgumentNull(deltaFeed, "deltaFeed");
+            this.DeltaFeed = deltaFeed;
+        }
+
+        /// <summary>
+        /// Gets the delta feed.
+        /// </summary>
+        /// <value>
+        /// The delta feed.
+        /// </value>
+        public ODataDeltaResourceSet DeltaFeed { get; private set; }
+    }
+}

--- a/src/Microsoft.OData.Client/Util.cs
+++ b/src/Microsoft.OData.Client/Util.cs
@@ -86,6 +86,8 @@ namespace Microsoft.OData.Client
             {
                 case ODataProtocolVersion.V4:
                     return Util.ODataVersion4;
+                case ODataProtocolVersion.V401:
+                    return Util.ODataVersion401;
                 default:
                     Debug.Assert(false, "Unexpected max protocol version values.");
                     return Util.ODataVersion4;

--- a/src/Microsoft.OData.Client/XmlConstants.cs
+++ b/src/Microsoft.OData.Client/XmlConstants.cs
@@ -39,6 +39,9 @@ namespace Microsoft.OData.Service
         /// <summary>'OData-Version' - HTTP header name for OData version.</summary>
         internal const string HttpODataVersion = "OData-Version";
 
+        /// <summary>'4.0' - the version 4.0 text for a data service.'</summary>
+        internal const string ODataVersion401 = "4.01";
+
         /// <summary>'OData-MaxVersion' - HTTP header name for maximum understood OData version.</summary>
         internal const string HttpODataMaxVersion = "OData-MaxVersion";
 
@@ -333,6 +336,9 @@ namespace Microsoft.OData.Service
 
         /// <summary>the type of the containing object or targeted property if the type of the object or targeted property cannot be heuristically determined.</summary>
         internal const string ODataType = "@odata.type";
+
+        /// <summary>Instance annotation used to mark a failed modification operation within a bulk payload.</summary>
+        internal const string DataModificationException = "Core.DataModificationException";
 
         #endregion OData constants
 

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Microsoft.OData.Client.TDDUnitTests.csproj
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Microsoft.OData.Client.TDDUnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="DateTimePrimitiveTypeReference.cs" />
     <Compile Include="Tests\Annotation\AnnotationTargetingOperationTestsProxy.cs" />
     <Compile Include="Tests\Annotation\ClientAnnotationTests.cs" />
+    <Compile Include="Tests\BulkUpdateE2ETests.cs" />
     <Compile Include="Tests\BulkUpdateSaveResultTests.cs" />
     <Compile Include="Tests\DeleteLinkTests.cs" />
     <Compile Include="Tests\CustomizedHttpWebRequestMessage.cs" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/BulkUpdateE2ETests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/BulkUpdateE2ETests.cs
@@ -1,0 +1,942 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="BulkUpdateE2ETests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+using AstoriaUnitTests.Tests;
+using FluentAssertions;
+using Microsoft.OData.Client.Materialization;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Edm.Csdl;
+using Xunit;
+
+namespace Microsoft.OData.Client.TDDUnitTests.Tests
+{
+    /// <summary>
+    /// BulkUpdate E2E tests.
+    /// </summary>
+    public class BulkUpdateE2ETests
+    {
+        private const string Edmx = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+    <edmx:DataServices>
+        <Schema Namespace=""Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+            <EntityType Name=""Person"">
+                <Key>
+                    <PropertyRef Name=""ID""/>
+                </Key>
+                <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false""/>
+                <Property Name=""Name"" Type=""Edm.String""/>
+                <NavigationProperty Name=""Cars"" Type=""Collection(Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Car)""/>
+            </EntityType>
+            <EntityType Name=""Car"">
+                <Key>
+                    <PropertyRef Name=""ID""/>
+                </Key>
+                <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false""/>
+                <Property Name=""Name"" Type=""Edm.String"" Nullable=""false""/>
+                <NavigationProperty Name=""Owner"" Type=""Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person""/>
+                <NavigationProperty Name=""Owners"" Type=""Collection(Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person)""/>
+                <NavigationProperty Name=""Manufacturers"" Type=""Collection(Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Manufacturer)""/>
+            </EntityType>
+            <EntityType Name=""Manufacturer"">
+                <Key>
+                    <PropertyRef Name=""ID""/>
+                </Key>
+                <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false""/>
+                <Property Name=""Name"" Type=""Edm.String""/>
+                <NavigationProperty Name=""Countries"" Type=""Collection(Microsoft.OData.Client.TDDUnitTests.Tests.Country)""/>
+            </EntityType>
+            <EntityType Name=""Country"">
+                <Key>
+                    <PropertyRef Name=""ID""/>
+                </Key>
+                <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false""/>
+                <Property Name=""Name"" Type=""Edm.String""/>
+            </EntityType>
+        </Schema>
+        <Schema Namespace=""Default"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+            <EntityContainer Name=""Container"">
+                <EntitySet Name=""Persons"" EntityType=""Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person"">
+                    <NavigationPropertyBinding Path=""Cars"" Target=""Cars""/>
+                </EntitySet>
+                <EntitySet Name=""Cars"" EntityType=""Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Car"">
+                    <NavigationPropertyBinding Path=""Owners"" Target=""Persons""/>
+                    <NavigationPropertyBinding Path=""Manufacturers"" Target=""Manufacturers""/>
+                </EntitySet>
+                <EntitySet Name=""Manufacturers"" EntityType=""Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Manufacturer"">
+                    <NavigationPropertyBinding Path=""Countries"" Target=""Countries""/>                 
+                </EntitySet>
+                <EntitySet Name=""Countries"" EntityType=""Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Country""/>
+            </EntityContainer>
+        </Schema>
+    </edmx:DataServices></edmx:Edmx>";
+
+        private const string persons = @"{
+            ""@odata.context"":""http://localhost:8000/$metadata#Persons"",
+            ""value"":[
+                {""ID"":100,""Name"":""Bing"", ""Cars"":[{""ID"":1001,""Name"":""CarA"",""Manufacturers"":[{""ID"":101,""Name"":""ManufacturerA""}], ""Owners"":[{""ID"":1,""Name"":""OwnerA""}]}]},
+                {""ID"":200,""Name"":""Edge"", ""Cars"":[{""ID"":1002,""Name"":""CarB"",""Manufacturers"":[{""ID"":101,""Name"":""ManufacturerB""}], ""Owners"":[{""ID"":1,""Name"":""OwnerA""}]}]},
+                {""ID"":300,""Name"":""Teams"", ""Cars"":[{""ID"":1003,""Name"":""CarC"",""Manufacturers"":[{""ID"":101,""Name"":""ManufacturerC""}], ""Owners"":[{""ID"":1,""Name"":""OwnerA""}]}]}
+            ]}";
+
+        private const string cars = @"{
+            ""@odata.context"":""http://localhost:8000/$metadata#Cars"",
+            ""value"":[
+                {""ID"":1001,""Name"":""CarA"",""Manufacturers"":[{""ID"":101,""Name"":""ManufacturerA""}], ""Owners"":[{""ID"":1,""Name"":""OwnerA""}]},
+                {""ID"":1002,""Name"":""CarB"",""Manufacturers"":[{""ID"":101,""Name"":""ManufacturerB""}], ""Owners"":[{""ID"":1,""Name"":""OwnerA""}]},
+                {""ID"":1003,""Name"":""CarC"",""Manufacturers"":[{""ID"":101,""Name"":""ManufacturerC""}], ""Owners"":[{""ID"":1,""Name"":""OwnerA""}]}
+            ]}";
+
+        private readonly Container context;
+        private readonly RequestInfo requestInfo;
+        private readonly Serializer serializer;
+        private readonly HeaderCollection headers;
+        private Dictionary<Descriptor, List<LinkDescriptor>> linkDescriptors;
+
+        public BulkUpdateE2ETests()
+        {
+            this.context = new Container(new Uri("http://localhost:8000"));
+            this.requestInfo = new RequestInfo(context);
+            this.serializer = new Serializer(this.requestInfo);
+            this.headers = new HeaderCollection();
+            this.linkDescriptors = new Dictionary<Descriptor, List<LinkDescriptor>>();
+        }
+
+        [Fact]
+        public void CallingBulkUpdate_WithNullArguments_ShouldThrowAnException()
+        {
+            Assert.Throws<ArgumentException>(() => this.context.BulkUpdate<Person>(null));
+        }
+
+        [Fact]
+        public void CallingBulkUpdateRequest_WithNullArguments_ShouldThrowAnException()
+        {
+            var result = new BulkUpdateSaveResult(this.context, Util.SaveChangesMethodName, SaveChangesOptions.BulkUpdate, null, null);
+            Assert.Throws<ArgumentException>(() => result.BulkUpdateRequest<Person>(null));
+        }
+
+        [Fact]
+        public void BulkUpdateAnEntry_WithOneLevelOfNesting_ReturnsOne_OperationResponse()
+        {
+            var expectedResponse = "{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"ID\":100,\"Name\":\"Bing\",\"Cars@delta\":[{\"ID\":\"1001\",\"Name\":\"A\"}]}]}";
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                expectedResponse);
+
+            var person = new Person
+            {
+                ID = 100,
+                Name = "Bing",
+            };
+
+            var car = new Car 
+            { 
+                ID = 1001,
+                Name = "A"
+            };
+
+            this.context.AttachTo("Persons", person);
+
+            this.context.AddRelatedObject(person, "Cars", car);
+
+            DataServiceResponse response = this.context.BulkUpdate<Person>(person);
+ 
+            Assert.Single(response);
+            Assert.Single(response.Single().NestedResponses);
+
+            var changeOperationResponse = response.First() as ChangeOperationResponse;
+            EntityDescriptor entityDescriptor = changeOperationResponse.Descriptor as EntityDescriptor;
+            var returnedPerson = entityDescriptor.Entity as Person;
+            var nestedResponse = changeOperationResponse.NestedResponses[0] as ChangeOperationResponse;
+            EntityDescriptor carDescriptor = nestedResponse.Descriptor as EntityDescriptor;
+            var returnedCar = carDescriptor.Entity as Car;
+
+            Assert.Equal("Bing", returnedPerson.Name);
+            Assert.Equal(1001, returnedCar.ID);
+        }
+
+        [Fact]
+        public void HandleResponse_Of_AnInvalidResponse_ThrowsException()
+        {
+            var expectedResponse = "{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"ID\":100,\"Name\":\"Bing\",\"Cars@delta\":[{\"ID\":null,\"Name\":null}]}]}";
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                expectedResponse);
+
+            var person = new Person
+            {
+                ID = 100,
+                Name = "Bing",
+            };
+
+            var car = new Car
+            {
+                ID = 1001,
+                Name = "A"
+            };
+
+            this.context.AttachTo("Persons", person);
+
+            this.context.AddRelatedObject(person, "Cars", car);
+
+            Assert.Throws<DataServiceRequestException>(() => this.context.BulkUpdate<Person>(person));
+        }
+
+        [Fact]
+        public void BulkUpdateAnEntry_WithANestedDelete_DeserializesSuccessfully()
+        {
+            var expectedResponse = "{\"@context\":\"http://www.odata.org/service.svc/$metadata#Persons/$delta\",\"value\":[{\"ID\":100,\"Name\":\"Bing\",\"Cars@delta\":[{\"@removed\":{\"reason\":\"changed\"},\"@id\":\"http://www.odata.org/service.svc/Cars(1002)\"}]}]}";
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                expectedResponse);
+
+            var person = new Person
+            {
+                ID = 100,
+                Name = "Bing",
+            };
+
+            var car = new Car
+            {
+                ID = 1002,
+            };
+
+            this.context.AttachTo("Persons", person);
+            this.context.AttachTo("Cars", car);
+            this.context.DeleteLink(person, "Cars", car);
+
+            DataServiceResponse response = this.context.BulkUpdate<Person>(person);
+
+            Assert.Single(response);
+            Assert.Single(response.Single().NestedResponses);
+
+            var changeOperationResponse = response.First() as ChangeOperationResponse;
+            EntityDescriptor entityDescriptor = changeOperationResponse.Descriptor as EntityDescriptor;
+            var returnedPerson = entityDescriptor.Entity as Person;
+            var nestedResponse = changeOperationResponse.NestedResponses[0] as ChangeOperationResponse;
+            LinkDescriptor carDescriptor = nestedResponse.Descriptor as LinkDescriptor;
+            var returnedCar = carDescriptor.Target as Car;
+
+            Assert.Equal("Bing", returnedPerson.Name);
+            Assert.Equal(1002, returnedCar.ID);
+        }
+
+        [Fact]
+        public void BulkUpdateTwoTopLevelObjects_ReturnsTwo_OperationResponses()
+        {
+            var expectedResponse = "{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"ID\":100,\"Name\":\"Bing\"},{\"ID\":200,\"Name\":\"Edge\"}]}";
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                expectedResponse);
+
+            var person = new Person
+            {
+                ID = 100,
+                Name = "Bing",
+            };
+
+            var person2 = new Person
+            {
+                ID = 200,
+                Name = "Edge"
+            };
+
+            this.context.AttachTo("Persons", person);
+            this.context.AttachTo("Persons", person2);
+
+            DataServiceResponse response = this.context.BulkUpdate(person, person2);
+            var personOperationResponse = response.First() as ChangeOperationResponse;
+            var person1 = (personOperationResponse.Descriptor as EntityDescriptor).Entity as Person;
+
+            var person2OperationResponse = response.Last() as ChangeOperationResponse;
+            var person2Response = (person2OperationResponse.Descriptor as EntityDescriptor).Entity as Person;
+
+            Assert.Equal(2, response.Count());
+            Assert.Equal("Bing", person1.Name);
+            Assert.Equal("Edge", person2Response.Name);
+        }
+
+        [Fact]
+        public void BulkUpdateTwoTopLevelObjects_WithTheSameNestedObject_DeserializesSuccessfully()
+        {
+            var expectedResponse = "{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"ID\":100,\"Name\":\"Bing\",\"Cars@delta\":[{\"@id\":\"http://localhost:8000/Cars(1001)\"}]},{\"ID\":200,\"Name\":\"Edge\",\"Cars@delta\":[{\"@id\":\"http://localhost:8000/Cars(1001)\"}]}]}";
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                expectedResponse);
+
+            var person = new Person
+            {
+                ID = 100,
+                Name = "Bing",
+            };
+
+            var person2 = new Person
+            {
+                ID = 200,
+                Name = "Edge"
+            };
+
+            var car = new Car
+            {
+                ID = 1002,
+                Name = "CarA"
+            };
+
+            this.context.AttachTo("Persons", person);
+            this.context.AttachTo("Persons", person2);
+            this.context.AttachTo("Cars", car);
+
+            this.context.AddLink(person, "Cars", car);
+            this.context.AddLink(person2, "Cars", car);
+
+            DataServiceResponse response = this.context.BulkUpdate(person, person2);
+            var personOperationResponse = response.First() as ChangeOperationResponse;
+            var person1 = (personOperationResponse.Descriptor as EntityDescriptor).Entity as Person;
+            var personcarOperationResponse = personOperationResponse.NestedResponses.FirstOrDefault() as ChangeOperationResponse;
+            var carTargetEntity = (personcarOperationResponse.Descriptor as LinkDescriptor).Target as Car;  
+            var person2OperationResponse = response.Last() as ChangeOperationResponse;
+            var person2Response = (person2OperationResponse.Descriptor as EntityDescriptor).Entity as Person;
+            var person2carOperationResponse = personOperationResponse.NestedResponses.FirstOrDefault() as ChangeOperationResponse;
+            var car2TargetEntity = (person2carOperationResponse.Descriptor as LinkDescriptor).Target as Car;
+
+            Assert.Equal(2, response.Count());
+            Assert.Equal("Bing", person1.Name);
+            Assert.Equal("Edge", person2Response.Name);
+            Assert.Equal(carTargetEntity, car2TargetEntity);
+        }
+
+        [Fact]
+        public void TwoTopLevelObjects_WithNestedProperties_UpdatedSuccessfully()
+        {
+            var expectedResponse = "{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"ID\":100,\"Name\":\"Bing\",\"Cars@delta\":[{\"@id\":\"http://localhost:8000/Cars(1001)\"}]},{\"ID\":200,\"Name\":\"Edge\",\"Cars@delta\":[{\"@id\":\"http://www.odata.org/service.svc/Cars(1002)\"}, {\"@id\":\"http://www.odata.org/service.svc/Cars(1003)\"}]}]}";
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                expectedResponse);
+
+            var person = new Person
+            {
+                ID = 100,
+                Name = "Bing",
+            };
+
+            var person2 = new Person
+            {
+                ID = 200,
+                Name = "Edge"
+            };
+
+            var car1 = new Car { ID = 1001 };
+            var car2 = new Car { ID = 1002 };
+            var car3 = new Car { ID = 1003 };
+
+            this.context.AttachTo("Persons", person);
+            this.context.AttachTo("Persons", person2);
+            this.context.AttachTo("Cars", car1);
+            this.context.AttachTo("Cars", car2);
+            this.context.AttachTo("Cars", car3);
+
+            this.context.AddLink(person, "Cars", car1);
+            this.context.AddLink(person2, "Cars", car2);
+            this.context.AddLink(person2, "Cars", car3);
+
+            DataServiceResponse response = this.context.BulkUpdate(person, person2);
+
+            Assert.Equal(2, response.Count());
+
+            var personOperationResponse = response.FirstOrDefault() as ChangeOperationResponse;
+            var person2OperationResponse = response.LastOrDefault() as ChangeOperationResponse;
+
+            Assert.Single(personOperationResponse.NestedResponses);
+            Assert.Equal(2, person2OperationResponse.NestedResponses.Count);
+        }
+
+        [Fact]
+        public void DeepUpdateAnElement_WithThreeLevelsOfNesting_UpdatesSuccessfully()
+        {
+            var expectedResponse = "{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"ID\":100,\"Name\":\"Bing\",\"Cars@delta\":[{\"ID\":1001,\"Name\":\"CarA\",\"Manufacturers@delta\":[{\"ID\":101,\"Name\":\"ManufactureA\"}]}]}]}";
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                expectedResponse);
+
+            var person = new Person
+            {
+                ID = 100,
+                Name = "Bing",
+            };
+
+            var car = new Car { ID = 1001, Name ="CarA" };
+            var manufacturer = new Manufacturer { ID = 101, Name = "ManufactureA" };
+
+            this.context.AttachTo("Persons", person);
+
+            this.context.AddRelatedObject(person, "Cars", car);
+            this.context.AddRelatedObject(car, "Manufacturers", manufacturer);
+
+            DataServiceResponse response = this.context.BulkUpdate(person);
+
+            Assert.Single(response);
+
+            var personOperationResponse = response.FirstOrDefault() as ChangeOperationResponse;
+            var person2OperationResponse = response.LastOrDefault() as ChangeOperationResponse;
+            var carOperationResponse = personOperationResponse.NestedResponses.FirstOrDefault() as ChangeOperationResponse;
+            var manufacturerOperationResponse = carOperationResponse.NestedResponses.FirstOrDefault() as ChangeOperationResponse;
+            var manufacturerDescriptor = manufacturerOperationResponse.Descriptor as EntityDescriptor;
+            var manufacturerEntity = manufacturerDescriptor.Entity as Manufacturer;
+
+            Assert.Single(personOperationResponse.NestedResponses);
+            Assert.Single(person2OperationResponse.NestedResponses);
+            Assert.Equal("ManufactureA", manufacturerEntity.Name);
+        }
+
+        [Fact]
+        public void DescriptorForAFailedCreateOperation_NotUpdated()
+        {
+            var expectedResponse = "{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"@removed\": {\"reason\": \"changed\"},\"@id\": \"http://localhost:8000/Persons(100)\",\"@Core.DataModificationException\": {\"@type\": \"#Org.OData.Core.V1.DataModificationExceptionType\"},\"Id\": 100,\"Name\": \"Bing\"}]}";
+            
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                expectedResponse);
+
+            var person = new Person
+            {
+                ID = 100,
+                Name = "Bing",
+            };
+
+            this.context.AttachTo("Persons", person);
+
+            DataServiceResponse response = this.context.BulkUpdate(person);
+
+            var personChangeOperationResponse = response.FirstOrDefault() as ChangeOperationResponse;
+
+            Assert.Equal(EntityStates.Unchanged, personChangeOperationResponse.Descriptor.SaveResultWasProcessed);
+        }
+
+        [Fact]
+        public void DescriptorsWithNullEntitySetName_ShouldBeSerializedSuccessfully()
+        {
+            BulkUpdateGraph bulkUpdateGraph = null;
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                persons);
+
+            var person = this.context.Persons.FirstOrDefault();
+
+            var personEntityDescriptor = this.context.GetEntityDescriptor(person);
+
+            Assert.Null(personEntityDescriptor.EntitySetName);
+
+            bulkUpdateGraph = this.GetBulkUpdateGraph(person);
+
+            var requestMessageArgs = new BuildingRequestEventArgs("PATCH", new Uri("http://www.odata.org/service.svc/$metadata#Persons/$delta"), this.headers, bulkUpdateGraph.TopLevelDescriptors[0], HttpStack.Auto);
+            var odataRequestMessageWrapper = ODataRequestMessageWrapper.CreateRequestMessageWrapper(requestMessageArgs, this.requestInfo);
+
+            using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, isParameterPayload:false))
+            {
+                ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, bulkUpdateGraph.EntitySetName, requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
+                serializer.WriteDeltaResourceSet(bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, bulkUpdateGraph, entryWriter);
+            }
+
+            MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
+            stream.Position = 0;
+
+            string payload = (new StreamReader(stream)).ReadToEnd();
+            payload.Should().Be("{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"@type\":\"#Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person\",\"ID\":100,\"Name\":\"Bing\"}]}");
+        }
+
+        [Fact]
+        public void DeepUpdate_WithOneLevelOfNesting_ShouldBeSerializedSuccessfully()
+        {
+            BulkUpdateGraph bulkUpdateGraph = null;
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                persons);
+
+            var person = this.context.Persons.FirstOrDefault();
+            var car = person.Cars[0];
+
+            car.Name = "UpdatedCar";
+
+            this.context.UpdateObject(car);
+
+            bulkUpdateGraph = this.GetBulkUpdateGraph(person);
+
+            var requestMessageArgs = new BuildingRequestEventArgs("PATCH", new Uri("http://www.odata.org/service.svc/$metadata#Persons/$delta"), this.headers, bulkUpdateGraph.TopLevelDescriptors[0], HttpStack.Auto);
+            var odataRequestMessageWrapper = ODataRequestMessageWrapper.CreateRequestMessageWrapper(requestMessageArgs, this.requestInfo);
+
+            using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, isParameterPayload: false))
+            {
+                ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, bulkUpdateGraph.EntitySetName, requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
+                serializer.WriteDeltaResourceSet(bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, bulkUpdateGraph, entryWriter);
+            }
+
+            MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
+            stream.Position = 0;
+
+            string payload = (new StreamReader(stream)).ReadToEnd();
+            payload.Should().Be("{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"@type\":\"#Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person\",\"ID\":100,\"Name\":\"Bing\",\"Cars@delta\":[{\"@type\":\"#Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Car\",\"ID\":1001,\"Name\":\"UpdatedCar\"}]}]}");
+        }
+
+        [Fact]
+        public void DeepUpdate_WithTwoLevelsOfNesting_ShouldBeSerializedSuccessfully()
+        {
+            BulkUpdateGraph bulkUpdateGraph = null;
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                persons);
+
+            var person = this.context.Persons.FirstOrDefault();
+            var car = person.Cars[0];
+
+            car.Name = "UpdatedCar";
+
+            this.context.UpdateObject(car);
+
+            var manufacturer = car.Manufacturers[0];
+            manufacturer.Name = "UpdatedManufacturer";
+
+            this.context.UpdateObject(manufacturer);
+
+            bulkUpdateGraph = this.GetBulkUpdateGraph(person);
+
+            var requestMessageArgs = new BuildingRequestEventArgs("PATCH", new Uri("http://www.odata.org/service.svc/$metadata#Persons/$delta"), this.headers, bulkUpdateGraph.TopLevelDescriptors[0], HttpStack.Auto);
+            var odataRequestMessageWrapper = ODataRequestMessageWrapper.CreateRequestMessageWrapper(requestMessageArgs, this.requestInfo);
+
+            using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, isParameterPayload: false))
+            {
+                ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, bulkUpdateGraph.EntitySetName, requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
+                serializer.WriteDeltaResourceSet(bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, bulkUpdateGraph, entryWriter);
+            }
+
+            MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
+            stream.Position = 0;
+
+            string payload = (new StreamReader(stream)).ReadToEnd();
+            payload.Should().Be("{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"@type\":\"#Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person\",\"ID\":100,\"Name\":\"Bing\",\"Cars@delta\":[{\"@type\":\"#Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Car\",\"ID\":1001,\"Name\":\"UpdatedCar\",\"Manufacturers@delta\":[{\"@type\":\"#Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Manufacturer\",\"ID\":101,\"Name\":\"UpdatedManufacturer\"}]}]}]}");
+        }
+
+        [Fact]
+        public void DeepUpdateAnEntry_WithTwoNestedProperties_ShouldBeSerializedSuccessfully()
+        {
+            BulkUpdateGraph bulkUpdateGraph = null;
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                cars);
+
+            var car = this.context.Cars.FirstOrDefault();
+            var manufacturer = car.Manufacturers[0];
+
+            manufacturer.Name = "UpdatedManufacturer";
+
+            this.context.UpdateObject(manufacturer);
+
+            var owner = car.Owners[0];
+            owner.Name = "UpdatedOwner";
+
+            this.context.UpdateObject(owner);
+
+            bulkUpdateGraph = this.GetBulkUpdateGraph(car);
+
+            var requestMessageArgs = new BuildingRequestEventArgs("PATCH", new Uri("http://www.odata.org/service.svc/$metadata#Persons/$delta"), this.headers, bulkUpdateGraph.TopLevelDescriptors[0], HttpStack.Auto);
+            var odataRequestMessageWrapper = ODataRequestMessageWrapper.CreateRequestMessageWrapper(requestMessageArgs, this.requestInfo);
+
+            using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, isParameterPayload: false))
+            {
+                ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, bulkUpdateGraph.EntitySetName, requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
+                serializer.WriteDeltaResourceSet(bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, bulkUpdateGraph, entryWriter);
+            }
+
+            MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
+            stream.Position = 0;
+
+            string payload = (new StreamReader(stream)).ReadToEnd();
+            payload.Should().Be("{\"@context\":\"http://localhost:8000/$metadata#Cars/$delta\",\"value\":[{\"@type\":\"#Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Car\",\"ID\":1001,\"Name\":\"CarA\",\"Manufacturers@delta\":[{\"@type\":\"#Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Manufacturer\",\"ID\":101,\"Name\":\"UpdatedManufacturer\"}],\"Owners@delta\":[{\"@type\":\"#Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person\",\"ID\":1,\"Name\":\"UpdatedOwner\"}]}]}");
+        }
+
+        [Fact]
+        public void UpdatedDescriptors_ShouldBeDerializedSuccessfully()
+        {
+            var expectedResponse = "{\"@context\":\"http://localhost:8000/$metadata#Persons/$delta\",\"value\":[{\"ID\":100,\"Name\":\"UpdatedName\"}]}";
+            
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                expectedResponse);
+
+            var person = new Person
+            {
+                ID = 100,
+                Name = "Bing"
+            };
+
+            this.context.AttachTo("Persons", person);
+
+            //update person name
+            person.Name = "UpdatedName";
+
+            this.context.UpdateObject(person);
+
+            // bulk update the changes
+            DataServiceResponse response = this.context.BulkUpdate(person);
+
+            var trackedEntity = this.context.Entities.First().Entity as Person;
+
+            Assert.Equal("UpdatedName", trackedEntity.Name);
+
+            var personChangeOperationResponse = response.FirstOrDefault() as ChangeOperationResponse;
+            var personDescriptor = personChangeOperationResponse.Descriptor as EntityDescriptor;
+            var personObj = personDescriptor.Entity as Person;
+
+            Assert.Equal(EntityStates.Modified, personChangeOperationResponse.Descriptor.SaveResultWasProcessed);
+            Assert.Equal("UpdatedName", personObj.Name);
+        }
+
+        [Fact]
+        public void CreateForDeltaFeed_WithNulEntitySetName_ShouldThrowException()
+        {
+            BulkUpdateGraph bulkUpdateGraph = null;
+
+            SetupContextWithRequestPipelineForSaving(
+                this.context,
+                persons);
+
+            var person = this.context.Persons.Execute().FirstOrDefault();
+
+            var personEntityDescriptor = this.context.GetEntityDescriptor(person);
+
+            Assert.Null(personEntityDescriptor.EntitySetName);
+
+            bulkUpdateGraph = this.GetBulkUpdateGraph(person);
+
+            var requestMessageArgs = new BuildingRequestEventArgs("PATCH", new Uri("http://www.odata.org/service.svc/$metadata#Persons/$delta"), this.headers, bulkUpdateGraph.TopLevelDescriptors[0], HttpStack.Auto);
+            var odataRequestMessageWrapper = ODataRequestMessageWrapper.CreateRequestMessageWrapper(requestMessageArgs, this.requestInfo);
+
+            using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, isParameterPayload: false))
+            {
+                Assert.Throws<ArgumentNullException>(() => ODataWriterWrapper.CreateForDeltaFeed(messageWriter, null, requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo));
+            }
+        }
+
+        [Fact]
+        public void MaterializerFeed_CreateDeltaFeed_CreatesAMaterializerDeltaFeed()
+        {
+            ODataDeltaResourceSet deltaFeed = new ODataDeltaResourceSet()
+            {
+                TypeName = "Collection(Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person)",
+                SerializationInfo = new ODataResourceSerializationInfo
+                {
+                    NavigationSourceName = "Persons",
+                    ExpectedTypeName = "Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person",
+                    NavigationSourceEntityTypeName = "Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person",
+                    NavigationSourceKind = EdmNavigationSourceKind.EntitySet
+                }
+            };
+
+            var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
+            var materializerContext = new TestMaterializerContext() { Model = clientEdmModel, Context = this.context };
+            
+            List<IMaterializerState> entries = new List<IMaterializerState>();
+            ODataResource entry = new ODataResource
+            {
+                Id = new Uri("http://localhost:8000/Persons(100)"),
+                Properties = new List<ODataProperty>()
+                    {
+                        new ODataProperty{ Name = "ID", Value = "100"},
+                        new ODataProperty { Name = "Name", Value = "Bing"}
+                    }
+            };
+
+            MaterializerEntry materializerEntry = MaterializerEntry.CreateEntry(entry, ODataFormat.Json, true, clientEdmModel, materializerContext);
+            entries.Add(materializerEntry);
+
+            MaterializerDeltaFeed materializerFeed = MaterializerDeltaFeed.CreateDeltaFeed(deltaFeed, entries, materializerContext);
+            Assert.IsType<ODataDeltaResourceSet>(materializerFeed.DeltaFeed);
+            Assert.Single(materializerFeed.Entries);       
+        }
+
+        [Fact]
+        public void CreateDeltaFeed_WithNullEntries_DoesNotThrowException()
+        {
+            ODataDeltaResourceSet deltaFeed = new ODataDeltaResourceSet()
+            {
+                TypeName = "Collection(Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person)",
+                SerializationInfo = new ODataResourceSerializationInfo
+                {
+                    NavigationSourceName = "Persons",
+                    ExpectedTypeName = "Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person",
+                    NavigationSourceEntityTypeName = "Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person",
+                    NavigationSourceKind = EdmNavigationSourceKind.EntitySet
+                }
+            };
+
+            var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
+            var materializerContext = new TestMaterializerContext() { Model = clientEdmModel, Context = this.context };
+            MaterializerDeltaFeed materializerFeed = MaterializerDeltaFeed.CreateDeltaFeed(deltaFeed, null, materializerContext);
+            
+            Assert.IsType<ODataDeltaResourceSet>(materializerFeed.DeltaFeed);
+            Assert.Empty(materializerFeed.Entries);
+        }
+
+        [Fact]
+        public void MaterializerNestedEntry_CreateNestedResourceInfo_CreatesAMaterializerNestedEntry()
+        {
+            var nestedResourceInfo = new ODataNestedResourceInfo 
+            {
+                Name = "Persons", 
+                IsCollection = true, 
+                Url = new Uri("Person", UriKind.Relative) 
+            };
+
+            var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
+            var materializerContext = new TestMaterializerContext() { Model = clientEdmModel, Context = this.context };
+
+            List<IMaterializerState> entries = new List<IMaterializerState>();
+            ODataResource entry = new ODataResource
+            {
+                Id = new Uri("http://localhost:8000/Persons(100)"),
+                Properties = new List<ODataProperty>()
+                    {
+                        new ODataProperty{ Name = "ID", Value = "100"},
+                        new ODataProperty { Name = "Name", Value = "Bing"}
+                    }
+            };
+
+            MaterializerEntry materializerEntry = MaterializerEntry.CreateEntry(entry, ODataFormat.Json, true, clientEdmModel, materializerContext);
+            entries.Add(materializerEntry);
+
+            MaterializerNestedEntry nestedEntry = MaterializerNestedEntry.CreateNestedResourceInfo(nestedResourceInfo, entries, materializerContext);
+            Assert.IsType<ODataNestedResourceInfo>(nestedEntry.NestedResourceInfo);
+            Assert.Single(nestedEntry.NestedItems);
+        }
+
+        [Fact]
+        public void MaterializerNestedEntry_WithNullEntries_DoesNotThrowException()
+        {
+            var nestedResourceInfo = new ODataNestedResourceInfo
+            {
+                Name = "Persons",
+                IsCollection = true,
+                Url = new Uri("Person", UriKind.Relative)
+            };
+
+            var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
+            var materializerContext = new TestMaterializerContext() { Model = clientEdmModel, Context = this.context };
+            
+            MaterializerNestedEntry nestedEntry = MaterializerNestedEntry.CreateNestedResourceInfo(nestedResourceInfo, null, materializerContext);
+
+            Assert.IsType<ODataNestedResourceInfo>(nestedEntry.NestedResourceInfo);
+            Assert.Empty(nestedEntry.NestedItems);
+        }
+
+        [Fact]
+        public void MaterializerDeletedEntry_CreateDeletedEntry_CreatesAMaterializerDeletedEntry()
+        {
+            var deletedEntry = new ODataDeletedResource
+                (new Uri("Person", UriKind.Relative), DeltaDeletedEntryReason.Changed)
+            {
+                SerializationInfo = new ODataResourceSerializationInfo
+                {
+                    NavigationSourceEntityTypeName = "Collection(Microsoft.OData.Client.TDDUnitTests.Tests.BulkUpdateE2ETests.Person)",
+                    NavigationSourceKind = EdmNavigationSourceKind.EntitySet,
+                    NavigationSourceName = "Persons"
+                },
+            };
+
+            var clientEdmModel = new ClientEdmModel(ODataProtocolVersion.V4);
+            var materializerContext = new TestMaterializerContext() { Model = clientEdmModel, Context = this.context };
+
+
+            MaterializerDeletedEntry materializerDeletedEntry = MaterializerDeletedEntry.CreateDeletedEntry(deletedEntry, materializerContext);
+            Assert.IsType<ODataDeletedResource>(materializerDeletedEntry.DeletedResource);
+        }
+
+        private void SetupContextWithRequestPipelineForSaving(DataServiceContext dataServiceContext, string response)
+        {
+            dataServiceContext.Configurations.RequestPipeline.OnMessageCreating =
+                    (args) => new CustomizedRequestMessage(
+                        args,
+                        response,
+                        new Dictionary<string, string>()
+                        {
+                            {"Content-Type", "application/json;charset=utf-8"},
+                        });
+        }
+
+        private BulkUpdateGraph GetBulkUpdateGraph<T>(params T[] objects)
+        {
+            BulkUpdateGraph bulkUpdateGraph = new BulkUpdateGraph(this.requestInfo);
+            
+            List<Descriptor> changedEntries = this.context.EntityTracker.Entities.Cast<Descriptor>()
+                                  .Union(context.EntityTracker.Links.Cast<Descriptor>())
+                                  .Union(context.EntityTracker.Entities.SelectMany(e => e.StreamDescriptors).Cast<Descriptor>())
+                                  .Where(o => o.IsModified && o.ChangeOrder != UInt32.MaxValue)
+                                  .OrderBy(o => o.ChangeOrder)
+                                  .ToList();
+
+            var result = new BulkUpdateSaveResult(this.context, Util.SaveChangesMethodName, SaveChangesOptions.BulkUpdate, null, null);
+            result.BuildDescriptorGraph(changedEntries, true, objects);
+            
+            bulkUpdateGraph = result.BulkUpdateGraph;
+            this.linkDescriptors = result.LinkDescriptors;
+
+            return bulkUpdateGraph;
+        }
+
+        public class CustomizedRequestMessage : HttpClientRequestMessage
+        {
+            public string Response { get; set; }
+
+            public Dictionary<string, string> CustomizedHeaders { get; set; }
+
+            public CustomizedRequestMessage(DataServiceClientRequestMessageArgs args, string response, Dictionary<string, string> headers)
+                : base(args)
+            {
+                this.Response = response;
+                this.CustomizedHeaders = headers;
+            }
+
+            public override Stream GetStream()
+            {
+                byte[] byteArray = Encoding.UTF8.GetBytes(Response);
+                return new MemoryStream(byteArray);
+            }
+
+            public override IAsyncResult BeginGetRequestStream(AsyncCallback callback, object state)
+            {
+                return GetCompletedTask(callback, state);
+            }
+
+            private static IAsyncResult GetCompletedTask(AsyncCallback callback, object state)
+            {
+                var tcs = new TaskCompletionSource<bool>(state);
+                tcs.TrySetResult(true);
+                callback(tcs.Task);
+                return tcs.Task;
+            }
+
+            public override Stream EndGetRequestStream(IAsyncResult asyncResult)
+            {
+                return GetStream();
+            }
+
+            public override IODataResponseMessage GetResponse()
+            {
+                return new HttpWebResponseMessage(
+                    this.CustomizedHeaders,
+                    200,
+                    () =>
+                    {
+                        byte[] byteArray = Encoding.UTF8.GetBytes(this.Response);
+                        return new MemoryStream(byteArray);
+                    });
+            }
+
+            public override IAsyncResult BeginGetResponse(AsyncCallback callback, object state)
+            {
+                return GetCompletedTask(callback, state);
+            }
+
+            public override IODataResponseMessage EndGetResponse(IAsyncResult asyncResult)
+            {
+                return GetResponse();
+            }
+        }
+
+        public class Container : DataServiceContext
+        {
+            public Container(global::System.Uri serviceRoot) :
+                base(serviceRoot, ODataProtocolVersion.V4)
+            {
+                this.Format.LoadServiceModel = () => CsdlReader.Parse(XmlReader.Create(new StringReader(Edmx)));
+                this.Format.UseJson();
+                this.Persons = base.CreateQuery<Person>("Persons");
+                this.Cars = base.CreateQuery<Car>("Cars");
+                this.Manufacturers = base.CreateQuery<Manufacturer>("Manufacturers");
+                this.Countries = base.CreateQuery<Country>("Countries");
+            }
+            public DataServiceQuery<Person> Persons { get; private set; }
+            public DataServiceQuery<Car> Cars { get; private set; }
+            public DataServiceQuery<Manufacturer> Manufacturers { get; private set; }
+            public DataServiceQuery<Country> Countries { get; private set; }
+        }
+
+        public class Car
+        {
+            public int ID { get; set; }
+            public string Name { get; set; }
+            public Person Owner { get; set; }
+            public List<Person> Owners { get; set; }
+            public List<Manufacturer> Manufacturers { get; set; }
+        }
+
+        public class Manufacturer
+        {
+            public int ID { get; set; }
+            public string Name { get; set; }
+            public List<Country> Countries { get; set; }
+        }
+
+        public class Country
+        {
+            public int ID { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class Person : INotifyPropertyChanged
+        {
+            private string _name;
+            public Person()
+            {
+                this.Cars = new List<Car>();
+            }
+
+            public int ID { get; set; }
+            public string Name
+            {
+                get
+                {
+                    return _name;
+                }
+
+                set
+                {
+                    if (value != _name)
+                    {
+                        _name = value;
+                        OnPropertyChanged("Name");
+                    }
+                }
+            }
+            public List<Car> Cars { get; set; }
+
+            public event PropertyChangedEventHandler PropertyChanged;
+
+            protected virtual void OnPropertyChanged(string property)
+            {
+                if ((this.PropertyChanged != null))
+                {
+                    this.PropertyChanged(this, new PropertyChangedEventArgs(property));
+                }
+            }
+        }
+    }
+}

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/BulkUpdateSaveResultTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/BulkUpdateSaveResultTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
         private readonly Serializer serializer;
         private readonly HeaderCollection headers;
         private BulkUpdateGraph bulkUpdateGraph;
+        private readonly Dictionary<Descriptor, List<LinkDescriptor>> linkDescriptors;
 
         public BulkUpdateSaveResultTests()
         {
@@ -32,6 +33,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             this.serializer = new Serializer(this.requestInfo);
             this.headers = new HeaderCollection();
             bulkUpdateGraph = new BulkUpdateGraph(this.requestInfo);
+            this.linkDescriptors = new Dictionary<Descriptor, List<LinkDescriptor>>();
         }
 
         [Fact]
@@ -60,7 +62,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Persons", requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
@@ -95,7 +97,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Persons", this.requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
@@ -131,7 +133,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Persons", this.requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, this.bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
@@ -164,7 +166,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Persons", this.requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, this.bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
@@ -205,7 +207,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Persons", this.requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, this.bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
@@ -240,7 +242,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Persons", this.requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, this.bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
@@ -282,7 +284,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Persons", this.requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, this.bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
@@ -319,7 +321,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Cars", this.requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, this.bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
@@ -362,7 +364,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Cars", this.requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, this.bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);
@@ -461,7 +463,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
             using (ODataMessageWriter messageWriter = Serializer.CreateDeltaMessageWriter(odataRequestMessageWrapper, this.requestInfo, false /*isParameterPayload*/))
             {
                 ODataWriterWrapper entryWriter = ODataWriterWrapper.CreateForDeltaFeed(messageWriter, "Cars", this.requestInfo.Configurations.RequestPipeline, odataRequestMessageWrapper, this.requestInfo);
-                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.bulkUpdateGraph, entryWriter);
+                serializer.WriteDeltaResourceSet(this.bulkUpdateGraph.TopLevelDescriptors, this.linkDescriptors, this.bulkUpdateGraph, entryWriter);
             }
 
             MemoryStream stream = (MemoryStream)(odataRequestMessageWrapper.CachedRequestStream.Stream);

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/ODataReaderWrapperWithEventsUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/Materialization/ODataReaderWrapperWithEventsUnitTests.cs
@@ -61,6 +61,28 @@ namespace AstoriaUnitTests.Tests
         }
 
         [Fact]
+        public void ShouldRaiseDeltaFeedStart()
+        {
+            this.TestConfigureAction<ODataDeltaResourceSet>((config) =>
+            {
+                config.OnDeltaFeedStarted((ReadingDeltaFeedArgs args) => args.DeltaFeed.Id = new Uri("urn:foo"));
+                return ODataReaderState.DeltaResourceSetStart;
+            },
+            (feed) => feed.Id.Should().Be(new Uri("urn:foo")));
+        }
+
+        [Fact]
+        public void ShouldRaiseDeltaFeedEnd()
+        {
+            this.TestConfigureAction<ODataDeltaResourceSet>((config) =>
+            {
+                config.OnDeltaFeedEnded((ReadingDeltaFeedArgs args) => args.DeltaFeed.Id = new Uri("urn:foo"));
+                return ODataReaderState.DeltaResourceSetEnd;
+            },
+            (feed) => feed.Id.Should().Be(new Uri("urn:foo")));
+        }
+
+        [Fact]
         public void ShouldRaiseNestedResourceInfoStart()
         {
             this.TestConfigureAction<ODataNestedResourceInfo>((config) =>

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -8127,6 +8127,8 @@ public class Microsoft.OData.Client.DataServiceClientRequestPipelineConfiguratio
 }
 
 public class Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration {
+    public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnDeltaFeedEnded (System.Action`1[[Microsoft.OData.Client.ReadingDeltaFeedArgs]] action)
+    public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnDeltaFeedStarted (System.Action`1[[Microsoft.OData.Client.ReadingDeltaFeedArgs]] action)
     public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnEntityMaterialized (System.Action`1[[Microsoft.OData.Client.MaterializedEntityArgs]] action)
     public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnEntryEnded (System.Action`1[[Microsoft.OData.Client.ReadingEntryArgs]] action)
     public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnEntryStarted (System.Action`1[[Microsoft.OData.Client.ReadingEntryArgs]] action)
@@ -8222,7 +8224,7 @@ public class Microsoft.OData.Client.DataServiceContext {
     public virtual System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.Uri nextLinkUri, System.AsyncCallback callback, object state)
     public virtual System.IAsyncResult BeginSaveChanges (System.AsyncCallback callback, object state)
     public virtual System.IAsyncResult BeginSaveChanges (Microsoft.OData.Client.SaveChangesOptions options, System.AsyncCallback callback, object state)
-    internal virtual void BulkUpdate (T[] objects)
+    public virtual Microsoft.OData.Client.DataServiceResponse BulkUpdate (T[] objects)
     public virtual void CancelRequest (System.IAsyncResult asyncResult)
     public virtual void ChangeState (object entity, Microsoft.OData.Client.EntityStates state)
     public virtual DataServiceQuery`1 CreateFunctionQuery ()
@@ -8862,6 +8864,12 @@ public sealed class Microsoft.OData.Client.QueryOperationResponse`1 : Microsoft.
 
     public DataServiceQueryContinuation`1 GetContinuation ()
     public virtual IEnumerator`1 GetEnumerator ()
+}
+
+public sealed class Microsoft.OData.Client.ReadingDeltaFeedArgs {
+    public ReadingDeltaFeedArgs (Microsoft.OData.ODataDeltaResourceSet deltaFeed)
+
+    Microsoft.OData.ODataDeltaResourceSet DeltaFeed  { public get; }
 }
 
 public sealed class Microsoft.OData.Client.ReadingEntryArgs {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -8127,6 +8127,8 @@ public class Microsoft.OData.Client.DataServiceClientRequestPipelineConfiguratio
 }
 
 public class Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration {
+    public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnDeltaFeedEnded (System.Action`1[[Microsoft.OData.Client.ReadingDeltaFeedArgs]] action)
+    public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnDeltaFeedStarted (System.Action`1[[Microsoft.OData.Client.ReadingDeltaFeedArgs]] action)
     public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnEntityMaterialized (System.Action`1[[Microsoft.OData.Client.MaterializedEntityArgs]] action)
     public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnEntryEnded (System.Action`1[[Microsoft.OData.Client.ReadingEntryArgs]] action)
     public Microsoft.OData.Client.DataServiceClientResponsePipelineConfiguration OnEntryStarted (System.Action`1[[Microsoft.OData.Client.ReadingEntryArgs]] action)
@@ -8222,7 +8224,7 @@ public class Microsoft.OData.Client.DataServiceContext {
     public virtual System.IAsyncResult BeginLoadProperty (object entity, string propertyName, System.Uri nextLinkUri, System.AsyncCallback callback, object state)
     public virtual System.IAsyncResult BeginSaveChanges (System.AsyncCallback callback, object state)
     public virtual System.IAsyncResult BeginSaveChanges (Microsoft.OData.Client.SaveChangesOptions options, System.AsyncCallback callback, object state)
-    internal virtual void BulkUpdate (T[] objects)
+    public virtual Microsoft.OData.Client.DataServiceResponse BulkUpdate (T[] objects)
     public virtual void CancelRequest (System.IAsyncResult asyncResult)
     public virtual void ChangeState (object entity, Microsoft.OData.Client.EntityStates state)
     public virtual DataServiceQuery`1 CreateFunctionQuery ()
@@ -8862,6 +8864,12 @@ public sealed class Microsoft.OData.Client.QueryOperationResponse`1 : Microsoft.
 
     public DataServiceQueryContinuation`1 GetContinuation ()
     public virtual IEnumerator`1 GetEnumerator ()
+}
+
+public sealed class Microsoft.OData.Client.ReadingDeltaFeedArgs {
+    public ReadingDeltaFeedArgs (Microsoft.OData.ODataDeltaResourceSet deltaFeed)
+
+    Microsoft.OData.ODataDeltaResourceSet DeltaFeed  { public get; }
 }
 
 public sealed class Microsoft.OData.Client.ReadingEntryArgs {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request is a continuation of this work #2561 .*

### Description

In the previous PR I added changes for writing bulk update requests in OData Client. This PR has changes for supporting reading bulk update requests in OData Client. Changes made:  The following classes and interfaces were added: 

1 . IMaterializerState - This is a marker interface that will be implemented by all the classes representing the different materializer states. 
2. MaterializerDeltaResourceSet  - This contains the materializer state for a delta resource set. 
3. MaterializerNestedEntry - This contains the materializer state for an ODataNestedResourceInfo.
4. MaterializerDeletedEntry - This contains the materializer state for an ODataDeletedResource. 

I have added logic for handling responses to the `BulkUpdateSaveResult` class. So when a payload is read, the various read resources will be represented by the various materializer states mentioned above. Then an object is created with the various materializer states. We then loop through the object and create an `OperationResponse` for each materializer state. To create an `OperationResponse` we need to know the descriptor that was used to create the response. We do a mapping of the descriptors that were used in building the descriptor graph that was used to create the bulk update request and the returned object with the various materializer states to identify the descriptors with their related materializer states. 


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
