### PR TITLE
Remove sync I/O from JsonValueUtils async write methods

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -788,6 +788,25 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
+        /// Writes a substring starting at a specified position on the string to the buffer.
+        /// This method is intended for use in async methods, where you cannot pass ref parameters.
+        /// </summary>
+        /// <param name="inputString">Input string value.</param>
+        /// <param name="currentIndex">The index in the string at which the substring begins.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
+        /// <param name="bufferIndex">Current position in the buffer after the substring has been written.</param>
+        /// <param name="substrLength">The length of the substring to be copied.</param>
+        private static void WriteSubstringToBuffer(string inputString, Ref<int> currentIndex, char[] buffer, Ref<int> bufferIndex, int substrLength)
+        {
+            Debug.Assert(inputString != null, "inputString != null");
+            Debug.Assert(buffer != null, "buffer != null");
+
+            inputString.CopyTo(currentIndex.Value, buffer, 0, substrLength);
+            bufferIndex.Value = substrLength;
+            currentIndex.Value += substrLength;
+        }
+
+        /// <summary>
         /// Writes an escaped string to the buffer.
         /// </summary>
         /// <param name="writer">The text writer to write the output to.</param>

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -498,7 +498,8 @@ namespace Microsoft.OData.Json
         /// <summary>
         /// Writes an escaped string to the buffer.
         /// </summary>
-        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="writer">The text writer to write the output.</param>
+
         /// <param name="inputString">Input string value.</param>
         /// <param name="currentIndex">The index in the string at which copying should begin.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -499,7 +499,6 @@ namespace Microsoft.OData.Json
         /// Writes an escaped string to the buffer.
         /// </summary>
         /// <param name="writer">The text writer to write the output.</param>
-
         /// <param name="inputString">Input string value.</param>
         /// <param name="currentIndex">The index in the string at which copying should begin.</param>
         /// <param name="buffer">Char buffer to use for streaming data.</param>

--- a/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtilsAsync.cs
@@ -412,13 +412,13 @@ namespace Microsoft.OData.Json
                 {
                     innerBuffer.Value = BufferUtils.InitializeBufferIfRequired(innerBufferPool, innerBuffer.Value);
                     int bufferLength = innerBuffer.Value.Length;
-                    int bufferIndex = 0;
-                    int currentIndex = 0;
+                    Ref<int> bufferIndex = new Ref<int>(0);
+                    Ref<int> currentIndex = new Ref<int>(0);
 
                     // Let's copy and flush strings up to the first index of the special char
-                    while (currentIndex < innerFirstIndex)
+                    while (currentIndex.Value < innerFirstIndex)
                     {
-                        int substrLength = innerFirstIndex - currentIndex;
+                        int substrLength = innerFirstIndex - currentIndex.Value;
 
                         Debug.Assert(substrLength > 0, "SubStrLength should be greater than 0 always");
 
@@ -427,23 +427,24 @@ namespace Microsoft.OData.Json
                         // Otherwise copy to the buffer and go on from there.
                         if (substrLength >= bufferLength)
                         {
-                            innerInputString.CopyTo(currentIndex, innerBuffer.Value, 0, bufferLength);
+                            innerInputString.CopyTo(currentIndex.Value, innerBuffer.Value, 0, bufferLength);
                             await innerWriter.WriteAsync(innerBuffer.Value, 0, bufferLength).ConfigureAwait(false);
-                            currentIndex += bufferLength;
+                            currentIndex.Value += bufferLength;
                         }
                         else
                         {
-                            WriteSubstringToBuffer(innerInputString, ref currentIndex, innerBuffer.Value, ref bufferIndex, substrLength);
+                            WriteSubstringToBuffer(innerInputString, currentIndex, innerBuffer.Value, bufferIndex, substrLength);
                         }
                     }
 
                     // Write escaped string to buffer
-                    WriteEscapedStringToBuffer(innerWriter, innerInputString, ref currentIndex, innerBuffer.Value, ref bufferIndex, innerStringEscapeOption);
+                    await WriteEscapedStringToBufferAsync(innerWriter, innerInputString, currentIndex, innerBuffer.Value, bufferIndex, innerStringEscapeOption)
+                        .ConfigureAwait(false);
 
                     // write any remaining chars to the writer
-                    if (bufferIndex > 0)
+                    if (bufferIndex.Value > 0)
                     {
-                        await innerWriter.WriteAsync(innerBuffer.Value, 0, bufferIndex).ConfigureAwait(false);
+                        await innerWriter.WriteAsync(innerBuffer.Value, 0, bufferIndex.Value).ConfigureAwait(false);
                     }
                 }
             }
