### PR TITLE
ODL 8.x - Deprecate support for JsonPCallback

### DIFF
--- a/src/Microsoft.OData.Core/Json/IJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriter.cs
@@ -21,11 +21,13 @@ namespace Microsoft.OData.Json
         /// <summary>
         /// Start the padding function scope.
         /// </summary>
+        [Obsolete("This will be dropped in the 9.x release.")]
         void StartPaddingFunctionScope();
 
         /// <summary>
         /// End the padding function scope.
         /// </summary>
+        [Obsolete("This will be dropped in the 9.x release.")]
         void EndPaddingFunctionScope();
 
         /// <summary>
@@ -58,6 +60,7 @@ namespace Microsoft.OData.Json
         /// Writes a function name for JSON padding.
         /// </summary>
         /// <param name="functionName">Name of the padding function to write.</param>
+        [Obsolete("This will be dropped in the 9.x release.")]
         void WritePaddingFunctionName(string functionName);
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/IJsonWriterAsync.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriterAsync.cs
@@ -23,12 +23,14 @@ namespace Microsoft.OData.Json
         /// Asynchronously starts the padding function scope.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation.</returns>
+        [Obsolete("This will be dropped in the 9.x release.")]
         Task StartPaddingFunctionScopeAsync();
 
         /// <summary>
         /// Asynchronously ends the padding function scope.
         /// </summary>
         /// <returns>A task that represents the asynchronous operation.</returns>
+        [Obsolete("This will be dropped in the 9.x release.")]
         Task EndPaddingFunctionScopeAsync();
 
         /// <summary>
@@ -67,6 +69,7 @@ namespace Microsoft.OData.Json
         /// </summary>
         /// <param name="functionName">Name of the padding function to write.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
