### PR TITLE
Implement streaming API in ODataUtf8JsonWriter

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
@@ -1,0 +1,357 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataUtf8JsonWriter.Stream.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETCOREAPP
+namespace Microsoft.OData.Json
+{
+    using System;
+    using System.Buffers;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal sealed partial class ODataUtf8JsonWriter
+    {
+        /// <summary>
+        /// Current stream for writing a binary property.
+        /// </summary>
+        private Stream binaryValueStream = null;
+
+        /// <summary>
+        /// Starts a scope for writing a stream value.
+        /// </summary>
+        /// <returns>A stream for writing the stream value.</returns>
+        public Stream StartStreamValueScope()
+        {
+            this.CommitUtf8JsonWriterContentsToBuffer();
+
+            this.WriteItemWithSeparatorIfNeeded();
+
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
+            this.Flush();
+
+            this.binaryValueStream =  new ODataUtf8JsonWriteStream(this);
+
+            return this.binaryValueStream;
+        }
+
+        /// <summary>
+        /// Ends a scope for writing a stream value.
+        /// </summary>
+        public void EndStreamValueScope()
+        {
+            this.binaryValueStream?.Dispose();
+            this.binaryValueStream = null;
+            this.Flush();
+
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
+
+            CheckIfSeparatorNeeded();
+            CheckIfManualValueAtArrayStart();
+        }
+
+        /// <summary>
+        /// Asynchronously starts a scope for writing a stream value.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation. The task result contains a stream for writing the stream value.</returns>
+        public async Task<Stream> StartStreamValueScopeAsync()
+        {
+            this.WriteSeparatorIfNecessary();
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
+            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+
+            this.binaryValueStream = new ODataUtf8JsonWriteStream(this);
+
+            return this.binaryValueStream;
+        }
+
+        /// <summary>
+        /// Asynchronously ends a scope for writing a stream value.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public async Task EndStreamValueScopeAsync()
+        {
+            if (this.binaryValueStream != null)
+            {
+                await this.binaryValueStream.DisposeAsync().ConfigureAwait(false);
+                this.binaryValueStream = null;
+            }
+
+            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+
+            this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
+
+            CheckIfSeparatorNeeded();
+            CheckIfManualValueAtArrayStart();
+        }
+
+        /// <summary>
+        /// Represents a stream for writing UTF-8 JSON data to an ODataUtf8JsonWriter.
+        /// </summary>
+        internal sealed class ODataUtf8JsonWriteStream : Stream
+        {
+            private readonly ODataUtf8JsonWriter jsonWriter = null;
+            private byte[] buffer;
+            int numBytesNotWrittenFromPreviousChunk = 0;
+
+            /// <summary>
+            /// Initializes a new instance of the <see cref="ODataUtf8JsonWriter"> class with the specified ODataUtf8JsonWriter.
+            /// </summary>
+            /// <param name="writer">The OData UTF-8 JSON writer to write to.</param>
+            internal ODataUtf8JsonWriteStream(ODataUtf8JsonWriter writer)
+            {
+                this.jsonWriter = writer;
+            }
+
+            public override bool CanRead => false;
+
+            public override bool CanSeek => false;
+
+            public override bool CanWrite => true;
+
+            /// <summary>
+            /// Gets the length in bytes of the stream. This is not supported by this stream.
+            public override long Length => throw new NotSupportedException();
+
+            /// <summary>
+            /// Gets or sets the position within the stream. This is not supported by this stream.
+            /// </summary>
+            public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+            /// <summary>
+            /// Flushes any buffered data to the underlying stream synchronously.
+            /// </summary>
+            public override void Flush()
+            {
+                this.jsonWriter.Flush();
+            }
+
+            /// <summary>
+            /// Flushes any buffered data to the underlying stream asynchronously.
+            /// </summary>
+            /// <param name="cancellationToken">A A cancellation token to observe while waiting for the flush operation to complete.</param>
+            /// <returns>A task representing the asynchronous flush operation.</returns>
+            public override async Task FlushAsync(CancellationToken cancellationToken)
+            {
+                await this.jsonWriter.FlushAsync().ConfigureAwait(false);
+            }
+
+            /// <summary>
+            /// Disposes the object.
+            /// </summary>
+            /// <param name="disposing">true if called from Dispose; false if called form the finalizer.</param>
+            protected override void Dispose(bool disposing)
+            {
+                if (this.numBytesNotWrittenFromPreviousChunk > 0)
+                {
+                    // If there are unprocessed bytes, encode and write them as the final block.
+                    ReadOnlySpan<byte> bytesNotProcessedFromPreviousChunk = this.buffer.AsSpan().Slice(0, this.numBytesNotWrittenFromPreviousChunk);
+
+                    this.jsonWriter.Base64EncodeAndWriteChunk(bytesNotProcessedFromPreviousChunk, isFinalBlock: true, out this.numBytesNotWrittenFromPreviousChunk);
+                    Debug.Assert(numBytesNotWrittenFromPreviousChunk == 0, "numBytesNotWrittenFromPreviousChunk == 0");
+                }
+
+                if (this.buffer != null)
+                {
+                    ArrayPool<byte>.Shared.Return(this.buffer);
+                }
+
+                this.Flush();
+                base.Dispose(disposing);
+            }
+
+            /// <summary>
+            /// Asynchronously disposes of the current object and performs cleanup operations.
+            /// </summary>
+            /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+            public override async ValueTask DisposeAsync()
+            {
+                if (this.numBytesNotWrittenFromPreviousChunk > 0)
+                {
+                    // If there are unprocessed bytes, encode and write them as the final block.
+                    ReadOnlyMemory<byte> bytesNotProcessedFromPreviousChunk = this.buffer.AsMemory().Slice(0, this.numBytesNotWrittenFromPreviousChunk);
+
+                    this.jsonWriter.Base64EncodeAndWriteChunk(bytesNotProcessedFromPreviousChunk.Span, isFinalBlock: true, out this.numBytesNotWrittenFromPreviousChunk);
+                    Debug.Assert(numBytesNotWrittenFromPreviousChunk == 0, "numBytesNotWrittenFromPreviousChunk == 0");
+                }
+
+                if (this.buffer != null)
+                {
+                    ArrayPool<byte>.Shared.Return(this.buffer);
+                }
+
+                await this.jsonWriter.FlushAsync().ConfigureAwait(false);
+            }
+
+            /// <summary>
+            /// Reads a sequence of bytes from the current stream and advances the position within the stream by the numbers of bytes read. This operation is not supported by this stream.
+            /// </summary>
+            public override int Read(byte[] buffer, int offset, int count)
+            {
+                throw new NotSupportedException();
+            }
+
+            /// <summary>
+            /// Sets the position within the stream. This operation is not supported by this stream.
+            /// </summary>
+            public override long Seek(long offset, SeekOrigin origin)
+            {
+                throw new NotSupportedException();
+            }
+
+            /// <summary>
+            /// Gets the length in bytes of the stream. This is not supported by this stream.
+            /// </summary>
+            public override void SetLength(long value)
+            {
+                throw new NotSupportedException();
+            }
+
+            /// <summary>
+            /// Writes a portion of a byte array to the underlying stream in chunks.
+            /// </summary>
+            /// <param name="buffer">An array of bytes. This method copies <paramref name="count"/>bytes from buffer to the current stream.</param>
+            /// <param name="offset">The zero-based byte offset in buffer at which to begin copying bytes to the current stream.</param>
+            /// <param name="count">The number of bytes to be written to the current stream.</param>
+            public override void Write(byte[] buffer, int offset, int count)
+            {
+                Span<byte> value = buffer.AsSpan().Slice(offset, count);
+
+                this.WriteByteValueInChunks(value);
+            }
+
+            /// <summary>
+            /// Asynchronously writes a portion of a byte array to the underlying stream in chunks.
+            /// </summary>
+            /// <param name="buffer">The byte array from which data will be written.</param>
+            /// <param name="offset">The zero-based byte offset in the buffer at which to begin copying bytes to the stream.</param>
+            /// <param name="count">The maximum number of bytes to write.</param>
+            /// <param name="token">A CancellationToken to observe while waiting for the task to complete.</param>
+            /// <returns>A task representing the asynchronous write operation.</returns>
+            public override async Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken token)
+            {
+                ReadOnlyMemory<byte> value = buffer.AsMemory().Slice(offset, count);
+                await this.WriteByteValueInChunksAsync(value).ConfigureAwait(false);
+            }
+
+            /// <summary>
+            /// Writes the byte value represented by the provided read-only span in chunks using Base64 encoding.
+            /// </summary>
+            /// <param name="value">The read-only span containing the byte value to be written.</param>
+            private void WriteByteValueInChunks(ReadOnlySpan<byte> value)
+            {
+                // Process the input value in chunks
+                for (int i = 0; i < value.Length; i += ODataUtf8JsonWriter.chunkSize)
+                {
+                    int remainingBytes = Math.Min(ODataUtf8JsonWriter.chunkSize, value.Length - i);
+                    bool isFinalBlock = false;
+
+                    // Take a chunk of bytes from the input value.
+                    ReadOnlySpan<byte> chunk = value.Slice(i, remainingBytes);
+
+                    // If the buffer is not empty, then we copy the bytes from the buffer
+                    // to the current chunk being processed.
+                    if (this.numBytesNotWrittenFromPreviousChunk > 0)
+                    {
+                        // Get unprocessed bytes from the buffer.
+                        ReadOnlySpan<byte> bytesNotProcessedFromPreviousChunk = this.buffer.AsSpan().Slice(0, this.numBytesNotWrittenFromPreviousChunk);
+                        int totalLength = bytesNotProcessedFromPreviousChunk.Length + chunk.Length;
+
+                        // Rent an array to hold bytes from both previous and current chunks.
+                        byte[] combinedArray = ArrayPool<byte>.Shared.Rent(totalLength);
+
+                        // Copy bytes from bytesNotProcessedFromPreviousChunk to the combined array
+                        bytesNotProcessedFromPreviousChunk.CopyTo(combinedArray);
+
+                        // Copy bytes from chunk to the combined array, starting from the end of bytesNotProcessedFromPreviousChunk
+                        chunk.CopyTo(combinedArray.AsSpan().Slice(bytesNotProcessedFromPreviousChunk.Length));
+
+                        WriteChunk(combinedArray.AsSpan().Slice(0, totalLength), totalLength, isFinalBlock);
+
+                        ArrayPool<byte>.Shared.Return(combinedArray);
+                    }
+                    else
+                    {
+                        WriteChunk(chunk, chunk.Length, isFinalBlock);
+                    }
+
+                    // Flush the writer if the buffer threshold is reached
+                    this.jsonWriter.FlushIfBufferThresholdReached();
+                }
+            }
+
+            /// <summary>
+            /// Writes the byte value represented by the provided read-only memory in chunks using Base64 encoding.
+            /// </summary>
+            /// <param name="value">The read-only memory containing the byte value to be written.</param>
+            private async ValueTask WriteByteValueInChunksAsync(ReadOnlyMemory<byte> value)
+            {
+                // Process the input value in chunks
+                for (int i = 0; i < value.Length; i += ODataUtf8JsonWriter.chunkSize)
+                {
+                    int remainingBytes = Math.Min(ODataUtf8JsonWriter.chunkSize, value.Length - i);
+                    bool isFinalBlock = false ;
+
+                    // Take a chunk of bytes from the input value.
+                    ReadOnlyMemory<byte> chunk = value.Slice(i, remainingBytes);
+
+                    // If the buffer is not empty, then we copy the bytes from the buffer
+                    // to the current chunk being processed.
+                    if (this.numBytesNotWrittenFromPreviousChunk > 0)
+                    {
+                        ReadOnlyMemory<byte> bytesNotProcessedFromPreviousChunk = this.buffer.AsMemory().Slice(0, this.numBytesNotWrittenFromPreviousChunk);
+
+                        int totalLength = bytesNotProcessedFromPreviousChunk.Length + chunk.Length;
+
+                        // Rent an array to hold bytes from both previous and current chunks.
+                        byte[] combinedArray = ArrayPool<byte>.Shared.Rent(totalLength);
+
+                        // Copy bytes from bytesNotProcessedFromPreviousChunk to the combined array
+                        bytesNotProcessedFromPreviousChunk.Span.CopyTo(combinedArray);
+
+                        // Copy bytes from chunk to the combined array, starting from the end of bytesNotProcessedFromPreviousChunk
+                        chunk.Span.CopyTo(combinedArray.AsSpan(bytesNotProcessedFromPreviousChunk.Length));
+
+                        WriteChunk(combinedArray.AsSpan().Slice(0, totalLength), totalLength, isFinalBlock);
+
+                        ArrayPool<byte>.Shared.Return(combinedArray);
+                    }
+                    else
+                    {
+                        WriteChunk(chunk.Span, chunk.Length, isFinalBlock);
+                    }
+
+                    // Flush the writer if the buffer threshold is reached
+                    await this.jsonWriter.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                }
+            }
+
+            /// <summary>
+            /// Writes a chunk of data, encoding it using Base64, and updates the buffer with any unprocessed bytes.
+            /// </summary>
+            /// <param name="chunk">The chunk of data to be encoded and written.</param>
+            /// <param name="isFinalBlock">A boolean indicating whether this is the final block of data.</param>
+            private void WriteChunk(ReadOnlySpan<byte> chunk, int chunkLength, bool isFinalBlock)
+            {
+                // Encode the current chunk using Base64 and write it
+                this.jsonWriter.Base64EncodeAndWriteChunk(chunk.Slice(0, chunkLength), isFinalBlock, out this.numBytesNotWrittenFromPreviousChunk);
+
+                if (this.numBytesNotWrittenFromPreviousChunk > 0)
+                {
+                    if (this.buffer == null)
+                    {
+                        this.buffer = ArrayPool<byte>.Shared.Rent(ODataUtf8JsonWriter.chunkSize);
+                    }
+
+                    // Update the buffer with unprocessed bytes from the current chunk.
+                    chunk.Slice(chunkLength - this.numBytesNotWrittenFromPreviousChunk).CopyTo(this.buffer.AsSpan());
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -1,0 +1,484 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataUtf8JsonWriter.TextWriter.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETCOREAPP
+namespace Microsoft.OData.Json
+{
+    using System;
+    using System.Buffers;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Text;
+    using System.Text.Unicode;
+    using System.Threading.Tasks;
+    using static System.Net.Mime.MediaTypeNames;
+
+    internal sealed partial class ODataUtf8JsonWriter
+    {
+        /// <summary>
+        /// Current textwriter for writing a stream property.
+        /// </summary>
+        private TextWriter textWriter = null;
+
+        /// <summary>
+        /// Flag indicating whether the current TextWriter is writing JSON.
+        /// </summary>
+        private bool isWritingJson;
+
+        /// <summary>
+        /// Content type of a value being written using TextWriter
+        /// </summary>
+        private string currentTextWriterContentType;
+
+        /// <summary>
+        /// Starts a TextWriter value scope with the specified content type.
+        /// </summary>
+        /// <param name="contentType">The content type of the TextWriter value scope.</param>
+        /// <returns>A TextWriter for writing JSON data.</returns>
+        public TextWriter StartTextWriterValueScope(string contentType)
+        {
+            this.CommitUtf8JsonWriterContentsToBuffer();
+
+            WriteItemWithSeparatorIfNeeded();
+
+            this.currentTextWriterContentType = contentType;
+            this.isWritingJson = this.CheckIfWritingJson(this.currentTextWriterContentType);
+
+            // We don't perform escaping when the content type is not JSON
+            // since we assume the input to be already a valid JSON with all escaping handled by the caller.
+            if (!this.isWritingJson)
+            {
+                this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
+            }
+
+            this.Flush();
+
+            this.textWriter = new ODataUtf8JsonTextWriter(this);
+
+            return this.textWriter;
+        }
+
+        /// <summary>
+        /// Ends a TextWriter value scope.
+        /// </summary>
+        public void EndTextWriterValueScope()
+        {
+            if (!this.isWritingJson)
+            {
+                this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
+            }
+
+            this.textWriter?.Dispose();
+            this.Flush();
+
+            CheckIfSeparatorNeeded();
+            CheckIfManualValueAtArrayStart();
+        }
+
+        /// <summary>
+        /// Asynchronously starts a TextWriter value scope with the specified content type.
+        /// </summary>
+        /// <param name="contentType">The content type of the TextWriter value scope.</param>
+        /// <returns>A task representing the asynchronous operation. The task result is a TextWriter for writing JSON data.</returns>
+        public async Task<TextWriter> StartTextWriterValueScopeAsync(string contentType)
+        {
+            await this.FlushAsync().ConfigureAwait(false);
+
+            WriteItemWithSeparatorIfNeeded();
+
+            this.currentTextWriterContentType = contentType;
+
+            this.isWritingJson = CheckIfWritingJson(this.currentTextWriterContentType);
+
+            if (!this.isWritingJson)
+            {
+                this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
+            }
+
+            await this.FlushAsync().ConfigureAwait(false);
+
+            this.textWriter = new ODataUtf8JsonTextWriter(this);
+
+            return this.textWriter;
+        }
+
+        /// <summary>
+        /// Asynchronously ends a TextWriter value scope.
+        /// </summary>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        public async Task EndTextWriterValueScopeAsync()
+        {
+            if (!this.isWritingJson)
+            {
+                this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
+            }
+
+            if (this.textWriter != null)
+            {
+                await this.textWriter.DisposeAsync();
+            }
+
+            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+
+            CheckIfSeparatorNeeded();
+            CheckIfManualValueAtArrayStart();
+        }
+
+        /// <summary>
+        /// Checks whether the current TextWriter is writing JSON
+        /// </summary>
+        /// <returns></returns>
+        private bool CheckIfWritingJson(string currentContentType)
+        {
+            return string.IsNullOrEmpty(currentContentType) || currentContentType.StartsWith(MimeConstants.MimeApplicationJson, StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// Represents a TextWriter implementation for writing UTF-8 JSON data to an ODataUtf8JsonWriter.
+        /// </summary>
+        internal sealed class ODataUtf8JsonTextWriter : TextWriter
+        {
+            private readonly ODataUtf8JsonWriter jsonWriter = null;
+            private char[] buffer;
+            private int numOfCharsNotWrittenFromPreviousChunk = 0;
+
+            public ODataUtf8JsonTextWriter(ODataUtf8JsonWriter jsonWriter)
+            {
+                this.jsonWriter = jsonWriter;
+            }
+
+            /// <summary>
+            /// Gets the character encoding in which the output is written. This is not supported by this text writer.
+            /// </summary>
+            public override Encoding Encoding => throw new NotSupportedException();
+
+            /// <summary>
+            /// Flushes any buffered data to the underlying stream synchronously.
+            /// </summary>
+            public override void Flush()
+            {
+                this.jsonWriter.Flush();
+            }
+
+            /// <summary>
+            /// Flushes any buffered data to the underlying stream asynchronously.
+            /// </summary>
+            /// <returns>A task representing the asynchronous flush operation.</returns>
+            public override async Task FlushAsync()
+            {
+                await this.jsonWriter.FlushAsync();
+            }
+
+            /// <summary>
+            /// Disposes the object.
+            /// </summary>
+            /// <param name="disposing">true if called from Dispose; false if called form the finalizer.</param>
+            protected override void Dispose(bool disposing)
+            {
+                if (this.buffer != null)
+                {
+                    ArrayPool<char>.Shared.Return(this.buffer);
+                }
+
+                this.Flush();
+                base.Dispose(disposing);
+            }
+
+            /// <summary>
+            /// Asynchronously disposes of the current object and performs cleanup operations.
+            /// </summary>
+            /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+            public override async ValueTask DisposeAsync()
+            {
+                if (this.buffer != null)
+                {
+                    ArrayPool<char>.Shared.Return(this.buffer);
+                }
+
+                await this.FlushAsync().ConfigureAwait(false);
+            }
+
+            /// <summary>
+            /// Writes a specified number of characters from the given character array to the ODataUtf8JsonWriter.
+            /// </summary>
+            /// <param name="value">The character array from which to write characters.</param>
+            /// <param name="index">The starting index in the character array from which to begin writing characters.</param>
+            /// <param name="count">The number of characters to write from the character array.</param>
+            public override void Write(char[] value, int index, int count)
+            {
+                if (!this.jsonWriter.isWritingJson)
+                {
+                    ReadOnlySpan<char> charsToWrite = value.AsSpan().Slice(index, count);
+                    this.WriteCharsInChunks(charsToWrite);
+                }
+                else
+                {
+                    ReadOnlySpan<char> charsToWrite = value.AsSpan().Slice(index, count);
+                    this.WriteCharsInChunksWithoutEscaping(charsToWrite);
+                }
+            }
+
+            /// <summary>
+            /// Asynchronously writes a specified number of characters from the given character array to theODataUtf8JsonWriter.
+            /// </summary>
+            /// <param name="value">The character array from which to write characters.</param>
+            /// <param name="index">The starting index in the character array from which to begin writing characters.</param>
+            /// <param name="count">The number of characters to write from the character array.</param>
+            /// <returns>A task representing the asynchronous write operation.</returns>
+            public override async Task WriteAsync(char[] value, int index, int count)
+            {
+                if (!this.jsonWriter.isWritingJson)
+                {
+                    ReadOnlyMemory<char> charsToWrite = value.AsMemory().Slice(index, count);
+                    await this.WriteCharsInChunksAsync(charsToWrite).ConfigureAwait(false);
+                }
+                else
+                {
+                    ReadOnlyMemory<char> charsToWrite = value.AsMemory().Slice(index, count);
+                    await this.WriteCharsInChunksWithoutEscapingAsync(charsToWrite).ConfigureAwait(false);
+                }
+            }
+
+            /// <summary>
+            /// Asynchronously writes the characters represented by the provided read-only span in chunks, processing them for escaping if necessary, and flushing the writer if the buffer threshold is reached.
+            /// </summary>
+            /// <param name="value">The read-only span containing the characters to be written.</param>
+            private void WriteCharsInChunks(ReadOnlySpan<char> value)
+            {
+                // Process the input value in chunks
+                for (int i = 0; i < value.Length; i += ODataUtf8JsonWriter.chunkSize)
+                {
+                    int remainingChars = Math.Min(ODataUtf8JsonWriter.chunkSize, value.Length - i);
+                    bool isFinalBlock = false;
+                    ReadOnlySpan<char> chunk = value.Slice(i, remainingChars);
+
+                    // If the buffer is not empty, then we copy the chars from the buffer
+                    // to the current chunk being processed.
+                    if (this.numOfCharsNotWrittenFromPreviousChunk > 0)
+                    {
+                        // Get unprocessed chars from the buffer.
+                        ReadOnlySpan<char> charsNotProcessedFromPreviousChunk = this.buffer.AsSpan().Slice(0, this.numOfCharsNotWrittenFromPreviousChunk);
+                        int totalLength = charsNotProcessedFromPreviousChunk.Length + chunk.Length;
+
+                        char[] combinedArray = ArrayPool<char>.Shared.Rent(totalLength);
+
+                        // Copy chars from charsNotProcessedFromPreviousChunk to the combined array
+                        charsNotProcessedFromPreviousChunk.CopyTo(combinedArray);
+
+                        // Copy chars from chunk to the combined array, starting from the end of charsNotProcessedFromPreviousChunk
+                        chunk.CopyTo(combinedArray.AsSpan().Slice(charsNotProcessedFromPreviousChunk.Length));
+                        
+                        int firstIndexToEscape = this.jsonWriter.NeedsEscaping(combinedArray);
+
+                        // Write the chunk.
+                        this.WriteChunk(combinedArray.AsSpan().Slice(0, totalLength), totalLength, firstIndexToEscape, isFinalBlock);
+
+                        ArrayPool<char>.Shared.Return(combinedArray);
+                    }
+                    else
+                    {
+                        int firstIndexToEscape = this.jsonWriter.NeedsEscaping(chunk);
+                        this.WriteChunk(chunk, chunk.Length, firstIndexToEscape, isFinalBlock);
+                    }
+
+                    // Flush the writer if the buffer threshold is reached
+                    this.jsonWriter.FlushIfBufferThresholdReached();
+                }
+            }
+
+            /// <summary>
+            /// Writes character values represented by the provided read-only memory in chunks, processing them for escaping if necessary, and asynchronously flushes the writer if the buffer threshold is reached.
+            /// </summary>
+            /// <param name="value">The read-only memory containing the character values to be written.</param>
+            /// <returns>A ValueTask representing the asynchronous operation.</returns>
+            private async ValueTask WriteCharsInChunksAsync(ReadOnlyMemory<char> value)
+            {
+                // Process the input value in chunks
+                for (int i = 0; i < value.Length; i += ODataUtf8JsonWriter.chunkSize)
+                {
+                    int remainingChars = Math.Min(ODataUtf8JsonWriter.chunkSize, value.Length - i);
+                    bool isFinalBlock = false;
+                    ReadOnlyMemory<char> chunk = value.Slice(i, remainingChars);
+
+                    // If the buffer is not empty, then we copy the chars from the buffer
+                    // to the current chunk being processed.
+                    if (this.numOfCharsNotWrittenFromPreviousChunk > 0)
+                    {
+                        // Get unprocessed chars from the buffer.
+                        ReadOnlyMemory<char> charsNotProcessedFromPreviousChunk = this.buffer.AsMemory().Slice(0, this.numOfCharsNotWrittenFromPreviousChunk);
+                        int totalLength = charsNotProcessedFromPreviousChunk.Length + chunk.Length;
+
+                        char[] combinedArray = ArrayPool<char>.Shared.Rent(totalLength);
+
+                        // Copy chars from charsNotProcessedFromPreviousChunk to the combined array
+                        charsNotProcessedFromPreviousChunk.CopyTo(combinedArray);
+
+                        // Copy chars from chunk to the combined array, starting from the end of charsNotProcessedFromPreviousChunk
+                        chunk.CopyTo(combinedArray.AsMemory().Slice(charsNotProcessedFromPreviousChunk.Length));
+
+                        int firstIndexToEscape = this.jsonWriter.NeedsEscaping(combinedArray);
+
+                        // Write the chunk.
+                        this.WriteChunk(combinedArray.AsSpan().Slice(0, totalLength), totalLength, firstIndexToEscape, isFinalBlock);
+
+                        ArrayPool<char>.Shared.Return(combinedArray);
+                    }
+                    else
+                    {
+                        int firstIndexToEscape = this.jsonWriter.NeedsEscaping(chunk.Span);
+
+                        // Write the chunk.
+                        this.WriteChunk(chunk.Span, chunk.Length, firstIndexToEscape, isFinalBlock);
+                    }
+
+                    // Flush the writer if the buffer threshold is reached
+                    await this.jsonWriter.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                }
+            }
+
+            /// <summary>
+            /// Writes the characters represented by the provided read-only span in chunks, processing them for escaping if necessary, and flushing the writer if the buffer threshold is reached.
+            /// </summary>
+            /// <param name="value">The read-only span containing the characters to be written.</param>
+            private void WriteCharsInChunksWithoutEscaping(ReadOnlySpan<char> value)
+            {
+                // Process the input value in chunks
+                for (int i = 0; i < value.Length; i += ODataUtf8JsonWriter.chunkSize)
+                {
+                    int remainingChars = Math.Min(ODataUtf8JsonWriter.chunkSize, value.Length - i);
+                    bool isFinalBlock = false;
+                    ReadOnlySpan<char> chunk = value.Slice(i, remainingChars);
+
+                    // If the buffer is not empty, then we copy the chars from the buffer
+                    // to the current chunk being processed.
+                    if (this.numOfCharsNotWrittenFromPreviousChunk > 0)
+                    {
+                        // Get unprocessed chars from the buffer.
+                        ReadOnlySpan<char> charsNotProcessedFromPreviousChunk = this.buffer.AsSpan().Slice(0, this.numOfCharsNotWrittenFromPreviousChunk);
+                        int totalLength = charsNotProcessedFromPreviousChunk.Length + chunk.Length;
+
+                        char[] combinedArray = ArrayPool<char>.Shared.Rent(totalLength);
+
+                        // Copy chars from charsNotProcessedFromPreviousChunk to the combined array
+                        charsNotProcessedFromPreviousChunk.CopyTo(combinedArray);
+
+                        // Copy chars from chunk to the combined array, starting from the end of charsNotProcessedFromPreviousChunk
+                        chunk.CopyTo(combinedArray.AsSpan().Slice(charsNotProcessedFromPreviousChunk.Length));
+
+                        // Write the chunk.
+                        this.WriteChunkWithoutEscaping(combinedArray.AsSpan().Slice(0, totalLength), totalLength, isFinalBlock);
+
+                        ArrayPool<char>.Shared.Return(combinedArray, true);
+                    }
+                    else
+                    {
+                        this.WriteChunkWithoutEscaping(chunk, chunk.Length, isFinalBlock);
+                    }
+
+                    // Flush the writer if the buffer threshold is reached
+                    this.jsonWriter.FlushIfBufferThresholdReached();
+                }
+            }
+
+            /// <summary>
+            /// Writes the characters represented by the provided read-only span in chunks, processing them for escaping if necessary, and flushing the writer if the buffer threshold is reached.
+            /// </summary>
+            /// <param name="value">The read-only span containing the characters to be written.</param>
+            private async ValueTask WriteCharsInChunksWithoutEscapingAsync(ReadOnlyMemory<char> value)
+            {
+                // Process the input value in chunks
+                for (int i = 0; i < value.Length; i += ODataUtf8JsonWriter.chunkSize)
+                {
+                    int remainingChars = Math.Min(ODataUtf8JsonWriter.chunkSize, value.Length - i);
+                    bool isFinalBlock = false;
+                    ReadOnlyMemory<char> chunk = value.Slice(i, remainingChars);
+
+                    // If the buffer is not empty, then we copy the chars from the buffer
+                    // to the current chunk being processed.
+                    if (this.numOfCharsNotWrittenFromPreviousChunk > 0)
+                    {
+                        // Get unprocessed chars from the buffer.
+                        ReadOnlyMemory<char> charsNotProcessedFromPreviousChunk = this.buffer.AsMemory().Slice(0, this.numOfCharsNotWrittenFromPreviousChunk);
+                        int totalLength = charsNotProcessedFromPreviousChunk.Length + chunk.Length;
+
+                        char[] combinedArray = ArrayPool<char>.Shared.Rent(totalLength);
+
+                        // Copy chars from charsNotProcessedFromPreviousChunk to the combined array
+                        charsNotProcessedFromPreviousChunk.CopyTo(combinedArray);
+
+                        // Copy chars from chunk to the combined array, starting from the end of charsNotProcessedFromPreviousChunk
+                        chunk.CopyTo(combinedArray.AsMemory().Slice(charsNotProcessedFromPreviousChunk.Length));
+
+                        // Write the chunk.
+                        this.WriteChunkWithoutEscaping(combinedArray.AsSpan().Slice(0, totalLength), totalLength, isFinalBlock);
+
+                        ArrayPool<char>.Shared.Return(combinedArray, true);
+                    }
+                    else
+                    {
+                        this.WriteChunkWithoutEscaping(chunk.Span, chunk.Length, isFinalBlock);
+                    }
+
+                    // Flush the writer if the buffer threshold is reached
+                    await this.jsonWriter.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                }
+            }
+
+            private void WriteChunk(ReadOnlySpan<char> chunk, int chunkLength, int firstIndexToEscape, bool isFinalBlock)
+            {
+                if (firstIndexToEscape != -1)
+                {
+                    this.jsonWriter.WriteEscapedStringChunk(chunk, firstIndexToEscape, isFinalBlock, out this.numOfCharsNotWrittenFromPreviousChunk);
+
+                    if (this.numOfCharsNotWrittenFromPreviousChunk > 0)
+                    {
+                        if (this.buffer == null)
+                        {
+                            this.buffer = ArrayPool<char>.Shared.Rent(ODataUtf8JsonWriter.chunkSize);
+                        }
+
+                        // Update the buffer with unprocessed bytes from the current chunk.
+                        chunk.Slice(chunkLength - this.numOfCharsNotWrittenFromPreviousChunk).CopyTo(this.buffer.AsSpan());
+                    }
+                }
+                else
+                {
+                    this.jsonWriter.WriteStringChunk(chunk, isFinalBlock);
+                }
+            }
+
+            private void WriteStringChunkWithoutEscaping(ReadOnlySpan<char> chunk, bool isFinalBlock, out int charsFromPrevChunkNotProcessed)
+            {
+                int maxUtf8Length = Encoding.UTF8.GetMaxByteCount(chunk.Length);
+
+                Span<byte> output = this.jsonWriter.bufferWriter.GetSpan(maxUtf8Length);
+                OperationStatus status = Utf8.FromUtf16(chunk, output, out int charsRead, out int charsWritten, isFinalBlock);
+
+                charsFromPrevChunkNotProcessed = chunk.Length - charsRead;
+
+                // notify the bufferWriter of the write
+                this.jsonWriter.bufferWriter.Advance(charsWritten);
+            }
+
+            private void WriteChunkWithoutEscaping(ReadOnlySpan<char> chunk, int chunkLength, bool isFinalBlock)
+            {
+                this.WriteStringChunkWithoutEscaping(chunk, isFinalBlock, out this.numOfCharsNotWrittenFromPreviousChunk);
+
+                if (this.numOfCharsNotWrittenFromPreviousChunk > 0)
+                {
+                    if (this.buffer == null)
+                    {
+                        this.buffer = ArrayPool<char>.Shared.Rent(ODataUtf8JsonWriter.chunkSize);
+                    }
+
+                    // Update the buffer with unprocessed bytes from the current chunk.
+                    chunk.Slice(chunkLength - this.numOfCharsNotWrittenFromPreviousChunk).CopyTo(this.buffer.AsSpan());
+                }
+            }
+        }
+    }
+}
+#endif

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData.Json
     /// Implementation of <see cref="IJsonWriter"/> that is based on
     /// <see cref="Utf8JsonWriter"/>.
     /// </summary>
-    internal sealed class ODataUtf8JsonWriter : IJsonWriter, IDisposable, IAsyncDisposable
+    internal sealed partial class ODataUtf8JsonWriter : IJsonWriter, IDisposable, IAsyncDisposable
     {
         private const int DefaultBufferSize = 16 * 1024;
         private readonly float bufferFlushThreshold;
@@ -1253,47 +1253,6 @@ namespace Microsoft.OData.Json
                 await this.FlushAsync().ConfigureAwait(false);
             }
         }
-
-        public Stream StartStreamValueScope()
-        {
-            throw new NotImplementedException();
-        }
-
-        public TextWriter StartTextWriterValueScope(string contentType)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void EndStreamValueScope()
-        {
-            throw new NotImplementedException();
-        }
-
-        public void EndTextWriterValueScope()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<Stream> StartStreamValueScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task<TextWriter> StartTextWriterValueScopeAsync(string contentType)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task EndStreamValueScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task EndTextWriterValueScopeAsync()
-        {
-            throw new NotImplementedException();
-        }
-
         #endregion
 
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -365,6 +365,125 @@ namespace Microsoft.OData.Tests.Json
                 (jsonWriter) => jsonWriter.WriteValue("foo\tbar"));
         }
 
+        [Theory]
+        [InlineData("text/plain")]
+        [InlineData("text/html")]
+        public void CorrectlyStreams_NonAsciiCharacters_ToOutput(string contentType)
+        {
+            string input = "😊😊😊😊😊😊😊😊";
+            string expectedOutput = "😊😊😊😊😊😊😊😊";
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
+
+                var tw = jsonWriter.StartTextWriterValueScope(contentType);
+
+                WriteSpecialCharsInChunksOfOddStringInChunks(tw, input);
+
+                jsonWriter.EndTextWriterValueScope();
+                jsonWriter.Flush();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal($"\"{expectedOutput}\"", rawOutput);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("text/plain")]
+        [InlineData("text/html")]
+        public void CorrectlyStreamsLargeStringsWithSpecialCharactersToOutput(string contentType)
+        {
+            int inputLength = 1024 * 1024; // 1MB
+            string input = new string('a', inputLength);
+
+            // Append special characters to the input string
+            input += "U+1F600";
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
+
+                var tw = jsonWriter.StartTextWriterValueScope(contentType);
+
+                WriteLargeStringInChunks(tw, input);
+
+                jsonWriter.EndTextWriterValueScope();
+                jsonWriter.Flush();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal($"\"{input}\"", rawOutput);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("text/plain")]
+        [InlineData("text/html")]
+        public void CorrectlyStreamsLargeStrings_WithOnlySpecialCharacters_ToOutput(string contentType)
+        {
+            string input = "\n\n\n\n\"\"\n\n\n\n\"\"";
+            string expectedOutput = "\\n\\n\\n\\n\\\"\\\"\\n\\n\\n\\n\\\"\\\"";
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
+
+                var tw = jsonWriter.StartTextWriterValueScope(contentType);
+
+                WriteSpecialCharsInChunksOfOddStringInChunks(tw, input);
+
+                jsonWriter.EndTextWriterValueScope();
+                jsonWriter.Flush();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal($"\"{expectedOutput}\"", rawOutput);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("text/plain")]
+        [InlineData("text/html")]
+        public void CorrectlyStreamsLargeStringsToOutput(string contentType)
+        {
+            int inputLength = 1024 * 1024; // 1MB
+            string input = new string('a', inputLength);
+            string expectedOutput = ExpectedOutPutStringWithSpecialCharacters(input);
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
+
+                var tw = jsonWriter.StartTextWriterValueScope(contentType);
+
+                WriteLargeStringsWithSpecialCharactersInChunks(tw, input);
+
+                jsonWriter.EndTextWriterValueScope();
+                jsonWriter.Flush();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal($"\"{expectedOutput}\"", rawOutput);
+                }
+            }
+        }
+
         private void SetupJsonWriterRunTestAndVerifyRent(Action<JsonWriter> action)
         {
             var jsonWriter = new JsonWriter(new StringWriter(builder), isIeee754Compatible: true);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonTextWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonTextWriterTests.cs
@@ -1,0 +1,24 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataUtf8JsonTextWriterTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETCOREAPP
+using System;
+using static Microsoft.OData.Json.ODataUtf8JsonWriter;
+using Xunit;
+
+namespace Microsoft.OData.Core.Tests.Json
+{
+    public class ODataUtf8JsonTextWriterTests
+    {
+        [Fact]
+        public void Encoding_ThrowsNotImplementedException()
+        {
+            var stream = new ODataUtf8JsonTextWriter(null);
+            Assert.Throws<NotSupportedException>(() => stream.Encoding);
+        }
+    }
+}
+#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -593,6 +593,90 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal(0, stream.Length);
         }
 
+        [Theory]
+        [InlineData("text/plain")]
+        [InlineData("text/html")]
+        public async Task CorrectlyStreamsLargeStrings_WithOnlySpecialCharacters_ToOutput(string contentType)
+        {
+            string input = "\n\n\n\n\"\"\n\n\n\n\"\"";
+            string expectedOutput = "\\n\\n\\n\\n\\u0022\\u0022\\n\\n\\n\\n\\u0022\\u0022";
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
+
+                var tw = await jsonWriter.StartTextWriterValueScopeAsync(contentType);
+
+                await WriteSpecialCharsInChunksOfOddStringInChunksAsync(tw, input);
+
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.FlushAsync();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = await reader.ReadToEndAsync();
+                    Assert.Equal($"\"{expectedOutput}\"", rawOutput);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("text/plain")]
+        [InlineData("text/html")]
+        public async Task CorrectlyStreams_NonAsciiCharacters_ToOutput(string contentType)
+        {
+            string input = "😊😊😊😊😊😊😊😊";
+            string expectedOutput = "\\uD83D\\uDE0A\\uD83D\\uDE0A\\uD83D\\uDE0A\\uD83D\\uDE0A\\uD83D\\uDE0A\\uD83D\\uDE0A\\uD83D\\uDE0A\\uD83D\\uDE0A";
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
+
+                var tw = await jsonWriter.StartTextWriterValueScopeAsync(contentType);
+
+                await WriteSpecialCharsInChunksOfOddStringInChunksAsync(tw, input);
+
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.FlushAsync();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = await reader.ReadToEndAsync();
+                    Assert.Equal($"\"{expectedOutput}\"", rawOutput);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task CorrectlyStreams_NonAsciiCharacters_ToOutput_UsingApplicationJson()
+        {
+            string input = "😊😊😊😊😊😊😊😊";
+            string expectedOutput = "😊😊😊😊😊😊😊😊";
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8);
+
+                var tw = await jsonWriter.StartTextWriterValueScopeAsync("application/json");
+
+                await WriteSpecialCharsInChunksOfOddStringInChunksAsync(tw, input);
+
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.FlushAsync();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = await reader.ReadToEndAsync();
+                    Assert.Equal(expectedOutput, rawOutput);
+                }
+            }
+        }
+
         /// <summary>
         /// Reads the test class's default stream with UTF8 encoding.
         /// </summary>
