### PR TITLE
Add support for "Any" and Predicates method call expressions

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/DataServiceQueryProvider.cs
+++ b/src/Microsoft.OData.Client/ALinq/DataServiceQueryProvider.cs
@@ -9,6 +9,7 @@ namespace Microsoft.OData.Client
     #region Namespaces
 
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
@@ -87,22 +88,6 @@ namespace Microsoft.OData.Client
 
         #endregion
 
-        private static Expression MakeCountExpression(Expression sourceExpression) 
-        {
-            return Expression.Call(
-                typeof(Enumerable), 
-                "Count", 
-                new Type[] { sourceExpression.Type.GetGenericArguments()[0] },
-                sourceExpression
-            );
-        }
-
-        private TElement GetValueForAny<TElement>(MethodCallExpression mce)
-        {
-            var countExpression = MakeCountExpression(mce.Arguments[0]);
-            DataServiceQuery<TElement> query = new DataServiceQuery<TElement>.DataServiceOrderedQuery(countExpression, this);
-            return query.GetValue(Context, ParseQuerySetCount<TElement>);
-        }
 
         /// <summary>Creates and executes a DataServiceQuery based on the passed in expression which results a single value</summary>
         /// <typeparam name="TElement">generic type</typeparam>
@@ -110,7 +95,7 @@ namespace Microsoft.OData.Client
         /// <returns>single valued results</returns>
         internal TElement ReturnSingleton<TElement>(Expression expression)
         {
-            IQueryable<TElement> query = new DataServiceQuery<TElement>.DataServiceOrderedQuery(expression, this);
+            IQueryable<TElement> query = CreateQuery<TElement>(expression);
 
             MethodCallExpression mce = expression as MethodCallExpression;
             Debug.Assert(mce != null, "mce != null");
@@ -122,17 +107,35 @@ namespace Microsoft.OData.Client
                 {
                     case SequenceMethod.Single:
                         return query.AsEnumerable().Single();
+                    case SequenceMethod.SinglePredicate:
+                        query = CreateQuery<TElement>(NestPredicateExpression(mce));
+                        return query.AsEnumerable().Single();
                     case SequenceMethod.SingleOrDefault:
+                        return query.AsEnumerable().SingleOrDefault();
+                    case SequenceMethod.SingleOrDefaultPredicate:
+                        query = CreateQuery<TElement>(NestPredicateExpression(mce));
                         return query.AsEnumerable().SingleOrDefault();
                     case SequenceMethod.First:
                         return query.AsEnumerable().First();
+                    case SequenceMethod.FirstPredicate:
+                        query = CreateQuery<TElement>(NestPredicateExpression(mce));
+                        return query.AsEnumerable().First();
                     case SequenceMethod.FirstOrDefault:
+                        return query.AsEnumerable().FirstOrDefault();
+                    case SequenceMethod.FirstOrDefaultPredicate:
+                        query = CreateQuery<TElement>(NestPredicateExpression(mce));
                         return query.AsEnumerable().FirstOrDefault();
                     case SequenceMethod.LongCount:
                     case SequenceMethod.Count:
                         return ((DataServiceQuery<TElement>)query).GetValue(this.Context, ParseQuerySetCount<TElement>);
+                    case SequenceMethod.LongCountPredicate:
+                    case SequenceMethod.CountPredicate:
+                        query = CreateQuery<TElement>(NestPredicateExpression(mce));
+                        return ((DataServiceQuery<TElement>)query).GetValue(this.Context, ParseQuerySetCount<TElement>);
                     case SequenceMethod.Any:
                         return GetValueForAny<TElement>(mce);
+                    case SequenceMethod.AnyPredicate:
+                        return GetValueForAny<TElement>(NestPredicateExpression(mce));
                     case SequenceMethod.SumIntSelector:
                     case SequenceMethod.SumDoubleSelector:
                     case SequenceMethod.SumDecimalSelector:
@@ -213,6 +216,52 @@ namespace Microsoft.OData.Client
             queryComponents.GroupByKeySelectorMap = applyQueryOptionExpr?.KeySelectorMap;
 
             return queryComponents;
+        }
+
+        /// <summary>
+        /// Transforms the 'any' query into a 'count' request since OData does not have a spcific query for 'any'.
+        /// Then the result is casted to the corresponding return type (boolean).
+        /// </summary>
+        /// <typeparam name="TElement">The return type.</typeparam>
+        /// <param name="mce">The original expression with predicate.</param>
+        /// <returns></returns>
+        private TElement GetValueForAny<TElement>(MethodCallExpression mce)
+        {
+            Expression arg0 = mce.Arguments[0];
+            Expression countExpression = Expression.Call(
+                typeof(Enumerable),
+                "Count",
+                new Type[] { arg0.Type.GetGenericArguments()[0] },
+                arg0
+            );
+            var query = CreateQuery<TElement>(countExpression) as DataServiceQuery<TElement>;
+            return query.GetValue(Context, ParseQuerySetCount<TElement>);
+        }
+
+        /// <summary>
+        /// Transforms the expression type to one of type 'where'.
+        /// Then it wraps this 'where' expression into one of the received type but without a predicate.
+        /// </summary>
+        /// <param name="mce">The original expression with predicate.</param>
+        /// <returns>The wrapped expression.</returns>
+        private static MethodCallExpression NestPredicateExpression(MethodCallExpression mce)
+        {
+            Type resourceType = mce.Arguments[0].Type.GetGenericArguments()[0];
+
+            Expression where = Expression.Call(
+                typeof(Queryable),
+                "Where",
+                new Type[] { resourceType },
+                mce.Arguments[0],
+                mce.Arguments[1]
+            );
+
+            return Expression.Call(
+                typeof(Enumerable),
+                mce.Method.Name,
+                new Type[] { resourceType },
+                where
+            );
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
@@ -71,41 +71,36 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void FirstPredicate()
         {
-            // Test behaviour with one match:
             _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'John'&$top=1");
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "]");
             Customer customer = _ctx.Customers.First(c => c.Name != "John");
             Assert.Equal("ALFKI", customer.Id);
             Assert.Equal("Maria Anders", customer.Name);
             Assert.Equal("Berlin", customer.City);
+        }
 
-            // Test behaviour with no match:
-            bool expectedExceptionThrown = false;
-            try
-            {
-                _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=1");
-                _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
-                _ctx.Customers.First(c => c.Name == "thisdoesntexist");
-            }
-            catch (InvalidOperationException)
-            {
-                expectedExceptionThrown = true;
-            }
-            Assert.True(expectedExceptionThrown);
+        [Fact]
+        public void FirstPredicate_ThrowsException_WhenNoMatchExists()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=1");
+            _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
+            Assert.Throws<InvalidOperationException>(() => _ctx.Customers.First(c => c.Name == "thisdoesntexist"));
         }
 
         [Fact]
         public void FirstOrDefaultPredicate()
         {
-            // Test behaviour with one match:
             _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'John'&$top=1");
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "]");
             Customer customer = _ctx.Customers.FirstOrDefault(c => c.Name != "John");
             Assert.Equal("ALFKI", customer.Id);
             Assert.Equal("Maria Anders", customer.Name);
             Assert.Equal("Berlin", customer.City);
