### PR TITLE
DeepInsert - Only handle non resolved entries in DeepInsertSaveResult. Fix for #2783.

### DIFF
--- a/src/Microsoft.OData.Client/DeepInsertSaveResult.cs
+++ b/src/Microsoft.OData.Client/DeepInsertSaveResult.cs
@@ -417,6 +417,11 @@ namespace Microsoft.OData.Client
 
         private void HandleDeepInsertResponseInternal(MaterializerEntry entry, bool isTopLevelDescriptor, Descriptor descriptor, OperationResponse parentOperationResponse)
         {
+            if (entry.EntityHasBeenResolved)
+            {
+                return;
+            }
+
             OperationResponse response = this.CreateOperationResponse(entry, isTopLevelDescriptor, descriptor, parentOperationResponse);
 
             List<Descriptor> relatedDescriptors = this.BulkUpdateGraph.GetRelatedDescriptors(descriptor);

--- a/src/Microsoft.OData.Client/Materialization/FeedAndEntryMaterializerAdapter.cs
+++ b/src/Microsoft.OData.Client/Materialization/FeedAndEntryMaterializerAdapter.cs
@@ -384,19 +384,15 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="materializerState">The <see cref="IMaterializerState"/> entry being added to the parent item.</param>
         private void AddDeltaResourceToParent(IMaterializerState materializerState)
         {
-            // Only add entries that are entities (having an Url).
-            if (materializerState is MaterializerNestedEntry nestedEntry && nestedEntry.NestedResourceInfo.Url != null)
-            {
-                IMaterializerState topItem = this.deltaMaterializerStateItems.Peek();
+            IMaterializerState topItem = this.deltaMaterializerStateItems.Peek();
 
-                if (topItem is MaterializerDeltaFeed delta)
-                {
-                    delta.AddEntry(materializerState);
-                }
-                else if (topItem is MaterializerEntry entry)
-                {
-                    entry.AddNestedItem(materializerState);
-                }
+            if (topItem is MaterializerDeltaFeed delta)
+            {
+                delta.AddEntry(materializerState);
+            }
+            else if (topItem is MaterializerEntry entry)
+            {
+                entry.AddNestedItem(materializerState);
             }
         }
 
@@ -406,15 +402,11 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="materializerState">The <see cref="IMaterializerState"/> entry being added to the parent item.</param>
         private void AddResourceToParent(IMaterializerState materializerState)
         {
-            // Only add entries that are entities (having an Url).
-            if (materializerState is MaterializerNestedEntry nestedEntry && nestedEntry.NestedResourceInfo.Url != null)
-            {
-                IMaterializerState topItem = this.entryMaterializerStateItems.Peek();
+            IMaterializerState topItem = this.entryMaterializerStateItems.Peek();
 
-                if (topItem is MaterializerEntry entry)
-                {
-                    entry.AddNestedItem(materializerState);
-                }
+            if (topItem is MaterializerEntry entry)
+            {
+                entry.AddNestedItem(materializerState);
             }
         }
 

--- a/src/Microsoft.OData.Client/Materialization/FeedAndEntryMaterializerAdapter.cs
+++ b/src/Microsoft.OData.Client/Materialization/FeedAndEntryMaterializerAdapter.cs
@@ -384,15 +384,19 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="materializerState">The <see cref="IMaterializerState"/> entry being added to the parent item.</param>
         private void AddDeltaResourceToParent(IMaterializerState materializerState)
         {
-            IMaterializerState topItem = this.deltaMaterializerStateItems.Peek();
+            // Only add entries that are entities (having an Url).
+            if (materializerState is MaterializerNestedEntry nestedEntry && nestedEntry.NestedResourceInfo.Url != null)
+            {
+                IMaterializerState topItem = this.deltaMaterializerStateItems.Peek();
 
-            if (topItem is MaterializerDeltaFeed delta)
-            {
-                delta.AddEntry(materializerState);
-            }
-            else if (topItem is MaterializerEntry entry)
-            {
-                entry.AddNestedItem(materializerState);
+                if (topItem is MaterializerDeltaFeed delta)
+                {
+                    delta.AddEntry(materializerState);
+                }
+                else if (topItem is MaterializerEntry entry)
+                {
+                    entry.AddNestedItem(materializerState);
+                }
             }
         }
 
@@ -402,11 +406,15 @@ namespace Microsoft.OData.Client.Materialization
         /// <param name="materializerState">The <see cref="IMaterializerState"/> entry being added to the parent item.</param>
         private void AddResourceToParent(IMaterializerState materializerState)
         {
-            IMaterializerState topItem = this.entryMaterializerStateItems.Peek();
-
-            if (topItem is MaterializerEntry entry)
+            // Only add entries that are entities (having an Url).
+            if (materializerState is MaterializerNestedEntry nestedEntry && nestedEntry.NestedResourceInfo.Url != null)
             {
-                entry.AddNestedItem(materializerState);
+                IMaterializerState topItem = this.entryMaterializerStateItems.Peek();
+
+                if (topItem is MaterializerEntry entry)
+                {
+                    entry.AddNestedItem(materializerState);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2783.*

### Description

*Entries are only added as nested item if it has an url (represents an entity).*

### Checklist (Uncheck if it is not completed)

- [ x] *Test cases added*
- [ x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
