### PR TITLE
Fix issue in parsing OData core vocabulary

### DIFF
--- a/src/Microsoft.OData.Edm/Vocabularies/AlternateKeysVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/AlternateKeysVocabularies.xml
@@ -1,5 +1,6 @@
-﻿<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OData.Community.Keys.V1" Alias="Keys">
-  <Term AppliesTo="EntityType" Type="Collection(Keys.AlternateKey)" Name="AlternateKeys">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="OData.Community.Keys.V1" Alias="Keys">
+  <Term AppliesTo="EntityType EntitySet NavigationProperty" Type="Collection(Keys.AlternateKey)" Name="AlternateKeys">
     <Annotation Term="Core.Description" String="Communicates available alternate keys"/>
   </Term>
   <ComplexType Name="AlternateKey">

--- a/src/Microsoft.OData.Edm/Vocabularies/AuthorizationVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/AuthorizationVocabularies.xml
@@ -20,7 +20,7 @@
   - OData Measures Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml.
   - OData Capabilities Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Capabilities.V1.xml.
   - OData Validation Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Validation.V1.xml.
-  - OData Aggregation Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggretation.V1.xml.
+  - OData Aggregation Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.xml.
   - OData Authorization Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Authorization.V1.xml.
 
   Related work:
@@ -49,24 +49,21 @@
         <Collection>
           <Record>
             <PropertyValue Property="rel" String="latest-version" />
-            <PropertyValue Property="href"
-              String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Authorization.V1.xml" />
+            <PropertyValue Property="href" String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Authorization.V1.xml" />
           </Record>
           <Record>
             <PropertyValue Property="rel" String="alternate" />
-            <PropertyValue Property="href"
-              String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Authorization.V1.json" />
+            <PropertyValue Property="href" String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Authorization.V1.json" />
           </Record>
           <Record>
             <PropertyValue Property="rel" String="describedby" />
-            <PropertyValue Property="href"
-              String="https://github.com/oasis-tcs/odata-vocabularies/blob/master/vocabularies/Org.OData.Authorization.V1.md" />
+            <PropertyValue Property="href" String="https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Authorization.V1.md" />
           </Record>
         </Collection>
       </Annotation>
 
       <Term Name="SecuritySchemes" Type="Collection(Auth.SecurityScheme)" Nullable="false" AppliesTo="EntityContainer">
-        <Annotation Term="Core.Description" String="At least one of the specified security schemes are required to make a request against the service."/> 
+        <Annotation Term="Core.Description" String="At least one of the specified security schemes are required to make a request against the service" />
       </Term>
 
       <ComplexType Name="SecurityScheme">
@@ -94,9 +91,8 @@
 
       <ComplexType Name="OpenIDConnect" BaseType="Auth.Authorization">
         <Property Name="IssuerUrl" Type="Edm.String" Nullable="false">
-          <Annotation Term="Core.Description"
-            String="Issuer location for the OpenID Provider. Configuration information can be obtained by appending `/.well-known/openid-configuration` to this Url." />
-          <Annotation Term="Core.IsURL" Bool="true"/>
+          <Annotation Term="Core.Description" String="Issuer location for the OpenID Provider. Configuration information can be obtained by appending `/.well-known/openid-configuration` to this Url." />
+          <Annotation Term="Core.IsURL" />
         </Property>
       </ComplexType>
 
@@ -115,39 +111,39 @@
         </Property>
         <Property Name="RefreshUrl" Type="Edm.String" Nullable="true">
           <Annotation Term="Core.Description" String="Refresh Url" />
-          <Annotation Term="Core.IsURL" Bool="true"/>
+          <Annotation Term="Core.IsURL" />
         </Property>
       </ComplexType>
 
       <ComplexType Name="OAuth2ClientCredentials" BaseType="Auth.OAuthAuthorization">
         <Property Name="TokenUrl" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="Token Url" />
-          <Annotation Term="Core.IsURL" Bool="true"/>
+          <Annotation Term="Core.IsURL" />
         </Property>
       </ComplexType>
 
       <ComplexType Name="OAuth2Implicit" BaseType="Auth.OAuthAuthorization">
         <Property Name="AuthorizationUrl" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="Authorization URL" />
-          <Annotation Term="Core.IsURL" Bool="true"/>
+          <Annotation Term="Core.IsURL" />
         </Property>
       </ComplexType>
 
       <ComplexType Name="OAuth2Password" BaseType="Auth.OAuthAuthorization">
         <Property Name="TokenUrl" Type="Edm.String" Nullable="false">
-         <Annotation Term="Core.Description" String="Token Url" />
-          <Annotation Term="Core.IsURL" Bool="true"/>
+          <Annotation Term="Core.Description" String="Token Url" />
+          <Annotation Term="Core.IsURL" />
         </Property>
       </ComplexType>
 
       <ComplexType Name="OAuth2AuthCode" BaseType="Auth.OAuthAuthorization">
         <Property Name="AuthorizationUrl" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="Authorization URL" />
-          <Annotation Term="Core.IsURL" Bool="true"/>
+          <Annotation Term="Core.IsURL" />
         </Property>
         <Property Name="TokenUrl" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="Token Url" />
-          <Annotation Term="Core.IsURL" Bool="true"/>
+          <Annotation Term="Core.IsURL" />
         </Property>
       </ComplexType>
 
@@ -185,7 +181,7 @@
       </EnumType>
 
       <TypeDefinition Name="SchemeName" UnderlyingType="Edm.String">
-          <Annotation Term="Core.Description" String="The name of the authorization scheme." />
+        <Annotation Term="Core.Description" String="The name of the authorization scheme." />
       </TypeDefinition>
 
     </Schema>

--- a/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CapabilitiesVocabularies.xml
@@ -65,7 +65,7 @@
           </Record>
           <Record>
             <PropertyValue Property="rel" String="describedby" />
-            <PropertyValue Property="href" String="https://github.com/oasis-tcs/odata-vocabularies/blob/master/vocabularies/Org.OData.Capabilities.V1.md" />
+            <PropertyValue Property="href" String="https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Capabilities.V1.md" />
           </Record>
         </Collection>
       </Annotation>
@@ -131,12 +131,12 @@ supported:
 
       <Term Name="SupportedFormats" Type="Collection(Edm.String)" Nullable="false" AppliesTo="EntityContainer">
         <Annotation Term="Core.Description" String="Media types of supported formats, including format parameters" />
-        <Annotation Term="Core.IsMediaType" Bool="true" />
+        <Annotation Term="Core.IsMediaType" />
       </Term>
 
       <Term Name="SupportedMetadataFormats" Type="Collection(Edm.String)" Nullable="false" AppliesTo="EntityContainer">
         <Annotation Term="Core.Description" String="Media types of supported formats for $metadata, including format parameters" />
-        <Annotation Term="Core.IsMediaType" Bool="true" />
+        <Annotation Term="Core.IsMediaType" />
       </Term>
 
       <Term Name="AcceptableEncodings" Type="Collection(Edm.String)" Nullable="false" AppliesTo="EntityContainer">
@@ -184,7 +184,7 @@ supported:
         </Property>
         <Property Name="DocumentationUrl" Type="Edm.String" Nullable="true">
           <Annotation Term="Core.Description" String="Human readable description of the meaning of the URL Template parameters" />
-          <Annotation Term="Core.IsURL" Bool="true" />
+          <Annotation Term="Core.IsURL" />
         </Property>
       </ComplexType>
 
@@ -207,7 +207,8 @@ supported:
 
       <!--Query Capabilities -->
 
-      <Term Name="CountRestrictions" Type="Capabilities.CountRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton">
+      <Term Name="CountRestrictions" Type="Capabilities.CountRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions on /$count path suffix and $count=true system query option" />
       </Term>
       <ComplexType Name="CountRestrictionsType">
@@ -222,7 +223,8 @@ supported:
         </Property>
       </ComplexType>
 
-      <Term Name="NavigationRestrictions" Type="Capabilities.NavigationRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton">
+      <Term Name="NavigationRestrictions" Type="Capabilities.NavigationRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions on navigating properties according to OData URL conventions" />
         <Annotation Term="Core.LongDescription" String="Restrictions specified on an entity set are valid whether the request is directly to the entity set or through a navigation property bound to that entity set. Services can specify a different set of restrictions specific to a path, in which case the more specific restrictions take precedence." />
       </Term>
@@ -235,8 +237,20 @@ supported:
         </Property>
       </ComplexType>
       <ComplexType Name="NavigationPropertyRestriction">