+        }
 
-            // Test behaviour with no match:
+        [Fact]
+        public void FirstOrDefaultPredicate_ReturnsNull_WhenNoMatchExists()
+        {
             _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName eq 'John'&$top=1");
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
             Assert.Null(_ctx.Customers.FirstOrDefault(c => c.Name == "John"));
@@ -114,74 +109,55 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void SinglePredicate()
         {
-            // Test behaviour with one match:
             _ctx.InterceptRequestAndAssertUri("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer2 + "]");
             Customer customer = _ctx.Customers.Single(c => c.Id == "CHOPS");
             Assert.Equal("CHOPS", customer.Id);
             Assert.Equal("Yang Wang", customer.Name);
             Assert.Equal("Bern", customer.City);
+        }
 
-            bool expectedExceptionThrown;
+        [Fact]
+        public void SinglePredicate_ThrowsException_WhenNoMatchExists()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=2");
+            _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
+            Assert.Throws<InvalidOperationException>(() => _ctx.Customers.Single(c => c.Name == "thisdoesntexist"));
+        }
 
-            // Test behaviour with no match:
-            try
-            {
-                expectedExceptionThrown = false;
-                _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=2");
-                _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
-                _ctx.Customers.Single(c => c.Name == "thisdoesntexist");
-            }
-            catch (InvalidOperationException)
-            {
-                expectedExceptionThrown = true;
-            }
-            Assert.True(expectedExceptionThrown);
-
-            // Test behaviour with more than one match:
-            try
-            {
-                expectedExceptionThrown = false;
-                _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
-                _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "," + TestContext.MockCustomer2 + "]");
-                _ctx.Customers.Single(c => c.Name != "thisdoesntexist");
-            }
-            catch (InvalidOperationException)
-            {
-                expectedExceptionThrown = true;
-            }
-            Assert.True(expectedExceptionThrown);
+        [Fact]
+        public void SinglePredicate_ThrowsException_WhenMoreThanOneMatchExists()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
+            _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "," + TestContext.MockCustomer2 + "]");
+            Assert.Throws<InvalidOperationException>(() => _ctx.Customers.Single(c => c.Name != "thisdoesntexist"));
         }
 
         [Fact]
         public void SingleOrDefaultPredicate()
         {
-            // Test behaviour with one match:
             _ctx.InterceptRequestAndAssertUri("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer2 + "]");
             Customer customer = _ctx.Customers.SingleOrDefault(c => c.Id == "CHOPS");
             Assert.Equal("CHOPS", customer.Id);
             Assert.Equal("Yang Wang", customer.Name);
             Assert.Equal("Bern", customer.City);
+        }
 
