### PR TITLE
Use same format as JsonWriter when serializing DateTimeOffset with ODataUtf8JsonWriter

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -208,7 +208,18 @@ namespace Microsoft.OData.Json
         internal static void WriteValue(TextWriter writer, DateTimeOffset value, ODataJsonDateTimeFormat dateTimeFormat)
         {
             Debug.Assert(writer != null, "writer != null");
+            string textValue = JsonValueUtils.FormatDateTimeOffset(value, dateTimeFormat);
+            JsonValueUtils.WriteQuoted(writer, textValue);
+        }
 
+        /// <summary>
+        /// Formats the DateTimeOffset value as a string based on the specified format.
+        /// </summary>
+        /// <param name="value">DateTimeOffset value to be formatted.</param>
+        /// <param name="dateTimeFormat">The format to use for conversion.</param>
+        /// <returns>The string representation of the DateTimeOffset based on the given format.</returns>
+        internal static string FormatDateTimeOffset(DateTimeOffset value, ODataJsonDateTimeFormat dateTimeFormat)
+        {
             switch (dateTimeFormat)
             {
                 case ODataJsonDateTimeFormat.ISO8601DateTime:
@@ -220,11 +231,8 @@ namespace Microsoft.OData.Json
                         //  quotation-mark
                         //
                         // offset = 4DIGIT
-                        string textValue = XmlConvert.ToString(value);
-                        JsonValueUtils.WriteQuoted(writer, textValue);
+                        return XmlConvert.ToString(value);
                     }
-
-                    break;
 
                 case ODataJsonDateTimeFormat.ODataDateTime:
                     {
@@ -238,12 +246,13 @@ namespace Microsoft.OData.Json
                         //
                         // ticks = *DIGIT
                         // offset = 4DIGIT
-                        string textValue = FormatDateTimeAsJsonTicksString(value);
-                        JsonValueUtils.WriteQuoted(writer, textValue);
+                        return FormatDateTimeAsJsonTicksString(value);
                     }
-
-                    break;
             }
