### PR TITLE
Fixes #2829: support built-in function in $orderby.

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FullUriFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FullUriFunctionalTests.cs
@@ -71,6 +71,17 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void ParseOrderbyWithBuiltInFunction()
+        {
+            ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://www.odata.com/OData"), new Uri("http://www.odata.com/OData/People?$orderby=tolower(Name)"));
+            ODataUri parsedUri = parser.ParseUri();
+            SingleValueFunctionCallNode funcCall = parsedUri.OrderBy.Expression.ShouldBeSingleValueFunctionCallQueryNode("tolower", EdmCoreModel.Instance.GetString(true));
+            QueryNode parameter = Assert.Single(funcCall.Parameters);
+            parameter.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonNameProp());
+            Assert.Equal(OrderByDirection.Ascending, parsedUri.OrderBy.Direction);
+        }
+
+        [Fact]
         public void SelectOrExpandCanOnlyBeCalledOnEntity()
         {
             ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://www.odata.com/OData"), new Uri("http://www.odata.com/OData/People(1)/Name?$select=Name"));


### PR DESCRIPTION
Add test case to verify built-in function in $orderby

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2829.*

Let's verify built-in function supported in ODL>

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
