### PR TITLE
fix exception in validation OData path

### DIFF
--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
@@ -164,7 +164,7 @@ namespace Microsoft.OData.UriParser.Validation.ValidationEngine
                 ValidateItem(parameter);
             }
 
-            foreach (IEdmOperation operation in segment.OperationImports)
+            foreach (IEdmOperationImport operation in segment.OperationImports)
             {
                 ValidateItem(operation);
                 ValidateItem(operation.ReturnType);


### PR DESCRIPTION
### Description
ODataUriParser.Validate() throws Unable to cast object of type 'Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsActionImport' to type 'Microsoft.OData.Edm.IEdmOperation'.
if validating path to FunctionImport

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
