### PR TITLE
Fixes #2774: set the identifier for segments

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/EntitySetSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/EntitySetSegment.cs
@@ -38,6 +38,7 @@ namespace Microsoft.OData.UriParser
             // creating a new collection type here because the type in the entity set is just the item type, there is no user-provided collection type.
             this.type = new EdmCollectionType(new EdmEntityTypeReference(this.entitySet.EntityType(), false));
 
+            this.Identifier = entitySet.Name;
             this.TargetEdmNavigationSource = entitySet;
             this.TargetEdmType = entitySet.EntityType();
             this.TargetKind = RequestTargetKind.Resource;

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/KeySegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/KeySegment.cs
@@ -56,6 +56,10 @@ namespace Microsoft.OData.UriParser
             {
                 ExceptionUtil.ThrowIfTypesUnrelated(edmType, navigationSource.EntityType(), "KeySegments");
             }
+
+            // We don't need to re-generate the indeitifer.
+            // Here, just put a place holder, the caller can override this if need more detail identifier.
+            this.Identifier = "{key}";
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/KeySegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/KeySegment.cs
@@ -57,7 +57,7 @@ namespace Microsoft.OData.UriParser
                 ExceptionUtil.ThrowIfTypesUnrelated(edmType, navigationSource.EntityType(), "KeySegments");
             }
 
-            // We don't need to re-generate the indeitifer.
+            // We don't need to regenerate the identifier.
             // Here, just put a place holder, the caller can override this if need more detail identifier.
             this.Identifier = "{key}";
         }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/OperationSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/OperationSegment.cs
@@ -77,6 +77,8 @@ namespace Microsoft.OData.UriParser
                 this.TargetEdmType = null;
                 this.TargetKind = RequestTargetKind.VoidOperation;
             }
+
+            this.Identifier = operation.FullName();
         }
 
         /// <summary>
@@ -128,6 +130,7 @@ namespace Microsoft.OData.UriParser
             this.computedReturnEdmType = typeSoFar;
             this.entitySet = entitySet;
             this.EnsureTypeAndSetAreCompatable();
+            this.Identifier = this.operations.First().FullName();
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SingletonSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SingletonSegment.cs
@@ -33,6 +33,7 @@ namespace Microsoft.OData.UriParser
 
             this.singleton = singleton;
 
+            this.Identifier = singleton.Name;
             this.TargetEdmNavigationSource = singleton;
             this.TargetEdmType = singleton.EntityType();
             this.TargetKind = RequestTargetKind.Resource;

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/TypeSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/TypeSegment.cs
@@ -63,6 +63,7 @@ namespace Microsoft.OData.UriParser
 
             this.expectedType = expectedType;
 
+            this.Identifier = actualType.AsElementType().FullTypeName();
             this.TargetEdmType = expectedType;
             this.TargetEdmNavigationSource = navigationSource;
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/EntitySetSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/EntitySetSegmentTests.cs
@@ -14,6 +14,13 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
     public class EntitySetSegmentTests
     {
         [Fact]
+        public void IdentifierByDefaultIsEntitySetName()
+        {
+            EntitySetSegment segment = new EntitySetSegment(HardCodedTestModel.GetPeopleSet());
+            Assert.Equal("People", segment.Identifier);
+        }
+
+        [Fact]
         public void TargetEdmEntitySetIsEntitySet()
         {
             EntitySetSegment segment = new EntitySetSegment(HardCodedTestModel.GetPeopleSet());

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/KeySegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/KeySegmentTests.cs
@@ -27,6 +27,14 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         }
 
         [Fact]
+        public void IdentifierByDefaultIsKeyDefaultName()
+        {
+            var set = ModelBuildingHelpers.BuildValidEntitySet();
+            KeySegment segment = new KeySegment(Key, set.EntityType(), set);
+            Assert.Equal("{key}", segment.Identifier);
+        }
+
+        [Fact]
         public void TypeIsSetCorrectly()
         {
             var set = ModelBuildingHelpers.BuildValidEntitySet();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/SingletonSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/SingletonSegmentTests.cs
@@ -1,0 +1,44 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="SingletonSegmentTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using Microsoft.OData.UriParser;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OData.Tests.UriParser.SemanticAst
+{
+    public class SingletonSegmentTests
+    {
+        [Fact]
+        public void CtorSingletonSegmentSetsCorrectly()
+        {
+            IEdmSingleton singleton = HardCodedTestModel.GetBossSingleton();
+            SingletonSegment segment = new SingletonSegment(singleton);
+
+            Assert.Equal("Boss", segment.Identifier);
+            Assert.Same(singleton, segment.TargetEdmNavigationSource);
+            Assert.Same(singleton.EntityType(), segment.TargetEdmType);
+            Assert.Equal(RequestTargetKind.Resource, segment.TargetKind);
+            Assert.True(segment.SingleResult);
+        }
+
+        [Fact]
+        public void SingletonCannotBeNull()
+        {
+            Action createWithNullSingleton = () => new SingletonSegment(null);
+            Assert.Throws<ArgumentNullException>("singleton", createWithNullSingleton);
+        }
+
+        [Fact]
+        public void EqualitySingletonSegmentIsCorrect()
+        {
+            SingletonSegment segment1 = new SingletonSegment(HardCodedTestModel.GetBossSingleton());
+            SingletonSegment segment2 = new SingletonSegment(HardCodedTestModel.GetBossSingleton());
+            Assert.True(segment1.Equals(segment2));
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/TypeSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/TypeSegmentTests.cs
@@ -28,6 +28,18 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         }
 
         [Fact]
+        public void IdentifierByDefaultSetsActualFullTypeName()
+        {
+            // Single
+            TypeSegment typeSegment = new TypeSegment(HardCodedTestModel.GetPersonType(), null);
+            Assert.Equal("Fully.Qualified.Namespace.Person", typeSegment.Identifier);
+
+            // Collection
+            typeSegment = new TypeSegment(new EdmCollectionType(new EdmEntityTypeReference(HardCodedTestModel.GetPersonType(), false)), null);
+            Assert.Equal("Fully.Qualified.Namespace.Person", typeSegment.Identifier);
+        }
+
+        [Fact]
         public void TypeSetCorrectly()
         {
             IEdmType type = ModelBuildingHelpers.BuildValidEntityType();


### PR DESCRIPTION
Most of segments have set the identifier. But Some doesn't. Identifier is used to generate Id, it cannot be 'null'.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2774.*

### Description

for example:
```C#
public class Foo
{
   public IList<Base> BaseProperties {get;set;}
}
public class Base { }
public class Dervied : Base 
{
     [Contained]
     [AutoExpand]
     public IList<EntityType> Entities {get;set;}
}
```
 'Entities ' is a contained navigation property in a derived type. 
So, if we query "~/foos/1/BaseProperties", ODL will 'auto-expand' 'Entities' if the instance of BaseProperties item is a 'Derived'.

ODL will try to build the 'Id' for each item of 'Entities' in 'full' metadata. ODL will generate 'extra' segment to build the Url to access each item in 'Entities', So, ODL creates a 'TypeSegment' and uses "identifier" of the segment to construct the 'Id' Uri. 

Since 'TypeSegment' didn't specify the 'Identifier' by default, ODL throws an exception. 
The fix is simple specify the 'Identifier' for 'TypeSegment', However, the 'Identifier' design looks like a bad design pattern.

In this PR, I also fix other segments.

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
