### PR TITLE
Fix issue in finding navigation target for type segment present in OData path

### DIFF
--- a/src/Microsoft.OData.Core/EdmExtensionMethods.cs
+++ b/src/Microsoft.OData.Core/EdmExtensionMethods.cs
@@ -86,7 +86,14 @@ namespace Microsoft.OData
                 }
             }
 
-            return new UnknownEntitySet(navigationSource, navigationProperty);
+            if (typeof(IEdmUnknownEntitySet).IsAssignableFrom(navigationSource.GetType()))
+            {
+                return new UnknownEntitySet(navigationSource, navigationProperty);
+            }
+            else
+            {
+                return navigationSource.FindNavigationTarget(navigationProperty);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2689.*

### Description

When the OData path ends with a type segment and the `$expand` expression starts with a non-contained navigation property, the `ExpandedNavigationSelectItem` item in the `SelectExpandClause` has `Microsoft.OData.UnknownEntitySet` as the navigation source.

Detailed description of the issue can be found here #2689.

**Be noted:** A minor consequence of this change is that by making the additional call to `IEdmNavigationSource.FindNavigationTarget(IEdmNavigationProperty)` in the attempt to resolve the navigation target, that method returns a `Microsoft.OData.Edm.EdmUnknownEntitySet` if it fails to find the navigation target, as opposed to `Microsoft.OData.UnknownEntitySet` returned from `EdmExtensionMethods.FindNavigationTarget(IEdmNavigationSource, IEdmNavigationProperty, Func<IEdmPathExpression, bool>)` before.
However, both methods return an `Microsoft.OData.Edm.IEdmNavigationSource`.
In addition, both `Microsoft.OData.Edm.EdmUnknownEntitySet` and `Microsoft.OData.UnknownEntitySet` derive from `Microsoft.OData.Edm.IEdmUnknownEntitySet`.
A significant number of tests hit that statement and none broke after the change.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
