### PR TITLE
fixes #2785: support property instance annotation without property value

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -1026,7 +1026,7 @@ namespace Microsoft.OData.JsonLight
             return property;
         }
 
-        protected static void AttachODataAnnotations(IODataJsonLightReaderResourceState resourceState, string propertyName, ODataProperty property)
+        protected static void AttachODataAnnotations(IODataJsonLightReaderResourceState resourceState, string propertyName, ODataPropertyInfo property)
         {
             foreach (KeyValuePair<string, object> annotation
                      in propertyName.Length == 0

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -1574,6 +1574,11 @@ namespace Microsoft.OData.JsonLight
         /// </remarks>
         private bool ReadAtNestedPropertyInfoSynchronously()
         {
+            Debug.Assert(this.CurrentScope.State == ODataReaderState.NestedProperty, "Must be on 'NestedProperty' scope.");
+            JsonLightNestedPropertyInfoScope nestedPropertyInfoScope = (JsonLightNestedPropertyInfoScope)this.CurrentScope;
+            ODataJsonLightReaderNestedPropertyInfo nestedPropertyInfo = nestedPropertyInfoScope.ReaderNestedPropertyInfo;
+            Debug.Assert(nestedPropertyInfo != null);
+
             ODataPropertyInfo propertyInfo = this.CurrentScope.Item as ODataPropertyInfo;
             Debug.Assert(propertyInfo != null, "Reading Nested Property Without an ODataPropertyInfo");
 
@@ -1582,10 +1587,18 @@ namespace Microsoft.OData.JsonLight
             {
                 this.StartNestedStreamInfo(new ODataJsonLightReaderStreamInfo(streamPropertyInfo.PrimitiveTypeKind, streamPropertyInfo.ContentType));
             }
+            else if (!nestedPropertyInfo.WithValue)
+            {
+                // It's a nested non-stream property
+                this.PopScope(ODataReaderState.NestedProperty);
+
+                // We are reading a next nested info.
+                return this.ReadNextNestedInfo();
+            }
             else
             {
                 this.StartNestedStreamInfo(
-                    new ODataJsonLightReaderStreamInfo(propertyInfo.PrimitiveTypeKind));
+                   new ODataJsonLightReaderStreamInfo(propertyInfo.PrimitiveTypeKind));
             }
 
             return true;
@@ -4096,7 +4109,13 @@ namespace Microsoft.OData.JsonLight
                       navigationSource, EdmCoreModel.Instance.GetPrimitive(EdmPrimitiveTypeKind.Stream, true), odataUri)
             {
                 Debug.Assert(nestedPropertyInfo != null, "JsonLightNestedInfoScope created with a null nestedPropertyInfo");
+                ReaderNestedPropertyInfo = nestedPropertyInfo;
             }
+
+            /// <summary>
+            /// The nested property info for the nested property info to report.
+            /// </summary>
+            public ODataJsonLightReaderNestedPropertyInfo ReaderNestedPropertyInfo { get; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReaderNestedPropertyInfo.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReaderNestedPropertyInfo.cs
@@ -12,11 +12,14 @@ namespace Microsoft.OData.JsonLight
 
     internal class ODataJsonLightReaderNestedPropertyInfo : ODataJsonLightReaderNestedInfo
     {
-        internal ODataJsonLightReaderNestedPropertyInfo(ODataPropertyInfo nestedPropertyInfo, IEdmProperty nestedProperty) : base(nestedProperty)
+        internal ODataJsonLightReaderNestedPropertyInfo(ODataPropertyInfo nestedPropertyInfo, IEdmProperty nestedProperty, bool withValue = true) : base(nestedProperty)
         {
-            this.NestedPropertyInfo = nestedPropertyInfo;
+            NestedPropertyInfo = nestedPropertyInfo;
+            WithValue = withValue;
         }
 
-        internal ODataPropertyInfo NestedPropertyInfo { get; set; }
+        internal ODataPropertyInfo NestedPropertyInfo { get; }
+
+        public bool WithValue { get; }
     }
 }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
@@ -1436,22 +1436,6 @@ namespace Microsoft.OData.JsonLight
             Debug.Assert(propertyName != null, "Property name must not be null");
 
             IEdmTypeReference propertyType = property?.Type;
-            IDictionary<string, object> odataAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(propertyName);
-            IList<KeyValuePair<string, object>> customAnnotations = resourceState.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations(propertyName).ToList();
-            if (odataAnnotations.Count == 0 && customAnnotations.Count == 0)
-            {
-                // If we don't have any annotations for the property, it could contain errors.
-                if (property != null)
-                {
-                    throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType(propertyName, propertyType.FullName()));
-                }
-                else
-                {
-                    // it's a dynamic property
-                    throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_OpenPropertyWithoutValue(propertyName));
-                }
-            }
-
             IEdmPrimitiveType primitiveType = propertyType == null ? null : propertyType.Definition.AsElementType() as IEdmPrimitiveType;
             ODataPropertyInfo propertyInfo = new ODataPropertyInfo
             {
@@ -1461,6 +1445,7 @@ namespace Microsoft.OData.JsonLight
 
             AttachODataAnnotations(resourceState, propertyName, propertyInfo);
 
+            IEnumerable<KeyValuePair<string, object>> customAnnotations = resourceState.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations(propertyName);
             foreach (KeyValuePair<string, object> annotation in customAnnotations)
             {
                  // annotation.Value == null indicates that this annotation should be skipped?

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightResourceDeserializer.cs
@@ -1437,8 +1437,8 @@ namespace Microsoft.OData.JsonLight
 
             IEdmTypeReference propertyType = property?.Type;
             IDictionary<string, object> odataAnnotations = resourceState.PropertyAndAnnotationCollector.GetODataPropertyAnnotations(propertyName);
-            IList<KeyValuePair<string, object>> propertyAnnotations = resourceState.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations(propertyName).ToList();
-            if ((odataAnnotations.Count + propertyAnnotations.Count) == 0)
+            IList<KeyValuePair<string, object>> customAnnotations = resourceState.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations(propertyName).ToList();
+            if (odataAnnotations.Count == 0 && customAnnotations.Count == 0)
             {
                 // If we don't have any annotations for the property, it could contain errors.
                 if (property != null)
@@ -1461,7 +1461,7 @@ namespace Microsoft.OData.JsonLight
 
             AttachODataAnnotations(resourceState, propertyName, propertyInfo);
 
-            foreach (KeyValuePair<string, object> annotation in propertyAnnotations)
+            foreach (KeyValuePair<string, object> annotation in customAnnotations)
             {
                  // annotation.Value == null indicates that this annotation should be skipped?
                  propertyInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation(annotation.Key, annotation.Value.ToODataValue()));
@@ -1756,7 +1756,6 @@ namespace Microsoft.OData.JsonLight
             // Property without a value can't be ignored if we don't know what it is.
             if (!propertyWithValue)
             {
-                // TODO: Shall we return ODataJsonLightReaderNestedPropertyInfo for a dynamic property without value?
                 throw new ODataException(ODataErrorStrings.ODataJsonLightResourceDeserializer_PropertyWithoutValueWithUnknownType(propertyName));
             }
 

--- a/src/Microsoft.OData.Core/PropertyAndAnnotationCollector.cs
+++ b/src/Microsoft.OData.Core/PropertyAndAnnotationCollector.cs
@@ -95,7 +95,7 @@ namespace Microsoft.OData
         /// Validates that no duplicate property exists.
         /// </summary>
         /// <param name="property">The property to be validated.</param>
-        internal void CheckForDuplicatePropertyNames(ODataProperty property)
+        internal void CheckForDuplicatePropertyNames(ODataPropertyInfo property)
         {
             Debug.Assert(property != null);
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerTests.cs
@@ -495,13 +495,19 @@ namespace Microsoft.OData.Tests.JsonLight
         #region Entity properties instance annotation
 
         [Fact]
-        public void ParsingInstanceAnnotationInNonExistingEntityPropertyShouldThrow()
+        public void ParsingInstanceAnnotationInNonExistingEntityPropertyShouldReadAsNestedPropertyInfo()
         {
             var deserializer = this.CreateJsonLightEntryAndFeedDeserializer("{\"ID@custom.annotation\":123}");
             AdvanceReaderToFirstProperty(deserializer.JsonReader);
             var entryState = new TestJsonLightReaderEntryState();
-            Action action = () => deserializer.ReadResourceContent(entryState);
-            action.Throws<ODataException>(ErrorStrings.ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType("ID", "Edm.Int32"));
+            var nestedInfo = deserializer.ReadResourceContent(entryState);
+            ODataJsonLightReaderNestedPropertyInfo nestedPropertyInfo = Assert.IsType<ODataJsonLightReaderNestedPropertyInfo>(nestedInfo);
+            Assert.False(nestedPropertyInfo.WithValue);
+            Assert.NotNull(nestedPropertyInfo.NestedProperty);
+            Assert.Equal("ID", nestedPropertyInfo.NestedProperty.Name);
+            ODataInstanceAnnotation annotation = Assert.Single(nestedPropertyInfo.NestedPropertyInfo.InstanceAnnotations);
+            Assert.Equal("custom.annotation", annotation.Name);
+            TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(123), annotation.Value);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceDeserializerTests.cs
@@ -306,6 +306,32 @@ namespace Microsoft.OData.Tests.JsonLight
         }
 
         [Fact]
+        public async Task ReadResourceContentWithPropertyWithoutValueButWithCustomAnnotationsAsync()
+        {
+            this.messageReaderSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("custom.instance");
+
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +
+                "\"Id\":41," +
+                "\"Name@custom.instance\":\"Food\"}";
+
+            await SetupJsonLightResourceSerializerAndRunReadResourceContextTestAsync(
+                payload,
+                this.categoriesEntitySet,
+                this.categoryEntityType,
+                (resourceState) =>
+                {
+                    var resource = resourceState.Resource;
+                    Assert.NotNull(resource);
+                    var idProperty = Assert.Single(resource.Properties);
+                    Assert.Equal("Id", idProperty.Name);
+                    Assert.Equal(41, idProperty.Value);
+
+                    var customAnnotations = resourceState.PropertyAndAnnotationCollector.GetCustomPropertyAnnotations("Name");
+                    Assert.Contains(new KeyValuePair<string, object>("custom.instance", "Food"), customAnnotations);
+                });
+        }
+
+        [Fact]
         public async Task ReadResourceContentWithExpandedSingletonNavigationPropertyInResponsePayloadAsync()
         {
             var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Categories/$entity\"," +

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamReadingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamReadingTests.cs
@@ -15,12 +15,122 @@ namespace Microsoft.OData.Tests.JsonLight
 {
     public class ODataJsonLightStreamReadingTests
     {
-        private EdmModel model;
-        private IEdmEntitySet customersEntitySet;
         private string binaryString = "binaryString";
         private string stringValue = "My String Value";
         private string binaryValue = "DGJpbmFyeVN0cmluZw==";
         private string resourcePayload = "{{\"@context\":\"http://testservice/$metadata#customers/$entity\",\"id\":\"1\"{0}}}";
+
+        // Since the model doesn't change for all test cases, let's create once for all test cases.
+        private static IEdmModel Model;
+        private static IEdmEntitySet CustomersEntitySet;
+        static ODataJsonLightStreamReadingTests()
+        {
+            var model = new EdmModel();
+            var enumType = new EdmEnumType("test", "gender");
+            enumType.AddMember(new EdmEnumMember(enumType, "male", new EdmEnumMemberValue(0)));
+            enumType.AddMember(new EdmEnumMember(enumType, "female", new EdmEnumMemberValue(1)));
+
+            var customerType = new EdmEntityType("test", "customer", null, false, true);
+            customerType.AddKeys(customerType.AddStructuralProperty("id", EdmPrimitiveTypeKind.String, false));
+            customerType.AddStructuralProperty("name", EdmPrimitiveTypeKind.String);
+            customerType.AddStructuralProperty("nickName", EdmPrimitiveTypeKind.String);
+            customerType.AddStructuralProperty("age", EdmPrimitiveTypeKind.Int32, false);
+            customerType.AddStructuralProperty("isMarvel", EdmPrimitiveTypeKind.Boolean, false);
+            customerType.AddStructuralProperty("gender", new EdmEnumTypeReference(enumType, true));
+            customerType.AddStructuralProperty("stream", EdmPrimitiveTypeKind.Stream);
+            customerType.AddStructuralProperty("binaryAsStream", EdmPrimitiveTypeKind.Binary);
+            customerType.AddStructuralProperty("comments", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true))));
+            model.AddElement(customerType);
+
+            var container = model.AddEntityContainer("test", "container");
+            CustomersEntitySet = container.AddEntitySet("customers", customerType);
+            Model = model;
+        }
+
+        [Fact]
+        public void ReadNonStreamPrimitivePropertyWithoutValueButWithInstanceAnnotations()
+        {
+            // Intentionally add 'name' property at the end of the payload.
+            string payload = String.Format(resourcePayload,
+                ",\"stream@Custom.ComplexAnnotation\": {\"description\":\"abc\"},\"name\":\"sam\""
+                );
+
+            foreach (Variant variant in GetVariants(null))
+            {
+                int expectedPropertyCount = variant.IsRequest ? 3 : 3;
+                ODataResource resource = null;
+                ODataPropertyInfo nestedPropertyInfo = null;
+
+                ODataReader reader = CreateODataReader(payload, variant);
+                while (reader.Read())
+                {
+                    switch (reader.State)
+                    {
+                        case ODataReaderState.ResourceStart:
+                            resource = reader.Item as ODataResource;
+                            break;
+
+                        case ODataReaderState.NestedProperty:
+                            nestedPropertyInfo = reader.Item as ODataPropertyInfo;
+                            break;
+                    }
+                }
+
+                Assert.Null(nestedPropertyInfo); // Make sure there's no extra nested property info created for stream property?
+                Assert.NotNull(resource);
+                Assert.Equal(expectedPropertyCount, resource.Properties.Count());
+                Assert.NotNull(resource.Properties.FirstOrDefault(p => p.Name == "id"));
+                Assert.Equal("sam", resource.Properties.FirstOrDefault(p => p.Name == "name").Value);
+
+                ODataProperty streamProperty = resource.Properties.FirstOrDefault(p => p.Name == "stream");
+                Assert.NotNull(streamProperty);
+                ODataInstanceAnnotation annotation = Assert.Single(streamProperty.InstanceAnnotations);
+                Assert.Equal("Custom.ComplexAnnotation", annotation.Name);
+                ODataResourceValue resourceValue = Assert.IsType<ODataResourceValue>(annotation.Value);
+                ODataProperty descProperty = Assert.Single(resourceValue.Properties);
+                Assert.Equal("description", descProperty.Name);
+                Assert.Equal("abc", descProperty.Value);
+            }
+        }
+
+        [Fact]
+        public void ReadStreamPrimitivePropertyWithoutValueButWithInstanceAnnotation()
+        {
+            // Intentionally add 'name' property at the end of the payload.
+            string payload = String.Format(resourcePayload,
+                ",\"age@Custom.StartAnnotation\":123,\"age@Custom.StartAnnotation2\":true,\"name\":\"sam\""
+                );
+
+            foreach (Variant variant in GetVariants(null))
+            {
+                int expectedPropertyCount = variant.IsRequest ? 2 : 3;
+                ODataResource resource = null;
+                ODataPropertyInfo nestedPropertyInfo = null;
+
+                ODataReader reader = CreateODataReader(payload, variant);
+                while (reader.Read())
+                {
+                    switch (reader.State)
+                    {
+                        case ODataReaderState.ResourceStart:
+                            resource = reader.Item as ODataResource;
+                            break;
+
+                        case ODataReaderState.NestedProperty:
+                            nestedPropertyInfo = reader.Item as ODataPropertyInfo;
+                            break;
+                    }
+                }
+
+                Assert.NotNull(resource);
+                Assert.Equal(expectedPropertyCount, resource.Properties.Count());
+                Assert.NotNull(resource.Properties.FirstOrDefault(p => p.Name == "id"));
+                Assert.Equal("sam", resource.Properties.FirstOrDefault(p => p.Name == "name").Value);
+                Assert.NotNull(nestedPropertyInfo);
+                Assert.Equal("age", nestedPropertyInfo.Name);
+                Assert.Equal(2, nestedPropertyInfo.InstanceAnnotations.Count);
+            }
+        }
 
         [Fact]
         public void ReadPrimitiveCollectionProperty()
@@ -1167,37 +1277,6 @@ namespace Microsoft.OData.Tests.JsonLight
         }
 
         #region Helpers
-        private IEdmModel GetModel()
-        {
-            if (this.model == null)
-            {
-                var model = new EdmModel();
-
-                var enumType = new EdmEnumType("test", "gender");
-                enumType.AddMember(new EdmEnumMember(enumType, "male", new EdmEnumMemberValue(0)));
-                enumType.AddMember(new EdmEnumMember(enumType, "female", new EdmEnumMemberValue(1)));
-
-                var customerType = new EdmEntityType("test", "customer", null, false, true);
-                customerType.AddKeys(customerType.AddStructuralProperty("id", EdmPrimitiveTypeKind.String, false));
-                customerType.AddStructuralProperty("name", EdmPrimitiveTypeKind.String);
-                customerType.AddStructuralProperty("nickName", EdmPrimitiveTypeKind.String);
-                customerType.AddStructuralProperty("age", EdmPrimitiveTypeKind.Int32, false);
-                customerType.AddStructuralProperty("isMarvel", EdmPrimitiveTypeKind.Boolean, false);
-                customerType.AddStructuralProperty("gender", new EdmEnumTypeReference(enumType, true));
-                customerType.AddStructuralProperty("stream", EdmPrimitiveTypeKind.Stream);
-                customerType.AddStructuralProperty("binaryAsStream", EdmPrimitiveTypeKind.Binary);
-                customerType.AddStructuralProperty("comments", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true))));
-                model.AddElement(customerType);
-
-                var container = model.AddEntityContainer("test", "container");
-                this.customersEntitySet = container.AddEntitySet("customers", customerType);
-
-                this.model = model;
-            }
-
-            return this.model;
-        }
-
         private class Variant
         {
             public string Description;
@@ -1215,7 +1294,7 @@ namespace Microsoft.OData.Tests.JsonLight
             Full
         }
 
