### PR TITLE
Do not fail if parenthesis are not in expected state

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -69,10 +69,12 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
-        /// Extracts the segment identifier and, if there is a valid parenthesis pair in the segment, the expression in the parenthesis.
-        /// This function does not validate anything and simply provides the raw text of both the identifier and parenthetical expression.
+        /// Extracts the segment identifier and, if there are parenthesis in the segment, the expression in the parenthesis.
+        /// Will throw if identifier is not found or if the parenthesis expression is malformed. This function does not validate
+        /// anything and simply provides the raw text of both the identifier and parenthetical expression.
         /// </summary>
         /// <remarks>Internal only so it can be called from tests. Should not be used outside <see cref="ODataPathParser"/>.</remarks>
+        /// <param name="enableKeyAsSegment">Whether key-as-segment is enabled.</param>
         /// <param name="segmentText">The segment text.</param>
         /// <param name="identifier">The identifier that was found.</param>
         /// <param name="parenthesisExpression">The query portion that was found. Will be null after the call if no query portion was present.</param>
@@ -112,6 +114,21 @@ namespace Microsoft.OData.UriParser
             {
                 identifier = segmentText;
                 parenthesisExpression = null;
+            }
+
+            if (identifier.Length == 0)
+            {
+                if (enableKeyAsSegment)
+                {
+                    // We already know that the segment itself is non-zero and so if the identifier is empty and we've enabled
+                    // key-as-segment we'll treat the entire segment as the identifier.
+                    identifier = segmentText;
+                    parenthesisExpression = null;
+                }
+                else
+                {
+                    throw ExceptionUtil.ResourceNotFoundError(ODataErrorStrings.RequestUriProcessor_EmptySegmentInRequestUrl);
+                }
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
@@ -419,11 +419,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         public void ParseFilter_AliasInFilterPathSegment_AliasAsFirstSegment()
         {
             Action parse = () => ParseUriAndVerify(
-                new Uri("http://gobbledygook/$filter(@p1)&@p1=true"),
+                new Uri("http://gobbledygook/$filter(@p1)?@p1=true"),
                 (oDataPath, filterClause, orderByClause, selectExpandClause, aliasNodes) =>
                 {
                 });
-            parse.Throws<ODataException>(Strings.RequestUriProcessor_SyntaxError);
+            parse.Throws<ODataUnrecognizedPathException>(Strings.RequestUriProcessor_FilterOnRoot);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -1359,7 +1359,7 @@ namespace Microsoft.OData.Tests.UriParser
         [InlineData("/entitySetEscaped::/32:/NonComposableParameter", typeof(ODataUnrecognizedPathException))]
         [InlineData("/entitySetEscaped('32')/NS.SpecialDrive::/ComposableParameter::/nestedNonComposableParameter:", typeof(ODataUnrecognizedPathException))]
         [InlineData("/entitySetEscaped(32)/:NS.SpecialDrive:/ComposableParameter::/nestedNonComposableParameter:", typeof(ODataException))]
-        [InlineData("/entitySetEscaped('32')::/NS.SpecialDrive:/ComposableParameter::/nestedNonComposableParameter:", typeof(ODataException))]
+        [InlineData("/entitySetEscaped('32')::/NS.SpecialDrive:/ComposableParameter::/nestedNonComposableParameter:", typeof(ODataUnrecognizedPathException))]
         public void ParseInvalidEscapeURIShouldThrow(string escapeFunctionUri, Type exceptionType)
         {
             // Arrange

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTests.cs
@@ -42,6 +42,8 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             ExtractSegmentIdentifierAndParenthesisExpression("multiple(123)", "multiple", "123");
             ExtractSegmentIdentifierAndParenthesisExpression("multiple(123;321)", "multiple", "123;321");
             ExtractSegmentIdentifierAndParenthesisExpression("set()", "set", string.Empty);
+            ExtractSegmentIdentifierAndParenthesisExpression("()", "()", null);
+            ExtractSegmentIdentifierAndParenthesisExpression("file(1).txt", "file(1).txt", null);
         }
 
         [Fact]
@@ -50,14 +52,8 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             string actualIdentifier;
             string queryPortion;
 
-            Action emptyString = () => ODataPathParser.ExtractSegmentIdentifierAndParenthesisExpression(string.Empty, out actualIdentifier, out queryPortion);
+            Action emptyString = () => ODataPathParser.TryExtractSegmentIdentifierAndParenthesisExpression(string.Empty, out actualIdentifier, out queryPortion);
             emptyString.Throws<ODataUnrecognizedPathException>(ErrorStrings.RequestUriProcessor_EmptySegmentInRequestUrl);
-
-            Action noIdentifier = () => ODataPathParser.ExtractSegmentIdentifierAndParenthesisExpression("()", out actualIdentifier, out queryPortion);
-            noIdentifier.Throws<ODataUnrecognizedPathException>(ErrorStrings.RequestUriProcessor_EmptySegmentInRequestUrl);
-
-            Action noEndParen = () => ODataPathParser.ExtractSegmentIdentifierAndParenthesisExpression("foo(", out actualIdentifier, out queryPortion);
-            noEndParen.Throws<ODataException>(ErrorStrings.RequestUriProcessor_SyntaxError);
         }
 
         #region $ref cases
@@ -815,7 +811,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
         {
             string actualIdentifier;
             string queryPortion;
-            ODataPathParser.ExtractSegmentIdentifierAndParenthesisExpression(segment, out actualIdentifier, out queryPortion);
+            ODataPathParser.TryExtractSegmentIdentifierAndParenthesisExpression(segment, out actualIdentifier, out queryPortion);
             Assert.Equal(expectedIdentifier, actualIdentifier);
             Assert.Equal(expectedQueryPortion, queryPortion);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/ODataPathParserTests.cs
@@ -46,7 +46,6 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: false, "multiple(123)", "multiple", "123");
             ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: false, "multiple(123;321)", "multiple", "123;321");
             ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: false, "set()", "set", string.Empty);