-            // Test behaviour with no match:
+        [Fact]
+        public void SingleOrDefaultPredicate_ReturnsNull_WhenNoMatchExists()
+        {
             _ctx.InterceptRequestAndAssertUri("/Customers?$filter=CustomerID eq '234111'&$top=2");
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
             Assert.Null(_ctx.Customers.SingleOrDefault(c => c.Id == "234111"));
+        }
 
-            // Test behaviour with more than one match:
-            bool expectedExceptionThrown = false;
-            try
-            {
-                _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
-                _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "," + TestContext.MockCustomer2 + "]");
-                _ctx.Customers.SingleOrDefault(c => c.Name != "thisdoesntexist");
-            }
-            catch (InvalidOperationException)
-            {
-                expectedExceptionThrown = true;
-            }
-            Assert.True(expectedExceptionThrown);
+        [Fact]
+        public void SingleOrDefaultPredicate_ThrowsException_WhenMoreThanOneMatchExists()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
+            _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "," + TestContext.MockCustomer2 + "]");
+            Assert.Throws<InvalidOperationException>(() => _ctx.Customers.SingleOrDefault(c => c.Name != "thisdoesntexist"));
         }
     }
 

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
@@ -29,11 +29,23 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void Any()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers/$count");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponse("91");
             Assert.True(_ctx.Customers.Any());
+        }
 
-            _ctx.InterceptRequestAndAssertUri("/Customers/$count?$filter=contains(ContactName,'thisdoesntexist')");
+        [Fact]
+        public void Any_ReturnsFalse_WhenNoMatchExists()
+        {
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'thisdoesntexist')");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponse("0");
             Assert.False(_ctx.Customers.Where(c => c.Name.Contains("thisdoesntexist")).Any());
         }
@@ -41,11 +53,23 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void AnyPredicate()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers/$count?$filter=contains(ContactName,'ab')");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'ab')");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponse("6");
             Assert.True(_ctx.Customers.Any(c => c.Name.Contains("ab")));
+        }
 
-            _ctx.InterceptRequestAndAssertUri("/Customers/$count?$filter=contains(ContactName,'thisdoesntexist')");
+        [Fact]
+        public void AnyPredicate_ReturnsFalse_WhenNoMatchExists()
+        {
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'thisdoesntexist')");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponse("0");
             Assert.False(_ctx.Customers.Any(c => c.Name.Contains("thisdoesntexist")));
         }
@@ -53,7 +77,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void CountPredicate()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers/$count?$filter=contains(ContactName,'ab')");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'ab')");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponse("6");
             int count = _ctx.Customers.Count(c => c.Name.Contains("ab"));
             Assert.Equal(6, count);
@@ -62,7 +90,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void LongCountPredicate()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers/$count?$filter=contains(ContactName,'ab')");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'ab')");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponse("6");
             long count = _ctx.Customers.LongCount(c => c.Name.Contains("ab"));
             Assert.Equal(6, count);
@@ -71,7 +103,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void FirstPredicate()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'John'&$top=1");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName ne 'John'&$top=1");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "]");
             Customer customer = _ctx.Customers.First(c => c.Name != "John");
             Assert.Equal("ALFKI", customer.Id);
@@ -82,7 +118,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void FirstPredicate_ThrowsException_WhenNoMatchExists()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=1");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=1");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
             Assert.Throws<InvalidOperationException>(() => _ctx.Customers.First(c => c.Name == "thisdoesntexist"));
         }
@@ -90,7 +130,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void FirstOrDefaultPredicate()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'John'&$top=1");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName ne 'John'&$top=1");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "]");
             Customer customer = _ctx.Customers.FirstOrDefault(c => c.Name != "John");
             Assert.Equal("ALFKI", customer.Id);
@@ -101,7 +145,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void FirstOrDefaultPredicate_ReturnsNull_WhenNoMatchExists()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName eq 'John'&$top=1");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName eq 'John'&$top=1");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
             Assert.Null(_ctx.Customers.FirstOrDefault(c => c.Name == "John"));
         }
@@ -109,7 +157,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void SinglePredicate()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer2 + "]");
             Customer customer = _ctx.Customers.Single(c => c.Id == "CHOPS");
             Assert.Equal("CHOPS", customer.Id);
@@ -120,7 +172,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void SinglePredicate_ThrowsException_WhenNoMatchExists()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=2");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
             Assert.Throws<InvalidOperationException>(() => _ctx.Customers.Single(c => c.Name == "thisdoesntexist"));
         }
@@ -128,7 +184,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void SinglePredicate_ThrowsException_WhenMoreThanOneMatchExists()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "," + TestContext.MockCustomer2 + "]");
             Assert.Throws<InvalidOperationException>(() => _ctx.Customers.Single(c => c.Name != "thisdoesntexist"));
         }
