### PR TITLE
Add flag to skip property verification in `ODataResource`

### DIFF
--- a/src/Microsoft.OData.Core/ODataResource.cs
+++ b/src/Microsoft.OData.Core/ODataResource.cs
@@ -176,6 +176,15 @@ namespace Microsoft.OData
             get { return this.MetadataBuilder.GetFunctions(); }
         }
 
+        /// <summary>
+        /// Gets or sets whether to skip property verification. When set to false (default behaviour),
+        /// the properties collection will be verified to ensure it doesn't contain invalid values.
+        /// When set to true, it's the caller's responsibility to ensure the property values are valid
+        /// before setting the <see cref="Properties"/> property. This can be a useful optimization
+        /// in hot paths when you're sure property values are valid.
+        /// </summary>
+        public bool SkipPropertyVerification { get; set; }
+
         /// <summary>Gets or sets the resource properties.</summary>
         /// <returns>The resource properties.</returns>
         /// <remarks>
@@ -190,7 +199,11 @@ namespace Microsoft.OData
 
             set
             {
-                VerifyProperties(value);
+                if (!this.SkipPropertyVerification)
+                {
+                    VerifyProperties(value);
+                }
+
                 this.properties = value;
             }
         }

--- a/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.OData.ODataResourceBase.SkipPropertyVerification.get -> bool
+Microsoft.OData.ODataResourceBase.SkipPropertyVerification.set -> void

--- a/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.OData.ODataResourceBase.SkipPropertyVerification.get -> bool
+Microsoft.OData.ODataResourceBase.SkipPropertyVerification.set -> void

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard1.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.OData.ODataResourceBase.SkipPropertyVerification.get -> bool
+Microsoft.OData.ODataResourceBase.SkipPropertyVerification.set -> void

--- a/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.OData.ODataResourceBase.SkipPropertyVerification.get -> bool
+Microsoft.OData.ODataResourceBase.SkipPropertyVerification.set -> void

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
@@ -316,5 +316,42 @@ namespace Microsoft.OData.Tests
             var exception = Assert.Throws<ODataException>(test);
             Assert.Equal(Strings.ODataResource_PropertyValueCannotBeODataResourceValue("CollectionProperty"), exception.Message);
         }
+
+        [Fact]
+        public void WhenSkipPropertyVerificatonIsTrue_ODataResourcePropertyWithODataResourceValue_DoesNotThrow()
+        {
+            ODataResource resource = new ODataResource
+            {
+                TypeName = "NS.Resource",
+                SkipPropertyVerification = true
+            };
+
+            resource.Properties = new[]
+            {
+                new ODataProperty { Name = "ResourceProperty", Value = new ODataResourceValue() }
+            };
+        }
+
+        [Fact]
+        public void WhenSkipPropertyVerificatonIsTrue_ODataResourcePropertyWithCollectionODataResourceValue_DoesNotThrow()
+        {
+            ODataResource resource = new ODataResource
+            {
+                TypeName = "NS.Resource",
+                SkipPropertyVerification = true
+            };
+
+            resource.Properties = new[]
+            {
+                new ODataProperty
+                {
+                    Name = "CollectionProperty",
+                    Value = new ODataCollectionValue
+                    {
+                        Items = new [] { new ODataResourceValue() }
+                    }
+                }
+            };
+        }
     }
 }

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -4826,6 +4826,7 @@ public abstract class Microsoft.OData.ODataResourceBase : Microsoft.OData.ODataI
     Microsoft.OData.ODataStreamReferenceValue MediaResource  { public get; public set; }
     System.Collections.Generic.IEnumerable`1[[Microsoft.OData.ODataProperty]] Properties  { public get; public set; }
     System.Uri ReadLink  { public get; public set; }
+    bool SkipPropertyVerification  { public get; public set; }
     string TypeName  { public get; public set; }
 
     public void AddAction (Microsoft.OData.ODataAction action)

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -4826,6 +4826,7 @@ public abstract class Microsoft.OData.ODataResourceBase : Microsoft.OData.ODataI
     Microsoft.OData.ODataStreamReferenceValue MediaResource  { public get; public set; }
     System.Collections.Generic.IEnumerable`1[[Microsoft.OData.ODataProperty]] Properties  { public get; public set; }
     System.Uri ReadLink  { public get; public set; }
+    bool SkipPropertyVerification  { public get; public set; }
     string TypeName  { public get; public set; }
 
     public void AddAction (Microsoft.OData.ODataAction action)

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -4826,6 +4826,7 @@ public abstract class Microsoft.OData.ODataResourceBase : Microsoft.OData.ODataI
     Microsoft.OData.ODataStreamReferenceValue MediaResource  { public get; public set; }
     System.Collections.Generic.IEnumerable`1[[Microsoft.OData.ODataProperty]] Properties  { public get; public set; }
     System.Uri ReadLink  { public get; public set; }
+    bool SkipPropertyVerification  { public get; public set; }
     string TypeName  { public get; public set; }
 
     public void AddAction (Microsoft.OData.ODataAction action)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2803*

### Description

This PR adds a `SkipPropertyVerification` property to `ODataResource` which skips property verification. By default, `ODataResource` will verify the property values when the `Properties` property is set. The aim of the of the verification is to ensure that properties `ODataResourceValue`s are not included in the properties. I.e. the property values should either primitive types or collections of primitive types (`ODataResourceValue` is intended for use in annotations).

However, in scenarios like AspNetCoreOData, where the library already creates `ODataResource` that already match this expectation, it's an unnecessary cost to still go ahead and perform this verification. This flag can be used in AspNetCoreOData to avoid paying this cost for every resource that is created.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