@@ -632,6 +716,21 @@ namespace Microsoft.OData.Tests.Json
         protected override IJsonWriter CreateJsonWriter(Stream stream, bool isIeee754Compatible, Encoding encoding)
         {
             return new ODataUtf8JsonWriter(stream, isIeee754Compatible, encoding);
+        }
+
+        internal async Task WriteSpecialCharsInChunksOfOddStringInChunksAsync(TextWriter tw, string input)
+        {
+            // Define chunk size
+            int chunkSize = 3;
+
+            // Stream the string to the output stream in chunks
+            for (int i = 0; i < input.Length; i += chunkSize)
+            {
+                int remainingLength = Math.Min(chunkSize, input.Length - i);
+                string chunk = input.Substring(i, remainingLength);
+                await tw.WriteAsync(chunk.ToCharArray());
+            }
+
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterStreamTests.cs
@@ -1,0 +1,82 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataUtf8JsonWriterTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+#if NETCOREAPP
+using System;
+using static Microsoft.OData.Json.ODataUtf8JsonWriter;
+using Xunit;
+using System.IO;
+
+namespace Microsoft.OData.Core.Tests.Json
+{
+    public class ODataUtf8JsonWriterStreamTests
+    {
+        [Fact]
+        public void CanRead_ReturnsFalse()
+        {
+            var stream = new ODataUtf8JsonWriteStream(null); // Passing null for the ODataUtf8JsonWriter parameter as it's not relevant for this test
+            Assert.False(stream.CanRead);
+        }
+
+        [Fact]
+        public void CanSeek_ReturnsFalse()
+        {
+            var stream = new ODataUtf8JsonWriteStream(null);
+            Assert.False(stream.CanSeek);
+        }
+
+        [Fact]
+        public void CanWrite_ReturnsTrue()
+        {
+            var stream = new ODataUtf8JsonWriteStream(null);
+            Assert.True(stream.CanWrite);
+        }
+
+        [Fact]
+        public void Length_ThrowsNotSupportedException()
+        {
+            var stream = new ODataUtf8JsonWriteStream(null);
+            Assert.Throws<NotSupportedException>(() => stream.Length);
+        }
+
+        [Fact]
+        public void Position_Get_ThrowsNotSupportedException()
+        {
+            var stream = new ODataUtf8JsonWriteStream(null);
+            Assert.Throws<NotSupportedException>(() => stream.Position);
+        }
+
+        [Fact]
+        public void Position_Set_ThrowsNotSupportedException()
+        {
+            var stream = new ODataUtf8JsonWriteStream(null);
+            Assert.Throws<NotSupportedException>(() => stream.Position = 0);
+        }
+
+        [Fact]
+        public void Read_ThrowsNotSupportedException()
+        {
+            var stream = new ODataUtf8JsonWriteStream(null);
+            byte[] buffer = new byte[10];
+            Assert.Throws<NotSupportedException>(() => stream.Read(buffer, 0, buffer.Length));
+        }
+
+        [Fact]
+        public void Seek_ThrowsNotSupportedException()
+        {
+            var stream = new ODataUtf8JsonWriteStream(null);
+            Assert.Throws<NotSupportedException>(() => stream.Seek(0, SeekOrigin.Begin));
+        }
+
+        [Fact]
+        public void SetLength_ThrowsNotSupportedException()
+        {
+            var stream = new ODataUtf8JsonWriteStream(null);
+            Assert.Throws<NotSupportedException>(() => stream.SetLength(10));
+        }
+    }
+}
+#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightValueSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightValueSerializerTests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.OData.Tests.JsonLight
         }
 
 #if NETCOREAPP
