### PR TITLE
[ODL 8]: Use `$filter` for all `Where` clauses and remove `KeyComparisonGeneratesFilter` flag

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/QueryableResourceExpression.cs
+++ b/src/Microsoft.OData.Client/ALinq/QueryableResourceExpression.cs
@@ -156,12 +156,6 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
-        /// If this expresssion contains at least one non-key predicate
-        /// This indicates that a filter should be used
-        /// </summary>
-        internal bool UseFilterAsPredicate { get; set; }
-
-        /// <summary>
         /// Filter query option for ResourceSet
         /// </summary>
         internal FilterQueryOptionExpression Filter

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -255,26 +255,8 @@ namespace Microsoft.OData.Client
 
             if (inputPredicates != null)
             {
-                List<Expression> keyPredicates = null;
-
-                if (keyPredicates != null)
-                {
-                    input.SetKeyPredicate(keyPredicates);
-                    input.RemoveFilterExpression();
-                }
-
-                // A key predicate cannot be applied if query options other than 'Expand' are present,
-                // so merge the key predicate into the filter query option instead.
-                if (keyPredicates != null && input.HasSequenceQueryOptions)
-                {
-                    input.ConvertKeyToFilterExpression();
-                }
-
-                if (keyPredicates == null)
-                {
-                    input.ConvertKeyToFilterExpression();
-                    input.AddFilter(inputPredicates);
-                }
+                input.ConvertKeyToFilterExpression();
+                input.AddFilter(inputPredicates);
             }
 
             return input; // No need to adjust this.currentResource - filters are merged in all cases

