### PR TITLE
Feature IEdmTargetPath to support path to a model element

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
@@ -448,6 +448,13 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
                             return new UnresolvedParameter(operationImport.Operation, parameterName, this.Location);
                         }
+
+                        IEdmTargetPath targetPath = model.GetTargetPath(target);
+
+                        if (targetPath != null)
+                        {
+                            return targetPath;
+                        }
                     }
 
                     string qualifiedOperationName = containerName + "/" + operationName;
@@ -460,6 +467,18 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                     {
                         return new UnresolvedParameter(unresolvedOperation, parameterName, this.Location);
                     }
+                }
+
+                if (targetSegmentsCount > 3)
+                {
+                    IEdmTargetPath targetPath = model.GetTargetPath(target);
+
+                    if (targetPath != null)
+                    {
+                        return targetPath;
+                    }
+
+                    return new UnresolvedProperty(new UnresolvedEntityType(this.model.ReplaceAlias(targetSegments[targetSegments.Length - 2]), this.Location), targetSegments[targetSegments.Length - 1], this.Location);
                 }
 
                 return new BadElement(new EdmError[] { new EdmError(this.Location, EdmErrorCode.ImpossibleAnnotationsTarget, Edm.Strings.CsdlSemantics_ImpossibleAnnotationsTarget(target)) });

--- a/src/Microsoft.OData.Edm/Csdl/SerializationExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/Csdl/SerializationExtensionMethods.cs
@@ -98,6 +98,13 @@ namespace Microsoft.OData.Edm.Csdl
             EdmUtil.CheckArgumentNull(annotation, "annotation");
             EdmUtil.CheckArgumentNull(model, "model");
 
+            if (annotation.Target is IEdmTargetPath targetPath &&
+                location != null &&
+                location.Value == EdmVocabularyAnnotationSerializationLocation.Inline)
+            {
+                throw new InvalidOperationException(Strings.EdmVocabularyAnnotations_InvalidLocationForTargetPathAnnotation(targetPath.Path));
+            }
+
             model.SetAnnotationValue(annotation, EdmConstants.InternalUri, CsdlConstants.AnnotationSerializationLocationAnnotation, (object)location);
         }
 

