### PR TITLE
Reduce buffer allocations

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 #if NETCOREAPP3_1_OR_GREATER
+#define POOLED_BUFFER
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -36,7 +37,11 @@ namespace Microsoft.OData.Json
         private readonly Stream outputStream;
         private readonly Stream writeStream;
         private readonly Utf8JsonWriter utf8JsonWriter;
+#if POOLED_BUFFER
+        private readonly PooledByteBufferWriter bufferWriter;
+#else
         private readonly ArrayBufferWriter<byte> bufferWriter;
+#endif
         private readonly int bufferSize;
         private readonly bool isIeee754Compatible;
         private readonly bool leaveStreamOpen;
@@ -102,7 +107,11 @@ namespace Microsoft.OData.Json
             this.outputStream = outputStream;
             this.isIeee754Compatible = isIeee754Compatible;
             this.bufferSize = bufferSize;
+#if POOLED_BUFFER
+            this.bufferWriter = new PooledByteBufferWriter(bufferSize);
+#else
             this.bufferWriter = new ArrayBufferWriter<byte>(bufferSize);
+#endif
             // flush when we're close to the buffer capacity to avoid allocating bigger buffers
             this.bufferFlushThreshold = 0.9f * this.bufferSize;
             this.leaveStreamOpen = leaveStreamOpen;
@@ -433,7 +442,8 @@ namespace Microsoft.OData.Json
                 this.bufferWriter.Write(itemSeparator.Slice(0, 1).Span);
             }
 
-            this.bufferWriter.Write(Encoding.UTF8.GetBytes(rawValue));
+            var rawBytes = Encoding.UTF8.GetBytes(rawValue);
+            this.bufferWriter.Write(rawBytes);
 
             // since we bypass the Utf8JsonWriter, we need to signal to other
             // Write methods that a separator should be written first
@@ -567,6 +577,9 @@ namespace Microsoft.OData.Json
             {
                 this.writeStream.Flush();
                 this.utf8JsonWriter.Dispose();
+#if POOLED_BUFFER
+                this.bufferWriter.Dispose();
+#endif
 
                 if (this.outputStream != this.writeStream)
                 {
@@ -867,6 +880,13 @@ namespace Microsoft.OData.Json
                 await this.outputStream.DisposeAsync().ConfigureAwait(false);
             }
 
+#if POOLED_BUFFER
+            if (this.bufferWriter != null)
+            {
+                this.bufferWriter.Dispose();
+            }
+#endif
+
             this.Dispose(false);
         }
 
@@ -878,7 +898,7 @@ namespace Microsoft.OData.Json
             }
         }
 
-        #endregion
+#endregion
 
     }
 }

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -5,7 +5,6 @@
 //---------------------------------------------------------------------
 
 #if NETCOREAPP3_1_OR_GREATER
-#define POOLED_BUFFER
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -37,11 +36,7 @@ namespace Microsoft.OData.Json
         private readonly Stream outputStream;
         private readonly Stream writeStream;
         private readonly Utf8JsonWriter utf8JsonWriter;
-#if POOLED_BUFFER
         private readonly PooledByteBufferWriter bufferWriter;
-#else
-        private readonly ArrayBufferWriter<byte> bufferWriter;
-#endif
         private readonly int bufferSize;
         private readonly bool isIeee754Compatible;
         private readonly bool leaveStreamOpen;
@@ -107,11 +102,7 @@ namespace Microsoft.OData.Json
             this.outputStream = outputStream;
             this.isIeee754Compatible = isIeee754Compatible;
             this.bufferSize = bufferSize;
-#if POOLED_BUFFER
             this.bufferWriter = new PooledByteBufferWriter(bufferSize);
-#else
-            this.bufferWriter = new ArrayBufferWriter<byte>(bufferSize);
-#endif
             // flush when we're close to the buffer capacity to avoid allocating bigger buffers
             this.bufferFlushThreshold = 0.9f * this.bufferSize;
             this.leaveStreamOpen = leaveStreamOpen;
@@ -577,9 +568,7 @@ namespace Microsoft.OData.Json
             {
                 this.writeStream.Flush();
                 this.utf8JsonWriter.Dispose();
-#if POOLED_BUFFER
                 this.bufferWriter.Dispose();
-#endif
 
                 if (this.outputStream != this.writeStream)
                 {
@@ -880,12 +869,10 @@ namespace Microsoft.OData.Json
                 await this.outputStream.DisposeAsync().ConfigureAwait(false);
             }
 
-#if POOLED_BUFFER
             if (this.bufferWriter != null)
             {
                 this.bufferWriter.Dispose();
             }
-#endif
 
             this.Dispose(false);
         }

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -433,8 +433,7 @@ namespace Microsoft.OData.Json
                 this.bufferWriter.Write(itemSeparator.Slice(0, 1).Span);
             }
 
-            var rawBytes = Encoding.UTF8.GetBytes(rawValue);
-            this.bufferWriter.Write(rawBytes);
+            this.bufferWriter.Write(Encoding.UTF8.GetBytes(rawValue));
 
             // since we bypass the Utf8JsonWriter, we need to signal to other
             // Write methods that a separator should be written first

