### PR TITLE
exposing `DataServiceActionQuery<T>` properties for testing purposes

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceActionQueryOfT.cs
+++ b/src/Microsoft.OData.Client/DataServiceActionQueryOfT.cs
@@ -20,12 +20,12 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Context associated with this query.
         /// </summary>
-        private readonly DataServiceContext Context;
+        private readonly DataServiceContext context;
 
         /// <summary>
         /// Parameters of this action.
         /// </summary>
-        private readonly BodyOperationParameter[] Parameters;
+        private readonly BodyOperationParameter[] parameters;
 
         /// <summary>
         /// Object of an action which returns a collection.
@@ -35,9 +35,34 @@ namespace Microsoft.OData.Client
         /// <param name="parameters">Parameters of this action.</param>
         public DataServiceActionQuery(DataServiceContext context, string requestUriString, params BodyOperationParameter[] parameters)
         {
-            this.Context = context;
+            this.context = context;
             this.RequestUri = new Uri(requestUriString);
-            this.Parameters = parameters;
+            this.parameters = parameters;
+        }
+
+        /// <summary>
+        /// Gets the <see cref="DataServiceContext"/> that will be used to execute the action query
+        /// </summary>
+        public DataServiceContext Context
+        {
+            get
+            {
+                return this.context;
+            }
+        }
+
+        /// <summary>
+        /// Gets the <see cref="BodyOperationParameter"/>s that will be provided to the action when the query is executed
+        /// </summary>
+        public IEnumerable<BodyOperationParameter> Parameters
+        {
+            get
+            {
+                foreach (var element in this.parameters)
+                {
+                    yield return element;
+                }
+            }
         }
 
         /// <summary>
@@ -52,7 +77,7 @@ namespace Microsoft.OData.Client
         /// <exception cref="InvalidOperationException">Problem materializing result of query into object.</exception>
         public IEnumerable<T> Execute()
         {
-            return Context.Execute<T>(this.RequestUri, XmlConstants.HttpMethodPost, false, Parameters);
+            return context.Execute<T>(this.RequestUri, XmlConstants.HttpMethodPost, false, parameters);
         }
 
         /// <summary>Asynchronously sends a request to the data service to execute a specific URI.</summary>
@@ -62,7 +87,7 @@ namespace Microsoft.OData.Client
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1004:GenericMethodsShouldProvideTypeParameter", Justification = "Type is used to infer result")]
         public IAsyncResult BeginExecute(AsyncCallback callback, object state)
         {
-            return Context.BeginExecute<T>(this.RequestUri, callback, state, XmlConstants.HttpMethodPost, false, Parameters);
+            return context.BeginExecute<T>(this.RequestUri, callback, state, XmlConstants.HttpMethodPost, false, parameters);
         }
 
         /// <summary>Asynchronously sends the request so that this call does not block processing while waiting for the results from the service.</summary>
@@ -77,7 +102,7 @@ namespace Microsoft.OData.Client
         /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
         public Task<IEnumerable<T>> ExecuteAsync(CancellationToken cancellationToken)
         {
-            return Context.ExecuteAsync<T>(this.RequestUri, XmlConstants.HttpMethodPost, false, cancellationToken, Parameters);
+            return context.ExecuteAsync<T>(this.RequestUri, XmlConstants.HttpMethodPost, false, cancellationToken, parameters);
         }
 
         /// <summary>Called to complete the <see cref="Microsoft.OData.Client.DataServiceActionQuery.BeginExecute(System.AsyncCallback,System.Object)" />.</summary>