-        [Fact(Skip="ODataUtf8JsonWriter does not currently implement logic for writing stream values")]
+        [Fact]
         public void WriteStreamValue_UsingODataUtf8JsonWriter_WritesStreamValue()
         {
             var stream = new MemoryStream();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
@@ -11,8 +11,11 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Core.Tests.DependencyInjection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
 #if NETCOREAPP
@@ -22,8 +25,6 @@ using Microsoft.OData.JsonLight;
 using Microsoft.OData.UriParser;
 using Microsoft.OData.Tests;
 using Xunit;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.OData.Core.Tests.DependencyInjection;
 
 namespace Microsoft.OData.Core.Tests.JsonLight
 {
@@ -1264,7 +1265,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
         }
 
 #if NETCOREAPP
-        [Fact(Skip="ODataUtf8JsonWriter does not currently implement logic for writing binary values to stream")]
+        [Fact]
         public async Task WriteBinaryValueToStream_WithODataUtf8JsonWriter_Async()
         {
             var addressResource = CreateAddressResource();
@@ -1291,10 +1292,10 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                     {
                         var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 };
 
-                        await stream.WriteAsync(bytes, 0, 4);
-                        await stream.WriteAsync(bytes, 4, 4);
-                        await stream.WriteAsync(bytes, 8, 2);
-                        await stream.FlushAsync();
+                        await stream.WriteAsync(bytes, 0, 4, CancellationToken.None);
+                        await stream.WriteAsync(bytes, 4, 4, CancellationToken.None);
+                        await stream.WriteAsync(bytes, 8, 2, CancellationToken.None);
+                        await stream.FlushAsync(CancellationToken.None);
                     }
 
                     await jsonLightWriter.WriteEndAsync();
@@ -1311,6 +1312,53 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                 "\"Stream@odata.mediaReadLink\":\"http://tempuri.org/Orders(1)/ShippingAddress/Stream/read\"," +
                 "\"Stream@odata.mediaContentType\":\"text/plain\"," +
                 "\"Stream\":\"AQIDBAUGBwgJAA==\"}",
+                result);
+        }
+
+        [Fact]
+        public async Task WriteStringValueToTextWriter_WithODataUtf8JsonWriter_Async()
+        {
+            var addressResource = CreateAddressResource();
+            var pangramProperty = new ODataPropertyInfo { Name = "Pangram" };
+
+            Action<IServiceCollection> configureWriter = (builder) =>
+            {
+                builder.AddSingleton<IJsonWriterFactory>(_ => ODataUtf8JsonWriterFactory.Default);
+            };
+
+            var result = await SetupJsonLightWriterAndRunTestAsync(
+                async (jsonLightWriter) =>
+                {
+                    await jsonLightWriter.WriteStartAsync(addressResource);
+                    await jsonLightWriter.WriteStartAsync(pangramProperty);
+
+                    using (var textWriter = await jsonLightWriter.CreateTextWriterAsync())
+                    {
+                        string value = "The quick brown";
+                        string value1 = " fox jumps over";
+                        string value2 = " the lazy dog";
+                        char[] charArray = value.ToCharArray();
+                        char[] charArray1 = value1.ToCharArray();
+                        char[] charArray2 = value2.ToCharArray();
+
+                        // Call WriteAsync passing in the byte array
+                        await textWriter.WriteAsync(charArray, 0, charArray.Length);
+                        await textWriter.WriteAsync(charArray1, 0, charArray1.Length);
+                        await textWriter.WriteAsync(charArray2, 0, charArray2.Length);
+                        await textWriter.FlushAsync();
+                    }
+
+                    await jsonLightWriter.WriteEndAsync();
+                    await jsonLightWriter.WriteEndAsync();
+                },
+                this.orderEntitySet,
+                this.orderEntityType,
+                configAction: configureWriter);
+
+            Assert.Equal(
+                "{\"@odata.context\":\"http://tempuri.org/$metadata#Orders/NS.Address/$entity\"," +
+                "\"Street\":\"One Microsoft Way\",\"City\":\"Redmond\"," +
+                "\"Pangram\":\"The quick brown fox jumps over the lazy dog\"}",
                 result);
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

This PR contains the following changes: 

1.  I structured the ODataUtfJsonWriter as a partial class to mitigate the accumulation of excessive code within this class related to supporting streaming APIs. With this restructuring, I added two new partial classes: `ODataUtf8JsonWriter.Stream.cs` and `ODataUtf8JsonWriter.TextWriter.cs`
2. The `ODataUtf8JsonWriter.Stream.cs` class offers a stream for writing streaming data using the ODataUtf8JsonWriter.  
3. The ODataUtf8JsonWriter.TextWriter.cs class offers a TextWriter for writing streaming data using the ODataUtf8JsonWriter.
4. I enabled the tests: `WriteStreamValue_UsingODataUtf8JsonWriter` and `WriteBinaryValueToStream_WithODataUtf8JsonWriter_Async` that had been disabled. 
5. I'm handling the incoming data in chunks, writing it to a buffer that's flushed when it's full. Here's what's important to remember: Sometimes, a chunk might not process all the data, so we keep track of the unprocessed data to include it in the next chunk. I've set up a buffer to hold this unprocessed data.
While dealing with each chunk, I check if it was fully processed. If not, I instantiate the buffer for holding unprocessed data with the unprocessed data's size. If there's no unprocessed data, I empty the buffer to ensure that at all times the buffer only holds unprocessed data from the previous chunk to make it easy to manage this buffer. When processing the next chunk, I check if there's anything in the buffer. If there is, I create a new array combining the buffer's data with the next chunk's data to process it together. It's tricky to know if we're on the final block since this is streaming data, so the final block is always false.
However, when we call the flush method after finishing writing, I check if there's any unprocessed data in the buffer. If there is, It's processed with the final block value set to true to ensure everything gets processed. 
### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
