### PR TITLE
Fixes #2693: Does not work for reading value for untyped property with odata.type annotated

### DIFF
--- a/src/Microsoft.OData.Core/ReaderValidationUtils.cs
+++ b/src/Microsoft.OData.Core/ReaderValidationUtils.cs
@@ -812,8 +812,11 @@ namespace Microsoft.OData
                 case EdmTypeKind.Complex:
                     if (payloadType != null)
                     {
-                        // The payload type must be compatible to the expected type.
-                        VerifyComplexType(expectedTypeReference, payloadType, /* failIfNotRelated */ true);
+                        if (!expectedTypeReference.IsUntyped())
+                        {
+                            // The payload type must be compatible to the expected type.
+                            VerifyComplexType(expectedTypeReference, payloadType, /* failIfNotRelated */ true);
+                        }
 
                         // Use the payload type
                         return payloadType.ToTypeReference(/*nullable*/ true);
@@ -836,7 +839,7 @@ namespace Microsoft.OData
 
                     break;
                 case EdmTypeKind.Enum:
-                    if (payloadType != null && string.CompareOrdinal(payloadType.FullTypeName(), expectedTypeReference.FullName()) != 0)
+                    if (!expectedTypeReference.IsUntyped() && payloadType != null && string.CompareOrdinal(payloadType.FullTypeName(), expectedTypeReference.FullName()) != 0)
                     {
                         throw new ODataException(Strings.ValidationUtils_IncompatibleType(payloadType.FullTypeName(), expectedTypeReference.FullName()));
                     }
@@ -845,7 +848,7 @@ namespace Microsoft.OData
                 case EdmTypeKind.Collection:
                     // The type must be exactly equal - note that we intentionally ignore nullability of the items here, since the payload type
                     // can't specify that.
-                    if (payloadType != null && !payloadType.IsElementTypeEquivalentTo(expectedTypeReference.Definition))
+                    if (!expectedTypeReference.IsUntyped() && payloadType != null && !payloadType.IsElementTypeEquivalentTo(expectedTypeReference.Definition))
                     {
                         VerifyCollectionComplexItemType(expectedTypeReference, payloadType);
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredTests.cs
@@ -56,6 +56,8 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             this.serverEntityType.AddKeys(this.serverEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
             this.serverEntityType.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, true));
             this.serverEntityType.AddStructuralProperty("MyEdmUntypedProp1", EdmCoreModel.Instance.GetUntyped());
+            this.serverEntityType.AddStructuralProperty("Infos",
+                new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetUntyped())));
 
             // open entity type
             this.serverOpenEntityType = new EdmEntityType("Server.NS", "ServerOpenEntityType",
@@ -1745,6 +1747,237 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
             });
 
             Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Id\":61880128,\"UndeclaredFloatId\":12.3,\"undeclaredComplex1\":{\"MyProp1\":\"aaaaaaaaa\",\"UndeclaredProp1\":\"bbbbbbb\"},\"Address\":{\"Street\":\"No.999,Zixing Rd Minhang\",\"UndeclaredStreet\":\"No.10000000999,Zixing Rd Minhang\",\"MyEdmUntypedProp3\":{\"MyProp12\":\"bbb222\",\"abc\":null}}}", result);
