### PR TITLE
Add dev-8.x branch to pipeline trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ For each profile above, it has the following libraries:
 
 For these libraries, we accept [issue reports](https://github.com/OData/odata.net/issues) and welcome contributions through [pull requests](https://github.com/OData/odata.net/pulls).
 
+**dev-8.x branch:**
+
+The `dev-8.x` branch is the active development branch for ODataV4 8.x.
+
 **maintenance-6.x branch:** (maintenance mode)
 
 The maintenance-6.x branch includes the .NET libraries for ODataV4 6.x maintenance releases.

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -13,6 +13,7 @@ schedules:
   branches:
    include:
     - main
+    - dev-8.x
 
 jobs:
 

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -7,10 +7,12 @@ trigger:
   branches:
     include:
     - main
+    - dev-8.x
    
 # Pull request (PR) triggers
 pr:
 - main
+- dev-8.x
 
 jobs:
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

This PR adds `dev-8.x` branch to the build pipeline triggers so that checks are triggered when a PR is made against the `dev-8.x` branch.

I also added a note in the README about the `dev-8.x` branch.