+        [Obsolete("This will be dropped in the 9.x release.")]
         Task WritePaddingFunctionNameAsync(string functionName);
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
@@ -165,50 +165,6 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
-        /// Asynchronously writes the function's name and start the JSONP scope if we are writing a response and the
-        /// JSONP function name is not null or empty.
-        /// </summary>
-        /// <param name="jsonWriter">JsonWriter to write to.</param>
-        /// <param name="settings">Writer settings.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        internal static Task StartJsonPaddingIfRequiredAsync(IJsonWriterAsync jsonWriter, ODataMessageWriterSettings settings)
-        {
-            Debug.Assert(jsonWriter != null, "jsonWriter should not be null");
-
-            if (settings.HasJsonPaddingFunction())
-            {
-                return StartJsonPaddingIfRequiredInnerAsync(jsonWriter, settings);
-
-                async Task StartJsonPaddingIfRequiredInnerAsync(IJsonWriterAsync innerJsonWriter, ODataMessageWriterSettings innerSettings)
-                {
-                    await innerJsonWriter.WritePaddingFunctionNameAsync(innerSettings.JsonPCallback).ConfigureAwait(false);
-                    await innerJsonWriter.StartPaddingFunctionScopeAsync().ConfigureAwait(false);
-                }
-            }
-
-            return TaskUtils.CompletedTask;
-        }
-
-        /// <summary>
-        /// If we are writing a response and the given Json Padding function name is not null or empty
-        /// this function will close the JSONP scope asynchronously.
-        /// </summary>
-        /// <param name="jsonWriter">JsonWriter to write to.</param>
-        /// <param name="settings">Writer settings.</param>
-        /// <returns>A task that represents the asynchronous operation.</returns>
-        internal static Task EndJsonPaddingIfRequiredAsync(IJsonWriterAsync jsonWriter, ODataMessageWriterSettings settings)
-        {
-            Debug.Assert(jsonWriter != null, "jsonWriter should not be null");
-
-            if (settings.HasJsonPaddingFunction())
-            {
-                return jsonWriter.EndPaddingFunctionScopeAsync();
-            }
-
-            return TaskUtils.CompletedTask;
-        }
-
-        /// <summary>
         /// Write an error message.
         /// </summary>
         /// <param name="jsonWriter">JSON writer.</param>

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightSerializer.cs
@@ -256,7 +256,18 @@ namespace Microsoft.OData.JsonLight
         /// <returns>A task that represents the asynchronous write operation.</returns>
         internal Task WritePayloadStartAsync()
         {
-            return ODataJsonWriterUtils.StartJsonPaddingIfRequiredAsync(this.AsynchronousJsonWriter, this.MessageWriterSettings);
+            if (this.MessageWriterSettings.HasJsonPaddingFunction())
+            {
+                return WritePayloadStartInnerAsync(this.AsynchronousJsonWriter, this.MessageWriterSettings.JsonPCallback);
+            }
+
+            return Task.CompletedTask;
+
+            async Task WritePayloadStartInnerAsync(IJsonWriterAsync localJsonWriter, string jsonPCallback)
+            {
+                await localJsonWriter.WritePaddingFunctionNameAsync(jsonPCallback).ConfigureAwait(false);
+                await localJsonWriter.StartPaddingFunctionScopeAsync().ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -265,7 +276,12 @@ namespace Microsoft.OData.JsonLight
         /// <returns>A task that represents the asynchronous write operation.</returns>
         internal Task WritePayloadEndAsync()
         {
-            return ODataJsonWriterUtils.EndJsonPaddingIfRequiredAsync(this.AsynchronousJsonWriter, this.MessageWriterSettings);
+            if (this.MessageWriterSettings.HasJsonPaddingFunction())
+            {
+                return this.AsynchronousJsonWriter.EndPaddingFunctionScopeAsync();
+            }
+
+            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -137,6 +137,7 @@ namespace Microsoft.OData
         /// <returns>The callback function used to wrap the response from server.</returns>
         /// <remarks>If it has a value and we are writing a JSON response, then we will wrap the entirety of the response in
         /// the provided function name and parenthesis for JSONP. Otherwise this value is ignored.</remarks>
+        [Obsolete("This will be dropped in the 9.x release.")]
         public string JsonPCallback { get; set; }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
@@ -21,56 +21,13 @@ namespace Microsoft.OData.Tests.Json
     {
         private StringWriter stringWriter;
         private IJsonWriterAsync jsonWriter;
-        private ODataMessageWriterSettings settings;
         private Func<ICollection<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate;
 
         public ODataJsonWriterUtilsAsyncTests()
         {
             this.stringWriter = new StringWriter();
             this.jsonWriter = new JsonWriter(this.stringWriter, isIeee754Compatible: true);
-            this.settings = new ODataMessageWriterSettings();
             this.writeInstanceAnnotationsDelegate = async (ICollection<ODataInstanceAnnotation> instanceAnnotations) => await TaskUtils.CompletedTask;
-        }
-
-        [Fact]
-        public async Task StartJsonPaddingIfRequiredAsync_DoesNothingIfNullFunctionName()
-        {
-            settings.JsonPCallback = null;
-            await ODataJsonWriterUtils.StartJsonPaddingIfRequiredAsync(this.jsonWriter, settings);
-            Assert.Empty(stringWriter.GetStringBuilder().ToString());
-        }
-
-        [Fact]
-        public async Task StartJsonPaddingIfRequiredAsync_DoesNothingIfEmptyFunctionName()
-        {
-            settings.JsonPCallback = "";
-            await ODataJsonWriterUtils.StartJsonPaddingIfRequiredAsync(this.jsonWriter, settings);
-            Assert.Empty(stringWriter.GetStringBuilder().ToString());
-        }
-
-        [Fact]
-        public async Task EndJsonPaddingIfRequiredAsync_DoesNothingIfNullFunctionName()
-        {
-            settings.JsonPCallback = null;
-            await ODataJsonWriterUtils.EndJsonPaddingIfRequiredAsync(this.jsonWriter, settings);
-            Assert.Empty(stringWriter.GetStringBuilder().ToString());
-        }
-
-        [Fact]
-        public async Task EndJsonPaddingIfRequiredAsync_DoesNothingIfEmptyFunctionName()
-        {
-            settings.JsonPCallback = "";
-            await ODataJsonWriterUtils.EndJsonPaddingIfRequiredAsync(this.jsonWriter, settings);
-            Assert.Empty(stringWriter.GetStringBuilder().ToString());
-        }
-
-        [Fact]
-        public async Task StartAndEndJsonPaddingAsync_SuccessTest()
-        {
-            settings.JsonPCallback = "functionName";
-            await ODataJsonWriterUtils.StartJsonPaddingIfRequiredAsync(this.jsonWriter, settings);
-            await ODataJsonWriterUtils.EndJsonPaddingIfRequiredAsync(this.jsonWriter, settings);
-            Assert.Equal("functionName()", stringWriter.GetStringBuilder().ToString());
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2478.*

### Description

Deprecate support for JsonPCallback

We currently wrap a response will a callback function if the callback function is specified using the `JsonPCallback` property of `ODataMessageWriterSettings` class. Owing to the decision to ensure that in 8.x customers can still write the same payload they did in 7.x, I opted for decorating the `JsonPCallback` property with `Obsolete("This will be dropped in 9.x release")` attribute. No additional value would be derived from introducing a compatibility flag for the customer to toggle since they can express that intention by initializing the `JsonPCallback` property or leaving it uninitialized.

This pull request also marks as obsolete the following methods defined in `IJsonWriter` and `IJsonWriterAsync`:
- `StartPaddingFunctionScope`
- `EndPaddingFunctionScope`
- `WritePaddingFunctionName`
- `StartPaddingFunctionScopeAsync`
- `EndPaddingFunctionScopeAsync`
- `WritePaddingFunctionNameAsync`

Dropped `StartJsonPaddingIfRequiredAsync` and `EndJsonPaddingIfRequiredAsync` because they add little/no value. They are only called from `WritePayloadStartAsync` and `WritePayloadEndAsync`. Their use introduces additional overheads in the form of async state machine and deeper call stack.

Replaced `TaskUtils.Completed` with `Task.CompleteTask` since `Task.Completed` is supported by the two frameworks that 8.x supports.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