+
+            // NOTE: This statement will not be reached because
+            // we exhausted all the options in the enum
+            return dateTimeFormat.ToString();
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -220,30 +220,36 @@ namespace Microsoft.OData.Json
         /// <returns>The string representation of the DateTimeOffset based on the given format.</returns>
         internal static string FormatDateTimeOffset(DateTimeOffset value, ODataJsonDateTimeFormat dateTimeFormat)
         {
-            if (dateTimeFormat == ODataJsonDateTimeFormat.ISO8601DateTime)
+            switch (dateTimeFormat)
             {
-                // Uses the same format as DateTime but with offset:
-                // jsonDateTime= quotation-mark
-                //  YYYY-MM-DDThh:mm:ss.sTZD
-                //  [("+" / "-") offset]
-                //  quotation-mark
-                //
-                // offset = 4DIGIT
-                return XmlConvert.ToString(value);
-            }
-            else
-            {
-                // Uses the same format as DateTime but with offset:
-                // jsonDateTime= quotation-mark
-                //  "\/Date("
-                //  ticks
-                //  [("+" / "-") offset]
-                //  ")\/"
-                //  quotation-mark
-                //
-                // ticks = *DIGIT
-                // offset = 4DIGIT
-                return FormatDateTimeAsJsonTicksString(value);
+                case ODataJsonDateTimeFormat.ISO8601DateTime:
+                    {
+                        // Uses the same format as DateTime but with offset:
+                        // jsonDateTime= quotation-mark
+                        //  YYYY-MM-DDThh:mm:ss.sTZD
+                        //  [("+" / "-") offset]
+                        //  quotation-mark
+                        //
+                        // offset = 4DIGIT
+                        return XmlConvert.ToString(value);
+                    }
+
+                case ODataJsonDateTimeFormat.ODataDateTime:
+                    {
+                        // Uses the same format as DateTime but with offset:
+                        // jsonDateTime= quotation-mark
+                        //  "\/Date("
+                        //  ticks
+                        //  [("+" / "-") offset]
+                        //  ")\/"
+                        //  quotation-mark
+                        //
+                        // ticks = *DIGIT
+                        // offset = 4DIGIT
+                        return FormatDateTimeAsJsonTicksString(value);
+                    }
+                default:
+                    throw new ODataException(Strings.ODataJsonWriter_UnsupportedDateTimeFormat);
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -220,39 +220,31 @@ namespace Microsoft.OData.Json
         /// <returns>The string representation of the DateTimeOffset based on the given format.</returns>
         internal static string FormatDateTimeOffset(DateTimeOffset value, ODataJsonDateTimeFormat dateTimeFormat)
         {
-            switch (dateTimeFormat)
+            if (dateTimeFormat == ODataJsonDateTimeFormat.ISO8601DateTime)
             {
-                case ODataJsonDateTimeFormat.ISO8601DateTime:
-                    {
-                        // Uses the same format as DateTime but with offset:
-                        // jsonDateTime= quotation-mark
-                        //  YYYY-MM-DDThh:mm:ss.sTZD
-                        //  [("+" / "-") offset]
-                        //  quotation-mark
-                        //
-                        // offset = 4DIGIT
-                        return XmlConvert.ToString(value);
-                    }
-
-                case ODataJsonDateTimeFormat.ODataDateTime:
-                    {
-                        // Uses the same format as DateTime but with offset:
-                        // jsonDateTime= quotation-mark
-                        //  "\/Date("
-                        //  ticks
-                        //  [("+" / "-") offset]
-                        //  ")\/"
-                        //  quotation-mark
-                        //
-                        // ticks = *DIGIT
-                        // offset = 4DIGIT
-                        return FormatDateTimeAsJsonTicksString(value);
-                    }
+                // Uses the same format as DateTime but with offset:
+                // jsonDateTime= quotation-mark
+                //  YYYY-MM-DDThh:mm:ss.sTZD
+                //  [("+" / "-") offset]
+                //  quotation-mark
+                //
+                // offset = 4DIGIT
+                return XmlConvert.ToString(value);
             }
-
-            // NOTE: This statement will not be reached because
-            // we exhausted all the options in the enum
-            return dateTimeFormat.ToString();
+            else
+            {
+                // Uses the same format as DateTime but with offset:
+                // jsonDateTime= quotation-mark
+                //  "\/Date("
+                //  ticks
+                //  [("+" / "-") offset]
+                //  ")\/"
+                //  quotation-mark
+                //
+                // ticks = *DIGIT
+                // offset = 4DIGIT
+                return FormatDateTimeAsJsonTicksString(value);
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -308,7 +308,21 @@ namespace Microsoft.OData.Json
         public void WriteValue(DateTimeOffset value)
         {
             this.WriteSeparatorIfNecessary();
-            this.utf8JsonWriter.WriteStringValue(value);
+            if (value.Offset == TimeSpan.Zero)
+            {
+                // The default JsonWriter uses the format 2022-11-09T09:42:30Z when the offset is 0
+                // Utf8JsonWriter uses the format 2022-11-09T09:42:30+00:00
+                // While both formats are valid IS0 8601, we decided to keep the output
+                // consistent between the two writers to avoid breaking any client that may
+                // have dependency on the original format.
+                string formattedValue = JsonValueUtils.FormatDateTimeOffset(value, ODataJsonDateTimeFormat.ISO8601DateTime);
+                this.utf8JsonWriter.WriteStringValue(formattedValue);
+            }
+            else
+            {
+                this.utf8JsonWriter.WriteStringValue(value);
+            }
+
             this.FlushIfBufferThresholdReached();
         }
 
@@ -725,7 +739,21 @@ namespace Microsoft.OData.Json
         public async Task WriteValueAsync(DateTimeOffset value)
         {
             this.WriteSeparatorIfNecessary();
-            this.utf8JsonWriter.WriteStringValue(value);
+            if (value.Offset == TimeSpan.Zero)
+            {
+                // The default JsonWriter uses the format 2022-11-09T09:42:30Z when the offset is 0
+                // Utf8JsonWriter uses the format 2022-11-09T09:42:30+00:00
+                // While both formats are valid IS0 8601, we decided to keep the output
+                // consistent between the two writers to avoid breaking any client that may
+                // have dependency on the original format.
+                string formattedValue = JsonValueUtils.FormatDateTimeOffset(value, ODataJsonDateTimeFormat.ISO8601DateTime);
+                this.utf8JsonWriter.WriteStringValue(formattedValue);
+            }
+            else
+            {
+                this.utf8JsonWriter.WriteStringValue(value);
+            }
+
             await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -310,8 +310,8 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             if (value.Offset == TimeSpan.Zero)
             {
-                // The default JsonWriter uses the format 2022-11-09T09:42:30Z when the offset is 0
-                // Utf8JsonWriter uses the format 2022-11-09T09:42:30+00:00
+                // The default JsonWriter uses the format yyyy-MM-ddThh:mm:ss.fffffffZ when the offset is 0
+                // Utf8JsonWriter uses the format yyyy-MM-ddThh:mm:ss.fffffff+00:00
                 // While both formats are valid IS0 8601, we decided to keep the output
                 // consistent between the two writers to avoid breaking any client that may
                 // have dependency on the original format.
@@ -741,8 +741,9 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             if (value.Offset == TimeSpan.Zero)
             {
-                // The default JsonWriter uses the format 2022-11-09T09:42:30Z when the offset is 0
-                // Utf8JsonWriter uses the format 2022-11-09T09:42:30+00:00
+
+                // The default JsonWriter uses the format yyyy-MM-ddThh:mm:ss.fffffffZ when the offset is 0
+                // Utf8JsonWriter uses the format yyyy-MM-ddThh:mm:ss.fffffff+00:00
                 // While both formats are valid IS0 8601, we decided to keep the output
                 // consistent between the two writers to avoid breaking any client that may
                 // have dependency on the original format.

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -75,6 +75,7 @@ namespace Microsoft.OData
         internal const string AtomValueUtils_CannotConvertValueToAtomPrimitive = "AtomValueUtils_CannotConvertValueToAtomPrimitive";
         internal const string ODataJsonWriter_UnsupportedValueType = "ODataJsonWriter_UnsupportedValueType";
         internal const string ODataJsonWriter_UnsupportedValueInCollection = "ODataJsonWriter_UnsupportedValueInCollection";
+        internal const string ODataJsonWriter_UnsupportedDateTimeFormat = "ODataJsonWriter_UnsupportedDateTimeFormat";
         internal const string ODataException_GeneralError = "ODataException_GeneralError";
         internal const string ODataErrorException_GeneralError = "ODataErrorException_GeneralError";
         internal const string ODataUriParserException_GeneralError = "ODataUriParserException_GeneralError";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -70,6 +70,7 @@ AtomValueUtils_CannotConvertValueToAtomPrimitive=Cannot convert a value of type 
 
 ODataJsonWriter_UnsupportedValueType=The value of type '{0}' is not supported and cannot be converted to a JSON representation.
 ODataJsonWriter_UnsupportedValueInCollection=Unable to serialize an object in a collection as it is not a supported ODataValue.
+ODataJsonWriter_UnsupportedDateTimeFormat=The specified ODataJsonDateTimeFormat is not supported.
 
 ODataException_GeneralError=An error occurred while processing the OData message.
 ODataErrorException_GeneralError=An error was read from the payload. See the 'Error' property for more details.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -515,6 +515,17 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The specified ODataJsonDateTimeFormat is not supported."
+        /// </summary>
+        internal static string ODataJsonWriter_UnsupportedDateTimeFormat
+        {
+            get
+            {
+                return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataJsonWriter_UnsupportedDateTimeFormat);
+            }
+        }
+
+        /// <summary>
         /// A string like "An error occurred while processing the OData message."
         /// </summary>
         internal static string ODataException_GeneralError

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
@@ -341,6 +341,12 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public async Task WritePrimitiveValueAsyncDateTimeOffsetWithZeroOffsetWithZeroOffset()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new DateTimeOffset(1, 2, 3, 4, 5, 6, 7, TimeSpan.Zero), "\"0001-02-03T04:05:06.007Z\"");
+        }
+
+        [Fact]
         public async Task WritePrimitiveValueAsyncGuid()
         {
             await this.VerifyWritePrimitiveValueAsync(new Guid("00000012-0000-0000-0000-012345678900"), "\"00000012-0000-0000-0000-012345678900\"");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -181,6 +181,12 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void WritePrimitiveValueDateTimeOffsetWithZeroOffset()
+        {
+            this.VerifyWritePrimitiveValue(new DateTimeOffset(1, 2, 3, 4, 5, 6, 7, TimeSpan.Zero), "\"0001-02-03T04:05:06.007Z\"");
+        }
+
+        [Fact]
         public void WritePrimitiveValueGuid()
         {
             this.VerifyWritePrimitiveValue(new Guid("00000012-0000-0000-0000-012345678900"), "\"00000012-0000-0000-0000-012345678900\"");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -207,6 +207,12 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public async Task WritePrimitiveValueAsync_DateTimeOffset_WithZeroOffsetWithZeroOffset()
+        {
+            await this.VerifyWritePrimitiveValueAsync(new DateTimeOffset(1, 2, 3, 4, 5, 6, 7, TimeSpan.Zero), "\"0001-02-03T04:05:06.007Z\"");
+        }
+
+        [Fact]
         public async Task WritePrimitiveValueAsync_Guid()
         {
             await this.VerifyWritePrimitiveValueAsync(new Guid("00000012-0000-0000-0000-012345678900"), "\"00000012-0000-0000-0000-012345678900\"");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -208,6 +208,12 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void WritePrimitiveValueDateTimeOffsetWithZeroOffset()
+        {
+            this.VerifyWritePrimitiveValue(new DateTimeOffset(1, 2, 3, 4, 5, 6, 7, TimeSpan.Zero), "\"0001-02-03T04:05:06.007Z\"");
+        }
+
+        [Fact]
         public void WritePrimitiveValueGuid()
         {
             this.VerifyWritePrimitiveValue(new Guid("00000012-0000-0000-0000-012345678900"), "\"00000012-0000-0000-0000-012345678900\"");


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

The default `JsonWriter` and `Utf8JsonWriter`, while both use ISO8601 format to write `DateTimeOffset`, they differ in the specific case when the time zone offset is 0.

`JsonWriter` uses `Z` to indicate the offset: `2022-11-09T09:42:30Z`
`Utf8JsonWriter` uses `+00:00`, i.e.: `2022-11-09T09:42:30+00:00`

This PR changes `ODataUtf8JsonWriter` to make it consistent with `JsonWriter` when emitting 0-offset DateTimeOffset values.

### Description

In the `WriteValue(DateTimeOffset value)` method, we check if the offset is 0. If the offset is 0, then it uses the DateTimeOffset string formatting utility in `JsonValueUtils` to convert it to a string first.

You may be wondering, why not just convert all `DateTimeOffset` values to string and not just those with 0 offsets? Well it turns out that if you convert the value to string, `Utf8JsonWriter` will escape the `+` offset with `\u002B`, i.e. `2022-11-09T09:42:30\u002B00:00`.

It may also be worse for perf.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