@@ -468,15 +469,18 @@ namespace Microsoft.OData.Json
             Ref<char[]> buffer,
             ICharArrayPool bufferPool)
         {
-            int bufferIndex = 0;
+            Ref<int> bufferIndex = new Ref<int>(0);
+            Ref<int> inputArrayOffsetRef = new Ref<int>(inputArrayOffset);
             buffer.Value = BufferUtils.InitializeBufferIfRequired(bufferPool, buffer.Value);
         
-            WriteEscapedCharArrayToBuffer(writer, inputArray, ref inputArrayOffset, inputArrayCount, buffer.Value, ref bufferIndex, stringEscapeOption);
+            await WriteEscapedCharArrayToBufferAsync(writer, inputArray, inputArrayOffsetRef, inputArrayCount, buffer.Value, bufferIndex, stringEscapeOption)
+                .ConfigureAwait(false);
+           
 
             // write remaining bytes in buffer
-            if (bufferIndex > 0)
+            if (bufferIndex.Value > 0)
             {
-                await writer.WriteAsync(buffer.Value, 0, bufferIndex).ConfigureAwait(false);
+                await writer.WriteAsync(buffer.Value, 0, bufferIndex.Value).ConfigureAwait(false);
             }
         }
 
@@ -489,6 +493,136 @@ namespace Microsoft.OData.Json
         {
             return writer.WriteAsync(
                 string.Concat(JsonConstants.QuoteCharacter, text, JsonConstants.QuoteCharacter));
+        }
+
+        /// <summary>
+        /// Writes an escaped string to the buffer.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="inputString">Input string value.</param>
+        /// <param name="currentIndex">The index in the string at which copying should begin.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
+        /// <param name="bufferIndex">Current position in the buffer after the string has been written.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
+        /// <remarks>
+        /// IMPORTANT: After all characters have been written,
+        /// caller is responsible for writing the final buffer contents to the writer.
+        /// </remarks>
+        private static async Task WriteEscapedStringToBufferAsync(
+            TextWriter writer,
+            string inputString,
+            Ref<int> currentIndex,
+            char[] buffer,
+            Ref<int> bufferIndex,
+            ODataStringEscapeOption stringEscapeOption)
+        {
+            Debug.Assert(inputString != null, "inputString != null");
+            Debug.Assert(buffer != null, "buffer != null");
+
+            for (; currentIndex.Value < inputString.Length; currentIndex.Value++)
+            {
+                bufferIndex.Value = await EscapeAndWriteCharToBufferAsync(
+                    writer,
+                    inputString[currentIndex.Value],
+                    buffer,
+                    bufferIndex.Value,
+                    stringEscapeOption
+                    )
+                    .ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Escapes and writes a character buffer, flushing to the writer as the buffer fills.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="character">The character to write to the buffer.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
+        /// <param name="bufferIndex">The index into the buffer in which to write the character.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
+        /// <returns>Current position in the buffer after the character has been written.</returns>
+        /// <remarks>
+        /// IMPORTANT: After all characters have been written,
+        /// caller is responsible for writing the final buffer contents to the writer.
+        /// </remarks>
+        private static async Task<int> EscapeAndWriteCharToBufferAsync(TextWriter writer, char character, char[] buffer, int bufferIndex, ODataStringEscapeOption stringEscapeOption)
+        {
+            int bufferLength = buffer.Length;
+            string escapedString = null;
+
+            if (stringEscapeOption == ODataStringEscapeOption.EscapeNonAscii || character <= 0x7F)
+            {
+                escapedString = JsonValueUtils.SpecialCharToEscapedStringMap[character];
+            }
+
+            // Append the unhandled characters (that do not require special treatment)
+            // to the buffer.
+            if (escapedString == null)
+            {
+                buffer[bufferIndex] = character;
+                bufferIndex++;
+            }
+            else
+            {
+                // Okay, an unhandled character was detected.
+                // First lets check if we can fit it in the existing buffer, if not,
+                // flush the current buffer and reset. Add the escaped string to the buffer
+                // and continue.
+                int escapedStringLength = escapedString.Length;
+                Debug.Assert(escapedStringLength <= bufferLength, "Buffer should be larger than the escaped string");
+
+                if ((bufferIndex + escapedStringLength) > bufferLength)
+                {
+                    await writer.WriteAsync(buffer, 0, bufferIndex).ConfigureAwait(false);
+                    bufferIndex = 0;
+                }
+
+                escapedString.CopyTo(0, buffer, bufferIndex, escapedStringLength);
+                bufferIndex += escapedStringLength;
+            }
+
+            if (bufferIndex >= bufferLength)
+            {
+                Debug.Assert(bufferIndex == bufferLength,
+                    "We should never encounter a situation where the buffer index is greater than the buffer length");
+                await writer.WriteAsync(buffer, 0, bufferIndex).ConfigureAwait(false);
+                bufferIndex = 0;
+            }
+
+            return bufferIndex;
+        }
+
+        /// <summary>
+        /// Writes an escaped char array to the buffer.
+        /// </summary>
+        /// <param name="writer">The text writer to write the output to.</param>
+        /// <param name="inputArray">Character array to write.</param>
+        /// <param name="inputArrayOffset">How many characters to skip in the input array.</param>
+        /// <param name="inputArrayCount">How many characters to write from the input array.</param>
+        /// <param name="buffer">Char buffer to use for streaming data.</param>
+        /// <param name="bufferIndex">Current position in the buffer after the string has been written.</param>
+        /// <param name="stringEscapeOption">The string escape option.</param>
+        /// <remarks>
+        /// IMPORTANT: After all characters have been written,
+        /// caller is responsible for writing the final buffer contents to the writer.
+        /// </remarks>
+        private static async Task WriteEscapedCharArrayToBufferAsync(
+            TextWriter writer,
+            char[] inputArray,
+            Ref<int> inputArrayOffset,
+            int inputArrayCount,
+            char[] buffer,
+            Ref<int> bufferIndex,
+            ODataStringEscapeOption stringEscapeOption)
+        {
+            Debug.Assert(inputArray != null, "inputArray != null");
+            Debug.Assert(buffer != null, "buffer != null");
+
+            for (; inputArrayOffset.Value < inputArrayCount; inputArrayOffset.Value++)
+            {
+                bufferIndex.Value = await EscapeAndWriteCharToBufferAsync(writer, inputArray[inputArrayOffset.Value], buffer, bufferIndex.Value, stringEscapeOption)
+                    .ConfigureAwait(false);
+            }
         }
     }
 }

