### PR TITLE
Support writing large json base64 and string values

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -536,6 +536,10 @@ namespace Microsoft.OData.Json
             Span<byte> output = bufferWriter.GetSpan(maxUtf8Length);
             OperationStatus status = Utf8.FromUtf16(chunk, output, out int charsRead, out int charsWritten, isFinalBlock);
             Debug.Assert(status == OperationStatus.Done || status == OperationStatus.NeedMoreData);
+
+            // The charsRead will always be equal to chunk.Length. This is because the characters
+            // that would cause utf-8 encoding to result in partial processing is already 
+            // taken care of by the JavascriptEncoder when escaping special characters. 
             Debug.Assert(charsRead == chunk.Length);
 
             // notify the bufferWriter of the write

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -378,7 +378,7 @@ namespace Microsoft.OData.Json
                 this.WriteSeparatorIfNecessary();
                 this.utf8JsonWriter.WriteNullValue();
             }
-            else if (value.Length > bufferWriter.FreeCapacity)
+            else if (value.Length > bufferWriter.FreeCapacity || value.Length > chunkSize)
             {
                 WriteStringValueInChunks(value.AsSpan());
             }
@@ -558,7 +558,7 @@ namespace Microsoft.OData.Json
                 this.WriteSeparatorIfNecessary();
                 this.utf8JsonWriter.WriteNullValue();
             }
-            else if (value.Length > bufferWriter.Capacity)
+            else if (value.Length > bufferWriter.FreeCapacity || value.Length > chunkSize)
             {
                 WriteByteValueInChunks(value.AsSpan());
             }
@@ -1065,7 +1065,7 @@ namespace Microsoft.OData.Json
                 this.WriteSeparatorIfNecessary();
                 this.utf8JsonWriter.WriteNullValue();
             }
-            else if (value.Length > bufferWriter.FreeCapacity)
+            else if (value.Length > bufferWriter.FreeCapacity || value.Length > chunkSize)
             {
                 await WriteStringValueInChunksAsync(value.AsMemory());
             }
@@ -1138,7 +1138,7 @@ namespace Microsoft.OData.Json
                 this.WriteSeparatorIfNecessary();
                 this.utf8JsonWriter.WriteNullValue();
             }
-            else if (value.Length > bufferWriter.Capacity)
+            else if (value.Length > bufferWriter.FreeCapacity || value.Length > chunkSize)
             {
                 await WriteByteValueInChunksAsync(value);
             }

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -449,7 +449,7 @@ namespace Microsoft.OData.Json
             // Write methods that a separator should be written first
             CheckIfSeparatorNeeded();
 
-            CheckIfAtManualValueArrayStart();
+            CheckIfManualValueAtArrayStart();
         }
 
         /// <summary>
@@ -613,7 +613,7 @@ namespace Microsoft.OData.Json
             // Write methods that a separator should be written first
             CheckIfSeparatorNeeded();
 
-            CheckIfAtManualValueArrayStart();
+            CheckIfManualValueAtArrayStart();
         }
 
         /// <summary>
@@ -684,12 +684,7 @@ namespace Microsoft.OData.Json
             // Write methods that a separator should be written first
             CheckIfSeparatorNeeded();
 
-            if (this.isWritingAtStartOfArray || this.isWritingConsecutiveRawValuesAtStartOfArray)
-            {
-                this.isWritingConsecutiveRawValuesAtStartOfArray = true;
-            }
-
-            this.isWritingAtStartOfArray = false;
+            CheckIfManualValueAtArrayStart();
         }
 
         /// <summary>
@@ -711,7 +706,7 @@ namespace Microsoft.OData.Json
         // <summary>
         /// Checks if the writer is at the start of a manual value array and updates the state accordingly.
         /// </summary>
