### PR TITLE
Default leaveOpen to false in ODataBinaryStreamValue constructor

### DIFF
--- a/src/Microsoft.OData.Core/Value/ODataBinaryStreamValue.cs
+++ b/src/Microsoft.OData.Core/Value/ODataBinaryStreamValue.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData
         /// </summary>
         /// <param name="stream">Input stream</param>
         public ODataBinaryStreamValue(Stream stream) :
-            this(stream, true) // Leaves the stream open by default, for backward compatibility.
+            this(stream, leaveOpen: false)
         {
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
@@ -235,6 +235,29 @@ namespace Microsoft.Test.OData.TDD.Tests.Writer.JsonLight
             Assert.Equal(result, actual);
         }
 
+        [Fact]
+        public void ODataBinaryStreamValue_Leaves_Stream_Not_Open_By_Default()
+        {
+            // With type name
+            // ODataBinaryStreamValue
+            var stream = new MemoryStream();
+            var writer = new BinaryWriter(stream);
+            writer.Write("1234567890");
+            writer.Flush();
+            stream.Position = 0;
+
+            var property = new ODataProperty
+            {
+                Name = "Data",
+                Value = new ODataBinaryStreamValue(stream)
+            };
+
+            string result = WriteDeclaredUntypedProperty(property);
+            Assert.Equal("{\"@odata.context\":\"http://www.sampletest.com/$metadata#serverEntitySet/$entity\",\"Data\":\"CjEyMzQ1Njc4OTA=\"}", result);
+
+            Assert.False(stream.CanRead);
+        }
+
         private string WriteDeclaredUntypedProperty(ODataProperty untypedProperty)
         {
             var entry = new ODataResource

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedSerializerUndecalredTests.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Writer.JsonLight
         }
 
         [Fact]
-        public void ODataBinaryStreamValue_Leaves_Stream_Not_Open_By_Default()
+        public void ODataBinaryStreamValue_Closes_Stream_By_Default()
         {
             // With type name
             // ODataBinaryStreamValue


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes https://github.com/OData/odata.net/issues/2599*

### Description

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
