### PR TITLE
Fixed the http header handling in Batch Requests

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchPayloadItemPropertiesCache.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightBatchPayloadItemPropertiesCache.cs
@@ -275,7 +275,11 @@ namespace Microsoft.OData.JsonLight
                                         contentTypeHeader = headerValue;
                                     }
 
-                                    headers.Add(headerName, headerValue);
+                                    // Don't add already existing headers
+                                    if (!headers.ContainsKeyOrdinal(headerName))
+                                    {
+                                        headers.Add(headerName, headerValue);
+                                    }
                                 }
 
                                 this.jsonReader.ReadEndObject();
@@ -415,7 +419,11 @@ namespace Microsoft.OData.JsonLight
                                     contentTypeHeader = headerValue;
                                 }
 
-                                headers.Add(headerName, headerValue);
+                                // Don't add already existing headers
+                                if (!headers.ContainsKeyOrdinal(headerName))
+                                {
+                                    headers.Add(headerName, headerValue);
+                                }
                             }
 
                             await this.asynchronousJsonReader.ReadEndObjectAsync()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightBatchReaderTests.cs
@@ -364,6 +364,40 @@ namespace Microsoft.OData.Core.Tests.JsonLight
         }
 
         [Fact]
+        public async Task ReadBatchRequestWithDuplicateHeadersAsync()
+        {
+            var payload = "{\"requests\":[{" +
+                "\"id\":\"1\"," +
+                "\"method\":\"POST\"," +
+                "\"url\":\"http://tempuri.org/Customers\"," +
+                "\"headers\":{\"odata-version\":\"4.0\",\"content-type\":\"application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8\",\"duplicate-header\":\"value1\",\"duplicate-header\":\"value2\"}, " +
+                "\"body\" :{\"@odata.type\":\"#NS.Customer\",\"Id\":1,\"Name\":\"Customer 1\",\"Type\":\"Retail\"}}]}";
+
+            await SetupJsonLightBatchReaderAndRunTestAsync(
+                payload,
+                async (jsonLightBatchReader) =>
+                {
+                    try
+                    {
+                        while (await jsonLightBatchReader.ReadAsync())
+                        {
+                            if (jsonLightBatchReader.State == ODataBatchReaderState.Operation)
+                            {
+                                await jsonLightBatchReader.CreateOperationRequestMessageAsync();
+                            }
+                        }
+
+                        Assert.True(true, "The test was successful, because no ArgumentException was thrown");
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        Assert.True(false, ex.Message);
+                    }
+                },
+                isResponse: false);
+        }
+
+        [Fact]
         public async Task ReadBatchResponseAsync()
         {
             var payload = "{\"responses\":[{" +


### PR DESCRIPTION
Fixed the http header handling in `ODataJsonLightBatchPayloadItemPropertiesCache`, by skipping duplicate headers.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

[*This pull request fixes Issue-2656*](https://github.com/OData/odata.net/issues/2656)

### Description

OData batching does return an HTTP 500 error, if the request includes duplicate HTTP headers.
This issue is caused by not proper handling/validation of the HTTP headers, before adding them into a dictionary.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

-/-