@@ -136,7 +196,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void SingleOrDefaultPredicate()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer2 + "]");
             Customer customer = _ctx.Customers.SingleOrDefault(c => c.Id == "CHOPS");
             Assert.Equal("CHOPS", customer.Id);
@@ -147,7 +211,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void SingleOrDefaultPredicate_ReturnsNull_WhenNoMatchExists()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=CustomerID eq '234111'&$top=2");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=CustomerID eq '234111'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
             Assert.Null(_ctx.Customers.SingleOrDefault(c => c.Id == "234111"));
         }
@@ -155,7 +223,11 @@ namespace Microsoft.OData.Client.Tests.ALinq
         [Fact]
         public void SingleOrDefaultPredicate_ThrowsException_WhenMoreThanOneMatchExists()
         {
-            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
+            _ctx.OnRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
             _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "," + TestContext.MockCustomer2 + "]");
             Assert.Throws<InvalidOperationException>(() => _ctx.Customers.SingleOrDefault(c => c.Name != "thisdoesntexist"));
         }
@@ -186,7 +258,7 @@ namespace Microsoft.OData.Client.Tests.ALinq
 
         private readonly string _rootUriStr;
 
-        private string _assertRequestUriPath = "";
+        public Action<string> OnRequestUriBuilt = null;
 
         public TestContext()
         {
@@ -203,17 +275,15 @@ namespace Microsoft.OData.Client.Tests.ALinq
 
             _ctx.BuildingRequest += (obj, args) =>
             {
-                if (_assertRequestUriPath == "") return;
-                string expectedUri = _rootUriStr + _assertRequestUriPath;
+                if (OnRequestUriBuilt == null) return;
                 string actualUri = args.RequestUri.ToString();
-                Assert.Equal(expectedUri, actualUri);
-                _assertRequestUriPath = "";
+                OnRequestUriBuilt(actualUri);
             };
         }
 