--- a/src/Microsoft.OData.Core/Json/NonIndentedTextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/NonIndentedTextWriter.cs
@@ -62,6 +62,18 @@ namespace Microsoft.OData.Json
             return this.writer.WriteAsync(value);
         }
 
+        /// <inheritdoc/>
+        public override void Write(char[] buffer, int index, int count)
+        {
+            this.writer.Write(buffer, index, count);
+        }
+
+        /// <inheritdoc/>
+        public override Task WriteAsync(char[] buffer, int index, int count)
+        {
+            return this.writer.WriteAsync(buffer, index, count);
+        }
+
         /// <summary>
         /// Writes a new line.
         /// </summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsAsyncTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.OData.Json;
 using Xunit;
@@ -16,7 +17,7 @@ namespace Microsoft.OData.Tests.Json
 {
     public class JsonValueUtilsAsyncTests
     {
-        private MemoryStream stream;
+        private Stream stream;
         private NonIndentedTextWriter writer;
         private Ref<char[]> buffer;
         private IDictionary<string, string> escapedCharMap;
@@ -58,7 +59,7 @@ namespace Microsoft.OData.Tests.Json
         public async Task WriteEmptyStringShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Empty, stringEscapeOption, this.buffer);
-            Assert.Equal("\"\"", this.StreamToString());
+            Assert.Equal("\"\"", await this.StreamToString());
         }
 
         [Theory]