-        <Property Name="NavigationProperty" Type="Edm.NavigationPropertyPath">
+        <Annotation Term="Core.LongDescription">
+          <String>Using a property of `NavigationPropertyRestriction` in a [`NavigationRestrictions`](#NavigationRestrictions) annotation
+          is discouraged in favor of using an annotation with the corresponding term from this vocabulary and a target path starting with a container and ending in the `NavigationProperty`,
+          unless the favored alternative is impossible because a dynamic expression requires an instance path whose evaluation
+          starts at the target of the `NavigationRestrictions` annotation. See [this example](../examples/Org.OData.Capabilities.V1.capabilities.md).</String>
+        </Annotation>
+        <Property Name="NavigationProperty" Type="Edm.NavigationPropertyPath" Nullable="false">
           <Annotation Term="Core.Description" String="Navigation properties can be navigated" />
+          <Annotation Term="Core.LongDescription">
+            <String>The target path of a [`NavigationRestrictions`](#NavigationRestrictions) annotation followed by this
+            navigation property path addresses the resource to which the other properties of `NavigationPropertyRestriction` apply.
+            Instance paths that occur in dynamic expressions are evaluated starting at the boundary between both paths,
+            which must therefore be chosen accordingly.</String>
+          </Annotation>
         </Property>
         <Property Name="Navigability" Type="Capabilities.NavigationType">
           <Annotation Term="Core.Description" String="Supported navigability of this navigation property" />
@@ -300,23 +314,28 @@ supported:
         </Member>
       </EnumType>
 
-      <Term Name="IndexableByKey" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntitySet">
+      <Term Name="IndexableByKey" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Supports key values according to OData URL conventions" />
       </Term>
 
-      <Term Name="TopSupported" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntitySet">
+      <Term Name="TopSupported" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Supports $top" />
       </Term>
 
-      <Term Name="SkipSupported" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntitySet">
+      <Term Name="SkipSupported" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Supports $skip" />
       </Term>
 
-      <Term Name="ComputeSupported" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntitySet">
+      <Term Name="ComputeSupported" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Supports $compute" />
       </Term>
 
-      <Term Name="SelectSupport" Type="Capabilities.SelectSupportType" Nullable="false" AppliesTo="EntityContainer EntitySet Singleton">
+      <Term Name="SelectSupport" Type="Capabilities.SelectSupportType" Nullable="false" AppliesTo="EntityContainer EntitySet Singleton Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Support for $select and nested query options within $select" />
       </Term>
       <ComplexType Name="SelectSupportType">
@@ -360,6 +379,12 @@ supported:
         <Annotation Term="Core.Description" String="Batch Support for the service" />
       </Term>
       <ComplexType Name="BatchSupportType">
+        <Annotation Term="Validation.ApplicableTerms">
+          <Collection>
+            <String>Core.Description</String>
+            <String>Core.LongDescription</String>
+          </Collection>
+        </Annotation>
         <Property Name="Supported" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
           <Annotation Term="Core.Description" String="Service supports requests to $batch" />
         </Property>
@@ -380,7 +405,7 @@ supported:
         </Property>
         <Property Name="SupportedFormats" Type="Collection(Edm.String)" Nullable="false">
           <Annotation Term="Core.Description" String="Media types of supported formats for $batch" />
-          <Annotation Term="Core.IsMediaType" Bool="true" />
+          <Annotation Term="Core.IsMediaType" />
           <Annotation Term="Validation.AllowedValues">
             <Collection>
               <Record>
@@ -396,15 +421,22 @@ supported:
         </Property>
       </ComplexType>
 
-      <Term Name="FilterFunctions" Type="Collection(Edm.String)" Nullable="false" AppliesTo="EntityContainer EntitySet">
+      <Term Name="FilterFunctions" Type="Collection(Edm.String)" Nullable="false" AppliesTo="EntityContainer EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="List of functions and operators supported in filter expressions" />
         <Annotation Term="Core.LongDescription" String="If not specified, null, or empty, all functions and operators may be attempted." />
       </Term>
 
-      <Term Name="FilterRestrictions" Type="Capabilities.FilterRestrictionsType" Nullable="false" AppliesTo="EntitySet">
+      <Term Name="FilterRestrictions" Type="Capabilities.FilterRestrictionsType" Nullable="false" AppliesTo="EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions on filter expressions" />
       </Term>
       <ComplexType Name="FilterRestrictionsType">
+        <Annotation Term="Validation.ApplicableTerms">
+          <Collection>
+            <String>Core.Description</String>
+          </Collection>
+        </Annotation>
         <Property Name="Filterable" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
           <Annotation Term="Core.Description" String="$filter is supported" />
         </Property>
@@ -465,10 +497,16 @@ supported:
         </Annotation>
       </TypeDefinition>
 
-      <Term Name="SortRestrictions" Type="Capabilities.SortRestrictionsType" Nullable="false" AppliesTo="EntitySet">
+      <Term Name="SortRestrictions" Type="Capabilities.SortRestrictionsType" Nullable="false" AppliesTo="EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions on orderby expressions" />
       </Term>
       <ComplexType Name="SortRestrictionsType">
+        <Annotation Term="Validation.ApplicableTerms">
+          <Collection>
+            <String>Core.Description</String>
+          </Collection>
+        </Annotation>
         <Property Name="Sortable" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
           <Annotation Term="Core.Description" String="$orderby is supported" />
         </Property>
@@ -483,15 +521,21 @@ supported:
         </Property>
       </ComplexType>
 
-      <Term Name="ExpandRestrictions" Type="Capabilities.ExpandRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton">
+      <Term Name="ExpandRestrictions" Type="Capabilities.ExpandRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions on expand expressions" />
       </Term>
       <ComplexType Name="ExpandRestrictionsType">
+        <Annotation Term="Validation.ApplicableTerms">
+          <Collection>
+            <String>Core.Description</String>
+          </Collection>
+        </Annotation>
         <Property Name="Expandable" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
           <Annotation Term="Core.Description" String="$expand is supported" />
         </Property>
         <Property Name="StreamsExpandable" Type="Edm.Boolean" Nullable="false" DefaultValue="false">
-          <Annotation Term="Core.Description" String="$expand is supported for stream properties and media resources" />
+          <Annotation Term="Core.Description" String="$expand is supported for stream properties and media streams" />
         </Property>
         <Property Name="NonExpandableProperties" Type="Collection(Edm.NavigationPropertyPath)" Nullable="false">
           <Annotation Term="Core.Description" String="These properties cannot be used in expand expressions" />
@@ -505,10 +549,16 @@ supported:
         </Property>
       </ComplexType>
 
-      <Term Name="SearchRestrictions" Type="Capabilities.SearchRestrictionsType" Nullable="false" AppliesTo="EntitySet">
+      <Term Name="SearchRestrictions" Type="Capabilities.SearchRestrictionsType" Nullable="false" AppliesTo="EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions on search expressions" />
       </Term>
       <ComplexType Name="SearchRestrictionsType">
+        <Annotation Term="Validation.ApplicableTerms">
+          <Collection>
+            <String>Core.Description</String>
+          </Collection>
+        </Annotation>
         <Property Name="Searchable" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
           <Annotation Term="Core.Description" String="$search is supported" />
         </Property>
@@ -547,7 +597,8 @@ supported:
 
       <!-- Data Modification Capabilities -->
 
-      <Term Name="InsertRestrictions" Type="Capabilities.InsertRestrictionsType" Nullable="false" AppliesTo="EntitySet EntityType">
+      <Term Name="InsertRestrictions" Type="Capabilities.InsertRestrictionsType" Nullable="false" AppliesTo="EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions on insert operations" />
       </Term>
       <ComplexType Name="InsertRestrictionsType">
@@ -583,11 +634,14 @@ supported:
         </Property>
         <Property Name="Description" Type="Edm.String" Nullable="true">
           <Annotation Term="Core.Description" String="A brief description of the request" />
-          <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+          <Annotation Term="Core.IsLanguageDependent" />
         </Property>
         <Property Name="LongDescription" Type="Edm.String" Nullable="true">
-          <Annotation Term="Core.Description" String="A lengthy description of the request" />
-          <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+          <Annotation Term="Core.Description" String="A long description of the request" />
+          <Annotation Term="Core.IsLanguageDependent" />
+        </Property>
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
+          <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
         </Property>
       </ComplexType>
 
@@ -620,7 +674,8 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
       </ComplexType>
 
-      <Term Name="DeepInsertSupport" Type="Capabilities.DeepInsertSupportType" AppliesTo="EntityContainer EntitySet">
+      <Term Name="DeepInsertSupport" Type="Capabilities.DeepInsertSupportType" AppliesTo="EntityContainer EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Deep Insert Support of the annotated resource (the whole service, an entity set, or a collection-valued resource)" />
       </Term>
       <ComplexType Name="DeepInsertSupportType">
@@ -632,7 +687,8 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
       </ComplexType>
 
-      <Term Name="UpdateRestrictions" Type="Capabilities.UpdateRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton EntityType">
+      <Term Name="UpdateRestrictions" Type="Capabilities.UpdateRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions on update operations" />
       </Term>
       <ComplexType Name="UpdateRestrictionsType">
@@ -655,7 +711,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description" String="Members of collections can be updated via a PATCH request with a type-cast segment and a `/$each` segment" />
         </Property>
         <Property Name="NonUpdatableProperties" Type="Collection(Edm.PropertyPath)" Nullable="false">
-          <Annotation Term="Core.Description" String="These structural properties cannot be specified on update" />
+          <Annotation Term="Core.Description" String="These structural properties cannot be updated" />
         </Property>
         <Property Name="NonUpdatableNavigationProperties" Type="Collection(Edm.NavigationPropertyPath)" Nullable="false">
           <Annotation Term="Core.Description" String="These navigation properties do not allow rebinding" />
@@ -680,11 +736,14 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
         <Property Name="Description" Type="Edm.String" Nullable="true">
           <Annotation Term="Core.Description" String="A brief description of the request" />
-          <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+          <Annotation Term="Core.IsLanguageDependent" />
         </Property>
         <Property Name="LongDescription" Type="Edm.String" Nullable="true">
-          <Annotation Term="Core.Description" String="A lengthy description of the request" />
-          <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+          <Annotation Term="Core.Description" String="A long description of the request" />
+          <Annotation Term="Core.IsLanguageDependent" />
+        </Property>
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
+          <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
         </Property>
       </ComplexType>
 
@@ -712,7 +771,8 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Member>
       </EnumType>
 
-      <Term Name="DeepUpdateSupport" Type="Capabilities.DeepUpdateSupportType" Nullable="false" AppliesTo="EntityContainer EntitySet">
+      <Term Name="DeepUpdateSupport" Type="Capabilities.DeepUpdateSupportType" Nullable="false" AppliesTo="EntityContainer EntitySet Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Deep Update Support of the annotated resource (the whole service, an entity set, or a collection-valued resource)" />
       </Term>
       <ComplexType Name="DeepUpdateSupportType">
@@ -724,7 +784,8 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
       </ComplexType>
 
-      <Term Name="DeleteRestrictions" Type="Capabilities.DeleteRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton EntityType">
+      <Term Name="DeleteRestrictions" Type="Capabilities.DeleteRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions on delete operations" />
       </Term>
       <ComplexType Name="DeleteRestrictionsType">
@@ -738,10 +799,10 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description" String="The maximum number of navigation properties that can be traversed when addressing the collection to delete from or the entity to delete. A value of -1 indicates there is no restriction." />
         </Property>
         <Property Name="FilterSegmentSupported" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
-          <Annotation Term="Core.Description" String="Members of collections can be updated via a PATCH request with a `/$filter(...)/$each` segment" />
+          <Annotation Term="Core.Description" String="Members of collections can be deleted via a DELETE request with a `/$filter(...)/$each` segment" />
         </Property>
         <Property Name="TypecastSegmentSupported" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
-          <Annotation Term="Core.Description" String="Members of collections can be updated via a PATCH request with a type-cast segment and a `/$each` segment" />
+          <Annotation Term="Core.Description" String="Members of collections can be deleted via a DELETE request with a type-cast segment and a `/$each` segment" />
         </Property>
         <Property Name="Permissions" Type="Collection(Capabilities.PermissionType)" Nullable="true">
           <Annotation Term="Core.Description" String="Required permissions. One of the specified sets of scopes is required to perform the delete." />
@@ -754,11 +815,14 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
         <Property Name="Description" Type="Edm.String" Nullable="true">
           <Annotation Term="Core.Description" String="A brief description of the request" />
-          <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+          <Annotation Term="Core.IsLanguageDependent" />
         </Property>
         <Property Name="LongDescription" Type="Edm.String" Nullable="true">
-          <Annotation Term="Core.Description" String="A lengthy description of the request" />
-          <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+          <Annotation Term="Core.Description" String="A long description of the request" />
+          <Annotation Term="Core.IsLanguageDependent" />
+        </Property>
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
+          <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
         </Property>
       </ComplexType>
 
@@ -819,6 +883,9 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         <Property Name="CustomQueryOptions" Type="Collection(Capabilities.CustomParameter)" Nullable="false">
           <Annotation Term="Core.Description" String="Supported or required custom query options" />
         </Property>
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
+          <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
+        </Property>
       </ComplexType>
       <Term Name="AnnotationValuesInQuerySupported" Type="Core.Tag" DefaultValue="true" Nullable="false" AppliesTo="EntityContainer">
         <Annotation Term="Core.Description" String="Supports annotation values within system query options" />
@@ -848,7 +915,8 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
       </ComplexType>
 
-      <Term Name="ReadRestrictions" Type="Capabilities.ReadRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton">
+      <Term Name="ReadRestrictions" Type="Capabilities.ReadRestrictionsType" Nullable="false" AppliesTo="EntitySet Singleton Collection">
+        <Annotation Term="Core.AppliesViaContainer" />
         <Annotation Term="Core.Description" String="Restrictions for retrieving a collection of entities, retrieving a singleton instance." />
       </Term>
       <ComplexType Name="ReadRestrictionsBase" Abstract="true">
@@ -866,17 +934,23 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
         <Property Name="Description" Type="Edm.String" Nullable="true">
           <Annotation Term="Core.Description" String="A brief description of the request" />
-          <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+          <Annotation Term="Core.IsLanguageDependent" />
         </Property>
         <Property Name="LongDescription" Type="Edm.String" Nullable="true">
-          <Annotation Term="Core.Description" String="A lengthy description of the request" />
-          <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+          <Annotation Term="Core.Description" String="A long description of the request" />
+          <Annotation Term="Core.IsLanguageDependent" />
+        </Property>
+        <Property Name="ErrorResponses" Type="Collection(Capabilities.HttpResponse)" Nullable="false">
+          <Annotation Term="Core.Description" String="Possible error responses returned by the request." />
         </Property>
       </ComplexType>
       <ComplexType Name="ReadByKeyRestrictionsType" BaseType="Capabilities.ReadRestrictionsBase">
         <Annotation Term="Core.Description" String="Restrictions for retrieving an entity by key" />
       </ComplexType>
       <ComplexType Name="ReadRestrictionsType" BaseType="Capabilities.ReadRestrictionsBase">
+        <Property Name="TypecastSegmentSupported" Type="Edm.Boolean" Nullable="false" DefaultValue="true">
+          <Annotation Term="Core.Description" String="Entities of a specific derived type can be read by specifying a type-cast segment" />
+        </Property>
         <Property Name="ReadByKeyRestrictions" Type="Capabilities.ReadByKeyRestrictionsType">
           <Annotation Term="Core.Description" String="Restrictions for retrieving an entity by key" />
           <Annotation Term="Core.LongDescription" String="Only valid when applied to a collection. If a property of `ReadByKeyRestrictions` is not specified, the corresponding property value of `ReadRestrictions` applies." />
@@ -950,7 +1024,7 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
           <Annotation Term="Core.Description" String="Description of the custom parameter" />
         </Property>
         <Property Name="DocumentationURL" Type="Edm.String">
-          <Annotation Term="Core.IsURL" Bool="true" />
+          <Annotation Term="Core.IsURL" />
           <Annotation Term="Core.Description" String="URL of related documentation" />
         </Property>
         <Property Name="Required" Type="Edm.Boolean" Nullable="false" DefaultValue="false">
@@ -961,10 +1035,20 @@ The absence of `RestrictedProperties` denotes all properties are accessible usin
         </Property>
       </ComplexType>
 
-      <Term Name="MediaLocationUpdateSupported" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Property">
+      <Term Name="MediaLocationUpdateSupported" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntityType Property">
         <Annotation Term="Core.RequiresType" String="Edm.Stream" />
-        <Annotation Term="Core.Description" String="Stream property supports update of its media edit URL and/or media read URL" />
+        <Annotation Term="Core.Description" String="Stream property or media stream supports update of its media edit URL and/or media read URL" />
       </Term>
+
+      <ComplexType Name="HttpResponse">
+        <Property Name="StatusCode" Type="Edm.String" Nullable="false">
+          <Annotation Term="Core.Description" String="HTTP response status code, for example 400, 403, 501" />
+        </Property>
+        <Property Name="Description" Type="Edm.String" Nullable="false">
+          <Annotation Term="Core.Description" String="Human-readable description of the response" />
+          <Annotation Term="Core.IsLanguageDependent" />
+        </Property>
+      </ComplexType>
 
     </Schema>
   </edmx:DataServices>

--- a/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/CoreVocabularies.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Org.OData.Core.V1"  Alias="Core">
+<Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Org.OData.Core.V1" Alias="Core">
   <Annotation Term="Core.Description">
     <String>Core terms needed to write vocabularies</String>
   </Annotation>
@@ -7,29 +7,26 @@
     <Collection>
       <Record>
         <PropertyValue Property="rel" String="latest-version" />
-        <PropertyValue Property="href"
-          String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml" />
+        <PropertyValue Property="href" String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml" />
       </Record>
       <Record>
         <PropertyValue Property="rel" String="alternate" />
-        <PropertyValue Property="href"
-          String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json" />
+        <PropertyValue Property="href" String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json" />
       </Record>
       <Record>
         <PropertyValue Property="rel" String="describedby" />
-        <PropertyValue Property="href"
-          String="https://github.com/oasis-tcs/odata-vocabularies/blob/master/vocabularies/Org.OData.Core.V1.md" />
+        <PropertyValue Property="href" String="https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md" />
       </Record>
     </Collection>
   </Annotation>
 
   <!-- Versioning -->
 
-  <Term Name="ODataVersions" Type="Edm.String" AppliesTo="EntityContainer">
+  <Term Name="ODataVersions" Type="Edm.String" Nullable="false" AppliesTo="EntityContainer">
     <Annotation Term="Core.Description" String="A space-separated list of supported versions of the OData Protocol. Note that 4.0 is implied by 4.01 and does not need to be separately listed." />
   </Term>
 
-  <Term Name="SchemaVersion" Type="Edm.String" AppliesTo="Schema Reference">
+  <Term Name="SchemaVersion" Type="Edm.String" Nullable="false" AppliesTo="Schema Reference">
     <Annotation Term="Core.Description" String="Service-defined value representing the version of the schema. Services MAY use semantic versioning, but clients MUST NOT assume this is the case." />
   </Term>
 
@@ -63,12 +60,12 @@
 
   <Term Name="Description" Type="Edm.String">
     <Annotation Term="Core.Description" String="A brief description of a model element" />
-    <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+    <Annotation Term="Core.IsLanguageDependent" />
   </Term>
 
   <Term Name="LongDescription" Type="Edm.String">
-    <Annotation Term="Core.Description" String="A lengthy description of a model element" />
-    <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+    <Annotation Term="Core.Description" String="A long description of a model element" />
+    <Annotation Term="Core.IsLanguageDependent" />
   </Term>
 
   <Term Name="Links" Type="Collection(Core.Link)" Nullable="false">
@@ -80,19 +77,16 @@
       <Annotation Term="Core.Description" String="Link relation type, see [IANA Link Relations](http://www.iana.org/assignments/link-relations/link-relations.xhtml)" />
     </Property>
     <Property Name="href" Type="Edm.String" Nullable="false">
-      <Annotation Term="Core.IsURL" Bool="true" />
+      <Annotation Term="Core.IsURL" />
       <Annotation Term="Core.Description" String="URL of related information" />
     </Property>
   </ComplexType>
 
-  <Term Name="Example" Type="Core.ExampleValue" Nullable="false"
-    AppliesTo="EntityType ComplexType TypeDefinition Term Property NavigationProperty Parameter ReturnType"
-  >
+  <Term Name="Example" Type="Core.ExampleValue" Nullable="false" AppliesTo="EntityType ComplexType TypeDefinition Term Property NavigationProperty Parameter ReturnType">
     <Annotation Term="Core.Description" String="Example for an instance of the annotated model element" />
     <Annotation Term="Core.Example">
       <Record>
-        <PropertyValue Property="Description"
-          String="The value of Core.Example is a record/object containing the example value and/or annotation examples." />
+        <PropertyValue Property="Description" String="The value of Core.Example is a record/object containing the example value and/or annotation examples." />
         <Annotation Term="Core.Example" Qualifier="primitive">
           <Record Type="Core.PrimitiveExampleValue">
             <PropertyValue Property="Description" String="Primitive example value" />
@@ -122,8 +116,7 @@
         <Annotation Term="Core.Example" Qualifier="external">
           <Record Type="Core.ExternalExampleValue">
             <PropertyValue Property="Description" String="External example" />
-            <PropertyValue Property="ExternalValue"
-              String="https://services.odata.org/TripPinRESTierService/(S(5fjoyrzpnvzrrvmxzzq25i4q))/Me" />
+            <PropertyValue Property="ExternalValue" String="https://services.odata.org/TripPinRESTierService/(S(5fjoyrzpnvzrrvmxzzq25i4q))/Me" />
           </Record>
         </Annotation>
       </Record>
@@ -152,7 +145,7 @@
   <ComplexType Name="ExternalExampleValue" BaseType="Core.ExampleValue">
     <Property Name="ExternalValue" Type="Edm.String" Nullable="false">
       <Annotation Term="Core.Description" String="Url reference to the value in its literal format" />
-      <Annotation Term="Core.IsURL" Bool="true" />
+      <Annotation Term="Core.IsURL" />
     </Property>
   </ComplexType>
 
@@ -167,14 +160,13 @@
     </Property>
     <Property Name="message" Type="Edm.String" Nullable="false">
       <Annotation Term="Core.Description" String="Human-readable, language-dependent message text" />
-      <Annotation Term="Core.IsLanguageDependent" Bool="true" />
+      <Annotation Term="Core.IsLanguageDependent" />
     </Property>
     <Property Name="severity" Type="Core.MessageSeverity" Nullable="false">
       <Annotation Term="Core.Description" String="Severity of the message" />
     </Property>
     <Property Name="target" Type="Edm.String" Nullable="true">
-      <Annotation Term="Core.Description"
-        String="A path to the target of the message detail, relative to the annotated instance" />
+      <Annotation Term="Core.Description" String="A path to the target of the message detail, relative to the annotated instance" />
     </Property>
     <Property Name="details" Type="Collection(Core.MessageType)" Nullable="false">
       <Annotation Term="Core.Description" String="List of detail messages" />
@@ -223,13 +215,12 @@
   <ComplexType Name="ResourceExceptionType" BaseType="Core.ExceptionType">
     <Property Name="retryLink" Type="Edm.String" Nullable="true">
       <Annotation Term="Core.Description" String="A GET request to this URL retries retrieving the problematic instance" />
-      <Annotation Term="Core.IsURL" Bool="true" />
+      <Annotation Term="Core.IsURL" />
     </Property>
   </ComplexType>
 
   <Term Name="DataModificationException" Type="Core.DataModificationExceptionType" Nullable="false">
-    <Annotation Term="Core.Description"
-      String="A modification operation failed on the annotated instance or collection within a success payload" />
+    <Annotation Term="Core.Description" String="A modification operation failed on the annotated instance or collection within a success payload" />
   </Term>
   <ComplexType Name="DataModificationExceptionType" BaseType="Core.ExceptionType">
     <Property Name="failedOperation" Type="Core.DataModificationOperationKind" Nullable="false">
@@ -264,6 +255,7 @@
       <Annotation Term="Core.Description" String="Remove link between entities" />
     </Member>
   </EnumType>
+
   <!-- Localization -->
 
   <Term Name="IsLanguageDependent" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Term Property">
@@ -276,15 +268,24 @@
   </TypeDefinition>
 
   <!-- Term Restrictions -->
-  <Term Name="RequiresType" Type="Edm.String" AppliesTo="Term">
+
+  <Term Name="RequiresType" Type="Edm.String" Nullable="false" AppliesTo="Term">
     <Annotation Term="Core.Description" String="Terms annotated with this term can only be applied to elements that have a type that is identical to or derived from the given type name" />
+  </Term>
+
+  <Term Name="AppliesViaContainer" Type="Core.Tag" DefaultValue="true" Nullable="false" AppliesTo="Term">
+    <Annotation Term="Core.Description" String="The target path of an annotation with the tagged term MUST start with an entity container or the annotation MUST be embedded within an entity container, entity set or singleton" />
+    <Annotation Term="Core.LongDescription">
+      <String>Services MAY additionally annotate a container-independent model element (entity type, property, navigation property) if allowed by the `AppliesTo` property of the term
+      and the annotation applies to all uses of that model element.</String>
+    </Annotation>
   </Term>
 
   <!--Resource Paths -->
 
-  <Term Name="ResourcePath" Type="Edm.String" AppliesTo="EntitySet Singleton ActionImport FunctionImport">
+  <Term Name="ResourcePath" Type="Edm.String" Nullable="false" AppliesTo="EntitySet Singleton ActionImport FunctionImport">
     <Annotation Term="Core.Description" String="Resource path for entity container child, can be relative to xml:base and the request URL" />
-    <Annotation Term="Core.IsURL" Bool="true" />
+    <Annotation Term="Core.IsURL" />
   </Term>
 
   <Term Name="DereferenceableIDs" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntityContainer">
@@ -297,29 +298,30 @@
 
   <!-- Permissions -->
 
-  <Term Name="Permissions" Type="Core.Permission" AppliesTo="Property ComplexType TypeDefinition EntityType EntitySet NavigationProperty Action Function">
+  <Term Name="Permissions" Type="Core.Permission" Nullable="false" AppliesTo="Property ComplexType TypeDefinition EntityType EntitySet NavigationProperty Action Function">
     <Annotation Term="Core.Description" String="Permissions for accessing a resource" />
   </Term>
   <EnumType Name="Permission" IsFlags="true">
-    <Member Name="None" Value="0" >
+    <Member Name="None" Value="0">
       <Annotation Term="Core.Description" String="No permissions" />
     </Member>
-    <Member Name="Read" Value="1" >
+    <Member Name="Read" Value="1">
       <Annotation Term="Core.Description" String="Read permission" />
     </Member>
-    <Member Name="Write" Value="2" >
+    <Member Name="Write" Value="2">
       <Annotation Term="Core.Description" String="Write permission" />
     </Member>
-    <Member Name="ReadWrite" Value="3" >
+    <Member Name="ReadWrite" Value="3">
       <Annotation Term="Core.Description" String="Read and write permission" />
     </Member>
-    <Member Name="Invoke" Value="4" >
+    <Member Name="Invoke" Value="4">
       <Annotation Term="Core.Description" String="Permission to invoke actions" />
     </Member>
   </EnumType>
 
   <!-- Batch Content ID -->
-  <Term Name="ContentID" Type="Edm.String">
+
+  <Term Name="ContentID" Nullable="false" Type="Edm.String">
     <Annotation Term="Core.Description" String="A unique identifier for nested entities within a request." />
   </Term>
 
@@ -341,20 +343,22 @@
   <Term Name="ComputedDefaultValue" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Property">
     <Annotation Term="Core.Description" String="A value for this property can be provided by the client on insert and update. If no value is provided on insert, a non-static default value is generated" />
   </Term>
+
   <Term Name="IsURL" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Property Term">
     <Annotation Term="Core.Description" String="Properties and terms annotated with this term MUST contain a valid URL" />
     <Annotation Term="Core.RequiresType" String="Edm.String" />
   </Term>
 
-  <Term Name="AcceptableMediaTypes" Type="Collection(Edm.String)" Nullable="false" AppliesTo="EntityType Property">
-    <Annotation Term="Core.Description" String="Lists the MIME types acceptable for the annotated entity type marked with HasStream=&quot;true&quot; or the annotated stream property" />
-    <Annotation Term="Core.IsMediaType" Bool="true" />
+  <Term Name="AcceptableMediaTypes" Type="Collection(Edm.String)" Nullable="false" AppliesTo="EntityType Property Term TypeDefinition Parameter ReturnType">
+    <Annotation Term="Core.Description" String="Lists the MIME types acceptable for the annotated entity type marked with HasStream=&quot;true&quot; or the annotated binary, stream, or string property or term" />
+    <Annotation Term="Core.LongDescription" String="The annotation of a TypeDefinition propagates to the model elements having this type" />
+    <Annotation Term="Core.IsMediaType" />
   </Term>
 
-  <Term Name="MediaType" Type="Edm.String" AppliesTo="Property">
-    <Annotation Term="Core.Description" String="The media type of a binary resource" />
-    <Annotation Term="Core.IsMediaType" Bool="true" />
-    <Annotation Term="Core.RequiresType" String="Edm.Binary" />
+  <Term Name="MediaType" Type="Edm.String" AppliesTo="EntityType Property Term TypeDefinition Parameter ReturnType">
+    <Annotation Term="Core.Description" String="The media type of the media stream of the annotated entity type marked with HasStream=&quot;true&quot; or the annotated binary, stream, or string property or term" />
+    <Annotation Term="Core.LongDescription" String="The annotation of a TypeDefinition propagates to the model elements having this type" />
+    <Annotation Term="Core.IsMediaType" />
   </Term>
 
   <Term Name="IsMediaType" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Property Term">
@@ -362,8 +366,21 @@
     <Annotation Term="Core.RequiresType" String="Edm.String" />
   </Term>
 
+  <Term Name="ContentDisposition" Type="Core.ContentDispositionType" Nullable="false" AppliesTo="EntityType Property Term">
+    <Annotation Term="Core.Description" String="The content disposition of the media stream of the annotated entity type marked with HasStream=&quot;true&quot; or the annotated binary, stream, or string property or term" />
+  </Term>
+
+  <ComplexType Name="ContentDispositionType">
+    <Property Name="Type" Type="Edm.String" Nullable="false" DefaultValue="attachment">
+      <Annotation Term="Core.Description" String="The disposition type of the binary or stream value, see [RFC 6266, Disposition Type](https://datatracker.ietf.org/doc/html/rfc6266#section-4.2)" />
+    </Property>
+    <Property Name="Filename" Type="Edm.String">
+      <Annotation Term="Core.Description" String="The proposed filename for downloading the binary or stream value, see [RFC 6266, Disposition Parameter: 'Filename'](https://datatracker.ietf.org/doc/html/rfc6266#section-4.3)" />
+    </Property>
+  </ComplexType>
+
   <Term Name="OptimisticConcurrency" Type="Collection(Edm.PropertyPath)" Nullable="false" AppliesTo="EntitySet">
-    <Annotation Term="Core.Description" String="Data modification requires the use of ETags. A non-empty collection contains the set of properties that are used to compute the ETag. An empty collection means that the service won't tell how it computes the ETag." />
+    <Annotation Term="Core.Description" String="Data modification requires the use of ETags. A non-empty collection contains the set of properties that are used to compute the ETag. An empty collection means that the service won't tell how it computes the ETag" />
   </Term>
 
   <Term Name="AdditionalProperties" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntityType ComplexType">
@@ -371,8 +388,8 @@
     <Annotation Term="Core.LongDescription" String="If specified as false clients can assume that instances will not contain dynamic properties, irrespective of the value of the OpenType attribute." />
   </Term>
 
-  <Term Name="AutoExpand" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="NavigationProperty Property">
-    <Annotation Term="Core.Description" String="The service will automatically expand this stream or navigation property even if not requested with $expand" />
+  <Term Name="AutoExpand" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntityType NavigationProperty Property">
+    <Annotation Term="Core.Description" String="The service will automatically expand this stream property, navigation property, or the media stream of this media entity type even if not requested with $expand" />
   </Term>
 
   <Term Name="AutoExpandReferences" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="NavigationProperty">
@@ -391,18 +408,22 @@
     <Annotation Term="Core.Description" String="The qualified name of a type in scope." />
   </TypeDefinition>
 
+  <TypeDefinition Name="QualifiedActionName" UnderlyingType="Edm.String">
+    <Annotation Term="Core.Description" String="The qualified name of an action in scope." />
+  </TypeDefinition>
+
   <TypeDefinition Name="QualifiedBoundOperationName" UnderlyingType="Edm.String">
     <Annotation Term="Core.Description" String="The qualified name of a bound action or function in scope." />
     <Annotation Term="Core.LongDescription">
       <String>Either
-- the qualified name of an action, to indicate the single bound overload with the specified binding parameter type,
-- the qualified name of a function, to indicate all bound overloads with the specified binding parameter type, or
+- the qualified name of an action, to indicate the single bound overload with the specified binding parameter type, 
+- the qualified name of a function, to indicate all bound overloads with the specified binding parameter type, or 
 - the qualified name of a function followed by parentheses containing a comma-separated list of parameter types, in the order of their definition, to identify a single function overload with the first (binding) parameter matching the specified parameter type.
 </String>
     </Annotation>
   </TypeDefinition>
 
-  <Term Name="Ordered" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Property NavigationProperty EntitySet ReturnType">
+  <Term Name="Ordered" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="Property NavigationProperty EntitySet ReturnType Term">
     <Annotation Term="Core.Description" String="Collection has a stable order. Ordered collections of primitive or complex types can be indexed by ordinal." />
   </Term>
 
@@ -410,7 +431,7 @@
     <Annotation Term="Core.Description" String="Items can be inserted at a given ordinal index." />
   </Term>
 
-  <Term Name="AlternateKeys" Type="Collection(Core.AlternateKey)" Nullable="false" AppliesTo="EntityType EntitySet NavigationProperty">
+  <Term Name="AlternateKeys" AppliesTo="EntityType EntitySet NavigationProperty" Type="Collection(Core.AlternateKey)" Nullable="false">
     <Annotation Term="Core.Description" String="Communicates available alternate keys" />
   </Term>
   <ComplexType Name="AlternateKey">
@@ -438,7 +459,7 @@ Any simple identifier | Any type listed in `Validation.OpenPropertyTypeConstrain
     </Annotation>
   </ComplexType>
 
-  <Term Name="OptionalParameter" Type="Core.OptionalParameterType" AppliesTo="Parameter">
+  <Term Name="OptionalParameter" Type="Core.OptionalParameterType" Nullable="false" AppliesTo="Parameter">
     <Annotation Term="Core.Description" String="Supplying a value for the action or function parameter is optional." />
     <Annotation Term="Core.LongDescription" String="All parameters marked as optional must come after any parameters not marked as optional. The binding parameter must not be marked as optional." />
   </Term>
@@ -455,7 +476,7 @@ Any simple identifier | Any type listed in `Validation.OpenPropertyTypeConstrain
   </Term>
 
   <Term Name="RequiresExplicitBinding" Type="Core.Tag" DefaultValue="true" AppliesTo="Action Function">
-	<Annotation Term="Core.Description" String="This bound action or function is only available on model elements annotated with the ExplicitOperationBindings term." />
+    <Annotation Term="Core.Description" String="This bound action or function is only available on model elements annotated with the ExplicitOperationBindings term." />
   </Term>
 
   <Term Name="ExplicitOperationBindings" Type="Collection(Core.QualifiedBoundOperationName)">
@@ -466,4 +487,38 @@ Any simple identifier | Any type listed in `Validation.OpenPropertyTypeConstrain
     <Annotation Term="Core.Description" String="A string representing a Local Date-Time value with no offset." />
     <Annotation Term="Validation.Pattern" String="^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9](\\.[0-9]+)?)?$" />
   </TypeDefinition>
+
+  <Term Name="SymbolicName" Type="Core.SimpleIdentifier" Nullable="false">
+    <Annotation Term="Core.Description" String="A symbolic name for a model element" />
+  </Term>
+
+  <TypeDefinition Name="SimpleIdentifier" UnderlyingType="Edm.String">
+    <Annotation Term="Core.Description" String="A [simple identifier](https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_SimpleIdentifier)" />
+    <Annotation Term="Validation.Pattern" String="^[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}]{0,}$" />
+  </TypeDefinition>
+
+  <Term Name="GeometryFeature" Type="Core.GeometryFeatureType">
+    <Annotation Term="Core.Description" String="A [Feature Object](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2) represents a spatially bounded thing" />
+  </Term>
+  <ComplexType Name="GeometryFeatureType">
+    <Annotation Term="Core.Description" String="A [Feature Object](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2) represents a spatially bounded thing" />
+    <Property Name="geometry" Type="Edm.Geometry" Nullable="true">
+      <Annotation Term="Core.Description" String="Location of the Feature" />
+    </Property>
+    <Property Name="properties" Type="Core.Dictionary" Nullable="true">
+      <Annotation Term="Core.Description" String="Properties of the Feature" />
+    </Property>
+    <Property Name="id" Type="Edm.String" Nullable="true">
+      <Annotation Term="Core.Description" String="Commonly used identifer for a Feature" />
+    </Property>
+  </ComplexType>
+
+  <Term Name="AnyStructure" Type="Core.Tag" Nullable="false" DefaultValue="true" AppliesTo="EntityType ComplexType">
+    <Annotation Term="Core.Description" String="Instances of a type are annotated with this tag if they have no common structure in a given response payload" />
+    <Annotation Term="Core.LongDescription">
+      <String>The select-list of a context URL MUST be `(@Core.AnyStructure)` if it would otherwise be empty,
+      but this instance annotation SHOULD be omitted from the response value.</String>
+    </Annotation>
+  </Term>
+
 </Schema>

--- a/src/Microsoft.OData.Edm/Vocabularies/MeasuresVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/MeasuresVocabularies.xml
@@ -15,41 +15,39 @@
         <Collection>
           <Record>
             <PropertyValue Property="rel" String="latest-version" />
-            <PropertyValue Property="href"
-              String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml" />
+            <PropertyValue Property="href" String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.xml" />
           </Record>
           <Record>
             <PropertyValue Property="rel" String="alternate" />
-            <PropertyValue Property="href"
-              String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.json" />
+            <PropertyValue Property="href" String="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Measures.V1.json" />
           </Record>
           <Record>
             <PropertyValue Property="rel" String="describedby" />
-            <PropertyValue Property="href"
-              String="https://github.com/oasis-tcs/odata-vocabularies/blob/master/vocabularies/Org.OData.Measures.V1.md" />
+            <PropertyValue Property="href" String="https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Measures.V1.md" />
           </Record>
         </Collection>
       </Annotation>
 
-      <Term Name="ISOCurrency" Type="Edm.String" Nullable="false" AppliesTo="Property">
+      <Term Name="ISOCurrency" Type="Edm.String" Nullable="false" AppliesTo="Parameter Property">
         <Annotation Term="Core.Description" String="The currency for this monetary amount as an ISO 4217 currency code" />
       </Term>
 
-      <Term Name="Scale" Type="Edm.Byte" Nullable="false" AppliesTo="Property">
-        <Annotation Term="Core.Description"
-          String="The number of significant decimal places in the scale part (less than or equal to the number declared in the Scale facet)" />
+      <Term Name="Scale" Type="Edm.Byte" Nullable="false" AppliesTo="Parameter Property">
+        <Annotation Term="Core.Description" String="The number of significant decimal places in the scale part (less than or equal to the number declared in the Scale facet)" />
         <Annotation Term="Core.RequiresType" String="Edm.Decimal" />
       </Term>
 
-      <Term Name="Unit" Type="Edm.String" Nullable="false" AppliesTo="Property">
-        <Annotation Term="Core.Description"
-          String="The unit of measure for this measured quantity, e.g. cm for centimeters or % for percentages" />
+      <Term Name="Unit" Type="Edm.String" Nullable="false" AppliesTo="Parameter Property">
+        <Annotation Term="Core.Description" String="The unit of measure for this measured quantity, e.g. cm for centimeters or % for percentages" />
       </Term>
 
-      <Term Name="DurationGranularity" Type="Measures.DurationGranularityType" Nullable="false" AppliesTo="Property">
+      <Term Name="UNECEUnit" Type="Edm.String" Nullable="false" AppliesTo="Parameter Property">
+        <Annotation Term="Core.Description" String="The unit of measure for this measured quantity, according to the [UN/CEFACT Recommendation 20](http://tfig.unece.org/contents/recommendation-20.htm)" />
+      </Term>
+
+      <Term Name="DurationGranularity" Type="Measures.DurationGranularityType" Nullable="false" AppliesTo="Parameter Property">
         <Annotation Term="Core.Description" String="The minimum granularity of duration values." />
-        <Annotation Term="Core.LongDescription"
-          String="Absence of this annotation means a granularity of seconds with sub-seconds according to the Precision facet." />
+        <Annotation Term="Core.LongDescription" String="Absence of this annotation means a granularity of seconds with sub-seconds according to the Precision facet." />
         <Annotation Term="Core.RequiresType" String="Edm.Duration" />
       </Term>
       <TypeDefinition Name="DurationGranularityType" UnderlyingType="Edm.String">

--- a/src/Microsoft.OData.Edm/Vocabularies/ValidationVocabularies.xml
+++ b/src/Microsoft.OData.Edm/Vocabularies/ValidationVocabularies.xml
@@ -1,15 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
+
   Technical Committee:
   OASIS Open Data Protocol (OData) TC
   https://www.oasis-open.org/committees/odata
+
   Chairs:
   - Ralf Handl (ralf.handl@sap.com), SAP SE
   - Ram Jeyaraman (Ram.Jeyaraman@microsoft.com), Microsoft
+
   Editors:
   - Ralf Handl (ralf.handl@sap.com), SAP SE
   - Ram Jeyaraman (Ram.Jeyaraman@microsoft.com), Microsoft
   - Michael Pizzo (mikep@microsoft.com), Microsoft
+
   Additional artifacts:
   This vocabulary is one component of a Work Product that also includes the following vocabulary components:
   - OData Core Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml.
@@ -18,6 +22,7 @@
   - OData Validation Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Validation.V1.xml.
   - OData Aggregation Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.xml.
   - OData Authorization Vocabulary. Latest version: https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Authorization.V1.xml.
+
   Related work:
   This vocabulary replaces or supersedes:
   - None.
@@ -28,8 +33,10 @@
   - OData Common Schema Definition Language (CSDL) XML Representation Version 4.01. Latest version: http://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html.
   - OData JSON Format Version 4.01. Latest version: http://docs.oasis-open.org/odata/odata-json-format/v4.01/odata-json-format-v4.01.html.
   - OData Extension for Data Aggregation Version 4.0. Latest version: http://docs.oasis-open.org/odata/odata-data-aggregation-ext/v4.0/odata-data-aggregation-ext-v4.0.html.
+
   Abstract:
   This document contains terms describing validation rules.
+
 -->
 <edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
   <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
@@ -88,6 +95,11 @@
         <Annotation Term="Core.Description" String="A collection of valid values for the annotated property, parameter, or type definition" />
       </Term>
       <ComplexType Name="AllowedValue">
+        <Annotation Term="Validation.ApplicableTerms">
+          <Collection>
+            <String>Core.SymbolicName</String>
+          </Collection>
+        </Annotation>
         <Property Name="Value" Type="Edm.PrimitiveType" Nullable="true">
           <Annotation Term="Core.Description" String="An allowed value for the property, parameter, or type definition" />
         </Property>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/AlternateKeysVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/AlternateKeysVocabularyTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.Description"" String=""A SimpleIdentifier that MUST be unique within the set of aliases, structural and navigation properties of the containing entity type that MUST be used in the key predicate of URLs"" />
     </Property>
   </ComplexType>
-  <Term Name=""AlternateKeys"" Type=""Collection(Keys.AlternateKey)"" AppliesTo=""EntityType"">
+  <Term Name=""AlternateKeys"" Type=""Collection(Keys.AlternateKey)"" AppliesTo=""EntityType EntitySet NavigationProperty"">
     <Annotation Term=""Core.Description"" String=""Communicates available alternate keys"" />
   </Term>
 </Schema>";
@@ -60,7 +60,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             string output = sw.ToString();
 
             Assert.False(errors.Any(), "No Errors");
-            Assert.True(expectedText == output, "expectedText = output");
+            Assert.Equal(expectedText, output);
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/AuthorizationVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/AuthorizationVocabularyTests.cs
@@ -50,7 +50,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <ComplexType Name=""OpenIDConnect"" BaseType=""Auth.Authorization"">
     <Property Name=""IssuerUrl"" Type=""Edm.String"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Issuer location for the OpenID Provider. Configuration information can be obtained by appending `/.well-known/openid-configuration` to this Url."" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""Http"" BaseType=""Auth.Authorization"">
@@ -67,35 +67,35 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Property Name=""RefreshUrl"" Type=""Edm.String"">
       <Annotation Term=""Core.Description"" String=""Refresh Url"" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""OAuth2ClientCredentials"" BaseType=""Auth.OAuthAuthorization"">
     <Property Name=""TokenUrl"" Type=""Edm.String"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Token Url"" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""OAuth2Implicit"" BaseType=""Auth.OAuthAuthorization"">
     <Property Name=""AuthorizationUrl"" Type=""Edm.String"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Authorization URL"" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""OAuth2Password"" BaseType=""Auth.OAuthAuthorization"">
     <Property Name=""TokenUrl"" Type=""Edm.String"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Token Url"" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""OAuth2AuthCode"" BaseType=""Auth.OAuthAuthorization"">
     <Property Name=""AuthorizationUrl"" Type=""Edm.String"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Authorization URL"" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
     <Property Name=""TokenUrl"" Type=""Edm.String"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Token Url"" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""AuthorizationScope"">
@@ -129,7 +129,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Member>
   </EnumType>
   <Term Name=""SecuritySchemes"" Type=""Collection(Auth.SecurityScheme)"" AppliesTo=""EntityContainer"" Nullable=""false"">
-    <Annotation Term=""Core.Description"" String=""At least one of the specified security schemes are required to make a request against the service."" />
+    <Annotation Term=""Core.Description"" String=""At least one of the specified security schemes are required to make a request against the service"" />
   </Term>
   <Term Name=""Authorizations"" Type=""Collection(Auth.Authorization)"" AppliesTo=""EntityContainer"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Lists the methods supported by the service to authorize access"" />

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.cs
@@ -69,7 +69,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Property Name=""DocumentationUrl"" Type=""Edm.String"">
       <Annotation Term=""Core.Description"" String=""Human readable description of the meaning of the URL Template parameters"" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""ChangeTrackingType"">
@@ -105,8 +105,9 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
   </ComplexType>
   <ComplexType Name=""NavigationPropertyRestriction"">
-    <Property Name=""NavigationProperty"" Type=""Edm.NavigationPropertyPath"">
+    <Property Name=""NavigationProperty"" Type=""Edm.NavigationPropertyPath"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Navigation properties can be navigated"" />
+      <Annotation Term=""Core.LongDescription"" String=""The target path of a [`NavigationRestrictions`](#NavigationRestrictions) annotation followed by this&#xA;            navigation property path addresses the resource to which the other properties of `NavigationPropertyRestriction` apply.&#xA;            Instance paths that occur in dynamic expressions are evaluated starting at the boundary between both paths,&#xA;            which must therefore be chosen accordingly."" />
     </Property>
     <Property Name=""Navigability"" Type=""Capabilities.NavigationType"">
       <Annotation Term=""Core.Description"" String=""Supported navigability of this navigation property"" />
@@ -157,6 +158,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Property Name=""ReadRestrictions"" Type=""Capabilities.ReadRestrictionsType"">
       <Annotation Term=""Core.Description"" String=""Restrictions for retrieving entities"" />
     </Property>
+    <Annotation Term=""Core.LongDescription"" String=""Using a property of `NavigationPropertyRestriction` in a [`NavigationRestrictions`](#NavigationRestrictions) annotation&#xA;          is discouraged in favor of using an annotation with the corresponding term from this vocabulary and a target path starting with a container and ending in the `NavigationProperty`,&#xA;          unless the favored alternative is impossible because a dynamic expression requires an instance path whose evaluation&#xA;          starts at the target of the `NavigationRestrictions` annotation. See [this example](../examples/Org.OData.Capabilities.V1.capabilities.md)."" />
   </ComplexType>
   <ComplexType Name=""SelectSupportType"">
     <Property Name=""Supported"" Type=""Edm.Boolean"" DefaultValue=""true"" Nullable=""false"">
@@ -211,7 +213,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Property Name=""SupportedFormats"" Type=""Collection(Edm.String)"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Media types of supported formats for $batch"" />
-      <Annotation Term=""Core.IsMediaType"" Bool=""true"" />
+      <Annotation Term=""Core.IsMediaType"" />
       <Annotation Term=""Validation.AllowedValues"">
         <Collection>
           <Record>
@@ -223,6 +225,12 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
         </Collection>
       </Annotation>
     </Property>
+    <Annotation Term=""Validation.ApplicableTerms"">
+      <Collection>
+        <String>Core.Description</String>
+        <String>Core.LongDescription</String>
+      </Collection>
+    </Annotation>
   </ComplexType>
   <ComplexType Name=""FilterRestrictionsType"">
     <Property Name=""Filterable"" Type=""Edm.Boolean"" DefaultValue=""true"" Nullable=""false"">
@@ -243,6 +251,11 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Property Name=""MaxLevels"" Type=""Edm.Int32"" DefaultValue=""-1"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""The maximum number of levels (including recursion) that can be traversed in a filter expression. A value of -1 indicates there is no restriction."" />
     </Property>
+    <Annotation Term=""Validation.ApplicableTerms"">
+      <Collection>
+        <String>Core.Description</String>
+      </Collection>
+    </Annotation>
   </ComplexType>
   <ComplexType Name=""FilterExpressionRestrictionType"">
     <Property Name=""Property"" Type=""Edm.PropertyPath"">
@@ -265,13 +278,18 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Property Name=""NonSortableProperties"" Type=""Collection(Edm.PropertyPath)"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""These structural properties cannot be used in orderby expressions"" />
     </Property>
+    <Annotation Term=""Validation.ApplicableTerms"">
+      <Collection>
+        <String>Core.Description</String>
+      </Collection>
+    </Annotation>
   </ComplexType>
   <ComplexType Name=""ExpandRestrictionsType"">
     <Property Name=""Expandable"" Type=""Edm.Boolean"" DefaultValue=""true"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""$expand is supported"" />
     </Property>
     <Property Name=""StreamsExpandable"" Type=""Edm.Boolean"" DefaultValue=""false"" Nullable=""false"">
-      <Annotation Term=""Core.Description"" String=""$expand is supported for stream properties and media resources"" />
+      <Annotation Term=""Core.Description"" String=""$expand is supported for stream properties and media streams"" />
     </Property>
     <Property Name=""NonExpandableProperties"" Type=""Collection(Edm.NavigationPropertyPath)"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""These properties cannot be used in expand expressions"" />
@@ -283,6 +301,11 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Property Name=""MaxLevels"" Type=""Edm.Int32"" DefaultValue=""-1"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""The maximum number of levels that can be expanded in a expand expression. A value of -1 indicates there is no restriction."" />
     </Property>
+    <Annotation Term=""Validation.ApplicableTerms"">
+      <Collection>
+        <String>Core.Description</String>
+      </Collection>
+    </Annotation>
   </ComplexType>
   <ComplexType Name=""SearchRestrictionsType"">
     <Property Name=""Searchable"" Type=""Edm.Boolean"" DefaultValue=""true"" Nullable=""false"">
@@ -291,6 +314,11 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Property Name=""UnsupportedExpressions"" Type=""Capabilities.SearchExpressions"" DefaultValue=""none"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Expressions not supported in $search"" />
     </Property>
+    <Annotation Term=""Validation.ApplicableTerms"">
+      <Collection>
+        <String>Core.Description</String>
+      </Collection>
+    </Annotation>
   </ComplexType>
   <ComplexType Name=""InsertRestrictionsType"">
     <Property Name=""Insertable"" Type=""Edm.Boolean"" DefaultValue=""true"" Nullable=""false"">
@@ -325,11 +353,14 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Property Name=""Description"" Type=""Edm.String"">
       <Annotation Term=""Core.Description"" String=""A brief description of the request"" />
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
     </Property>
     <Property Name=""LongDescription"" Type=""Edm.String"">
-      <Annotation Term=""Core.Description"" String=""A lengthy description of the request"" />
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.Description"" String=""A long description of the request"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
+    </Property>
+    <Property Name=""ErrorResponses"" Type=""Collection(Capabilities.HttpResponse)"" Nullable=""false"">
+      <Annotation Term=""Core.Description"" String=""Possible error responses returned by the request."" />
     </Property>
   </ComplexType>
   <ComplexType Name=""PermissionType"">
@@ -377,7 +408,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.Description"" String=""Members of collections can be updated via a PATCH request with a type-cast segment and a `/$each` segment"" />
     </Property>
     <Property Name=""NonUpdatableProperties"" Type=""Collection(Edm.PropertyPath)"" Nullable=""false"">
-      <Annotation Term=""Core.Description"" String=""These structural properties cannot be specified on update"" />
+      <Annotation Term=""Core.Description"" String=""These structural properties cannot be updated"" />
     </Property>
     <Property Name=""NonUpdatableNavigationProperties"" Type=""Collection(Edm.NavigationPropertyPath)"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""These navigation properties do not allow rebinding"" />
@@ -402,11 +433,14 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Property Name=""Description"" Type=""Edm.String"">
       <Annotation Term=""Core.Description"" String=""A brief description of the request"" />
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
     </Property>
     <Property Name=""LongDescription"" Type=""Edm.String"">
-      <Annotation Term=""Core.Description"" String=""A lengthy description of the request"" />
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.Description"" String=""A long description of the request"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
+    </Property>
+    <Property Name=""ErrorResponses"" Type=""Collection(Capabilities.HttpResponse)"" Nullable=""false"">
+      <Annotation Term=""Core.Description"" String=""Possible error responses returned by the request."" />
     </Property>
   </ComplexType>
   <ComplexType Name=""DeepUpdateSupportType"">
@@ -428,10 +462,10 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.Description"" String=""The maximum number of navigation properties that can be traversed when addressing the collection to delete from or the entity to delete. A value of -1 indicates there is no restriction."" />
     </Property>
     <Property Name=""FilterSegmentSupported"" Type=""Edm.Boolean"" DefaultValue=""true"" Nullable=""false"">
-      <Annotation Term=""Core.Description"" String=""Members of collections can be updated via a PATCH request with a `/$filter(...)/$each` segment"" />
+      <Annotation Term=""Core.Description"" String=""Members of collections can be deleted via a DELETE request with a `/$filter(...)/$each` segment"" />
     </Property>
     <Property Name=""TypecastSegmentSupported"" Type=""Edm.Boolean"" DefaultValue=""true"" Nullable=""false"">
-      <Annotation Term=""Core.Description"" String=""Members of collections can be updated via a PATCH request with a type-cast segment and a `/$each` segment"" />
+      <Annotation Term=""Core.Description"" String=""Members of collections can be deleted via a DELETE request with a type-cast segment and a `/$each` segment"" />
     </Property>
     <Property Name=""Permissions"" Type=""Collection(Capabilities.PermissionType)"">
       <Annotation Term=""Core.Description"" String=""Required permissions. One of the specified sets of scopes is required to perform the delete."" />
@@ -444,11 +478,14 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Property Name=""Description"" Type=""Edm.String"">
       <Annotation Term=""Core.Description"" String=""A brief description of the request"" />
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
     </Property>
     <Property Name=""LongDescription"" Type=""Edm.String"">
-      <Annotation Term=""Core.Description"" String=""A lengthy description of the request"" />
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.Description"" String=""A long description of the request"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
+    </Property>
+    <Property Name=""ErrorResponses"" Type=""Collection(Capabilities.HttpResponse)"" Nullable=""false"">
+      <Annotation Term=""Core.Description"" String=""Possible error responses returned by the request."" />
     </Property>
   </ComplexType>
   <ComplexType Name=""CollectionPropertyRestrictionsType"">
@@ -501,6 +538,9 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Property Name=""CustomQueryOptions"" Type=""Collection(Capabilities.CustomParameter)"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Supported or required custom query options"" />
     </Property>
+    <Property Name=""ErrorResponses"" Type=""Collection(Capabilities.HttpResponse)"" Nullable=""false"">
+      <Annotation Term=""Core.Description"" String=""Possible error responses returned by the request."" />
+    </Property>
   </ComplexType>
   <ComplexType Name=""ModificationQueryOptionsType"">
     <Property Name=""ExpandSupported"" Type=""Edm.Boolean"" DefaultValue=""false"" Nullable=""false"">
@@ -537,17 +577,23 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Property Name=""Description"" Type=""Edm.String"">
       <Annotation Term=""Core.Description"" String=""A brief description of the request"" />
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
     </Property>
     <Property Name=""LongDescription"" Type=""Edm.String"">
-      <Annotation Term=""Core.Description"" String=""A lengthy description of the request"" />
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.Description"" String=""A long description of the request"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
+    </Property>
+    <Property Name=""ErrorResponses"" Type=""Collection(Capabilities.HttpResponse)"" Nullable=""false"">
+      <Annotation Term=""Core.Description"" String=""Possible error responses returned by the request."" />
     </Property>
   </ComplexType>
   <ComplexType Name=""ReadByKeyRestrictionsType"" BaseType=""Capabilities.ReadRestrictionsBase"">
     <Annotation Term=""Core.Description"" String=""Restrictions for retrieving an entity by key"" />
   </ComplexType>
   <ComplexType Name=""ReadRestrictionsType"" BaseType=""Capabilities.ReadRestrictionsBase"">
+    <Property Name=""TypecastSegmentSupported"" Type=""Edm.Boolean"" DefaultValue=""true"" Nullable=""false"">
+      <Annotation Term=""Core.Description"" String=""Entities of a specific derived type can be read by specifying a type-cast segment"" />
+    </Property>
     <Property Name=""ReadByKeyRestrictions"" Type=""Capabilities.ReadByKeyRestrictionsType"">
       <Annotation Term=""Core.Description"" String=""Restrictions for retrieving an entity by key"" />
       <Annotation Term=""Core.LongDescription"" String=""Only valid when applied to a collection. If a property of `ReadByKeyRestrictions` is not specified, the corresponding property value of `ReadRestrictions` applies."" />
@@ -561,7 +607,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.Description"" String=""Description of the custom parameter"" />
     </Property>
     <Property Name=""DocumentationURL"" Type=""Edm.String"">
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
       <Annotation Term=""Core.Description"" String=""URL of related documentation"" />
     </Property>
     <Property Name=""Required"" Type=""Edm.Boolean"" DefaultValue=""false"" Nullable=""false"">
@@ -572,6 +618,15 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Annotation Term=""Core.Description"" String=""A custom parameter is either a header or a query option"" />
     <Annotation Term=""Core.LongDescription"" String=""The type of a custom parameter is always a string. Restrictions on the parameter values can be expressed by annotating the record expression describing the parameter with terms from the Validation vocabulary, e.g. Validation.Pattern or Validation.AllowedValues."" />
+  </ComplexType>
+  <ComplexType Name=""HttpResponse"">
+    <Property Name=""StatusCode"" Type=""Edm.String"" Nullable=""false"">
+      <Annotation Term=""Core.Description"" String=""HTTP response status code, for example 400, 403, 501"" />
+    </Property>
+    <Property Name=""Description"" Type=""Edm.String"" Nullable=""false"">
+      <Annotation Term=""Core.Description"" String=""Human-readable description of the response"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
+    </Property>
   </ComplexType>
   <EnumType Name=""ConformanceLevelType"">
     <Member Name=""Minimal"">
@@ -648,11 +703,11 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   </Term>
   <Term Name=""SupportedFormats"" Type=""Collection(Edm.String)"" AppliesTo=""EntityContainer"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Media types of supported formats, including format parameters"" />
-    <Annotation Term=""Core.IsMediaType"" Bool=""true"" />
+    <Annotation Term=""Core.IsMediaType"" />
   </Term>
   <Term Name=""SupportedMetadataFormats"" Type=""Collection(Edm.String)"" AppliesTo=""EntityContainer"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Media types of supported formats for $metadata, including format parameters"" />
-    <Annotation Term=""Core.IsMediaType"" Bool=""true"" />
+    <Annotation Term=""Core.IsMediaType"" />
   </Term>
   <Term Name=""AcceptableEncodings"" Type=""Collection(Edm.String)"" AppliesTo=""EntityContainer"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""List of acceptable compression methods for ($batch) requests, e.g. gzip"" />
@@ -675,26 +730,33 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""ChangeTracking"" Type=""Capabilities.ChangeTrackingType"" AppliesTo=""EntitySet Singleton Function FunctionImport NavigationProperty"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Change tracking capabilities of this service or entity set"" />
   </Term>
-  <Term Name=""CountRestrictions"" Type=""Capabilities.CountRestrictionsType"" AppliesTo=""EntitySet Singleton"" Nullable=""false"">
+  <Term Name=""CountRestrictions"" Type=""Capabilities.CountRestrictionsType"" AppliesTo=""EntitySet Singleton Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions on /$count path suffix and $count=true system query option"" />
   </Term>
-  <Term Name=""NavigationRestrictions"" Type=""Capabilities.NavigationRestrictionsType"" AppliesTo=""EntitySet Singleton"" Nullable=""false"">
+  <Term Name=""NavigationRestrictions"" Type=""Capabilities.NavigationRestrictionsType"" AppliesTo=""EntitySet Singleton Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions on navigating properties according to OData URL conventions"" />
     <Annotation Term=""Core.LongDescription"" String=""Restrictions specified on an entity set are valid whether the request is directly to the entity set or through a navigation property bound to that entity set. Services can specify a different set of restrictions specific to a path, in which case the more specific restrictions take precedence."" />
   </Term>
-  <Term Name=""IndexableByKey"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet"" Nullable=""false"">
+  <Term Name=""IndexableByKey"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Supports key values according to OData URL conventions"" />
   </Term>
-  <Term Name=""TopSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet"" Nullable=""false"">
+  <Term Name=""TopSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Supports $top"" />
   </Term>
-  <Term Name=""SkipSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet"" Nullable=""false"">
+  <Term Name=""SkipSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Supports $skip"" />
   </Term>
-  <Term Name=""ComputeSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet"" Nullable=""false"">
+  <Term Name=""ComputeSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Supports $compute"" />
   </Term>
-  <Term Name=""SelectSupport"" Type=""Capabilities.SelectSupportType"" AppliesTo=""EntityContainer EntitySet Singleton"" Nullable=""false"">
+  <Term Name=""SelectSupport"" Type=""Capabilities.SelectSupportType"" AppliesTo=""EntityContainer EntitySet Singleton Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Support for $select and nested query options within $select"" />
   </Term>
   <Term Name=""BatchSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityContainer"" Nullable=""false"">
@@ -703,20 +765,25 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""BatchSupport"" Type=""Capabilities.BatchSupportType"" AppliesTo=""EntityContainer"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Batch Support for the service"" />
   </Term>
-  <Term Name=""FilterFunctions"" Type=""Collection(Edm.String)"" AppliesTo=""EntityContainer EntitySet"" Nullable=""false"">
+  <Term Name=""FilterFunctions"" Type=""Collection(Edm.String)"" AppliesTo=""EntityContainer EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""List of functions and operators supported in filter expressions"" />
     <Annotation Term=""Core.LongDescription"" String=""If not specified, null, or empty, all functions and operators may be attempted."" />
   </Term>
-  <Term Name=""FilterRestrictions"" Type=""Capabilities.FilterRestrictionsType"" AppliesTo=""EntitySet"" Nullable=""false"">
+  <Term Name=""FilterRestrictions"" Type=""Capabilities.FilterRestrictionsType"" AppliesTo=""EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions on filter expressions"" />
   </Term>
-  <Term Name=""SortRestrictions"" Type=""Capabilities.SortRestrictionsType"" AppliesTo=""EntitySet"" Nullable=""false"">
+  <Term Name=""SortRestrictions"" Type=""Capabilities.SortRestrictionsType"" AppliesTo=""EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions on orderby expressions"" />
   </Term>
-  <Term Name=""ExpandRestrictions"" Type=""Capabilities.ExpandRestrictionsType"" AppliesTo=""EntitySet Singleton"" Nullable=""false"">
+  <Term Name=""ExpandRestrictions"" Type=""Capabilities.ExpandRestrictionsType"" AppliesTo=""EntitySet Singleton Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions on expand expressions"" />
   </Term>
-  <Term Name=""SearchRestrictions"" Type=""Capabilities.SearchRestrictionsType"" AppliesTo=""EntitySet"" Nullable=""false"">
+  <Term Name=""SearchRestrictions"" Type=""Capabilities.SearchRestrictionsType"" AppliesTo=""EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions on search expressions"" />
   </Term>
   <Term Name=""KeyAsSegmentSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityContainer"" Nullable=""false"">
@@ -725,19 +792,24 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""QuerySegmentSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityContainer"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Supports [passing query options in the request body](http://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_PassingQueryOptionsintheRequestBody)"" />
   </Term>
-  <Term Name=""InsertRestrictions"" Type=""Capabilities.InsertRestrictionsType"" AppliesTo=""EntitySet EntityType"" Nullable=""false"">
+  <Term Name=""InsertRestrictions"" Type=""Capabilities.InsertRestrictionsType"" AppliesTo=""EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions on insert operations"" />
   </Term>
-  <Term Name=""DeepInsertSupport"" Type=""Capabilities.DeepInsertSupportType"" AppliesTo=""EntityContainer EntitySet"">
+  <Term Name=""DeepInsertSupport"" Type=""Capabilities.DeepInsertSupportType"" AppliesTo=""EntityContainer EntitySet Collection"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Deep Insert Support of the annotated resource (the whole service, an entity set, or a collection-valued resource)"" />
   </Term>
-  <Term Name=""UpdateRestrictions"" Type=""Capabilities.UpdateRestrictionsType"" AppliesTo=""EntitySet Singleton EntityType"" Nullable=""false"">
+  <Term Name=""UpdateRestrictions"" Type=""Capabilities.UpdateRestrictionsType"" AppliesTo=""EntitySet Singleton Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions on update operations"" />
   </Term>
-  <Term Name=""DeepUpdateSupport"" Type=""Capabilities.DeepUpdateSupportType"" AppliesTo=""EntityContainer EntitySet"" Nullable=""false"">
+  <Term Name=""DeepUpdateSupport"" Type=""Capabilities.DeepUpdateSupportType"" AppliesTo=""EntityContainer EntitySet Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Deep Update Support of the annotated resource (the whole service, an entity set, or a collection-valued resource)"" />
   </Term>
-  <Term Name=""DeleteRestrictions"" Type=""Capabilities.DeleteRestrictionsType"" AppliesTo=""EntitySet Singleton EntityType"" Nullable=""false"">
+  <Term Name=""DeleteRestrictions"" Type=""Capabilities.DeleteRestrictionsType"" AppliesTo=""EntitySet Singleton Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions on delete operations"" />
   </Term>
   <Term Name=""CollectionPropertyRestrictions"" Type=""Collection(Capabilities.CollectionPropertyRestrictionsType)"" AppliesTo=""EntitySet Singleton"" Nullable=""false"">
@@ -752,7 +824,8 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""ModificationQueryOptions"" Type=""Capabilities.ModificationQueryOptionsType"" AppliesTo=""EntityContainer Action ActionImport"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Support for query options with modification requests (insert, update, action invocation)"" />
   </Term>
-  <Term Name=""ReadRestrictions"" Type=""Capabilities.ReadRestrictionsType"" AppliesTo=""EntitySet Singleton"" Nullable=""false"">
+  <Term Name=""ReadRestrictions"" Type=""Capabilities.ReadRestrictionsType"" AppliesTo=""EntitySet Singleton Collection"" Nullable=""false"">
+    <Annotation Term=""Core.AppliesViaContainer"" />
     <Annotation Term=""Core.Description"" String=""Restrictions for retrieving a collection of entities, retrieving a singleton instance."" />
   </Term>
   <Term Name=""CustomHeaders"" Type=""Collection(Capabilities.CustomParameter)"" AppliesTo=""EntityContainer"" Nullable=""false"">
@@ -768,9 +841,9 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Record />
     </Annotation>
   </Term>
-  <Term Name=""MediaLocationUpdateSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Property"" Nullable=""false"">
+  <Term Name=""MediaLocationUpdateSupported"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityType Property"" Nullable=""false"">
     <Annotation Term=""Core.RequiresType"" String=""Edm.Stream"" />
-    <Annotation Term=""Core.Description"" String=""Stream property supports update of its media edit URL and/or media read URL"" />
+    <Annotation Term=""Core.Description"" String=""Stream property or media stream supports update of its media edit URL and/or media read URL"" />
   </Term>
 </Schema>";
 
@@ -1157,9 +1230,9 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
         [InlineData("AsynchronousRequestsSupported", "EntityContainer")]
         [InlineData("BatchContinueOnErrorSupported", "EntityContainer")]
         [InlineData("CrossJoinSupported", "EntityContainer")]
-        [InlineData("TopSupported", "EntitySet")]
-        [InlineData("SkipSupported", "EntitySet")]
-        [InlineData("IndexableByKey", "EntitySet")]
+        [InlineData("TopSupported", "EntitySet Collection")]
+        [InlineData("SkipSupported", "EntitySet Collection")]
+        [InlineData("IndexableByKey", "EntitySet Collection")]
         [InlineData("BatchSupported", "EntityContainer")]
         [InlineData("KeyAsSegmentSupported", "EntityContainer")]
         public void TestCapabilitiesVocabularySupportedTerm(string name, string appliesTo)

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
@@ -54,13 +54,20 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <TypeDefinition Name=""QualifiedTypeName"" UnderlyingType=""Edm.String"">
     <Annotation Term=""Core.Description"" String=""The qualified name of a type in scope."" />
   </TypeDefinition>
+  <TypeDefinition Name=""QualifiedActionName"" UnderlyingType=""Edm.String"">
+    <Annotation Term=""Core.Description"" String=""The qualified name of an action in scope."" />
+  </TypeDefinition>
   <TypeDefinition Name=""QualifiedBoundOperationName"" UnderlyingType=""Edm.String"">
     <Annotation Term=""Core.Description"" String=""The qualified name of a bound action or function in scope."" />
-    <Annotation Term=""Core.LongDescription"" String=""Either&#xA;- the qualified name of an action, to indicate the single bound overload with the specified binding parameter type,&#xA;- the qualified name of a function, to indicate all bound overloads with the specified binding parameter type, or&#xA;- the qualified name of a function followed by parentheses containing a comma-separated list of parameter types, in the order of their definition, to identify a single function overload with the first (binding) parameter matching the specified parameter type.&#xA;"" />
+    <Annotation Term=""Core.LongDescription"" String=""Either&#xA;- the qualified name of an action, to indicate the single bound overload with the specified binding parameter type, &#xA;- the qualified name of a function, to indicate all bound overloads with the specified binding parameter type, or &#xA;- the qualified name of a function followed by parentheses containing a comma-separated list of parameter types, in the order of their definition, to identify a single function overload with the first (binding) parameter matching the specified parameter type.&#xA;"" />
   </TypeDefinition>
   <TypeDefinition Name=""LocalDateTime"" UnderlyingType=""Edm.String"">
     <Annotation Term=""Core.Description"" String=""A string representing a Local Date-Time value with no offset."" />
     <Annotation Term=""Validation.Pattern"" String=""^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):[0-5][0-9](:[0-5][0-9](\\.[0-9]+)?)?$"" />
+  </TypeDefinition>
+  <TypeDefinition Name=""SimpleIdentifier"" UnderlyingType=""Edm.String"">
+    <Annotation Term=""Core.Description"" String=""A [simple identifier](https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_SimpleIdentifier)"" />
+    <Annotation Term=""Validation.Pattern"" String=""^[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}]{0,}$"" />
   </TypeDefinition>
   <ComplexType Name=""RevisionType"">
     <Property Name=""Version"" Type=""Edm.String"">
@@ -78,7 +85,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.Description"" String=""Link relation type, see [IANA Link Relations](http://www.iana.org/assignments/link-relations/link-relations.xhtml)"" />
     </Property>
     <Property Name=""href"" Type=""Edm.String"" Nullable=""false"">
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
       <Annotation Term=""Core.Description"" String=""URL of related information"" />
     </Property>
     <Annotation Term=""Core.Description"" String=""The Link term is inspired by the `atom:link` element, see [RFC4287](https://tools.ietf.org/html/rfc4287#section-4.2.7), and the `Link` HTTP header, see [RFC5988](https://tools.ietf.org/html/rfc5988)"" />
@@ -106,7 +113,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <ComplexType Name=""ExternalExampleValue"" BaseType=""Core.ExampleValue"">
     <Property Name=""ExternalValue"" Type=""Edm.String"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Url reference to the value in its literal format"" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""MessageType"">
@@ -115,7 +122,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     </Property>
     <Property Name=""message"" Type=""Edm.String"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Human-readable, language-dependent message text"" />
-      <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+      <Annotation Term=""Core.IsLanguageDependent"" />
     </Property>
     <Property Name=""severity"" Type=""Core.MessageSeverity"" Nullable=""false"">
       <Annotation Term=""Core.Description"" String=""Severity of the message"" />
@@ -140,7 +147,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <ComplexType Name=""ResourceExceptionType"" BaseType=""Core.ExceptionType"">
     <Property Name=""retryLink"" Type=""Edm.String"">
       <Annotation Term=""Core.Description"" String=""A GET request to this URL retries retrieving the problematic instance"" />
-      <Annotation Term=""Core.IsURL"" Bool=""true"" />
+      <Annotation Term=""Core.IsURL"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""DataModificationExceptionType"" BaseType=""Core.ExceptionType"">
@@ -151,6 +158,14 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.Description"" String=""Response code of the failed operation, e.g. 424 for a failed dependency"" />
       <Annotation Term=""Validation.Minimum"" Decimal=""100"" />
       <Annotation Term=""Validation.Maximum"" Decimal=""599"" />
+    </Property>
+  </ComplexType>
+  <ComplexType Name=""ContentDispositionType"">
+    <Property Name=""Type"" Type=""Edm.String"" DefaultValue=""attachment"" Nullable=""false"">
+      <Annotation Term=""Core.Description"" String=""The disposition type of the binary or stream value, see [RFC 6266, Disposition Type](https://datatracker.ietf.org/doc/html/rfc6266#section-4.2)"" />
+    </Property>
+    <Property Name=""Filename"" Type=""Edm.String"">
+      <Annotation Term=""Core.Description"" String=""The proposed filename for downloading the binary or stream value, see [RFC 6266, Disposition Parameter: 'Filename'](https://datatracker.ietf.org/doc/html/rfc6266#section-4.3)"" />
     </Property>
   </ComplexType>
   <ComplexType Name=""AlternateKey"">
@@ -175,6 +190,18 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.Description"" String=""Default value for an optional parameter of primitive or enumeration type, using the same rules as the `cast` function in URLs."" />
       <Annotation Term=""Core.LongDescription"" String=""If no explicit DefaultValue is specified, the service is free on how to interpret omitting the parameter from the request. For example, a service might interpret an omitted optional parameter `KeyDate` as having the current date."" />
     </Property>
+  </ComplexType>
+  <ComplexType Name=""GeometryFeatureType"">
+    <Property Name=""geometry"" Type=""Edm.Geometry"">
+      <Annotation Term=""Core.Description"" String=""Location of the Feature"" />
+    </Property>
+    <Property Name=""properties"" Type=""Core.Dictionary"">
+      <Annotation Term=""Core.Description"" String=""Properties of the Feature"" />
+    </Property>
+    <Property Name=""id"" Type=""Edm.String"">
+      <Annotation Term=""Core.Description"" String=""Commonly used identifer for a Feature"" />
+    </Property>
+    <Annotation Term=""Core.Description"" String=""A [Feature Object](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2) represents a spatially bounded thing"" />
   </ComplexType>
   <EnumType Name=""RevisionKind"">
     <Member Name=""Added"">
@@ -227,10 +254,10 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
       <Annotation Term=""Core.Description"" String=""Permission to invoke actions"" />
     </Member>
   </EnumType>
-  <Term Name=""ODataVersions"" Type=""Edm.String"" AppliesTo=""EntityContainer"">
+  <Term Name=""ODataVersions"" Type=""Edm.String"" AppliesTo=""EntityContainer"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""A space-separated list of supported versions of the OData Protocol. Note that 4.0 is implied by 4.01 and does not need to be separately listed."" />
   </Term>
-  <Term Name=""SchemaVersion"" Type=""Edm.String"" AppliesTo=""Schema Reference"">
+  <Term Name=""SchemaVersion"" Type=""Edm.String"" AppliesTo=""Schema Reference"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Service-defined value representing the version of the schema. Services MAY use semantic versioning, but clients MUST NOT assume this is the case."" />
   </Term>
   <Term Name=""Revisions"" Type=""Collection(Core.RevisionType)"" Nullable=""false"">
@@ -238,11 +265,11 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   </Term>
   <Term Name=""Description"" Type=""Edm.String"">
     <Annotation Term=""Core.Description"" String=""A brief description of a model element"" />
-    <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+    <Annotation Term=""Core.IsLanguageDependent"" />
   </Term>
   <Term Name=""LongDescription"" Type=""Edm.String"">
-    <Annotation Term=""Core.Description"" String=""A lengthy description of a model element"" />
-    <Annotation Term=""Core.IsLanguageDependent"" Bool=""true"" />
+    <Annotation Term=""Core.Description"" String=""A long description of a model element"" />
+    <Annotation Term=""Core.IsLanguageDependent"" />
   </Term>
   <Term Name=""Links"" Type=""Collection(Core.Link)"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Link to related information"" />
@@ -271,12 +298,16 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Annotation Term=""Core.Description"" String=""Properties and terms annotated with this term are language-dependent"" />
     <Annotation Term=""Core.RequiresType"" String=""Edm.String"" />
   </Term>
-  <Term Name=""RequiresType"" Type=""Edm.String"" AppliesTo=""Term"">
+  <Term Name=""RequiresType"" Type=""Edm.String"" AppliesTo=""Term"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Terms annotated with this term can only be applied to elements that have a type that is identical to or derived from the given type name"" />
   </Term>
-  <Term Name=""ResourcePath"" Type=""Edm.String"" AppliesTo=""EntitySet Singleton ActionImport FunctionImport"">
+  <Term Name=""AppliesViaContainer"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Term"" Nullable=""false"">
+    <Annotation Term=""Core.Description"" String=""The target path of an annotation with the tagged term MUST start with an entity container or the annotation MUST be embedded within an entity container, entity set or singleton"" />
+    <Annotation Term=""Core.LongDescription"" String=""Services MAY additionally annotate a container-independent model element (entity type, property, navigation property) if allowed by the `AppliesTo` property of the term&#xA;      and the annotation applies to all uses of that model element."" />
+  </Term>
+  <Term Name=""ResourcePath"" Type=""Edm.String"" AppliesTo=""EntitySet Singleton ActionImport FunctionImport"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Resource path for entity container child, can be relative to xml:base and the request URL"" />
-    <Annotation Term=""Core.IsURL"" Bool=""true"" />
+    <Annotation Term=""Core.IsURL"" />
   </Term>
   <Term Name=""DereferenceableIDs"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityContainer"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Entity-ids are URLs that locate the identified entity"" />
@@ -284,10 +315,10 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""ConventionalIDs"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityContainer"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Entity-ids follow OData URL conventions"" />
   </Term>
-  <Term Name=""Permissions"" Type=""Core.Permission"" AppliesTo=""Property ComplexType TypeDefinition EntityType EntitySet NavigationProperty Action Function"">
+  <Term Name=""Permissions"" Type=""Core.Permission"" AppliesTo=""Property ComplexType TypeDefinition EntityType EntitySet NavigationProperty Action Function"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Permissions for accessing a resource"" />
   </Term>
-  <Term Name=""ContentID"" Type=""Edm.String"">
+  <Term Name=""ContentID"" Type=""Edm.String"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""A unique identifier for nested entities within a request."" />
   </Term>
   <Term Name=""DefaultNamespace"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Schema Include"" Nullable=""false"">
@@ -307,28 +338,32 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Annotation Term=""Core.Description"" String=""Properties and terms annotated with this term MUST contain a valid URL"" />
     <Annotation Term=""Core.RequiresType"" String=""Edm.String"" />
   </Term>
-  <Term Name=""AcceptableMediaTypes"" Type=""Collection(Edm.String)"" AppliesTo=""EntityType Property"" Nullable=""false"">
-    <Annotation Term=""Core.Description"" String=""Lists the MIME types acceptable for the annotated entity type marked with HasStream=&quot;true&quot; or the annotated stream property"" />
-    <Annotation Term=""Core.IsMediaType"" Bool=""true"" />
+  <Term Name=""AcceptableMediaTypes"" Type=""Collection(Edm.String)"" AppliesTo=""EntityType Property Term TypeDefinition Parameter ReturnType"" Nullable=""false"">
+    <Annotation Term=""Core.Description"" String=""Lists the MIME types acceptable for the annotated entity type marked with HasStream=&quot;true&quot; or the annotated binary, stream, or string property or term"" />
+    <Annotation Term=""Core.LongDescription"" String=""The annotation of a TypeDefinition propagates to the model elements having this type"" />
+    <Annotation Term=""Core.IsMediaType"" />
   </Term>
-  <Term Name=""MediaType"" Type=""Edm.String"" AppliesTo=""Property"">
-    <Annotation Term=""Core.Description"" String=""The media type of a binary resource"" />
-    <Annotation Term=""Core.IsMediaType"" Bool=""true"" />
-    <Annotation Term=""Core.RequiresType"" String=""Edm.Binary"" />
+  <Term Name=""MediaType"" Type=""Edm.String"" AppliesTo=""EntityType Property Term TypeDefinition Parameter ReturnType"">
+    <Annotation Term=""Core.Description"" String=""The media type of the media stream of the annotated entity type marked with HasStream=&quot;true&quot; or the annotated binary, stream, or string property or term"" />
+    <Annotation Term=""Core.LongDescription"" String=""The annotation of a TypeDefinition propagates to the model elements having this type"" />
+    <Annotation Term=""Core.IsMediaType"" />
   </Term>
   <Term Name=""IsMediaType"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Property Term"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Properties and terms annotated with this term MUST contain a valid MIME type"" />
     <Annotation Term=""Core.RequiresType"" String=""Edm.String"" />
   </Term>
+  <Term Name=""ContentDisposition"" Type=""Core.ContentDispositionType"" AppliesTo=""EntityType Property Term"" Nullable=""false"">
+    <Annotation Term=""Core.Description"" String=""The content disposition of the media stream of the annotated entity type marked with HasStream=&quot;true&quot; or the annotated binary, stream, or string property or term"" />
+  </Term>
   <Term Name=""OptimisticConcurrency"" Type=""Collection(Edm.PropertyPath)"" AppliesTo=""EntitySet"" Nullable=""false"">
-    <Annotation Term=""Core.Description"" String=""Data modification requires the use of ETags. A non-empty collection contains the set of properties that are used to compute the ETag. An empty collection means that the service won't tell how it computes the ETag."" />
+    <Annotation Term=""Core.Description"" String=""Data modification requires the use of ETags. A non-empty collection contains the set of properties that are used to compute the ETag. An empty collection means that the service won't tell how it computes the ETag"" />
   </Term>
   <Term Name=""AdditionalProperties"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityType ComplexType"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Instances of this type may contain properties in addition to those declared in $metadata"" />
     <Annotation Term=""Core.LongDescription"" String=""If specified as false clients can assume that instances will not contain dynamic properties, irrespective of the value of the OpenType attribute."" />
   </Term>
-  <Term Name=""AutoExpand"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""NavigationProperty Property"" Nullable=""false"">
-    <Annotation Term=""Core.Description"" String=""The service will automatically expand this stream or navigation property even if not requested with $expand"" />
+  <Term Name=""AutoExpand"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityType NavigationProperty Property"" Nullable=""false"">
+    <Annotation Term=""Core.Description"" String=""The service will automatically expand this stream property, navigation property, or the media stream of this media entity type even if not requested with $expand"" />
   </Term>
   <Term Name=""AutoExpandReferences"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""NavigationProperty"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""The service will automatically expand this navigation property as entity references even if not requested with $expand=.../$ref"" />
@@ -336,7 +371,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""MayImplement"" Type=""Collection(Core.QualifiedTypeName)"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""A collection of qualified type names outside of the type hierarchy that instances of this type might be addressable as by using a type-cast segment."" />
   </Term>
-  <Term Name=""Ordered"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Property NavigationProperty EntitySet ReturnType"" Nullable=""false"">
+  <Term Name=""Ordered"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Property NavigationProperty EntitySet ReturnType Term"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Collection has a stable order. Ordered collections of primitive or complex types can be indexed by ordinal."" />
   </Term>
   <Term Name=""PositionalInsert"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""Property NavigationProperty EntitySet"" Nullable=""false"">
@@ -345,7 +380,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""AlternateKeys"" Type=""Collection(Core.AlternateKey)"" AppliesTo=""EntityType EntitySet NavigationProperty"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Communicates available alternate keys"" />
   </Term>
-  <Term Name=""OptionalParameter"" Type=""Core.OptionalParameterType"" AppliesTo=""Parameter"">
+  <Term Name=""OptionalParameter"" Type=""Core.OptionalParameterType"" AppliesTo=""Parameter"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""Supplying a value for the action or function parameter is optional."" />
     <Annotation Term=""Core.LongDescription"" String=""All parameters marked as optional must come after any parameters not marked as optional. The binding parameter must not be marked as optional."" />
   </Term>
@@ -358,6 +393,16 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   </Term>
   <Term Name=""ExplicitOperationBindings"" Type=""Collection(Core.QualifiedBoundOperationName)"">
     <Annotation Term=""Core.Description"" String=""The qualified names of explicitly bound operations that are supported on the target model element. These operations are in addition to any operations not annotated with RequiresExplicitBinding that are bound to the type of the target model element."" />
+  </Term>
+  <Term Name=""SymbolicName"" Type=""Core.SimpleIdentifier"" Nullable=""false"">
+    <Annotation Term=""Core.Description"" String=""A symbolic name for a model element"" />
+  </Term>
+  <Term Name=""GeometryFeature"" Type=""Core.GeometryFeatureType"">
+    <Annotation Term=""Core.Description"" String=""A [Feature Object](https://datatracker.ietf.org/doc/html/rfc7946#section-3.2) represents a spatially bounded thing"" />
+  </Term>
+  <Term Name=""AnyStructure"" Type=""Core.Tag"" DefaultValue=""true"" AppliesTo=""EntityType ComplexType"" Nullable=""false"">
+    <Annotation Term=""Core.Description"" String=""Instances of a type are annotated with this tag if they have no common structure in a given response payload"" />
+    <Annotation Term=""Core.LongDescription"" String=""The select-list of a context URL MUST be `(@Core.AnyStructure)` if it would otherwise be empty,&#xA;      but this instance annotation SHOULD be omitted from the response value."" />
   </Term>
 </Schema>";
 
@@ -492,15 +537,15 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
         [InlineData("OptionalParameter", "Org.OData.Core.V1.OptionalParameterType", "Parameter")]
         [InlineData("AlternateKeys", "Collection(Org.OData.Core.V1.AlternateKey)", "EntityType EntitySet NavigationProperty")]
         [InlineData("PositionalInsert", "Org.OData.Core.V1.Tag", "Property NavigationProperty EntitySet")]
-        [InlineData("Ordered", "Org.OData.Core.V1.Tag", "Property NavigationProperty EntitySet ReturnType")]
+        [InlineData("Ordered", "Org.OData.Core.V1.Tag", "Property NavigationProperty EntitySet ReturnType Term")]
         [InlineData("MayImplement", "Collection(Org.OData.Core.V1.QualifiedTypeName)", null)]
         [InlineData("AutoExpandReferences", "Org.OData.Core.V1.Tag", "NavigationProperty")]
-        [InlineData("AutoExpand", "Org.OData.Core.V1.Tag", "NavigationProperty Property")]
+        [InlineData("AutoExpand", "Org.OData.Core.V1.Tag", "EntityType NavigationProperty Property")]
         [InlineData("AdditionalProperties", "Org.OData.Core.V1.Tag", "EntityType ComplexType")]
         [InlineData("OptimisticConcurrency", "Collection(Edm.PropertyPath)", "EntitySet")]
         [InlineData("IsMediaType", "Org.OData.Core.V1.Tag", "Property Term")]
-        [InlineData("MediaType", "Edm.String", "Property")]
-        [InlineData("AcceptableMediaTypes", "Collection(Edm.String)", "EntityType Property")]
+        [InlineData("MediaType", "Edm.String", "EntityType Property Term TypeDefinition Parameter ReturnType")]
+        [InlineData("AcceptableMediaTypes", "Collection(Edm.String)", "EntityType Property Term TypeDefinition Parameter ReturnType")]
         [InlineData("IsURL", "Org.OData.Core.V1.Tag", "Property Term")]
         [InlineData("ComputedDefaultValue", "Org.OData.Core.V1.Tag", "Property")]
         [InlineData("Computed", "Org.OData.Core.V1.Tag", "Property")]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.cs
@@ -36,6 +36,11 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
     <Property Name=""Value"" Type=""Edm.PrimitiveType"">
       <Annotation Term=""Core.Description"" String=""An allowed value for the property, parameter, or type definition"" />
     </Property>
+    <Annotation Term=""Validation.ApplicableTerms"">
+      <Collection>
+        <String>Core.SymbolicName</String>
+      </Collection>
+    </Annotation>
   </ComplexType>
   <ComplexType Name=""ConstraintType"">
     <Property Name=""FailureMessage"" Type=""Edm.String"">


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2246.*

### Description

When trying to parse the OData core vocabulary CSDL (https://raw.githubusercontent.com/oasis-tcs/odata-vocabularies/main/vocabularies/Org.OData.Core.V1.xml) using the `CsdlReader`, an exception with the following message is thrown:
```
UnexpectedXmlAttribute : The attribute 'MaxLength' was not expected in the given context. : (523, 75)
```

The error in parsing the core vocabulary (Org.OData.Core.V1.xml) is caused by `SimpleIdentifier` type definition that has a `MaxLength` property:
```xml
<TypeDefinition Name="SimpleIdentifier" UnderlyingType="Edm.String" MaxLength="128">
    <Annotation Term="Core.Description" String="A [simple identifier](https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_SimpleIdentifier)" />
    <Annotation Term="Validation.Pattern" String="^[\p{L}\p{Nl}_][\p{L}\p{Nl}\p{Nd}\p{Mn}\p{Mc}\p{Pc}\p{Cf}]{0,}$" />
</TypeDefinition>
```
The Edm library currently doesn't support parsing of facets (`MaxLength`, `Unicode`, `Precision`, `Scale` and `SRID`) on type definitions. The library however supports parsing of facets specified where the type definition is used, e.g.:
```xml
<Term Name="SymbolicName" Type="Core.SimpleIdentifier" MaxLength="128" Nullable="false">
	<Annotation Term="Core.Description" String="A symbolic name for a model element" />
</Term>
```

This pull request updates the OData vocabularies since they had diverged from those on [the OASIS TCS repository](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies).

Existing tests have also been updated to verify the updated vocabularies.
The `MaxLength` facet on the `SimpleIdentifier` has been intentionally stripped so parsing does break pending the redesign of the library to handle parsing of facets on type definition - to be tracked separately.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*