--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -256,25 +256,6 @@ namespace Microsoft.OData.Client
             if (inputPredicates != null)
             {
                 List<Expression> keyPredicates = null;
-                List<Expression> nonKeyPredicates = null;
-
-                // Get the current key predicates
-                List<Expression> currentPredicates = input.KeyPredicateConjuncts.ToList();
-
-                if (input.Filter != null && input.Filter.PredicateConjuncts.Count > 0)
-                {
-                    // Get the filter predicates
-                    currentPredicates = currentPredicates.Union(input.Filter.PredicateConjuncts.Union(inputPredicates)).ToList();
-                }
-                else
-                {
-                    currentPredicates = currentPredicates.Union(inputPredicates).ToList();
-                }
-
-                if (!input.UseFilterAsPredicate && !context.KeyComparisonGeneratesFilterQuery)
-                {
-                    keyPredicates = ExtractKeyPredicate(input, currentPredicates, model, out nonKeyPredicates);
-                }
 
                 if (keyPredicates != null)
                 {
@@ -373,8 +354,6 @@ namespace Microsoft.OData.Client
 
             if (nonKeyPredicates != null && nonKeyPredicates.Count > 0)
             {
-                // If there is any non-key predicate, everything must go in filter statement,
-                target.UseFilterAsPredicate = true;
                 keyPredicates = null;
             }
             else

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -695,15 +695,6 @@ namespace Microsoft.OData.Client
         /// </summary>
         public virtual bool EnableWritingODataAnnotationWithoutPrefix { get; set; }
 
-        /// <summary>
-        /// Indicates whether a Where clause that just compares the key property generates a $filter query option.
-        /// </summary>
-        public virtual bool KeyComparisonGeneratesFilterQuery
-        {
-            get { return this.keyComparisonGeneratesFilterQuery; }
-            set { this.keyComparisonGeneratesFilterQuery = value; }
-        }
-
         /// <summary>Gets or sets the option for the form of Uri to be generated for a delete link request.</summary>
         public virtual DeleteLinkUriOption DeleteLinkUriOption
         {

--- a/src/Microsoft.OData.Client/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -921,8 +921,6 @@ virtual Microsoft.OData.Client.DataServiceContext.GetReadStreamUri(object entity
 virtual Microsoft.OData.Client.DataServiceContext.GetReadStreamUri(object entity, string name) -> System.Uri
 virtual Microsoft.OData.Client.DataServiceContext.IgnoreResourceNotFoundException.get -> bool
 virtual Microsoft.OData.Client.DataServiceContext.IgnoreResourceNotFoundException.set -> void
-virtual Microsoft.OData.Client.DataServiceContext.KeyComparisonGeneratesFilterQuery.get -> bool
-virtual Microsoft.OData.Client.DataServiceContext.KeyComparisonGeneratesFilterQuery.set -> void
 virtual Microsoft.OData.Client.DataServiceContext.Links.get -> System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.OData.Client.LinkDescriptor>
 virtual Microsoft.OData.Client.DataServiceContext.LoadProperty(object entity, string propertyName) -> Microsoft.OData.Client.QueryOperationResponse
 virtual Microsoft.OData.Client.DataServiceContext.LoadProperty(object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation) -> Microsoft.OData.Client.QueryOperationResponse

--- a/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -921,8 +921,6 @@ virtual Microsoft.OData.Client.DataServiceContext.GetReadStreamUri(object entity
 virtual Microsoft.OData.Client.DataServiceContext.GetReadStreamUri(object entity, string name) -> System.Uri
 virtual Microsoft.OData.Client.DataServiceContext.IgnoreResourceNotFoundException.get -> bool
 virtual Microsoft.OData.Client.DataServiceContext.IgnoreResourceNotFoundException.set -> void
-virtual Microsoft.OData.Client.DataServiceContext.KeyComparisonGeneratesFilterQuery.get -> bool
-virtual Microsoft.OData.Client.DataServiceContext.KeyComparisonGeneratesFilterQuery.set -> void
 virtual Microsoft.OData.Client.DataServiceContext.Links.get -> System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.OData.Client.LinkDescriptor>
 virtual Microsoft.OData.Client.DataServiceContext.LoadProperty(object entity, string propertyName) -> Microsoft.OData.Client.QueryOperationResponse
 virtual Microsoft.OData.Client.DataServiceContext.LoadProperty(object entity, string propertyName, Microsoft.OData.Client.DataServiceQueryContinuation continuation) -> Microsoft.OData.Client.QueryOperationResponse

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1317,30 +1317,17 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
         }
 
         /// <summary>
-        /// When DataServiceContext.KeyComparisonGeneratesFilterQuery=true, An expression that compares only the key property, will generate a $filter query option.
+        /// Verify that an expression that compares only the key property will generate a $filter query option.
         /// </summary>
         [Fact]
-        public void Linq_Where_Generates_Filter_When_KeyComparisonGeneratesFilterQuery_Is_True()
-        {
-            var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            context.KeyComparisonGeneratesFilterQuery = true;
-            var query = context.Customer.Where(c => c.CustomerId == -10);
-            var uri = query.ToString();
-            Assert.EndsWith("$filter=CustomerId eq -10", uri);
-        }
-
-        /// <summary>
-        /// When DataServiceContext.KeyComparisonGeneratesFilterQuery=false, An expression that compares only the key property, should create a ByKey Uri.
-        /// </summary>
-        [Fact]
-        public void Linq_Where_Generates_ByKey_When_KeyComparisonGeneratesFilterQuery_Is_False()
+        public void Linq_Where_Generates_Filter_WhenPredicateIsKeyLookup()
         {
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
             // By default context.KeyComparisonGeneratesFilterQuery = false;
             // So we don't need to set it
             var query = context.Customer.Where(c => c.CustomerId == -10);
             var uri = query.ToString();
-            Assert.EndsWith("Customer(-10)", uri);
+            Assert.EndsWith("$filter=CustomerId eq -10", uri);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/WhereClauseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/ALinq/WhereClauseTests.cs
@@ -1,0 +1,66 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DollarFilterWithCastTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.Tests.ALinq
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Xml;
+    using Microsoft.OData.Client.Tests.Tracking;
+    using Microsoft.OData.Edm.Csdl;
+    using Xunit;
+
+    /// <summary>
+    /// Dollar Filter with cast tests
+    /// </summary>
+    public class WhereClauseTests : DollarApplyTestsBase
+    {
+        private const string Response = @"{""@odata.context"":""http://localhost:8000/$metadata#Products"",""value"":[{""Id"":1,""Name"":""Hat""},{""Id"":2,""Name"":""Socks""},{""Id"":3,""Name"":""Scarf""}]}";
+
+        public WhereClauseTests() : base()
+        {
+        }
+
+        [Fact]
+        public void WhereClause_WithKeyFieldOnly()
+        {
+            var queryable = this.dsContext.CreateQuery<Product>("Products");
+
+            var query = queryable.Where(p => p.Id == "p1");
+            Assert.Equal(
+                $"{serviceUri}/Products?$filter=Id eq 'p1'",
+                query.ToString());
+        }
+
+        [Fact]
+        public void WhereClause_WithKeyAndNonKeyFields()
+        {
+            var products = this.dsContext.CreateQuery<Product>("Products");
+
+            var query = products.Where(p => p.Id == "p1" && p.Color == "Red");
+            Assert.Equal(
+                $"{serviceUri}/Products?$filter=Id eq 'p1' and Color eq 'Red'",
+                query.ToString()
+            );
+
+        }
+
+
+        [Fact]
+        public void WhereClause_WithNonKeyFieldsOnly()
+        {
+            var products = this.dsContext.CreateQuery<Product>("Products");
+
+            var query = products.Where(p => p.TaxRate < 0.2m || p.Color == "Red");
+            Assert.Equal(
+                $"{serviceUri}/Products?$filter=TaxRate lt 0.2 or Color eq 'Red'",
+                query.ToString()
+            );
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2208*

### Description

- Removes the `DataServiceContext.KeyComparisonGeneratesFilter` property
- Translates `Where` clause into a `$filter` query option even when the where clause only does a key lookup. Previous, this would generate a key segment instead of a `$filter` unless the flag above was set to `true`.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*