-        private void CheckIfAtManualValueArrayStart()
+        private void CheckIfManualValueAtArrayStart()
         {
             if(this.isWritingAtStartOfArray || this.isWritingConsecutiveRawValuesAtStartOfArray)
             {
@@ -1136,7 +1131,7 @@ namespace Microsoft.OData.Json
             // Write methods that a separator should be written first
             CheckIfSeparatorNeeded();
 
-            CheckIfAtManualValueArrayStart();
+            CheckIfManualValueAtArrayStart();
         }
 
         public async Task WriteValueAsync(byte[] value)
@@ -1193,7 +1188,7 @@ namespace Microsoft.OData.Json
             // Write methods that a separator should be written first
             CheckIfSeparatorNeeded();
 
-            CheckIfAtManualValueArrayStart();
+            CheckIfManualValueAtArrayStart();
         }
 
         public async Task WriteValueAsync(JsonElement value)

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Json
         /// <summary>
         /// Rrepresents a read-only memory block containing the byte representation of the double quote character ("). 
         /// </summary>
-        private readonly static ReadOnlyMemory<byte> _doubleQuote = new byte[] { (byte)'"' };
+        private readonly ReadOnlyMemory<byte> DoubleQuote = new byte[] { (byte)'"' };
 
         /// <summary>
         /// Creates an instance of <see cref="ODataUtf8JsonWriter"/>.
@@ -415,7 +415,7 @@ namespace Microsoft.OData.Json
 
             WriteItemWithSeparatorIfNeeded();
 
-            this.bufferWriter.Write(_doubleQuote.Slice(0, 1).Span);
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
             this.Flush();
 
@@ -443,7 +443,7 @@ namespace Microsoft.OData.Json
                 this.FlushIfBufferThresholdReached();
             }
 
-            this.bufferWriter.Write(_doubleQuote.Slice(0, 1).Span);
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
             // since we bypass the Utf8JsonWriter, we need to signal to other
             // Write methods that a separator should be written first
@@ -593,7 +593,7 @@ namespace Microsoft.OData.Json
 
             WriteItemWithSeparatorIfNeeded();
 
-            this.bufferWriter.Write(_doubleQuote.Slice(0, 1).Span);
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
             this.Flush();
 
@@ -611,7 +611,7 @@ namespace Microsoft.OData.Json
                 this.FlushIfBufferThresholdReached();
             }
 
-            this.bufferWriter.Write(_doubleQuote.Slice(0, 1).Span);
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
             // since we bypass the Utf8JsonWriter, we need to signal to other
             // Write methods that a separator should be written first
@@ -1100,7 +1100,7 @@ namespace Microsoft.OData.Json
 
             WriteItemWithSeparatorIfNeeded();
 
-            this.bufferWriter.Write(_doubleQuote.Slice(0, 1).Span);
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
             await this.FlushAsync();
 
@@ -1129,7 +1129,7 @@ namespace Microsoft.OData.Json
                 await this.FlushIfBufferThresholdReachedAsync();
             }
 
-            this.bufferWriter.Write(_doubleQuote.Slice(0, 1).Span);
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
             // since we bypass the Utf8JsonWriter, we need to signal to other
             // Write methods that a separator should be written first
@@ -1168,7 +1168,7 @@ namespace Microsoft.OData.Json
 
             WriteItemWithSeparatorIfNeeded();
 
-            this.bufferWriter.Write(_doubleQuote.Slice(0, 1).Span);
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
             await FlushAsync().ConfigureAwait(false);
 
@@ -1186,7 +1186,7 @@ namespace Microsoft.OData.Json
                 await FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
             }
 
-            this.bufferWriter.Write(_doubleQuote.Slice(0, 1).Span);
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
             // since we bypass the Utf8JsonWriter, we need to signal to other
             // Write methods that a separator should be written first

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -8,6 +8,7 @@
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
     <DefineConstants>$(DefineConstants);ODATA_CORE;SUPPRESS_PORTABLELIB_TARGETFRAMEWORK_ATTRIBUTE;DelaySignKeys</DefineConstants>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -188,6 +188,15 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void WritePrimitiveValueLargeStringWithSurrogatePairs()
