### PR TITLE
Micro-optimization for `IsPrimitiveType`

### DIFF
--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -595,13 +595,26 @@ namespace Microsoft.OData.Metadata
         {
             Debug.Assert(clrType != null, "clrType != null");
 
-            if (clrType == typeof(UInt16) || clrType == typeof(UInt32) || clrType == typeof(UInt64))
-            {
+            // Directly check the most common types for first
+            // for better performance.
+            return clrType == typeof(string)
+                || clrType == typeof(int)
+                || clrType == typeof(bool)
+                || clrType == typeof(double)
+                || clrType == typeof(DateTimeOffset)
+                || clrType == typeof(Guid)
+                || clrType == typeof(Date)
+                || clrType == typeof(Decimal)
+                || clrType == typeof(Int64)
                 // Since UInt types are not in the core model, they cannot be found in the map below.
-                return true;
-            }
-
-            return PrimitiveTypeReferenceMap.ContainsKey(clrType) || typeof(ISpatial).IsAssignableFrom(clrType);
+                || clrType == typeof(UInt16)
+                || clrType == typeof(UInt32)
+                || clrType == typeof(UInt64)
+                // Lookup the primitive type map for remaining types. If we add more predicates to this conditions
+                // then it could take longer to reach the types in the last predicates than to look them up in the
+                // dictionary. So for a good balance handle common types directly and the rest in the dictionary.
+                || PrimitiveTypeReferenceMap.ContainsKey(clrType)
+                || typeof(ISpatial).IsAssignableFrom(clrType);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -45,6 +45,14 @@ namespace Microsoft.OData.Metadata
         /// </summary>
         private static readonly Dictionary<Type, IEdmPrimitiveTypeReference> PrimitiveTypeReferenceMap = new Dictionary<Type, IEdmPrimitiveTypeReference>(EqualityComparer<Type>.Default);
 
+#if !NETSTANDARD1_1
+        /// <summary>
+        /// Packs the <see cref="TypeCode"/> of supported primitive types. This is used to speed up the <see cref="IsPrimitiveType(Type)"/> method.
+        /// If the bit at a given type code position is set, it means that's a support primitive type.
+        /// </summary>
+        private static readonly int PrimitiveTypeCodeBitMap = 0;
+#endif
+
         /// <summary>Type reference for Edm.Boolean.</summary>
         private static readonly EdmPrimitiveTypeReference BooleanTypeReference = ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Boolean), false);
 
@@ -131,6 +139,25 @@ namespace Microsoft.OData.Metadata
             PrimitiveTypeReferenceMap.Add(typeof(Date?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Date), true));
             PrimitiveTypeReferenceMap.Add(typeof(TimeOfDay), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), false));
             PrimitiveTypeReferenceMap.Add(typeof(TimeOfDay?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), true));
+
+#if !NETSTANDARD1_1
+            // Pack type codes of supported primitive types in the bitmap
+            // See the type codes here: https://learn.microsoft.com/en-us/dotnet/api/system.typecode
+            PrimitiveTypeCodeBitMap = 0;
+
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.Byte;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.Decimal;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.Double;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.Int16;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.Int32;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.Int64;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.SByte;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.Single;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.String;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.UInt16;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.UInt32;
+            PrimitiveTypeCodeBitMap |= 1 << (int)TypeCode.UInt64;
+#endif
         }
 
         #region Internal methods
