### PR TITLE
Fix memory regression in DuplicatePropertyNameChecker

### DIFF
--- a/src/Microsoft.OData.Core/DuplicatePropertyNameChecker.cs
+++ b/src/Microsoft.OData.Core/DuplicatePropertyNameChecker.cs
@@ -129,6 +129,12 @@ namespace Microsoft.OData
     /// </summary>
     internal class NullDuplicatePropertyNameChecker : IDuplicatePropertyNameChecker
     {
+        /// <summary>
+        /// Singleton instance of the <see cref="NullDuplicatePropertyNameChecker"/>. Since
+        /// it does nothing, we can safely re-use the same instance throughout the process.
+        /// </summary>
+        public static NullDuplicatePropertyNameChecker Instance = new NullDuplicatePropertyNameChecker();
+
         public void ValidatePropertyUniqueness(ODataPropertyInfo property)
         {
             // nop

--- a/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
@@ -229,30 +229,14 @@ namespace Microsoft.OData.Evaluation
             ODataProperty property = null;
             if (resource.NonComputedProperties != null)
             {
-                // since this method is called frequently, we implement SingleOrDefault manually
-                // to avoid allocating predicate closures.
-                using (IEnumerator<ODataProperty> e = resource.NonComputedProperties.GetEnumerator())
+                // We use a manual loop instead of a for-loop to avoid
+                // closure allocations given how frequently this method is called.
+                foreach (ODataProperty item in resource.NonComputedProperties)
                 {
-                    while (e.MoveNext())
+                    if (item.Name == propertyName)
                     {
-                        ODataProperty temp = e.Current;
-                        if (temp.Name == propertyName)
-                        {
-                            // We should re-evaluate whether it's necessary to check for duplicates
-                            // at this point. Doing this duplicate-check here is inefficient given
-                            // that this method maybe called multiple times for the same resource.
-                            // It's implemented as-is for now to retain the behaviour of the previous
-                            // implementation that made use of SingleOrDefault().
-                            while (e.MoveNext())
-                            {
-                                if (e.Current.Name == propertyName)
-                                {
-                                    throw new InvalidOperationException(Strings.DuplicatePropertyNamesNotAllowed(propertyName));
-                                }
-                            }
-
-                            property = temp;
-                        }
+                        property = item;
+                        break;
                     }
                 }
             }

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -95,6 +95,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+	<PackageReference Include="Microsoft.Extensions.ObjectPool">
+	  <Version>6.0.3</Version>
+	</PackageReference>
+  </ItemGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI\$(TargetFramework)\**" />
   </ItemGroup>

--- a/src/Microsoft.OData.Core/WriterValidator.cs
+++ b/src/Microsoft.OData.Core/WriterValidator.cs
@@ -31,11 +31,6 @@ namespace Microsoft.OData
 #endif
 
         /// <summary>
-        /// Instances of the NullDuplicatePropertyNameChecker.
-        /// </summary>
-        private IDuplicatePropertyNameChecker nullDuplicatePropertyNameChecker;
-
-        /// <summary>
         /// Creates a WriterValidator instance and binds it to settings.
         /// </summary>
         /// <param name="settings">The ODataMessageWriterSettings instance to bind to.</param>
@@ -66,13 +61,7 @@ namespace Microsoft.OData
             }
             else
             {
-                if (this.nullDuplicatePropertyNameChecker == null)
-                {
-                    // NullDuplicatePropertyNameChecker does nothing, so we can use a single instance during the writing process.
-                    this.nullDuplicatePropertyNameChecker = new NullDuplicatePropertyNameChecker();
-                }
-
-                duplicatePropertyNameChecker = this.nullDuplicatePropertyNameChecker;
+                duplicatePropertyNameChecker = NullDuplicatePropertyNameChecker.Instance;
             }
 
             return duplicatePropertyNameChecker;

--- a/src/Microsoft.OData.Core/WriterValidator.cs
+++ b/src/Microsoft.OData.Core/WriterValidator.cs
@@ -6,9 +6,8 @@
 
 namespace Microsoft.OData
 {
-    using System;
     using System.Collections.Generic;
-#if NETSTANDARD2_0_OR_GREATER
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
     using Microsoft.Extensions.ObjectPool;
 #endif
     using Microsoft.OData.Edm;
@@ -24,7 +23,7 @@ namespace Microsoft.OData
         /// </summary>
         private readonly ODataMessageWriterSettings settings;
 
-#if NETSTANDARD2_0_OR_GREATER
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
         /// <summary>
         /// Object pool that stores instances of the DuplicatePropertyNameChecker.
         /// </summary>
@@ -52,7 +51,7 @@ namespace Microsoft.OData
 
             if (settings.ThrowOnDuplicatePropertyNames)
             {
-#if NETSTANDARD2_0_OR_GREATER
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
                 if (this.duplicatePropertyNameCheckerObjectPool == null)
                 {
                     DefaultObjectPoolProvider poolProvider = new DefaultObjectPoolProvider { MaximumRetained = 8 };
@@ -82,7 +81,7 @@ namespace Microsoft.OData
         /// <inheritdoc/>
         public void ReturnDuplicatePropertyNameChecker(IDuplicatePropertyNameChecker duplicatePropertyNameChecker)
         {
-#if NETSTANDARD2_0_OR_GREATER
+#if NETSTANDARD2_0_OR_GREATER || NETCOREAPP3_1_OR_GREATER
             // We only return the DuplicatePropertyNameChecker to the object pool and ignore the NullDuplicatePropertyNameChecker.
             if (duplicatePropertyNameChecker is DuplicatePropertyNameChecker duplicateChecker)
             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2813 

### Description

This PR fixes a couple of "low-hanging" excessive memory allocaitons.

#### `DuplicatePropertyNameChecker`

The `#if` flags we used to conditionally compile object-pooling for the `DuplicatePropertyNameChecker` only applied to .NET Standard 2.0. I've extended them to also cover .NET Core 3.1. The regression was probably introduced when we added `.netcoreapp3.1` as an explicit framework target.

I also made `NullDuplicatePropertyChecker` a "global" singleton instead of creating per request/WriterValidator. The impact here is low, but it doesn't hurt. In any case, I'd argue it makes the code cleaner anyway.

#### LINQ `Func<T,bool>` predicate

Found a case of `Func<T,bool>` lurking on a hot path from calling `resource.NonComputedProperties.SingleOrDefault(r => r.Name == propertyName)`. I reduced the allocation by implementing `SingleOrDefault` manually (raw while loop and `enumerator.MoveNext()`).

While this reduced the allocations, I question our use of `SingleOrDefault`. Personally, I think we should reduce or avoid the use of SingleOrDefault in our library. In cases where we need to validate uniqueness, I think it would much better to consider pre-validating the collection before use, or ways to ensure we validate uniqueness only once, or in some cases just consider duplicates undefined behaviour and leave it to the customer to deal with. In this case, we potentially do a full scan of the property list each time we need to fetch the value of a single property. And yet we'll still validate property name uniqueness with the duplicate property name checker inside the writer.

**Update**

Following this comment thread: https://github.com/OData/odata.net/pull/2834#discussion_r1441858961, I made the following change:

I removed the duplicate property name check from the `ODataResourceMetadataContext` because:
- it doesn't break existing tests
- the duplicate check adds extra cost on a hot path

I opted **not** to move the duplicate-check to the `ODataResource.Properties` setter because:
- we already have duplicate property name checking logic in the writer via `DuplicatePropertyNameChecker`
- in WebApi and OData Client, we can guarantee in the serializer that the property names are unique. That's also the best place to guarantee uniqueness since they have access the original property collection
- For customers using ODL directly, and who have disabled writer validation, we can assume they know what they're doing and already ensure that properties are unique.

However, if the last assumption doesn't hold, this could be a breaking change (though I think chances are extremely low). So, I'm open to restoring the original behaviour or moving the duplicate-check to the `ODataResource.Properties` setter if you or someone else believes it necessary to do so.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Results

**Before**

![image](https://github.com/OData/odata.net/assets/8460169/9a3a80d3-35af-43c3-b55f-94e429bc507a)

**After**

![image](https://github.com/OData/odata.net/assets/8460169/6a649567-7a92-409c-a06a-d590813c6d01)

**Before**
![image](https://github.com/OData/odata.net/assets/8460169/0b49c180-81fb-4646-9556-d7d53f991c8f)

**After**

![image](https://github.com/OData/odata.net/assets/8460169/ccfd2000-1c22-456f-ae00-473e64b991b5)

![image](https://github.com/OData/odata.net/assets/8460169/18c1743d-f81b-45d2-8fca-bc5544f3dbdd)

**Before**
![image](https://github.com/OData/odata.net/assets/8460169/c459898f-4279-4846-8abb-b199d71451fb)

**After**
![image](https://github.com/OData/odata.net/assets/8460169/d90d2461-f567-450d-8e22-0490be605eca)

**Before**
![image](https://github.com/OData/odata.net/assets/8460169/16ddbe78-70cf-44fc-a180-4e17386b645e)

**After**
![image](https://github.com/OData/odata.net/assets/8460169/83ea5f0a-4e99-47b8-b955-17898f5a47a3)

**Before**
![image](https://github.com/OData/odata.net/assets/8460169/a01acbc0-304b-4521-8d03-8d52f248d6f9)

**After**
![image](https://github.com/OData/odata.net/assets/8460169/326e3a32-9cc1-4243-a32a-3dbe57d94512)

