### PR TITLE
fix issue #2771 : fix method InBinder.ProcessSingleQuotedStringItem

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -299,9 +299,11 @@ namespace Microsoft.OData.UriParser
                         {
                             if(k > 2 && input[k - 2] == '\'')
                             {
-                                // Ignore we have 3 single quotes e.g 'xyz'''
-                                // It means we need to escape the double quotes to return the result "xyz'"
-                                continue;
+                                // We have 3 single quotes e.g 'ghi'''
+                                // It means we need to unescape the double single quotes
+                                // and escape double quote to return the result "ghi'" and process next items
+                                sb.Append('"');
+                                return k;
                             }
                             // We append \"\" so as to return "\"\"" instead of "".
                             // This is to avoid passing an empty string to the ConstantNode.

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2138,17 +2138,18 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Fact]
         public void FilterWithInOperationWithParensStringCollection_EscapedSingleQuote()
         {
-            FilterClause filter = ParseFilter("SSN in ('a''bc','''def','xyz''')", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+            FilterClause filter = ParseFilter("SSN in ('a''bc','''def','ghi''','xyz''')", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
 
             var inNode = Assert.IsType<InNode>(filter.Expression);
             Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
 
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
-            Assert.Equal("('a''bc','''def','xyz''')", collectionNode.LiteralText);
-            Assert.Equal(3, collectionNode.Collection.Count);
+            Assert.Equal("('a''bc','''def','ghi''','xyz''')", collectionNode.LiteralText);
+            Assert.Equal(4, collectionNode.Collection.Count);
             collectionNode.Collection.ElementAt(0).ShouldBeConstantQueryNode("a'bc");
             collectionNode.Collection.ElementAt(1).ShouldBeConstantQueryNode("'def");
-            collectionNode.Collection.ElementAt(2).ShouldBeConstantQueryNode("xyz'");
+            collectionNode.Collection.ElementAt(2).ShouldBeConstantQueryNode("ghi'");
+            collectionNode.Collection.ElementAt(3).ShouldBeConstantQueryNode("xyz'");
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2152,6 +2152,59 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             collectionNode.Collection.ElementAt(3).ShouldBeConstantQueryNode("xyz'");
         }
 
+        [Theory]
+        [InlineData("('a''bc')", "('a''bc')", 1)]
+        [InlineData("('''def')", "('''def')", 1)]
+        [InlineData("('xyz''')", "('xyz''')", 1)]
+        [InlineData("('''pqr''')", "('''pqr''')", 1)]
+        [InlineData("('a''bc','''def')", "('a''bc','''def')", 2)]
+        [InlineData("('a''bc','xyz''')", "('a''bc','xyz''')", 2)]
+        [InlineData("('a''bc','''pqr''')", "('a''bc','''pqr''')", 2)]
+        [InlineData("('''def','a''bc')", "('''def','a''bc')", 2)]
+        [InlineData("('''def','xyz''')", "('''def','xyz''')", 2)]
+        [InlineData("('''def','''pqr''')", "('''def','''pqr''')", 2)]
+        [InlineData("('xyz''','a''bc')", "('xyz''','a''bc')", 2)]
+        [InlineData("('xyz''','''def')", "('xyz''','''def')", 2)]
+        [InlineData("('xyz''','''pqr''')", "('xyz''','''pqr''')", 2)]
+        [InlineData("('''pqr''','a''bc')", "('''pqr''','a''bc')", 2)]
+        [InlineData("('''pqr''','''def')", "('''pqr''','''def')", 2)]
+        [InlineData("('''pqr''','xyz''')", "('''pqr''','xyz''')", 2)]
+        [InlineData("('a''bc','''def','xyz''')", "('a''bc','''def','xyz''')", 3)]
+        [InlineData("('a''bc','''def','''pqr''')", "('a''bc','''def','''pqr''')", 3)]
+        [InlineData("('a''bc','xyz''','''def')", "('a''bc','xyz''','''def')", 3)]
+        [InlineData("('a''bc','xyz''','''pqr''')", "('a''bc','xyz''','''pqr''')", 3)]
+        [InlineData("('a''bc','''pqr''','''def')", "('a''bc','''pqr''','''def')", 3)]
+        [InlineData("('a''bc','''pqr''','xyz''')", "('a''bc','''pqr''','xyz''')", 3)]
+        [InlineData("('''def','a''bc','xyz''')", "('''def','a''bc','xyz''')", 3)]
+        [InlineData("('''def','a''bc','''pqr''')", "('''def','a''bc','''pqr''')", 3)]
+        [InlineData("('''def','xyz''','a''bc')", "('''def','xyz''','a''bc')", 3)]
+        [InlineData("('''def','xyz''','''pqr''')", "('''def','xyz''','''pqr''')", 3)]
+        [InlineData("('''def','''pqr''','a''bc')", "('''def','''pqr''','a''bc')", 3)]
+        [InlineData("('''def','''pqr''','xyz''')", "('''def','''pqr''','xyz''')", 3)]
+        [InlineData("('xyz''','a''bc','''def')", "('xyz''','a''bc','''def')", 3)]
+        [InlineData("('xyz''','a''bc','''pqr''')", "('xyz''','a''bc','''pqr''')", 3)]
+        [InlineData("('xyz''','''def','''pqr''')", "('xyz''','''def','''pqr''')", 3)]
+        [InlineData("('xyz''','''def','a''bc')", "('xyz''','''def','a''bc')", 3)]
+        [InlineData("('xyz''','''pqr''','a''bc')", "('xyz''','''pqr''','a''bc')", 3)]
+        [InlineData("('xyz''','''pqr''','''def')", "('xyz''','''pqr''','''def')", 3)]
+        [InlineData("('''pqr''','a''bc','''def')", "('''pqr''','a''bc','''def')", 3)]
+        [InlineData("('''pqr''','a''bc','xyz''')", "('''pqr''','a''bc','xyz''')", 3)]
+        [InlineData("('''pqr''','''def','a''bc')", "('''pqr''','''def','a''bc')", 3)]
+        [InlineData("('''pqr''','''def','xyz''')", "('''pqr''','''def','xyz''')", 3)]
+        [InlineData("('''pqr''','xyz''','a''bc')", "('''pqr''','xyz''','a''bc')", 3)]
+        [InlineData("('''pqr''','xyz''','''def')", "('''pqr''','xyz''','''def')", 3)]
+        public void FilterWithInExpressionContainingEscapedSingleQuotes(string inExpr, string parsedExpr, int count)
+        {
+            FilterClause filter = ParseFilter($"SSN in {inExpr}", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            var inNode = Assert.IsType<InNode>(filter.Expression);
+            Assert.Equal("SSN", Assert.IsType<SingleValuePropertyAccessNode>(inNode.Left).Property.Name);
+
+            CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
+            Assert.Equal(parsedExpr, collectionNode.LiteralText);
+            Assert.Equal(count, collectionNode.Collection.Count);
+        }
+
         [Fact]
         public void FilterWithInOperationWithParensStringCollection_DoubleQuoteInSingleQuoteString()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2771 
https://github.com/OData/odata.net/issues/2771

### Description

I have applied small change in method InBinder.ProcessSingleQuotedStringItem

### Checklist (Uncheck if it is not completed)

- I have updated test FilterAndOrderByFunctionalTests.FilterWithInOperationWithParensStringCollection_EscapedSingleQuote

### Additional work necessary