--- a/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
+++ b/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
@@ -143,9 +143,6 @@ namespace Microsoft.OData.Json
 
         public Span<byte> GetSpan(int sizeHint = MinimumBufferSize)
         {
-            // TODO: this condition is here cause without it the sizeHint is getting set to 0
-            // instead of the MinimumBufferSize when the method is called without params.
-            // I don't understand why this is happening, will investigate later
             if (sizeHint == 0)
             {
                 sizeHint = MinimumBufferSize;

--- a/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
+++ b/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
@@ -1,0 +1,215 @@
+﻿#if NETCOREAPP3_1_OR_GREATER
+using Microsoft.OData;
+using System.Buffers;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace System.Text.Json
+{
+    /// <summary>
+    /// An implementation of <see cref="IBufferWriter{byte}"/> that rents
+    /// buffers from an array pool instead of allocating a new array every time.
+    /// </summary>
+    internal sealed class PooledByteBufferWriter : IBufferWriter<byte>, IDisposable
+    {
+        // This class allows two possible configurations: if rentedBuffer is not null then
+        // it can be used as an IBufferWriter and holds a buffer that should eventually be
+        // returned to the shared pool. If rentedBuffer is null, then the instance is in a
+        // cleared/disposed state and it must re-rent a buffer before it can be used again.
+        private byte[]? _rentedBuffer;
+        private int _index;
+
+        private const int MinimumBufferSize = 256;
+
+        // Value copied from Array.MaxLength in System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Array.cs.
+        public const int MaximumBufferSize = 0X7FFFFFC7;
+
+        private PooledByteBufferWriter()
+        {
+        }
+
+        public PooledByteBufferWriter(int initialCapacity) : this()
+        {
+            Debug.Assert(initialCapacity > 0);
+
+            _rentedBuffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+            _index = 0;
+        }
+
+        public ReadOnlyMemory<byte> WrittenMemory
+        {
+            get
+            {
+                Debug.Assert(_rentedBuffer != null);
+                Debug.Assert(_index <= _rentedBuffer.Length);
+                return _rentedBuffer.AsMemory(0, _index);
+            }
+        }
+
+        public int WrittenCount
+        {
+            get
+            {
+                Debug.Assert(_rentedBuffer != null);
+                return _index;
+            }
+        }
+
+        public int Capacity
+        {
+            get
+            {
+                Debug.Assert(_rentedBuffer != null);
+                return _rentedBuffer.Length;
+            }
+        }
+
+        public int FreeCapacity
+        {
+            get
+            {
+                Debug.Assert(_rentedBuffer != null);
+                return _rentedBuffer.Length - _index;
+            }
+        }
+
+        public void Clear()
+        {
+            ClearHelper();
+        }
+
+        public void ClearAndReturnBuffers()
+        {
+            Debug.Assert(_rentedBuffer != null);
+
+            ClearHelper();
+            byte[] toReturn = _rentedBuffer;
+            _rentedBuffer = null;
+            ArrayPool<byte>.Shared.Return(toReturn);
+        }
+
+        private void ClearHelper()
+        {
+            Debug.Assert(_rentedBuffer != null);
+            Debug.Assert(_index <= _rentedBuffer.Length);
+
+            _rentedBuffer.AsSpan(0, _index).Clear();
+            _index = 0;
+        }
+
+        // Returns the rented buffer back to the pool
+        public void Dispose()
+        {
+            if (_rentedBuffer == null)
+            {
+                return;
+            }
+
+            ClearHelper();
+            byte[] toReturn = _rentedBuffer;
+            _rentedBuffer = null;
+            ArrayPool<byte>.Shared.Return(toReturn);
+        }
+
+        public void InitializeEmptyInstance(int initialCapacity)
+        {
+            Debug.Assert(initialCapacity > 0);
+            Debug.Assert(_rentedBuffer is null);
+
+            _rentedBuffer = ArrayPool<byte>.Shared.Rent(initialCapacity);
+            _index = 0;
+        }
+
+        public static PooledByteBufferWriter CreateEmptyInstanceForCaching() => new PooledByteBufferWriter();
+
+        public void Advance(int count)
+        {
+            Debug.Assert(_rentedBuffer != null);
+            Debug.Assert(count >= 0);
+            Debug.Assert(_index <= _rentedBuffer.Length - count);
+            _index += count;
+        }
+
+        public Memory<byte> GetMemory(int sizeHint = MinimumBufferSize)
+        {
+            CheckAndResizeBuffer(sizeHint);
+            return _rentedBuffer.AsMemory(_index);
+        }
+
+        public Span<byte> GetSpan(int sizeHint = MinimumBufferSize)
+        {
+            // TODO: this condition is here cause without it the sizeHint is getting set to 0
+            // instead of the MinimumBufferSize when the method is called without params.
+            // I don't understand why this is happening, will investigate later
+            if (sizeHint == 0)
+            {
+                sizeHint = MinimumBufferSize;
+            }
+
+            CheckAndResizeBuffer(sizeHint);
+            return _rentedBuffer.AsSpan(_index);
+        }
+
+        internal ValueTask WriteToStreamAsync(Stream destination, CancellationToken cancellationToken)
+        {
+            return destination.WriteAsync(WrittenMemory, cancellationToken);
+        }
+
+        internal void WriteToStream(Stream destination)
+        {
+            destination.Write(WrittenMemory.Span);
+        }
+
+        private void CheckAndResizeBuffer(int sizeHint)
+        {
+            Debug.Assert(_rentedBuffer != null);
+            Debug.Assert(sizeHint > 0);
+
+            int currentLength = _rentedBuffer.Length;
+            int availableSpace = currentLength - _index;
+
+            // If we've reached ~1GB written, grow to the maximum buffer
+            // length to avoid incessant minimal growths causing perf issues.
+            if (_index >= MaximumBufferSize / 2)
+            {
+                sizeHint = Math.Max(sizeHint, MaximumBufferSize - currentLength);
+            }
+
+            if (sizeHint > availableSpace)
+            {
+                int growBy = Math.Max(sizeHint, currentLength);
+
+                int newSize = currentLength + growBy;
+
+                if ((uint)newSize > MaximumBufferSize)
+                {
+                    newSize = currentLength + sizeHint;
+                    if ((uint)newSize > MaximumBufferSize)
+                    {
+                        throw new OutOfMemoryException(Strings.ODataMessageWriter_Buffer_Maximum_Size_Exceeded(newSize));
+                    }
+                }
+
+                byte[] oldBuffer = _rentedBuffer;
+
+                _rentedBuffer = ArrayPool<byte>.Shared.Rent(newSize);
+
+                Debug.Assert(oldBuffer.Length >= _index);
+                Debug.Assert(_rentedBuffer.Length >= _index);
+
+                Span<byte> oldBufferAsSpan = oldBuffer.AsSpan(0, _index);
+                oldBufferAsSpan.CopyTo(_rentedBuffer);
+                oldBufferAsSpan.Clear();
+                ArrayPool<byte>.Shared.Return(oldBuffer);
+            }
+
+            Debug.Assert(_rentedBuffer.Length - _index > 0);
+            Debug.Assert(_rentedBuffer.Length - _index >= sizeHint);
+        }
+    }
+}
+#endif

--- a/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
+++ b/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
@@ -106,6 +106,15 @@ namespace Microsoft.OData.Json
         /// <inheritdoc/>
         public Memory<byte> GetMemory(int sizeHint = MinimumBufferSize)
         {
+            // When called through an IBufferWriter interface,
+            // the sizeHint will be initialized to 0.
+            // IBufferWriter expects a non-empty buffer to be returned
+            // when a 0 sizeHint is provided.
+            if (sizeHint == 0)
+            {
+                sizeHint = MinimumBufferSize;
+            }
+
             CheckAndResizeBuffer(sizeHint);
             return this.rentedBuffer.AsMemory(index);
         }
@@ -113,6 +122,10 @@ namespace Microsoft.OData.Json
         /// <inheritdoc/>
         public Span<byte> GetSpan(int sizeHint = MinimumBufferSize)
         {
+            // When called through an IBufferWriter interface,
+            // the sizeHint will be initialized to 0.
+            // IBufferWriter expects a non-empty buffer to be returned
+            // when a 0 sizeHint is provided.
             if (sizeHint == 0)
             {
                 sizeHint = MinimumBufferSize;

--- a/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
+++ b/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
@@ -1,14 +1,15 @@
-﻿#if NETCOREAPP3_1_OR_GREATER
-using Microsoft.OData;
+﻿//---------------------------------------------------------------------
+// <copyright file="PooledByteBufferWriter.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETCOREAPP3_1_OR_GREATER
+using System;
 using System.Buffers;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
-using System.IO;
-using System.Runtime.CompilerServices;
-using System.Threading;
-using System.Threading.Tasks;
 
-namespace System.Text.Json
+namespace Microsoft.OData.Json
 {
     /// <summary>
     /// An implementation of <see cref="IBufferWriter{byte}"/> that rents
@@ -152,16 +153,6 @@ namespace System.Text.Json
 
             CheckAndResizeBuffer(sizeHint);
             return _rentedBuffer.AsSpan(_index);
-        }
-
-        internal ValueTask WriteToStreamAsync(Stream destination, CancellationToken cancellationToken)
-        {
-            return destination.WriteAsync(WrittenMemory, cancellationToken);
-        }
-
-        internal void WriteToStream(Stream destination)
-        {
-            destination.Write(WrittenMemory.Span);
         }
 
         private void CheckAndResizeBuffer(int sizeHint)

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -88,22 +88,7 @@ namespace Microsoft.OData.JsonLight
             {
                 this.messageOutputStream = messageInfo.MessageStream;
 
-                Stream outputStream;
-                if (this.Synchronous)
-                {
-                    outputStream = this.messageOutputStream;
-                }
-                else
-                {
-#if NETSTANDARD1_1
-                    this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
-#else 
-                    this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, ODataConstants.DefaultOutputBufferSize);
-#endif
-                    outputStream = this.asynchronousOutputStream;
-                }
-
-                this.textWriter = new StreamWriter(outputStream, messageInfo.Encoding);
+                
 
                 bool isIeee754Compatible = messageInfo.MediaType.HasIeee754CompatibleSetToTrue();
 
@@ -112,9 +97,17 @@ namespace Microsoft.OData.JsonLight
 
                 if (streamBasedJsonWriterFactory != null)
                 {
+#if !NETSTANDARD1_1
+                    // When using IStreamBasedJsonWriterFactory, we do not wrap the ouput stream in a buffered stream.
+                    // The assumption is that the default ODataUtf8JsonWriter will be used, and that writer handles
+                    // its own buffering (more efficiently). It leads to too many byte[] array allocations if we have
+                    // both the BufferedStream and ODataUtf8JsonWriter allocating buffers unnecessarily.
+                    this.asynchronousOutputStream = this.messageOutputStream;
+#endif
+
                     this.asynchronousJsonWriter = CreateAsynchronousJsonWriter(
                         streamBasedJsonWriterFactory,
-                        outputStream,
+                        this.messageOutputStream,
                         isIeee754Compatible,
                         messageInfo.Encoding);
 
@@ -125,6 +118,22 @@ namespace Microsoft.OData.JsonLight
                 // Then fallback to the TextWriter-based approach
                 if (this.asynchronousJsonWriter == null && this.jsonWriter == null)
                 {
+                    Stream outputStream;
+                    if (this.Synchronous)
+                    {
+                        outputStream = this.messageOutputStream;
+                    }
+                    else
+                    {
+#if NETSTANDARD1_1
+                        this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
+#else
+                    this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, ODataConstants.DefaultOutputBufferSize);
+#endif
+                        outputStream = this.asynchronousOutputStream;
+                    }
+
+                    this.textWriter = new StreamWriter(outputStream, messageInfo.Encoding);
                     this.jsonWriter = CreateJsonWriter(this.Container, this.textWriter, isIeee754Compatible, messageWriterSettings);
 
                     if (!(this.jsonWriter is IJsonWriterAsync))

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -128,7 +128,7 @@ namespace Microsoft.OData.JsonLight
 #if NETSTANDARD1_1
                         this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
 #else
-                    this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, ODataConstants.DefaultOutputBufferSize);
+                    this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, this.MessageWriterSettings.BufferSize);
 #endif
                         outputStream = this.asynchronousOutputStream;
                     }

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightOutputContext.cs
@@ -128,7 +128,7 @@ namespace Microsoft.OData.JsonLight
 #if NETSTANDARD1_1
                         this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
 #else
-                    this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, this.MessageWriterSettings.BufferSize);
+                        this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, this.MessageWriterSettings.BufferSize);
 #endif
                         outputStream = this.asynchronousOutputStream;
                     }

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -103,6 +103,7 @@ namespace Microsoft.OData
         internal const string ODataMessageWriter_StreamBasedJsonWriterFactory_ReturnedNull = "ODataMessageWriter_StreamBasedJsonWriterFactory_ReturnedNull";
         internal const string ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter = "ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter";
         internal const string ODataMessageWriter_IJsonWriter_And_IJsonWriterAsync_Are_Different_Instances = "ODataMessageWriter_IJsonWriter_And_IJsonWriterAsync_Are_Different_Instances";