@@ -67,7 +68,7 @@ namespace Microsoft.OData.Tests.Json
         public async Task WriteNonSpecialCharactersShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "abcdefg123", stringEscapeOption, this.buffer);
-            Assert.Equal("\"abcdefg123\"", this.StreamToString());
+            Assert.Equal("\"abcdefg123\"", await this.StreamToString());
         }
 
         [Theory]
@@ -76,21 +77,21 @@ namespace Microsoft.OData.Tests.Json
         public async Task WriteLowSpecialCharactersShouldWorkForEscapeOption(ODataStringEscapeOption stringEscapeOption)
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_\n\r\b", stringEscapeOption, this.buffer);
-            Assert.Equal("\"cA_\\n\\r\\b\"", this.StreamToString());
+            Assert.Equal("\"cA_\\n\\r\\b\"", await this.StreamToString());
         }
 
         [Fact]
         public async Task WriteHighSpecialCharactersShouldWorkForEscapeNonAsciiOption()
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-            Assert.Equal("\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\"", this.StreamToString());
+            Assert.Equal("\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\"", await this.StreamToString());
         }
 
         [Fact]
         public async Task WriteHighSpecialCharactersShouldWorkForEscapeOnlyControlsOption()
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeOnlyControls, this.buffer);
-            Assert.Equal("\"cA_Россия\"", this.StreamToString());
+            Assert.Equal("\"cA_Россия\"", await this.StreamToString());
         }
 
         [Fact]
@@ -101,7 +102,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
+                Assert.Equal(string.Format("\"{0}\"", this.escapedCharMap[specialChar]), await this.StreamToString());
             }
         }
 
@@ -113,7 +114,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}MiddleEnd", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"{0}MiddleEnd\"", this.escapedCharMap[specialChar]), this.StreamToString());
+                Assert.Equal(string.Format("\"{0}MiddleEnd\"", this.escapedCharMap[specialChar]), await this.StreamToString());
             }
         }
 
@@ -125,7 +126,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("Start{0}End", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"Start{0}End\"", this.escapedCharMap[specialChar]), this.StreamToString());
+                Assert.Equal(string.Format("\"Start{0}End\"", this.escapedCharMap[specialChar]), await this.StreamToString());
             }
         }
 
@@ -137,7 +138,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("StartMiddle{0}", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"StartMiddle{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
+                Assert.Equal(string.Format("\"StartMiddle{0}\"", this.escapedCharMap[specialChar]), await this.StreamToString());
             }
         }
 
@@ -149,7 +150,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}Start{0}Middle{0}End", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"{0}Start{0}Middle{0}End\"", this.escapedCharMap[specialChar]), this.StreamToString());
+                Assert.Equal(string.Format("\"{0}Start{0}Middle{0}End\"", this.escapedCharMap[specialChar]), await this.StreamToString());
             }
         }
 
@@ -162,7 +163,7 @@ namespace Microsoft.OData.Tests.Json
                 Ref<char[]> charBuffer = new Ref<char[]>(new char[10]);
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("StartMiddle{0}End", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, charBuffer);
-                Assert.Equal(string.Format("\"StartMiddle{0}End\"", this.escapedCharMap[specialChar]), this.StreamToString());
+                Assert.Equal(string.Format("\"StartMiddle{0}End\"", this.escapedCharMap[specialChar]), await this.StreamToString());
             }
         }
 
@@ -175,7 +176,7 @@ namespace Microsoft.OData.Tests.Json
                 Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("Start{0}Middle{0}End{0}", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, charBuffer);