-        public void InterceptRequestAndAssertUri(string uriPath)
+        public string BuildUriFromPath(string uriPath)
         {
-            _assertRequestUriPath = uriPath;
+            return _rootUriStr + uriPath;
         }
 
         public void InterceptRequestAndMockResponse(string mockResponse)

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
@@ -19,254 +19,25 @@ namespace Microsoft.OData.Client.Tests.ALinq
     /// </summary>
     public class SequenceMethodsTests
     {
-        private readonly TestContext _ctx;
+        private const string MockCustomer1 = "{\"CustomerID\":\"ALFKI\",\"CompanyName\":\"Alfreds Futterkiste\",\"ContactName\":\"Maria Anders\",\"Address\":\"Obere Str. 57\",\"City\":\"Berlin\"}";
 
-        public SequenceMethodsTests()
-        {
-            _ctx = new TestContext();
-        }
+        private const string MockCustomer2 = "{\"CustomerID\":\"CHOPS\",\"CompanyName\":\"Chop-suey Chinese\",\"ContactName\":\"Yang Wang\",\"Address\":\"Hauptstr. 29\",\"City\":\"Bern\"}";
 
-        [Fact]
-        public void Any()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponse("91");
-            Assert.True(_ctx.Customers.Any());
-        }
-
-        [Fact]
-        public void Any_ReturnsFalse_WhenNoMatchExists()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'thisdoesntexist')");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponse("0");
-            Assert.False(_ctx.Customers.Where(c => c.Name.Contains("thisdoesntexist")).Any());
-        }
-
-        [Fact]
-        public void AnyPredicate()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'ab')");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponse("6");
-            Assert.True(_ctx.Customers.Any(c => c.Name.Contains("ab")));
-        }
-
-        [Fact]
-        public void AnyPredicate_ReturnsFalse_WhenNoMatchExists()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'thisdoesntexist')");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponse("0");
-            Assert.False(_ctx.Customers.Any(c => c.Name.Contains("thisdoesntexist")));
-        }
-
-        [Fact]
-        public void CountPredicate()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'ab')");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponse("6");
-            int count = _ctx.Customers.Count(c => c.Name.Contains("ab"));
-            Assert.Equal(6, count);
-        }
-
-        [Fact]
-        public void LongCountPredicate()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'ab')");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponse("6");
-            long count = _ctx.Customers.LongCount(c => c.Name.Contains("ab"));
-            Assert.Equal(6, count);
-        }
-
-        [Fact]
-        public void FirstPredicate()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName ne 'John'&$top=1");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "]");
-            Customer customer = _ctx.Customers.First(c => c.Name != "John");
-            Assert.Equal("ALFKI", customer.Id);
-            Assert.Equal("Maria Anders", customer.Name);
-            Assert.Equal("Berlin", customer.City);
-        }
-
-        [Fact]
-        public void FirstPredicate_ThrowsException_WhenNoMatchExists()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=1");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
-            Assert.Throws<InvalidOperationException>(() => _ctx.Customers.First(c => c.Name == "thisdoesntexist"));
-        }
-
-        [Fact]
-        public void FirstOrDefaultPredicate()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName ne 'John'&$top=1");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "]");
-            Customer customer = _ctx.Customers.FirstOrDefault(c => c.Name != "John");
-            Assert.Equal("ALFKI", customer.Id);
-            Assert.Equal("Maria Anders", customer.Name);
-            Assert.Equal("Berlin", customer.City);
-        }
-
-        [Fact]
-        public void FirstOrDefaultPredicate_ReturnsNull_WhenNoMatchExists()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName eq 'John'&$top=1");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
-            Assert.Null(_ctx.Customers.FirstOrDefault(c => c.Name == "John"));
-        }
-
-        [Fact]
-        public void SinglePredicate()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer2 + "]");
-            Customer customer = _ctx.Customers.Single(c => c.Id == "CHOPS");
-            Assert.Equal("CHOPS", customer.Id);
-            Assert.Equal("Yang Wang", customer.Name);
-            Assert.Equal("Bern", customer.City);
-        }
-
-        [Fact]
-        public void SinglePredicate_ThrowsException_WhenNoMatchExists()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=2");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
-            Assert.Throws<InvalidOperationException>(() => _ctx.Customers.Single(c => c.Name == "thisdoesntexist"));
-        }
-
-        [Fact]
-        public void SinglePredicate_ThrowsException_WhenMoreThanOneMatchExists()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "," + TestContext.MockCustomer2 + "]");
-            Assert.Throws<InvalidOperationException>(() => _ctx.Customers.Single(c => c.Name != "thisdoesntexist"));
-        }
-
-        [Fact]
-        public void SingleOrDefaultPredicate()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer2 + "]");
-            Customer customer = _ctx.Customers.SingleOrDefault(c => c.Id == "CHOPS");
-            Assert.Equal("CHOPS", customer.Id);
-            Assert.Equal("Yang Wang", customer.Name);
-            Assert.Equal("Bern", customer.City);
-        }
-
-        [Fact]
-        public void SingleOrDefaultPredicate_ReturnsNull_WhenNoMatchExists()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=CustomerID eq '234111'&$top=2");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
-            Assert.Null(_ctx.Customers.SingleOrDefault(c => c.Id == "234111"));
-        }
-
-        [Fact]
-        public void SingleOrDefaultPredicate_ThrowsException_WhenMoreThanOneMatchExists()
-        {
-            _ctx.OnRequestUriBuilt = (string builtUri) =>
-            {
-                string expectedUri = _ctx.BuildUriFromPath("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
-                Assert.Equal(expectedUri, builtUri);
-            };
-            _ctx.InterceptRequestAndMockResponseValue("Customers", "[" + TestContext.MockCustomer1 + "," + TestContext.MockCustomer2 + "]");
-            Assert.Throws<InvalidOperationException>(() => _ctx.Customers.SingleOrDefault(c => c.Name != "thisdoesntexist"));
-        }
-    }
-
-
-    [Key("CustomerID")]
-    public class Customer
-    {
-        [OriginalName("CustomerID")]
-        public string Id { get; set; }
-
-        public string City { get; set; }
-
-        [OriginalName("ContactName")]
-        public string Name { get; set; }
-    }
-
-    public class TestContext
-    {
-        public const string MockCustomer1 = "{\"CustomerID\":\"ALFKI\",\"CompanyName\":\"Alfreds Futterkiste\",\"ContactName\":\"Maria Anders\",\"Address\":\"Obere Str. 57\",\"City\":\"Berlin\"}";
-
-        public const string MockCustomer2 = "{\"CustomerID\":\"CHOPS\",\"CompanyName\":\"Chop-suey Chinese\",\"ContactName\":\"Yang Wang\",\"Address\":\"Hauptstr. 29\",\"City\":\"Bern\"}";
-
-        public readonly DataServiceQuery<Customer> Customers;
+        private readonly DataServiceQuery<Customer> _customers;
 
         private readonly DataServiceContext _ctx;
 
         private readonly string _rootUriStr;
 
-        public Action<string> OnRequestUriBuilt = null;
+        private Action<string> _onRequestUriBuilt = null;
 
-        public TestContext()
+        public SequenceMethodsTests()
         {
             _rootUriStr = "https://mock.odata.service";
             Uri uri = new Uri(_rootUriStr);
 
             _ctx = new DataServiceContext(uri);
-            Customers = _ctx.CreateQuery<Customer>("Customers");
+            _customers = _ctx.CreateQuery<Customer>("Customers");
 
             EdmModel model = BuildEdmModel();
             _ctx.Format.UseJson(model);
@@ -275,18 +46,224 @@ namespace Microsoft.OData.Client.Tests.ALinq
 
             _ctx.BuildingRequest += (obj, args) =>
             {
-                if (OnRequestUriBuilt == null) return;
-                string actualUri = args.RequestUri.ToString();
-                OnRequestUriBuilt(actualUri);
+                if (_onRequestUriBuilt == null) return;
+                string actualUri = args.RequestUri.OriginalString;
+                _onRequestUriBuilt(actualUri);
             };
         }
 
-        public string BuildUriFromPath(string uriPath)
+        [Fact]
+        public void Any()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers/$count");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponse("91");
+            Assert.True(_customers.Any());
+        }
+
+        [Fact]
+        public void Any_ReturnsFalse_WhenNoMatchExists()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'thisdoesntexist')");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponse("0");
+            Assert.False(_customers.Where(c => c.Name.Contains("thisdoesntexist")).Any());
+        }
+
+        [Fact]
+        public void AnyPredicate()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'ab')");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponse("6");
+            Assert.True(_customers.Any(c => c.Name.Contains("ab")));
+        }
+
+        [Fact]
+        public void AnyPredicate_ReturnsFalse_WhenNoMatchExists()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'thisdoesntexist')");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponse("0");
+            Assert.False(_customers.Any(c => c.Name.Contains("thisdoesntexist")));
+        }
+
+        [Fact]
+        public void CountPredicate()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'ab')");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponse("6");
+            int count = _customers.Count(c => c.Name.Contains("ab"));
+            Assert.Equal(6, count);
+        }
+
+        [Fact]
+        public void LongCountPredicate()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers/$count?$filter=contains(ContactName,'ab')");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponse("6");
+            long count = _customers.LongCount(c => c.Name.Contains("ab"));
+            Assert.Equal(6, count);
+        }
+
+        [Fact]
+        public void FirstPredicate()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=ContactName ne 'John'&$top=1");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer1 + "]");
+            Customer customer = _customers.First(c => c.Name != "John");
+            Assert.Equal("ALFKI", customer.Id);
+            Assert.Equal("Maria Anders", customer.Name);
+            Assert.Equal("Berlin", customer.City);
+        }
+
+        [Fact]
+        public void FirstPredicate_ThrowsException_WhenNoMatchExists()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=1");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[]");
+            Assert.Throws<InvalidOperationException>(() => _customers.First(c => c.Name == "thisdoesntexist"));
+        }
+
+        [Fact]
+        public void FirstOrDefaultPredicate()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=ContactName ne 'John'&$top=1");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer1 + "]");
+            Customer customer = _customers.FirstOrDefault(c => c.Name != "John");
+            Assert.Equal("ALFKI", customer.Id);
+            Assert.Equal("Maria Anders", customer.Name);
+            Assert.Equal("Berlin", customer.City);
+        }
+
+        [Fact]
+        public void FirstOrDefaultPredicate_ReturnsNull_WhenNoMatchExists()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=ContactName eq 'John'&$top=1");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[]");
+            Assert.Null(_customers.FirstOrDefault(c => c.Name == "John"));
+        }
+
+        [Fact]
+        public void SinglePredicate()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer2 + "]");
+            Customer customer = _customers.Single(c => c.Id == "CHOPS");
+            Assert.Equal("CHOPS", customer.Id);
+            Assert.Equal("Yang Wang", customer.Name);
+            Assert.Equal("Bern", customer.City);
+        }
+
+        [Fact]
+        public void SinglePredicate_ThrowsException_WhenNoMatchExists()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=ContactName eq 'thisdoesntexist'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[]");
+            Assert.Throws<InvalidOperationException>(() => _customers.Single(c => c.Name == "thisdoesntexist"));
+        }
+
+        [Fact]
+        public void SinglePredicate_ThrowsException_WhenMoreThanOneMatchExists()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer1 + "," + MockCustomer2 + "]");
+            Assert.Throws<InvalidOperationException>(() => _customers.Single(c => c.Name != "thisdoesntexist"));
+        }
+
+        [Fact]
+        public void SingleOrDefaultPredicate()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer2 + "]");
+            Customer customer = _customers.SingleOrDefault(c => c.Id == "CHOPS");
+            Assert.Equal("CHOPS", customer.Id);
+            Assert.Equal("Yang Wang", customer.Name);
+            Assert.Equal("Bern", customer.City);
+        }
+
+        [Fact]
+        public void SingleOrDefaultPredicate_ReturnsNull_WhenNoMatchExists()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=CustomerID eq '234111'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[]");
+            Assert.Null(_customers.SingleOrDefault(c => c.Id == "234111"));
+        }
+
+        [Fact]
+        public void SingleOrDefaultPredicate_ThrowsException_WhenMoreThanOneMatchExists()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=ContactName ne 'thisdoesntexist'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer1 + "," + MockCustomer2 + "]");
+            Assert.Throws<InvalidOperationException>(() => _customers.SingleOrDefault(c => c.Name != "thisdoesntexist"));
+        }
+
+        private string BuildUriFromPath(string uriPath)
         {
             return _rootUriStr + uriPath;
         }
 
