### PR TITLE
Slight performance improvement for `IEdmNavigationSource.EntityType()`

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEntitySet.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsEntitySet.cs
@@ -19,9 +19,19 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         {
         }
 
+        private IEdmType type;
+
         public override IEdmType Type
         {
-            get { return new EdmCollectionType(new EdmEntityTypeReference(this.typeCache.GetValue(this, ComputeElementTypeFunc, null), false)); }
+            get 
+            {
+                if (type == null)
+                {
+                    type = new EdmCollectionType(new EdmEntityTypeReference(this.typeCache.GetValue(this, ComputeElementTypeFunc, null), false));
+                }
+
+                return type;
+            }
         }
 
         public override EdmContainerElementKind ContainerElementKind

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsSingleton.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsSingleton.cs
@@ -19,9 +19,19 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         {
         }
 
+        private IEdmType type;
+
         public override IEdmType Type
         {
-            get { return this.typeCache.GetValue(this, ComputeElementTypeFunc, null); }
+            get
+            { 
+                if (type == null)
+                {
+                    type = this.typeCache.GetValue(this, ComputeElementTypeFunc, null);
+                }
+
+                return type;
+            }
         }
 
         public override EdmContainerElementKind ContainerElementKind

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -2822,34 +2822,7 @@ namespace Microsoft.OData.Edm
         /// <returns>The entity type of the navigation source.</returns>
         public static IEdmEntityType EntityType(this IEdmNavigationSource navigationSource)
         {
-            var entitySetBase = navigationSource as IEdmEntitySetBase;
-            if (entitySetBase != null)
-            {
-                IEdmCollectionType collectionType = entitySetBase.Type as IEdmCollectionType;
-
-                if (collectionType != null)
-                {
-                    return collectionType.ElementType.Definition as IEdmEntityType;
-                }
-
-                var unknownEntitySet = entitySetBase as IEdmUnknownEntitySet;
-                if (unknownEntitySet != null)
-                {
-                    // Handle missing navigation target for nullable
-                    // singleton navigation property.
-                    return unknownEntitySet.Type as IEdmEntityType;
-                }
-
-                return null;
-            }
-
-            var singleton = navigationSource as IEdmSingleton;
-            if (singleton != null)
-            {
-                return singleton.Type as IEdmEntityType;
-            }
-
-            return null;
+            return navigationSource?.Type.AsElementType() as IEdmEntityType;
         }
 
         #endregion


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2805 

### Description

This PR slightly reduces the cost of calling `IEdmNavigationSource.EntityType()` extension method. Firstly, it simplifies the method implementation by referring to the `IEdmNavigationSource.Type` directly instead of casting the interface to different sub-types and calling `.Type` on them.

This method works because for all code paths in the original code, the `Type` property was used to retrieve the `IEdmType` then cast to `IEdmEntityType`. Since `IEdmNavigationSource` has the `Type` property, we don't need the casts to access it. In the original code, `IEntitySetBase` was treated differently because its type is expected to be a collection type, in which case, the `ElementType` is called. This is now handled by the call to `AsElementType()`.

The current implementation makes the following assumptions:
- Only `IEntitySetBase` instances other than `UnknownEdmEntitySet` have a collection type
- The navigation source is either an entity set or singleton, and if it's not, then its type is not an entity type

Here are examples that would break these assumptions:
- A navigation source that is an `IEdmEntitySet` which is not `UnknownEdmEntitySet` and whose `Type` property return an `IEdmEntityType` instead of a `IEdmCollectionType` that wraps the entity type
- A navigation source that's neither an entity set nor a singleton but whose type property returns an `IEdmEntityType`

In those scenarios the original implementation would return `null` but the new implementation would return an instance of `IEdmEntitType`. But I don't think those scenarios are valid, our existing implementations of these interfaces adhere to the assumptions I had. Maybe a service may have a custom implementation that breaks these assumptions. Since no tests failed when I changed the implementation, I took it as confirmation that these scenarios were not accounted for in the design of te class.

However, if you argue that the assumptions do not hold, that those scenarios are valid or that we should ensure that an implementation change should exactly match the behaviour of the existing method in all possible scenarios, then we could consider the following alternative implementations:

- Add an `EntityType` property to `IEdmNavigationSource`, and implement in on all classes that implement the interface. This could be more efficient because it would avoid calling `ElementType` each time we want to get the entity type of an entity set. However, this would be a breaking change
- Add an `IHasEntityType` interface that exposes an `EntityType` interface. Implement this interface for built-in entity set and singleton classes. The `EntityType()` exchange method would then look like:

```c#
if (navigationSource is IHasEntityType sourceWithEntityType)
{
      return sourceWithEntityType.EntityType;
}

// fallback to existing implementation
return CurrentImplementationOfEntityType(navigationSource);
```

See: https://github.com/habbes/odata.net/blob/entity-type-perf-tests/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs#L2868

This approach would be slightly be more complex. I tried this approach and benchmarked it too, and found that the proposed implementation seems to have better results overall.

