### PR TITLE
Add support for NaN and infinity to ODataUtf8JsonWriter

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -29,6 +29,9 @@ namespace Microsoft.OData.Json
         private readonly float bufferFlushThreshold;
         private readonly static ReadOnlyMemory<byte> parentheses = new byte[] { (byte)'(', (byte)')' };
         private readonly static ReadOnlyMemory<byte> itemSeparator = new byte[] { (byte)',' };
+        private readonly static ReadOnlyMemory<byte> nanValue = new byte[] { (byte)'N', (byte)'a', (byte)'N' };
+        private readonly static ReadOnlyMemory<byte> positiveInfinityValue = new byte[] { (byte)'I', (byte)'N', (byte)'F' };
+        private readonly static ReadOnlyMemory<byte> negativeInfinityValue = new byte[] { (byte)'-', (byte)'I', (byte)'N', (byte)'F' };
 
         private readonly Stream outputStream;
         private readonly Stream writeStream;
@@ -262,15 +265,15 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             if (double.IsNaN(value))
             {
-                this.utf8JsonWriter.WriteStringValue("NaN");
+                this.utf8JsonWriter.WriteStringValue(nanValue.Span);
             }
             else if (double.IsPositiveInfinity(value))
             {
-                this.utf8JsonWriter.WriteStringValue("INF");
+                this.utf8JsonWriter.WriteStringValue(positiveInfinityValue.Span);
             }
             else if (double.IsNegativeInfinity(value))
             {
-                this.utf8JsonWriter.WriteStringValue("-INF");
+                this.utf8JsonWriter.WriteStringValue(negativeInfinityValue.Span);
             }
             else
             {
@@ -679,15 +682,15 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             if (double.IsNaN(value))
             {
-                this.utf8JsonWriter.WriteStringValue("NaN");
+                this.utf8JsonWriter.WriteStringValue(nanValue.Span);
             }
             else if (double.IsPositiveInfinity(value))
             {
-                this.utf8JsonWriter.WriteStringValue("INF");
+                this.utf8JsonWriter.WriteStringValue(positiveInfinityValue.Span);
             }
             else if (double.IsNegativeInfinity(value))
             {
-                this.utf8JsonWriter.WriteStringValue("-INF");
+                this.utf8JsonWriter.WriteStringValue(negativeInfinityValue.Span);
             }
             else
             {

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -260,7 +260,23 @@ namespace Microsoft.OData.Json
         public void WriteValue(double value)
         {
             this.WriteSeparatorIfNecessary();
-            this.utf8JsonWriter.WriteNumberValue(value);
+            if (double.IsNaN(value))
+            {
+                this.utf8JsonWriter.WriteStringValue("NaN");
+            }
+            else if (double.IsPositiveInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue("INF");
+            }
+            else if (double.IsNegativeInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue("-INF");
+            }
+            else
+            {
+                this.utf8JsonWriter.WriteNumberValue(value);
+            }
+            
             this.FlushIfBufferThresholdReached();
         }
 
@@ -661,7 +677,23 @@ namespace Microsoft.OData.Json
         public async Task WriteValueAsync(double value)
         {
             this.WriteSeparatorIfNecessary();
-            this.utf8JsonWriter.WriteNumberValue(value);
+            if (double.IsNaN(value))
+            {
+                this.utf8JsonWriter.WriteStringValue("NaN");
+            }
+            else if (double.IsPositiveInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue("INF");
+            }
+            else if (double.IsNegativeInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue("-INF");
+            }
+            else
+            {
+                this.utf8JsonWriter.WriteNumberValue(value);
+            }
+
             await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
@@ -269,6 +269,24 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public async Task WritePrimitiveValueAsyncDoubleNaN()
+        {
+            await this.VerifyWritePrimitiveValueAsync(double.NaN, "\"NaN\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncDoublePositiveInfinity()
+        {
+            await this.VerifyWritePrimitiveValueAsync (double.PositiveInfinity, "\"INF\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncDoubleNegativeInfinity()
+        {
+            await this.VerifyWritePrimitiveValueAsync(double.NegativeInfinity, "\"-INF\"");
+        }
+
+        [Fact]
         public async Task WritePrimitiveValueAsyncInt16()
         {
             await this.VerifyWritePrimitiveValueAsync((short)876, "876");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -85,6 +85,24 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void WritePrimitiveValueDoubleNaN()
+        {
+            this.VerifyWritePrimitiveValue(double.NaN, "\"NaN\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueDoublePositiveInfinity()
+        {
+            this.VerifyWritePrimitiveValue(double.PositiveInfinity, "\"INF\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueDoubleNegativeInfinity()
+        {
+            this.VerifyWritePrimitiveValue(double.NegativeInfinity, "\"-INF\"");
+        }
+
+        [Fact]
         public void WritePrimitiveValueInt16()
         {
             this.VerifyWritePrimitiveValue((short)876, "876");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -109,6 +109,24 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public async Task WritePrimitiveValueAsyncDoubleNaN()
+        {
+            await this.VerifyWritePrimitiveValueAsync(double.NaN, "\"NaN\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncDoublePositiveInfinity()
+        {
+            await this.VerifyWritePrimitiveValueAsync(double.PositiveInfinity, "\"INF\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncDoubleNegativeInfinity()
+        {
+            await this.VerifyWritePrimitiveValueAsync(double.NegativeInfinity, "\"-INF\"");
+        }
+
+        [Fact]
         public async Task WritePrimitiveValueAsync_Int16()
         {
             await this.VerifyWritePrimitiveValueAsync((short)876, "876");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -110,6 +110,24 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void WritePrimitiveValueDoubleNaN()
+        {
+            this.VerifyWritePrimitiveValue(double.NaN, "\"NaN\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueDoublePositiveInfinity()
+        {
+            this.VerifyWritePrimitiveValue(double.PositiveInfinity, "\"INF\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueDoubleNegativeInfinity()
+        {
+            this.VerifyWritePrimitiveValue(double.NegativeInfinity, "\"-INF\"");
+        }
+
+        [Fact]
         public void WritePrimitiveValueInt16()
         {
             this.VerifyWritePrimitiveValue((short)876, "876");


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2728 *

### Description

This PR adds support for `double.NaN`, `double.PositiveInfinity` and `double.NegativeInfinity` by serializing them as the strings `"NaN"`, `"INF"` and `"-INF"` respectively, to match the behaviour of the default `JsonWriter`.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