-                Assert.Equal(string.Format("\"Start{0}Middle{0}End{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
+                Assert.Equal(string.Format("\"Start{0}Middle{0}End{0}\"", this.escapedCharMap[specialChar]), await this.StreamToString());
             }
         }
 
@@ -188,7 +189,7 @@ namespace Microsoft.OData.Tests.Json
                 Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("Start{0}", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, charBuffer);
-                Assert.Equal(string.Format("\"Start{0}\"", this.escapedCharMap[specialChar]), this.StreamToString());
+                Assert.Equal(string.Format("\"Start{0}\"", this.escapedCharMap[specialChar]), await this.StreamToString());
             }
         }
 
@@ -203,8 +204,37 @@ namespace Microsoft.OData.Tests.Json
                 Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("S{0}M{0}E{0}", specialChar),
                     escapeOption, charBuffer);
-                Assert.Equal(string.Format("\"S{0}M{0}E{0}\"", this.controlCharsMap[specialChar]), this.StreamToString());
+                Assert.Equal(string.Format("\"S{0}M{0}E{0}\"", this.controlCharsMap[specialChar]), await this.StreamToString());
             }
+        }
+
+        [Fact]
+        public async Task WriteLongEscapedStringShouldWork()
+        {
+            this.Reset();
+            Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
+            string value = string.Join("\t", Enumerable.Repeat('\n', 95000));
+            await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, value,
+                ODataStringEscapeOption.EscapeNonAscii, charBuffer);
+            string expected = "\"" + string.Join("\\t", Enumerable.Repeat("\\n", 95000)) + "\"";
+            Assert.Equal(expected, await this.StreamToString());
+        }
+
+        [Fact]
+        public async Task WriteLongEscapedCharArrayShouldWork()
+        {
+            Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
+            string value = string.Join("\t", Enumerable.Repeat('\n', 95000));
+            await JsonValueUtils.WriteEscapedCharArrayAsync(
+                this.writer,
+                value.ToCharArray(),
+                0,
+                value.Length,
+                ODataStringEscapeOption.EscapeNonAscii,
+                charBuffer,
+                null);
+            string expected = string.Join("\\t", Enumerable.Repeat("\\n", 95000));
+            Assert.Equal(expected, await this.StreamToString());
         }
 
         [Theory]
@@ -215,7 +245,7 @@ namespace Microsoft.OData.Tests.Json
             this.Reset();
             Ref<char[]> charBuffer = new Ref<char[]>(null);
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "StartMiddleEnd", stringEscapeOption, charBuffer);
-            Assert.Equal("\"StartMiddleEnd\"", this.StreamToString());
+            Assert.Equal("\"StartMiddleEnd\"", await this.StreamToString());
             Assert.Null(charBuffer.Value);
         }
 
@@ -231,7 +261,7 @@ namespace Microsoft.OData.Tests.Json
             }
 
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "StartVeryVeryLongMiddleEnd", stringEscapeOption, charBuffer);
-            Assert.Equal("\"StartVeryVeryLongMiddleEnd\"", this.StreamToString());
+            Assert.Equal("\"StartVeryVeryLongMiddleEnd\"", await this.StreamToString());
         }
 
         [Fact]
@@ -239,7 +269,7 @@ namespace Microsoft.OData.Tests.Json
         {
             var byteArray = new byte[] { 1, 2, 3 };
             await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
-            Assert.Equal("\"AQID\"", this.StreamToString());
+            Assert.Equal("\"AQID\"", await this.StreamToString());
         }
 
         [Fact]
@@ -254,7 +284,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Act, Get Base64 string from OData library
             await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
-            string convertedBase64String = this.StreamToString();
+            string convertedBase64String = await this.StreamToString();
 
             // Get Base64 string directly calling the converter.
             string actualBase64String = JsonConstants.QuoteCharacter + Convert.ToBase64String(byteArray) + JsonConstants.QuoteCharacter;
@@ -283,7 +313,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Act, Get Base64 string from OData library
             await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