+        }
+        #endregion
+
+        #region declared Edm.Untyped property with odata.type
+        [Fact]
+        public void ReadSingleValueEdmUntypedPropertyWithODataTypeResourceTest()
+        {
+            const string payload = @"{
+  ""MyEdmUntypedProp1"":{
+    ""@odata.type"": ""#Server.NS.Address"",
+    ""Street"":""Mars Rd""
+  }
+}";
+            ODataResource topLevelResource = null;
+            ODataResource nestedResource = null;
+            ODataNestedResourceInfo nestedInfo = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    if (topLevelResource == null)
+                    {
+                        topLevelResource = (reader.Item as ODataResource);
+                    }
+                    else
+                    {
+                        nestedResource = (reader.Item as ODataResource);
+                    }
+                }
+                else if (reader.State == ODataReaderState.NestedResourceInfoStart)
+                {
+                    nestedInfo = (reader.Item as ODataNestedResourceInfo);
+                }
+            }, false, true /*reading request*/);
+
+            Assert.Empty(topLevelResource.Properties);
+            ODataProperty property = Assert.Single(nestedResource.Properties);
+            Assert.Equal("Street", property.Name);
+            Assert.Equal("Mars Rd", property.Value);
+            Assert.Equal("MyEdmUntypedProp1", nestedInfo.Name);
+
+            topLevelResource.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(topLevelResource);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(topLevelResource);
+                writer.WriteStart(nestedInfo);
+                writer.WriteStart(nestedResource);
+                writer.WriteEnd();
+                writer.WriteEnd();
+                writer.WriteEnd();
+            });
+
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\"," +
+                "\"MyEdmUntypedProp1\":{" +
+                  "\"Street\":\"Mars Rd\"" +
+                "}" +
+              "}", result);
+        }
+
+        [Fact]
+        public void ReadSingleValueEdmUntypedPropertyWithODataTypeEnumTest()
+        {
+            const string payload = @"{
+  ""MyEdmUntypedProp1@odata.type"": ""#Server.NS.EnumType"",
+  ""MyEdmUntypedProp1"": ""Member""
+}";
+            ODataResource topLevelResource = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    topLevelResource = (reader.Item as ODataResource);
+                }
+            }, false, true /*reading request*/);
+
+            ODataProperty property = Assert.Single(topLevelResource.Properties);
+            Assert.Equal("MyEdmUntypedProp1", property.Name);
+            ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(property.Value);
+            Assert.Equal("Server.NS.EnumType", enumValue.TypeName);
+            Assert.Equal("Member", enumValue.Value);
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ReadSingleValueEdmUntypedPropertyWithODataTypePrimitiveCollectionTest(bool readUntypedAsValue)
+        {
+            const string payload = @"{
+  ""MyEdmUntypedProp1@odata.type"": ""#Collection(Edm.Int32)"",
+  ""MyEdmUntypedProp1"": [5, 3]
+}";
+            ODataResource topLevelResource = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    topLevelResource = (reader.Item as ODataResource);
+                }
+            },
+            readUntypedAsValue, // it doesn't matter since the value is typed.
+            true /*reading request*/);
+
+            ODataProperty property = Assert.Single(topLevelResource.Properties);
+            Assert.Equal("MyEdmUntypedProp1", property.Name);
+            ODataCollectionValue collectionValue = Assert.IsType<ODataCollectionValue>(property.Value);
+
+            Assert.Equal("Collection(Edm.Int32)", collectionValue.TypeName);
+            Assert.Equal(2, collectionValue.Items.Count());
+            Assert.Equal(5, collectionValue.Items.First());
+            Assert.Equal(3, collectionValue.Items.Last());
+        }
+
+        [Fact]
+        public void ReadSingleValueEdmUntypedPropertyWithODataTypeMixCollectionTest()
+        {
+            const string payload = @"{
+  ""MyEdmUntypedProp1"": [
+      5,
+      {
+        ""@odata.type"": ""#Server.NS.Address"",
+        ""Street"":""Mars Rd""
+      }
+  ]
+}";
+            ODataResource topLevelResource = null;
+            ODataResource nestedResource = null;
+            ODataNestedResourceInfo nestedInfo = null;
+            ODataPrimitiveValue primitiveValue = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    if (topLevelResource == null)
+                    {
+                        topLevelResource = (reader.Item as ODataResource);
+                    }
+                    else
+                    {
+                        nestedResource = (reader.Item as ODataResource);
+                    }
+                }
+                else if (reader.State == ODataReaderState.NestedResourceInfoStart)
+                {
+                    nestedInfo = (reader.Item as ODataNestedResourceInfo);
+                }
+                else if (reader.State == ODataReaderState.Primitive)
+                {
+                    primitiveValue = (reader.Item as ODataPrimitiveValue);
+                }
+            }, true, true /*reading request*/);
+
+            Assert.Empty(topLevelResource.Properties);
+            Assert.Equal("MyEdmUntypedProp1", nestedInfo.Name);
+            Assert.Equal(5, primitiveValue.Value);
+
+            ODataProperty property = Assert.Single(nestedResource.Properties);
+            Assert.Equal("Street", property.Name);
+            Assert.Equal("Mars Rd", property.Value);
+        }
+
+        [Fact]
+        public void ReadCollectionEdmUntypedPropertyWithODataTypeMixCollectionTest()
+        {
+            const string payload = @"{
+  ""Infos"":[
+    {
+      ""@odata.type"": ""#Server.NS.Address"",
+      ""Street"":""Mars Rd""
+    },
+    42
+  ]
+}";
+            ODataResource topLevelResource = null;
+            ODataResource nestedResource = null;
+            ODataResourceSet resourceSet = null;
+            ODataNestedResourceInfo nestedInfo = null;
+            ODataPrimitiveValue primitiveValue = null;
+            this.ReadEntryPayload(payload, this.serverEntitySet, this.serverEntityType, reader =>
+            {
+                if (reader.State == ODataReaderState.ResourceStart)
+                {
+                    if (topLevelResource == null)
+                    {
+                        topLevelResource = (reader.Item as ODataResource);
+                    }
+                    else
+                    {
+                        nestedResource = (reader.Item as ODataResource);
+                    }
+                }
+                else if (reader.State == ODataReaderState.ResourceSetStart)
+                {
+                    resourceSet = (reader.Item as ODataResourceSet);
+                }
+                else if (reader.State == ODataReaderState.NestedResourceInfoStart)
+                {
+                    nestedInfo = (reader.Item as ODataNestedResourceInfo);
+                }
+                else if (reader.State == ODataReaderState.Primitive)
+                {
+                    primitiveValue = (reader.Item as ODataPrimitiveValue);
+                }
+            }, false, true /*reading request*/);
+
+            Assert.Empty(topLevelResource.Properties);
+            ODataProperty property = Assert.Single(nestedResource.Properties);
+            Assert.Equal("Street", property.Name);
+            Assert.Equal("Mars Rd", property.Value);
+            Assert.Equal(42, primitiveValue.Value);
+            Assert.Equal("Infos", nestedInfo.Name);
+
+            topLevelResource.MetadataBuilder = new Microsoft.OData.Evaluation.NoOpResourceMetadataBuilder(topLevelResource);
+            string result = this.WriteEntryPayload(this.serverEntitySet, this.serverEntityType, writer =>
+            {
+                writer.WriteStart(topLevelResource);
+                writer.WriteStart(nestedInfo);
+                writer.WriteStart(resourceSet);
+                writer.WritePrimitive(primitiveValue); // switch the order intentionally
+                writer.WriteStart(nestedResource);
+                writer.WriteEnd();
+                writer.WriteEnd();
+                writer.WriteEnd();
+                writer.WriteEnd();
+            });
+
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\"," +
+                "\"Infos\":[" +
+                  "42," +
+                  "{\"@odata.type\":\"#Server.NS.Address\",\"Street\":\"Mars Rd\"}" +
+                "]" +
+              "}", result);
         }
         #endregion
 


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2693.*

### Description

*Enable to use @odata.type annotation for untyped property for untyped property

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
