### PR TITLE
Upgrade Microsoft.Bcl.AsyncInterfaces dependency to 7.0.0

### DIFF
--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -151,7 +151,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
@@ -22,7 +22,7 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Spatial" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
         <dependency id="Microsoft.OData.Edm" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" />
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
@@ -23,7 +23,7 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Spatial" version="[$VersionNuGetSemantic$]" />
         <dependency id="Microsoft.OData.Edm" version="[$VersionNuGetSemantic$]" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="5.0.0" />
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Microsoft.OData.Core/GlobalSuppressions.cs
+++ b/src/Microsoft.OData.Core/GlobalSuppressions.cs
@@ -59,3 +59,4 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Microsoft.OData.UriParser.CountSegmentParser.#CreateCountSegmentToken(Microsoft.OData.UriParser.QueryToken)")]
 [assembly: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Microsoft.OData.UriParser.SelectExpandOptionParser.#BuildSelectTermToken(Microsoft.OData.UriParser.PathSegmentToken,System.String)")]
 
+[assembly: SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Fix in next major release", Scope = "member", Target = "~P:Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Messages")]

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -88,7 +88,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>5.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.ObjectPool">
       <Version>6.0.3</Version>

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -90,7 +90,7 @@
   </ItemGroup>
     
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Microsoft.Spatial/Microsoft.Spatial.csproj
+++ b/src/Microsoft.Spatial/Microsoft.Spatial.csproj
@@ -31,7 +31,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Common/Microsoft.Test.OData.DependencyInjection/Microsoft.Test.OData.DependencyInjection.csproj
+++ b/test/Common/Microsoft.Test.OData.DependencyInjection/Microsoft.Test.OData.DependencyInjection.csproj
@@ -13,7 +13,7 @@
   <Import Project="..\Build.props" />
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.32" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' or '$(TargetFramework)' == 'net45'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="1.1.0" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -71,13 +71,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>5.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>5.0.0</Version>
+      <Version>7.0.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/test/PublicApiTests/Microsoft.OData.PublicApi.Tests.csproj
+++ b/test/PublicApiTests/Microsoft.OData.PublicApi.Tests.csproj
@@ -21,7 +21,7 @@
     <EmbeddedResource Include="BaseLine\Microsoft.OData.PublicApi.netstandard2.0.bsl" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2780.*

### Description

Upgrade **Microsoft.Bcl.AsyncInterfaces** dependency to 7.0.0. We reference the Microsoft.Bcl.AsyncInterfaces package conditionally against .NetStandard2.0 framework. It should be safe to upgrade the dependency from 5.0.0 to 7.0.0 to since .NetStandard2.0 is one of the supported frameworks https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/7.0.0#supportedframeworks-body-tab

### Checklist (Uncheck if it is not completed)

- [ ] *Build and test with one-click build and test script passed*