-            string convertedBase64String = this.StreamToString();
+            string convertedBase64String = await this.StreamToString();
 
             // Get Base64 string directly calling the converter.
             string actualBase64String = JsonConstants.QuoteCharacter + Convert.ToBase64String(byteArray) + JsonConstants.QuoteCharacter;
@@ -298,29 +328,30 @@ namespace Microsoft.OData.Tests.Json
         {
             var byteArray = new byte[] { };
             await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
-            Assert.Equal("\"\"", this.StreamToString());
+            Assert.Equal("\"\"", await this.StreamToString());
         }
 
         [Fact]
         public async Task WriteNullByteShouldWork()
         {
             await JsonValueUtils.WriteValueAsync(this.writer, (byte[])null, this.buffer);
-            Assert.Equal("null", this.StreamToString());
+            Assert.Equal("null", await this.StreamToString());
         }
 
         private void Reset()
         {
             this.buffer = new Ref<char[]>();
-            this.stream = new MemoryStream();
+            this.stream = new AsyncStream(new MemoryStream());
             StreamWriter innerWriter = new StreamWriter(this.stream);
-            innerWriter.AutoFlush = true;
             this.writer = new NonIndentedTextWriter(innerWriter);
         }
 
-        private string StreamToString()
+        private async Task<string> StreamToString()
         {
+            await this.writer.FlushAsync();
             this.stream.Position = 0;
-            return (new StreamReader(this.stream)).ReadToEnd();
+            string result = await (new StreamReader(this.stream)).ReadToEndAsync();
+            return result;
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonValueUtilsAsyncTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.OData.Tests.Json
         public async Task WriteEmptyStringShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Empty, stringEscapeOption, this.buffer);
-            Assert.Equal("\"\"", await this.StreamToString());
+            Assert.Equal("\"\"", await this.StreamToStringAsync());
         }
 
         [Theory]
@@ -68,7 +68,7 @@ namespace Microsoft.OData.Tests.Json
         public async Task WriteNonSpecialCharactersShouldWork(ODataStringEscapeOption stringEscapeOption)
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "abcdefg123", stringEscapeOption, this.buffer);
-            Assert.Equal("\"abcdefg123\"", await this.StreamToString());
+            Assert.Equal("\"abcdefg123\"", await this.StreamToStringAsync());
         }
 
         [Theory]
@@ -77,21 +77,21 @@ namespace Microsoft.OData.Tests.Json
         public async Task WriteLowSpecialCharactersShouldWorkForEscapeOption(ODataStringEscapeOption stringEscapeOption)
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_\n\r\b", stringEscapeOption, this.buffer);
-            Assert.Equal("\"cA_\\n\\r\\b\"", await this.StreamToString());
+            Assert.Equal("\"cA_\\n\\r\\b\"", await this.StreamToStringAsync());
         }
 
         [Fact]
         public async Task WriteHighSpecialCharactersShouldWorkForEscapeNonAsciiOption()
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-            Assert.Equal("\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\"", await this.StreamToString());
+            Assert.Equal("\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\"", await this.StreamToStringAsync());
         }
 
         [Fact]
         public async Task WriteHighSpecialCharactersShouldWorkForEscapeOnlyControlsOption()
         {
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "cA_Россия", ODataStringEscapeOption.EscapeOnlyControls, this.buffer);
-            Assert.Equal("\"cA_Россия\"", await this.StreamToString());
+            Assert.Equal("\"cA_Россия\"", await this.StreamToStringAsync());
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"{0}\"", this.escapedCharMap[specialChar]), await this.StreamToString());
+                Assert.Equal(string.Format("\"{0}\"", this.escapedCharMap[specialChar]), await this.StreamToStringAsync());
             }
         }
 
@@ -114,7 +114,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}MiddleEnd", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"{0}MiddleEnd\"", this.escapedCharMap[specialChar]), await this.StreamToString());
+                Assert.Equal(string.Format("\"{0}MiddleEnd\"", this.escapedCharMap[specialChar]), await this.StreamToStringAsync());
             }
         }
 