-        public void InterceptRequestAndMockResponse(string mockResponse)
+        private void InterceptRequestAndMockResponse(string mockResponse)
         {
             _ctx.Configurations.RequestPipeline.OnMessageCreating = (args) =>
             {
@@ -303,7 +280,7 @@ namespace Microsoft.OData.Client.Tests.ALinq
             };
         }
 
-        public void InterceptRequestAndMockResponseValue(string entitySetName, string mockResponseValue)
+        private void InterceptRequestAndMockResponseValue(string entitySetName, string mockResponseValue)
         {
             string mockResponse = "{\"@odata.context\":\"" + _rootUriStr + "/$metadata#" + entitySetName + "\",\"value\":" + mockResponseValue + "}";
 
@@ -331,6 +308,18 @@ namespace Microsoft.OData.Client.Tests.ALinq
             container.AddEntitySet("Customers", customerType);
 
             return model;
+        }
+
+        [Key("CustomerID")]
+        public class Customer
+        {
+            [OriginalName("CustomerID")]
+            public string Id { get; set; }
+
+            public string City { get; set; }
+
+            [OriginalName("ContactName")]
+            public string Name { get; set; }
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
@@ -1,0 +1,209 @@
+//---------------------------------------------------------------------
+// <copyright file="SequenceMethodsTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.ALinq
+{
+    /// <summary>
+    /// Tests to check sequence methods support.
+    /// </summary>
+    public class SequenceMethodsTests
+    {
+        private readonly TestContext _ctx;
+
+        public SequenceMethodsTests()
+        {
+            _ctx = new TestContext();
+        }
+
+        [Fact]
+        public void Any()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers/$count");
+            _ctx.InterceptRequestAndMockResponse("91");
+            bool exists1 = _ctx.Customers.Any();
+            Assert.True(exists1);
+        }
+
+        [Fact]
+        public void AnyPredicate()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers/$count?$filter=contains(ContactName,'ab')");
+            _ctx.InterceptRequestAndMockResponse("6");
+            bool exists2 = _ctx.Customers.Any(c => c.Name.Contains("ab"));
+            Assert.True(exists2);
+
+            _ctx.InterceptRequestAndAssertUri("/Customers/$count?$filter=contains(ContactName,'thisdoesntexist')");
+            _ctx.InterceptRequestAndMockResponse("0");
+            bool exists3 = _ctx.Customers.Any(c => c.Name.Contains("thisdoesntexist"));
+            Assert.False(exists3);
+        }
+
+        [Fact]
+        public void CountPredicate()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers/$count?$filter=contains(ContactName,'ab')");
+            _ctx.InterceptRequestAndMockResponse("6");
+            int count1 = _ctx.Customers.Count(c => c.Name.Contains("ab"));
+            Assert.Equal(6, count1);
+        }
+
+        [Fact]
+        public void LongCountPredicate()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers/$count?$filter=contains(ContactName,'ab')");
+            _ctx.InterceptRequestAndMockResponse("6");
+            long count2 = _ctx.Customers.LongCount(c => c.Name.Contains("ab"));
+            Assert.Equal(6, count2);
+        }
+
+        [Fact]
+        public void FirstPredicate()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName ne 'John'&$top=1");
+            _ctx.InterceptRequestAndMockResponseValue("Customers", "[{\"CustomerID\":\"ALFKI\",\"CompanyName\":\"Alfreds Futterkiste\",\"ContactName\":\"Maria Anders\",\"Address\":\"Obere Str. 57\",\"City\":\"Berlin\"}]");
+            Customer c1 = _ctx.Customers.First(c => c.Name != "John");
+            Assert.Equal("ALFKI", c1.Id);
+            Assert.Equal("Maria Anders", c1.Name);
+            Assert.Equal("Berlin", c1.City);
+        }
+
+        [Fact]
+        public void FirstOrDefaultPredicate()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=ContactName eq 'John'&$top=1");
+            _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
+            Customer c2 = _ctx.Customers.FirstOrDefault(c => c.Name == "John");
+            Assert.Null(c2);
+        }
+
+        [Fact]
+        public void SinglePredicate()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=CustomerID eq 'CHOPS'&$top=2");
+            _ctx.InterceptRequestAndMockResponseValue("Customers", "[{\"CustomerID\":\"CHOPS\",\"CompanyName\":\"Chop-suey Chinese\",\"ContactName\":\"Yang Wang\",\"ContactTitle\":\"Owner\",\"Address\":\"Hauptstr. 29\",\"City\":\"Bern\"}]");
+            Customer c3 = _ctx.Customers.Single(c => c.Id == "CHOPS");
+            Assert.Equal("CHOPS", c3.Id);
+            Assert.Equal("Yang Wang", c3.Name);
+            Assert.Equal("Bern", c3.City);
+        }
+
+        [Fact]
+        public void SingleOrDefaultPredicate()
+        {
+            _ctx.InterceptRequestAndAssertUri("/Customers?$filter=CustomerID eq '234111'&$top=2");
+            _ctx.InterceptRequestAndMockResponseValue("Customers", "[]");
+            Customer c4 = _ctx.Customers.SingleOrDefault(c => c.Id == "234111");
+            Assert.Null(c4);
+        }
+    }
+
+
+    [Key("CustomerID")]
+    public class Customer
+    {
+        [OriginalName("CustomerID")]
+        public string Id { get; set; }
+
+        public string City { get; set; }
+
+        [OriginalName("ContactName")]
+        public string Name { get; set; }
+    }
+
+    public class TestContext
+    {
+        public readonly DataServiceQuery<Customer> Customers;
+
+        private readonly DataServiceContext _ctx;
+
+        private readonly string _rootUriStr;
+
+        private string _assertRequestUriPath = "";
+
+        public TestContext()
+        {
+            _rootUriStr = "https://mock.odata.service";
+            Uri uri = new Uri(_rootUriStr);
+
+            _ctx = new DataServiceContext(uri);
+            Customers = _ctx.CreateQuery<Customer>("Customers");
+
+            EdmModel model = BuildEdmModel();
+            _ctx.Format.UseJson(model);
+            _ctx.ResolveName = (type) => $"NS.{type.Name}";
+            _ctx.KeyComparisonGeneratesFilterQuery = true;
+
+            _ctx.BuildingRequest += (obj, args) =>
+            {
+                if (_assertRequestUriPath == "") return;
+                string expectedUri = _rootUriStr + _assertRequestUriPath;
+                string actualUri = args.RequestUri.ToString();
+                Assert.Equal(expectedUri, actualUri);
+                _assertRequestUriPath = "";
+            };
+        }
+
+        public void InterceptRequestAndAssertUri(string uriPath)
+        {
+            _assertRequestUriPath = uriPath;
+        }
+
+        public void InterceptRequestAndMockResponse(string mockResponse)
+        {
+            _ctx.Configurations.RequestPipeline.OnMessageCreating = (args) =>
+            {
+                var contentTypeHeader = "application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8";
+                var odataVersionHeader = "4.0";
+
+                return new TestHttpWebRequestMessage(args,
+                    new Dictionary<string, string>
+                    {
+                        {"Content-Type", contentTypeHeader},
+                        {"OData-Version", odataVersionHeader},
+                    },
+                    () => new MemoryStream(Encoding.UTF8.GetBytes(mockResponse)));
+            };
+        }
+
+        public void InterceptRequestAndMockResponseValue(string entitySetName, string mockResponseValue)
+        {
+            string mockResponse = "{\"@odata.context\":\"" + _rootUriStr + "/$metadata#" + entitySetName + "\",\"value\":" + mockResponseValue + "}";
+
+            InterceptRequestAndMockResponse(mockResponse);
+        }
+
+        private static EdmModel BuildEdmModel()
+        {
+            var model = new EdmModel();
+
+            // Create the Customer entity type
+            var customerType = new EdmEntityType("NS", "Customer");
+            var customerId = customerType.AddStructuralProperty("CustomerID", EdmPrimitiveTypeKind.String, false);
+            customerType.AddKeys(customerId);
+            customerType.AddStructuralProperty("CompanyName", EdmPrimitiveTypeKind.String, false);
+            customerType.AddStructuralProperty("ContactName", EdmPrimitiveTypeKind.String, true);
+            customerType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String, true);
+            model.AddElement(customerType);
+
+            // Create the EntityContainer
+            var container = new EdmEntityContainer("NS", "Container");
+            model.AddElement(container);
+
+            // Create Entity Sets
+            container.AddEntitySet("Customers", customerType);
+
+            return model;
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1996.*

### Description

This PR implmements `Any` method support. (Internally it fakes a `Count` request and transforms numeric response into boolean value).
It also adds support for the following sequence methods:
`AnyPredicate`, `CountPredicate`, `LongCountPredicate`, `FirstPredicate`, `FirstOrDefaultPredicate`, `SinglePredicate`, `SingleOrDefaultPredicate`

E.g.:
```csharp
var ctx = new DataServiceContext(new Uri(...));
var dataSet = ctx.CreateQuery<Customer>("Customers");
// The following lines will work fine without throwing Exception now:
bool exists1 = dataSet.Any();
bool exists2 = dataSet.Any(c => c.Name.Contains("ab"));
int count1 = dataSet.Count(c => c.Name.Contains("ab"));
long count2 = dataSet.LongCount(c => c.Name.Contains("ab"));
Customer c1 =  dataSet.First(c => c.Name != "John");
Customer c2 =  dataSet.FirstOrDefault(c => c.Name == "John");
Customer c3 =  dataSet.Single(c => c.Id == "234111");
Customer c4 =  dataSet.SingleOrDefault(c => c.Id == "234111");
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