-        private IEnumerable<Variant> GetVariants(Func<IEdmPrimitiveType, bool, string, IEdmProperty, bool> readAsStream, bool includeUnordered = true)
+        private static IEnumerable<Variant> GetVariants(Func<IEdmPrimitiveType, bool, string, IEdmProperty, bool> readAsStream, bool includeUnordered = true)
         {
             List<Variant> variants = new List<Variant>();
             foreach (ODataVersion version in new ODataVersion[] { ODataVersion.V4, ODataVersion.V401 })
@@ -1244,6 +1323,7 @@ namespace Microsoft.OData.Tests.JsonLight
                                     Version = version,
                                     ReadUntypedAsString = false,
                                     ReadAsStreamFunc = readAsStream,
+                                    ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*")
                                 },
                                 IsRequest = isRequest,
                                 IsStreaming = isStreaming,
@@ -1257,11 +1337,21 @@ namespace Microsoft.OData.Tests.JsonLight
             return variants;
         }
 
-        private ODataReader CreateODataReader(string payload, Variant variant)
+        private static IDictionary<string, string> AnnotationPrefixes = new Dictionary<string, string>
+        {
+            { "@context", "@odata.context" },
+            { "@type", "@odata.type" },
+            { "@mediaContentType", "@odata.mediaContentType" }
+        };
+
+        private static ODataReader CreateODataReader(string payload, Variant variant)
         {
             if (variant.Version < ODataVersion.V401)
             {
-                payload = payload.Replace("@", "@odata.");
+                foreach (var item in AnnotationPrefixes)
+                {
+                    payload = payload.Replace(item.Key, item.Value);
+                }
             }
 
             var stream = new MemoryStream();
@@ -1279,7 +1369,7 @@ namespace Microsoft.OData.Tests.JsonLight
                 {
                     requestMessage.SetHeader("Content-Type", "application/json;odata.streaming=true");
                 }
-                messageReader = new ODataMessageReader(requestMessage, variant.Settings, this.GetModel());
+                messageReader = new ODataMessageReader(requestMessage, variant.Settings, Model);
             }
             else
             {
@@ -1288,14 +1378,14 @@ namespace Microsoft.OData.Tests.JsonLight
                 {
                     responseMessage.SetHeader("Content-Type", "application/json;odata.streaming=true");
                 }
-                    messageReader = new ODataMessageReader(responseMessage, variant.Settings, this.GetModel());
+                    messageReader = new ODataMessageReader(responseMessage, variant.Settings, Model);
             }
 