--- a/src/Microsoft.OData.Edm/EdmUtil.cs
+++ b/src/Microsoft.OData.Edm/EdmUtil.cs
@@ -421,7 +421,13 @@ namespace Microsoft.OData.Edm
 
         internal static string FullyQualifiedName(IEdmVocabularyAnnotatable element)
         {
+            if (element is IEdmTargetPath targetPath)
+            {
+                return targetPath.Path;
+            }
+
             IEdmSchemaElement schemaElement = element as IEdmSchemaElement;
+
             if (schemaElement != null)
             {
                 IEdmOperation operation = schemaElement as IEdmOperation;

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1570,16 +1570,16 @@ namespace Microsoft.OData.Edm
         /// </summary>
         /// <param name="model">The EdmModel.</param>
         /// <param name="targetPath">Target path containing segments separated by '/'. For example: "A.B/C/D.E/Func1(NS.T,NS.T2)/P1".</param>
-        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <param name="ignoreCase">Property name case-insensitive or not.</param>
         /// <returns>The created <see cref="IEdmTargetPath"/>.</returns>
-        public static IEdmTargetPath GetTargetPath(this IEdmModel model, string targetPath, bool caseInsensitive = true)
+        public static IEdmTargetPath GetTargetPath(this IEdmModel model, string targetPath, bool ignoreCase = true)
         {
             EdmUtil.CheckArgumentNull(model, nameof(model));
             EdmUtil.CheckArgumentNull(targetPath, nameof(targetPath));
 
             string[] targetPathSegments = targetPath.Split('/');
 
-            IEnumerable<IEdmElement> pathSegments = model.GetTargetSegments(targetPathSegments, caseInsensitive);
+            IEnumerable<IEdmElement> pathSegments = model.GetTargetSegments(targetPathSegments, ignoreCase);
 
             if (pathSegments.Any())
             {

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1566,10 +1566,10 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Get the <see cref="IEdmTargetPath"/> from a target path string.
+        /// Returns an <see cref="IEdmTargetPath"/> given a target path string.
         /// </summary>
-        /// <param name="model">The EdmModel.</param>
-        /// <param name="targetPath">Target path containing segments separated by '/'. For example: "A.B/C/D.E/Func1(NS.T,NS.T2)/P1".</param>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="targetPath">The target path string comprising of segments separated by '/', e.g., "A.B/C/D.E/Func1(NS.T,NS.T2)/P1".</param>
         /// <param name="ignoreCase">Property name case-insensitive or not.</param>
         /// <returns>The created <see cref="IEdmTargetPath"/>.</returns>
         public static IEdmTargetPath GetTargetPath(this IEdmModel model, string targetPath, bool ignoreCase = true)
@@ -2973,9 +2973,9 @@ namespace Microsoft.OData.Edm
         #region IEdmTargetPath extensions
 
         /// <summary>
-        /// Get the path string from the <see cref="IEdmTargetPath"/>.
+        /// Returns the target path string given an <see cref="IEdmTargetPath"/>.
         /// </summary>
-        /// <param name="targetPath">The target path.</param>
+        /// <param name="targetPath">The <see cref="IEdmTargetPath"/>.</param>
         /// <returns>The target path string.</returns>
         internal static string GetPathString(this IEdmTargetPath targetPath)
         {
@@ -3007,7 +3007,6 @@ namespace Microsoft.OData.Edm
                 {
                     segments[index] = EdmUtil.FullyQualifiedName(schemaType);
                 }
-
                 else if (targetPath.Segments[index] is IEdmProperty edmProperty)
                 {
                     segments[index] = edmProperty.Name;

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -2995,10 +2995,9 @@ namespace Microsoft.OData.Edm
                 throw new InvalidOperationException(Strings.TargetPath_SecondSegmentMustBeIEdmEntityContainerElement);
             }
 
-            StringBuilder stringBuilder = new StringBuilder();
-            stringBuilder.Append(container.FullName());
-            stringBuilder.Append("/");
-            stringBuilder.Append(containerElement.Name);
+            string[] segments = new string[targetPath.Segments.Count];
+            segments[0] = container.FullName();
+            segments[1] = containerElement.Name;
 
             int index = 2;
 
@@ -3006,20 +3005,18 @@ namespace Microsoft.OData.Edm
             {
                 if (targetPath.Segments[index] is IEdmSchemaType schemaType)
                 {
-                    stringBuilder.Append("/");
-                    stringBuilder.Append(EdmUtil.FullyQualifiedName(schemaType));
+                    segments[index] = EdmUtil.FullyQualifiedName(schemaType);
                 }
 
                 else if (targetPath.Segments[index] is IEdmProperty edmProperty)
                 {
-                    stringBuilder.Append("/");
-                    stringBuilder.Append(edmProperty.Name);
+                    segments[index] = edmProperty.Name;
                 }
 
                 index++;
             }
 
-            return stringBuilder.ToString();
+            return string.Join("/", segments);
         }
 
         #endregion

--- a/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
@@ -21,9 +21,9 @@ namespace Microsoft.OData.Edm
         /// </summary>
         /// <param name="model">The EdmModel.</param>
         /// <param name="targetSegments">Segments for the target path..</param>
-        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <param name="ignoreCase">Property name case-insensitive or not.</param>
         /// <returns>The created enumeration of <see cref="IEdmElement"/>.</returns>
-        public static IEnumerable<IEdmElement> GetTargetSegments(this IEdmModel model, string[] targetSegments, bool caseInsensitive)
+        public static IEnumerable<IEdmElement> GetTargetSegments(this IEdmModel model, string[] targetSegments, bool ignoreCase)
         {
             EdmUtil.CheckArgumentNull(model, nameof(model));
             EdmUtil.CheckArgumentNull(targetSegments, nameof(targetSegments));
@@ -39,22 +39,22 @@ namespace Microsoft.OData.Edm
             pathSegments.Add(container);
             int index = 1; // index of the targetSegments.
 
-            IEdmVocabularyAnnotatable vocabularyAnnotatable =  HandleEntityContainer(model, pathSegments, container, targetSegments, index, caseInsensitive);
+            IEdmVocabularyAnnotatable vocabularyAnnotatable =  HandleEntityContainer(model, pathSegments, container, targetSegments, index, ignoreCase);
             index++;
 
             while (index < targetSegments.Length)
             {
                 if (vocabularyAnnotatable is IEdmEntityContainerElement containerElement)
                 {
-                    vocabularyAnnotatable = HandleContainerElement(model, pathSegments, containerElement, targetSegments, index, caseInsensitive);
+                    vocabularyAnnotatable = HandleContainerElement(model, pathSegments, containerElement, targetSegments, index, ignoreCase);
                 }
                 else if (vocabularyAnnotatable is IEdmSchemaType schemaType)
                 {
-                    vocabularyAnnotatable = HandleSchemaType(model, pathSegments, schemaType, targetSegments, index, caseInsensitive);
+                    vocabularyAnnotatable = HandleSchemaType(model, pathSegments, schemaType, targetSegments, index, ignoreCase);
                 }
                 else if (vocabularyAnnotatable is IEdmProperty property)
                 {
-                    vocabularyAnnotatable = HandleProperty(model, pathSegments, property, targetSegments, index, caseInsensitive);
+                    vocabularyAnnotatable = HandleProperty(model, pathSegments, property, targetSegments, index, ignoreCase);
                 }
                 else
                 {
@@ -75,9 +75,9 @@ namespace Microsoft.OData.Edm
         /// <param name="entityContainer">The entity container.</param>
         /// <param name="targetSegments">The target segments to resolve.</param>
         /// <param name="index">The index of the target segments.</param>
-        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <param name="ignoreCase">Property name case-insensitive or not.</param>
         /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
-        private static IEdmVocabularyAnnotatable HandleEntityContainer(IEdmModel model, List<IEdmElement> pathSegments, IEdmEntityContainer entityContainer, string[] targetSegments, int index, bool caseInsensitive)
+        private static IEdmVocabularyAnnotatable HandleEntityContainer(IEdmModel model, List<IEdmElement> pathSegments, IEdmEntityContainer entityContainer, string[] targetSegments, int index, bool ignoreCase)
         {
             IEdmEntitySet entitySet = entityContainer.FindEntitySetExtended(targetSegments[index]);
 
@@ -108,9 +108,9 @@ namespace Microsoft.OData.Edm
         /// <param name="entityContainerElement">The entity container element.</param>
         /// <param name="targetSegments">The target segments to resolve.</param>
         /// <param name="index">The index of the target segments.</param>
-        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <param name="ignoreCase">Property name case-insensitive or not.</param>
         /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
-        private static IEdmVocabularyAnnotatable HandleContainerElement(IEdmModel model, List<IEdmElement> pathSegments, IEdmEntityContainerElement entityContainerElement, string[] targetSegments, int index, bool caseInsensitive)
+        private static IEdmVocabularyAnnotatable HandleContainerElement(IEdmModel model, List<IEdmElement> pathSegments, IEdmEntityContainerElement entityContainerElement, string[] targetSegments, int index, bool ignoreCase)
         {
             // .../MyEntitySet/MySchema.MyEntityType/...
             // .../MyEntitySet/MyComplexProperty/...
@@ -144,7 +144,7 @@ namespace Microsoft.OData.Edm
                 // .../MySingleton/MyProperty/...
                 // .../MySingleton/MyNavigationProperty/...
 
-                return HandleStructuredType(model, pathSegments, structuredType, targetSegments, index, caseInsensitive);
+                return HandleStructuredType(model, pathSegments, structuredType, targetSegments, index, ignoreCase);
             }
 
             return null;
@@ -158,9 +158,9 @@ namespace Microsoft.OData.Edm
         /// <param name="schemaType">The schema type.</param>
         /// <param name="targetSegments">The target segments to resolve.</param>
         /// <param name="index">The index of the target segments.</param>
-        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <param name="ignoreCase">Property name case-insensitive or not.</param>
         /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
-        private static IEdmVocabularyAnnotatable HandleSchemaType(IEdmModel model, List<IEdmElement> pathSegments, IEdmSchemaType schemaType, string[] targetSegments, int index, bool caseInsensitive)
+        private static IEdmVocabularyAnnotatable HandleSchemaType(IEdmModel model, List<IEdmElement> pathSegments, IEdmSchemaType schemaType, string[] targetSegments, int index, bool ignoreCase)
         {
             // Validate schema type is not followed by schema type e.g entitycontainer/entityset/NS.TypeCase1/NS.TypeCase2/...
             IEdmSchemaType nextSchemaType = model.FindType(targetSegments[index]);
@@ -172,7 +172,7 @@ namespace Microsoft.OData.Edm
 
             if (schemaType is IEdmStructuredType structuredType)
             {
-                return HandleStructuredType(model, pathSegments, structuredType, targetSegments, index, caseInsensitive);
+                return HandleStructuredType(model, pathSegments, structuredType, targetSegments, index, ignoreCase);
             }
 
             return null;
@@ -232,9 +232,9 @@ namespace Microsoft.OData.Edm
         /// <param name="edmProperty">The edm property.</param>
         /// <param name="targetSegments">The target segments to resolve.</param>
         /// <param name="index">The index of the target segments.</param>
-        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <param name="ignoreCase">Property name case-insensitive or not.</param>
         /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
-        private static IEdmVocabularyAnnotatable HandleProperty(IEdmModel model, List<IEdmElement> pathSegments, IEdmProperty edmProperty, string[] targetSegments, int index, bool caseInsensitive)
+        private static IEdmVocabularyAnnotatable HandleProperty(IEdmModel model, List<IEdmElement> pathSegments, IEdmProperty edmProperty, string[] targetSegments, int index, bool ignoreCase)
         {
             IEdmSchemaType schemaType = model.FindType(targetSegments[index]);
 
@@ -254,7 +254,7 @@ namespace Microsoft.OData.Edm
             {
                 // .../MyProperty1/MyProperty2/...
 
-                return HandleStructuredType(model, pathSegments, structuredType, targetSegments, index, caseInsensitive);
+                return HandleStructuredType(model, pathSegments, structuredType, targetSegments, index, ignoreCase);
             }
 
             return null;
@@ -268,11 +268,11 @@ namespace Microsoft.OData.Edm
         /// <param name="structuredType">The structured type.</param>
         /// <param name="targetSegments">The target segments to resolve.</param>
         /// <param name="index">The index of the target segments.</param>
-        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <param name="ignoreCase">Property name case-insensitive or not.</param>
         /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
-        private static IEdmVocabularyAnnotatable HandleStructuredType(IEdmModel model, List<IEdmElement> pathSegments, IEdmStructuredType structuredType, string[] targetSegments, int index, bool caseInsensitive)
+        private static IEdmVocabularyAnnotatable HandleStructuredType(IEdmModel model, List<IEdmElement> pathSegments, IEdmStructuredType structuredType, string[] targetSegments, int index, bool ignoreCase)
         {
-            IEdmProperty property = structuredType.FindProperty(targetSegments[index], caseInsensitive);
+            IEdmProperty property = structuredType.FindProperty(targetSegments[index], ignoreCase);
 
             if (property != null)
             {

--- a/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
@@ -188,7 +188,7 @@ namespace Microsoft.OData.Edm
         {
             IEdmElement previousElement = pathSegments[index - 1];
 
-            bool isValid = IsDerivedTypeValid(previousElement, schemaType);
+            bool isValid = IsTypeCastValid(previousElement, schemaType);
 
             if (!isValid)
             {
@@ -196,7 +196,7 @@ namespace Microsoft.OData.Edm
             }
         }
 
-        private static bool IsDerivedTypeValid(IEdmElement element, IEdmSchemaType schemaType)
+        private static bool IsTypeCastValid(IEdmElement element, IEdmSchemaType schemaType)
         {
             IEdmType elementEdmType = null;
             if (element is IEdmProperty property)

--- a/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
@@ -12,17 +12,17 @@ namespace Microsoft.OData.Edm
     using Microsoft.OData.Edm.Vocabularies;
 
     /// <summary>
-    /// Target path helper.
+    /// Helper for <see cref="EdmTargetPath"/> class.
     /// </summary>
     internal static class TargetPathHelper
     {
         /// <summary>
-        /// Get the Segments from a target path string as enumeration of Edm elements.
+        /// Returns the segments of a target path string as a collection of Edm elements.
         /// </summary>
-        /// <param name="model">The EdmModel.</param>
-        /// <param name="targetSegments">Segments for the target path..</param>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="targetSegments">Segments for the target path string.</param>
         /// <param name="ignoreCase">Property name case-insensitive or not.</param>
-        /// <returns>The created enumeration of <see cref="IEdmElement"/>.</returns>
+        /// <returns>The collection of <see cref="IEdmElement"/>.</returns>
         public static IEnumerable<IEdmElement> GetTargetSegments(this IEdmModel model, string[] targetSegments, bool ignoreCase)
         {
             EdmUtil.CheckArgumentNull(model, nameof(model));
@@ -68,15 +68,15 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Returns an Entity container element from the entity container.
+        /// Returns an entity container element from the specified entity container.
         /// </summary>
-        /// <param name="model">The edm model.</param>
+        /// <param name="model">The Edm model.</param>
         /// <param name="pathSegments">The path segments of already resolved target segments.</param>
         /// <param name="entityContainer">The entity container.</param>
-        /// <param name="targetSegments">The target segments to resolve.</param>
-        /// <param name="index">The index of the target segments.</param>
+        /// <param name="targetSegments">The array of segments in the target path string.</param>
+        /// <param name="index">The index of the target segment.</param>
         /// <param name="ignoreCase">Property name case-insensitive or not.</param>
-        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        /// <returns>An Edm entity container element as an <see cref="IEdmVocabularyAnnotatable"/>.</returns>
         private static IEdmVocabularyAnnotatable HandleEntityContainer(IEdmModel model, List<IEdmElement> pathSegments, IEdmEntityContainer entityContainer, string[] targetSegments, int index, bool ignoreCase)
         {
             IEdmEntitySet entitySet = entityContainer.FindEntitySetExtended(targetSegments[index]);
@@ -103,13 +103,13 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Returns a schema type or property from an entity container element.
         /// </summary>
-        /// <param name="model">The edm model.</param>
+        /// <param name="model">The Edm model.</param>
         /// <param name="pathSegments">The path segments of already resolved target segments.</param>
         /// <param name="entityContainerElement">The entity container element.</param>
-        /// <param name="targetSegments">The target segments to resolve.</param>
-        /// <param name="index">The index of the target segments.</param>
+        /// <param name="targetSegments">The array of segments in the target path string.</param>
+        /// <param name="index">The index of the target segment.</param>
         /// <param name="ignoreCase">Property name case-insensitive or not.</param>
-        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        /// <returns>An Edm schema type or property element as an <see cref="IEdmVocabularyAnnotatable"/>.</returns>
         private static IEdmVocabularyAnnotatable HandleContainerElement(IEdmModel model, List<IEdmElement> pathSegments, IEdmEntityContainerElement entityContainerElement, string[] targetSegments, int index, bool ignoreCase)
         {
             // .../MyEntitySet/MySchema.MyEntityType/...
@@ -153,13 +153,13 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Returns a property from a schema type.
         /// </summary>
-        /// <param name="model">The edm model.</param>
+        /// <param name="model">The Edm model.</param>
         /// <param name="pathSegments">The path segments of already resolved target segments.</param>
         /// <param name="schemaType">The schema type.</param>
-        /// <param name="targetSegments">The target segments to resolve.</param>
-        /// <param name="index">The index of the target segments.</param>
+        /// <param name="targetSegments">The array of segments in the target path string.</param>
+        /// <param name="index">The index of the target segment.</param>
         /// <param name="ignoreCase">Property name case-insensitive or not.</param>
-        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        /// <returns>An Edm schema type or property element as an <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
         private static IEdmVocabularyAnnotatable HandleSchemaType(IEdmModel model, List<IEdmElement> pathSegments, IEdmSchemaType schemaType, string[] targetSegments, int index, bool ignoreCase)
         {
             // Validate schema type is not followed by schema type e.g entitycontainer/entityset/NS.TypeCase1/NS.TypeCase2/...
@@ -179,11 +179,11 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Validate a schema type.
+        /// Validates a schema type.
         /// </summary>
         /// <param name="schemaType">The schema type.</param>
         /// <param name="pathSegments">The path segments of already resolved target segments.</param>
-        /// <param name="index">The index of the path segments.</param>
+        /// <param name="index">The index of the target segment.</param>
         private static void ValidateSchemaType(IEdmSchemaType schemaType, List<IEdmElement> pathSegments, int index)
         {
             IEdmElement previousElement = pathSegments[index - 1];
@@ -227,13 +227,13 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Returns a schema type or property from a property.
         /// </summary>
-        /// <param name="model">The edm model.</param>
+        /// <param name="model">The Edm model.</param>
         /// <param name="pathSegments">The path segments of already resolved target segments.</param>
         /// <param name="edmProperty">The edm property.</param>
-        /// <param name="targetSegments">The target segments to resolve.</param>
-        /// <param name="index">The index of the target segments.</param>
+        /// <param name="targetSegments">The array of segments in the target path string.</param>
+        /// <param name="index">The index of the target segment.</param>
         /// <param name="ignoreCase">Property name case-insensitive or not.</param>
-        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        /// <returns>An Edm schema type or property element as an <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
         private static IEdmVocabularyAnnotatable HandleProperty(IEdmModel model, List<IEdmElement> pathSegments, IEdmProperty edmProperty, string[] targetSegments, int index, bool ignoreCase)
         {
             IEdmSchemaType schemaType = model.FindType(targetSegments[index]);
@@ -263,13 +263,13 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Returns a property from a structured type.
         /// </summary>
-        /// <param name="model">The edm model.</param>
+        /// <param name="model">The Edm model.</param>
         /// <param name="pathSegments">The path segments of already resolved target segments.</param>
         /// <param name="structuredType">The structured type.</param>
-        /// <param name="targetSegments">The target segments to resolve.</param>
-        /// <param name="index">The index of the target segments.</param>
+        /// <param name="targetSegments">The array of segments in the target path string.</param>
+        /// <param name="index">The index of the target segment.</param>
         /// <param name="ignoreCase">Property name case-insensitive or not.</param>
-        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        /// <returns>An Edm property element as an <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
         private static IEdmVocabularyAnnotatable HandleStructuredType(IEdmModel model, List<IEdmElement> pathSegments, IEdmStructuredType structuredType, string[] targetSegments, int index, bool ignoreCase)
         {
             IEdmProperty property = structuredType.FindProperty(targetSegments[index], ignoreCase);

--- a/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
@@ -1,0 +1,287 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="TargetPathHelper.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Edm
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.OData.Edm.Vocabularies;
+
+    /// <summary>
+    /// Target path helper.
+    /// </summary>
+    internal static class TargetPathHelper
+    {
+        /// <summary>
+        /// Get the Segments from a target path string as enumeration of Edm elements.
+        /// </summary>
+        /// <param name="model">The EdmModel.</param>
+        /// <param name="targetSegments">Segments for the target path..</param>
+        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <returns>The created enumeration of <see cref="IEdmElement"/>.</returns>
+        public static IEnumerable<IEdmElement> GetTargetSegments(this IEdmModel model, string[] targetSegments, bool caseInsensitive)
+        {
+            EdmUtil.CheckArgumentNull(model, nameof(model));
+            EdmUtil.CheckArgumentNull(targetSegments, nameof(targetSegments));
+
+            IEdmEntityContainer container = model.FindEntityContainer(targetSegments[0]);
+
+            if (container == null)
+            {
+                return Enumerable.Empty<IEdmElement>();
+            }
+
+            List<IEdmElement> pathSegments = new List<IEdmElement>();
+            pathSegments.Add(container);
+            int index = 1; // index of the targetSegments.
+
+            IEdmVocabularyAnnotatable vocabularyAnnotatable =  HandleEntityContainer(model, pathSegments, container, targetSegments, index, caseInsensitive);
+            index++;
+
+            while (index < targetSegments.Length)
+            {
+                if (vocabularyAnnotatable is IEdmEntityContainerElement containerElement)
+                {
+                    vocabularyAnnotatable = HandleContainerElement(model, pathSegments, containerElement, targetSegments, index, caseInsensitive);
+                }
+                else if (vocabularyAnnotatable is IEdmSchemaType schemaType)
+                {
+                    vocabularyAnnotatable = HandleSchemaType(model, pathSegments, schemaType, targetSegments, index, caseInsensitive);
+                }
+                else if (vocabularyAnnotatable is IEdmProperty property)
+                {
+                    vocabularyAnnotatable = HandleProperty(model, pathSegments, property, targetSegments, index, caseInsensitive);
+                }
+                else
+                {
+                    return Enumerable.Empty<IEdmElement>();
+                }
+
+                index++;
+            }
+
+            return pathSegments;
+        }
+
+        /// <summary>
+        /// Returns an Entity container element from the entity container.
+        /// </summary>
+        /// <param name="model">The edm model.</param>
+        /// <param name="pathSegments">The path segments of already resolved target segments.</param>
+        /// <param name="entityContainer">The entity container.</param>
+        /// <param name="targetSegments">The target segments to resolve.</param>
+        /// <param name="index">The index of the target segments.</param>
+        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        private static IEdmVocabularyAnnotatable HandleEntityContainer(IEdmModel model, List<IEdmElement> pathSegments, IEdmEntityContainer entityContainer, string[] targetSegments, int index, bool caseInsensitive)
+        {
+            IEdmEntitySet entitySet = entityContainer.FindEntitySetExtended(targetSegments[index]);
+
+            if (entitySet != null)
+            {
+                pathSegments.Add(entitySet);
+
+                return entitySet;
+            }
+
+            IEdmSingleton singleton = entityContainer.FindSingletonExtended(targetSegments[index]);
+
+            if (singleton != null)
+            {
+                pathSegments.Add(singleton);
+
+                return singleton;
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a schema type or property from an entity container element.
+        /// </summary>
+        /// <param name="model">The edm model.</param>
+        /// <param name="pathSegments">The path segments of already resolved target segments.</param>
+        /// <param name="entityContainerElement">The entity container element.</param>
+        /// <param name="targetSegments">The target segments to resolve.</param>
+        /// <param name="index">The index of the target segments.</param>
+        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        private static IEdmVocabularyAnnotatable HandleContainerElement(IEdmModel model, List<IEdmElement> pathSegments, IEdmEntityContainerElement entityContainerElement, string[] targetSegments, int index, bool caseInsensitive)
+        {
+            // .../MyEntitySet/MySchema.MyEntityType/...
+            // .../MyEntitySet/MyComplexProperty/...
+            // .../MySingleton/MyComplexProperty/...
+            IEdmSchemaType schemaType = model.FindType(targetSegments[index]);
+
+            if (schemaType != null)
+            {
+                ValidateSchemaType(schemaType, pathSegments, index);
+                pathSegments.Add(schemaType);
+
+                return schemaType;
+            }
+
+            IEdmType edmType = null;
+
+            if (entityContainerElement is IEdmEntitySet edmEntitySet)
+            {
+                edmType = edmEntitySet.Type.AsElementType();
+            }
+
+            if (entityContainerElement is IEdmSingleton edmSingleton)
+            {
+                edmType = edmSingleton.Type.AsElementType();
+            }
+
+            if (edmType is IEdmStructuredType structuredType)
+            {
+                // .../MyEntitySet/MyProperty/...
+                // .../MyEntitySet/MyNavigationProperty/...
+                // .../MySingleton/MyProperty/...
+                // .../MySingleton/MyNavigationProperty/...
+
+                return HandleStructuredType(model, pathSegments, structuredType, targetSegments, index, caseInsensitive);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a property from a schema type.
+        /// </summary>
+        /// <param name="model">The edm model.</param>
+        /// <param name="pathSegments">The path segments of already resolved target segments.</param>
+        /// <param name="schemaType">The schema type.</param>
+        /// <param name="targetSegments">The target segments to resolve.</param>
+        /// <param name="index">The index of the target segments.</param>
+        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        private static IEdmVocabularyAnnotatable HandleSchemaType(IEdmModel model, List<IEdmElement> pathSegments, IEdmSchemaType schemaType, string[] targetSegments, int index, bool caseInsensitive)
+        {
+            // Validate schema type is not followed by schema type e.g entitycontainer/entityset/NS.TypeCase1/NS.TypeCase2/...
+            IEdmSchemaType nextSchemaType = model.FindType(targetSegments[index]);
+
+            if (nextSchemaType != null)
+            {
+                throw new InvalidOperationException(Strings.TypeCast_HierarchyNotFollowed(schemaType, nextSchemaType));
+            }
+
+            if (schemaType is IEdmStructuredType structuredType)
+            {
+                return HandleStructuredType(model, pathSegments, structuredType, targetSegments, index, caseInsensitive);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Validate a schema type.
+        /// </summary>
+        /// <param name="schemaType">The schema type.</param>
+        /// <param name="pathSegments">The path segments of already resolved target segments.</param>
+        /// <param name="index">The index of the path segments.</param>
+        private static void ValidateSchemaType(IEdmSchemaType schemaType, List<IEdmElement> pathSegments, int index)
+        {
+            IEdmElement previousElement = pathSegments[index - 1];
+
+            bool isValid = IsDerivedTypeValid(previousElement, schemaType);
+
+            if (!isValid)
+            {
+                throw new InvalidOperationException(Strings.TypeCast_HierarchyNotFollowed(previousElement, schemaType));
+            }
+        }
+
+        private static bool IsDerivedTypeValid(IEdmElement element, IEdmSchemaType schemaType)
+        {
+            IEdmType elementEdmType = null;
+            if (element is IEdmProperty property)
+            {
+                elementEdmType = property.Type.Definition;
+            }
+            else if (element is IEdmSchemaType elementSchemaType)
+            {
+                elementEdmType = elementSchemaType.AsElementType();
+            }
+            else if (element is IEdmEntitySet entitySet)
+            {
+                elementEdmType = entitySet.EntityType().AsElementType();
+            }
+            else if (element is IEdmSingleton singleton)
+            {
+                elementEdmType = singleton.EntityType().AsElementType();
+            }
+
+            if (elementEdmType != null)
+            {
+                return schemaType.AsElementType().IsOrInheritsFrom(elementEdmType);
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns a schema type or property from a property.
+        /// </summary>
+        /// <param name="model">The edm model.</param>
+        /// <param name="pathSegments">The path segments of already resolved target segments.</param>
+        /// <param name="edmProperty">The edm property.</param>
+        /// <param name="targetSegments">The target segments to resolve.</param>
+        /// <param name="index">The index of the target segments.</param>
+        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        private static IEdmVocabularyAnnotatable HandleProperty(IEdmModel model, List<IEdmElement> pathSegments, IEdmProperty edmProperty, string[] targetSegments, int index, bool caseInsensitive)
+        {
+            IEdmSchemaType schemaType = model.FindType(targetSegments[index]);
+
+            if (schemaType != null)
+            {
+                ValidateSchemaType(schemaType, pathSegments, index);
+                pathSegments.Add(schemaType);
+
+                return schemaType;
+            }
+
+            IEdmTypeReference typeReference = edmProperty.Type;
+
+            IEdmType edmType = typeReference.Definition;
+
+            if (edmType is IEdmStructuredType structuredType)
+            {
+                // .../MyProperty1/MyProperty2/...
+
+                return HandleStructuredType(model, pathSegments, structuredType, targetSegments, index, caseInsensitive);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Returns a property from a structured type.
+        /// </summary>
+        /// <param name="model">The edm model.</param>
+        /// <param name="pathSegments">The path segments of already resolved target segments.</param>
+        /// <param name="structuredType">The structured type.</param>
+        /// <param name="targetSegments">The target segments to resolve.</param>
+        /// <param name="index">The index of the target segments.</param>
+        /// <param name="caseInsensitive">Property name case-insensitive or not.</param>
+        /// <returns>An <see cref="IEdmVocabularyAnnotatable"/> object.</returns>
+        private static IEdmVocabularyAnnotatable HandleStructuredType(IEdmModel model, List<IEdmElement> pathSegments, IEdmStructuredType structuredType, string[] targetSegments, int index, bool caseInsensitive)
+        {
+            IEdmProperty property = structuredType.FindProperty(targetSegments[index], caseInsensitive);
+
+            if (property != null)
+            {
+                pathSegments.Add(property);
+
+                return property;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
@@ -35,7 +35,7 @@ namespace Microsoft.OData.Edm
                 return Enumerable.Empty<IEdmElement>();
             }
 
-            List<IEdmElement> pathSegments = new List<IEdmElement>();
+            List<IEdmElement> pathSegments = new List<IEdmElement>(targetSegments.Length);
             pathSegments.Add(container);
             int index = 1; // index of the targetSegments.
 

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
@@ -42,6 +42,7 @@ namespace Microsoft.OData.Edm
         internal const string MultipleMatchingPropertiesFound = "MultipleMatchingPropertiesFound";
         internal const string TargetPath_FirstSegmentMustBeIEdmEntityContainer = "TargetPath_FirstSegmentMustBeIEdmEntityContainer";
         internal const string TargetPath_SecondSegmentMustBeIEdmEntityContainerElement = "TargetPath_SecondSegmentMustBeIEdmEntityContainerElement";
+        internal const string TargetPath_SegmentsMustNotContainNullSegment = "TargetPath_SegmentsMustNotContainNullSegment";
         internal const string TypeCast_HierarchyNotFollowed = "TypeCast_HierarchyNotFollowed";
         internal const string Edm_Evaluator_NoTermTypeAnnotationOnType = "Edm_Evaluator_NoTermTypeAnnotationOnType";
         internal const string Edm_Evaluator_NoValueAnnotationOnType = "Edm_Evaluator_NoValueAnnotationOnType";

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.cs
@@ -40,6 +40,9 @@ namespace Microsoft.OData.Edm
         internal const string EdmType_UnexpectedEdmType = "EdmType_UnexpectedEdmType";
         internal const string NavigationPropertyBinding_PathIsNotValid = "NavigationPropertyBinding_PathIsNotValid";
         internal const string MultipleMatchingPropertiesFound = "MultipleMatchingPropertiesFound";
+        internal const string TargetPath_FirstSegmentMustBeIEdmEntityContainer = "TargetPath_FirstSegmentMustBeIEdmEntityContainer";
+        internal const string TargetPath_SecondSegmentMustBeIEdmEntityContainerElement = "TargetPath_SecondSegmentMustBeIEdmEntityContainerElement";
+        internal const string TypeCast_HierarchyNotFollowed = "TypeCast_HierarchyNotFollowed";
         internal const string Edm_Evaluator_NoTermTypeAnnotationOnType = "Edm_Evaluator_NoTermTypeAnnotationOnType";
         internal const string Edm_Evaluator_NoValueAnnotationOnType = "Edm_Evaluator_NoValueAnnotationOnType";
         internal const string Edm_Evaluator_NoValueAnnotationOnElement = "Edm_Evaluator_NoValueAnnotationOnElement";
@@ -328,6 +331,7 @@ namespace Microsoft.OData.Edm
         internal const string TimeOfDay_InvalidCompareToTarget = "TimeOfDay_InvalidCompareToTarget";
         internal const string EdmVocabularyAnnotations_DidNotFindDefaultValue = "EdmVocabularyAnnotations_DidNotFindDefaultValue";
         internal const string EdmVocabularyAnnotations_TermTypeNotSupported = "EdmVocabularyAnnotations_TermTypeNotSupported";
+        internal const string EdmVocabularyAnnotations_InvalidLocationForTargetPathAnnotation = "EdmVocabularyAnnotations_InvalidLocationForTargetPathAnnotation";
 
         static EdmRes loader = null;
         ResourceManager resources;

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -20,6 +20,9 @@ Constructable_DependentPropertyCountMustMatchNumberOfPropertiesOnPrincipalType=T
 EdmType_UnexpectedEdmType=Unexpected Edm type.
 NavigationPropertyBinding_PathIsNotValid=The navigation property binding path is not valid.
 MultipleMatchingPropertiesFound=More than one properties match the name '{0}' were found in type '{1}'.
+TargetPath_FirstSegmentMustBeIEdmEntityContainer=First segment must be IEdmEntityContainer.
+TargetPath_SecondSegmentMustBeIEdmEntityContainerElement=Second segment must be IEdmEntityContainerElement.
+TypeCast_HierarchyNotFollowed=Encountered invalid type cast. '{0}' is not assignable from '{1}'.
 
 ; Evaluation messages
 Edm_Evaluator_NoTermTypeAnnotationOnType=Type '{0}' must have a single type annotation with term type '{1}'.
@@ -341,3 +344,4 @@ TimeOfDay_InvalidParsingString=String '{0}' was not recognized as a valid TimeOf
 TimeOfDay_InvalidCompareToTarget=Target object '{0}' is not an instance with type of TimeOfDay.
 EdmVocabularyAnnotations_DidNotFindDefaultValue=Annotation expressions must specify a value or use a term with a specified default value. Cannot find a default value for the given annotation term, '{0}'.
 EdmVocabularyAnnotations_TermTypeNotSupported=Term type '{0}' is not supported for value retrieval.
+EdmVocabularyAnnotations_InvalidLocationForTargetPathAnnotation=Invalid to set inline location for a path target '{0}'.

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.txt
@@ -22,6 +22,7 @@ NavigationPropertyBinding_PathIsNotValid=The navigation property binding path is
 MultipleMatchingPropertiesFound=More than one properties match the name '{0}' were found in type '{1}'.
 TargetPath_FirstSegmentMustBeIEdmEntityContainer=First segment must be IEdmEntityContainer.
 TargetPath_SecondSegmentMustBeIEdmEntityContainerElement=Second segment must be IEdmEntityContainerElement.
+TargetPath_SegmentsMustNotContainNullSegment=Target path segments must not contain a null segment.
 TypeCast_HierarchyNotFollowed=Encountered invalid type cast. '{0}' is not assignable from '{1}'.
 
 ; Evaluation messages

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -187,6 +187,36 @@ namespace Microsoft.OData.Edm {
         }
 
         /// <summary>
+        /// A string like "First segment must be IEdmEntityContainer."
+        /// </summary>
+        internal static string TargetPath_FirstSegmentMustBeIEdmEntityContainer
+        {
+            get
+            {
+                return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.TargetPath_FirstSegmentMustBeIEdmEntityContainer);
+            }
+        }
+
+        /// <summary>
+        /// A string like "Second segment must be IEdmEntityContainerElement."
+        /// </summary>
+        internal static string TargetPath_SecondSegmentMustBeIEdmEntityContainerElement
+        {
+            get
+            {
+                return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.TargetPath_SecondSegmentMustBeIEdmEntityContainerElement);
+            }
+        }
+
+        /// <summary>
+        /// A string like "Encountered invalid type cast. '{0}' is not assignable from '{1}'."
+        /// </summary>
+        internal static string TypeCast_HierarchyNotFollowed(object p0, object p1)
+        {
+            return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.TypeCast_HierarchyNotFollowed, p0, p1);
+        }
+
+        /// <summary>
         /// A string like "Type '{0}' must have a single type annotation with term type '{1}'."
         /// </summary>
         internal static string Edm_Evaluator_NoTermTypeAnnotationOnType(object p0, object p1)
@@ -2635,6 +2665,14 @@ namespace Microsoft.OData.Edm {
         internal static string EdmVocabularyAnnotations_TermTypeNotSupported(object p0)
         {
             return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.EdmVocabularyAnnotations_TermTypeNotSupported, p0);
+        }
+
+        /// <summary>
+        /// A string like "Invalid to set inline location for a path target '{0}'."
+        /// </summary>
+        internal static string EdmVocabularyAnnotations_InvalidLocationForTargetPathAnnotation(object p0)
+        {
+            return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.EdmVocabularyAnnotations_InvalidLocationForTargetPathAnnotation, p0);
         }
 
     }

--- a/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
+++ b/src/Microsoft.OData.Edm/Parameterized.Microsoft.OData.Edm.cs
@@ -209,6 +209,17 @@ namespace Microsoft.OData.Edm {
         }
 
         /// <summary>
+        /// A string like "Target path segments must not contain a null segment."
+        /// </summary>
+        internal static string TargetPath_SegmentsMustNotContainNullSegment
+        {
+            get
+            {
+                return Microsoft.OData.Edm.EdmRes.GetString(Microsoft.OData.Edm.EdmRes.TargetPath_SegmentsMustNotContainNullSegment);
+            }
+        }
+
+        /// <summary>
         /// A string like "Encountered invalid type cast. '{0}' is not assignable from '{1}'."
         /// </summary>
         internal static string TypeCast_HierarchyNotFollowed(object p0, object p1)

--- a/src/Microsoft.OData.Edm/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -11,5 +11,3 @@ override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
 static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>
-static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
-System.Collections.Generic.ReadOnlyListExtensions

--- a/src/Microsoft.OData.Edm/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -9,5 +9,5 @@ Microsoft.OData.Edm.IEdmTargetPath.Segments.get -> System.Collections.Generic.IR
 override Microsoft.OData.Edm.EdmTargetPath.Equals(object obj) -> bool
 override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
 static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
-static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
+static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool ignoreCase = true) -> Microsoft.OData.Edm.IEdmTargetPath
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>

--- a/src/Microsoft.OData.Edm/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,2 +1,15 @@
-﻿static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
+﻿Microsoft.OData.Edm.EdmTargetPath
+Microsoft.OData.Edm.EdmTargetPath.EdmTargetPath(params Microsoft.OData.Edm.IEdmElement[] segments) -> void
+Microsoft.OData.Edm.EdmTargetPath.EdmTargetPath(System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmElement> segments) -> void
+Microsoft.OData.Edm.EdmTargetPath.Path.get -> string
+Microsoft.OData.Edm.EdmTargetPath.Segments.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.Edm.IEdmElement>
+Microsoft.OData.Edm.IEdmTargetPath
+Microsoft.OData.Edm.IEdmTargetPath.Path.get -> string
+Microsoft.OData.Edm.IEdmTargetPath.Segments.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.Edm.IEdmElement>
+override Microsoft.OData.Edm.EdmTargetPath.Equals(object obj) -> bool
+override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
+static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
+static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
+static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>
+static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
 System.Collections.Generic.ReadOnlyListExtensions

--- a/src/Microsoft.OData.Edm/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
@@ -11,5 +11,3 @@ override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
 static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>
-static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
-System.Collections.Generic.ReadOnlyListExtensions

--- a/src/Microsoft.OData.Edm/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
@@ -9,5 +9,5 @@ Microsoft.OData.Edm.IEdmTargetPath.Segments.get -> System.Collections.Generic.IR
 override Microsoft.OData.Edm.EdmTargetPath.Equals(object obj) -> bool
 override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
 static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
-static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
+static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool ignoreCase = true) -> Microsoft.OData.Edm.IEdmTargetPath
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>

--- a/src/Microsoft.OData.Edm/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
@@ -10,9 +10,6 @@ override Microsoft.OData.Edm.EdmTargetPath.Equals(object obj) -> bool
 override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
 static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
-<<<<<<< HEAD
-=======
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>
 static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
 System.Collections.Generic.ReadOnlyListExtensions
->>>>>>> 66b5fb949 (Review comments)

--- a/src/Microsoft.OData.Edm/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
@@ -1,2 +1,18 @@
-﻿static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
+﻿Microsoft.OData.Edm.EdmTargetPath
+Microsoft.OData.Edm.EdmTargetPath.EdmTargetPath(params Microsoft.OData.Edm.IEdmElement[] segments) -> void
+Microsoft.OData.Edm.EdmTargetPath.EdmTargetPath(System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmElement> segments) -> void
+Microsoft.OData.Edm.EdmTargetPath.Path.get -> string
+Microsoft.OData.Edm.EdmTargetPath.Segments.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.Edm.IEdmElement>
+Microsoft.OData.Edm.IEdmTargetPath
+Microsoft.OData.Edm.IEdmTargetPath.Path.get -> string
+Microsoft.OData.Edm.IEdmTargetPath.Segments.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.Edm.IEdmElement>
+override Microsoft.OData.Edm.EdmTargetPath.Equals(object obj) -> bool
+override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
+static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
+static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
+<<<<<<< HEAD
+=======
+static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>
+static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
 System.Collections.Generic.ReadOnlyListExtensions
+>>>>>>> 66b5fb949 (Review comments)

--- a/src/Microsoft.OData.Edm/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -11,5 +11,3 @@ override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
 static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>
-static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
-System.Collections.Generic.ReadOnlyListExtensions

--- a/src/Microsoft.OData.Edm/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -9,5 +9,5 @@ Microsoft.OData.Edm.IEdmTargetPath.Segments.get -> System.Collections.Generic.IR
 override Microsoft.OData.Edm.EdmTargetPath.Equals(object obj) -> bool
 override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
 static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
-static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
+static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool ignoreCase = true) -> Microsoft.OData.Edm.IEdmTargetPath
 static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>

--- a/src/Microsoft.OData.Edm/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,15 @@
-﻿static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
+﻿Microsoft.OData.Edm.EdmTargetPath
+Microsoft.OData.Edm.EdmTargetPath.EdmTargetPath(params Microsoft.OData.Edm.IEdmElement[] segments) -> void
+Microsoft.OData.Edm.EdmTargetPath.EdmTargetPath(System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmElement> segments) -> void
+Microsoft.OData.Edm.EdmTargetPath.Path.get -> string
+Microsoft.OData.Edm.EdmTargetPath.Segments.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.Edm.IEdmElement>
+Microsoft.OData.Edm.IEdmTargetPath
+Microsoft.OData.Edm.IEdmTargetPath.Path.get -> string
+Microsoft.OData.Edm.IEdmTargetPath.Segments.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.Edm.IEdmElement>
+override Microsoft.OData.Edm.EdmTargetPath.Equals(object obj) -> bool
+override Microsoft.OData.Edm.EdmTargetPath.GetHashCode() -> int
+static Microsoft.OData.Edm.ExtensionMethods.FindVocabularyAnnotations<T>(this Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<T>
+static Microsoft.OData.Edm.ExtensionMethods.GetTargetPath(this Microsoft.OData.Edm.IEdmModel model, string targetPath, bool caseInsensitive = true) -> Microsoft.OData.Edm.IEdmTargetPath
+static Microsoft.OData.Edm.ExtensionMethods.GetTargetPathAnnotations(this Microsoft.OData.Edm.IEdmModel model, string targetPath) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation>
+static System.Collections.Generic.ReadOnlyListExtensions.FindLastIndex<T>(this System.Collections.Generic.IReadOnlyList<T> list, System.Func<T, bool> predicate) -> int
 System.Collections.Generic.ReadOnlyListExtensions

--- a/src/Microsoft.OData.Edm/Schema/EdmTargetPath.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmTargetPath.cs
@@ -99,7 +99,7 @@ namespace Microsoft.OData.Edm
             // Validate no segment is null
             if (this.segments.Contains(null))
             {
-                throw Error.ArgumentNull(nameof(segments));
+                throw new ArgumentException(Strings.TargetPath_SegmentsMustNotContainNullSegment);
             }
 
             // Validate that the first element is Container.

--- a/src/Microsoft.OData.Edm/Schema/EdmTargetPath.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmTargetPath.cs
@@ -1,0 +1,119 @@
+//---------------------------------------------------------------------
+// <copyright file="EdmTargetPath.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Microsoft.OData.Edm
+{
+    /// <inheritdoc/>
+    public class EdmTargetPath : IEdmTargetPath
+    {
+        private List<IEdmElement> segments;
+        private string path;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmTargetPath"/> class.
+        /// </summary>
+        /// <param name="segments">Target path segments.</param>
+        public EdmTargetPath(IEnumerable<IEdmElement> segments)
+        {
+            EdmUtil.CheckArgumentNull(segments, nameof(segments));
+
+            this.segments = segments.ToList();
+
+            ValidateSegments();
+
+            this.path = this.GetPathString();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmTargetPath"/> class.
+        /// </summary>
+        /// <param name="segments">Target path segments.</param>
+        public EdmTargetPath(params IEdmElement[] segments)
+            :this(segments.AsEnumerable())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmTargetPath"/> class.
+        /// </summary>
+        /// <param name="segments">Target path segments.</param>
+        /// <param name="path">Target path string.</param>
+        internal EdmTargetPath(IEnumerable<IEdmElement> segments, string path)
+        {
+            EdmUtil.CheckArgumentNull(segments, nameof(segments));
+            EdmUtil.CheckArgumentNull(path, nameof(path));
+
+            this.segments = segments.ToList();
+
+            ValidateSegments();
+
+            this.path = path;
+        }
+
+        /// <inheritdoc/>
+        public IReadOnlyList<IEdmElement> Segments
+        {
+            get { return this.segments; }
+        }
+
+        /// <inheritdoc/>
+        public string Path
+        {
+            get
+            {
+                if (this.path == null)
+                {
+                    this.path = this.GetPathString();
+                }
+
+                return this.path;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj == null)
+            {
+                return false;
+            }
+
+            EdmTargetPath other = obj as EdmTargetPath;
+
+            return string.Equals(this.Path, other.Path, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            return this.path.GetHashCode();
+        }
+
+        private void ValidateSegments()
+        {
+            // Validate no segment is null
+            if (this.segments.Contains(null))
+            {
+                throw Error.ArgumentNull(nameof(segments));
+            }
+
+            // Validate that the first element is Container.
+
+            if (this.segments.Count > 0 && !(this.segments[0] is IEdmEntityContainer))
+            {
+                throw new InvalidOperationException(Strings.TargetPath_FirstSegmentMustBeIEdmEntityContainer);
+            }
+
+            // Validate the second element is a Container element.
+            if (this.segments.Count > 1 && !(this.segments[1] is IEdmEntityContainerElement))
+            {
+                throw new InvalidOperationException(Strings.TargetPath_SecondSegmentMustBeIEdmEntityContainerElement);
+            }
+        }
+    }
+}

--- a/src/Microsoft.OData.Edm/Schema/EdmTargetPath.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmTargetPath.cs
@@ -77,6 +77,7 @@ namespace Microsoft.OData.Edm
             }
         }
 
+        /// <inheritdoc/>
         public override bool Equals(object obj)
         {
             if (obj == null)
@@ -89,6 +90,7 @@ namespace Microsoft.OData.Edm
             return string.Equals(this.Path, other.Path, StringComparison.Ordinal);
         }
 
+        /// <inheritdoc/>
         public override int GetHashCode()
         {
             return this.path.GetHashCode();

--- a/src/Microsoft.OData.Edm/Schema/EdmTargetPath.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmTargetPath.cs
@@ -86,7 +86,7 @@ namespace Microsoft.OData.Edm
 
             EdmTargetPath other = obj as EdmTargetPath;
 
-            return string.Equals(this.Path, other.Path, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(this.Path, other.Path, StringComparison.Ordinal);
         }
 
         public override int GetHashCode()

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmTargetPath.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmTargetPath.cs
@@ -1,0 +1,27 @@
+//---------------------------------------------------------------------
+// <copyright file="IEdmTargetPath.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.OData.Edm.Vocabularies;
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Represents a path to a model element.
+    /// </summary>
+    public interface IEdmTargetPath : IEdmVocabularyAnnotatable
+    {
+        /// <summary>
+        /// The target path.
+        /// </summary>
+        string Path { get; }
+
+        /// <summary>
+        /// Gets the target path segments as Edm elements.
+        /// </summary>
+        IReadOnlyList<IEdmElement> Segments { get; }
+    }
+}

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmTargetPath.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmTargetPath.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.Edm
     public interface IEdmTargetPath : IEdmVocabularyAnnotatable
     {
         /// <summary>
-        /// The target path.
+        /// Gets the target path.
         /// </summary>
         string Path { get; }
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.TargetPath.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.TargetPath.cs
@@ -101,7 +101,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
         [Fact]
         public void ParsingEntitySetNavigationPropertyOnComplexTypeOutOfLineAnnotationsWorks()
         {
-            // Test for MySchema.MyEntityContainer/MyComplexProperty/MyNavigationProperty
+            // Test for MySchema.MyEntityContainer/MyEntitySet/MyComplexProperty/MyNavigationProperty
 
             string types =
 @"<EntityType Name=""City"">
@@ -147,7 +147,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
         [Fact]
         public void ParsingEntitySetNavigationPropertySubPropertyOnComplexTypeOutOfLineAnnotationsWorks()
         {
-            // Test for MySchema.MyEntityContainer/MyComplexProperty/MyNavigationProperty/MyProperty
+            // Test for MySchema.MyEntityContainer/MyEntitySet/MyComplexProperty/MyNavigationProperty/MyProperty
 
             string types =
 @"<EntityType Name=""City"">
@@ -193,7 +193,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
         [Fact]
         public void ParsingEntitySetPropertyOnComplexTypeOutOfLineAnnotationsWorks()
         {
-            // Test for MySchema.MyEntityContainer/MyComplexProperty/MyProperty
+            // Test for MySchema.MyEntityContainer/MyEntitySet/MyComplexProperty/MyProperty
 
             string types =
 @"<EntityType Name=""City"">
@@ -319,8 +319,6 @@ namespace Microsoft.OData.Edm.Tests.Csdl
         [Fact]
         public void ParsingInvalidAnnotationTargetValidationFails()
         {
-            // Test for MySchema.MyEntityContainer/MySingleton/MyNavigationProperty
-
             string types =
 @"
 <Annotations Target=""NS.Default/Me/Orders/NS.VipOrder/OrderId"" >

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.TargetPath.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.TargetPath.cs
@@ -1,0 +1,467 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CsdlReaderTests.TargetPath.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
+using Xunit;
+
+namespace Microsoft.OData.Edm.Tests.Csdl
+{
+    public partial class CsdlReaderTests
+    {
+        [Fact]
+        public void ParsingEntitySetPropertyOutOfLineAnnotationsWorks()
+        {
+            // Test for MySchema.MyEntityContainer/MyEntitySet/MyProperty
+
+            string types =
+@"<Term Name=""MyTerm"" Type=""Edm.String""/>
+<Annotations Target=""NS.Default/Customers/Name"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>";
+
+            string properties =
+                @"<Property Name=""Name"" Type=""Edm.String"" Nullable=""false"" />";
+
+            IEdmModel model = GetModel(types: types, properties: properties);
+            Assert.NotNull(model);
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors), String.Format("Errors in validating model. {0}", String.Concat(errors.Select(e => e.ErrorMessage))));
+
+            var customer = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Customer");
+            Assert.NotNull(customer);
+
+            IEdmTerm myTerm = model.FindDeclaredTerm("NS.MyTerm");
+            Assert.NotNull(myTerm);
+
+            // Name
+            IEdmProperty nameProperty = customer.DeclaredProperties.Where(x => x.Name == "Name").FirstOrDefault();
+            Assert.NotNull(nameProperty);
+
+            IEdmTargetPath targetPath = model.GetTargetPath("NS.Default/Customers/Name");
+
+            string nameAnnotation = GetAnnotation(model, targetPath, myTerm, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            Assert.Equal("Name OutOfLine MyTerm Value", nameAnnotation);
+        }
+
+        [Fact]
+        public void ParsingEntitySetNavigationPropertyOutOfLineAnnotationsWorks()
+        {
+            // Test for MySchema.MyEntityContainer/MyEntitySet/MyNavigationProperty
+
+            string types =
+@"<EntityType Name=""Order"">
+    <Key>
+        <PropertyRef Name=""OrderId""/>
+    </Key>
+    <Property Name=""OrderId"" Type=""Edm.String"" Nullable=""false""/>
+    <Property Name=""OrderName"" Type=""Edm.String"" Nullable=""false""/>
+</EntityType>
+<Term Name=""MyTerm"" Type=""Edm.String""/>
+<Annotations Target=""NS.Default/Customers/Orders"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>";
+
+            string properties =
+                @"<NavigationProperty Name=""Orders"" Type=""Collection(NS.Order)"" ContainsTarget=""true"" />";
+
+            IEdmModel model = GetModel(types: types, properties: properties);
+            Assert.NotNull(model);
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors), String.Format("Errors in validating model. {0}", String.Concat(errors.Select(e => e.ErrorMessage))));
+
+            var customer = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Customer");
+            Assert.NotNull(customer);
+
+            IEdmTerm myTerm = model.FindDeclaredTerm("NS.MyTerm");
+            Assert.NotNull(myTerm);
+
+            // Name
+            IEdmProperty nameProperty = customer.DeclaredNavigationProperties().Where(x => x.Name == "Orders").FirstOrDefault();
+            Assert.NotNull(nameProperty);
+
+            IEdmTargetPath targetPath = model.GetTargetPath("NS.Default/Customers/Orders");
+
+            string nameAnnotation = GetAnnotation(model, targetPath, myTerm, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            Assert.Equal("Name OutOfLine MyTerm Value", nameAnnotation);
+        }
+
+        [Fact]
+        public void ParsingEntitySetNavigationPropertyOnComplexTypeOutOfLineAnnotationsWorks()
+        {
+            // Test for MySchema.MyEntityContainer/MyComplexProperty/MyNavigationProperty
+
+            string types =
+@"<EntityType Name=""City"">
+    <Key>
+        <PropertyRef Name=""Name""/>
+    </Key>
+    <Property Name=""Name"" Nullable=""false"" Type=""Edm.String""/>
+</EntityType>
+<ComplexType Name=""Address"">
+    <Property Name=""Road"" Type=""Edm.String"" Nullable=""false""/>
+    <NavigationProperty Name=""City"" Type=""NS.City"" Nullable=""false"" ContainsTarget=""true"" />
+</ComplexType>
+<Term Name=""MyTerm"" Type=""Edm.String""/>
+<Annotations Target=""NS.Default/Customers/Address/City"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>";
+
+            string properties =
+                @"<Property Name=""Address"" Type=""NS.Address"" />";
+
+            IEdmModel model = GetModel(types: types, properties: properties);
+            Assert.NotNull(model);
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors), String.Format("Errors in validating model. {0}", String.Concat(errors.Select(e => e.ErrorMessage))));
+
+            var customer = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Customer");
+            Assert.NotNull(customer);
+
+            IEdmTerm myTerm = model.FindDeclaredTerm("NS.MyTerm");
+            Assert.NotNull(myTerm);
+
+            // Name
+            IEdmProperty nameProperty = customer.DeclaredProperties.Where(x => x.Name == "Address").FirstOrDefault();
+            Assert.NotNull(nameProperty);
+
+            IEdmTargetPath targetPath = model.GetTargetPath("NS.Default/Customers/Address/City");
+
+            string nameAnnotation = GetAnnotation(model, targetPath, myTerm, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            Assert.Equal("Name OutOfLine MyTerm Value", nameAnnotation);
+        }
+
+        [Fact]
+        public void ParsingEntitySetNavigationPropertySubPropertyOnComplexTypeOutOfLineAnnotationsWorks()
+        {
+            // Test for MySchema.MyEntityContainer/MyComplexProperty/MyNavigationProperty/MyProperty
+
+            string types =
+@"<EntityType Name=""City"">
+    <Key>
+        <PropertyRef Name=""Name""/>
+    </Key>
+    <Property Name=""Name"" Nullable=""false"" Type=""Edm.String""/>
+</EntityType>
+<ComplexType Name=""Address"">
+    <Property Name=""Road"" Type=""Edm.String"" Nullable=""false""/>
+    <NavigationProperty Name=""City"" Type=""NS.City"" Nullable=""false"" ContainsTarget=""true"" />
+</ComplexType>
+<Term Name=""MyTerm"" Type=""Edm.String""/>
+<Annotations Target=""NS.Default/Customers/Address/City/Name"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>";
+
+            string properties =
+                @"<Property Name=""Address"" Type=""NS.Address"" />";
+
+            IEdmModel model = GetModel(types: types, properties: properties);
+            Assert.NotNull(model);
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors), String.Format("Errors in validating model. {0}", String.Concat(errors.Select(e => e.ErrorMessage))));
+
+            var customer = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Customer");
+            Assert.NotNull(customer);
+
+            IEdmTerm myTerm = model.FindDeclaredTerm("NS.MyTerm");
+            Assert.NotNull(myTerm);
+
+            // Name
+            IEdmProperty nameProperty = customer.DeclaredProperties.Where(x => x.Name == "Address").FirstOrDefault();
+            Assert.NotNull(nameProperty);
+
+            IEdmTargetPath targetPath = model.GetTargetPath("NS.Default/Customers/Address/City/Name");
+
+            string nameAnnotation = GetAnnotation(model, targetPath, myTerm, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            Assert.Equal("Name OutOfLine MyTerm Value", nameAnnotation);
+        }
+
+        [Fact]
+        public void ParsingEntitySetPropertyOnComplexTypeOutOfLineAnnotationsWorks()
+        {
+            // Test for MySchema.MyEntityContainer/MyComplexProperty/MyProperty
+
+            string types =
+@"<EntityType Name=""City"">
+    <Key>
+        <PropertyRef Name=""Name""/>
+    </Key>
+    <Property Name=""Name"" Nullable=""false"" Type=""Edm.String""/>
+</EntityType>
+<ComplexType Name=""Address"">
+    <Property Name=""Road"" Type=""Edm.String"" Nullable=""false""/>
+</ComplexType>
+<Term Name=""MyTerm"" Type=""Edm.String""/>
+<Annotations Target=""NS.Default/Customers/Address/Road"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>";
+
+            string properties =
+                @"<Property Name=""Address"" Type=""NS.Address"" />";
+
+            IEdmModel model = GetModel(types: types, properties: properties);
+            Assert.NotNull(model);
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors), String.Format("Errors in validating model. {0}", String.Concat(errors.Select(e => e.ErrorMessage))));
+
+            var customer = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Customer");
+            Assert.NotNull(customer);
+
+            IEdmTerm myTerm = model.FindDeclaredTerm("NS.MyTerm");
+            Assert.NotNull(myTerm);
+
+            // Name
+            IEdmProperty nameProperty = customer.DeclaredProperties.Where(x => x.Name == "Address").FirstOrDefault();
+            Assert.NotNull(nameProperty);
+
+            IEdmTargetPath targetPath = model.GetTargetPath("NS.Default/Customers/Address/Road");
+
+            string nameAnnotation = GetAnnotation(model, targetPath, myTerm, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            Assert.Equal("Name OutOfLine MyTerm Value", nameAnnotation);
+        }
+
+        [Fact]
+        public void ParsingEntitySetPropertyOnDerivedTypeOutOfLineAnnotationsWorks()
+        {
+            // Test for MySchema.MyEntityContainer/MyEntitySet/MySchema.DerivedType/MyProperty
+
+            string types =
+@"<EntityType Name =""VipCustomer"" BaseType=""NS.Customer"">
+ <Property Name=""VipNumber"" Type=""Edm.String"" Nullable=""false"" />
+</EntityType>
+<Term Name=""MyTerm"" Type=""Edm.String""/>
+<Annotations Target=""NS.Default/Customers/NS.VipCustomer/VipNumber"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>";
+
+            string properties = "";
+
+            IEdmModel model = GetModel(types: types, properties: properties);
+            Assert.NotNull(model);
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors), String.Format("Errors in validating model. {0}", String.Concat(errors.Select(e => e.ErrorMessage))));
+
+            var vipCustomer = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "VipCustomer");
+            Assert.NotNull(vipCustomer);
+
+            IEdmTerm myTerm = model.FindDeclaredTerm("NS.MyTerm");
+            Assert.NotNull(myTerm);
+
+            // Name
+            IEdmProperty vipNumberProperty = vipCustomer.DeclaredProperties.Where(x => x.Name == "VipNumber").FirstOrDefault();
+            Assert.NotNull(vipNumberProperty);
+
+            IEdmTargetPath targetPath = model.GetTargetPath("NS.Default/Customers/NS.VipCustomer/VipNumber");
+
+            string nameAnnotation = GetAnnotation(model, targetPath, myTerm, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            Assert.Equal("Name OutOfLine MyTerm Value", nameAnnotation);
+        }
+
+        [Fact]
+        public void ParsingSingletonNavigationPropertyOutOfLineAnnotationsWorks()
+        {
+            // Test for MySchema.MyEntityContainer/MySingleton/MyNavigationProperty
+
+            string types =
+@"<EntityType Name=""Order"">
+    <Key>
+        <PropertyRef Name=""OrderId""/>
+    </Key>
+    <Property Name=""OrderId"" Type=""Edm.String"" Nullable=""false""/>
+    <Property Name=""OrderName"" Type=""Edm.String"" Nullable=""false""/>
+</EntityType>
+<Term Name=""MyTerm"" Type=""Edm.String""/>
+<Annotations Target=""NS.Default/Me/Orders"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>";
+
+            string properties =
+                @"<NavigationProperty Name=""Orders"" Type=""Collection(NS.Order)"" ContainsTarget=""true"" />";
+
+            IEdmModel model = GetModel(types: types, properties: properties);
+            Assert.NotNull(model);
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors), String.Format("Errors in validating model. {0}", String.Concat(errors.Select(e => e.ErrorMessage))));
+
+            var customer = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Customer");
+            Assert.NotNull(customer);
+
+            IEdmTerm myTerm = model.FindDeclaredTerm("NS.MyTerm");
+            Assert.NotNull(myTerm);
+
+            // Name
+            IEdmProperty nameProperty = customer.DeclaredNavigationProperties().Where(x => x.Name == "Orders").FirstOrDefault();
+            Assert.NotNull(nameProperty);
+
+            IEdmTargetPath targetPath = model.GetTargetPath("NS.Default/Me/Orders");
+
+            string nameAnnotation = GetAnnotation(model, targetPath, myTerm, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            Assert.Equal("Name OutOfLine MyTerm Value", nameAnnotation);
+        }
+
+        [Fact]
+        public void ParsingInvalidAnnotationTargetValidationFails()
+        {
+            // Test for MySchema.MyEntityContainer/MySingleton/MyNavigationProperty
+
+            string types =
+@"
+<Annotations Target=""NS.Default/Me/Orders/NS.VipOrder/OrderId"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>";
+
+            string properties ="";
+
+            IEdmModel model = GetModel(types: types, properties: properties);
+            Assert.NotNull(model);
+
+            IEnumerable<EdmError> errors;
+            Assert.False(model.Validate(out errors));
+            var error1 = errors.First();
+            var error2 = errors.ElementAt(1);
+            Assert.Equal(EdmErrorCode.BadUnresolvedProperty, error1.ErrorCode);
+            Assert.Equal(EdmErrorCode.BadUnresolvedTarget, error2.ErrorCode);
+        }
+
+        [Fact]
+        public void ParsingMultipleOutOfLineAnnotationsWorks()
+        {
+            string types =
+@"<EntityType Name=""Order"">
+    <Key>
+        <PropertyRef Name=""OrderId""/>
+    </Key>
+    <Property Name=""OrderId"" Type=""Edm.String"" Nullable=""false""/>
+    <Property Name=""OrderName"" Type=""Edm.String"" Nullable=""false""/>
+</EntityType>
+<Term Name=""MyTerm"" Type=""Edm.String""/>
+<Term Name=""MyTerm2"" Type=""Edm.String""/>
+<Annotations Target=""NS.Default/Me/Orders"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>
+<Annotations Target=""NS.Default/Me/Orders"" >
+  <Annotation Term=""NS.MyTerm2"" String=""Name OutOfLine MyTerm Value 2"" />
+</Annotations>
+<Annotations Target=""NS.Default/Customers/Orders"" >
+  <Annotation Term=""NS.MyTerm"" String=""Name OutOfLine MyTerm Value"" />
+</Annotations>";
+
+            string properties =
+                @"<NavigationProperty Name=""Orders"" Type=""Collection(NS.Order)"" ContainsTarget=""true"" />";
+
+            IEdmModel model = GetModel(types: types, properties: properties);
+            Assert.NotNull(model);
+
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors), String.Format("Errors in validating model. {0}", String.Concat(errors.Select(e => e.ErrorMessage))));
+
+            var customer = model.SchemaElements.OfType<IEdmEntityType>().FirstOrDefault(c => c.Name == "Customer");
+            Assert.NotNull(customer);
+
+            IEdmTerm myTerm = model.FindDeclaredTerm("NS.MyTerm");
+            Assert.NotNull(myTerm);
+
+            // Name
+            IEdmProperty nameProperty = customer.DeclaredNavigationProperties().Where(x => x.Name == "Orders").FirstOrDefault();
+            Assert.NotNull(nameProperty);
+
+            // Mark model as Immutable so as to cache annotations.
+            model.MarkAsImmutable();
+
+            IEdmTargetPath targetPath = model.GetTargetPath("NS.Default/Me/Orders");
+
+            string nameAnnotation = GetAnnotation(model, targetPath, myTerm, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            Assert.Equal("Name OutOfLine MyTerm Value", nameAnnotation);
+
+            IEnumerable<IEdmVocabularyAnnotation> allAnnotations = model.VocabularyAnnotations;
+            Assert.Equal(3, allAnnotations.Count()); // 2 NS.Default/Me/Orders and 1 NS.Default/Customers/Orders
+
+            // Call FindXXX(...) multiple times to test there is no memory leak in VocabularyAnnotationsCache
+            IEnumerable<IEdmVocabularyAnnotation> edmTargetPathAnnotations = model.FindVocabularyAnnotations(targetPath);
+            edmTargetPathAnnotations = model.FindVocabularyAnnotations(targetPath);
+            edmTargetPathAnnotations = model.FindVocabularyAnnotations(targetPath);
+            IEnumerable<IEdmVocabularyAnnotation> targetPathStringAnnotations = model.GetTargetPathAnnotations("NS.Default/Me/Orders");
+            targetPathStringAnnotations = model.GetTargetPathAnnotations("NS.Default/Me/Orders");
+            targetPathStringAnnotations = model.GetTargetPathAnnotations("NS.Default/Me/Orders");
+
+            Assert.Equal(2, edmTargetPathAnnotations.Count());
+            Assert.Equal(2, targetPathStringAnnotations.Count());
+
+            Assert.IsAssignableFrom<IEdmTargetPath>(edmTargetPathAnnotations.First().Target);
+            Assert.IsAssignableFrom<IEdmTargetPath>(edmTargetPathAnnotations.Last().Target);
+            Assert.IsAssignableFrom<IEdmTargetPath>(targetPathStringAnnotations.First().Target);
+            Assert.IsAssignableFrom<IEdmTargetPath>(targetPathStringAnnotations.Last().Target);
+
+            IEdmVocabularyAnnotation annotation = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>("NS.Default/Me/Orders", myTerm).FirstOrDefault();
+            IEdmVocabularyAnnotation annotation1 = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>("NS.Default/Me/Orders", myTerm).FirstOrDefault();
+            IEdmVocabularyAnnotation annotation2 = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>("NS.Default/Me/Orders", myTerm).FirstOrDefault();
+            Assert.NotNull(annotation);
+        }
+
+        private string GetAnnotation(IEdmModel model, IEdmVocabularyAnnotatable target, IEdmTerm term, EdmVocabularyAnnotationSerializationLocation location)
+        {
+            IEdmVocabularyAnnotation annotation = model.FindVocabularyAnnotations<IEdmVocabularyAnnotation>(target, term).FirstOrDefault();
+            if (annotation != null)
+            {
+                Assert.True(typeof(IEdmTargetPath).IsAssignableFrom(annotation.Target.GetType()));
+
+                Assert.True(annotation.GetSerializationLocation(model) == location);
+
+                IEdmStringConstantExpression stringConstant = annotation.Value as IEdmStringConstantExpression;
+                if (stringConstant != null)
+                {
+                    return stringConstant.Value;
+                }
+            }
+
+            return null;
+        }
+
+        private static IEdmModel GetModel(string types = "", string properties = "")
+        {
+            const string template = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
+  <edmx:DataServices>
+    <Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
+      <EntityType Name=""Customer"">
+        <Key>
+          <PropertyRef Name=""ID"" />
+        </Key>
+        <Property Name=""ID"" Type=""Edm.Int32"" Nullable=""false"" />
+        {1}
+      </EntityType>
+      {0}
+      <EntityContainer Name =""Default"">
+         <EntitySet Name=""Customers"" EntityType=""NS.Customer"" />
+         <Singleton Name=""Me"" Type=""NS.Customer"" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>";
+            string modelText = string.Format(template, types, properties);
+
+            IEdmModel model;
+            IEnumerable<EdmError> errors;
+
+            bool result = CsdlReader.TryParse(XElement.Parse(modelText).CreateReader(), out model, out errors);
+            Assert.True(result);
+            return model;
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -20,7 +20,7 @@ using ErrorStrings = Microsoft.OData.Edm.Strings;
 
 namespace Microsoft.OData.Edm.Tests.Csdl
 {
-    public class CsdlReaderTests
+    public partial class CsdlReaderTests
     {
         private const string ValidEdmx = @"<edmx:Edmx Version=""4.0"" xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"">
   <edmx:DataServices>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.TargetPath.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.TargetPath.cs
@@ -1,0 +1,448 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CsdlWriterTests.TargetPath.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Vocabularies;
+using Xunit;
+
+namespace Microsoft.OData.Edm.Tests.Csdl
+{
+    public partial class CsdlWriterTests
+    {
+        [Fact]
+        public void ShouldWriteAnnotationForEntitySetProperty()
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            model.AddElement(customer);
+
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntitySet entitySet = new EdmEntitySet(container, "Customers", customer);
+            container.AddElement(entitySet);
+            model.AddElement(container);
+
+            IEdmProperty nameProperty = customer.DeclaredProperties.Where(x => x.Name == "Name").FirstOrDefault();
+
+            EdmTargetPath targetPath = new EdmTargetPath(container, entitySet, nameProperty);
+
+            EdmTerm term = new EdmTerm("NS", "MyTerm", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(term);
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(targetPath, term, new EdmStringConstant("Name OutOfLine MyTerm Value"));
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            model.SetVocabularyAnnotation(annotation);
+
+            WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+              "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+                "<edmx:DataServices>" +
+                  "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                    "<EntityType Name=\"Customer\">" +
+                      "<Key>" +
+                        "<PropertyRef Name=\"Id\" />" +
+                      "</Key>" +
+                      "<Property Name=\"Id\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                      "<Property Name=\"Name\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                    "</EntityType>" +
+                    "<Term Name=\"MyTerm\" Type=\"Edm.String\" />" +
+                    "<EntityContainer Name=\"Default\">" +
+                       "<EntitySet Name=\"Customers\" EntityType=\"NS.Customer\" />" +
+                    "</EntityContainer>" +
+                    "<Annotations Target=\"NS.Default/Customers/Name\">" +
+                      "<Annotation Term=\"NS.MyTerm\" String=\"Name OutOfLine MyTerm Value\" />" +
+                    "</Annotations>" +
+                  "</Schema>" +
+                "</edmx:DataServices>" +
+              "</edmx:Edmx>");
+
+            // Act & Assert for JSON
+            WriteAndVerifyJson(model, @"{
+  ""$Version"": ""4.0"",
+  ""$EntityContainer"": ""NS.Default"",
+  ""NS"": {
+    ""Customer"": {
+      ""$Kind"": ""EntityType"",
+      ""$Key"": [
+        ""Id""
+      ],
+      ""Id"": {
+        ""$Type"": ""Edm.Int32""
+      },
+      ""Name"": {}
+    },
+    ""MyTerm"": {
+      ""$Kind"": ""Term"",
+      ""$Nullable"": true
+    },
+    ""Default"": {
+      ""$Kind"": ""EntityContainer"",
+      ""Customers"": {
+        ""$Collection"": true,
+        ""$Type"": ""NS.Customer""
+      }
+    },
+    ""$Annotations"": {
+      ""NS.Default/Customers/Name"": {
+        ""@NS.MyTerm"": ""Name OutOfLine MyTerm Value""
+      }
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void WriteInlineAnnotationForTargetPathThrows()
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            model.AddElement(customer);
+
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntitySet entitySet = new EdmEntitySet(container, "Customers", customer);
+            container.AddElement(entitySet);
+            model.AddElement(container);
+
+            IEdmProperty nameProperty = customer.DeclaredProperties.Where(x => x.Name == "Name").FirstOrDefault();
+
+            EdmTargetPath targetPath = new EdmTargetPath(container, entitySet, nameProperty);
+
+            EdmTerm term = new EdmTerm("NS", "MyTerm", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(term);
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(targetPath, term, new EdmStringConstant("Name OutOfLine MyTerm Value"));
+
+            // Act & Assert
+            Action action = () => annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(action);
+            Assert.Equal(Strings.EdmVocabularyAnnotations_InvalidLocationForTargetPathAnnotation(annotation.TargetString()), exception.Message);
+        }
+
+        [Fact]
+        public void ShouldWriteAnnotationForEntitySetComplexTypeProperty()
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+
+            EdmComplexType addressType = new EdmComplexType("NS", "Address");
+            addressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressType.AddStructuralProperty("PostalCode", EdmPrimitiveTypeKind.Int32, isNullable: false);
+            model.AddElement(addressType);
+
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            customer.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, isNullable: false));
+            model.AddElement(customer);
+
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntitySet entitySet = new EdmEntitySet(container, "Customers", customer);
+            container.AddElement(entitySet);
+            model.AddElement(container);
+
+            IEdmProperty addressProperty = customer.DeclaredProperties.Where(x => x.Name == "Address").FirstOrDefault();
+            IEdmProperty streetProperty = addressType.DeclaredProperties.Where(x => x.Name == "Street").FirstOrDefault();
+
+            EdmTargetPath targetPath = new EdmTargetPath(container, entitySet, addressProperty, streetProperty);
+
+            EdmTerm term = new EdmTerm("NS", "MyTerm", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(term);
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(targetPath, term, new EdmStringConstant("Name OutOfLine MyTerm Value"));
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            model.SetVocabularyAnnotation(annotation);
+
+            WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+              "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+                "<edmx:DataServices>" +
+                  "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                    "<ComplexType Name=\"Address\">" +
+                      "<Property Name=\"Street\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                      "<Property Name=\"City\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                      "<Property Name=\"PostalCode\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                    "</ComplexType>" +
+                    "<EntityType Name=\"Customer\">" +
+                      "<Key>" +
+                        "<PropertyRef Name=\"Id\" />" +
+                      "</Key>" +
+                      "<Property Name=\"Id\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                      "<Property Name=\"Name\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                      "<Property Name=\"Address\" Type=\"NS.Address\" Nullable=\"false\" />" +
+                    "</EntityType>" +
+                    "<Term Name=\"MyTerm\" Type=\"Edm.String\" />" +
+                    "<EntityContainer Name=\"Default\">" +
+                       "<EntitySet Name=\"Customers\" EntityType=\"NS.Customer\" />" +
+                    "</EntityContainer>" +
+                    "<Annotations Target=\"NS.Default/Customers/Address/Street\">" +
+                      "<Annotation Term=\"NS.MyTerm\" String=\"Name OutOfLine MyTerm Value\" />" +
+                    "</Annotations>" +
+                  "</Schema>" +
+                "</edmx:DataServices>" +
+              "</edmx:Edmx>");
+
+            // Act & Assert for JSON
+            WriteAndVerifyJson(model, @"{
+  ""$Version"": ""4.0"",
+  ""$EntityContainer"": ""NS.Default"",
+  ""NS"": {
+    ""Address"": {
+      ""$Kind"": ""ComplexType"",
+      ""Street"": {},
+      ""City"": {},
+      ""PostalCode"": {
+        ""$Type"": ""Edm.Int32""
+      }
+    },
+    ""Customer"": {
+      ""$Kind"": ""EntityType"",
+      ""$Key"": [
+        ""Id""
+      ],
+      ""Id"": {
+        ""$Type"": ""Edm.Int32""
+      },
+      ""Name"": {},
+      ""Address"": {
+        ""$Type"": ""NS.Address""
+      }
+    },
+    ""MyTerm"": {
+      ""$Kind"": ""Term"",
+      ""$Nullable"": true
+    },
+    ""Default"": {
+      ""$Kind"": ""EntityContainer"",
+      ""Customers"": {
+        ""$Collection"": true,
+        ""$Type"": ""NS.Customer""
+      }
+    },
+    ""$Annotations"": {
+      ""NS.Default/Customers/Address/Street"": {
+        ""@NS.MyTerm"": ""Name OutOfLine MyTerm Value""
+      }
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void ShouldWriteAnnotationForSingletonComplexTypeProperty()
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+
+            EdmComplexType addressType = new EdmComplexType("NS", "Address");
+            addressType.AddStructuralProperty("Street", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String, isNullable: false);
+            addressType.AddStructuralProperty("PostalCode", EdmPrimitiveTypeKind.Int32, isNullable: false);
+            model.AddElement(addressType);
+
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            customer.AddStructuralProperty("Address", new EdmComplexTypeReference(addressType, isNullable: false));
+            model.AddElement(customer);
+
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntitySet entitySet = new EdmEntitySet(container, "Customers", customer);
+            container.AddElement(entitySet);
+            IEdmSingleton singleton = container.AddSingleton("SpecialCustomer", customer);
+            model.AddElement(container);
+
+            IEdmProperty addressProperty = customer.DeclaredProperties.Where(x => x.Name == "Address").FirstOrDefault();
+            IEdmProperty streetProperty = addressType.DeclaredProperties.Where(x => x.Name == "Street").FirstOrDefault();
+
+            EdmTargetPath targetPath = new EdmTargetPath(container, singleton, addressProperty, streetProperty);
+
+            EdmTerm term = new EdmTerm("NS", "MyTerm", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(term);
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(targetPath, term, new EdmStringConstant("Name OutOfLine MyTerm Value"));
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            model.SetVocabularyAnnotation(annotation);
+
+            WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+              "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+                "<edmx:DataServices>" +
+                  "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                    "<ComplexType Name=\"Address\">" +
+                      "<Property Name=\"Street\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                      "<Property Name=\"City\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                      "<Property Name=\"PostalCode\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                    "</ComplexType>" +
+                    "<EntityType Name=\"Customer\">" +
+                      "<Key>" +
+                        "<PropertyRef Name=\"Id\" />" +
+                      "</Key>" +
+                      "<Property Name=\"Id\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                      "<Property Name=\"Name\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                      "<Property Name=\"Address\" Type=\"NS.Address\" Nullable=\"false\" />" +
+                    "</EntityType>" +
+                    "<Term Name=\"MyTerm\" Type=\"Edm.String\" />" +
+                    "<EntityContainer Name=\"Default\">" +
+                       "<EntitySet Name=\"Customers\" EntityType=\"NS.Customer\" />" +
+                       "<Singleton Name=\"SpecialCustomer\" Type=\"NS.Customer\" />" +
+                    "</EntityContainer>" +
+                    "<Annotations Target=\"NS.Default/SpecialCustomer/Address/Street\">" +
+                      "<Annotation Term=\"NS.MyTerm\" String=\"Name OutOfLine MyTerm Value\" />" +
+                    "</Annotations>" +
+                  "</Schema>" +
+                "</edmx:DataServices>" +
+              "</edmx:Edmx>");
+
+            // Act & Assert for JSON
+            WriteAndVerifyJson(model, @"{
+  ""$Version"": ""4.0"",
+  ""$EntityContainer"": ""NS.Default"",
+  ""NS"": {
+    ""Address"": {
+      ""$Kind"": ""ComplexType"",
+      ""Street"": {},
+      ""City"": {},
+      ""PostalCode"": {
+        ""$Type"": ""Edm.Int32""
+      }
+    },
+    ""Customer"": {
+      ""$Kind"": ""EntityType"",
+      ""$Key"": [
+        ""Id""
+      ],
+      ""Id"": {
+        ""$Type"": ""Edm.Int32""
+      },
+      ""Name"": {},
+      ""Address"": {
+        ""$Type"": ""NS.Address""
+      }
+    },
+    ""MyTerm"": {
+      ""$Kind"": ""Term"",
+      ""$Nullable"": true
+    },
+    ""Default"": {
+      ""$Kind"": ""EntityContainer"",
+      ""Customers"": {
+        ""$Collection"": true,
+        ""$Type"": ""NS.Customer""
+      },
+      ""SpecialCustomer"": {
+        ""$Type"": ""NS.Customer""
+      }
+    },
+    ""$Annotations"": {
+      ""NS.Default/SpecialCustomer/Address/Street"": {
+        ""@NS.MyTerm"": ""Name OutOfLine MyTerm Value""
+      }
+    }
+  }
+}");
+        }
+
+        [Fact]
+        public void ShouldWriteAnnotationForEntitySetDerivedTypeProperty()
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            model.AddElement(customer);
+
+            EdmEntityType vipCustomer = new EdmEntityType("NS", "VipCustomer", customer);
+            vipCustomer.AddStructuralProperty("VipNumber", EdmPrimitiveTypeKind.String, isNullable: false);
+            model.AddElement(vipCustomer);
+
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntitySet entitySet = new EdmEntitySet(container, "Customers", customer);
+            container.AddElement(entitySet);
+            model.AddElement(container);
+
+            IEdmProperty vipNoProperty = vipCustomer.DeclaredProperties.Where(x => x.Name == "VipNumber").FirstOrDefault();
+
+            EdmTargetPath targetPath = new EdmTargetPath(container, entitySet, vipCustomer, vipNoProperty);
+
+            EdmTerm term = new EdmTerm("NS", "MyTerm", EdmCoreModel.Instance.GetString(true));
+            model.AddElement(term);
+            EdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(targetPath, term, new EdmStringConstant("Name OutOfLine MyTerm Value"));
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.OutOfLine);
+            model.SetVocabularyAnnotation(annotation);
+
+            WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+              "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+                "<edmx:DataServices>" +
+                  "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                    "<EntityType Name=\"Customer\">" +
+                      "<Key>" +
+                        "<PropertyRef Name=\"Id\" />" +
+                      "</Key>" +
+                      "<Property Name=\"Id\" Type=\"Edm.Int32\" Nullable=\"false\" />" +
+                      "<Property Name=\"Name\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                    "</EntityType>" +
+                    "<EntityType Name=\"VipCustomer\" BaseType=\"NS.Customer\">" +
+                      "<Property Name=\"VipNumber\" Type=\"Edm.String\" Nullable=\"false\" />" +
+                    "</EntityType>" +
+                    "<Term Name=\"MyTerm\" Type=\"Edm.String\" />" +
+                    "<EntityContainer Name=\"Default\">" +
+                       "<EntitySet Name=\"Customers\" EntityType=\"NS.Customer\" />" +
+                    "</EntityContainer>" +
+                    "<Annotations Target=\"NS.Default/Customers/NS.VipCustomer/VipNumber\">" +
+                      "<Annotation Term=\"NS.MyTerm\" String=\"Name OutOfLine MyTerm Value\" />" +
+                    "</Annotations>" +
+                  "</Schema>" +
+                "</edmx:DataServices>" +
+              "</edmx:Edmx>");
+
+            // Act & Assert for JSON
+            WriteAndVerifyJson(model, @"{
+  ""$Version"": ""4.0"",
+  ""$EntityContainer"": ""NS.Default"",
+  ""NS"": {
+    ""Customer"": {
+      ""$Kind"": ""EntityType"",
+      ""$Key"": [
+        ""Id""
+      ],
+      ""Id"": {
+        ""$Type"": ""Edm.Int32""
+      },
+      ""Name"": {}
+    },
+    ""VipCustomer"": {
+      ""$Kind"": ""EntityType"",
+      ""$BaseType"": ""NS.Customer"",
+      ""VipNumber"": {}
+    },
+    ""MyTerm"": {
+      ""$Kind"": ""Term"",
+      ""$Nullable"": true
+    },
+    ""Default"": {
+      ""$Kind"": ""EntityContainer"",
+      ""Customers"": {
+        ""$Collection"": true,
+        ""$Type"": ""NS.Customer""
+      }
+    },
+    ""$Annotations"": {
+      ""NS.Default/Customers/NS.VipCustomer/VipNumber"": {
+        ""@NS.MyTerm"": ""Name OutOfLine MyTerm Value""
+      }
+    }
+  }
+}");
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -23,7 +23,7 @@ using Xunit;
 
 namespace Microsoft.OData.Edm.Tests.Csdl
 {
-    public class CsdlWriterTests
+    public partial class CsdlWriterTests
     {
         #region Reference
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/EdmUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/EdmUtilTests.cs
@@ -14,14 +14,14 @@ namespace Microsoft.OData.Edm.Tests
     ///</summary>
     public class EdmUtilTests
     {
-        private static EdmEntityType customer = new EdmEntityType("NS", "Customer");
-        private static EdmEntityType vipCustomer = new EdmEntityType("NS", "VipCustomer", customer);
-        private static EdmEntityType city = new EdmEntityType("NS", "City");
-        private static EdmComplexType complex = new EdmComplexType("NS", "Address");
-        private static EdmComplexType derivedcomplex = new EdmComplexType("NS", "DerivedAddress", complex);
-        private static EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
-        private static EdmEntitySet entitySet = new EdmEntitySet(container, "Customers", customer);
-        private static EdmSingleton singleton = new EdmSingleton(container, "Me", customer);
+        private static EdmEntityType customer;
+        private static EdmEntityType vipCustomer;
+        private static EdmEntityType city;
+        private static EdmComplexType complex;
+        private static EdmComplexType derivedcomplex;
+        private static EdmEntityContainer container;
+        private static EdmEntitySet entitySet;
+        private static EdmSingleton singleton;
 
         private static IEdmProperty nameProperty;
         private static IEdmProperty addressProperty;
@@ -29,13 +29,13 @@ namespace Microsoft.OData.Edm.Tests
         private static EdmNavigationProperty navUnderComplex;
         private static EdmNavigationProperty navUnderCustomer;
 
-        public EdmUtilTests()
+        static EdmUtilTests()
         {
-            customer.AddKeys(customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
-            customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            city = new EdmEntityType("NS", "City");
 
+            complex = new EdmComplexType("NS", "Address");
             complex.AddStructuralProperty("Road", EdmCoreModel.Instance.GetString(false));
-            derivedcomplex.AddStructuralProperty("MyRoad", EdmCoreModel.Instance.GetString(false));
+
             navUnderComplex = complex.AddUnidirectionalNavigation(
                 new EdmNavigationPropertyInfo()
                 {
@@ -44,6 +44,12 @@ namespace Microsoft.OData.Edm.Tests
                     TargetMultiplicity = EdmMultiplicity.One,
                 });
 
+            derivedcomplex = new EdmComplexType("NS", "DerivedAddress", complex);
+            derivedcomplex.AddStructuralProperty("MyRoad", EdmCoreModel.Instance.GetString(false));
+
+            customer = new EdmEntityType("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
             customer.AddStructuralProperty("Address", new EdmComplexTypeReference(complex, false));
 
             navUnderCustomer = customer.AddUnidirectionalNavigation(
@@ -53,6 +59,12 @@ namespace Microsoft.OData.Edm.Tests
                     Target = city,
                     TargetMultiplicity = EdmMultiplicity.Many,
                 });
+
+            vipCustomer = new EdmEntityType("NS", "VipCustomer", customer);
+
+            container = new EdmEntityContainer("NS", "Default");
+            entitySet = new EdmEntitySet(container, "Customers", customer);
+            singleton = new EdmSingleton(container, "Me", customer);
 
             nameProperty = customer.DeclaredProperties.Where(x => x.Name == "Name").FirstOrDefault();
             addressProperty = customer.DeclaredProperties.Where(x => x.Name == "Address").FirstOrDefault();

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/TargetHelperTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/TargetHelperTests.cs
@@ -1,0 +1,211 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="TargetHelperTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.OData.Edm.Tests.ExtensionMethods
+{
+    public class TargetHelperTests
+    {
+        private static TargetPathSampleModel sampleModel;
+        private static IEdmModel edmModel;
+        static TargetHelperTests()
+        {
+            sampleModel = new TargetPathSampleModel();
+
+            edmModel = sampleModel.Model;
+        }
+
+        [Fact]
+        public void GetTargetSegmentsForEntitySetProperty()
+        {
+            string targetPath = "NS.Default/Customers/Name";
+            List<IEdmElement> segments = edmModel.GetTargetSegments(targetPath.Split('/'), true).ToList();
+
+            Assert.Equal(3, segments.Count);
+            Assert.IsAssignableFrom<IEdmEntityContainer>(segments[0]);
+            Assert.IsAssignableFrom<IEdmEntitySet>(segments[1]);
+            Assert.IsAssignableFrom<IEdmStructuralProperty>(segments[2]);
+            Assert.Equal("Customers", (segments[1] as IEdmEntitySet).Name);
+            Assert.Equal("Name", (segments[2] as IEdmStructuralProperty).Name);
+        }
+
+        [Fact]
+        public void GetTargetSegmentsForEntitySetPropertyOnDerivedType()
+        {
+            string targetPath = "NS.Default/Customers/NS.VipCustomer/Name";
+            List<IEdmElement> segments = edmModel.GetTargetSegments(targetPath.Split('/'), true).ToList();
+
+            Assert.Equal(4, segments.Count);
+            Assert.IsAssignableFrom<IEdmEntityContainer>(segments[0]);
+            Assert.IsAssignableFrom<IEdmEntitySet>(segments[1]);
+            Assert.IsAssignableFrom<IEdmSchemaType>(segments[2]);
+            Assert.IsAssignableFrom<IEdmStructuralProperty>(segments[3]);
+            Assert.Equal("Customers", (segments[1] as IEdmEntitySet).Name);
+            Assert.Equal("VipCustomer", (segments[2] as IEdmSchemaType).Name);
+            Assert.Equal("Name", (segments[3] as IEdmStructuralProperty).Name);
+        }
+
+        [Fact]
+        public void GetTargetSegmentsForEntitySetNavigationProperty()
+        {
+            string targetPath = "NS.Default/Customers/Cities";
+            List<IEdmElement> segments = edmModel.GetTargetSegments(targetPath.Split('/'), true).ToList();
+
+            Assert.Equal(3, segments.Count);
+            Assert.IsAssignableFrom<IEdmEntityContainer>(segments[0]);
+            Assert.IsAssignableFrom<IEdmEntitySet>(segments[1]);
+            Assert.IsAssignableFrom<IEdmNavigationProperty>(segments[2]);
+            Assert.Equal("Customers", (segments[1] as IEdmEntitySet).Name);
+            Assert.Equal("Cities", (segments[2] as IEdmNavigationProperty).Name);
+        }
+
+        [Fact]
+        public void GetTargetSegmentsForEntitySetNavigationPropertyUnderComplexProperty()
+        {
+            string targetPath = "NS.Default/Customers/Address/City";
+            List<IEdmElement> segments = edmModel.GetTargetSegments(targetPath.Split('/'), true).ToList();
+
+            Assert.Equal(4, segments.Count);
+            Assert.IsAssignableFrom<IEdmEntityContainer>(segments[0]);
+            Assert.IsAssignableFrom<IEdmEntitySet>(segments[1]);
+            Assert.IsAssignableFrom<IEdmStructuralProperty>(segments[2]);
+            Assert.IsAssignableFrom<IEdmNavigationProperty>(segments[3]);
+            Assert.Equal("Customers", (segments[1] as IEdmEntitySet).Name);
+            Assert.Equal("Address", (segments[2] as IEdmStructuralProperty).Name);
+            Assert.Equal("City", (segments[3] as IEdmNavigationProperty).Name);
+        }
+
+        [Fact]
+        public void GetTargetSegmentsForEntitySetNavigationPropertyUnderDerivedComplexProperty()
+        {
+            string targetPath = "NS.Default/Customers/Address/NS.DerivedAddress/MyRoad";
+            List<IEdmElement> segments = edmModel.GetTargetSegments(targetPath.Split('/'), true).ToList();
+
+            Assert.Equal(5, segments.Count);
+            Assert.IsAssignableFrom<IEdmEntityContainer>(segments[0]);
+            Assert.IsAssignableFrom<IEdmEntitySet>(segments[1]);
+            Assert.IsAssignableFrom<IEdmProperty>(segments[2]);
+            Assert.IsAssignableFrom<IEdmSchemaType>(segments[3]);
+            Assert.IsAssignableFrom<IEdmStructuralProperty>(segments[4]);
+            Assert.Equal("Customers", (segments[1] as IEdmEntitySet).Name);
+            Assert.Equal("Address", (segments[2] as IEdmProperty).Name);
+            Assert.Equal("DerivedAddress", (segments[3] as IEdmSchemaType).Name);
+            Assert.Equal("MyRoad", (segments[4] as IEdmStructuralProperty).Name);
+        }
+
+        [Fact]
+        public void GetTargetSegmentsForSingletonNavigationPropertyUnderComplexProperty()
+        {
+            string targetPath = "NS.Default/Me/Address/City";
+            List<IEdmElement> segments = edmModel.GetTargetSegments(targetPath.Split('/'), true).ToList();
+
+            Assert.Equal(4, segments.Count);
+            Assert.IsAssignableFrom<IEdmEntityContainer>(segments[0]);
+            Assert.IsAssignableFrom<IEdmSingleton>(segments[1]);
+            Assert.IsAssignableFrom<IEdmStructuralProperty>(segments[2]);
+            Assert.IsAssignableFrom<IEdmNavigationProperty>(segments[3]);
+            Assert.Equal("Me", (segments[1] as IEdmSingleton).Name);
+            Assert.Equal("Address", (segments[2] as IEdmStructuralProperty).Name);
+            Assert.Equal("City", (segments[3] as IEdmNavigationProperty).Name);
+        }
+
+        [Fact]
+        public void GetTargetSegmentsForInValidTypeCastThrows()
+        {
+            string targetPath = "NS.Default/Customers/NS.City/Name";
+
+            // Act & Assert
+            Action action = () => edmModel.GetTargetSegments(targetPath.Split('/'), true).ToList();
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(action);
+            Assert.Equal(Strings.TypeCast_HierarchyNotFollowed(sampleModel.EntitySet, sampleModel.City), exception.Message);
+        }
+
+        [Fact]
+        public void GetTargetSegmentsForTwoTypeCastThrows()
+        {
+            string targetPath = "NS.Default/Customers/NS.VipCustomer/NS.City/Name";
+
+            // Act & Assert
+            Action action = () => edmModel.GetTargetSegments(targetPath.Split('/'), true).ToList();
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(action);
+            Assert.Equal(Strings.TypeCast_HierarchyNotFollowed(sampleModel.VipCustomer, sampleModel.City), exception.Message);
+        }
+    }
+
+    internal class TargetPathSampleModel
+    {
+        public TargetPathSampleModel()
+        {
+            this.Model = new EdmModel();
+            this.Address = new EdmComplexType("NS", "Address");
+            this.Address.AddStructuralProperty("Road", EdmCoreModel.Instance.GetString(false));
+            this.Model.AddElement(this.Address);
+
+            this.DerivedAddress = new EdmComplexType("NS", "DerivedAddress", this.Address);
+            this.DerivedAddress.AddStructuralProperty("MyRoad", EdmCoreModel.Instance.GetString(false));
+            this.Model.AddElement(this.DerivedAddress);
+
+            this.Customer = new EdmEntityType("NS", "Customer");
+            this.Customer.AddKeys(this.Customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            this.Customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            this.Customer.AddStructuralProperty("Address", new EdmComplexTypeReference(this.Address, false));
+            this.Model.AddElement(this.Customer);
+
+            this.VipCustomer = new EdmEntityType("NS", "VipCustomer", this.Customer);
+            this.Model.AddElement(this.VipCustomer);
+            this.City = new EdmEntityType("NS", "City");
+            this.City.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            this.Model.AddElement(this.City);
+
+            this.NavUnderComplex = this.Address.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo()
+                {
+                    Name = "City",
+                    Target = this.City,
+                    TargetMultiplicity = EdmMultiplicity.One,
+                });
+
+            this.NavUnderCustomer = this.Customer.AddUnidirectionalNavigation(
+                new EdmNavigationPropertyInfo()
+                {
+                    Name = "Cities",
+                    Target = this.City,
+                    TargetMultiplicity = EdmMultiplicity.Many,
+                });
+
+            this.NameProperty = this.Customer.DeclaredProperties.Where(x => x.Name == "Name").FirstOrDefault();
+            this.AddressProperty = this.Customer.DeclaredProperties.Where(x => x.Name == "Address").FirstOrDefault();
+
+            this.Container = new EdmEntityContainer("NS", "Default");
+            this.EntitySet = new EdmEntitySet(this.Container, "Customers", this.Customer);
+            this.Singleton = new EdmSingleton(this.Container, "Me", this.Customer);
+            this.Container.AddElement(this.EntitySet);
+            this.Container.AddElement(this.Singleton);
+
+            this.Model.AddElement(this.Container);
+        }
+
+        public EdmModel Model { get; private set; }
+        public EdmEntityContainer Container { get; private set; }
+        public EdmEntitySet EntitySet { get; private set; }
+        public EdmSingleton Singleton { get; private set; }
+        public EdmEntityType Customer { get; private set; }
+        public EdmEntityType VipCustomer { get; private set; }
+        public EdmEntityType City { get; private set; }
+        public EdmComplexType Address { get; private set; }
+        public EdmComplexType DerivedAddress { get; private set; }
+        public IEdmProperty NameProperty { get; private set; }
+        public IEdmProperty AddressProperty { get; private set; }
+        public EdmNavigationProperty NavUnderComplex { get; private set; }
+        public EdmNavigationProperty NavUnderCustomer { get; private set; }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmTargetPathTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmTargetPathTests.cs
@@ -70,7 +70,8 @@ namespace Microsoft.OData.Edm.Tests.Library
             // Act & Assert
             Action action = () => new EdmTargetPath(container, null, customer);
 
-            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(action);
+            ArgumentException exception = Assert.Throws<ArgumentException>(action);
+            Assert.Equal(Strings.TargetPath_SegmentsMustNotContainNullSegment, exception.Message);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmTargetPathTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmTargetPathTests.cs
@@ -1,0 +1,112 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="EdmTargetPathTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
+using Microsoft.OData.Edm.Vocabularies.V1;
+using Xunit;
+
+namespace Microsoft.OData.Edm.Tests.Library
+{
+    public class EdmTargetPathTests
+    {
+        [Fact]
+        public void InitializeEdmTargetPathWithNull()
+        {
+            Action parseAction = () => new EdmTargetPath(null);
+
+            Assert.Throws<ArgumentNullException>(parseAction);
+        }
+
+        [Fact]
+        public void InitializeEdmTargetPath_FirstSegmentIsNotContainer()
+        {
+            // Arrange
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+            customer.AddKeys(customer.AddStructuralProperty("Id", EdmCoreModel.Instance.GetInt32(false)));
+            customer.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String, isNullable: false);
+            IEdmProperty nameProperty = customer.DeclaredProperties.Where(x => x.Name == "Name").FirstOrDefault();
+
+            // Act & Assert
+            Action action = () => new EdmTargetPath(customer, nameProperty);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(action);
+            Assert.Equal(Strings.TargetPath_FirstSegmentMustBeIEdmEntityContainer, exception.Message);
+        }
+
+        [Fact]
+        public void InitializeEdmTargetPath_SecondSegmentIsNotContainerElement()
+        {
+            // Arrange
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+
+            // Act & Assert
+            Action action = () => new EdmTargetPath(container,customer);
+
+            InvalidOperationException exception = Assert.Throws<InvalidOperationException>(action);
+            Assert.Equal(Strings.TargetPath_SecondSegmentMustBeIEdmEntityContainerElement, exception.Message);
+        }
+
+        [Fact]
+        public void InitializeEdmTargetPath_WithNullElement()
+        {
+            // Arrange
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+
+            // Act & Assert
+            Action action = () => new EdmTargetPath(container, null, customer);
+
+            ArgumentNullException exception = Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void TwoEqualEdmTargetPaths_ReturnsTrue()
+        {
+            // Arrange
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+            EdmEntitySet entitySet = new EdmEntitySet(container, "Customers", customer);
+
+            // Act & Assert
+            EdmTargetPath targetPath1 = new EdmTargetPath(container, entitySet, customer);
+            EdmTargetPath targetPath2 = new EdmTargetPath(container, entitySet, customer);
+
+            Assert.True(targetPath1.Equals(targetPath2));
+        }
+
+        [Fact]
+        public void TwoUnEqualEdmTargetPaths_ReturnsFalse()
+        {
+            // Arrange
+            EdmEntityContainer container = new EdmEntityContainer("NS", "Default");
+            EdmEntityType customer = new EdmEntityType("NS", "Customer");
+            EdmEntityType derivedCustomer = new EdmEntityType("NS", "DerivedCustomer", customer);
+            EdmEntitySet entitySet = new EdmEntitySet(container, "Customers", customer);
+
+            // Act & Assert
+            EdmTargetPath targetPath1 = new EdmTargetPath(container, entitySet, customer);
+            EdmTargetPath targetPath2 = new EdmTargetPath(container, entitySet, derivedCustomer);
+
+            Assert.False(targetPath1.Equals(targetPath2));
+
+            EdmTargetPath targetPath3 = new EdmTargetPath(container, entitySet, customer);
+            EdmTargetPath targetPath4 = new EdmTargetPath(container, entitySet);
+
+            Assert.False(targetPath3.Equals(targetPath4));
+        }
+    }
+}

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -1056,7 +1056,8 @@ public interface Microsoft.OData.Edm.IEdmStructuredTypeReference : IEdmElement, 
 }
 
 public interface Microsoft.OData.Edm.IEdmTargetPath : IEdmElement, IEdmVocabularyAnnotatable {
-    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
+    string Path  { public abstract get; }
+    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
 }
 
 public interface Microsoft.OData.Edm.IEdmTemporalTypeReference : IEdmElement, IEdmPrimitiveTypeReference, IEdmTypeReference {
@@ -1932,11 +1933,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
-
-    [
-    ExtensionAttribute(),
-    ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
 
     [
@@ -2052,11 +2048,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static string GetPathString (Microsoft.OData.Edm.IEdmTargetPath targetPath)
-
-    [
-    ExtensionAttribute(),
-    ]
     public static Microsoft.OData.Edm.IPrimitiveValueConverter GetPrimitiveValueConverter (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmTypeReference type)
 
     [
@@ -2068,6 +2059,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool caseInsensitive)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] GetTargetPathAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
 
     [
     ExtensionAttribute(),
@@ -2859,7 +2855,11 @@ public class Microsoft.OData.Edm.EdmTargetPath : IEdmElement, IEdmTargetPath, IE
     public EdmTargetPath (Microsoft.OData.Edm.IEdmElement[] segments)
     public EdmTargetPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] segments)
 
-    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
+    string Path  { public virtual get; }
+    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
+
+    public virtual bool Equals (object obj)
+    public virtual int GetHashCode ()
 }
 
 public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.EdmPrimitiveTypeReference, IEdmElement, IEdmPrimitiveTypeReference, IEdmTemporalTypeReference, IEdmTypeReference {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -1055,6 +1055,10 @@ public interface Microsoft.OData.Edm.IEdmStructuredType : IEdmElement, IEdmType 
 public interface Microsoft.OData.Edm.IEdmStructuredTypeReference : IEdmElement, IEdmTypeReference {
 }
 
+public interface Microsoft.OData.Edm.IEdmTargetPath : IEdmElement, IEdmVocabularyAnnotatable {
+    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
+}
+
 public interface Microsoft.OData.Edm.IEdmTemporalTypeReference : IEdmElement, IEdmPrimitiveTypeReference, IEdmTypeReference {
     System.Nullable`1[[System.Int32]] Precision  { public abstract get; }
 }
@@ -1928,12 +1932,22 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
 
     [
     ExtensionAttribute(),
     ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, string termName)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
 
     [
     ExtensionAttribute(),
@@ -2038,12 +2052,22 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static string GetPathString (Microsoft.OData.Edm.IEdmTargetPath targetPath)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static Microsoft.OData.Edm.IPrimitiveValueConverter GetPrimitiveValueConverter (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmTypeReference type)
 
     [
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.IEdmOperationReturn GetReturn (Microsoft.OData.Edm.IEdmOperation operation)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool caseInsensitive)
 
     [
     ExtensionAttribute(),
@@ -2829,6 +2853,13 @@ public class Microsoft.OData.Edm.EdmStructuralProperty : Microsoft.OData.Edm.Edm
 
     string DefaultValueString  { public virtual get; }
     Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
+}
+
+public class Microsoft.OData.Edm.EdmTargetPath : IEdmElement, IEdmTargetPath, IEdmVocabularyAnnotatable {
+    public EdmTargetPath (Microsoft.OData.Edm.IEdmElement[] segments)
+    public EdmTargetPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] segments)
+
+    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
 }
 
 public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.EdmPrimitiveTypeReference, IEdmElement, IEdmPrimitiveTypeReference, IEdmTemporalTypeReference, IEdmTypeReference {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -2058,7 +2058,7 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool caseInsensitive)
+    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool ignoreCase)
 
     [
     ExtensionAttribute(),

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -1056,7 +1056,8 @@ public interface Microsoft.OData.Edm.IEdmStructuredTypeReference : IEdmElement, 
 }
 
 public interface Microsoft.OData.Edm.IEdmTargetPath : IEdmElement, IEdmVocabularyAnnotatable {
-    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
+    string Path  { public abstract get; }
+    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
 }
 
 public interface Microsoft.OData.Edm.IEdmTemporalTypeReference : IEdmElement, IEdmPrimitiveTypeReference, IEdmTypeReference {
@@ -1932,11 +1933,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
-
-    [
-    ExtensionAttribute(),
-    ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
 
     [
@@ -2052,11 +2048,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static string GetPathString (Microsoft.OData.Edm.IEdmTargetPath targetPath)
-
-    [
-    ExtensionAttribute(),
-    ]
     public static Microsoft.OData.Edm.IPrimitiveValueConverter GetPrimitiveValueConverter (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmTypeReference type)
 
     [
@@ -2068,6 +2059,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool caseInsensitive)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] GetTargetPathAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
 
     [
     ExtensionAttribute(),
@@ -2859,7 +2855,11 @@ public class Microsoft.OData.Edm.EdmTargetPath : IEdmElement, IEdmTargetPath, IE
     public EdmTargetPath (Microsoft.OData.Edm.IEdmElement[] segments)
     public EdmTargetPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] segments)
 
-    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
+    string Path  { public virtual get; }
+    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
+
+    public virtual bool Equals (object obj)
+    public virtual int GetHashCode ()
 }
 
 public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.EdmPrimitiveTypeReference, IEdmElement, IEdmPrimitiveTypeReference, IEdmTemporalTypeReference, IEdmTypeReference {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -1055,6 +1055,10 @@ public interface Microsoft.OData.Edm.IEdmStructuredType : IEdmElement, IEdmType 
 public interface Microsoft.OData.Edm.IEdmStructuredTypeReference : IEdmElement, IEdmTypeReference {
 }
 
+public interface Microsoft.OData.Edm.IEdmTargetPath : IEdmElement, IEdmVocabularyAnnotatable {
+    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
+}
+
 public interface Microsoft.OData.Edm.IEdmTemporalTypeReference : IEdmElement, IEdmPrimitiveTypeReference, IEdmTypeReference {
     System.Nullable`1[[System.Int32]] Precision  { public abstract get; }
 }
@@ -1928,12 +1932,22 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
 
     [
     ExtensionAttribute(),
     ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, string termName)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
 
     [
     ExtensionAttribute(),
@@ -2038,12 +2052,22 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static string GetPathString (Microsoft.OData.Edm.IEdmTargetPath targetPath)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static Microsoft.OData.Edm.IPrimitiveValueConverter GetPrimitiveValueConverter (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmTypeReference type)
 
     [
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.IEdmOperationReturn GetReturn (Microsoft.OData.Edm.IEdmOperation operation)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool caseInsensitive)
 
     [
     ExtensionAttribute(),
@@ -2829,6 +2853,13 @@ public class Microsoft.OData.Edm.EdmStructuralProperty : Microsoft.OData.Edm.Edm
 
     string DefaultValueString  { public virtual get; }
     Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
+}
+
+public class Microsoft.OData.Edm.EdmTargetPath : IEdmElement, IEdmTargetPath, IEdmVocabularyAnnotatable {
+    public EdmTargetPath (Microsoft.OData.Edm.IEdmElement[] segments)
+    public EdmTargetPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] segments)
+
+    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
 }
 
 public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.EdmPrimitiveTypeReference, IEdmElement, IEdmPrimitiveTypeReference, IEdmTemporalTypeReference, IEdmTypeReference {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -2058,7 +2058,7 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool caseInsensitive)
+    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool ignoreCase)
 
     [
     ExtensionAttribute(),

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -1056,7 +1056,8 @@ public interface Microsoft.OData.Edm.IEdmStructuredTypeReference : IEdmElement, 
 }
 
 public interface Microsoft.OData.Edm.IEdmTargetPath : IEdmElement, IEdmVocabularyAnnotatable {
-    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
+    string Path  { public abstract get; }
+    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
 }
 
 public interface Microsoft.OData.Edm.IEdmTemporalTypeReference : IEdmElement, IEdmPrimitiveTypeReference, IEdmTypeReference {
@@ -1932,11 +1933,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
-
-    [
-    ExtensionAttribute(),
-    ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
 
     [
@@ -2052,11 +2048,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static string GetPathString (Microsoft.OData.Edm.IEdmTargetPath targetPath)
-
-    [
-    ExtensionAttribute(),
-    ]
     public static Microsoft.OData.Edm.IPrimitiveValueConverter GetPrimitiveValueConverter (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmTypeReference type)
 
     [
@@ -2068,6 +2059,11 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool caseInsensitive)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] GetTargetPathAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
 
     [
     ExtensionAttribute(),
@@ -2859,7 +2855,11 @@ public class Microsoft.OData.Edm.EdmTargetPath : IEdmElement, IEdmTargetPath, IE
     public EdmTargetPath (Microsoft.OData.Edm.IEdmElement[] segments)
     public EdmTargetPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] segments)
 
-    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
+    string Path  { public virtual get; }
+    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
+
+    public virtual bool Equals (object obj)
+    public virtual int GetHashCode ()
 }
 
 public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.EdmPrimitiveTypeReference, IEdmElement, IEdmPrimitiveTypeReference, IEdmTemporalTypeReference, IEdmTypeReference {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -1055,6 +1055,10 @@ public interface Microsoft.OData.Edm.IEdmStructuredType : IEdmElement, IEdmType 
 public interface Microsoft.OData.Edm.IEdmStructuredTypeReference : IEdmElement, IEdmTypeReference {
 }
 
+public interface Microsoft.OData.Edm.IEdmTargetPath : IEdmElement, IEdmVocabularyAnnotatable {
+    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
+}
+
 public interface Microsoft.OData.Edm.IEdmTemporalTypeReference : IEdmElement, IEdmPrimitiveTypeReference, IEdmTypeReference {
     System.Nullable`1[[System.Int32]] Precision  { public abstract get; }
 }
@@ -1928,12 +1932,22 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
 
     [
     ExtensionAttribute(),
     ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, string termName)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
 
     [
     ExtensionAttribute(),
@@ -2038,12 +2052,22 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
+    public static string GetPathString (Microsoft.OData.Edm.IEdmTargetPath targetPath)
+
+    [
+    ExtensionAttribute(),
+    ]
     public static Microsoft.OData.Edm.IPrimitiveValueConverter GetPrimitiveValueConverter (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.IEdmTypeReference type)
 
     [
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.IEdmOperationReturn GetReturn (Microsoft.OData.Edm.IEdmOperation operation)
+
+    [
+    ExtensionAttribute(),
+    ]
+    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool caseInsensitive)
 
     [
     ExtensionAttribute(),
@@ -2829,6 +2853,13 @@ public class Microsoft.OData.Edm.EdmStructuralProperty : Microsoft.OData.Edm.Edm
 
     string DefaultValueString  { public virtual get; }
     Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
+}
+
+public class Microsoft.OData.Edm.EdmTargetPath : IEdmElement, IEdmTargetPath, IEdmVocabularyAnnotatable {
+    public EdmTargetPath (Microsoft.OData.Edm.IEdmElement[] segments)
+    public EdmTargetPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] segments)
+
+    System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
 }
 
 public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.EdmPrimitiveTypeReference, IEdmElement, IEdmPrimitiveTypeReference, IEdmTemporalTypeReference, IEdmTypeReference {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -2058,7 +2058,7 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool caseInsensitive)
+    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool ignoreCase)
 
     [
     ExtensionAttribute(),


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2070 .*

### Description

We define a new interface 
```csharp
public interface IEdmTargetPath: IEdmVocabularyAnnotatable
{
    IEnumerable<IEdmElement> Segments { get; }
}
```
and a class that implements the interface
```csharp
public class EdmTargetPath : IEdmTargetPath
{
}
```
`EdmTargetPath` is used to handle the path to the model element that starts with `IEdmEntityContainer`. The `Segments` will contains the `IEdmElement`s in the target path.
e.g
```
MySchema.MyEntityContainer/MyEntitySet/MyProperty 
MySchema.MyEntityContainer/MyEntitySet/MyNavigationProperty 
MySchema.MyEntityContainer/MyEntitySet/MySchema.MyEntityType/MyProperty 
MySchema.MyEntityContainer/MyEntitySet/MySchema.MyEntityType/MyNavProperty
MySchema.MyEntityContainer/MyEntitySet/MyComplexProperty/MyProperty
MySchema.MyEntityContainer/MyEntitySet/MyComplexProperty/MyNavigationProperty
MySchema.MyEntityContainer/MySingleton/MyComplexProperty/MyNavigationProperty 
```
Annotations target example in csdl
```xml
<Annotations Target="NS.Default/SpecialCustomer/Address/Street">
    <Annotation Term="NS.MyTerm" String="Name OutOfLine MyTerm Value" />
</Annotations>"
```

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
