### PR TITLE
Fixes #2754, enable key in parenthesis after composable function with parameters

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
@@ -1047,9 +1047,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
-        public void KeyLookupCannotAppearAfterFunctionWithParameters()
+        public void KeyLookupCanAppearAfterFunctionWithParameters()
         {
-            PathFunctionalTestsUtil.RunParseErrorPath("People(1)/Fully.Qualified.Namespace.AllMyFriendsDogs(inOffice=true)(1)", ODataErrorStrings.ExpressionLexer_SyntaxError(14, "inOffice=true)(1"));
+            var path = PathFunctionalTestsUtil.RunParsePath("People(1)/Fully.Qualified.Namespace.AllMyFriendsDogs(inOffice=true)(42)");
+            Assert.Equal(4, path.Count);
+            path.Segments[0].ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
+            path.Segments[1].ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 1));
+            path.Segments[2].ShouldBeOperationSegment(HardCodedTestModel.GetFunctionForAllMyFriendsDogs(2));
+            path.Segments[3].ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 42));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -2232,9 +2232,9 @@ namespace Microsoft.OData.Tests.UriParser
             return TestModel.EntityContainer.FindOperationImports("IsAddressGood").Single() as IEdmFunctionImport;
         }
 
-        public static IEdmFunction GetFunctionForAllMyFriendsDogs()
+        public static IEdmFunction GetFunctionForAllMyFriendsDogs(int parameterCount = 1)
         {
-            return TestModel.FindOperations("Fully.Qualified.Namespace.AllMyFriendsDogs").Single(f => f.Parameters.Count() == 1) as IEdmFunction;
+            return TestModel.FindOperations("Fully.Qualified.Namespace.AllMyFriendsDogs").Single(f => f.Parameters.Count() == parameterCount) as IEdmFunction;
         }
 
         public static IEdmOperationImport[] GetAllFunctionImportsForGetMostImportantPerson()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/FunctionParameterParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/FunctionParameterParserTests.cs
@@ -21,6 +21,19 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
     /// </summary>
     public class FunctionParameterParserTests
     {
+        [Theory]
+        [InlineData("1", "1", null)]
+        [InlineData(")(1", "", "1")]
+        [InlineData("person=People(1)", "person=People(1)", null)]
+        [InlineData("person=People(1))('bca(aa('", "person=People(1)", "'bca(aa('")]
+        [InlineData("degree=1)('fawn'", "degree=1", "'fawn'")]
+        public void SplitOperationParametersAndParenthesisKey_WorksForInputExpression(string expression, string parameters, string keys)
+        {
+            FunctionParameterParser.SplitOperationParametersAndParenthesisKey(expression, out string acutalParams, out string actualKeys);
+            Assert.Equal(parameters, acutalParams);
+            Assert.Equal(keys, actualKeys);
+        }
+
         [Fact]
         public void FunctionParameterParserShouldSupportUnresolvedAliasesInPath()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTests.cs
@@ -801,6 +801,30 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         }
 
         [Fact]
+        public void ParseKeyInParenthesisAfterBoundFunctionReturnsCollectionOfEntitiesShouldWork()
+        {
+            // People(1)/Fully.Qualified.Namespace.AllMyFriendsDogs(inOffice = true)(42)
+            IList<ODataPathSegment> path = this.testSubject.ParsePath(new[] { "People(1)", "Fully.Qualified.Namespace.AllMyFriendsDogs(inOffice=true)(42)" });
+            Assert.Equal(4, path.Count);
+            path[0].ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
+            path[1].ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 1));
+            path[2].ShouldBeOperationSegment(HardCodedTestModel.GetFunctionForAllMyFriendsDogs(2));
+            path[3].ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 42));
+        }
+
+        [Fact]
+        public void ParseKeyAsSegmentAfterBoundFunctionReturnsCollectionOfEntitiesShouldWork()
+        {
+            // People(1)/Fully.Qualified.Namespace.AllMyFriendsDogs(inOffice = true)/42
+            IList<ODataPathSegment> path = this.testSubject.ParsePath(new[] { "People(1)", "Fully.Qualified.Namespace.AllMyFriendsDogs(inOffice=true)", "42" });
+            Assert.Equal(4, path.Count);
+            path[0].ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
+            path[1].ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 1));
+            path[2].ShouldBeOperationSegment(HardCodedTestModel.GetFunctionForAllMyFriendsDogs(2));
+            path[3].ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 42));
+        }
+
+        [Fact]
         public void ParseBoundFunctionWithTypeDefinitionAsParameterAndReturnTypeShouldWork()
         {
             var path = this.testSubject.ParsePath(new[] { "People(1)", "Fully.Qualified.Namespace.GetFullName(nickname='abc')" });


### PR DESCRIPTION
… parameters

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2754.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
