### PR TITLE
Rename master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ For more information about OData, please refer to the following resources:
 
 ## 2. Project structure
 
-The project currently has a  [master](https://github.com/OData/odata.net/tree/master) branch and three archived branches: [maintenance-6.x](https://github.com/OData/odata.net/tree/maintenance-6.x), [maintenance-5.x](https://github.com/OData/odata.net/tree/maintenance-5.x), and [maintenance-wcf-dataservice-v4](https://github.com/OData/odata.net/tree/maintenance-wcf-dataservice-v4).
+The project currently has a  [main](https://github.com/OData/odata.net/tree/main) branch and three archived branches: [maintenance-6.x](https://github.com/OData/odata.net/tree/maintenance-6.x), [maintenance-5.x](https://github.com/OData/odata.net/tree/maintenance-5.x), and [maintenance-wcf-dataservice-v4](https://github.com/OData/odata.net/tree/maintenance-wcf-dataservice-v4).
 
-**master branch:**
+**main branch:**
 
-The master branch is the active development branch for ODataV4 7.x. It produces libraries targeting .NET 4.5 as well as [.NET Standard 1.1 and 2.0](https://docs.microsoft.com/en-us/dotnet/articles/standard/library). The branch builds with Visual Studio 2019.
+The **main** branch is the active development branch for ODataV4 7.x. It produces libraries targeting .NET 4.5 as well as [.NET Standard 1.1 and 2.0](https://docs.microsoft.com/en-us/dotnet/articles/standard/library). The branch builds with Visual Studio 2019.
 
 For each profile above, it has the following libraries:
 
@@ -221,7 +221,7 @@ the `base=true` variable to the command, e.g.:
 crank --config benchmarks.yml --scenario ODataWriter --profile local --variable base=true
 ```
 
-This will cause the crank agent to clone the official repo and run the tests against the `master` branch.
+This will cause the crank agent to clone the official repo and run the tests against the `main` branch.
 
 You can specify a different branch, commit or tag using the `baseBranch` variable:
 
@@ -279,7 +279,7 @@ Please visit the [ODataLib docs](https://docs.microsoft.com/en-us/odata/) on doc
 
 ### 5.1 Contribution
 
-There are many ways for you to contribute to OData .NET. The easiest way is to participate in discussion of features and issues. You can also contribute by sending pull requests of features or bug fixes to us. Contribution to the documentations is also highly welcomed. Please refer to the [CONTRIBUTING.md](https://github.com/OData/odata.net/blob/master/.github/CONTRIBUTING.md) for more details.
+There are many ways for you to contribute to OData .NET. The easiest way is to participate in discussion of features and issues. You can also contribute by sending pull requests of features or bug fixes to us. Contribution to the documentations is also highly welcomed. Please refer to the [CONTRIBUTING.md](https://github.com/OData/odata.net/blob/main/.github/CONTRIBUTING.md) for more details.
 
 ### 5.2 Reporting Security Issues
 

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -12,7 +12,7 @@ schedules:
   displayName: midnightly build
   branches:
    include:
-    - master
+    - main
 
 jobs:
 

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -6,11 +6,11 @@ trigger:
   batch: true
   branches:
     include:
-    - master
+    - main
    
 # Pull request (PR) triggers
 pr:
-- master
+- main
 
 jobs:
 

--- a/benchmarks.yml
+++ b/benchmarks.yml
@@ -1,13 +1,13 @@
 variables:
-  # set to true to run benchmarks against master branch of main/official repo
+  # set to true to run benchmarks against main branch of main/official repo
   base: false
   # the branch of the official repo against which to run the benchmarks
-  baseBranch: master
+  baseBranch: main
   # this script sets the source for the benchmarks to either the official repo
   # or the local directory based on the base variable
   setSourceScript: |
     if (job.variables && job.variables.base && job.variables.base.toString() === 'true') {
-      const branch = (job.variables && job.variables.baseBranch && job.variables.baseBranch.toString()) || 'master';
+      const branch = (job.variables && job.variables.baseBranch && job.variables.baseBranch.toString()) || 'main';
       console.log('Run benchmarks against official repository branch', branch);
       job.source.repository = 'https://github.com/OData/odata.net';
       job.source.branchOrCommit = branch;

--- a/tools/Release/CreateAndPushBranch.ps1
+++ b/tools/Release/CreateAndPushBranch.ps1
@@ -45,4 +45,4 @@ git push --set-upstream origin $branchName
 
 Write-Host
 Write-Host -ForegroundColor Green "A new release branch at $branchName has been created and pushed; create a PR for that branch by navigating to:"
-Write-Host -ForegroundColor Green "https://github.com/OData/odata.net/compare/master...$branchName"
+Write-Host -ForegroundColor Green "https://github.com/OData/odata.net/compare/main...$branchName"


### PR DESCRIPTION
Since we renamed the default branch from `master` to `main`. This PR updates our docs, pipelines and scripts accordingly.