+        internal const string ODataMessageWriter_Buffer_Maximum_Size_Exceeded = "ODataMessageWriter_Buffer_Maximum_Size_Exceeded";
         internal const string ODataMessageWriterSettings_MessageWriterSettingsXmlCustomizationCallbacksMustBeSpecifiedBoth = "ODataMessageWriterSettings_MessageWriterSettingsXmlCustomizationCallbacksMustBeSpecifiedBoth";
         internal const string ODataCollectionWriterCore_InvalidTransitionFromStart = "ODataCollectionWriterCore_InvalidTransitionFromStart";
         internal const string ODataCollectionWriterCore_InvalidTransitionFromCollection = "ODataCollectionWriterCore_InvalidTransitionFromCollection";

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -101,7 +101,7 @@ ODataMessageWriter_NotAllowedWriteTopLevelPropertyWithResourceValue=Not allowed 
 ODataMessageWriter_StreamBasedJsonWriterFactory_ReturnedNull=The provided implementation of IStreamBasedJsonWriterFactory returned null for arguments: isIeee754Compatible '{0}', encoding '{1}'. The factory should return a concrete IJsonWriter implementation.
 ODataMessageWriter_IJsonWriterAsync_Must_Implement_IJsonWriter=The provided IJsonWriterAsync instance must also implement IJsonWriter.
 ODataMessageWriter_IJsonWriter_And_IJsonWriterAsync_Are_Different_Instances=Detected different instances of IJsonWriter and IJsonWriterAsync. The writer instance returned by the factory should implement both IJsonWriter and IJsonWriterAsync.