-            ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: false, "()", string.Empty, string.Empty);
 
             // Failure cases
             Action emptyString =
@@ -57,6 +56,15 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                         out actualIdentifier,
                         out queryPortion);
             emptyString.Throws<ODataUnrecognizedPathException>(ErrorStrings.RequestUriProcessor_EmptySegmentInRequestUrl);
+
+            Action noIdentifier =
+                () =>
+                    ODataPathParser.ExtractSegmentIdentifierAndParenthesisExpression(
+                        enableKeyAsSegment: false,
+                        "()",
+                        out actualIdentifier,
+                        out queryPortion);
+            noIdentifier.Throws<ODataUnrecognizedPathException>(ErrorStrings.RequestUriProcessor_EmptySegmentInRequestUrl);
 
             Action noEndParen =
                 () =>
@@ -80,7 +88,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: true, "multiple(123)", "multiple", "123");
             ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: true, "multiple(123;321)", "multiple", "123;321");
             ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: true, "set()", "set", string.Empty);
-            ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: true, "()", string.Empty, string.Empty);
+            ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: true, "()", "()", null);
             ExtractSegmentIdentifierAndParenthesisExpression(enableKeyAsSegment: true, "foo(", "foo(", null);
 
             // Failure cases

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
@@ -377,7 +377,6 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 new {Input = "}{"   , Error = Strings.ExpressionLexer_InvalidCharacter("}", 6, "onCat=}{")},
                 new {Input = "{{}"  , Error = Strings.ExpressionLexer_UnbalancedBracketExpression}, // Thrown by ODataPathParser::TryBindingParametersAndMatchingOperation
                 new {Input = "{}}"  , Error = Strings.ExpressionLexer_InvalidCharacter("}", 8, "onCat={}}")},
-                new {Input = "{#}"  , Error = Strings.RequestUriProcessor_SyntaxError},
             };
 
             foreach (var errorCase in errorCases)
@@ -403,7 +402,6 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 new {Input = "}{"   , Error = Strings.ExpressionLexer_InvalidCharacter("}", 1, "(}{)")},
                 new {Input = "{{}"  , Error = Strings.ExpressionLexer_UnbalancedBracketExpression}, // Thrown by ODataPathParser::TryBindKeyFromParentheses
                 new {Input = "{}}"  , Error = Strings.ExpressionLexer_InvalidCharacter("}", 3, "({}})")},
-                new {Input = "{#}"  , Error = Strings.RequestUriProcessor_SyntaxError},
             };
 
             foreach (var errorCase in errorCases)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
@@ -377,6 +377,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 new {Input = "}{"   , Error = Strings.ExpressionLexer_InvalidCharacter("}", 6, "onCat=}{")},
                 new {Input = "{{}"  , Error = Strings.ExpressionLexer_UnbalancedBracketExpression}, // Thrown by ODataPathParser::TryBindingParametersAndMatchingOperation
                 new {Input = "{}}"  , Error = Strings.ExpressionLexer_InvalidCharacter("}", 8, "onCat={}}")},
+                new {Input = "{#}"  , Error = Strings.RequestUriProcessor_ResourceNotFound("Fully.Qualified.Namespace.HasHat(onCat={")},
             };
 
             foreach (var errorCase in errorCases)
@@ -387,7 +388,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 };
 
                 Action action = () => uriParser.ParsePath();
-                action.Throws<ODataException>(errorCase.Error);
+                action.ThrowsAny<ODataException>(errorCase.Error);
             }
         }
 
@@ -402,6 +403,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 new {Input = "}{"   , Error = Strings.ExpressionLexer_InvalidCharacter("}", 1, "(}{)")},
                 new {Input = "{{}"  , Error = Strings.ExpressionLexer_UnbalancedBracketExpression}, // Thrown by ODataPathParser::TryBindKeyFromParentheses
                 new {Input = "{}}"  , Error = Strings.ExpressionLexer_InvalidCharacter("}", 3, "({}})")},
+                new {Input = "{#}"  , Error = Strings.RequestUriProcessor_ResourceNotFound("People({")},
             };
 
             foreach (var errorCase in errorCases)
@@ -412,7 +414,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 };
 
                 Action action = () => uriParser.ParsePath();
-                action.Throws<ODataException>(errorCase.Error);
+                action.ThrowsAny<ODataException>(errorCase.Error);
             }
         }
         #endregion


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues
*This pull request fixes https://github.com/OData/odata.net/issues/2827*

### Description

*Modify `ExtractSegmentIdentifierAndParenthesisExpression` so that it doesn't throw when the parenthesis are in an unexpected state for key-as-parameter.*

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*