@@ -92,7 +117,7 @@ namespace Microsoft.OData.Client
         public IEnumerable<T> EndExecute(IAsyncResult asyncResult)
         {
             Util.CheckArgumentNull(asyncResult, "asyncResult");
-            return Context.EndExecute<T>(asyncResult);
+            return context.EndExecute<T>(asyncResult);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.OData.Client.DataServiceActionQuery<T>.Context.get -> Microsoft.OData.Client.DataServiceContext
+Microsoft.OData.Client.DataServiceActionQuery<T>.Parameters.get -> System.Collections.Generic.IEnumerable<Microsoft.OData.Client.BodyOperationParameter>

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.net45.bsl
@@ -1055,11 +1055,6 @@ public interface Microsoft.OData.Edm.IEdmStructuredType : IEdmElement, IEdmType 
 public interface Microsoft.OData.Edm.IEdmStructuredTypeReference : IEdmElement, IEdmTypeReference {
 }
 
-public interface Microsoft.OData.Edm.IEdmTargetPath : IEdmElement, IEdmVocabularyAnnotatable {
-    string Path  { public abstract get; }
-    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
-}
-
 public interface Microsoft.OData.Edm.IEdmTemporalTypeReference : IEdmElement, IEdmPrimitiveTypeReference, IEdmTypeReference {
     System.Nullable`1[[System.Int32]] Precision  { public abstract get; }
 }
@@ -1943,11 +1938,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
-
-    [
-    ExtensionAttribute(),
-    ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, Microsoft.OData.Edm.Vocabularies.IEdmTerm term, string qualifier)
 
     [
@@ -2054,16 +2044,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.IEdmOperationReturn GetReturn (Microsoft.OData.Edm.IEdmOperation operation)
-
-    [
-    ExtensionAttribute(),
-    ]
-    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool ignoreCase)
-
-    [
-    ExtensionAttribute(),
-    ]
-    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] GetTargetPathAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
 
     [
     ExtensionAttribute(),
@@ -2849,17 +2829,6 @@ public class Microsoft.OData.Edm.EdmStructuralProperty : Microsoft.OData.Edm.Edm
 
     string DefaultValueString  { public virtual get; }
     Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
-}
-
-public class Microsoft.OData.Edm.EdmTargetPath : IEdmElement, IEdmTargetPath, IEdmVocabularyAnnotatable {
-    public EdmTargetPath (Microsoft.OData.Edm.IEdmElement[] segments)
-    public EdmTargetPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] segments)
-
-    string Path  { public virtual get; }
-    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
-
-    public virtual bool Equals (object obj)
-    public virtual int GetHashCode ()
 }
 
 public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.EdmPrimitiveTypeReference, IEdmElement, IEdmPrimitiveTypeReference, IEdmTemporalTypeReference, IEdmTypeReference {
@@ -4857,7 +4826,6 @@ public abstract class Microsoft.OData.ODataResourceBase : Microsoft.OData.ODataI
     Microsoft.OData.ODataStreamReferenceValue MediaResource  { public get; public set; }
     System.Collections.Generic.IEnumerable`1[[Microsoft.OData.ODataProperty]] Properties  { public get; public set; }
     System.Uri ReadLink  { public get; public set; }
-    bool SkipPropertyVerification  { public get; public set; }
     string TypeName  { public get; public set; }
 
     public void AddAction (Microsoft.OData.ODataAction action)
@@ -5654,7 +5622,6 @@ public sealed class Microsoft.OData.ODataMessageWriterSettings {
     bool AlwaysAddTypeAnnotationsForDerivedTypes  { public get; public set; }
     Microsoft.OData.Buffers.ICharArrayPool ArrayPool  { public get; public set; }
     System.Uri BaseUri  { public get; public set; }
-    int BufferSize  { public get; public set; }
     bool EnableCharactersCheck  { public get; public set; }
     bool EnableMessageStreamDisposal  { public get; public set; }
     string JsonPCallback  { public get; public set; }
@@ -6516,16 +6483,12 @@ public class Microsoft.OData.UriParser.ODataExpandPath : Microsoft.OData.UriPars
     public ODataExpandPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 }
 
-[
-DefaultMemberAttribute(),
-]
 public class Microsoft.OData.UriParser.ODataPath : IEnumerable, IEnumerable`1 {
     public ODataPath (Microsoft.OData.UriParser.ODataPathSegment[] segments)
     public ODataPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 
     int Count  { public get; }
     Microsoft.OData.UriParser.ODataPathSegment FirstSegment  { public get; }
-    Microsoft.OData.UriParser.ODataPathSegment Item [int index] { public get; }
     Microsoft.OData.UriParser.ODataPathSegment LastSegment  { public get; }
 
     public virtual System.Collections.Generic.IEnumerator`1[[Microsoft.OData.UriParser.ODataPathSegment]] GetEnumerator ()
@@ -8968,15 +8931,6 @@ public sealed class Microsoft.OData.Client.StreamDescriptor : Microsoft.OData.Cl
 public sealed class Microsoft.OData.Client.UriEntityOperationParameter : Microsoft.OData.Client.UriOperationParameter {
     public UriEntityOperationParameter (string name, object value)
     public UriEntityOperationParameter (string name, object value, bool useEntityReference)
-}
-
-[
-AttributeUsageAttribute(),
-]
-public sealed class Microsoft.OData.Client.UriFunctionAttribute : System.Attribute {
-    public UriFunctionAttribute (params bool allowClientSideEvaluation)
-
-    bool AllowClientSideEvaluation  { public get; }
 }
 
 public sealed class Microsoft.OData.Client.WritingEntityReferenceLinkArgs {

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard1.1.bsl
@@ -1055,11 +1055,6 @@ public interface Microsoft.OData.Edm.IEdmStructuredType : IEdmElement, IEdmType 
 public interface Microsoft.OData.Edm.IEdmStructuredTypeReference : IEdmElement, IEdmTypeReference {
 }
 
-public interface Microsoft.OData.Edm.IEdmTargetPath : IEdmElement, IEdmVocabularyAnnotatable {
-    string Path  { public abstract get; }
-    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
-}
-
 public interface Microsoft.OData.Edm.IEdmTemporalTypeReference : IEdmElement, IEdmPrimitiveTypeReference, IEdmTypeReference {
     System.Nullable`1[[System.Int32]] Precision  { public abstract get; }
 }
@@ -1943,11 +1938,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
-
-    [
-    ExtensionAttribute(),
-    ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, Microsoft.OData.Edm.Vocabularies.IEdmTerm term, string qualifier)
 
     [
@@ -2054,16 +2044,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.IEdmOperationReturn GetReturn (Microsoft.OData.Edm.IEdmOperation operation)
-
-    [
-    ExtensionAttribute(),
-    ]
-    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool ignoreCase)
-
-    [
-    ExtensionAttribute(),
-    ]
-    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] GetTargetPathAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
 
     [
     ExtensionAttribute(),
@@ -2849,17 +2829,6 @@ public class Microsoft.OData.Edm.EdmStructuralProperty : Microsoft.OData.Edm.Edm
 
     string DefaultValueString  { public virtual get; }
     Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
-}
-
-public class Microsoft.OData.Edm.EdmTargetPath : IEdmElement, IEdmTargetPath, IEdmVocabularyAnnotatable {
-    public EdmTargetPath (Microsoft.OData.Edm.IEdmElement[] segments)
-    public EdmTargetPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] segments)
-
-    string Path  { public virtual get; }
-    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
-
-    public virtual bool Equals (object obj)
-    public virtual int GetHashCode ()
 }
 
 public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.EdmPrimitiveTypeReference, IEdmElement, IEdmPrimitiveTypeReference, IEdmTemporalTypeReference, IEdmTypeReference {
@@ -4857,7 +4826,6 @@ public abstract class Microsoft.OData.ODataResourceBase : Microsoft.OData.ODataI
     Microsoft.OData.ODataStreamReferenceValue MediaResource  { public get; public set; }
     System.Collections.Generic.IEnumerable`1[[Microsoft.OData.ODataProperty]] Properties  { public get; public set; }
     System.Uri ReadLink  { public get; public set; }
-    bool SkipPropertyVerification  { public get; public set; }
     string TypeName  { public get; public set; }
 
     public void AddAction (Microsoft.OData.ODataAction action)
@@ -5654,7 +5622,6 @@ public sealed class Microsoft.OData.ODataMessageWriterSettings {
     bool AlwaysAddTypeAnnotationsForDerivedTypes  { public get; public set; }
     Microsoft.OData.Buffers.ICharArrayPool ArrayPool  { public get; public set; }
     System.Uri BaseUri  { public get; public set; }
-    int BufferSize  { public get; public set; }
     bool EnableCharactersCheck  { public get; public set; }
     bool EnableMessageStreamDisposal  { public get; public set; }
     string JsonPCallback  { public get; public set; }
@@ -6516,16 +6483,12 @@ public class Microsoft.OData.UriParser.ODataExpandPath : Microsoft.OData.UriPars
     public ODataExpandPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 }
 
-[
-DefaultMemberAttribute(),
-]
 public class Microsoft.OData.UriParser.ODataPath : IEnumerable, IEnumerable`1 {
     public ODataPath (Microsoft.OData.UriParser.ODataPathSegment[] segments)
     public ODataPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 
     int Count  { public get; }
     Microsoft.OData.UriParser.ODataPathSegment FirstSegment  { public get; }
-    Microsoft.OData.UriParser.ODataPathSegment Item [int index] { public get; }
     Microsoft.OData.UriParser.ODataPathSegment LastSegment  { public get; }
 
     public virtual System.Collections.Generic.IEnumerator`1[[Microsoft.OData.UriParser.ODataPathSegment]] GetEnumerator ()

--- a/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
+++ b/test/PublicApiTests/BaseLine/Microsoft.OData.PublicApi.netstandard2.0.bsl
@@ -1055,11 +1055,6 @@ public interface Microsoft.OData.Edm.IEdmStructuredType : IEdmElement, IEdmType 
 public interface Microsoft.OData.Edm.IEdmStructuredTypeReference : IEdmElement, IEdmTypeReference {
 }
 
-public interface Microsoft.OData.Edm.IEdmTargetPath : IEdmElement, IEdmVocabularyAnnotatable {
-    string Path  { public abstract get; }
-    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public abstract get; }
-}
-
 public interface Microsoft.OData.Edm.IEdmTemporalTypeReference : IEdmElement, IEdmPrimitiveTypeReference, IEdmTypeReference {
     System.Nullable`1[[System.Int32]] Precision  { public abstract get; }
 }
@@ -1943,11 +1938,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     [
     ExtensionAttribute(),
     ]
-    public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath, Microsoft.OData.Edm.Vocabularies.IEdmTerm term)
-
-    [
-    ExtensionAttribute(),
-    ]
     public static IEnumerable`1 FindVocabularyAnnotations (Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable element, Microsoft.OData.Edm.Vocabularies.IEdmTerm term, string qualifier)
 
     [
@@ -2054,16 +2044,6 @@ public sealed class Microsoft.OData.Edm.ExtensionMethods {
     ExtensionAttribute(),
     ]
     public static Microsoft.OData.Edm.IEdmOperationReturn GetReturn (Microsoft.OData.Edm.IEdmOperation operation)
-
-    [
-    ExtensionAttribute(),
-    ]
-    public static Microsoft.OData.Edm.IEdmTargetPath GetTargetPath (Microsoft.OData.Edm.IEdmModel model, string targetPath, params bool ignoreCase)
-
-    [
-    ExtensionAttribute(),
-    ]
-    public static System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation]] GetTargetPathAnnotations (Microsoft.OData.Edm.IEdmModel model, string targetPath)
 
     [
     ExtensionAttribute(),
@@ -2849,17 +2829,6 @@ public class Microsoft.OData.Edm.EdmStructuralProperty : Microsoft.OData.Edm.Edm
 
     string DefaultValueString  { public virtual get; }
     Microsoft.OData.Edm.EdmPropertyKind PropertyKind  { public virtual get; }
-}
-
-public class Microsoft.OData.Edm.EdmTargetPath : IEdmElement, IEdmTargetPath, IEdmVocabularyAnnotatable {
-    public EdmTargetPath (Microsoft.OData.Edm.IEdmElement[] segments)
-    public EdmTargetPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.Edm.IEdmElement]] segments)
-
-    string Path  { public virtual get; }
-    System.Collections.Generic.IReadOnlyList`1[[Microsoft.OData.Edm.IEdmElement]] Segments  { public virtual get; }
-
-    public virtual bool Equals (object obj)
-    public virtual int GetHashCode ()
 }
 
 public class Microsoft.OData.Edm.EdmTemporalTypeReference : Microsoft.OData.Edm.EdmPrimitiveTypeReference, IEdmElement, IEdmPrimitiveTypeReference, IEdmTemporalTypeReference, IEdmTypeReference {
@@ -4857,7 +4826,6 @@ public abstract class Microsoft.OData.ODataResourceBase : Microsoft.OData.ODataI
     Microsoft.OData.ODataStreamReferenceValue MediaResource  { public get; public set; }
     System.Collections.Generic.IEnumerable`1[[Microsoft.OData.ODataProperty]] Properties  { public get; public set; }
     System.Uri ReadLink  { public get; public set; }
-    bool SkipPropertyVerification  { public get; public set; }
     string TypeName  { public get; public set; }
 
     public void AddAction (Microsoft.OData.ODataAction action)
@@ -5654,7 +5622,6 @@ public sealed class Microsoft.OData.ODataMessageWriterSettings {
     bool AlwaysAddTypeAnnotationsForDerivedTypes  { public get; public set; }
     Microsoft.OData.Buffers.ICharArrayPool ArrayPool  { public get; public set; }
     System.Uri BaseUri  { public get; public set; }
-    int BufferSize  { public get; public set; }
     bool EnableCharactersCheck  { public get; public set; }
     bool EnableMessageStreamDisposal  { public get; public set; }
     string JsonPCallback  { public get; public set; }
@@ -6516,16 +6483,12 @@ public class Microsoft.OData.UriParser.ODataExpandPath : Microsoft.OData.UriPars
     public ODataExpandPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 }
 
-[
-DefaultMemberAttribute(),
-]
 public class Microsoft.OData.UriParser.ODataPath : IEnumerable, IEnumerable`1 {
     public ODataPath (Microsoft.OData.UriParser.ODataPathSegment[] segments)
     public ODataPath (System.Collections.Generic.IEnumerable`1[[Microsoft.OData.UriParser.ODataPathSegment]] segments)
 
     int Count  { public get; }
     Microsoft.OData.UriParser.ODataPathSegment FirstSegment  { public get; }
-    Microsoft.OData.UriParser.ODataPathSegment Item [int index] { public get; }
     Microsoft.OData.UriParser.ODataPathSegment LastSegment  { public get; }
 
     public virtual System.Collections.Generic.IEnumerator`1[[Microsoft.OData.UriParser.ODataPathSegment]] GetEnumerator ()
@@ -8968,15 +8931,6 @@ public sealed class Microsoft.OData.Client.StreamDescriptor : Microsoft.OData.Cl
 public sealed class Microsoft.OData.Client.UriEntityOperationParameter : Microsoft.OData.Client.UriOperationParameter {
     public UriEntityOperationParameter (string name, object value)
     public UriEntityOperationParameter (string name, object value, bool useEntityReference)
-}
-
-[
-AttributeUsageAttribute(),
-]
-public sealed class Microsoft.OData.Client.UriFunctionAttribute : System.Attribute {
-    public UriFunctionAttribute (params bool allowClientSideEvaluation)
-
-    bool AllowClientSideEvaluation  { public get; }
 }
 
 public sealed class Microsoft.OData.Client.WritingEntityReferenceLinkArgs {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2841.*

### Description

Exposing two properties on `DataServiceActionQuery<T>` to facilitate testing