I also took the opportunity to make optimizations to the `Type` properties in `CsdlSemanticsEntitySet` and `CsdlSemanticsSingleton`. The properties were calling `Cache.GetValue` on each access. The `Cache` does store the computed value in internal field so future invocations will not re-compute the value, however it's still more work than just storing the value inside a field in the singleton or entity set. And for the entity set, it created an `EdmCollectionType` instance for every access, which I think is unnecessary.

Since this is a micro-optimization that may be hard to spot in the larger benchmarks, I created a micro-benchmark to analyze it. I run `EntityType()` on singletons and entity set from a CSDL model (parsed from a file) and from and `EdmModel` (created programmatically). The `EntityType_` methods use the original implementation, the `EntityTypeOptimized` use the proposed implementation in this PR, the `EntityTypeOptimized2` used the implementation based on `IHasEntityType` interface.

Benchmarks source: https://github.com/habbes/odata.net/blob/entity-type-perf-tests/test/PerformanceTests/ComponentTests/EdmLib/ExtensionMethodsTests.cs

**Before optimizing the CsdlSemanticsEntitySet and Singleton** (you can see the allocations from the CSDL entityset due to creating `EdmCollectionType` objects)

|                                 Method |     Mean |    Error |   StdDev |   Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------- |---------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
|               EntityType_WithEntitySet | 53.00 ns | 1.238 ns | 3.472 ns | 52.00 ns | 0.0129 |     - |     - |      56 B |
|               EntityType_WithSingleton | 36.98 ns | 0.729 ns | 1.705 ns | 36.81 ns |      - |     - |     - |         - |
|     EntityTypeOptimizied_WithEntitySet | 48.24 ns | 0.992 ns | 2.782 ns | 47.37 ns | 0.0129 |     - |     - |      56 B |
|      EntityTypeOptimized_WithSingleton | 25.49 ns | 0.345 ns | 0.288 ns | 25.59 ns |      - |     - |     - |         - |
|    EntityTypeOptimizied2_WithEntitySet | 43.63 ns | 0.638 ns | 0.974 ns | 43.25 ns | 0.0129 |     - |     - |      56 B |
|     EntityTypeOptimized2_WithSingleton | 28.88 ns | 0.534 ns | 0.500 ns | 28.76 ns |      - |     - |     - |         - |
|            EntityType_WithEdmEntitySet | 20.79 ns | 0.369 ns | 0.308 ns | 20.81 ns |      - |     - |     - |         - |
|            EntityType_WithEdmSingleton | 33.71 ns | 0.153 ns | 0.143 ns | 33.73 ns |      - |     - |     - |         - |
|  EntityTypeOptimizied_WithEdmEntitySet | 19.47 ns | 0.152 ns | 0.127 ns | 19.46 ns |      - |     - |     - |         - |
|   EntityTypeOptimized_WithEdmSingleton | 25.56 ns | 0.287 ns | 0.268 ns | 25.60 ns |      - |     - |     - |         - |
| EntityTypeOptimizied2_WithEdmEntitySet | 28.06 ns | 0.530 ns | 0.496 ns | 27.77 ns |      - |     - |     - |         - |
|  EntityTypeOptimized2_WithEdmSingleton | 28.61 ns | 0.177 ns | 0.157 ns | 28.58 ns |      - |     - |     - |         - |

**After optimizing the CsdlSemanticsEntitySet and Singleton**


|                                 Method |     Mean |    Error |   StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------------------------------------- |---------:|---------:|---------:|------:|------:|------:|----------:|
|               EntityType_WithEntitySet | 23.54 ns | 0.458 ns | 0.471 ns |     - |     - |     - |         - |
|               EntityType_WithSingleton | 21.94 ns | 0.424 ns | 0.552 ns |     - |     - |     - |         - |
|     EntityTypeOptimizied_WithEntitySet | 20.62 ns | 0.342 ns | 0.285 ns |     - |     - |     - |         - |
|      EntityTypeOptimized_WithSingleton | 14.13 ns | 0.227 ns | 0.270 ns |     - |     - |     - |         - |
|    EntityTypeOptimizied2_WithEntitySet | 17.38 ns | 0.346 ns | 0.339 ns |     - |     - |     - |         - |
|     EntityTypeOptimized2_WithSingleton | 17.03 ns | 0.261 ns | 0.218 ns |     - |     - |     - |         - |
|            EntityType_WithEdmEntitySet | 20.51 ns | 0.217 ns | 0.181 ns |     - |     - |     - |         - |
|            EntityType_WithEdmSingleton | 21.83 ns | 0.435 ns | 0.624 ns |     - |     - |     - |         - |
|  EntityTypeOptimizied_WithEdmEntitySet | 19.77 ns | 0.312 ns | 0.261 ns |     - |     - |     - |         - |
|   EntityTypeOptimized_WithEdmSingleton | 13.90 ns | 0.057 ns | 0.047 ns |     - |     - |     - |         - |
| EntityTypeOptimizied2_WithEdmEntitySet | 28.27 ns | 0.563 ns | 0.789 ns |     - |     - |     - |         - |
|  EntityTypeOptimized2_WithEdmSingleton | 16.74 ns | 0.222 ns | 0.173 ns |     - |     - |     - |         - |



### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