-            ODataReader reader = messageReader.CreateODataResourceReader(this.customersEntitySet, this.customersEntitySet.EntityType());
+            ODataReader reader = messageReader.CreateODataResourceReader(CustomersEntitySet, CustomersEntitySet.EntityType());
             return reader;
         }
 
-        private string ReadStream(ODataReader reader)
+        private static string ReadStream(ODataReader reader)
         {
             ODataStreamItem streamValue = reader.Item as ODataStreamItem;
             Assert.NotNull(streamValue);
@@ -1319,7 +1409,7 @@ namespace Microsoft.OData.Tests.JsonLight
             return result;
         }
 
-        private string ReadPartialStream(ODataReader reader)
+        private static string ReadPartialStream(ODataReader reader)
         {
             ODataStreamItem streamValue = reader.Item as ODataStreamItem;
             Assert.NotNull(streamValue);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
@@ -68,6 +68,55 @@ namespace Microsoft.OData.Tests.JsonLight
         }
 
         [Fact]
+        public void CanWritePrimitivePropertyInstanceAnnotationWithoutPropertyValue()
+        {
+            string expectedPayload = String.Format(resourcePayload,
+                ",\"age@Custom.StartAnnotation\":123"
+                );
+
+            RunTest((ODataWriter writer) =>
+            {
+                ODataPrimitiveValue primitiveValue = new ODataPrimitiveValue(123);
+                ODataPropertyInfo propertyInfo = new ODataPropertyInfo { Name = "age" };
+                propertyInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation("Custom.StartAnnotation", primitiveValue));
+
+                // write some properties within the resource and others separately
+                writer.WriteStart(resource);
+
+                writer.WriteStart(propertyInfo);
+                writer.WriteEnd(); // property
+
+                writer.WriteEnd(); // resource
+            },
+            expectedPayload);
+        }
+
+        [Fact]
+        public void CanWritePrimitivePropertyInstanceAnnotationWithPropertyValue()
+        {
+            string expectedPayload = String.Format(resourcePayload,
+                ",\"age@Custom.StartAnnotation\":123,\"age\":37"
+                );
+
+            RunTest((ODataWriter writer) =>
+            {
+                ODataPrimitiveValue primitiveValue = new ODataPrimitiveValue(123);
+                ODataPropertyInfo propertyInfo = new ODataPropertyInfo { Name = "age" };
+                propertyInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation("Custom.StartAnnotation", primitiveValue));
+
+                // write some properties within the resource and others separately
+                writer.WriteStart(resource);
+
+                writer.WriteStart(propertyInfo);
+                    writer.WritePrimitive(new ODataPrimitiveValue(37));
+                writer.WriteEnd(); // property
+
+                writer.WriteEnd(); // resource
+            },
+            expectedPayload);
+        }
+
+        [Fact]
         public void CanWriteBinaryPropertyAsStream()
         {
             string expectedPayload = String.Format(resourcePayload,
@@ -724,6 +773,7 @@ namespace Microsoft.OData.Tests.JsonLight
                     RequestUri = new Uri("http://testService/customers")
                 },
             };
