### PR TITLE
extremely minor perf updates

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonLightInstanceAnnotationWriter.cs
@@ -505,14 +505,12 @@ namespace Microsoft.OData
             bool ignoreFilter = false,
             string propertyName = null)
         {
-
             if (!instanceAnnotationNames.Add(annotation.Name))
             {
                 throw new ODataException(ODataErrorStrings.JsonLightInstanceAnnotationWriter_DuplicateAnnotationNameInCollection(annotation.Name));
             }
 
-            if (!tracker.IsAnnotationWritten(annotation.Name)
-                        && (!ODataAnnotationNames.IsODataAnnotationName(annotation.Name) || ODataAnnotationNames.IsUnknownODataAnnotationName(annotation.Name)))
+            if (!tracker.IsAnnotationWritten(annotation.Name))
             {
                 this.WriteInstanceAnnotation(annotation, ignoreFilter, propertyName);
                 tracker.MarkAnnotationWritten(annotation.Name);

--- a/src/Microsoft.OData.Core/ODataInstanceAnnotation.cs
+++ b/src/Microsoft.OData.Core/ODataInstanceAnnotation.cs
@@ -62,7 +62,9 @@ namespace Microsoft.OData
         /// <param name="name">Name to validate.</param>
         internal static void ValidateName(string name)
         {
-            if (name.IndexOf('.') < 0 || name[0] == '.' || name[name.Length - 1] == '.')
+            // being internal, all callers validate that the name is not empty, but don't validate anything else; here, we validate that there is a namespace, 
+            // indicated by the presence of a period and by characters before and after the period
+            if (name.Length < 3 || name[0] == '.' || name[name.Length - 1] == '.' || name.IndexOf('.', 1, name.Length - 2) < 0)
             {
                 throw new ArgumentException(Strings.ODataInstanceAnnotation_NeedPeriodInName(name));
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataInstanceAnnotationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataInstanceAnnotationTests.cs
@@ -32,6 +32,16 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
+        public void InstanceAnnotationNameWithoutNamespaceShouldThrowArgumentException()
+        {
+            foreach (string name in new[] { ".", "f.", ".f" })
+            {
+                Action test = () => new ODataInstanceAnnotation(name, new ODataPrimitiveValue("value"));
+                test.Throws<ArgumentException>(Strings.ODataInstanceAnnotation_NeedPeriodInName(name));
+            }
+        }
+
+        [Fact]
         public void AtInInstanceAnnotationNameShouldThrowArgumentException()
         {
             foreach (string name in new[] { "@foo.bar", "foo.b@ar", "foo.bar@" })


### PR DESCRIPTION
While writing instance annotations, we only write annotations if they don't start with `odata.` or if they do start with `odata.` but they aren't in a list of known annotation names. These checks are conceptually correct, but the logic as written requires checking the annotation name for `odata.` more than once. While updating the code to remove this logic, I wrote a test to validate that instance annotations of different kind were still written/not written accordingly. While doing this, I discovered that the `ODataInstanceAnnotation` type validates that the name isn't an OData instance annotation in the first place. Because of this, there is no reason to validate the annotation name at all while writing the annotations, so I've removed that unnecessary logic.

The `ODataInstanceAnnotation` type also validates that the name is well-formed by checking if it contains a `.` character to ensure that a namespace is present. It further confirms that the `.` does not come at the beginning or the end of the name. The code as written would check for the presence of a `.` and then would check if the first or last character was a `.`. However, if the first or last character is a `.`, there's no need to do the initial check. I have changed the order of these predicates so that the string is not enumerated unless all of the other conditions are met first. 