### PR TITLE
Fix JsonElementValue support edge cases

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
@@ -10,6 +10,7 @@ namespace Microsoft.OData.Evaluation
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
+    using Microsoft.OData;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Edm.Vocabularies;
     using Microsoft.OData.Edm.Vocabularies.V1;
@@ -260,6 +261,12 @@ namespace Microsoft.OData.Evaluation
 
             if (propertyValue is ODataValue && !(propertyValue is ODataEnumValue))
             {
+#if NETCOREAPP3_1_OR_GREATER
+                if (propertyValue is ODataJsonElementValue)
+                {
+                    return propertyValue;
+                }
+#endif
                 throw new ODataException(Strings.ODataResourceMetadataContext_KeyOrETagValuesMustBePrimitiveValues(property.Name, entityTypeName));
             }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2650

There are certain scenarios where the serializer expects a primitive value and throws an error if what it finds is an `ODataJsonElementValue`. This PR adds support or exceptions for `ODataJsonElementValue` in those cases.

### Description

There are certain scenarios where the serializer expects a primitive value and throws an error if what it finds is an `ODataJsonElementValue`. This PR adds support or exceptions for `ODataJsonElementValue` in those cases:

- When generating an `@odata.id` (e.g. when writing a contained entity), the writer validates that the ID is a primitive type. This PR does not throw the exception if the value is an `ODataJsonElementValue`.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