+            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
 
             ODataMessageWriter messageWriter;
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
@@ -117,6 +117,30 @@ namespace Microsoft.OData.Tests.JsonLight
         }
 
         [Fact]
+        public void CanWriteDynamicPropertyWithInstanceAnnotationsButWithoutPropertyValue()
+        {
+            string expectedPayload = String.Format(resourcePayload,
+                 ",\"aDynamicProperty@Custom.StartAnnotation\":123"
+                 );
+
+            RunTest((ODataWriter writer) =>
+            {
+                ODataPrimitiveValue primitiveValue = new ODataPrimitiveValue(123);
+                ODataPropertyInfo propertyInfo = new ODataPropertyInfo { Name = "aDynamicProperty" };
+                propertyInfo.InstanceAnnotations.Add(new ODataInstanceAnnotation("Custom.StartAnnotation", primitiveValue));
+
+                // write some properties within the resource and others separately
+                writer.WriteStart(resource);
+
+                writer.WriteStart(propertyInfo);
+                writer.WriteEnd(); // property
+
+                writer.WriteEnd(); // resource
+            },
+            expectedPayload);
+        }
+
+        [Fact]
         public void CanWriteBinaryPropertyAsStream()
         {
             string expectedPayload = String.Format(resourcePayload,

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/StreamReferenceValueReaderJsonLightTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/StreamReferenceValueReaderJsonLightTests.cs
@@ -237,7 +237,6 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                     ExpectedEntity = PayloadBuilder.Entity(),
                     Json = 
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Name", JsonLightConstants.ODataMediaEditLinkAnnotationName) + "\":\"http://odata.org/streamproperty/editlink\"",
-                   // ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType", "Name", "Edm.String"),
                     OnlyResponse = true
                 },
                 new StreamPropertyTestCase

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/StreamReferenceValueReaderJsonLightTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/StreamReferenceValueReaderJsonLightTests.cs
@@ -126,14 +126,14 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "With odata.type annotation - should fail",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, null, null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataTypeAnnotationName) + "\":\"Edm.Stream\"",
                 },
                 new StreamPropertyTestCase
                 {
                     DebugDescription = "Everything with navigation link URL annotation - should fail",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", "http://odata.org/streamproperty/readlink", "http://odata.org/streamproperty/editlink", "streamproperty:contenttype", "streamproperty:etag"),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaEditLinkAnnotationName) + "\":\"http://odata.org/streamproperty/editlink\"," +
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaReadLinkAnnotationName) + "\":\"http://odata.org/streamproperty/readlink\"," +
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataNavigationLinkUrlAnnotationName) + "\":\"http://odata.org/streamproperty/navlink\"," +
@@ -145,7 +145,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "Invalid edit link - wrong primitive",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, null, null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaEditLinkAnnotationName) + "\":42",
                     ExpectedException = ODataExpectedExceptions.ODataException("JsonReaderExtensions_CannotReadPropertyValueAsString", "42", JsonLightConstants.ODataMediaEditLinkAnnotationName),
                     OnlyResponse = true,