@@ -126,7 +126,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("Start{0}End", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"Start{0}End\"", this.escapedCharMap[specialChar]), await this.StreamToString());
+                Assert.Equal(string.Format("\"Start{0}End\"", this.escapedCharMap[specialChar]), await this.StreamToStringAsync());
             }
         }
 
@@ -138,7 +138,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("StartMiddle{0}", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"StartMiddle{0}\"", this.escapedCharMap[specialChar]), await this.StreamToString());
+                Assert.Equal(string.Format("\"StartMiddle{0}\"", this.escapedCharMap[specialChar]), await this.StreamToStringAsync());
             }
         }
 
@@ -150,7 +150,7 @@ namespace Microsoft.OData.Tests.Json
                 this.Reset();
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("{0}Start{0}Middle{0}End", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, this.buffer);
-                Assert.Equal(string.Format("\"{0}Start{0}Middle{0}End\"", this.escapedCharMap[specialChar]), await this.StreamToString());
+                Assert.Equal(string.Format("\"{0}Start{0}Middle{0}End\"", this.escapedCharMap[specialChar]), await this.StreamToStringAsync());
             }
         }
 
@@ -163,7 +163,7 @@ namespace Microsoft.OData.Tests.Json
                 Ref<char[]> charBuffer = new Ref<char[]>(new char[10]);
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("StartMiddle{0}End", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, charBuffer);
-                Assert.Equal(string.Format("\"StartMiddle{0}End\"", this.escapedCharMap[specialChar]), await this.StreamToString());
+                Assert.Equal(string.Format("\"StartMiddle{0}End\"", this.escapedCharMap[specialChar]), await this.StreamToStringAsync());
             }
         }
 
@@ -176,7 +176,7 @@ namespace Microsoft.OData.Tests.Json
                 Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("Start{0}Middle{0}End{0}", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, charBuffer);
-                Assert.Equal(string.Format("\"Start{0}Middle{0}End{0}\"", this.escapedCharMap[specialChar]), await this.StreamToString());
+                Assert.Equal(string.Format("\"Start{0}Middle{0}End{0}\"", this.escapedCharMap[specialChar]), await this.StreamToStringAsync());
             }
         }
 
@@ -189,7 +189,7 @@ namespace Microsoft.OData.Tests.Json
                 Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("Start{0}", specialChar),
                     ODataStringEscapeOption.EscapeNonAscii, charBuffer);
-                Assert.Equal(string.Format("\"Start{0}\"", this.escapedCharMap[specialChar]), await this.StreamToString());
+                Assert.Equal(string.Format("\"Start{0}\"", this.escapedCharMap[specialChar]), await this.StreamToStringAsync());
             }
         }
 
@@ -204,7 +204,7 @@ namespace Microsoft.OData.Tests.Json
                 Ref<char[]> charBuffer = new Ref<char[]>(new char[6]);
                 await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, string.Format("S{0}M{0}E{0}", specialChar),
                     escapeOption, charBuffer);
-                Assert.Equal(string.Format("\"S{0}M{0}E{0}\"", this.controlCharsMap[specialChar]), await this.StreamToString());
+                Assert.Equal(string.Format("\"S{0}M{0}E{0}\"", this.controlCharsMap[specialChar]), await this.StreamToStringAsync());
             }
         }
 
@@ -217,7 +217,7 @@ namespace Microsoft.OData.Tests.Json
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, value,
                 ODataStringEscapeOption.EscapeNonAscii, charBuffer);
             string expected = "\"" + string.Join("\\t", Enumerable.Repeat("\\n", 95000)) + "\"";
-            Assert.Equal(expected, await this.StreamToString());
+            Assert.Equal(expected, await this.StreamToStringAsync());
         }
 
         [Fact]
@@ -234,7 +234,7 @@ namespace Microsoft.OData.Tests.Json
                 charBuffer,
                 null);
             string expected = string.Join("\\t", Enumerable.Repeat("\\n", 95000));
-            Assert.Equal(expected, await this.StreamToString());
+            Assert.Equal(expected, await this.StreamToStringAsync());
         }
 
         [Theory]