@@ -594,22 +621,19 @@ namespace Microsoft.OData.Metadata
         internal static bool IsPrimitiveType(Type clrType)
         {
             Debug.Assert(clrType != null, "clrType != null");
+#if !NETSTANDARD1_1
+            int typeCode = 1 << (int)Type.GetTypeCode(clrType);
+#endif
 
-            // Directly check the most common types for first
-            // for better performance.
-            return clrType == typeof(string)
-                || clrType == typeof(int)
-                || clrType == typeof(bool)
-                || clrType == typeof(double)
-                || clrType == typeof(DateTimeOffset)
+            return
+#if !NETSTANDARD1_1
+                (PrimitiveTypeCodeBitMap & typeCode) == typeCode
+                ||
+#endif
+                // DateTimeOffset and Guid don't have dedicated type codes, but they are
+                // common types, so we check them first to optimize their lookup before falling back to the dictionary.
+                clrType == typeof(DateTimeOffset)
                 || clrType == typeof(Guid)
-                || clrType == typeof(Date)
-                || clrType == typeof(Decimal)
-                || clrType == typeof(Int64)
-                // Since UInt types are not in the core model, they cannot be found in the map below.
-                || clrType == typeof(UInt16)
-                || clrType == typeof(UInt32)
-                || clrType == typeof(UInt64)
                 // Lookup the primitive type map for remaining types. If we add more predicates to this conditions
                 // then it could take longer to reach the types in the last predicates than to look them up in the
                 // dictionary. So for a good balance handle common types directly and the rest in the dictionary.

--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -629,6 +629,10 @@ namespace Microsoft.OData.Metadata
 #if !NETSTANDARD1_1
                 (PrimitiveTypeCodeBitMap & typeCode) == typeCode
                 ||
+#else
+                // .netstandard1.1 does not support TypeCode
+                clrType == typeof(UInt16) || clrType == typeof(UInt32) || clrType == typeof(UInt64)
+                ||
 #endif
                 // DateTimeOffset and Guid don't have dedicated type codes, but they are
                 // common types, so we check them first to optimize their lookup before falling back to the dictionary.


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2806

### Description

This PR improves the performance of creating an `ODataPrimitiveValue` instance for arguably the most common types (int, bool, string, dates, Guid). It does this by refactoring `IsPrimitiveType`. In the existing implementation, `IsPrimitiveType` checks whether the type is in the `PrimitveTypeReferenceMap` dictionary. This lookup is relatively costly. For most common types, I compare the type directly with the input CLR type using a compound `||` expression. Initially I had tried to put all the types in a long `||` expression, but what I found while benchmarking is that testing for types that were in the last predicates of the expression would take longer than looking them in the dictionary. So I tried to strike a balance by limiting the number of types I check outside the dictionary to only what I consider to be the most common ones. The Uint types are checked outside the dictionary regardless because they are not in that map. Maybe I should move them to the end of the expression since I suspect they are not that common. This "optimization" may make the dictionary look up more expensive for some types since it has do to more work before getting to the dictionary, but I think it's a reasonable trade off to have slightly lower perf for less frequent types in favour of the more frequent ones. I'm also open to suggestions on whether the list of types I've considered the most common is reasonable.

Since this micro-optimization might be harder to assess in larger benchmarks, I created some micro-benchmarks here: 
https://github.com/habbes/odata.net/blob/entity-type-perf-tests/test/PerformanceTests/ComponentTests/CoreLib/PrimitiveValueTests.cs

**`ODataPrimitiveValue` performance before**

|                                Method |      Mean |     Error |    StdDev |    Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------------- |----------:|----------:|----------:|----------:|-------:|------:|------:|----------:|
|                        CreateIntValue | 40.711 ns | 0.8791 ns | 1.7146 ns | 40.630 ns | 0.0148 |     - |     - |      64 B |
|                       CreateBoolValue | 40.263 ns | 0.7957 ns | 0.6644 ns | 40.101 ns | 0.0148 |     - |     - |      64 B |
|                     CreateStringValue | 38.614 ns | 0.8505 ns | 1.7564 ns | 38.873 ns | 0.0092 |     - |     - |      40 B |
|                       CreateDateValue | 39.929 ns | 0.5751 ns | 0.5098 ns | 39.754 ns | 0.0167 |     - |     - |      72 B |
|                  CreateByteArrayValue | 38.615 ns | 0.8148 ns | 0.8003 ns | 38.254 ns | 0.0092 |     - |     - |      40 B |
|                       CreateGuidValue | 45.000 ns | 0.9237 ns | 1.4651 ns | 45.196 ns | 0.0167 |     - |     - |      72 B |
|                CreateNullableIntValue | 96.605 ns | 2.0524 ns | 5.9545 ns | 94.499 ns | 0.0148 |     - |     - |      64 B |
|                     CreateUint64Value | 16.575 ns | 0.4084 ns | 0.6595 ns | 16.511 ns | 0.0148 |     - |     - |      64 B |
|                  CreateTimeOfDayValue | 40.141 ns | 0.8394 ns | 0.8981 ns | 40.247 ns | 0.0148 |     - |     - |      64 B |

**`ODataPrimitiveValue` performance after**

|                 Method |     Mean |    Error |   StdDev |   Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |---------:|---------:|---------:|---------:|-------:|------:|------:|----------:|
|         CreateIntValue | 15.09 ns | 0.151 ns | 0.118 ns | 15.08 ns | 0.0148 |     - |     - |      64 B |
|        CreateBoolValue | 17.41 ns | 0.414 ns | 0.632 ns | 17.26 ns | 0.0148 |     - |     - |      64 B |
|      CreateStringValue | 11.11 ns | 0.060 ns | 0.047 ns | 11.13 ns | 0.0093 |     - |     - |      40 B |
|        CreateDateValue | 21.31 ns | 0.492 ns | 0.567 ns | 21.07 ns | 0.0167 |     - |     - |      72 B |
|   CreateByteArrayValue | 50.69 ns | 0.647 ns | 0.540 ns | 50.59 ns | 0.0092 |     - |     - |      40 B |
|        CreateGuidValue | 23.20 ns | 0.337 ns | 0.388 ns | 23.05 ns | 0.0167 |     - |     - |      72 B |
| CreateNullableIntValue | 67.13 ns | 1.408 ns | 2.844 ns | 65.68 ns | 0.0148 |     - |     - |      64 B |
|      CreateUint64Value | 30.49 ns | 0.489 ns | 0.458 ns | 30.50 ns | 0.0148 |     - |     - |      64 B |
|   CreateTimeOfDayValue | 58.25 ns | 1.211 ns | 2.274 ns | 57.89 ns | 0.0148 |     - |     - |      64 B |

I compare runningd `IsPrimitiveType` against different types.  I tested three implementations of the method:
- The `IsPrimitiveType_` methods use the original implementation
- `IsPrimitiveTypeOptimized_` do not use the dictionary, all the types are checked directly in a long expression with predicates combined by `||`
- `IsPrimitiveTypeOptimized2_` is hybrid implementation that checks the most common types directly and uses the dictionary for the rest. This is the version adopted in this PR.

Here are the results:
|                                Method |      Mean |     Error |    StdDev |    Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|-------------------------------------- |----------:|----------:|----------:|----------:|-------:|------:|------:|----------:|
|                   IsPrimitiveType_Int | 22.601 ns | 0.4719 ns | 0.5969 ns | 22.376 ns |      - |     - |     - |         - |
|                IsPrimitiveType_String | 22.289 ns | 0.2468 ns | 0.2308 ns | 22.209 ns |      - |     - |     - |         - |
|                  IsPrimitiveType_Bool | 21.033 ns | 0.1256 ns | 0.1114 ns | 21.008 ns |      - |     - |     - |         - |
|                  IsPrimitiveType_Date | 22.475 ns | 0.4751 ns | 0.6814 ns | 22.361 ns |      - |     - |     - |         - |
|             IsPrimitiveType_ByteArray | 24.060 ns | 0.4876 ns | 0.4323 ns | 24.266 ns |      - |     - |     - |         - |
|                  IsPrimitiveType_Guid | 22.531 ns | 0.4556 ns | 0.4475 ns | 22.513 ns |      - |     - |     - |         - |
|           IsPrimitiveType_NullableInt | 78.908 ns | 1.6046 ns | 2.9341 ns | 78.545 ns | 0.0055 |     - |     - |      24 B |
|                IsPrimitiveType_Uint64 |  5.689 ns | 0.1445 ns | 0.3111 ns |  5.615 ns |      - |     - |     - |         - |
|             IsPrimitiveType_TimeOfDay | 22.624 ns | 0.4729 ns | 0.7221 ns | 22.705 ns |      - |     - |     - |         - |
|          IsPrimitiveTypeOptimized_Int |  4.901 ns | 0.1214 ns | 0.1077 ns |  4.882 ns |      - |     - |     - |         - |
|       IsPrimitiveTypeOptimized_String |  3.780 ns | 0.0754 ns | 0.0705 ns |  3.759 ns |      - |     - |     - |         - |
|         IsPrimitiveTypeOptimized_Bool |  6.699 ns | 0.1548 ns | 0.1720 ns |  6.682 ns |      - |     - |     - |         - |
|         IsPrimitiveTypeOptimized_Date |  8.810 ns | 0.1957 ns | 0.2743 ns |  8.751 ns |      - |     - |     - |         - |
|    IsPrimitiveTypeOptimized_ByteArray | 29.467 ns | 0.3959 ns | 0.3510 ns | 29.443 ns |      - |     - |     - |         - |
|         IsPrimitiveTypeOptimized_Guid | 21.046 ns | 0.4198 ns | 0.3721 ns | 21.104 ns |      - |     - |     - |         - |
|  IsPrimitiveTypeOptimized_NullableInt | 51.598 ns | 1.0570 ns | 2.0864 ns | 50.789 ns | 0.0055 |     - |     - |      24 B |
|       IsPrimitiveTypeOptimized_Uint64 | 61.068 ns | 0.4529 ns | 0.4237 ns | 61.058 ns |      - |     - |     - |         - |
|    IsPrimitiveTypeOptimized_TimeOfDay | 55.378 ns | 1.1278 ns | 1.2988 ns | 54.893 ns |      - |     - |     - |         - |
|         IsPrimitiveTypeOptimized2_Int |  4.850 ns | 0.0787 ns | 0.0698 ns |  4.862 ns |      - |     - |     - |         - |
|      IsPrimitiveTypeOptimized2_String |  3.784 ns | 0.0403 ns | 0.0377 ns |  3.772 ns |      - |     - |     - |         - |
|        IsPrimitiveTypeOptimized2_Bool |  6.568 ns | 0.1424 ns | 0.1332 ns |  6.532 ns |      - |     - |     - |         - |
|        IsPrimitiveTypeOptimized2_Date |  9.076 ns | 0.1464 ns | 0.1298 ns |  9.123 ns |      - |     - |     - |         - |
|   IsPrimitiveTypeOptimized2_ByteArray | 41.829 ns | 0.6950 ns | 0.7137 ns | 41.517 ns |      - |     - |     - |         - |
|        IsPrimitiveTypeOptimized2_Guid | 10.579 ns | 0.2309 ns | 0.5488 ns | 10.348 ns |      - |     - |     - |         - |
| IsPrimitiveTypeOptimized2_NullableInt | 55.496 ns | 1.1484 ns | 3.3499 ns | 55.042 ns | 0.0055 |     - |     - |      24 B |
|      IsPrimitiveTypeOptimized2_Uint64 | 19.755 ns | 0.4191 ns | 0.5301 ns | 19.552 ns |      - |     - |     - |         - |
|   IsPrimitiveTypeOptimized2_TimeOfDay | 39.894 ns | 0.6160 ns | 0.5762 ns | 39.639 ns |      - |     - |     - |         - |


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