@@ -154,7 +154,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "Invalid edit link - null",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, null, null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaEditLinkAnnotationName) + "\":null",
                     ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightReaderUtils_AnnotationWithNullValue", JsonLightConstants.ODataMediaEditLinkAnnotationName),
                     OnlyResponse = true,
@@ -163,7 +163,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "Invalid read link - wrong primitive",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, null, null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaReadLinkAnnotationName) + "\":true",
                     ExpectedException = ODataExpectedExceptions.ODataException("JsonReaderExtensions_CannotReadPropertyValueAsString", "True", JsonLightConstants.ODataMediaReadLinkAnnotationName),
                     OnlyResponse = true,
@@ -172,7 +172,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "Invalid read link - null",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, null, null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaReadLinkAnnotationName) + "\":null",
                     ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightReaderUtils_AnnotationWithNullValue", JsonLightConstants.ODataMediaReadLinkAnnotationName),
                     OnlyResponse = true,
@@ -181,7 +181,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "Invalid ETag - non primitive",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, null, null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaETagAnnotationName) + "\":[]",
                     ExpectedException = ODataExpectedExceptions.ODataException("JsonReaderExtensions_UnexpectedNodeDetected", "PrimitiveValue", "StartArray"),
                     OnlyResponse = true,
@@ -190,7 +190,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "Invalid ETag - null",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, null, null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaETagAnnotationName) + "\":null",
                     ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightReaderUtils_AnnotationWithNullValue", JsonLightConstants.ODataMediaETagAnnotationName),
                     OnlyResponse = true,
