### PR TITLE
Fix NRE in CompareElements

### DIFF
--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmDirectValueAnnotationsManager.cs
@@ -336,6 +336,11 @@ namespace Microsoft.OData.Edm.Vocabularies
                 return 0;
             }
 
+            if (left is null || right is null)
+            {
+                return 0;
+            }
+
             /* Left and right are distinct. */
 
             int leftHash = left.GetHashCode();


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

CompareElements can NRE if one of the elements is null.

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
