### PR TITLE
Fix "OriginalNameAttribute not being captured when DataServiceQuery<T> is casted to DataServiceQuery<InterfaceT>"

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
+++ b/src/Microsoft.OData.Client/ALinq/ExpressionWriter.cs
@@ -506,7 +506,8 @@ namespace Microsoft.OData.Client
             }
             else
             {
-                this.builder.Append(ClientTypeUtil.GetServerDefinedName(m.Member));
+                var member = m.Expression.Type.GetMember(m.Member.Name).First();
+                this.builder.Append(ClientTypeUtil.GetServerDefinedName(member));
             }
 
             return m;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2856.*

### Description

Capture member from original class, so attributes are not lost in case the query generic parameter is casted to an interface.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