@@ -199,7 +199,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "Invalid content type - non primitive",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, null, null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaContentTypeAnnotationName) + "\":{}",
                     ExpectedException = ODataExpectedExceptions.ODataException("JsonReaderExtensions_UnexpectedNodeDetected", "PrimitiveValue", "StartObject"),
                     OnlyResponse = true,
@@ -208,7 +208,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "Invalid content type - null",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, null, null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaContentTypeAnnotationName) + "\":null",
                     ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightReaderUtils_AnnotationWithNullValue", JsonLightConstants.ODataMediaContentTypeAnnotationName),
                     OnlyResponse = true,
@@ -218,7 +218,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                     DebugDescription = "Open stream property",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("OpenSkyline", null, "http://odata.org/streamproperty/editlink", null, null),
                     OwningEntityType = model.FindDeclaredType("TestModel.CityOpenType").ToTypeReference(),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("OpenSkyline", JsonLightConstants.ODataMediaEditLinkAnnotationName) + "\":\"http://odata.org/streamproperty/editlink\"",
                     OnlyResponse = true
                 },
@@ -226,7 +226,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 {
                     DebugDescription = "Undeclared stream property (disallowed by default)",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("NewSkyline", null, "http://odata.org/streamproperty/editlink", null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("NewSkyline", JsonLightConstants.ODataMediaEditLinkAnnotationName) + "\":\"http://odata.org/streamproperty/editlink\"",
                     ExpectedException = ODataExpectedExceptions.ODataException("ValidationUtils_PropertyDoesNotExistOnType", "NewSkyline", "TestModel.CityType"),
                     OnlyResponse = true
@@ -234,17 +234,17 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
                 new StreamPropertyTestCase
                 {
                     DebugDescription = "Stream property declared with non-stream type",
-                    ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Name", null, "http://odata.org/streamproperty/editlink", null, null),
+                    ExpectedEntity = PayloadBuilder.Entity(),
                     Json = 
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Name", JsonLightConstants.ODataMediaEditLinkAnnotationName) + "\":\"http://odata.org/streamproperty/editlink\"",
-                    ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType", "Name", "Edm.String"),
+                   // ExpectedException = ODataExpectedExceptions.ODataException("ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType", "Name", "Edm.String"),
                     OnlyResponse = true
                 },
                 new StreamPropertyTestCase
                 {
                     DebugDescription = "Stream property with value",
                     ExpectedEntity = PayloadBuilder.Entity().StreamProperty("Skyline", null, "http://odata.org/streamproperty/editlink", null, null),
-                    Json = 
+                    Json =
                         "\"" + JsonLightUtils.GetPropertyAnnotationName("Skyline", JsonLightConstants.ODataMediaEditLinkAnnotationName) + "\":\"http://odata.org/streamproperty/editlink\"," +
                         "\"Skyline\":\"value\"",
                     OnlyResponse = true

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/AssociationLinkReaderTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/AssociationLinkReaderTests.cs
@@ -102,10 +102,6 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.Reader
                     ExpectedResultCallback = 
                         (tc) => new PayloadReaderTestExpectedResult(this.Settings.ExpectedResultSettings)
                                 {
-                                    //ExpectedException = 
-                                    //    (tc.Format == ODataFormat.Json)
-                                    //    ? ODataExpectedExceptions.ODataException("ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType", "Name", "Edm.String")
-                                    //    : ODataExpectedExceptions.ODataException("ValidationUtils_NavigationPropertyExpected", "Name", "TestModel.CityType", "Structural"),
                                     ExpectedException = null
                                 },
                 },

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/AssociationLinkReaderTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/AssociationLinkReaderTests.cs
@@ -102,10 +102,11 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.Reader
                     ExpectedResultCallback = 
                         (tc) => new PayloadReaderTestExpectedResult(this.Settings.ExpectedResultSettings)
                                 {
-                                    ExpectedException = 
-                                        (tc.Format == ODataFormat.Json)
-                                        ? ODataExpectedExceptions.ODataException("ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType", "Name", "Edm.String")
-                                        : ODataExpectedExceptions.ODataException("ValidationUtils_NavigationPropertyExpected", "Name", "TestModel.CityType", "Structural"),
+                                    //ExpectedException = 
+                                    //    (tc.Format == ODataFormat.Json)
+                                    //    ? ODataExpectedExceptions.ODataException("ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType", "Name", "Edm.String")
+                                    //    : ODataExpectedExceptions.ODataException("ValidationUtils_NavigationPropertyExpected", "Name", "TestModel.CityType", "Structural"),
+                                    ExpectedException = null
                                 },
                 },
             };

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/PropertyReaderTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/PropertyReaderTests.cs
@@ -116,9 +116,6 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.Reader
                         ExpectedResultCallback = tc =>
                             new PayloadReaderTestExpectedResult(this.Settings.ExpectedResultSettings)
                             {
-                                //ExpectedException = tc.Format == ODataFormat.Json
-                                //        ? ODataExpectedExceptions.ODataException("ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType", "NonStreamProperty", "Edm.Boolean")
-                                //        : ODataExpectedExceptions.ODataException("JsonReaderExtensions_UnexpectedNodeDetected", "PrimitiveValue", "StartObject")
                                 ExpectedException = null
                             },
                     },

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/PropertyReaderTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Reader/PropertyReaderTests.cs
@@ -110,14 +110,16 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.Reader
                     // A stream is not allowed in a property with a non-stream property kind.
                     new PayloadReaderTestDescriptor(this.Settings)
                     {
-                        PayloadElement = PayloadBuilder.Entity("TestModel.EntityTypeWithStreamProperty").StreamProperty("NonStreamProperty", "http://readlink", "http://editlink"),
+                        PayloadElement = PayloadBuilder.Entity("TestModel.EntityTypeWithStreamProperty").Property("Id", PayloadBuilder.PrimitiveValue(1))
+                            .StreamProperty("NonStreamProperty", "http://readlink", "http://editlink"),
                         PayloadEdmModel = model,
                         ExpectedResultCallback = tc =>
                             new PayloadReaderTestExpectedResult(this.Settings.ExpectedResultSettings)
                             {
-                                ExpectedException = tc.Format == ODataFormat.Json
-                                        ? ODataExpectedExceptions.ODataException("ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType", "NonStreamProperty", "Edm.Boolean")
-                                        : ODataExpectedExceptions.ODataException("JsonReaderExtensions_UnexpectedNodeDetected", "PrimitiveValue", "StartObject")
+                                //ExpectedException = tc.Format == ODataFormat.Json
+                                //        ? ODataExpectedExceptions.ODataException("ODataJsonLightResourceDeserializer_PropertyWithoutValueWithWrongType", "NonStreamProperty", "Edm.Boolean")
+                                //        : ODataExpectedExceptions.ODataException("JsonReaderExtensions_UnexpectedNodeDetected", "PrimitiveValue", "StartObject")
+                                ExpectedException = null
                             },
                     },
                     // Top-level property of stream type is not allowed


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2785.*

### Description

1) Can write property instance annotations without property value.
2) Can read property instance annotations without property value.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
