### PR TITLE
Fix function path validation

### DIFF
--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
@@ -167,7 +167,10 @@ namespace Microsoft.OData.UriParser.Validation.ValidationEngine
             foreach (IEdmOperationImport operation in segment.OperationImports)
             {
                 ValidateItem(operation);
-                ValidateItem(operation.ReturnType);
+                if (operation.EntitySet != null)
+                {
+                    ValidateItem(operation.EntitySet);
+                }
             }
         }
 

--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
@@ -164,7 +164,7 @@ namespace Microsoft.OData.UriParser.Validation.ValidationEngine
                 ValidateItem(parameter);
             }
 
-            foreach (IEdmOperation operation in segment.OperationImports)
+            foreach (IEdmOperationImport operation in segment.OperationImports)
             {
                 ValidateItem(operation);
                 ValidateItem(operation.ReturnType);

--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
@@ -167,7 +167,7 @@ namespace Microsoft.OData.UriParser.Validation.ValidationEngine
             foreach (IEdmOperationImport operation in segment.OperationImports)
             {
                 ValidateItem(operation);
-                ValidateItem(operation.Operation.ReturnType);                
+                ValidateItem(operation.Operation.ReturnType);
             }
         }
 

--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/PathSegmentValidator.cs
@@ -167,10 +167,7 @@ namespace Microsoft.OData.UriParser.Validation.ValidationEngine
             foreach (IEdmOperationImport operation in segment.OperationImports)
             {
                 ValidateItem(operation);
-                if (operation.EntitySet != null)
-                {
-                    ValidateItem(operation.EntitySet);
-                }
+                ValidateItem(operation.Operation.ReturnType);                
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -912,6 +912,7 @@ namespace Microsoft.OData.Tests.UriParser
             // Act
             var parser = new ODataUriParser(model, new Uri("http://host"), new Uri("http://host/" + functionPath));
             var pathSegments = parser.ParsePath().ToList();
+            parser.Validate(OData.UriParser.Validation.ODataUrlValidationRuleSet.AllRules, out var messages);
 
             // Assert
             Assert.Single(pathSegments);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -13,6 +13,7 @@ using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Vocabularies;
 using Microsoft.OData.Edm.Vocabularies.Community.V1;
 using Microsoft.OData.UriParser;
+using Microsoft.OData.UriParser.Validation;
 using Xunit;
 using ODataErrorStrings = Microsoft.OData.Strings;
 
@@ -912,7 +913,7 @@ namespace Microsoft.OData.Tests.UriParser
             // Act
             var parser = new ODataUriParser(model, new Uri("http://host"), new Uri("http://host/" + functionPath));
             var pathSegments = parser.ParsePath().ToList();
-            parser.Validate(OData.UriParser.Validation.ODataUrlValidationRuleSet.AllRules, out var messages);
+            parser.Validate(ODataUrlValidationRuleSet.AllRules, out IEnumerable<ODataUrlValidationMessage> messages);
 
             // Assert
             Assert.Single(pathSegments);


### PR DESCRIPTION
### Description
ODataUriParser.Validate() throws Unable to cast object of type 'Microsoft.OData.Edm.Csdl.CsdlSemantics.CsdlSemanticsActionImport' to type 'Microsoft.OData.Edm.IEdmOperation'.
if validating path to FunctionImport

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
