### PR TITLE
Add index-based access to ODataPath

### DIFF
--- a/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.UriParser.ODataPath.this[int index].get -> Microsoft.OData.UriParser.ODataPathSegment

--- a/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.UriParser.ODataPath.this[int index].get -> Microsoft.OData.UriParser.ODataPathSegment

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.UriParser.ODataPath.this[int index].get -> Microsoft.OData.UriParser.ODataPathSegment

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.OData.UriParser.ODataPath.this[int index].get -> Microsoft.OData.UriParser.ODataPathSegment

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
@@ -77,7 +77,7 @@ namespace Microsoft.OData.UriParser
         {
             get
             {
-                return this.segments.Count > 0 ? this.segments[0] : default;
+                return this.segments.Count > 0 ? this.segments[0] : null;
             }
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.OData.UriParser
         {
             get
             {
-                return this.segments.Count > 0 ? this.segments[this.segments.Count - 1] : default;
+                return this.segments.Count > 0 ? this.segments[this.segments.Count - 1] : null;
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
@@ -93,6 +93,12 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
+        /// Get the segment at the specified index.
+        /// </summary>
+        /// <param name="index">The index of the segment to retrieve</param>
+        public ODataPathSegment this[int index] => this.segments[index];
+
+        /// <summary>
         /// Get the number of segments in this path.
         /// </summary>
         public int Count

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/ODataPath.cs
@@ -77,7 +77,7 @@ namespace Microsoft.OData.UriParser
         {
             get
             {
-                return this.segments.FirstOrDefault();
+                return this.segments.Count > 0 ? this.segments[0] : default;
             }
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.OData.UriParser
         {
             get
             {
-                return this.segments.LastOrDefault();
+                return this.segments.Count > 0 ? this.segments[this.segments.Count - 1] : default;
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathTests.cs
@@ -107,5 +107,24 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         {
             Assert.False(new ODataPath().Equals(new ODataPath(BatchSegment.Instance)));
         }
+
+        [Fact]
+        public void IndexShouldReturnCorrectSegment()
+        {
+            ODataPath path = new ODataPath(BatchSegment.Instance, CountSegment.Instance);
+            path[0].ShouldBeBatchSegment();
+            path[1].ShouldBeCountSegment();
+        }
+
+        [Fact]
+        public void IndexingOutOfBoundsShouldThrowException()
+        {
+            ODataPath path = new ODataPath();
+            Assert.Throws<ArgumentOutOfRangeException>(() => path[0]);
+
+            ODataPath path2 = new ODataPath(BatchSegment.Instance, CountSegment.Instance);
+            Assert.Throws<ArgumentOutOfRangeException>(() => path2[2]);
+            Assert.Throws<ArgumentOutOfRangeException>(() => path2[-1]);
+        }
     }
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -6484,12 +6484,16 @@ public class Microsoft.OData.UriParser.ODataExpandPath : Microsoft.OData.UriPars
     public ODataExpandPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 }
 
+[
+DefaultMemberAttribute(),
+]
 public class Microsoft.OData.UriParser.ODataPath : IEnumerable, IEnumerable`1 {
     public ODataPath (Microsoft.OData.UriParser.ODataPathSegment[] segments)
     public ODataPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 
     int Count  { public get; }
     Microsoft.OData.UriParser.ODataPathSegment FirstSegment  { public get; }
+    Microsoft.OData.UriParser.ODataPathSegment Item [int index] { public get; }
     Microsoft.OData.UriParser.ODataPathSegment LastSegment  { public get; }
 
     public virtual System.Collections.Generic.IEnumerator`1[[Microsoft.OData.UriParser.ODataPathSegment]] GetEnumerator ()

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -6484,12 +6484,16 @@ public class Microsoft.OData.UriParser.ODataExpandPath : Microsoft.OData.UriPars
     public ODataExpandPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 }
 
+[
+DefaultMemberAttribute(),
+]
 public class Microsoft.OData.UriParser.ODataPath : IEnumerable, IEnumerable`1 {
     public ODataPath (Microsoft.OData.UriParser.ODataPathSegment[] segments)
     public ODataPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 
     int Count  { public get; }
     Microsoft.OData.UriParser.ODataPathSegment FirstSegment  { public get; }
+    Microsoft.OData.UriParser.ODataPathSegment Item [int index] { public get; }
     Microsoft.OData.UriParser.ODataPathSegment LastSegment  { public get; }
 
     public virtual System.Collections.Generic.IEnumerator`1[[Microsoft.OData.UriParser.ODataPathSegment]] GetEnumerator ()

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -6484,12 +6484,16 @@ public class Microsoft.OData.UriParser.ODataExpandPath : Microsoft.OData.UriPars
     public ODataExpandPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 }
 
+[
+DefaultMemberAttribute(),
+]
 public class Microsoft.OData.UriParser.ODataPath : IEnumerable, IEnumerable`1 {
     public ODataPath (Microsoft.OData.UriParser.ODataPathSegment[] segments)
     public ODataPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 
     int Count  { public get; }
     Microsoft.OData.UriParser.ODataPathSegment FirstSegment  { public get; }
+    Microsoft.OData.UriParser.ODataPathSegment Item [int index] { public get; }
     Microsoft.OData.UriParser.ODataPathSegment LastSegment  { public get; }
 
     public virtual System.Collections.Generic.IEnumerator`1[[Microsoft.OData.UriParser.ODataPathSegment]] GetEnumerator ()


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2804*

### Description

This PR adds an indexer to `ODataPath` to make random-access of segments in the path possible. This will help us simplify and optimize operations where we rely on Linq, `ToList()` or `PathHandler`s in hot paths.

With this PR, `ODataPath` would statisfy all the requirements of an `IReadOnlyList`, in that case, would it be harmful to explicitly implement that interface (even if in a future release)?

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

Once (if) this PR is merged, we can go ahead and make improvements to some path operations both in ODL and AspNetCoreOData (e.g. `path.NavigationSource()` extension method in AspNetCoreOData)