-
+ODataMessageWriter_Buffer_Maximum_Size_Exceeded=The requested buffer capacity {0} exceeds the max buffer size.
 ODataMessageWriterSettings_MessageWriterSettingsXmlCustomizationCallbacksMustBeSpecifiedBoth=Both startResourceXmlCustomizationCallback and endResourceXmlCustomizationCallback must be either null or non-null.
 
 

--- a/src/Microsoft.OData.Core/ODataConstants.cs
+++ b/src/Microsoft.OData.Core/ODataConstants.cs
@@ -218,7 +218,7 @@ namespace Microsoft.OData
         /// <summary>
         /// The default size used for buffering output data.
         /// </summary>
-        internal const int DefaultOutputBufferSize = 84000;
+        internal const int DefaultOutputBufferSize = 16 * 1024;
 
         #endregion Context URL
     }

--- a/src/Microsoft.OData.Core/ODataConstants.cs
+++ b/src/Microsoft.OData.Core/ODataConstants.cs
@@ -218,7 +218,7 @@ namespace Microsoft.OData
         /// <summary>
         /// The default size used for buffering output data.
         /// </summary>
-        internal const int DefaultOutputBufferSize = 16 * 1024;
+        internal const int DefaultOutputBufferSize = 84000;
 
         #endregion Context URL
     }

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -79,6 +79,7 @@ namespace Microsoft.OData
             this.LibraryCompatibility = ODataLibraryCompatibility.Latest;
             this.MultipartNewLine = "\r\n";
             this.AlwaysAddTypeAnnotationsForDerivedTypes = false;
+            this.BufferSize = ODataConstants.DefaultOutputBufferSize;
         }
 
         /// <summary>
@@ -142,6 +143,12 @@ namespace Microsoft.OData
         /// Get/sets the character buffer pool.
         /// </summary>
         public ICharArrayPool ArrayPool { get; set; }
+
+        /// <summary>
+        /// Gets/sets the size of the buffer used to buffer writes to the output
+        /// stream. Note that this is a hint and may override it when deemed fit.
+        /// </summary>
+        public int BufferSize { get; set; }
 
         /// <summary>
         /// Quotas to use for limiting resource consumption when writing an OData message.
@@ -447,6 +454,7 @@ namespace Microsoft.OData
             this.ThrowOnDuplicatePropertyNames = other.ThrowOnDuplicatePropertyNames;
             this.ThrowOnUndeclaredPropertyForNonOpenType = other.ThrowOnUndeclaredPropertyForNonOpenType;
             this.ArrayPool = other.ArrayPool;
+            this.BufferSize = other.BufferSize;
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -145,8 +145,8 @@ namespace Microsoft.OData
         public ICharArrayPool ArrayPool { get; set; }
 
         /// <summary>
-        /// Gets/sets the size of the buffer used to buffer writes to the output
-        /// stream. Note that this is a hint and may override it when deemed fit.
+        /// Gets or sets the size of the buffer used to buffer writes to the output
+        /// stream. Note that this is a hint and may be disregarded where deemed fit.
         /// </summary>
         public int BufferSize { get; set; }
 

--- a/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
@@ -61,7 +61,7 @@ namespace Microsoft.OData
 #if NETSTANDARD1_1
                     this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
 #else
-                    this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, ODataConstants.DefaultOutputBufferSize);
+                    this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, messageWriterSettings.BufferSize);
 #endif
                     outputStream = this.asynchronousOutputStream;
                 }

--- a/src/Microsoft.OData.Core/ODataRawOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawOutputContext.cs
@@ -71,7 +71,7 @@ namespace Microsoft.OData
 #if NETSTANDARD1_1
                     this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
 #else
-	                this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, ODataConstants.DefaultOutputBufferSize);
+	                this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, messageWriterSettings.BufferSize);
 #endif
                     this.outputStream = this.asynchronousOutputStream;
                 }

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -796,6 +796,14 @@ namespace Microsoft.OData {
         }
 
         /// <summary>
+        /// A string like "The requested buffer capacity {0} exceeds the max buffer size."
+        /// </summary>
+        internal static string ODataMessageWriter_Buffer_Maximum_Size_Exceeded(object p0)
+        {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ODataMessageWriter_Buffer_Maximum_Size_Exceeded, p0);
+        }
+
+        /// <summary>
         /// A string like "Both startResourceXmlCustomizationCallback and endResourceXmlCustomizationCallback must be either null or non-null."
         /// </summary>
         internal static string ODataMessageWriterSettings_MessageWriterSettingsXmlCustomizationCallbacksMustBeSpecifiedBoth