+        {
+            this.VerifyWritePrimitiveValue(
+                new string('x', 2010) + "Foo ия" + char.ConvertFromUtf32(0x1F60A) + new string('x', 10000) + char.ConvertFromUtf32(0x1F60A),
+                "\"" + new string('x', 2010) + "Foo \\u0438\\u044F" + "\\uD83D\\uDE0A" + new string('x', 10000) + "\\uD83D\\uDE0A" + "\""
+                );
+        }
+
+        [Fact]
         public void WritePrimitiveValueStringWritesNullIfArgumentIsNull()
         {
             this.writer.WriteValue((string)null);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -170,6 +170,24 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void WritePrimitiveValueLargeString()
+        {
+            this.VerifyWritePrimitiveValue(
+                new string('x', 30000),
+                "\"" + new string('x', 30000) + "\""
+                );
+        }
+
+        [Fact]
+        public void WritePrimitiveValueLargeStringWithSpecialChars()
+        {
+            this.VerifyWritePrimitiveValue(
+                new string('x', 20000) + "Foo ия" + new string('x', 10000),
+                "\"" + new string('x', 20000) + "Foo \\u0438\\u044F" + new string('x', 10000) + "\""
+                );
+        }
+
+        [Fact]
         public void WritePrimitiveValueStringWritesNullIfArgumentIsNull()
         {
             this.writer.WriteValue((string)null);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2845.*

### Description
This pull request introduces functionality to handle the writing of large string and byte array values. It accomplishes this by breaking down oversized strings and bytes into smaller chunks and directly writing them to the buffer.

The process involves first checking if the size of the string or byte array exceeds the buffer's capacity. If it does, the program iterates through the large string, dividing it into chunks of a predefined size. Each chunk is then written to the buffer until the entire string is successfully written.

Furthermore, special characters within the string are properly escaped to ensure accurate representation during the writing process.

Methods added: 
1. WriteStringValueInChunks(ReadOnlySpan<char> value)
2. WriteStringValueInChunksAsync
3. WriteByteValueInChunks(ReadOnlySpan<byte> value)
4. WriteByteValueInChunksAsync(ReadOnlyMemory<byte> value)


LOH allocations before these changes: 
char[] in LOH:
![GetImage](https://github.com/OData/odata.net/assets/25525526/70dfeba6-af4e-4c0c-ac8c-daa234997984)
byte[] in LOH from growing the writer buffer when calling WriteStringValue  
![GetImage (1)](https://github.com/OData/odata.net/assets/25525526/195e419f-46b4-4125-aab4-46237a5726e9)

LOH allocations after these changes: 
No byte[] or char[] in the LOH that comes from ODataUtf8JsonWriter 
 
![GetImage (3)](https://github.com/OData/odata.net/assets/25525526/87d65c99-f8b9-4683-a576-e59ae307e56b)

Latency Before:
Bombarding https://localhost:7120/customers/ODataMessageWriter-Utf8JsonWriter-Async?count=10&largeFields=true for 30s using 30 connection(s) 

[=================================================================================================================] 30s 

Done! 

Statistics        Avg      Stdev        Max 
  Reqs/sec        23.70      69.93    1492.98 
  Latency         1.71s      0.87s      7.36s 
  Latency Distribution 
     50%      1.60s 
     75%      1.73s 
     90%      1.87s 
     95%      2.29s 
     99%      6.58s 
  HTTP codes: 
    1xx - 0, 2xx - 534, 3xx - 0, 4xx - 0, 5xx - 0 
    others - 2 
  Errors: 
    tls handshake timed out - 2 
  Throughput:   533.38MB/s 

Latency After: 
Bombarding https://localhost:7120/customers/ODataMessageWriter-Utf8JsonWriter-Async?count=10&largeFields=true for 30s using 30 connection(s) 
[=================================================================================================================] 30s 
Done! 
Statistics        Avg      Stdev        Max 
  Reqs/sec        26.07      44.40     429.41 
  Latency         1.41s   578.31ms      5.48s 
  Latency Distribution 
     50%      1.33s 
     75%      1.47s 
     90%      1.64s 
     95%      1.86s 
     99%      4.79s 
  HTTP codes: 
    1xx - 0, 2xx - 648, 3xx - 0, 4xx - 0, 5xx - 0 
    others - 0 
  Throughput:   651.77MB/s 

With this changes, there is an improvement in latency and there are no allocations in the LOH. 
### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