@@ -245,7 +245,7 @@ namespace Microsoft.OData.Tests.Json
             this.Reset();
             Ref<char[]> charBuffer = new Ref<char[]>(null);
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "StartMiddleEnd", stringEscapeOption, charBuffer);
-            Assert.Equal("\"StartMiddleEnd\"", await this.StreamToString());
+            Assert.Equal("\"StartMiddleEnd\"", await this.StreamToStringAsync());
             Assert.Null(charBuffer.Value);
         }
 
@@ -261,7 +261,7 @@ namespace Microsoft.OData.Tests.Json
             }
 
             await JsonValueUtils.WriteEscapedJsonStringAsync(this.writer, "StartVeryVeryLongMiddleEnd", stringEscapeOption, charBuffer);
-            Assert.Equal("\"StartVeryVeryLongMiddleEnd\"", await this.StreamToString());
+            Assert.Equal("\"StartVeryVeryLongMiddleEnd\"", await this.StreamToStringAsync());
         }
 
         [Fact]
@@ -269,7 +269,7 @@ namespace Microsoft.OData.Tests.Json
         {
             var byteArray = new byte[] { 1, 2, 3 };
             await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
-            Assert.Equal("\"AQID\"", await this.StreamToString());
+            Assert.Equal("\"AQID\"", await this.StreamToStringAsync());
         }
 
         [Fact]
@@ -284,7 +284,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Act, Get Base64 string from OData library
             await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
-            string convertedBase64String = await this.StreamToString();
+            string convertedBase64String = await this.StreamToStringAsync();
 
             // Get Base64 string directly calling the converter.
             string actualBase64String = JsonConstants.QuoteCharacter + Convert.ToBase64String(byteArray) + JsonConstants.QuoteCharacter;
@@ -313,7 +313,7 @@ namespace Microsoft.OData.Tests.Json
 
             // Act, Get Base64 string from OData library
             await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
-            string convertedBase64String = await this.StreamToString();
+            string convertedBase64String = await this.StreamToStringAsync();
 
             // Get Base64 string directly calling the converter.
             string actualBase64String = JsonConstants.QuoteCharacter + Convert.ToBase64String(byteArray) + JsonConstants.QuoteCharacter;
@@ -328,14 +328,14 @@ namespace Microsoft.OData.Tests.Json
         {
             var byteArray = new byte[] { };
             await JsonValueUtils.WriteValueAsync(this.writer, byteArray, this.buffer);
-            Assert.Equal("\"\"", await this.StreamToString());
+            Assert.Equal("\"\"", await this.StreamToStringAsync());
         }
 
         [Fact]
         public async Task WriteNullByteShouldWork()
         {
             await JsonValueUtils.WriteValueAsync(this.writer, (byte[])null, this.buffer);
-            Assert.Equal("null", await this.StreamToString());
+            Assert.Equal("null", await this.StreamToStringAsync());
         }
 
         private void Reset()
@@ -346,7 +346,7 @@ namespace Microsoft.OData.Tests.Json
             this.writer = new NonIndentedTextWriter(innerWriter);
         }
 
-        private async Task<string> StreamToString()
+        private async Task<string> StreamToStringAsync()
         {
             await this.writer.FlushAsync();
             this.stream.Position = 0;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2704 .*

### Description

The following async helper methods from `JsonValueUtils` had cases of synchronous I/O:
- `WriteEscapedJsonStringAsync`
- `WriteEscapedCharArrayAsync`
- `WriteValueAsync(byte[])`

Part of the reason was because the methods called other helper methods that performed synchronous `TextWriter.Write` calls. In such cases, I created true async versions of the affected methods.

The other reason was that the `NonIndentedTextWriter` did not override the async `WriteAsync(char[] buffer, int index, int count)` method. And the default implementation of `TextWriter.WriteAsync(char[], int, int)` calls the synchronous version. So I added an async override to the class.

Something else what pointing out is that because the internal `StreamWriter` is buffered, it would take a bunch of `Write()` calls before it actually flushes to the stream. This means that this issue would go undetected in many cases. To test this, I create a long payload to ensure that the `StreamWriter` actually flushes its content.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