--- a/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
+Microsoft.OData.ODataMessageWriterSettings.BufferSize.get -> int
+Microsoft.OData.ODataMessageWriterSettings.BufferSize.set -> void
 static Microsoft.OData.UriParser.ODataPathExtensions.TrimEndingTypeAndKeySegments(this Microsoft.OData.UriParser.ODataPath path) -> Microsoft.OData.UriParser.ODataPath

--- a/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
+Microsoft.OData.ODataMessageWriterSettings.BufferSize.get -> int
+Microsoft.OData.ODataMessageWriterSettings.BufferSize.set -> void
 static Microsoft.OData.UriParser.ODataPathExtensions.TrimEndingTypeAndKeySegments(this Microsoft.OData.UriParser.ODataPath path) -> Microsoft.OData.UriParser.ODataPath

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
+Microsoft.OData.ODataMessageWriterSettings.BufferSize.get -> int
+Microsoft.OData.ODataMessageWriterSettings.BufferSize.set -> void
 static Microsoft.OData.UriParser.ODataPathExtensions.TrimEndingTypeAndKeySegments(this Microsoft.OData.UriParser.ODataPath path) -> Microsoft.OData.UriParser.ODataPath

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
+Microsoft.OData.ODataMessageWriterSettings.BufferSize.get -> int
+Microsoft.OData.ODataMessageWriterSettings.BufferSize.set -> void
 static Microsoft.OData.UriParser.ODataPathExtensions.TrimEndingTypeAndKeySegments(this Microsoft.OData.UriParser.ODataPath path) -> Microsoft.OData.UriParser.ODataPath

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/PooledByteBufferWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/PooledByteBufferWriterTests.cs
@@ -1,0 +1,187 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="PooledByteBufferWriterTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETCOREAPP3_1_OR_GREATER
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.OData.Json;
+using Xunit;
+
+namespace Microsoft.OData.Tests.Json
+{
+    public class PooledByteBufferWriterTests
+    {
+        [Fact]
+        public void ContstructorInitializesBufferToInititalCapacity()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(512);
+            Assert.Equal(0, bufferWriter.WrittenMemory.Span.Length);
+            Assert.Equal(0, bufferWriter.WrittenCount);
+            Assert.Equal(512, bufferWriter.Capacity);
+            Assert.Equal(512, bufferWriter.FreeCapacity);
+            Assert.Equal(0, bufferWriter.WrittenMemory.Length);
+        }
+
+        [Fact]
+        public void GetSpan_WhenBufferIsEmpty_ReturnsSpanWithDefaultCapacity()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(512);
+            Span<byte> span = bufferWriter.GetSpan();
+            Assert.Equal(512, span.Length);
+        }
+
+        [Fact]
+        public void GetMemory_WhenBufferIsEmpty_ReturnsMemoryWithDefaultCapacity()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(512);
+            Memory<byte> memory = bufferWriter.GetMemory();
+            Assert.Equal(512, memory.Length);
+        }
+
+        [Fact]
+        public void Advance_UpdatesPositionOfTheBuffer()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(512);
+            Span<byte> buffer = bufferWriter.GetSpan(10);
+            buffer.Slice(0, 10).Fill(1);
+
+            bufferWriter.Advance(10);
+
+            Assert.Equal(502, bufferWriter.FreeCapacity);
+            Assert.Equal(10, bufferWriter.WrittenCount);
+            Assert.Equal(512, bufferWriter.Capacity);
+
+            bufferWriter.Advance(10);
+
+            Assert.Equal(492, bufferWriter.FreeCapacity);
+            Assert.Equal(20, bufferWriter.WrittenCount);
+            Assert.Equal(512, bufferWriter.Capacity);
+        }
+
+        [Fact]
+        public void GetSpan_ResizesBufferWhenCapacityExceeded()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(256);
+
+            Span<byte> buffer = bufferWriter.GetSpan(200);
+            buffer.Slice(0, 200).Fill(1);
+
+            bufferWriter.Advance(200);
+            Assert.Equal(56, bufferWriter.FreeCapacity);
+            Assert.Equal(200, bufferWriter.WrittenCount);
+            Assert.Equal(256, bufferWriter.Capacity);
+
+            buffer = bufferWriter.GetSpan(200);
+            buffer.Slice(0, 200).Fill(1);
+            bufferWriter.Advance(200);
+
+            Assert.Equal(112, bufferWriter.FreeCapacity);
+            Assert.Equal(400, bufferWriter.WrittenCount);
+            Assert.Equal(512, bufferWriter.Capacity);
+        }
+
+        [Fact]
+        public void GetMemory_ResizesBufferWhenCapacityExceeded()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(256);
+
+            Memory<byte> buffer = bufferWriter.GetMemory(200);
+            buffer.Slice(0, 200).Span.Fill(1);
+
+            bufferWriter.Advance(200);
+            Assert.Equal(56, bufferWriter.FreeCapacity);
+            Assert.Equal(200, bufferWriter.WrittenCount);
+            Assert.Equal(256, bufferWriter.Capacity);
+
+            buffer = bufferWriter.GetMemory(200);
+            buffer.Slice(0, 200).Span.Fill(1);
+            bufferWriter.Advance(200);
+
+            Assert.Equal(112, bufferWriter.FreeCapacity);
+            Assert.Equal(400, bufferWriter.WrittenCount);
+            Assert.Equal(512, bufferWriter.Capacity);
+        }
+
+        [Fact]
+        public void GetSpan_NewBufferDoNotOverwritePreviousOne()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(256);
+            Span<byte> buffer = bufferWriter.GetSpan(1);
+            buffer[0] = 143;
+
+            bufferWriter.Advance(1);
+
+            buffer = bufferWriter.GetSpan(1);
+            Assert.NotEqual(143, buffer[0]);
+        }
+
+        [Fact]
+        public void GetMemory_NewBufferDoNotOverwritePreviousOne()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(256);
+            Memory<byte> buffer = bufferWriter.GetMemory(1);
+            buffer.Span[0] = 143;
+
+            bufferWriter.Advance(1);
+
+            buffer = bufferWriter.GetMemory(1);
+            Assert.NotEqual(143, buffer.Span[0]);
+        }
+
+        [Fact]
+        public void Clear_ResetsTheBuffer()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(256);
+            Span<byte> buffer = bufferWriter.GetSpan(200);
+            bufferWriter.Advance(200);
+
+            Assert.Equal(200, bufferWriter.WrittenCount);
+            Assert.Equal(56, bufferWriter.FreeCapacity);
+            Assert.Equal(256, bufferWriter.Capacity);
+
+            bufferWriter.Clear();
+
+            Assert.Equal(0, bufferWriter.WrittenCount);
+            Assert.Equal(256, bufferWriter.FreeCapacity);
+            Assert.Equal(256, bufferWriter.Capacity);
+            Assert.Equal(0, bufferWriter.WrittenMemory.Length);
+        }
+
+        [Fact]
+        public void WrittenMemory_ReturnsDataWrittenSoFar()
+        {
+            using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(256);
+            Span<byte> buffer = bufferWriter.GetSpan(5);
+            for (int i = 0; i < 5; i++)
+            {
+                buffer[i] = (byte)(i + 1);
+            }
+
+            bufferWriter.Advance(5);
+
+            buffer = bufferWriter.GetSpan(5);
+            for (int i = 0; i < 5; i++)
+            {
+                buffer[i] = (byte)(i + 6);
+            }
+
+            bufferWriter.Advance(5);
+
+            ReadOnlySpan<byte> data = bufferWriter.WrittenMemory.Span;
+            Assert.Equal(10, data.Length);
+            for (int i = 0; i < data.Length; i++)
+            {
+                Assert.Equal(i + 1, data[i]);
+            }
+        }
+    }
+}
+
+#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/PooledByteBufferWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/PooledByteBufferWriterTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.OData.Tests.Json
     public class PooledByteBufferWriterTests
     {
         [Fact]
-        public void ContstructorInitializesBufferToInititalCapacity()
+        public void Constructor_InitializesBufferToInititalCapacity()
         {
             using PooledByteBufferWriter bufferWriter = new PooledByteBufferWriter(512);
             Assert.Equal(0, bufferWriter.WrittenMemory.Span.Length);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -181,6 +181,12 @@ namespace Microsoft.OData.Tests
             Assert.True(this.settings.ThrowOnDuplicatePropertyNames);
         }
 
+        [Fact]
+        public void BufferSizeShouldDefaultToDefaultOutputBufferSize()
+        {
+            Assert.Equal(ODataConstants.DefaultOutputBufferSize, this.settings.BufferSize);
+        }
+
         #endregion Default settings tests
 
         #region Copy constructor tests
@@ -341,6 +347,7 @@ namespace Microsoft.OData.Tests
             this.settings.ArrayPool = new TestCharArrayPool(5);
             this.settings.EnableMessageStreamDisposal = false;
             this.settings.EnableCharactersCheck = true;
+            this.settings.BufferSize = 4096;
 
             var edmModel = new EdmModel();
             var defaultContainer = new EdmEntityContainer("TestModel", "DefaultContainer");

--- a/test/PerformanceTests/SerializationComparisonsTests/Lib/ODataMessageWriterAsyncPayloadWriter.cs
+++ b/test/PerformanceTests/SerializationComparisonsTests/Lib/ODataMessageWriterAsyncPayloadWriter.cs
@@ -49,7 +49,7 @@ namespace ExperimentsLib
             
             IODataResponseMessage message = this.messageFactory(stream);
 
-            var messageWriter = new ODataMessageWriter(message, settings, this.model);
+            await using var messageWriter = new ODataMessageWriter(message, settings, this.model);
             var entitySet = this.model.EntityContainer.FindEntitySet("Customers");
             ODataWriter writer = await messageWriter.CreateODataResourceSetWriterAsync(entitySet);
 

--- a/test/PerformanceTests/SerializationComparisonsTests/Lib/ODataMessageWriterPayloadWriter.cs
+++ b/test/PerformanceTests/SerializationComparisonsTests/Lib/ODataMessageWriterPayloadWriter.cs
@@ -51,7 +51,7 @@ namespace ExperimentsLib
 
             IODataResponseMessage message = messageFactory(stream);
 
-            var messageWriter = new ODataMessageWriter(message, settings, model);
+            using var messageWriter = new ODataMessageWriter(message, settings, model);
             var entitySet = model.EntityContainer.FindEntitySet("Customers");
             var writer = messageWriter.CreateODataResourceSetWriter(entitySet);
 

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -5622,6 +5622,7 @@ public sealed class Microsoft.OData.ODataMessageWriterSettings {
     bool AlwaysAddTypeAnnotationsForDerivedTypes  { public get; public set; }
     Microsoft.OData.Buffers.ICharArrayPool ArrayPool  { public get; public set; }
     System.Uri BaseUri  { public get; public set; }
+    int BufferSize  { public get; public set; }
     bool EnableCharactersCheck  { public get; public set; }
     bool EnableMessageStreamDisposal  { public get; public set; }
     string JsonPCallback  { public get; public set; }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -5622,6 +5622,7 @@ public sealed class Microsoft.OData.ODataMessageWriterSettings {
     bool AlwaysAddTypeAnnotationsForDerivedTypes  { public get; public set; }
     Microsoft.OData.Buffers.ICharArrayPool ArrayPool  { public get; public set; }
     System.Uri BaseUri  { public get; public set; }
+    int BufferSize  { public get; public set; }
     bool EnableCharactersCheck  { public get; public set; }
     bool EnableMessageStreamDisposal  { public get; public set; }
     string JsonPCallback  { public get; public set; }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -5622,6 +5622,7 @@ public sealed class Microsoft.OData.ODataMessageWriterSettings {
     bool AlwaysAddTypeAnnotationsForDerivedTypes  { public get; public set; }
     Microsoft.OData.Buffers.ICharArrayPool ArrayPool  { public get; public set; }
     System.Uri BaseUri  { public get; public set; }
+    int BufferSize  { public get; public set; }
     bool EnableCharactersCheck  { public get; public set; }
     bool EnableMessageStreamDisposal  { public get; public set; }
     string JsonPCallback  { public get; public set; }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2790 .*

### Description

This PR reduces allocations of buffer used by ODL's internal JSON writer:
- When using `JsonWriter`:
  - made the buffer size of `BufferedStream` configurable using `ODataMessageWriterSettings.BufferSize`
- When using the `ODataUtf8JsonWriter`:
  - we do not wrap the stream in a `BufferedStream` since `ODataUtf8JsonWriter` handles its own buffering
  - replaces the `ArrayBufferWriter` used by `ODataUtf8JsonWriter` with a custom `PooledByteBufferWriter` that rents buffers from the Array pool

The `PooledByteBufferWriter` was adapted from .NET's implementation: https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs

**Update**: Instead of hardcoding the default size to a lower value, I made it configurable by adding a `BufferSize` property to `ODataMessageWriterSettings`. However, this setting is only used when creating an asynchronous `JsonWriter`. It is not used when creating an instance of `ODataUtf8JsonWriter`. The reason is because `IStreamBasedJsonWriterFactory.CreateJsonWriter` unfortunately does not expose a parameter for passing the buffer size.

I also made changes to the `SerializationComparisonTests` benchmarks to ensure that the writers are disposed after the payload has been written. This required refactoring the `JsonWriterBenchmarks` such that a new stream is used for each write call. The benchmarks can't re-use the stream cause the stream gets disposed. The changes make the benchmarks arguably cleaner even though each benchmark call is doing a bit more work than just writing the payload. This means that a comparison of benchmark results between this PR and the master branch is no longer an apples to apples comparison.

 When using `JsonWriter`, I had initially reduced the `BufferedStream` buffer size from 84k to 16k but I observed mixed results from the benchmarks, no strong evidence of improvement, and in some cases there was a regression. As a result I retained the original 84k buffer size but made it configurable via `ODataMessageWriterSettings.BufferSize`

Generally, I didn't see a lot of conclusive improvement in latency. But it doesn't seem to make latency worse. If it improves memory, without degrading latency, I think that's a good enough improvement to have.

### Benchmarks

I used the `TestServer` project in `SerializationComparisonsTests` to compare the heap allocations and latency/throughput before and after the changes.

#### Memory allocations

I set the count to 2000 to get the payload size above 400KB, which is a relatively large payload size, but matches a sample payload size of one of the customers.

Command used for testing:
-  Warm up request `bombardier -l -c 1 -n 1 https://localhost:7120/customers/ODataMessageWriter-Async`
- Concurrent requests: `bombardier -l -c 10 -n 50 https://localhost:7120/customers/ODataMessageWriter-Async`

**`JsonWriter` Before**

![image](https://github.com/OData/odata.net/assets/8460169/c3fffb6e-323a-4aab-9a9c-a8fbd414a9ca)

![image](https://github.com/OData/odata.net/assets/8460169/18fec3a4-ab68-4f38-9de3-c109a4820aa4)

**`JsonWriter` After**

![image](https://github.com/OData/odata.net/assets/8460169/b9694850-52ce-49b8-9a12-a432f346501a)

![image](https://github.com/OData/odata.net/assets/8460169/ae77f440-ebc1-4756-b87f-76e94c7bf824)


**`Utf8JsonWriter` Before**

![image](https://github.com/OData/odata.net/assets/8460169/f495b825-9b4e-450e-aa8f-00b6ee68ecc7)

![image](https://github.com/OData/odata.net/assets/8460169/ea035463-2c3a-49f5-bdbb-e1fedf696cb9)


**`Utf8JsonWriter` After**

![image](https://github.com/OData/odata.net/assets/8460169/d4c4bd68-9ad3-49ec-be23-e9c9433da236)

![image](https://github.com/OData/odata.net/assets/8460169/5f5d3f8b-c336-4772-8e9f-82ed48bb420d)


#### Request metrics

Command used for testing:

- Sequential request latency: `bombardier -l -c 1 -n 100 https://localhost:7120/customers/ODataMessageWriter-Async?count=2000`
- Concurrent requests: `bombardier -l -c 50 -d 1m https://localhost:7120/customers/ODataMessageWriter-Async?count=2000`
- High load (timeouts expected): `Utf8JsonWriter`: `bombardier -l -c 100 -d 1m https://localhost:7120/customers/ODataMessageWriter-Async?

**`JsonWriter` before**

- Sequential requests:
Statistics        Avg      Stdev        Max
  Reqs/sec        12.76      18.91      82.50
  Latency       76.91ms    45.08ms   406.04ms
  Latency Distribution
     50%    64.69ms
     75%    66.31ms
     90%    75.04ms
     95%   174.68ms
     99%   220.88ms
  HTTP codes:
    1xx - 0, 2xx - 100, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     7.43MB/s

- 50 connections concurrent requests:

Statistics        Avg      Stdev        Max
  Reqs/sec        63.07     145.61    3849.11
  Latency         0.94s    98.78ms      1.67s
  Latency Distribution
     50%      0.94s
     75%      1.00s
     90%      1.06s
     95%      1.11s
     99%      1.33s
  HTTP codes:
    1xx - 0, 2xx - 3193, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    30.32MB/s

- 100 connections

Statistics        Avg      Stdev        Max
  Reqs/sec        49.50     117.08    1467.94
  Latency         2.28s      1.88s     13.83s
  Latency Distribution
     50%      1.75s
     75%      1.87s
     90%      4.13s
     95%      6.53s
     99%     12.67s
  HTTP codes:
    1xx - 0, 2xx - 2639, 3xx - 0, 4xx - 0, 5xx - 0
    others - 31

**`JsonWriter` after**

- Sequential requests:

Statistics        Avg      Stdev        Max
  Reqs/sec        12.68      19.03      88.51
  Latency       78.80ms    40.66ms   426.61ms
  Latency Distribution
     50%    68.24ms
     75%    71.52ms
     90%    81.92ms
     95%   140.85ms
     99%   160.52ms
  HTTP codes:
    1xx - 0, 2xx - 100, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     7.29MB/s

- 50 connections, concurrent requests:

Statistics        Avg      Stdev        Max
  Reqs/sec        66.39     139.43    3841.72
  Latency         0.90s    84.35ms      1.28s
  Latency Distribution
     50%      0.90s
     75%      0.95s
     90%      1.00s
     95%      1.04s
     99%      1.13s
  HTTP codes:
    1xx - 0, 2xx - 3361, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    31.99MB/s

- 100 connections

Statistics        Avg      Stdev        Max
  Reqs/sec        53.45     179.59    5419.08
  Latency         2.36s      2.02s     13.55s
  Latency Distribution
     50%      1.75s
     75%      1.89s
     90%      4.22s
     95%      6.94s
     99%     12.67s
  HTTP codes:
    1xx - 0, 2xx - 2546, 3xx - 0, 4xx - 0, 5xx - 0
    others - 34

**`Utf8JsonWriter` before**
- Sequential requests

Statistics        Avg      Stdev        Max
  Reqs/sec        15.01      19.06      63.33
  Latency       66.21ms    34.34ms   345.19ms
  Latency Distribution
     50%    56.89ms
     75%    59.79ms
     90%    70.13ms
     95%   109.54ms
     99%   159.28ms
  HTTP codes:
    1xx - 0, 2xx - 100, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     8.89MB/s

- 50 connections

Statistics        Avg      Stdev        Max
  Reqs/sec        76.40     160.26    3675.45
  Latency      818.42ms    96.34ms      1.23s
  Latency Distribution
     50%   807.87ms
     75%      0.88s
     90%      0.95s
     95%      1.01s
     99%      1.10s
  HTTP codes:
    1xx - 0, 2xx - 3681, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    35.96MB/s

- 100 connections

Statistics        Avg      Stdev        Max
  Reqs/sec        71.17     131.48    2669.99
  Latency         1.65s   391.15ms     11.73s
  Latency Distribution
     50%      1.61s
     75%      1.70s
     90%      1.82s
     95%      1.89s
     99%      4.12s
  HTTP codes:
    1xx - 0, 2xx - 3663, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    36.03MB/s

**`Utf8JsonWriter` after**

- Sequential requests

Statistics        Avg      Stdev        Max
  Reqs/sec        17.12      62.12    1135.20
  Latency       70.11ms    36.60ms   347.11ms
  Latency Distribution
     50%    57.99ms
     75%    61.92ms
     90%   107.97ms
     95%   138.66ms
     99%   156.07ms
  HTTP codes:
    1xx - 0, 2xx - 100, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:     8.40MB/s

- 50 connections

Statistics        Avg      Stdev        Max
  Reqs/sec        75.81     147.23    3844.68
  Latency      792.53ms    80.07ms      1.33s
  Latency Distribution
     50%   790.36ms
     75%   845.36ms
     90%      0.90s
     95%      0.93s
     99%      1.00s
  HTTP codes:
    1xx - 0, 2xx - 3802, 3xx - 0, 4xx - 0, 5xx - 0
    others - 0
  Throughput:    37.13MB/s

-100 connections

Statistics        Avg      Stdev        Max
  Reqs/sec        73.47     209.24    5402.75
  Latency         1.71s   544.48ms      9.21s
  Latency Distribution
     50%      1.63s
     75%      1.74s
     90%      1.86s
     95%      1.97s
     99%      4.21s
  HTTP codes:
    1xx - 0, 2xx - 3533, 3xx - 0, 4xx - 0, 5xx - 0
    others - 1
  Errors:
    tls handshake timed out - 1
  Throughput:    35.44MB/s

#### Writer benchmarks

**Before**
|           Method |                                           WriterName |       Mean |      Error |     StdDev |     Median |      Gen 0 |     Gen 1 |  Allocated |
|----------------- |----------------------------------------------------- |-----------:|-----------:|-----------:|-----------:|-----------:|----------:|-----------:|
| WriteToFileAsync |                                   ODataMessageWriter | 380.980 ms |  7.4531 ms |  6.6070 ms | 379.283 ms | 53000.0000 |         - | 224,003 KB |
| WriteToFileAsync |                             ODataMessageWriter-Async | 684.025 ms |  9.7998 ms |  9.1667 ms | 681.923 ms | 63000.0000 | 1000.0000 | 266,767 KB |
| WriteToFileAsync |                    ODataMessageWriter-Utf8JsonWriter | 353.918 ms |  6.9733 ms |  5.8231 ms | 354.351 ms | 51000.0000 | 1000.0000 | 217,429 KB |
| WriteToFileAsync |              ODataMessageWriter-Utf8JsonWriter-Async | 620.257 ms | 12.2123 ms | 15.8794 ms | 613.840 ms | 51000.0000 | 1000.0000 | 218,772 KB |

**After**

|           Method |                                           WriterName |       Mean |      Error |     StdDev |     Median |      Gen 0 |     Gen 1 |  Allocated |
|----------------- |----------------------------------------------------- |-----------:|-----------:|-----------:|-----------:|-----------:|----------:|-----------:|
| WriteToFileAsync |                                   ODataMessageWriter | 399.640 ms |  7.9563 ms |  9.4714 ms | 396.437 ms | 53000.0000 |         - | 224,018 KB |
| WriteToFileAsync |                             ODataMessageWriter-Async | 704.245 ms | 13.5573 ms | 14.5062 ms | 698.330 ms | 63000.0000 | 1000.0000 | 266,773 KB |
| WriteToFileAsync |                    ODataMessageWriter-Utf8JsonWriter | 378.397 ms |  3.2468 ms |  2.8782 ms | 378.249 ms | 51000.0000 |         - | 217,344 KB |
| WriteToFileAsync |              ODataMessageWriter-Utf8JsonWriter-Async | 627.557 ms | 12.4976 ms | 20.8807 ms | 623.245 ms | 51000.0000 |         - | 218,138 KB |

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

