### PR TITLE
Add option to make Content-ID header optional

### DIFF
--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchInputContext.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchInputContext.cs
@@ -75,8 +75,9 @@ namespace Microsoft.OData.MultipartMixed
         /// <param name="synchronous">If the reader should be created for synchronous or asynchronous API.</param>
         /// <returns>The newly created <see cref="ODataCollectionReader"/>.</returns>
         private ODataBatchReader CreateBatchReaderImplementation(bool synchronous)
-        {
-            return new ODataMultipartMixedBatchReader(this, this.batchBoundary, this.Encoding, synchronous);
+        {            
+            return new ODataMultipartMixedBatchReader(this, this.batchBoundary, this.Encoding, synchronous,
+                this.MessageReaderSettings.ThrowIfMissingContentIdInChangeset);
         }
     }
 }

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchReader.cs
@@ -34,18 +34,25 @@ namespace Microsoft.OData.MultipartMixed
         private string currentContentId;
 
         /// <summary>
+        /// Require Content-Id header in changesets
+        /// If turned off allows to read OData 2.0 requests without Content-Id header present.
+        /// </summary>
+        private bool requireContentId = true;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="inputContext">The input context to read the content from.</param>
         /// <param name="batchBoundary">The boundary string for the batch structure itself.</param>
         /// <param name="batchEncoding">The encoding to use to read from the batch stream.</param>
         /// <param name="synchronous">true if the reader is created for synchronous operation; false for asynchronous.</param>
-        internal ODataMultipartMixedBatchReader(ODataMultipartMixedBatchInputContext inputContext, string batchBoundary, Encoding batchEncoding, bool synchronous)
+        internal ODataMultipartMixedBatchReader(ODataMultipartMixedBatchInputContext inputContext, string batchBoundary, Encoding batchEncoding, bool synchronous, bool requireContentId)
             : base(inputContext, synchronous)
         {
             Debug.Assert(inputContext != null, "inputContext != null");
             Debug.Assert(!string.IsNullOrEmpty(batchBoundary), "!string.IsNullOrEmpty(batchBoundary)");
 
+            this.requireContentId = requireContentId;
             this.batchStream = new ODataMultipartMixedBatchReaderStream(this.MultipartMixedBatchInputContext, batchBoundary, batchEncoding);
             this.dependsOnIdsTracker = new DependsOnIdsTracker();
         }
@@ -85,7 +92,14 @@ namespace Microsoft.OData.MultipartMixed
 
                     if (this.currentContentId == null)
                     {
-                        throw new ODataException(Strings.ODataBatchOperationHeaderDictionary_KeyNotFound(ODataConstants.ContentIdHeader));
+                        if (requireContentId)
+                        {
+                            throw new ODataException(Strings.ODataBatchOperationHeaderDictionary_KeyNotFound(ODataConstants.ContentIdHeader));
+                        }
+                        else
+                        {
+                            this.currentContentId = Guid.NewGuid().ToString();
+                        }
                     }
                 }
             }

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -93,6 +93,7 @@ namespace Microsoft.OData
                 ThrowOnDuplicatePropertyNames = (validations & ValidationKinds.ThrowOnDuplicatePropertyNames) != 0;
                 ThrowIfTypeConflictsWithMetadata = (validations & ValidationKinds.ThrowIfTypeConflictsWithMetadata) != 0;
                 ThrowOnUndeclaredPropertyForNonOpenType = (validations & ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType) != 0;
+                ThrowIfMissingContentIdInChangeset = (validations & ValidationKinds.ThrowIfMissingContentIdInChangeset) != 0;
             }
         }
 
@@ -236,6 +237,12 @@ namespace Microsoft.OData
         internal bool ThrowOnUndeclaredPropertyForNonOpenType { get; private set; }
 
         /// <summary>
+        /// Require Content-Id header in changesets
+        /// If turned off allows to read OData 2.0 requests without Content-Id header present.
+        /// </summary>
+        internal bool ThrowIfMissingContentIdInChangeset { get; private set; }
+
+        /// <summary>
         /// Creates a shallow copy of this <see cref="ODataMessageReaderSettings"/>.
         /// </summary>
         /// <returns>A shallow copy of this <see cref="ODataMessageReaderSettings"/>.</returns>
@@ -296,6 +303,7 @@ namespace Microsoft.OData
             this.ThrowOnDuplicatePropertyNames = other.ThrowOnDuplicatePropertyNames;
             this.ThrowIfTypeConflictsWithMetadata = other.ThrowIfTypeConflictsWithMetadata;
             this.ThrowOnUndeclaredPropertyForNonOpenType = other.ThrowOnUndeclaredPropertyForNonOpenType;
+            this.ThrowIfMissingContentIdInChangeset = other.ThrowIfMissingContentIdInChangeset;
             this.LibraryCompatibility = other.LibraryCompatibility;
             this.Version = other.Version;
             this.ReadAsStreamFunc = other.ReadAsStreamFunc;

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.ValidationKinds.ThrowIfMissingContentIdInChangeset = 8 -> Microsoft.OData.ValidationKinds

--- a/src/Microsoft.OData.Core/ValidationKinds.cs
+++ b/src/Microsoft.OData.Core/ValidationKinds.cs
@@ -37,6 +37,12 @@ namespace Microsoft.OData
         ThrowIfTypeConflictsWithMetadata = 4,
 
         /// <summary>
+        /// Require Content-Id header in changesets
+        /// If turned off allows to read OData 2.0 requests without Content-Id header present.
+        /// </summary>
+        ThrowIfMissingContentIdInChangeset = 8,
+
+        /// <summary>
         /// Enable all validations.
         /// </summary>
         All = ~0


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request adds ability to read OData 2.0 batch requests that do not require Content-ID header

### Description

Add options to disable throwing exceptions if no Content-ID header is present in chgangeset

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
