### PR TITLE
Upgrade Microsoft.Bcl.AsyncInterfaces dependency to 8.0.0

### DIFF
--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
@@ -22,7 +22,7 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Spatial" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
         <dependency id="Microsoft.OData.Edm" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" />
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
@@ -23,7 +23,7 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
       <group targetFramework=".NETStandard2.0">
         <dependency id="Microsoft.Spatial" version="[$VersionNuGetSemantic$]" />
         <dependency id="Microsoft.OData.Edm" version="[$VersionNuGetSemantic$]" />
-        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" />
+        <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -88,7 +88,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>7.0.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.ObjectPool">
       <Version>6.0.3</Version>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -71,13 +71,13 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>7.0.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>7.0.0</Version>
+      <Version>8.0.0</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/test/PublicApiTests/Microsoft.OData.PublicApi.Tests.csproj
+++ b/test/PublicApiTests/Microsoft.OData.PublicApi.Tests.csproj
@@ -21,7 +21,7 @@
     <EmbeddedResource Include="BaseLine\Microsoft.OData.PublicApi.netstandard2.0.bsl" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

This pull request upgrades **Microsoft.Bcl.AsyncInterfaces** dependency to 8.0.0 due to reported vulnerabilities in 7.0.0
