### PR TITLE
[ODL 8]: Deprecate `KeyComparisonGeneratesFilterQuery` and set default to `true`.

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -288,7 +288,7 @@ namespace Microsoft.OData.Client
             this.httpStack = HttpStack.Auto;
             this.UsingDataServiceCollection = false;
             this.UsePostTunneling = false;
-            this.keyComparisonGeneratesFilterQuery = false;
+            this.keyComparisonGeneratesFilterQuery = true;
             this.deleteLinkUriOption = DeleteLinkUriOption.IdQueryParam;
         }
 
@@ -696,8 +696,10 @@ namespace Microsoft.OData.Client
         public virtual bool EnableWritingODataAnnotationWithoutPrefix { get; set; }
 
         /// <summary>
-        /// Indicates whether a Where clause that just compares the key property generates a $filter query option.
+        /// When true, a Where clause that just compares the key property generates a $filter query option, otherwise a key segment is generated.
+        /// The default value is true.
         /// </summary>
+        [Obsolete("This property will be removed in a future major release.")]
         public virtual bool KeyComparisonGeneratesFilterQuery
         {
             get { return this.keyComparisonGeneratesFilterQuery; }

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -696,7 +696,7 @@ namespace Microsoft.OData.Client
         public virtual bool EnableWritingODataAnnotationWithoutPrefix { get; set; }
 
         /// <summary>
-        /// When true, a Where clause that just compares the key property generates a $filter query option, otherwise a key segment is generated.
+        /// When true, a Where clause that has only the key property in the predicate generates a $filter query option, otherwise a key segment is generated.
         /// The default value is true.
         /// </summary>
         [Obsolete("This property will be removed in a future major release.")]

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1323,8 +1323,6 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
         public void Linq_Where_Generates_Filter_When_KeyComparisonGeneratesFilterQuery_Is_True()
         {
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            // By default context.KeyComparisonGeneratesFilterQuery = true;
-            // So we don't need to set it
             var query = context.Customer.Where(c => c.CustomerId == -10);
             var uri = query.ToString();
             Assert.EndsWith("$filter=CustomerId eq -10", uri);

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1325,7 +1325,6 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
             // By default context.KeyComparisonGeneratesFilterQuery = true;
             // So we don't need to set it
-            context.KeyComparisonGeneratesFilterQuery = true;
             var query = context.Customer.Where(c => c.CustomerId == -10);
             var uri = query.ToString();
             Assert.EndsWith("$filter=CustomerId eq -10", uri);

--- a/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/AsynchronousTests/AsynchronousQueryTests.cs
@@ -1323,6 +1323,8 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
         public void Linq_Where_Generates_Filter_When_KeyComparisonGeneratesFilterQuery_Is_True()
         {
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
+            // By default context.KeyComparisonGeneratesFilterQuery = true;
+            // So we don't need to set it
             context.KeyComparisonGeneratesFilterQuery = true;
             var query = context.Customer.Where(c => c.CustomerId == -10);
             var uri = query.ToString();
@@ -1336,8 +1338,7 @@ namespace Microsoft.Test.OData.Tests.Client.AsynchronousTests
         public void Linq_Where_Generates_ByKey_When_KeyComparisonGeneratesFilterQuery_Is_False()
         {
             var context = this.CreateWrappedContext<DefaultContainer>().Context;
-            // By default context.KeyComparisonGeneratesFilterQuery = false;
-            // So we don't need to set it
+            context.KeyComparisonGeneratesFilterQuery = false;
             var query = context.Customer.Where(c => c.CustomerId == -10);
             var uri = query.ToString();
             Assert.EndsWith("Customer(-10)", uri);

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/DataServiceContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/DataServiceContextTests.cs
@@ -1,0 +1,14 @@
+﻿using Xunit;
+
+namespace Microsoft.OData.Client.Tests
+{
+    public class DataServiceContextTests
+    {
+        [Fact]
+        public void KeyComparisonGeneratesFilterQuery_Defaults_To_True()
+        {
+            var context = new DataServiceContext();
+            Assert.True(context.KeyComparisonGeneratesFilterQuery);
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Partially addresses #2208 

### Description

- Marks the `DataServiceContext.KeyComparisonGeneratesFilterQuery` property as deprecated for removal in the next major release. This property was added to avoid breaking changes when we made Where clause generate a `$filter` query even when the predicate was only a key lookup.
- Changes the default value of the property from `false` to `true`.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*