### PR TITLE
Add EntityType property to IEdmNavigationSource

### DIFF
--- a/src/CodeGen/ODataT4CodeGenerator.cs
+++ b/src/CodeGen/ODataT4CodeGenerator.cs
@@ -1525,7 +1525,7 @@ public abstract class ODataClientTemplate : TemplateBase
 
         foreach (IEdmEntitySet entitySet in container.EntitySets())
         {
-            IEdmEntityType entitySetElementType = entitySet.EntityType();
+            IEdmEntityType entitySetElementType = entitySet.EntityType;
             string entitySetElementTypeName = GetElementTypeName(entitySetElementType, container);
 
             string camelCaseEntitySetName = entitySet.Name;
@@ -1536,10 +1536,10 @@ public abstract class ODataClientTemplate : TemplateBase
 
             this.WriteContextEntitySetProperty(camelCaseEntitySetName, GetFixedName(camelCaseEntitySetName), entitySet.Name, GetFixedName(entitySetElementTypeName));
             List<IEdmNavigationSource> edmNavigationSourceList = null;
-            if (!this.context.ElementTypeToNavigationSourceMap.TryGetValue(entitySet.EntityType(), out edmNavigationSourceList))
+            if (!this.context.ElementTypeToNavigationSourceMap.TryGetValue(entitySet.EntityType, out edmNavigationSourceList))
             {
                 edmNavigationSourceList = new List<IEdmNavigationSource>();
-                this.context.ElementTypeToNavigationSourceMap.Add(entitySet.EntityType(), edmNavigationSourceList);
+                this.context.ElementTypeToNavigationSourceMap.Add(entitySet.EntityType, edmNavigationSourceList);
             }
 
             edmNavigationSourceList.Add(entitySet);
@@ -1547,7 +1547,7 @@ public abstract class ODataClientTemplate : TemplateBase
 
         foreach (IEdmEntitySet entitySet in container.EntitySets())
         {
-            IEdmEntityType entitySetElementType = entitySet.EntityType();
+            IEdmEntityType entitySetElementType = entitySet.EntityType;
             
             string entitySetElementTypeName = GetElementTypeName(entitySetElementType, container);
 
@@ -1565,7 +1565,7 @@ public abstract class ODataClientTemplate : TemplateBase
 
         foreach (IEdmSingleton singleton in container.Singletons())
         {
-            IEdmEntityType singletonElementType = singleton.EntityType();
+            IEdmEntityType singletonElementType = singleton.EntityType;
             string singletonElementTypeName = GetElementTypeName(singletonElementType, container);
             string camelCaseSingletonName = singleton.Name;
             if (this.context.EnableNamingAlias)
@@ -1576,7 +1576,7 @@ public abstract class ODataClientTemplate : TemplateBase
             this.WriteContextSingletonProperty(camelCaseSingletonName, GetFixedName(camelCaseSingletonName), singleton.Name, singletonElementTypeName + "Single");
 
             List<IEdmNavigationSource> edmNavigationSourceList = null;
-            if (this.context.ElementTypeToNavigationSourceMap.TryGetValue(singleton.EntityType(), out edmNavigationSourceList))
+            if (this.context.ElementTypeToNavigationSourceMap.TryGetValue(singleton.EntityType, out edmNavigationSourceList))
             {
                 edmNavigationSourceList.Add(singleton);
             }

--- a/src/Microsoft.OData.Client/TypeResolver.cs
+++ b/src/Microsoft.OData.Client/TypeResolver.cs
@@ -346,7 +346,7 @@ namespace Microsoft.OData.Client
             var entitySet = this.serviceModel.FindDeclaredEntitySet(entitySetName);
             if (entitySet != null)
             {
-                serverTypeName = ExtensionMethods.FullName(entitySet.EntityType());
+                serverTypeName = ExtensionMethods.FullName(entitySet.EntityType);
                 return true;
             }
 

--- a/src/Microsoft.OData.Core/Metadata/EdmTypeReaderResolver.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmTypeReaderResolver.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OData.Metadata
         /// <returns>The <see cref="IEdmEntityType"/> representing the entity type of the <paramref name="navigationSource" />.</returns>
         internal override IEdmEntityType GetElementType(IEdmNavigationSource navigationSource)
         {
-            IEdmEntityType entityType = navigationSource.EntityType();
+            IEdmEntityType entityType = navigationSource?.EntityType;
 
             if (entityType == null)
             {

--- a/src/Microsoft.OData.Core/Metadata/EdmTypeWriterResolver.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmTypeWriterResolver.cs
@@ -35,7 +35,7 @@ namespace Microsoft.OData.Metadata
         /// <returns>The <see cref="IEdmEntityType"/> representing the entity type of the <paramref name="navigationSource" />.</returns>
         internal override IEdmEntityType GetElementType(IEdmNavigationSource navigationSource)
         {
-            return navigationSource.EntityType();
+            return navigationSource?.EntityType;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -142,7 +142,7 @@ namespace Microsoft.OData
         internal static ODataContextUrlInfo Create(IEdmNavigationSource navigationSource, string expectedEntityTypeName, bool isSingle, ODataUri odataUri, ODataVersion version)
         {
             EdmNavigationSourceKind kind = navigationSource.NavigationSourceKind();
-            string navigationSourceEntityType = navigationSource.EntityType().FullName();
+            string navigationSourceEntityType = navigationSource.EntityType.FullName();
             return new ODataContextUrlInfo()
             {
                 IsUnknownEntitySet = kind == EdmNavigationSourceKind.UnknownEntitySet,
@@ -169,7 +169,7 @@ namespace Microsoft.OData
         internal static ODataContextUrlInfo Create(IEdmNavigationSource navigationSource, string expectedEntityTypeName, bool isSingle, in ODataUriSlim odataUri, ODataVersion version)
         {
             EdmNavigationSourceKind kind = navigationSource.NavigationSourceKind();
-            string navigationSourceEntityType = navigationSource.EntityType().FullName();
+            string navigationSourceEntityType = navigationSource.EntityType.FullName();
             return new ODataContextUrlInfo()
             {
                 IsUnknownEntitySet = kind == EdmNavigationSourceKind.UnknownEntitySet,

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -2306,12 +2306,12 @@ namespace Microsoft.OData
                         // if the (deleted) resource is in the top level of a delta resource set, it doesn't
                         // need to match the delta resource set, but must match the navigation source resolved for
                         // the current scope
-                        if (!resourceScope.NavigationSource.EntityType().IsAssignableFrom(resourceType))
+                        if (!resourceScope.NavigationSource.EntityType.IsAssignableFrom(resourceType))
                         {
-                            throw new ODataException(Strings.ResourceSetWithoutExpectedTypeValidator_IncompatibleTypes(resourceType.FullTypeName(), resourceScope.NavigationSource.EntityType()));
+                            throw new ODataException(Strings.ResourceSetWithoutExpectedTypeValidator_IncompatibleTypes(resourceType.FullTypeName(), resourceScope.NavigationSource.EntityType));
                         }
 
-                        resourceScope.ResourceTypeFromMetadata = resourceScope.NavigationSource.EntityType();
+                        resourceScope.ResourceTypeFromMetadata = resourceScope.NavigationSource.EntityType;
                     }
                     else
                     {
@@ -2605,7 +2605,7 @@ namespace Microsoft.OData
                                     ODataUriParser uriParser = new ODataUriParser(model, new Uri(serializationInfo.NavigationSourceName, UriKind.Relative), this.outputContext.Container);
                                     odataUri = new ODataUriSlim(uriParser.ParseUri());
                                     navigationSource = odataUri.Path.NavigationSource();
-                                    itemType = itemType ?? navigationSource.EntityType();
+                                    itemType = itemType ?? navigationSource?.EntityType;
                                 }
 
                                 if (typeNameFromResource == null)

--- a/src/Microsoft.OData.Core/UnknownEntitySet.cs
+++ b/src/Microsoft.OData.Core/UnknownEntitySet.cs
@@ -14,6 +14,7 @@ namespace Microsoft.OData
         private readonly IEdmNavigationProperty navigationProperty;
         private readonly IEdmNavigationSource parentNavigationSource;
         private IEdmPathExpression path;
+        private IEdmEntityType entityType;
 
         public UnknownEntitySet(IEdmNavigationSource parentNavigationSource, IEdmNavigationProperty navigationProperty)
         {
@@ -41,6 +42,20 @@ namespace Microsoft.OData
             get
             {
                 return this.navigationProperty.Type.Definition;
+            }
+        }
+
+        /// <inheritdoc/>
+        public IEdmEntityType EntityType
+        {
+            get
+            {
+                if (this.entityType == null)
+                {
+                    this.entityType = this.Type.AsElementType() as IEdmEntityType;
+                }
+
+                return this.entityType;
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/SelectExpandBinder.cs
@@ -928,7 +928,7 @@ namespace Microsoft.OData.UriParser
             {
                 ImplicitRangeVariable =
                     NodeFactory.CreateImplicitRangeVariable(elementType != null ? elementType :
-                        targetNavigationSource.EntityType().ToTypeReference(), targetNavigationSource)
+                        targetNavigationSource.EntityType.ToTypeReference(), targetNavigationSource)
             };
 
             state.AggregatedPropertyNames = generatedProperties;
@@ -941,13 +941,13 @@ namespace Microsoft.OData.UriParser
                 // We are adding a rangeVariable whose navigationSource is the resource path entity set.
                 // ODATA spec: Example 106 http://docs.oasis-open.org/odata/odata/v4.01/csprd05/part2-url-conventions/odata-v4.01-csprd05-part2-url-conventions.html#sec_it
                 RangeVariable explicitRangeVariable = NodeFactory.CreateImplicitRangeVariable(
-                    resourcePathNavigationSource.EntityType().ToTypeReference(), resourcePathNavigationSource);
+                    resourcePathNavigationSource.EntityType.ToTypeReference(), resourcePathNavigationSource);
                 state.RangeVariables.Push(explicitRangeVariable);
             }
 
             // Create $this rangeVariable and add it to the Stack.
             RangeVariable dollarThisRangeVariable = NodeFactory.CreateDollarThisRangeVariable(
-                elementType != null ? elementType : targetNavigationSource.EntityType().ToTypeReference(), targetNavigationSource);
+                elementType != null ? elementType : targetNavigationSource.EntityType.ToTypeReference(), targetNavigationSource);
             state.RangeVariables.Push(dollarThisRangeVariable);
 
             return state;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -550,7 +550,7 @@ namespace Microsoft.OData.UriParser
             // Creating a filter clause helps validate the expression and create the expression nodes (including nested parameter aliases).
             FilterClause filterClause = GenerateFilterClause(
                 lastNavigationSource,
-                typeSegment == null ? lastNavigationSource.EntityType() : typeSegment.TargetEdmType,
+                typeSegment == null ? lastNavigationSource.EntityType : typeSegment.TargetEdmType,
                 filterExpression);
 
             // 4) Create filter segment with the validated expression and add it to parsed segments.

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/BatchReferenceSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/BatchReferenceSegment.cs
@@ -63,7 +63,7 @@ namespace Microsoft.OData.UriParser
 
             if (entitySet != null)
             {
-                ExceptionUtil.ThrowIfTypesUnrelated(edmType, entitySet.EntityType(), "BatchReferenceSegments");
+                ExceptionUtil.ThrowIfTypesUnrelated(edmType, entitySet.EntityType, "BatchReferenceSegments");
             }
         }
 

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/EntitySetSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/EntitySetSegment.cs
@@ -36,11 +36,11 @@ namespace Microsoft.OData.UriParser
             this.entitySet = entitySet;
 
             // creating a new collection type here because the type in the entity set is just the item type, there is no user-provided collection type.
-            this.type = new EdmCollectionType(new EdmEntityTypeReference(this.entitySet.EntityType(), false));
+            this.type = new EdmCollectionType(new EdmEntityTypeReference(this.entitySet.EntityType, false));
 
             this.Identifier = entitySet.Name;
             this.TargetEdmNavigationSource = entitySet;
-            this.TargetEdmType = entitySet.EntityType();
+            this.TargetEdmType = entitySet.EntityType;
             this.TargetKind = RequestTargetKind.Resource;
             this.SingleResult = false;
         }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/KeySegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/KeySegment.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OData.UriParser
             // Check that the type they gave us is related to the type of the set
             if (navigationSource != null)
             {
-                ExceptionUtil.ThrowIfTypesUnrelated(edmType, navigationSource.EntityType(), "KeySegments");
+                ExceptionUtil.ThrowIfTypesUnrelated(edmType, navigationSource.EntityType, "KeySegments");
             }
 
             // We don't need to regenerate the identifier.

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/OperationImportSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/OperationImportSegment.cs
@@ -268,7 +268,7 @@ namespace Microsoft.OData.UriParser
             }
 
             // Ensure that the return type is in the same type hierarchy as the entity set provided
-            if (!this.entitySet.EntityType().IsOrInheritsFrom(unwrappedCollectionType) && !unwrappedCollectionType.IsOrInheritsFrom(this.entitySet.EntityType()))
+            if (!this.entitySet.EntityType.IsOrInheritsFrom(unwrappedCollectionType) && !unwrappedCollectionType.IsOrInheritsFrom(this.entitySet.EntityType))
             {
                 throw new ODataException(ODataErrorStrings.OperationSegment_CannotReturnNull);
             }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/OperationSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/OperationSegment.cs
@@ -267,7 +267,7 @@ namespace Microsoft.OData.UriParser
             }
 
             // Ensure that the return type is in the same type hierarchy as the entity set provided
-            if (!this.entitySet.EntityType().IsOrInheritsFrom(unwrappedCollectionType) && !unwrappedCollectionType.IsOrInheritsFrom(this.entitySet.EntityType()))
+            if (!this.entitySet.EntityType.IsOrInheritsFrom(unwrappedCollectionType) && !unwrappedCollectionType.IsOrInheritsFrom(this.entitySet.EntityType))
             {
                 throw new ODataException(ODataErrorStrings.OperationSegment_CannotReturnNull);
             }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SingletonSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SingletonSegment.cs
@@ -35,7 +35,7 @@ namespace Microsoft.OData.UriParser
 
             this.Identifier = singleton.Name;
             this.TargetEdmNavigationSource = singleton;
-            this.TargetEdmType = singleton.EntityType();
+            this.TargetEdmType = singleton.EntityType;
             this.TargetKind = RequestTargetKind.Resource;
             this.SingleResult = true;
         }
@@ -54,7 +54,7 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         public override IEdmType EdmType
         {
-            get { return this.singleton.EntityType(); }
+            get { return this.singleton.EntityType; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/TypeSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/TypeSegment.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OData.UriParser
         /// <exception cref="System.ArgumentNullException">Throws if the actual edmType is null.</exception>
         /// <exception cref="ODataException">Throws if the actual edmType is not related to the type of elements in the input navigationSource.</exception>
         public TypeSegment(IEdmType actualType, IEdmNavigationSource navigationSource)
-            : this(actualType, navigationSource == null ? actualType : navigationSource.EntityType(), navigationSource)
+            : this(actualType, navigationSource == null ? actualType : navigationSource.EntityType, navigationSource)
         {
         }
 

--- a/src/Microsoft.OData.Core/UrlValidation/Rules/DeprecationRules.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/Rules/DeprecationRules.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OData.UriParser.Validation.Rules
         "DeprecatedNavigationSourceRule",
         (ODataUrlValidationContext context, IEdmNavigationSource source) =>
         {
-            Validate(source, source.EntityType(), context);
+            Validate(source, source.EntityType, context);
         },
         /*includeImpliedProperties*/ true);
 

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsNavigationSource.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsNavigationSource.cs
@@ -45,6 +45,9 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         private readonly ConcurrentDictionary<IEdmNavigationProperty, IEnumerable<IEdmNavigationPropertyBinding>> navigationPropertyBindingCache = 
             new ConcurrentDictionary<IEdmNavigationProperty, IEnumerable<IEdmNavigationPropertyBinding>>();
 
+        private IEdmEntityType entityType;
+        private bool entityTypeSet = false;
+
         public CsdlSemanticsNavigationSource(CsdlSemanticsEntityContainer container, CsdlAbstractNavigationSource navigationSource)
             : base(navigationSource)
         {
@@ -85,6 +88,21 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         public IEnumerable<IEdmNavigationPropertyBinding> NavigationPropertyBindings
         {
             get { return this.navigationTargetsCache.GetValue(this, ComputeNavigationTargetsFunc, null); }
+        }
+
+        /// <inheritdoc/>
+        public IEdmEntityType EntityType
+        {
+            get
+            {
+                if (!this.entityTypeSet)
+                {
+                    this.entityType = this.Type.AsElementType() as IEdmEntityType;
+                    this.entityTypeSet = true;
+                }
+
+                return this.entityType;
+            }
         }
 
         public IEdmNavigationSource FindNavigationTarget(IEdmNavigationProperty property, IEdmPathExpression bindingPath)

--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
@@ -106,7 +106,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
                     IEdmNavigationSource navigationSource = bindingTarget as IEdmNavigationSource;
                     if (navigationSource != null)
                     {
-                        bindingContext = navigationSource.EntityType();
+                        bindingContext = navigationSource.EntityType;
                     }
                 }
 

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
@@ -640,7 +640,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.jsonWriter.WriteRequiredProperty("$Collection", true);
 
             // The entity set object MUST contain the member $Type whose string value is the qualified name of an entity type.
-            this.jsonWriter.WriteRequiredProperty("$Type", entitySet.EntityType().FullName());
+            this.jsonWriter.WriteRequiredProperty("$Type", entitySet.EntityType.FullName());
 
             // It MAY contain the members $IncludeInServiceDocument. Absence of the member means true.
             this.jsonWriter.WriteOptionalProperty("$IncludeInServiceDocument", entitySet.IncludeInServiceDocument, true);
@@ -659,7 +659,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.jsonWriter.WriteStartObject();
 
             // The singleton object MUST contain the member $Type whose string value is the qualified name of an entity type.
-            this.jsonWriter.WriteRequiredProperty("$Type", singleton.EntityType().FullName());
+            this.jsonWriter.WriteRequiredProperty("$Type", singleton.EntityType.FullName());
 
             // The singleton object MAY contain the member $Nullable. In OData 4.0 responses this member MUST NOT be specified.
             // So far, IEdmSingleton doesn't have the property defined, so skip it now.

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
@@ -122,14 +122,14 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         {
             this.xmlWriter.WriteStartElement(CsdlConstants.Element_EntitySet);
             this.WriteRequiredAttribute(CsdlConstants.Attribute_Name, entitySet.Name, EdmValueWriter.StringAsXml);
-            this.WriteRequiredAttribute(CsdlConstants.Attribute_EntityType, entitySet.EntityType().FullName(), EdmValueWriter.StringAsXml);
+            this.WriteRequiredAttribute(CsdlConstants.Attribute_EntityType, entitySet.EntityType.FullName(), EdmValueWriter.StringAsXml);
         }
 
         internal override void WriteSingletonElementHeader(IEdmSingleton singleton)
         {
             this.xmlWriter.WriteStartElement(CsdlConstants.Element_Singleton);
             this.WriteRequiredAttribute(CsdlConstants.Attribute_Name, singleton.Name, EdmValueWriter.StringAsXml);
-            this.WriteRequiredAttribute(CsdlConstants.Attribute_Type, singleton.EntityType().FullName(), EdmValueWriter.StringAsXml);
+            this.WriteRequiredAttribute(CsdlConstants.Attribute_Type, singleton.EntityType.FullName(), EdmValueWriter.StringAsXml);
         }
 
         internal override void WriteEntityTypeElementHeader(IEdmEntityType entityType)

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/SerializationValidator.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/SerializationValidator.cs
@@ -58,12 +58,12 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             new ValidationRule<IEdmEntitySet>(
                 (context, set) =>
                 {
-                    if (!EdmUtil.IsQualifiedName(set.EntityType().FullName()))
+                    if (!EdmUtil.IsQualifiedName(set.EntityType.FullName()))
                     {
                         context.AddError(
                             set.Location(),
                             EdmErrorCode.ReferencedTypeMustHaveValidName,
-                            Strings.Serializer_ReferencedTypeMustHaveValidName(set.EntityType().FullName()));
+                            Strings.Serializer_ReferencedTypeMustHaveValidName(set.EntityType.FullName()));
                     }
                 });
 

--- a/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs
@@ -1820,7 +1820,7 @@ namespace Microsoft.OData.Edm
         /// <returns>The element type of this references definition.</returns>
         public static IEdmType AsElementType(this IEdmType type)
         {   
-            if(type == null)
+            if (type == null)
             {
                 return type;
             }
@@ -2880,6 +2880,8 @@ namespace Microsoft.OData.Edm
         /// </summary>
         /// <param name="navigationSource">The navigation source.</param>
         /// <returns>The entity type of the navigation source.</returns>
+        /// <remarks>This extension method is obsolete and will be dropped in the 9.x release. Use <see cref"IEdmNavigationSource.EntityType"> property.</remarks>
+        [Obsolete("This will be dropped in the 9.x release. Use IEdmNavigationSource.EntityType property.")]
         public static IEdmEntityType EntityType(this IEdmNavigationSource navigationSource)
         {
             return navigationSource?.Type.AsElementType() as IEdmEntityType;
@@ -3395,7 +3397,7 @@ namespace Microsoft.OData.Edm
             for (int i = nextIndex; i < pathSegments.Length && navigationSource != null; i++)
             {
                 subPathSegments.Add(pathSegments[i]);
-                IEdmNavigationProperty navProp = navigationSource.EntityType().FindProperty(pathSegments[i]) as IEdmNavigationProperty;
+                IEdmNavigationProperty navProp = navigationSource.EntityType.FindProperty(pathSegments[i]) as IEdmNavigationProperty;
                 if (navProp != null)
                 {
                     navigationSource = navigationSource.FindNavigationTarget(navProp, new EdmPathExpression(subPathSegments));

--- a/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
+++ b/src/Microsoft.OData.Edm/ExtensionMethods/TargetPathHelper.cs
@@ -209,11 +209,11 @@ namespace Microsoft.OData.Edm
             }
             else if (element is IEdmEntitySet entitySet)
             {
-                elementEdmType = entitySet.EntityType().AsElementType();
+                elementEdmType = entitySet.EntityType.AsElementType();
             }
             else if (element is IEdmSingleton singleton)
             {
-                elementEdmType = singleton.EntityType().AsElementType();
+                elementEdmType = singleton.EntityType.AsElementType();
             }
 
             if (elementEdmType != null)

--- a/src/Microsoft.OData.Edm/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -348,6 +348,7 @@ Microsoft.OData.Edm.EdmNavigationSource
 Microsoft.OData.Edm.EdmNavigationSource.AddNavigationTarget(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty, Microsoft.OData.Edm.IEdmNavigationSource target) -> void
 Microsoft.OData.Edm.EdmNavigationSource.AddNavigationTarget(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty, Microsoft.OData.Edm.IEdmNavigationSource target, Microsoft.OData.Edm.IEdmPathExpression bindingPath) -> void
 Microsoft.OData.Edm.EdmNavigationSource.EdmNavigationSource(string name) -> void
+Microsoft.OData.Edm.EdmNavigationSource.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 Microsoft.OData.Edm.EdmNavigationSource.NavigationPropertyBindings.get -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmNavigationPropertyBinding>
 Microsoft.OData.Edm.EdmNavigationSourceKind
 Microsoft.OData.Edm.EdmNavigationSourceKind.ContainedEntitySet = 3 -> Microsoft.OData.Edm.EdmNavigationSourceKind
@@ -648,6 +649,7 @@ Microsoft.OData.Edm.IEdmNavigationPropertyBinding.NavigationProperty.get -> Micr
 Microsoft.OData.Edm.IEdmNavigationPropertyBinding.Path.get -> Microsoft.OData.Edm.IEdmPathExpression
 Microsoft.OData.Edm.IEdmNavigationPropertyBinding.Target.get -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.Edm.IEdmNavigationSource
+Microsoft.OData.Edm.IEdmNavigationSource.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 Microsoft.OData.Edm.IEdmNavigationSource.FindNavigationPropertyBindings(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmNavigationPropertyBinding>
 Microsoft.OData.Edm.IEdmNavigationSource.FindNavigationTarget(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty) -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.Edm.IEdmNavigationSource.FindNavigationTarget(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty, Microsoft.OData.Edm.IEdmPathExpression bindingPath) -> Microsoft.OData.Edm.IEdmNavigationSource

--- a/src/Microsoft.OData.Edm/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -365,6 +365,7 @@ Microsoft.OData.Edm.EdmNavigationSource
 Microsoft.OData.Edm.EdmNavigationSource.AddNavigationTarget(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty, Microsoft.OData.Edm.IEdmNavigationSource target) -> void
 Microsoft.OData.Edm.EdmNavigationSource.AddNavigationTarget(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty, Microsoft.OData.Edm.IEdmNavigationSource target, Microsoft.OData.Edm.IEdmPathExpression bindingPath) -> void
 Microsoft.OData.Edm.EdmNavigationSource.EdmNavigationSource(string name) -> void
+Microsoft.OData.Edm.EdmNavigationSource.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 Microsoft.OData.Edm.EdmNavigationSource.NavigationPropertyBindings.get -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmNavigationPropertyBinding>
 Microsoft.OData.Edm.EdmNavigationSourceKind
 Microsoft.OData.Edm.EdmNavigationSourceKind.ContainedEntitySet = 3 -> Microsoft.OData.Edm.EdmNavigationSourceKind
@@ -665,6 +666,7 @@ Microsoft.OData.Edm.IEdmNavigationPropertyBinding.NavigationProperty.get -> Micr
 Microsoft.OData.Edm.IEdmNavigationPropertyBinding.Path.get -> Microsoft.OData.Edm.IEdmPathExpression
 Microsoft.OData.Edm.IEdmNavigationPropertyBinding.Target.get -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.Edm.IEdmNavigationSource
+Microsoft.OData.Edm.IEdmNavigationSource.EntityType.get -> Microsoft.OData.Edm.IEdmEntityType
 Microsoft.OData.Edm.IEdmNavigationSource.FindNavigationPropertyBindings(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty) -> System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmNavigationPropertyBinding>
 Microsoft.OData.Edm.IEdmNavigationSource.FindNavigationTarget(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty) -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.Edm.IEdmNavigationSource.FindNavigationTarget(Microsoft.OData.Edm.IEdmNavigationProperty navigationProperty, Microsoft.OData.Edm.IEdmPathExpression bindingPath) -> Microsoft.OData.Edm.IEdmNavigationSource

--- a/src/Microsoft.OData.Edm/Schema/AmbiguousEntitySetBinding.cs
+++ b/src/Microsoft.OData.Edm/Schema/AmbiguousEntitySetBinding.cs
@@ -12,6 +12,8 @@ namespace Microsoft.OData.Edm
 {
     internal class AmbiguousEntitySetBinding : AmbiguousBinding<IEdmEntitySet>, IEdmEntitySet
     {
+        private IEdmEntityType entityType;
+
         public AmbiguousEntitySetBinding(IEdmEntitySet first, IEdmEntitySet second)
             : base(first, second)
         {
@@ -39,6 +41,20 @@ namespace Microsoft.OData.Edm
         public IEdmType Type
         {
             get { return new EdmCollectionType(new EdmEntityTypeReference(new BadEntityType(String.Empty, this.Errors), false)); }
+        }
+
+        /// <inheritdoc/>
+        public IEdmEntityType EntityType
+        {
+            get
+            {
+                if (this.entityType == null)
+                {
+                    this.entityType = this.Type.AsElementType() as IEdmEntityType;
+                }
+
+                return this.entityType;
+            }
         }
 
         public bool IncludeInServiceDocument

--- a/src/Microsoft.OData.Edm/Schema/AmbiguousSingletonBinding.cs
+++ b/src/Microsoft.OData.Edm/Schema/AmbiguousSingletonBinding.cs
@@ -12,6 +12,8 @@ namespace Microsoft.OData.Edm
 {
     internal class AmbiguousSingletonBinding : AmbiguousBinding<IEdmSingleton>, IEdmSingleton
     {
+        private IEdmEntityType entityType;
+
         public AmbiguousSingletonBinding(IEdmSingleton first, IEdmSingleton second)
             : base(first, second)
         {
@@ -22,6 +24,19 @@ namespace Microsoft.OData.Edm
             get { return new BadEntityType(String.Empty, this.Errors); }
         }
 
+        /// <inheritdoc/>
+        public IEdmEntityType EntityType
+        {
+            get
+            {
+                if (this.entityType == null)
+                {
+                    this.entityType = this.Type.AsElementType() as IEdmEntityType;
+                }
+
+                return this.entityType;
+            }
+        }
 
         public EdmContainerElementKind ContainerElementKind
         {

--- a/src/Microsoft.OData.Edm/Schema/BadEntitySet.cs
+++ b/src/Microsoft.OData.Edm/Schema/BadEntitySet.cs
@@ -18,6 +18,7 @@ namespace Microsoft.OData.Edm
     {
         private readonly string name;
         private readonly IEdmEntityContainer container;
+        private IEdmEntityType entityType;
 
         public BadEntitySet(string name, IEdmEntityContainer container, IEnumerable<EdmError> errors)
             : base(errors)
@@ -54,6 +55,20 @@ namespace Microsoft.OData.Edm
         public IEdmType Type
         {
             get { return new EdmCollectionType(new EdmEntityTypeReference(new BadEntityType(String.Empty, this.Errors), false)); }
+        }
+
+        /// <inheritdoc/>
+        public IEdmEntityType EntityType
+        {
+            get
+            {
+                if (this.entityType == null)
+                {
+                    this.entityType = this.Type.AsElementType() as IEdmEntityType;
+                }
+
+                return this.entityType;
+            }
         }
 
         public bool IncludeInServiceDocument

--- a/src/Microsoft.OData.Edm/Schema/EdmNavigationSource.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmNavigationSource.cs
@@ -23,6 +23,9 @@ namespace Microsoft.OData.Edm
         private readonly Cache<EdmNavigationSource, IEnumerable<IEdmNavigationPropertyBinding>> navigationTargetsCache = new Cache<EdmNavigationSource, IEnumerable<IEdmNavigationPropertyBinding>>();
         private static readonly Func<EdmNavigationSource, IEnumerable<IEdmNavigationPropertyBinding>> ComputeNavigationTargetsFunc = (me) => me.ComputeNavigationTargets();
 
+        private IEdmEntityType entityType;
+        private bool entityTypeSet = false;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="EdmNavigationSource"/> class.
         /// </summary>
@@ -44,6 +47,23 @@ namespace Microsoft.OData.Edm
         /// Gets the type of this navigation source.
         /// </summary>
         public abstract IEdmType Type { get; }
+
+        /// <summary>
+        /// Gets the entity type of the navigation source. Can be null.
+        /// </summary>
+        public IEdmEntityType EntityType
+        {
+            get
+            {
+                if (!this.entityTypeSet)
+                {
+                    this.entityType = this.Type.AsElementType() as IEdmEntityType;
+                    this.entityTypeSet = true;
+                }
+
+                return this.entityType;
+            }
+        }
 
         /// <summary>
         /// Gets the path that a navigation property targets.

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmNavigationSource.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmNavigationSource.cs
@@ -60,6 +60,11 @@ namespace Microsoft.OData.Edm
         IEdmType Type { get; }
 
         /// <summary>
+        /// Gets the entity type of the navigation source. Can be null.
+        /// </summary>
+        IEdmEntityType EntityType { get; }
+
+        /// <summary>
         /// Finds the navigation source that a navigation property targets.
         /// </summary>
         /// <param name="navigationProperty">The navigation property.</param>

--- a/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
+++ b/src/Microsoft.OData.Edm/Validation/ValidationRules.cs
@@ -299,18 +299,18 @@ namespace Microsoft.OData.Edm.Validation
                         return;
                     }
 
-                    IEdmEntityType entityType = navigationSource.EntityType();
+                    IEdmEntityType entityType = navigationSource?.EntityType;
 
                     if (entityType == null)
                     {
                         return;
                     }
 
-                    if ((navigationSource.EntityType().Key() == null || !navigationSource.EntityType().Key().Any()) && !context.IsBad(navigationSource.EntityType()))
+                    if ((entityType.Key() == null || !entityType.Key().Any()) && !context.IsBad(entityType))
                     {
                         string errorMessage = Strings.EdmModel_Validator_Semantic_NavigationSourceTypeHasNoKeys(
                             navigationSource.Name,
-                            navigationSource.EntityType().Name);
+                            entityType.Name);
 
                         context.AddError(
                             navigationSource.Location(),
@@ -326,7 +326,7 @@ namespace Microsoft.OData.Edm.Validation
             new ValidationRule<IEdmNavigationSource>(
                 (context, navigationSource) =>
                 {
-                    IEdmEntityType entityType = navigationSource.EntityType();
+                    IEdmEntityType entityType = navigationSource?.EntityType;
 
                     if (entityType == null)
                     {
@@ -355,7 +355,7 @@ namespace Microsoft.OData.Edm.Validation
             new ValidationRule<IEdmNavigationSource>(
                 (context, navigationSource) =>
                 {
-                    IEdmEntityType entityType = navigationSource.EntityType();
+                    IEdmEntityType entityType = navigationSource?.EntityType;
                     if (entityType != null && !context.IsBad(entityType))
                     {
                         CheckForUnreacheableTypeError(context, entityType, navigationSource.Location());
@@ -397,7 +397,8 @@ namespace Microsoft.OData.Edm.Validation
                             continue;
                         }
 
-                        if (!(mapping.Target.EntityType().IsOrInheritsFrom(mapping.NavigationProperty.ToEntityType()) || mapping.NavigationProperty.ToEntityType().IsOrInheritsFrom(mapping.Target.EntityType())) && !context.IsBad(mapping.Target))
+                        IEdmEntityType navigationPropertyEntityType = mapping.NavigationProperty.ToEntityType();
+                        if (!(mapping.Target.EntityType.IsOrInheritsFrom(navigationPropertyEntityType) || navigationPropertyEntityType.IsOrInheritsFrom(mapping.Target.EntityType)) && !context.IsBad(mapping.Target))
                         {
                             context.AddError(
                                 navigationSource.Location(),
@@ -1705,7 +1706,7 @@ namespace Microsoft.OData.Edm.Validation
                             IEnumerable<EdmError> errors;
                             if (operationImport.TryGetStaticEntitySet(context.Model, out entitySet))
                             {
-                                IEdmEntityType entitySetElementType = entitySet.EntityType();
+                                IEdmEntityType entitySetElementType = entitySet.EntityType;
                                 if (!returnedEntityType.IsOrInheritsFrom(entitySetElementType) && !context.IsBad(returnedEntityType) && !context.IsBad(entitySet) && !context.IsBad(entitySetElementType))
                                 {
                                     string errorMessage = Strings.EdmModel_Validator_Semantic_OperationImportEntityTypeDoesNotMatchEntitySet(
@@ -2759,7 +2760,7 @@ namespace Microsoft.OData.Edm.Validation
         {
             var pathSegments = binding.Path.PathSegments.ToArray();
             IEdmNavigationProperty lastNavProp = null;
-            var definingType = navigationSource.EntityType() as IEdmStructuredType;
+            var definingType = navigationSource?.EntityType as IEdmStructuredType;
 
             for (int index = 0; index < pathSegments.Length; index++)
             {

--- a/test/EndToEndTests/Services/ODataWCFLibrary/ExpandSelectItemHandler.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/ExpandSelectItemHandler.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
 
             if (this.ExpandedChildElement is IEnumerable)
             {
-                var entityInstanceType = EdmClrTypeUtils.GetInstanceType(item.NavigationSource.EntityType().FullName());
+                var entityInstanceType = EdmClrTypeUtils.GetInstanceType(item.NavigationSource.EntityType.FullName());
                 Expression resultExpression = (this.ExpandedChildElement as IEnumerable).AsQueryable().Expression;
 
                 if (item.FilterOption != null)
@@ -179,7 +179,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
 
             if (this.ExpandedChildElement is IEnumerable)
             {
-                var entityInstanceType = EdmClrTypeUtils.GetInstanceType(item.NavigationSource.EntityType().FullName());
+                var entityInstanceType = EdmClrTypeUtils.GetInstanceType(item.NavigationSource.EntityType.FullName());
                 Expression resultExpression = (this.ExpandedChildElement as IEnumerable).AsQueryable().Expression;
 
                 if (item.FilterOption != null)

--- a/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/CreateHandler.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/CreateHandler.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
             {
                 var odataItemStack = new Stack<ODataItem>();
                 var entityStack = new Stack<IEdmEntitySetBase>();
-                var entryReader = messageReader.CreateODataResourceReader(entitySet, entitySet.EntityType());
+                var entryReader = messageReader.CreateODataResourceReader(entitySet, entitySet.EntityType);
                 var currentTargetEntitySet = entitySet;
 
                 while (entryReader.Read())
@@ -228,12 +228,12 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
                             {
                                 odataItemStack.Push(entryReader.Item);
                                 var nestedResourceInfo = (ODataNestedResourceInfo)entryReader.Item;
-                                IEdmNavigationProperty navigationProperty = currentTargetEntitySet == null ? null : currentTargetEntitySet.EntityType().FindProperty(nestedResourceInfo.Name) as IEdmNavigationProperty;
+                                IEdmNavigationProperty navigationProperty = currentTargetEntitySet == null ? null : currentTargetEntitySet.EntityType.FindProperty(nestedResourceInfo.Name) as IEdmNavigationProperty;
 
                                 // Current model implementation doesn't expose associations otherwise this would be much cleaner.
                                 if (navigationProperty != null)
                                 {
-                                    currentTargetEntitySet = this.DataSource.Model.EntityContainer.EntitySets().Single(s => s.EntityType() == navigationProperty.Type.Definition);
+                                    currentTargetEntitySet = this.DataSource.Model.EntityContainer.EntitySets().Single(s => s.EntityType == navigationProperty.Type.Definition);
                                 }
                                 else
                                 {

--- a/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/DeltaLinkHandler.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/DeltaLinkHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
                 using (var messageWriter = this.CreateMessageWriter(responseMessage))
                 {
                     var entitySet = this.DataSource.Model.FindDeclaredEntitySet("Customers");
-                    var entityType = entitySet.EntityType();
+                    var entityType = entitySet.EntityType;
                     ODataWriter deltaWriter = messageWriter.CreateODataDeltaResourceSetWriter(entitySet, entityType);
 
                     var deltaFeed = new ODataDeltaResourceSet();
@@ -101,10 +101,10 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
                 using (var messageWriter = this.CreateMessageWriter(responseMessage))
                 {
                     var accountsSet = this.DataSource.Model.FindDeclaredEntitySet("Accounts");
-                    var accountType = accountsSet.EntityType();
+                    var accountType = accountsSet.EntityType;
                     var myPisNav = accountType.FindProperty("MyPaymentInstruments") as IEdmNavigationProperty;
                     var piSet = accountsSet.FindNavigationTarget(myPisNav);
-                    var piType = piSet.EntityType();
+                    var piType = piSet.EntityType;
                     ODataWriter deltaWriter = messageWriter.CreateODataDeltaResourceSetWriter(piSet as IEdmContainedEntitySet, piType);
 
                     var deltaFeed = new ODataDeltaResourceSet();
@@ -165,7 +165,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
                 using (var messageWriter = this.CreateMessageWriter(responseMessage))
                 {
                     var peopleSet = this.DataSource.Model.FindDeclaredEntitySet("People");
-                    var personType = peopleSet.EntityType();
+                    var personType = peopleSet.EntityType;
                     ODataWriter deltaWriter = messageWriter.CreateODataDeltaResourceSetWriter(peopleSet, personType);
 
                     var deltaFeed = new ODataDeltaResourceSet();
@@ -229,7 +229,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
                     var customerSet = this.DataSource.Model.FindDeclaredEntitySet("Customers");
                     var orderSet = this.DataSource.Model.FindDeclaredEntitySet("Orders");
                     var peopleSet = this.DataSource.Model.FindDeclaredEntitySet("People");
-                    var customerType = customerSet.EntityType();
+                    var customerType = customerSet.EntityType;
                     ODataWriter deltaWriter = messageWriter.CreateODataDeltaResourceSetWriter(customerSet, customerType);
 
                     // Delta feed and entry
@@ -348,7 +348,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
                 using (var messageWriter = this.CreateMessageWriter(responseMessage))
                 {
                     var entitySet = this.DataSource.Model.FindDeclaredEntitySet("Customers");
-                    var entityType = entitySet.EntityType();
+                    var entityType = entitySet.EntityType;
                     ODataWriter deltaWriter = messageWriter.CreateODataDeltaResourceSetWriter(entitySet, entityType);
 
                     var deltaFeed = new ODataDeltaResourceSet();

--- a/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/UpdateHandler.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/UpdateHandler.cs
@@ -374,12 +374,12 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
                                     var propertyInstance = property.GetValue(parent);
                                     parentInstances.Push(propertyInstance);
 
-                                    IEdmNavigationProperty navigationProperty = currentTargetEntitySet == null ? null : currentTargetEntitySet.EntityType().FindProperty(nestedResourceInfo.Name) as IEdmNavigationProperty;
+                                    IEdmNavigationProperty navigationProperty = currentTargetEntitySet == null ? null : currentTargetEntitySet.EntityType.FindProperty(nestedResourceInfo.Name) as IEdmNavigationProperty;
 
                                     // Current model implementation doesn't expose associations otherwise this would be much cleaner.
                                     if (navigationProperty != null)
                                     {
-                                        currentTargetEntitySet = this.DataSource.Model.EntityContainer.EntitySets().Single(s => s.EntityType() == navigationProperty.Type.Definition);
+                                        currentTargetEntitySet = this.DataSource.Model.EntityContainer.EntitySets().Single(s => s.EntityType == navigationProperty.Type.Definition);
                                     }
                                     else
                                     {

--- a/test/EndToEndTests/Services/ODataWCFLibrary/ODataAnnotationUriBuilder.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/ODataAnnotationUriBuilder.cs
@@ -96,18 +96,18 @@ namespace Microsoft.OData.Core.Evaluation
 
             var navigationSource = this.ComputeNavigationSource();
             this.entitySetName = navigationSource.Name;
-            this.entityTypeName = navigationSource.EntityType().FullTypeName();
+            this.entityTypeName = navigationSource.EntityType.FullTypeName();
 
             this.computedUri = this.ServiceRoot;
 
             switch (navigationSource.NavigationSourceKind())
             {
                 case EdmNavigationSourceKind.EntitySet:
-                    this.keyProperties = ValidateKeyPropertiesAgainstEntityType(keyProperties, navigationSource.EntityType());
+                    this.keyProperties = ValidateKeyPropertiesAgainstEntityType(keyProperties, navigationSource.EntityType);
                     return this.keyProperties != null ? this.ComputeIdForEntitySet() : null;
 
                 case EdmNavigationSourceKind.ContainedEntitySet:
-                    this.keyProperties = ValidateKeyPropertiesAgainstEntityType(keyProperties, navigationSource.EntityType());
+                    this.keyProperties = ValidateKeyPropertiesAgainstEntityType(keyProperties, navigationSource.EntityType);
                     return this.keyProperties != null ? this.ComputeIdForContainedEntitySet() : null;
 
                 case EdmNavigationSourceKind.Singleton:

--- a/test/EndToEndTests/Services/ODataWCFLibrary/ODataObjectModelConverter.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/ODataObjectModelConverter.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
             if (entitySource != null && !(entitySource is IEdmContainedEntitySet))
             {
                 Uri entryUri = BuildEntryUri(element, entitySource, targetVersion);
-                if (element.GetType().BaseType != null && entitySource.EntityType().Name != typeName)
+                if (element.GetType().BaseType != null && entitySource.EntityType.Name != typeName)
                 {
                     var editLink = new Uri(entryUri.AbsoluteUri.TrimEnd('/') + "/" + entry.TypeName);
                     entry.EditLink = editLink;
@@ -656,7 +656,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService
             if (navigationSource is IEdmEntitySet)
             {
                 var entitySet = navigationSource as IEdmEntitySet;
-                string keySegment = BuildKeyString(entry, entitySet.EntityType(), targetVersion);
+                string keySegment = BuildKeyString(entry, entitySet.EntityType, targetVersion);
                 return new Uri(ServiceConstants.ServiceBaseUri, entitySet.Name + "(" + keySegment + ")");
             }
             else if (navigationSource is IEdmSingleton)

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/DeltaTests/DeltaTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/DeltaTests/DeltaTests.cs
@@ -7,8 +7,11 @@
 namespace Microsoft.Test.OData.Tests.Client.DeltaTests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.OData;
     using Microsoft.OData.Edm;
+    using Microsoft.Spatial;
     using Microsoft.Test.OData.Services.TestServices;
     using Microsoft.Test.OData.Services.TestServices.ODataWCFServiceReference;
     using Microsoft.Test.OData.Tests.Client.Common;
@@ -22,217 +25,918 @@ namespace Microsoft.Test.OData.Tests.Client.DeltaTests
 
         }
 
-        private readonly string[] deltaMimeTypes = new string[]
-            {
-                MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata,
-                MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata,
-                MimeTypes.ApplicationJson + MimeTypes.ODataParameterNoMetadata,
-            };
+        public static readonly IEnumerable<object[]> DeltaMimeTypes = new List<object[]>
+        {
+            new object[] { MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata },
+            new object[] { MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata },
+            new object[] { MimeTypes.ApplicationJson + MimeTypes.ODataParameterNoMetadata },
+        };
 
-        [Fact]
-        public void RequestDeltaLink()
+        [Theory]
+        [MemberData(nameof(DeltaMimeTypes))]
+        public void RequestDeltaLink(string mimeType)
         {
             var customersSet = Model.FindDeclaredEntitySet("Customers");
-            var customerType = customersSet.EntityType();
+            var customerType = customersSet.EntityType;
 
-            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
+            var readerSettings = new ODataMessageReaderSettings { BaseUri = ServiceBaseUri };
 
-            foreach (var mimeType in deltaMimeTypes)
+            var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta", UriKind.Absolute));
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = requestMessage.GetResponse();
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
             {
-                var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta", UriKind.Absolute));
-                requestMessage.SetHeader("Accept", mimeType);
-                var responseMessage = requestMessage.GetResponse();
-                Assert.Equal(200, responseMessage.StatusCode);
+                var resourceSetCounter = 0;
+                var deltaResourceSetCounter = 0;
+                var resourceCounter = 0;
+                var nestedResourceInfoCounter = 0;
+                var deletedResourceCounter = 0;
+                var deltaLinkCounter = 0;
+                var deltaDeletedLinkCounter = 0;
 
-                if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+                using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
                 {
-                    using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
+                    var deltaReader = messageReader.CreateODataDeltaResourceSetReader(customersSet, customerType);
+
+                    while (deltaReader.Read())
                     {
-                        var deltaReader = messageReader.CreateODataDeltaReader(customersSet, customerType);
-
-                        while (deltaReader.Read())
+                        switch (deltaReader.State)
                         {
-                            if (deltaReader.State == ODataDeltaReaderState.DeltaResourceEnd)
-                            {
-                                ODataResource entry = deltaReader.Item as ODataResource;
-                            }
-                            else if (deltaReader.State == ODataDeltaReaderState.DeltaResourceSetEnd)
-                            {
-                                ODataDeltaResourceSet feed = deltaReader.Item as ODataDeltaResourceSet;
-                            }
-                        }
-                        Assert.Equal(ODataDeltaReaderState.Completed, deltaReader.State);
-                    }
-                }
-            }
-        }
+                            case ODataReaderState.ResourceSetEnd:
+                                resourceSetCounter++;
 
-        [Fact]
-        public void RequestDeltaLink_Containment()
-        {
-            var accountsSet = this.Model.FindDeclaredEntitySet("Accounts");
-            var accountType = accountsSet.EntityType();
-            var myPisNav = accountType.FindProperty("MyPaymentInstruments") as IEdmNavigationProperty;
-            var piSet = accountsSet.FindNavigationTarget(myPisNav) as IEdmEntitySetBase;
-            var piType = piSet.EntityType();
+                                break;
+                            case ODataReaderState.DeltaResourceSetEnd:
+                                var deltaFeed = deltaReader.Item as ODataDeltaResourceSet;
+                                Assert.NotNull(deltaFeed);
+                                deltaResourceSetCounter++;
 
-            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
-
-            foreach (var mimeType in deltaMimeTypes)
-            {
-                var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta?$token=containment", UriKind.Absolute));
-                requestMessage.SetHeader("Accept", mimeType);
-                var responseMessage = requestMessage.GetResponse();
-                Assert.Equal(200, responseMessage.StatusCode);
-
-                if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
-                {
-                    using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
-                    {
-                        var deltaReader = messageReader.CreateODataDeltaReader(piSet, piType);
-
-                        while (deltaReader.Read())
-                        {
-                            if (deltaReader.State == ODataDeltaReaderState.DeltaResourceEnd)
-                            {
-                                ODataResource entry = deltaReader.Item as ODataResource;
-
-                            }
-                        }
-                        Assert.Equal(ODataDeltaReaderState.Completed, deltaReader.State);
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        public void RequestDeltaLink_Derived()
-        {
-            var peopleSet = Model.FindDeclaredEntitySet("People");
-            var personType = peopleSet.EntityType();
-
-            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
-
-            foreach (var mimeType in deltaMimeTypes)
-            {
-                var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta?$token=derived", UriKind.Absolute));
-                requestMessage.SetHeader("Accept", mimeType);
-                var responseMessage = requestMessage.GetResponse();
-                Assert.Equal(200, responseMessage.StatusCode);
-
-                if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
-                {
-                    using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
-                    {
-                        var deltaReader = messageReader.CreateODataDeltaReader(peopleSet, personType);
-
-                        while (deltaReader.Read())
-                        {
-                            if (deltaReader.State == ODataDeltaReaderState.DeltaResourceEnd)
-                            {
-                                ODataResource entry = deltaReader.Item as ODataResource;
-
-                            }
-                        }
-                        Assert.Equal(ODataDeltaReaderState.Completed, deltaReader.State);
-                    }
-                }
-            }
-        }
-
-        [Fact]
-        public void RequestDeltaLink_Expanded()
-        {
-            var customersSet = Model.FindDeclaredEntitySet("Customers");
-            var customerType = customersSet.EntityType();
-
-            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
-
-            foreach (var mimeType in deltaMimeTypes)
-            {
-                var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta?$token=expanded", UriKind.Absolute));
-                requestMessage.SetHeader("Accept", mimeType);
-                var responseMessage = requestMessage.GetResponse();
-                Assert.Equal(200, responseMessage.StatusCode);
-
-                // Currently don't test full metadata because the delta reader doesn't support reading
-                // annotations on expanded navigation properties, metadata reference properties and paging.
-                if (mimeType.Contains(MimeTypes.ODataParameterMinimalMetadata))
-                {
-                    using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
-                    {
-                        var deltaReader = messageReader.CreateODataDeltaReader(customersSet, customerType);
-
-                        while (deltaReader.Read())
-                        {
-                            if (deltaReader.State == ODataDeltaReaderState.DeltaResourceSetEnd)
-                            {
-                                Assert.NotNull(deltaReader.Item as ODataDeltaResourceSet);
-                            }
-                            else if (deltaReader.State == ODataDeltaReaderState.DeltaResourceEnd)
-                            {
-                                Assert.NotNull(deltaReader.Item as ODataResource);
-                            }
-                            else if (deltaReader.State == ODataDeltaReaderState.NestedResource)
-                            {
-                                switch (deltaReader.SubState)
+                                break;
+                            case ODataReaderState.ResourceEnd:
+                                var entry = deltaReader.Item as ODataResource;
+                                Assert.NotNull(entry);
+                                var properties = entry.Properties.ToArray();
+                                switch (resourceCounter)
                                 {
-                                    case ODataReaderState.Start:
-                                        Assert.NotNull(deltaReader.Item as ODataNestedResourceInfo);
+                                    case 0:
+                                        var property = Assert.Single(properties);
+                                        Assert.Equal("FirstName", property.Name);
+                                        Assert.Equal("GGGG", property.Value);
+                                        Assert.EndsWith("/Customers(1)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Customers(1)", entry.EditLink.OriginalString);
+                                        }
+
                                         break;
-                                    case ODataReaderState.ResourceSetEnd:
-                                        Assert.NotNull(deltaReader.Item as ODataResourceSet);
+                                    case 1:
+                                        Assert.Equal(2, properties.Length);
+                                        Assert.Equal("OrderID", properties[0].Name);
+                                        Assert.Equal(100, properties[0].Value);
+                                        Assert.Equal("OrderDate", properties[1].Name);
+                                        Assert.EndsWith("/Orders(100)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Orders(100)", entry.EditLink.OriginalString);
+                                        }
+
                                         break;
-                                    case ODataReaderState.ResourceEnd:
-                                        Assert.NotNull(deltaReader.Item as ODataResource);
-                                        break;
-                                    case ODataReaderState.NestedResourceInfoEnd:
-                                        Assert.NotNull(deltaReader.Item as ODataNestedResourceInfo);
-                                        break;
-                                    case ODataReaderState.Completed:
-                                        Assert.NotNull(deltaReader.Item);
+                                    default:
+                                        Assert.True(false, "Expected only 2 resources");
+
                                         break;
                                 }
-                            }
-                        }
 
-                        Assert.Equal(ODataDeltaReaderState.Completed, deltaReader.State);
+                                resourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeletedResourceEnd:
+                                var deletedResource = deltaReader.Item as ODataDeletedResource;
+                                Assert.NotNull(deletedResource);
+                                Assert.EndsWith("/Customers(2)", deletedResource.Id.AbsoluteUri);
+                                Assert.Equal(DeltaDeletedEntryReason.Deleted, deletedResource.Reason);
+                                deletedResourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaLink:
+                                var deltaLink = deltaReader.Item as ODataDeltaLink;
+                                Assert.NotNull(deltaLink);
+                                Assert.EndsWith("/Customers(1)", deltaLink.Source.AbsoluteUri);
+                                Assert.EndsWith("/Orders(7)", deltaLink.Target.AbsoluteUri);
+                                Assert.Equal("Orders", deltaLink.Relationship);
+                                deltaLinkCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaDeletedLink:
+                                var deltaDeletedLink = deltaReader.Item as ODataDeltaDeletedLink;
+                                Assert.EndsWith("/Customers(1)", deltaDeletedLink.Source.AbsoluteUri);
+                                Assert.EndsWith("Orders(8)", deltaDeletedLink.Target.AbsoluteUri);
+                                Assert.Equal("Orders", deltaDeletedLink.Relationship);
+                                Assert.NotNull(deltaDeletedLink);
+                                deltaDeletedLinkCounter++;
+
+                                break;
+                            case ODataReaderState.NestedResourceInfoEnd:
+                                Assert.EndsWith("odata.metadata=full", mimeType);
+                                var nestedResourceInfo = deltaReader.Item as ODataNestedResourceInfo;
+                                Assert.NotNull(nestedResourceInfo);
+                                switch (nestedResourceInfo.Name)
+                                {
+                                    case "Parent":
+                                    case "Orders":
+                                    case "Company":
+                                        break;
+                                    default:
+                                        Assert.True(false, $"Unexpected nested resource: {nestedResourceInfo.Name}");
+
+                                        break;
+                                }
+
+                                Assert.EndsWith($"/Customers(1)/{nestedResourceInfo.Name}/$ref", nestedResourceInfo.AssociationLinkUrl.AbsoluteUri);
+                                Assert.EndsWith($"/Customers(1)/{nestedResourceInfo.Name}", nestedResourceInfo.Url.AbsoluteUri);
+                                nestedResourceInfoCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaResourceSetStart:
+                            case ODataReaderState.ResourceStart:
+                            case ODataReaderState.DeletedResourceStart:
+                            case ODataReaderState.NestedResourceInfoStart:
+
+                                break;
+                            default:
+                                Assert.True(false, $"Unexpected ODataReaderState: {deltaReader.State}");
+
+                                break;
+                        }
                     }
+
+                    Assert.Equal(ODataReaderState.Completed, deltaReader.State);
+                }
+
+                Assert.Equal(0, resourceSetCounter);
+                Assert.Equal(1, deltaResourceSetCounter);
+                Assert.Equal(2, resourceCounter);
+                Assert.Equal(1, deletedResourceCounter);
+                Assert.Equal(1, deltaLinkCounter);
+                Assert.Equal(1, deltaDeletedLinkCounter);
+                if (mimeType.EndsWith("odata.metadata=full"))
+                {
+                    Assert.Equal(3, nestedResourceInfoCounter);
+                }
+                else if (mimeType.EndsWith("odata.metadata=minimal"))
+                {
+                    Assert.Equal(0, nestedResourceInfoCounter);
                 }
             }
         }
 
-        [Fact]
-        public void RequestDeltaLink_Projection()
+        [Theory]
+        [MemberData(nameof(DeltaMimeTypes))]
+        public void RequestDeltaLink_Containment(string mimeType)
+        {
+            var accountsSet = this.Model.FindDeclaredEntitySet("Accounts");
+            var accountType = accountsSet.EntityType;
+            var myPisNav = accountType.FindProperty("MyPaymentInstruments") as IEdmNavigationProperty;
+            var piSet = accountsSet.FindNavigationTarget(myPisNav) as IEdmEntitySetBase;
+            var piType = piSet.EntityType;
+
+            var readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
+
+            var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta?$token=containment", UriKind.Absolute));
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = requestMessage.GetResponse();
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                var resourceSetCounter = 0;
+                var deltaResourceSetCounter = 0;
+                var resourceCounter = 0;
+                var nestedResourceInfoCounter = 0;
+                var deletedResourceCounter = 0;
+                var deltaLinkCounter = 0;
+                var deltaDeletedLinkCounter = 0;
+
+                using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
+                {
+                    var deltaReader = messageReader.CreateODataDeltaResourceSetReader(piSet, piType);
+
+                    while (deltaReader.Read())
+                    {
+                        switch (deltaReader.State)
+                        {
+                            case ODataReaderState.ResourceSetEnd:
+                                resourceSetCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaResourceSetEnd:
+                                var deltaFeed = deltaReader.Item as ODataDeltaResourceSet;
+                                Assert.NotNull(deltaFeed);
+                                deltaResourceSetCounter++;
+
+                                break;
+                            case ODataReaderState.ResourceEnd:
+                                var entry = deltaReader.Item as ODataResource;
+                                Assert.NotNull(entry);
+                                var properties = entry.Properties.ToArray();
+                                switch (resourceCounter)
+                                {
+                                    case 0:
+                                        var property = Assert.Single(properties);
+                                        Assert.Equal("FriendlyName", property.Name);
+                                        Assert.Equal("GGGG", property.Value);
+                                        Assert.EndsWith("/Accounts(103)/MyPaymentInstruments(103901)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Accounts(103)/MyPaymentInstruments(103901)", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    case 1:
+                                        Assert.Equal(3, properties.Length);
+                                        Assert.Equal("TransactionType", properties[0].Name);
+                                        Assert.Equal("OnlinePurchase", properties[0].Value);
+                                        Assert.Equal("TransactionDescription", properties[1].Name);
+                                        Assert.Equal("unknown purchase", properties[1].Value);
+                                        Assert.Equal("Amount", properties[2].Name);
+                                        Assert.Equal(32.1, properties[2].Value);
+                                        Assert.EndsWith("/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901005)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901005)", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    default:
+                                        Assert.True(false, "Expected only 2 resources");
+
+                                        break;
+                                }
+
+                                resourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeletedResourceEnd:
+                                var deletedResource = deltaReader.Item as ODataDeletedResource;
+                                Assert.NotNull(deletedResource);
+                                Assert.EndsWith("/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)", deletedResource.Id.AbsoluteUri);
+                                Assert.Equal(DeltaDeletedEntryReason.Deleted, deletedResource.Reason);
+                                deletedResourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaLink:
+                                var deltaLink = deltaReader.Item as ODataDeltaLink;
+                                Assert.NotNull(deltaLink);
+                                Assert.EndsWith("/Accounts(103)/MyPaymentInstruments(103901)", deltaLink.Source.AbsoluteUri);
+                                Assert.EndsWith("/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901005)", deltaLink.Target.AbsoluteUri);
+                                Assert.Equal("BillingStatements", deltaLink.Relationship);
+                                deltaLinkCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaDeletedLink:
+                                var deltaDeletedLink = deltaReader.Item as ODataDeltaDeletedLink;
+                                Assert.EndsWith("/Accounts(103)/MyPaymentInstruments(103901)", deltaDeletedLink.Source.AbsoluteUri);
+                                Assert.EndsWith("/Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)", deltaDeletedLink.Target.AbsoluteUri);
+                                Assert.Equal("BillingStatements", deltaDeletedLink.Relationship);
+                                Assert.NotNull(deltaDeletedLink);
+                                deltaDeletedLinkCounter++;
+
+                                break;
+                            case ODataReaderState.NestedResourceInfoEnd:
+                                Assert.EndsWith("odata.metadata=full", mimeType);
+                                var nestedResourceInfo = deltaReader.Item as ODataNestedResourceInfo;
+                                Assert.NotNull(nestedResourceInfo);
+                                switch (nestedResourceInfo.Name)
+                                {
+                                    case "TheStoredPI":
+                                    case "BillingStatements":
+                                    case "BackupStoredPI":
+                                        break;
+                                    default:
+                                        Assert.True(false, $"Unexpected nested resource: {nestedResourceInfo.Name}");
+
+                                        break;
+                                }
+
+                                Assert.EndsWith($"/Accounts(103)/MyPaymentInstruments(103901)/{nestedResourceInfo.Name}/$ref", nestedResourceInfo.AssociationLinkUrl.AbsoluteUri);
+                                Assert.EndsWith($"/Accounts(103)/MyPaymentInstruments(103901)/{nestedResourceInfo.Name}", nestedResourceInfo.Url.AbsoluteUri);
+                                nestedResourceInfoCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaResourceSetStart:
+                            case ODataReaderState.ResourceStart:
+                            case ODataReaderState.DeletedResourceStart:
+                            case ODataReaderState.NestedResourceInfoStart:
+                                break;
+                            default:
+                                Assert.True(false, $"Unexpected ODataReaderState: {deltaReader.State}");
+
+                                break;
+                        }
+                    }
+
+                    Assert.Equal(ODataReaderState.Completed, deltaReader.State);
+                }
+
+                Assert.Equal(0, resourceSetCounter);
+                Assert.Equal(1, deltaResourceSetCounter);
+                Assert.Equal(2, resourceCounter);
+                Assert.Equal(1, deletedResourceCounter);
+                Assert.Equal(1, deltaLinkCounter);
+                Assert.Equal(1, deltaDeletedLinkCounter);
+                if (mimeType.EndsWith("odata.metadata=full"))
+                {
+                    Assert.Equal(3, nestedResourceInfoCounter);
+                }
+                else if (mimeType.EndsWith("odata.metadata=minimal"))
+                {
+                    Assert.Equal(0, nestedResourceInfoCounter);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DeltaMimeTypes))]
+        public void RequestDeltaLink_Derived(string mimeType)
+        {
+            var peopleSet = Model.FindDeclaredEntitySet("People");
+            var personType = peopleSet.EntityType;
+
+            var readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
+
+            var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta?$token=derived", UriKind.Absolute));
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = requestMessage.GetResponse();
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                var resourceSetCounter = 0;
+                var deltaResourceSetCounter = 0;
+                var resourceCounter = 0;
+                var nestedResourceInfoCounter = 0;
+                var deletedResourceCounter = 0;
+                var deltaLinkCounter = 0;
+                var deltaDeletedLinkCounter = 0;
+
+                using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
+                {
+                    var deltaReader = messageReader.CreateODataDeltaResourceSetReader(peopleSet, personType);
+
+                    while (deltaReader.Read())
+                    {
+                        switch (deltaReader.State)
+                        {
+                            case ODataReaderState.ResourceSetEnd:
+                                resourceSetCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaResourceSetEnd:
+                                var deltaFeed = deltaReader.Item as ODataDeltaResourceSet;
+                                Assert.NotNull(deltaFeed);
+                                deltaResourceSetCounter++;
+
+                                break;
+                            case ODataReaderState.ResourceEnd:
+                                var entry = deltaReader.Item as ODataResource;
+                                Assert.NotNull(entry);
+                                var properties = entry.Properties.ToArray();
+                                switch (resourceCounter)
+                                {
+                                    case 0:
+                                        var property = Assert.Single(properties);
+                                        Assert.Equal("City", property.Name);
+                                        Assert.Equal("GGGG", property.Value);
+                                        Assert.EndsWith("/People(1)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("People(1)/Microsoft.Test.OData.Services.ODataWCFService.Customer", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    case 1:
+                                        Assert.Equal(2, properties.Length);
+                                        Assert.Equal("OrderID", properties[0].Name);
+                                        Assert.Equal(100, properties[0].Value);
+                                        Assert.Equal("OrderDate", properties[1].Name);
+                                        Assert.EndsWith("/Orders(100)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Orders(100)", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    default:
+                                        Assert.True(false, "Expected only 2 resources");
+
+                                        break;
+                                }
+
+                                resourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeletedResourceEnd:
+                                var deletedResource = deltaReader.Item as ODataDeletedResource;
+                                Assert.NotNull(deletedResource);
+                                Assert.EndsWith("/People(2)", deletedResource.Id.AbsoluteUri);
+                                Assert.Equal(DeltaDeletedEntryReason.Changed, deletedResource.Reason);
+                                deletedResourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaLink:
+                                var deltaLink = deltaReader.Item as ODataDeltaLink;
+                                Assert.NotNull(deltaLink);
+                                Assert.EndsWith("/People(1)", deltaLink.Source.AbsoluteUri);
+                                Assert.EndsWith("/Orders(7)", deltaLink.Target.AbsoluteUri);
+                                Assert.Equal("Orders", deltaLink.Relationship);
+                                deltaLinkCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaDeletedLink:
+                                var deltaDeletedLink = deltaReader.Item as ODataDeltaDeletedLink;
+                                Assert.EndsWith("/People(1)", deltaDeletedLink.Source.AbsoluteUri);
+                                Assert.EndsWith("Orders(8)", deltaDeletedLink.Target.AbsoluteUri);
+                                Assert.Equal("Orders", deltaDeletedLink.Relationship);
+                                Assert.NotNull(deltaDeletedLink);
+                                deltaDeletedLinkCounter++;
+
+                                break;
+                            case ODataReaderState.NestedResourceInfoEnd:
+                                Assert.EndsWith("odata.metadata=full", mimeType);
+                                var nestedResourceInfo = deltaReader.Item as ODataNestedResourceInfo;
+                                Assert.NotNull(nestedResourceInfo);
+                                switch (nestedResourceInfo.Name)
+                                {
+                                    case "Parent":
+                                    case "Orders":
+                                    case "Company":
+                                        break;
+                                    default:
+                                        Assert.True(false, $"Unexpected nested resource: {nestedResourceInfo.Name}");
+
+                                        break;
+                                }
+
+                                Assert.EndsWith($"/People(1)/Microsoft.Test.OData.Services.ODataWCFService.Customer/{nestedResourceInfo.Name}/$ref", nestedResourceInfo.AssociationLinkUrl.AbsoluteUri);
+                                Assert.EndsWith($"/People(1)/Microsoft.Test.OData.Services.ODataWCFService.Customer/{nestedResourceInfo.Name}", nestedResourceInfo.Url.AbsoluteUri);
+                                nestedResourceInfoCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaResourceSetStart:
+                            case ODataReaderState.ResourceStart:
+                            case ODataReaderState.DeletedResourceStart:
+                            case ODataReaderState.NestedResourceInfoStart:
+                                break;
+                            default:
+                                Assert.True(false, $"Unexpected ODataReaderState: {deltaReader.State}");
+
+                                break;
+                        }
+
+                    }
+
+                    Assert.Equal(ODataReaderState.Completed, deltaReader.State);
+                }
+
+                Assert.Equal(0, resourceSetCounter);
+                Assert.Equal(1, deltaResourceSetCounter);
+                Assert.Equal(2, resourceCounter);
+                Assert.Equal(1, deletedResourceCounter);
+                Assert.Equal(1, deltaLinkCounter);
+                Assert.Equal(1, deltaDeletedLinkCounter);
+                if (mimeType.EndsWith("odata.metadata=full"))
+                {
+                    Assert.Equal(3, nestedResourceInfoCounter);
+                }
+                else if (mimeType.EndsWith("odata.metadata=minimal"))
+                {
+                    Assert.Equal(0, nestedResourceInfoCounter);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DeltaMimeTypes))]
+        public void RequestDeltaLink_Expanded(string mimeType)
         {
             var customersSet = Model.FindDeclaredEntitySet("Customers");
-            var cutomerType = customersSet.EntityType();
+            var customerType = customersSet.EntityType;
 
-            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
+            var readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
 
-            foreach (var mimeType in deltaMimeTypes)
+            var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta?$token=expanded", UriKind.Absolute));
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = requestMessage.GetResponse();
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
             {
-                var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta?$token=projection", UriKind.Absolute));
-                requestMessage.SetHeader("Accept", mimeType);
-                var responseMessage = requestMessage.GetResponse();
-                Assert.Equal(200, responseMessage.StatusCode);
+                var resourceSetCounter = 0;
+                var deltaResourceSetCounter = 0;
+                var resourceCounter = 0;
+                var nestedResourceInfoCounter = 0;
+                var deletedResourceCounter = 0;
+                var deltaLinkCounter = 0;
+                var deltaDeletedLinkCounter = 0;
 
-                if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+
+                using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
                 {
-                    using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
+                    var deltaReader = messageReader.CreateODataDeltaResourceSetReader(customersSet, customerType);
+
+                    while (deltaReader.Read())
                     {
-                        var deltaReader = messageReader.CreateODataDeltaReader(customersSet, cutomerType);
-
-                        while (deltaReader.Read())
+                        switch (deltaReader.State)
                         {
-                            if (deltaReader.State == ODataDeltaReaderState.DeltaResourceEnd)
-                            {
-                                ODataResource entry = deltaReader.Item as ODataResource;
+                            case ODataReaderState.ResourceSetEnd:
+                                var feed = deltaReader.Item as ODataResourceSet;
+                                Assert.NotNull(feed);
+                                resourceSetCounter++;
 
-                            }
+                                break;
+                            case ODataReaderState.DeltaResourceSetEnd:
+                                var deltaFeed = deltaReader.Item as ODataDeltaResourceSet;
+                                Assert.NotNull(deltaFeed);
+                                deltaResourceSetCounter++;
+
+                                break;
+                            case ODataReaderState.ResourceEnd:
+                                var entry = deltaReader.Item as ODataResource;
+                                Assert.NotNull(entry);
+                                var properties = entry.Properties.ToArray();
+                                switch (resourceCounter)
+                                {
+                                    case 0: // HomeAddress complex property
+                                        Assert.Equal(3, properties.Length);
+                                        Assert.Equal("Street", properties[0].Name);
+                                        Assert.Equal("Zixing Road", properties[0].Value);
+                                        Assert.Equal("City", properties[1].Name);
+                                        Assert.Equal("Shanghai", properties[1].Value);
+                                        Assert.Equal("PostalCode", properties[2].Name);
+                                        Assert.Equal("200001", properties[2].Value);
+
+                                        break;
+                                    case 1: // InfoFromCustomer complex property
+                                        var customerMessageProperty = Assert.Single(properties);
+                                        Assert.Equal("CustomerMessage", customerMessageProperty.Name);
+                                        Assert.Equal("XXL", customerMessageProperty.Value);
+
+                                        break;
+                                    case 2:
+                                        Assert.Equal(6, properties.Length);
+                                        Assert.Equal("OrderDate", properties[0].Name);
+                                        Assert.Equal("OrderID", properties[1].Name);
+                                        Assert.Equal(8, properties[1].Value);
+                                        Assert.Equal("OrderShelfLifes", properties[2].Name);
+                                        var orderShelfLifesValue = Assert.IsType<ODataCollectionValue>(properties[2].Value);
+                                        Assert.Single(orderShelfLifesValue.Items);
+                                        Assert.Equal("ShelfLife", properties[3].Name);
+                                        Assert.Equal("ShipDate", properties[4].Name);
+                                        Assert.Equal("ShipTime", properties[5].Name);
+                                        Assert.EndsWith("/Orders(8)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Orders(8)", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    case 3:
+                                        Assert.Equal(6, properties.Length);
+                                        Assert.Equal("FirstName", properties[0].Name);
+                                        Assert.Equal("Jill", properties[0].Value);
+                                        Assert.Equal("LastName", properties[1].Name);
+                                        Assert.Equal("Jones", properties[1].Value);
+                                        Assert.Equal("Numbers", properties[2].Name);
+                                        Assert.Empty(Assert.IsType<ODataCollectionValue>(properties[2].Value).Items);
+                                        Assert.Equal("Emails", properties[3].Name);
+                                        Assert.Empty(Assert.IsType<ODataCollectionValue>(properties[3].Value).Items);
+                                        Assert.Equal("PersonID", properties[4].Name);
+                                        Assert.Equal(2, properties[4].Value);
+                                        Assert.Equal("Home", properties[5].Name);
+                                        Assert.IsAssignableFrom<GeographyPoint>(properties[5].Value);
+                                        Assert.EndsWith("People(2)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("People(2)", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    case 4:
+                                        var firstNameProperty = Assert.Single(properties);
+                                        Assert.Equal("FirstName", firstNameProperty.Name);
+                                        Assert.Equal("GGGG", firstNameProperty.Value);
+                                        Assert.EndsWith("/Customers(1)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Customers(1)", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    default:
+                                        Assert.True(false, "Expected only 5 resources");
+
+                                        break;
+                                }
+
+                                resourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeletedResourceEnd:
+                                deletedResourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaLink:
+                                deltaLinkCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaDeletedLink:
+                                deltaDeletedLinkCounter++;
+
+                                break;
+                            case ODataReaderState.NestedResourceInfoEnd:
+                                var nestedResourceInfo = deltaReader.Item as ODataNestedResourceInfo;
+                                Assert.NotNull(nestedResourceInfo);
+                                switch (nestedResourceInfo.Name)
+                                {
+                                    case "HomeAddress":
+                                        // Complex nested resource info
+                                        Assert.Null(nestedResourceInfo.AssociationLinkUrl);
+                                        Assert.Null(nestedResourceInfo.Url);
+
+                                        break;
+                                    case "InfoFromCustomer":
+                                        // Complex nested resource info
+                                        Assert.Null(nestedResourceInfo.AssociationLinkUrl);
+                                        Assert.Null(nestedResourceInfo.Url);
+
+                                        break;
+                                    case "LoggedInEmployee":
+                                        // Reading of annotations on expanded navigation properties currently not supported
+                                        Assert.Null(nestedResourceInfo.AssociationLinkUrl);
+                                        Assert.Null(nestedResourceInfo.Url);
+
+                                        break;
+                                    case "CustomerForOrder":
+                                        // Reading of annotations on expanded navigation properties currently not supported
+                                        Assert.Null(nestedResourceInfo.AssociationLinkUrl);
+                                        Assert.Null(nestedResourceInfo.Url);
+
+                                        break;
+                                    case "OrderDetails":
+                                        // Reading of annotations on expanded navigation properties currently not supported
+                                        Assert.Null(nestedResourceInfo.AssociationLinkUrl);
+                                        Assert.Null(nestedResourceInfo.Url);
+
+                                        break;
+                                    case "Orders":
+                                        Assert.EndsWith("/Customers(1)/Orders/$ref", nestedResourceInfo.AssociationLinkUrl.AbsoluteUri);
+                                        Assert.EndsWith("/Customers(1)/Orders", nestedResourceInfo.Url.AbsoluteUri);
+
+                                        break;
+                                    case "Parent":
+                                        var associationLink = nestedResourceInfo.AssociationLinkUrl.AbsoluteUri;
+                                        var navigationLink = nestedResourceInfo.Url.AbsoluteUri;
+                                        Assert.True(associationLink.EndsWith("/People(2)/Parent/$ref") || associationLink.EndsWith("/Customers(1)/Parent/$ref"));
+                                        Assert.True(navigationLink.EndsWith("/People(2)/Parent") || navigationLink.EndsWith("/Customers(1)/Parent"));
+
+                                        break;
+                                    case "Company":
+                                        Assert.EndsWith("/Customers(1)/Company/$ref", nestedResourceInfo.AssociationLinkUrl.AbsoluteUri);
+                                        Assert.EndsWith("/Customers(1)/Company", nestedResourceInfo.Url.AbsoluteUri);
+
+                                        break;
+                                    default:
+                                        Assert.True(false, $"Unexpected nested resource: {nestedResourceInfo.Name}");
+
+                                        break;
+                                }
+
+                                nestedResourceInfoCounter++;
+
+                                break;
+                            case ODataReaderState.ResourceSetStart:
+                            case ODataReaderState.DeltaResourceSetStart:
+                            case ODataReaderState.ResourceStart:
+                            case ODataReaderState.DeletedResourceStart:
+                            case ODataReaderState.NestedResourceInfoStart:
+                                break;
+                            default:
+                                Assert.True(false, $"Unexpected ODataReaderState: {deltaReader.State}");
+
+                                break;
                         }
-                        Assert.Equal(ODataDeltaReaderState.Completed, deltaReader.State);
+
                     }
+
+                    Assert.Equal(ODataReaderState.Completed, deltaReader.State);
+                }
+
+                Assert.Equal(1, resourceSetCounter);
+                Assert.Equal(1, deltaResourceSetCounter);
+                Assert.Equal(5, resourceCounter);
+                Assert.Equal(0, deletedResourceCounter);
+                Assert.Equal(0, deltaLinkCounter);
+                Assert.Equal(0, deltaDeletedLinkCounter);
+                if (mimeType.EndsWith("odata.metadata=full"))
+                {
+                    Assert.Equal(9, nestedResourceInfoCounter);
+                }
+                else if (mimeType.EndsWith("odata.metadata=minimal"))
+                {
+                    Assert.Equal(4, nestedResourceInfoCounter);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(DeltaMimeTypes))]
+        public void RequestDeltaLink_Projection(string mimeType)
+        {
+            var customersSet = Model.FindDeclaredEntitySet("Customers");
+            var cutomerType = customersSet.EntityType;
+
+            var readerSettings = new ODataMessageReaderSettings() { BaseUri = ServiceBaseUri };
+
+            var requestMessage = new HttpWebRequestMessage(new Uri(ServiceBaseUri.AbsoluteUri + "$delta?$token=projection", UriKind.Absolute));
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = requestMessage.GetResponse();
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                var resourceSetCounter = 0;
+                var deltaResourceSetCounter = 0;
+                var resourceCounter = 0;
+                var nestedResourceInfoCounter = 0;
+                var deletedResourceCounter = 0;
+                var deltaLinkCounter = 0;
+                var deltaDeletedLinkCounter = 0;
+
+                using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, Model))
+                {
+                    var deltaReader = messageReader.CreateODataDeltaResourceSetReader(customersSet, cutomerType);
+
+                    while (deltaReader.Read())
+                    {
+                        switch (deltaReader.State)
+                        {
+                            case ODataReaderState.ResourceSetEnd:
+                                resourceSetCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaResourceSetEnd:
+                                var deltaFeed = deltaReader.Item as ODataDeltaResourceSet;
+                                Assert.NotNull(deltaFeed);
+                                deltaResourceSetCounter++;
+
+                                break;
+                            case ODataReaderState.ResourceEnd:
+                                var entry = deltaReader.Item as ODataResource;
+                                Assert.NotNull(entry);
+                                var properties = entry.Properties.ToArray();
+                                switch (resourceCounter)
+                                {
+                                    case 0:
+                                        Assert.Equal(4, properties.Length);
+                                        Assert.Equal("PersonID", properties[0].Name);
+                                        Assert.Equal(1, properties[0].Value);
+                                        Assert.Equal("FirstName", properties[1].Name);
+                                        Assert.Equal("FFFF", properties[1].Value);
+                                        Assert.Equal("LastName", properties[2].Name);
+                                        Assert.Equal("LLLL", properties[2].Value);
+                                        Assert.Equal("City", properties[3].Name);
+                                        Assert.Equal("Beijing", properties[3].Value);
+                                        Assert.EndsWith("/Customers(1)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Customers(1)", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    case 1:
+                                        Assert.Equal(2, properties.Length);
+                                        Assert.Equal("OrderID", properties[0].Name);
+                                        Assert.Equal(100, properties[0].Value);
+                                        Assert.Equal("OrderDate", properties[1].Name);
+                                        Assert.EndsWith("/Orders(100)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Orders(100)", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    case 2:
+                                        Assert.Equal(2, properties.Length);
+                                        Assert.Equal("PersonID", properties[0].Name);
+                                        Assert.Equal(2, properties[0].Value);
+                                        Assert.Equal("FirstName", properties[1].Name);
+                                        Assert.Equal("AAAA", properties[1].Value);
+                                        Assert.EndsWith("/Customers(2)", entry.Id.AbsoluteUri);
+                                        if (mimeType.EndsWith("odata.metadata=full"))
+                                        {
+                                            Assert.NotNull(entry.EditLink);
+                                            Assert.EndsWith("Customers(2)", entry.EditLink.OriginalString);
+                                        }
+
+                                        break;
+                                    default:
+                                        Assert.True(false, "Expected only 3 resources");
+
+                                        break;
+                                }
+
+                                resourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeletedResourceEnd:
+                                var deletedResource = deltaReader.Item as ODataDeletedResource;
+                                Assert.NotNull(deletedResource);
+                                Assert.EndsWith("/Orders(20)", deletedResource.Id.AbsoluteUri);
+                                Assert.Equal(DeltaDeletedEntryReason.Deleted, deletedResource.Reason);
+                                deletedResourceCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaLink:
+                                var deltaLink = deltaReader.Item as ODataDeltaLink;
+                                Assert.NotNull(deltaLink);
+                                Assert.EndsWith("/Customers(1)", deltaLink.Source.AbsoluteUri);
+                                Assert.EndsWith("/Orders(7)", deltaLink.Target.AbsoluteUri);
+                                Assert.Equal("Orders", deltaLink.Relationship);
+                                deltaLinkCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaDeletedLink:
+                                var deltaDeletedLink = deltaReader.Item as ODataDeltaDeletedLink;
+                                Assert.EndsWith("/Customers(1)", deltaDeletedLink.Source.AbsoluteUri);
+                                Assert.EndsWith("Orders(8)", deltaDeletedLink.Target.AbsoluteUri);
+                                Assert.Equal("Orders", deltaDeletedLink.Relationship);
+                                Assert.NotNull(deltaDeletedLink);
+                                deltaDeletedLinkCounter++;
+
+                                break;
+                            case ODataReaderState.NestedResourceInfoEnd:
+                                Assert.EndsWith("odata.metadata=full", mimeType);
+                                var nestedResourceInfo = deltaReader.Item as ODataNestedResourceInfo;
+                                Assert.NotNull(nestedResourceInfo);
+                                switch (nestedResourceInfo.Name)
+                                {
+                                    case "Orders":
+                                        var associationLink = nestedResourceInfo.AssociationLinkUrl.AbsoluteUri;
+                                        var navigationLink = nestedResourceInfo.Url.AbsoluteUri;
+                                        Assert.True(associationLink.EndsWith("Customers(1)/Orders/$ref") || associationLink.EndsWith("Customers(2)/Orders/$ref"));
+                                        Assert.True(navigationLink.EndsWith("Customers(1)/Orders") || navigationLink.EndsWith("Customers(2)/Orders"));
+
+                                        break;
+                                    default:
+                                        Assert.True(false, $"Unexpected nested resource: {nestedResourceInfo.Name}");
+
+                                        break;
+                                }
+
+                                nestedResourceInfoCounter++;
+
+                                break;
+                            case ODataReaderState.DeltaResourceSetStart:
+                            case ODataReaderState.ResourceStart:
+                            case ODataReaderState.DeletedResourceStart:
+                            case ODataReaderState.NestedResourceInfoStart:
+                                break;
+                            default:
+                                Assert.True(false, $"Unexpected ODataReaderState: {deltaReader.State}");
+
+                                break;
+                        }
+                    }
+
+                    Assert.Equal(ODataReaderState.Completed, deltaReader.State);
+                }
+
+                Assert.Equal(0, resourceSetCounter);
+                Assert.Equal(1, deltaResourceSetCounter);
+                Assert.Equal(3, resourceCounter);
+                Assert.Equal(1, deletedResourceCounter);
+                Assert.Equal(1, deltaLinkCounter);
+                Assert.Equal(1, deltaDeletedLinkCounter);
+                if (mimeType.EndsWith("odata.metadata=full"))
+                {
+                    Assert.Equal(2, nestedResourceInfoCounter);
+                }
+                else if (mimeType.EndsWith("odata.metadata=minimal"))
+                {
+                    Assert.Equal(0, nestedResourceInfoCounter);
                 }
             }
         }

--- a/test/FunctionalTests/Framework/Util/MetadataUtil.cs
+++ b/test/FunctionalTests/Framework/Util/MetadataUtil.cs
@@ -176,7 +176,7 @@ namespace System.Data.Test.Astoria
                 {
                     foreach (IEdmEntitySet set in container.EntitySets())
                     {
-                        if (IsAssignableFrom(set.EntityType(), edmType))
+                        if (IsAssignableFrom(set.EntityType, edmType))
                             return false;
                     }
                 }
@@ -266,7 +266,7 @@ namespace System.Data.Test.Astoria
 
                 AstoriaTestLog.IsNotNull(dataWebEntitySetBase);
                 AstoriaTestLog.AreEqual(entitySetBase.Name, dataWebEntitySetBase.Name);
-                AstoriaTestLog.AreEqual(entitySetBase.EntityType().FullName(), dataWebEntitySetBase.EntityType().FullName());
+                AstoriaTestLog.AreEqual(entitySetBase.EntityType.FullName(), dataWebEntitySetBase.EntityType.FullName());
 
                 ++numberOfEntitySets;
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMetadataContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataMetadataContextTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OData.Tests.Evaluation
                 null /*metadataDocumentUri*/,
                 null /*requestUri*/);
             IEdmEntitySet set = this.edmModel.EntityContainer.FindEntitySet("Products");
-            ODataResource entry = TestUtils.CreateODataEntry(set, new EdmStructuredValue(new EdmEntityTypeReference(set.EntityType(), true), new IEdmPropertyValue[0]), set.EntityType());
+            ODataResource entry = TestUtils.CreateODataEntry(set, new EdmStructuredValue(new EdmEntityTypeReference(set.EntityType, true), new IEdmPropertyValue[0]), set.EntityType);
             Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree), NavigationSource = set }, false);
             action.Throws<ODataException>(Strings.ODataJsonLightResourceMetadataContext_MetadataAnnotationMustBeInPayload("odata.context"));
         }
@@ -49,7 +49,7 @@ namespace Microsoft.OData.Tests.Evaluation
                 new Uri("http://myservice.svc/$metadata", UriKind.Absolute),
                 null /*requestUri*/);
             IEdmEntitySet set = this.edmModel.EntityContainer.FindEntitySet("Products");
-            ODataResource entry = TestUtils.CreateODataEntry(set, new EdmStructuredValue(new EdmEntityTypeReference(set.EntityType(), true), new IEdmPropertyValue[0]), set.EntityType());
+            ODataResource entry = TestUtils.CreateODataEntry(set, new EdmStructuredValue(new EdmEntityTypeReference(set.EntityType, true), new IEdmPropertyValue[0]), set.EntityType);
             Action action = () => context.GetResourceMetadataBuilderForReader(new TestJsonLightReaderEntryState { Resource = entry, SelectedProperties = new SelectedPropertiesNode("*", null, null), NavigationSource = set }, false);
             action.DoesNotThrow();
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -572,7 +572,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
                 var writer = new ODataMessageWriter((IODataResponseMessage)message, settings, model);
 
                 // write payload
-                var entitySetWriter = writer.CreateODataResourceSetWriter(entitySet, entitySet.EntityType());
+                var entitySetWriter = writer.CreateODataResourceSetWriter(entitySet, entitySet.EntityType);
                 entitySetWriter.WriteStart(new ODataResourceSet());
                 var resource = new ODataResource
                 {
@@ -2118,7 +2118,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             {
                 NavigationSourceKind = EdmNavigationSourceKind.EntitySet,
                 ExpectedTypeName = EntityType.FullName(),
-                NavigationSourceEntityTypeName = EntitySet.EntityType().FullName(),
+                NavigationSourceEntityTypeName = EntitySet.EntityType.FullName(),
                 IsFromCollection = true,
                 NavigationSourceName = EntitySet.Name
             };

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
@@ -767,6 +767,8 @@ namespace Microsoft.OData.Core.Tests.JsonLight
 
             public IEdmType Type => new EdmEntityType("ns", "products");
 
+            public IEdmEntityType EntityType => this.Type.AsElementType() as IEdmEntityType;
+
             public string Name => "products";
 
             public IEdmNavigationSource ParentNavigationSource => throw new NotImplementedException();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderTests.cs
@@ -274,7 +274,7 @@ namespace Microsoft.OData.Tests
 
             IEdmEntitySet customers = Assert.Single(model.EntityContainer.EntitySets());
             Assert.Equal("Customers", customers.Name);
-            Assert.Same(customerType, customers.EntityType());
+            Assert.Same(customerType, customers.EntityType);
 #else
             Action test = () => reader.ReadMetadataDocument();
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/MetadataUriRoundTripTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/MetadataUriRoundTripTests.cs
@@ -62,7 +62,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
             readerResponseMemoryMessage.SetHeader("Content-Type", "application/json");
 
             var messageReader = new ODataMessageReader((IODataResponseMessage)readerResponseMemoryMessage, new ODataMessageReaderSettings() {MaxProtocolVersion = ODataVersion.V4, EnableMessageStreamDisposal = false}, this.model);
-            var organizationReader = messageReader.CreateODataResourceReader(this.organizationsSet, this.organizationsSet.EntityType());
+            var organizationReader = messageReader.CreateODataResourceReader(this.organizationsSet, this.organizationsSet.EntityType);
             Assert.True(organizationReader.Read());
             Assert.IsType<ODataResource>(organizationReader.Item);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamReadingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamReadingTests.cs
@@ -1436,7 +1436,7 @@ namespace Microsoft.OData.Tests.JsonLight
                     messageReader = new ODataMessageReader(responseMessage, variant.Settings, Model);
             }
 
-            ODataReader reader = messageReader.CreateODataResourceReader(CustomersEntitySet, CustomersEntitySet.EntityType());
+            ODataReader reader = messageReader.CreateODataResourceReader(CustomersEntitySet, CustomersEntitySet.EntityType);
             return reader;
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
@@ -820,7 +820,7 @@ namespace Microsoft.OData.Tests.JsonLight
                 messageWriter =  new ODataMessageWriter(responseMessage, settings, this.GetModel());
             }
 
-            ODataWriter writer = messageWriter.CreateODataResourceWriter(this.customersEntitySet, this.customersEntitySet.EntityType());
+            ODataWriter writer = messageWriter.CreateODataResourceWriter(this.customersEntitySet, this.customersEntitySet.EntityType);
             return writer;
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/UrlBuilderWithParameterAliasTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/UrlBuilderWithParameterAliasTests.cs
@@ -235,7 +235,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.NotNull(function);
             var functionCallNode = odataUri.Filter.Expression.ShouldBeSingleValueFunctionCallQueryNode(function);
             Assert.IsType<NamedFunctionParameterNode>(functionCallNode.Parameters.Last()).Value.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetString(true));
-            aliasNodes["@p1"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType().FindProperty("Name"));
+            aliasNodes["@p1"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType.FindProperty("Name"));
 
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(fullUri, actualUri, new UriComparer<Uri>());
@@ -259,7 +259,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             var functionCallNode = odataUri.Filter.Expression.ShouldBeSingleValueFunctionCallQueryNode(function);
             Assert.IsType<NamedFunctionParameterNode>(functionCallNode.Parameters.Last()).Value.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetString(true));
             aliasNodes["@p1"].ShouldBeParameterAliasNode("@p2", EdmCoreModel.Instance.GetString(true));
-            aliasNodes["@p2"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType().FindProperty("Name"));
+            aliasNodes["@p2"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType.FindProperty("Name"));
 
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(fullUri, actualUri, new UriComparer<Uri>());
@@ -284,7 +284,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
 
             Assert.IsType<NamedFunctionParameterNode>(functionCallNode.Parameters.Last()).Value.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetString(true));
             aliasNodes["@p1"].ShouldBeParameterAliasNode("@p2", EdmCoreModel.Instance.GetString(true));
-            aliasNodes["@p2"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType().FindProperty("Name"));
+            aliasNodes["@p2"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType.FindProperty("Name"));
 
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(fullUri, actualUri, new UriComparer<Uri>());
@@ -348,7 +348,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
 
             IDictionary<string, SingleValueNode> aliasNodes = odataUri.ParameterAliasNodes;
             Assert.IsType<SingleValueFunctionCallNode>(odataUri.Filter.Expression).Parameters.First().ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetString(true));
-            aliasNodes["@p1"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType().FindProperty("Name"));
+            aliasNodes["@p1"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType.FindProperty("Name"));
 
             Uri actualUri = odataUri.BuildUri(ODataUrlKeyDelimiter.Parentheses);
             Assert.Equal(fullUri, actualUri, new UriComparer<Uri>());

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
@@ -316,7 +316,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                     var parameters = filterClause.Expression.ShouldBeSingleValueFunctionCallQueryNode(function).Parameters;
                     var paramNode = Assert.IsType<NamedFunctionParameterNode>(parameters.Last());
                     paramNode.Value.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetString(true));
-                    aliasNodes["@p1"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType().FindProperty("Name"));
+                    aliasNodes["@p1"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType.FindProperty("Name"));
                 });
         }
 
@@ -334,7 +334,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                     var paramNode = Assert.IsType<NamedFunctionParameterNode>(parameters.Last());
                     paramNode.Value.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetString(true));
                     aliasNodes["@p1"].ShouldBeParameterAliasNode("@p2", EdmCoreModel.Instance.GetString(true));
-                    aliasNodes["@p2"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType().FindProperty("Name"));
+                    aliasNodes["@p2"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType.FindProperty("Name"));
                 });
         }
 
@@ -364,7 +364,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                     var paramNode = Assert.IsType<NamedFunctionParameterNode>(parameters.Last());
                     paramNode.Value.ShouldBeParameterAliasNode("@p1", EdmCoreModel.Instance.GetString(true));
                     aliasNodes["@p1"].ShouldBeParameterAliasNode("@p2", EdmCoreModel.Instance.GetString(true));
-                    aliasNodes["@p2"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType().FindProperty("Name"));
+                    aliasNodes["@p2"].ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPeopleSet().EntityType.FindProperty("Name"));
                 });
         }
 
@@ -1033,7 +1033,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                 IEdmEntitySet entitySet = entitySource as IEdmEntitySet;
 
                 var dic = queries.ToDictionary(customQueryOptionToken => customQueryOptionToken.Name, customQueryOptionToken => queries.GetQueryOptionValue(customQueryOptionToken.Name));
-                ODataQueryOptionParser queryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel, entitySet.EntityType(), entitySet, dic)
+                ODataQueryOptionParser queryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel, entitySet?.EntityType, entitySet, dic)
                 {
                     Configuration = { ParameterAliasValueAccessor = parser.ParameterAliasValueAccessor }
                 };

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SetBasedOperationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/SetBasedOperationTests.cs
@@ -432,7 +432,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                 IEdmEntitySet entitySet = entitySource as IEdmEntitySet;
 
                 var dic = queries.ToDictionary(customQueryOptionToken => customQueryOptionToken.Name, customQueryOptionToken => queries.GetQueryOptionValue(customQueryOptionToken.Name));
-                ODataQueryOptionParser queryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel, entitySet.EntityType(), entitySet, dic)
+                ODataQueryOptionParser queryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel, entitySet?.EntityType, entitySet, dic)
                 {
                     Configuration = { ParameterAliasValueAccessor = parser.ParameterAliasValueAccessor }
                 };

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/CommonWritingValidationScenarioTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/CommonWritingValidationScenarioTests.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer
             foreach (string contentType in new string[] { "application/json" })
             {
                 var messageWriter = CreateODataMessageWriter(model, contentType);
-                var odataWriter = messageWriter.CreateODataResourceWriter(null, entitySet.EntityType());
+                var odataWriter = messageWriter.CreateODataResourceWriter(null, entitySet.EntityType);
                 Action test = () =>
                 {
                     var entry = new ODataResource();
@@ -110,7 +110,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer
             foreach (string contentType in new string[] { "application/json" })
             {
                 var messageWriter = CreateODataMessageWriter(model, contentType);
-                var odataWriter = messageWriter.CreateODataResourceWriter(null, entitySet.EntityType());
+                var odataWriter = messageWriter.CreateODataResourceWriter(null, entitySet.EntityType);
                 Action test = () =>
                 {
                     var entry = new ODataResource()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/KeyBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/KeyBinderTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             var namedValues = new[] { new NamedValue(null, new LiteralToken(123)), new NamedValue(null, new LiteralToken(456)), };
 
             Action bind = () => this.keyBinder.BindKeyValues(collectionNode, namedValues, model);
-            bind.Throws<ODataException>(Strings.MetadataBinder_UnnamedKeyValueOnTypeWithMultipleKeyProperties(HardCodedTestModel.GetLionSet().EntityType().FullTypeName()));
+            bind.Throws<ODataException>(Strings.MetadataBinder_UnnamedKeyValueOnTypeWithMultipleKeyProperties(HardCodedTestModel.GetLionSet().EntityType.FullTypeName()));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/EntitySetNode.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/EntitySetNode.cs
@@ -38,7 +38,7 @@ namespace Microsoft.OData.Tests.UriParser
         {
             ExceptionUtils.CheckArgumentNotNull(entitySet, "entitySet");
             this.entitySet = entitySet;
-            this.entityType = new EdmEntityTypeReference(this.NavigationSource.EntityType(), false);
+            this.entityType = new EdmEntityTypeReference(this.NavigationSource.EntityType, false);
             this.collectionTypeReference = EdmCoreModel.GetCollection(this.entityType);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/PathParserModelUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Metadata/PathParserModelUtilsTests.cs
@@ -120,7 +120,7 @@ namespace Microsoft.OData.Tests.UriParser.Metadata
             var container = new EdmEntityContainer("Fake", "Container");
             model.AddElement(container);
             var entitySet = container.AddEntitySet("EntitySet", new EdmEntityType("Fake", "EntityType"));
-            var function = new EdmFunction("Fake", "FakeFunction", new EdmEntityTypeReference(entitySet.EntityType(), false));
+            var function = new EdmFunction("Fake", "FakeFunction", new EdmEntityTypeReference(entitySet.EntityType, false));
             var operationImport = container.AddFunctionImport("FakeAction", function, new EdmPathExpression(entitySet.Name));
             Assert.Same(entitySet, operationImport.GetTargetEntitySet(null, model));
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/EntitySetSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/EntitySetSegmentTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void TargetEdmTypeIsTypeOfEntitySet()
         {
             EntitySetSegment segment = new EntitySetSegment(HardCodedTestModel.GetPeopleSet());
-            Assert.Same(HardCodedTestModel.GetPeopleSet().EntityType(), segment.TargetEdmType);
+            Assert.Same(HardCodedTestModel.GetPeopleSet().EntityType, segment.TargetEdmType);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/FilterSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/FilterSegmentTests.cs
@@ -162,7 +162,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
 
             // Use query option parser to help create the filter because it takes care of a bunch of instantiations
             ODataQueryOptionParser queryOptionParser =
-                new ODataQueryOptionParser(HardCodedTestModel.TestModel, entitySet.EntityType(), entitySet, queryOptions);
+                new ODataQueryOptionParser(HardCodedTestModel.TestModel, entitySet?.EntityType, entitySet, queryOptions);
 
             return queryOptionParser.ParseFilter();
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/KeySegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/KeySegmentTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void KeySetCorrectly()
         {
             var set = ModelBuildingHelpers.BuildValidEntitySet();
-            KeySegment segment = new KeySegment(Key, set.EntityType(), set);
+            KeySegment segment = new KeySegment(Key, set.EntityType, set);
             var key = Assert.Single(segment.Keys);
             Assert.Equal("key", key.Key);
             Assert.Equal("value", key.Value);
@@ -30,7 +30,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void IdentifierByDefaultIsKeyDefaultName()
         {
             var set = ModelBuildingHelpers.BuildValidEntitySet();
-            KeySegment segment = new KeySegment(Key, set.EntityType(), set);
+            KeySegment segment = new KeySegment(Key, set.EntityType, set);
             Assert.Equal("{key}", segment.Identifier);
         }
 
@@ -38,15 +38,15 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void TypeIsSetCorrectly()
         {
             var set = ModelBuildingHelpers.BuildValidEntitySet();
-            KeySegment segment = new KeySegment(Key, set.EntityType(), set);
-            Assert.Same(set.EntityType(), segment.EdmType);
+            KeySegment segment = new KeySegment(Key, set.EntityType, set);
+            Assert.Same(set.EntityType, segment.EdmType);
         }
 
         [Fact]
         public void SetIsCopiedFromPreviousSegment()
         {
             var set = ModelBuildingHelpers.BuildValidEntitySet();
-            KeySegment segment = new KeySegment(Key, set.EntityType(), set);
+            KeySegment segment = new KeySegment(Key, set.EntityType, set);
             Assert.Same(set, segment.NavigationSource);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/ODataPathExtensionsTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
                 new EntitySetSegment(entitySet)
             });
 
-            IEdmType entitySetCollection = new EdmCollectionType(new EdmEntityTypeReference(entitySet.EntityType(), false));
+            IEdmType entitySetCollection = new EdmCollectionType(new EdmEntityTypeReference(entitySet.EntityType, false));
             Assert.True(path.EdmType().IsEquivalentTo(entitySetCollection.ToTypeReference()));
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/SingletonSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/SingletonSegmentTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
 
             Assert.Equal("Boss", segment.Identifier);
             Assert.Same(singleton, segment.TargetEdmNavigationSource);
-            Assert.Same(singleton.EntityType(), segment.TargetEdmType);
+            Assert.Same(singleton.EntityType, segment.TargetEdmType);
             Assert.Equal(RequestTargetKind.Resource, segment.TargetKind);
             Assert.True(segment.SingleResult);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/TypeSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/TypeSegmentTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
         public void SetIsSetCorrectly()
         {
             var set = ModelBuildingHelpers.BuildValidEntitySet();
-            IEdmType type = set.EntityType();
+            IEdmType type = set.EntityType;
             TypeSegment segment = new TypeSegment(type, set);
             Assert.Same(set, segment.NavigationSource);
         }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -262,7 +262,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             var setA = model.FindDeclaredNavigationSource("SetA");
             Assert.NotNull(setA);
 
-            var navProp = setA.EntityType().FindProperty("Nav") as IEdmNavigationProperty;
+            var navProp = setA.EntityType.FindProperty("Nav") as IEdmNavigationProperty;
             Assert.NotNull(navProp);
             Assert.Equal(2, setA.NavigationPropertyBindings.Count());
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/ExtensionMethods/ExtensionMethodTests.cs
@@ -774,7 +774,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         {
             var entitySet = TestModel.Instance.Model.FindDeclaredEntitySet(TestModel.Instance.EntitySet.Name);
             Assert.NotNull(entitySet);
-            Assert.Same(TestModel.Instance.EntitySet.EntityType(), entitySet.EntityType());
+            Assert.Same(TestModel.Instance.EntitySet.EntityType, entitySet.EntityType);
         }
 
         [Fact]
@@ -782,7 +782,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         {
             var entitySet = TestModel.Instance.Model.FindDeclaredEntitySet(TestModel.Instance.Container.Name + "." + TestModel.Instance.EntitySet.Name);
             Assert.NotNull(entitySet);
-            Assert.Same(TestModel.Instance.EntitySet.EntityType(), entitySet.EntityType());
+            Assert.Same(TestModel.Instance.EntitySet.EntityType, entitySet.EntityType);
         }
 
         [Fact]
@@ -790,7 +790,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         {
             var entitySet = TestModel.Instance.Model.FindDeclaredEntitySet(TestModel.Instance.Container.ShortQualifiedName() + "." + TestModel.Instance.EntitySet.Name);
             Assert.NotNull(entitySet);
-            Assert.Same(TestModel.Instance.EntitySet.EntityType(), entitySet.EntityType());
+            Assert.Same(TestModel.Instance.EntitySet.EntityType, entitySet.EntityType);
         }
 
         [Fact]
@@ -807,7 +807,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
             for(int i=1; i <10; i++)
             {
                 Assert.Equal(HasAnyCheap(list), HasAnyExpensive(list));
-                list.Add(new EdmEntityType("NS", "f" + i, TestModel.Instance.EntitySet.EntityType()));
+                list.Add(new EdmEntityType("NS", "f" + i, TestModel.Instance.EntitySet.EntityType));
             }
         }
 
@@ -822,7 +822,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         {
             var singleton = TestModel.Instance.Model.FindDeclaredSingleton(TestModel.Instance.Singleton.Name);
             Assert.NotNull(singleton);
-            Assert.Same(TestModel.Instance.Singleton.EntityType(), singleton.EntityType());
+            Assert.Same(TestModel.Instance.Singleton.EntityType, singleton.EntityType);
         }
 
         [Fact]
@@ -830,7 +830,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         {
             var singleton = TestModel.Instance.Model.FindDeclaredSingleton(TestModel.Instance.Container.Name + "." + TestModel.Instance.Singleton.Name);
             Assert.NotNull(singleton);
-            Assert.Same(TestModel.Instance.Singleton.EntityType(), singleton.EntityType());
+            Assert.Same(TestModel.Instance.Singleton.EntityType, singleton.EntityType);
         }
 
         [Fact]
@@ -838,7 +838,7 @@ namespace Microsoft.OData.Edm.Tests.ExtensionMethods
         {
             var singleton = TestModel.Instance.Model.FindDeclaredSingleton(TestModel.Instance.Container.ShortQualifiedName() + "." + TestModel.Instance.Singleton.Name);
             Assert.NotNull(singleton);
-            Assert.Same(TestModel.Instance.Singleton.EntityType(), singleton.EntityType());
+            Assert.Same(TestModel.Instance.Singleton.EntityType, singleton.EntityType);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmSingletonTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/EdmSingletonTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             EdmSingleton singleton = new EdmSingleton(this.entityContainer, "VIP", customerType);
             Assert.Same(this.entityContainer, singleton.Container);
             Assert.Equal(EdmContainerElementKind.Singleton, singleton.ContainerElementKind);
-            Assert.Same(customerType, singleton.EntityType());
+            Assert.Same(customerType, singleton.EntityType);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Validation/ValidationRulesTests.cs
@@ -1751,6 +1751,11 @@ namespace Microsoft.OData.Edm.Tests.Validation
                 set { type = value; }
             }
 
+            public IEdmEntityType EntityType
+            {
+                get { return this.Type.AsElementType() as IEdmEntityType; }
+            }
+
             public bool IncludeInServiceDocument
             {
                 get; set;
@@ -1814,6 +1819,11 @@ namespace Microsoft.OData.Edm.Tests.Validation
             {
                 get { return type; }
                 set { type = value; }
+            }
+
+            public IEdmEntityType EntityType
+            {
+                get { return this.Type.AsElementType() as IEdmEntityType; }
             }
         }
     }

--- a/test/FunctionalTests/Service/Microsoft/OData/Service/Providers/MetadataProviderEdmEntitySet.cs
+++ b/test/FunctionalTests/Service/Microsoft/OData/Service/Providers/MetadataProviderEdmEntitySet.cs
@@ -66,6 +66,14 @@ namespace Microsoft.OData.Service.Providers
         }
 
         /// <summary>
+        /// Gets the entity type of the navigation source.
+        /// </summary>
+        public IEdmEntityType EntityType
+        {
+            get { return this.Type.AsElementType() as IEdmEntityType; }
+        }
+
+        /// <summary>
         /// The entity container kind of the entity set; returns EdmContainerElementKind.EntitySet.
         /// </summary>
         public EdmContainerElementKind ContainerElementKind

--- a/test/FunctionalTests/Taupo/Source/Taupo.Edmlib/EdmToTaupoModelConverter.cs
+++ b/test/FunctionalTests/Taupo/Source/Taupo.Edmlib/EdmToTaupoModelConverter.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Test.Taupo.Edmlib
         private EntitySet ConvertToTaupoEntitySet(IEdmEntitySet edmEntitySet)
         {
             var taupoEntitySet = new EntitySet(edmEntitySet.Name);
-            taupoEntitySet.EntityType = new EntityTypeReference(edmEntitySet.EntityType().Namespace, edmEntitySet.EntityType().Name);
+            taupoEntitySet.EntityType = new EntityTypeReference(edmEntitySet.EntityType.Namespace, edmEntitySet.EntityType.Name);
 
             this.ConvertAnnotationsIntoTaupo(edmEntitySet, taupoEntitySet);
             return taupoEntitySet;

--- a/test/FunctionalTests/Taupo/Source/Taupo.Edmlib/StubEdm/StubEdmEntitySet.cs
+++ b/test/FunctionalTests/Taupo/Source/Taupo.Edmlib/StubEdm/StubEdmEntitySet.cs
@@ -34,6 +34,14 @@ namespace Microsoft.Test.Taupo.Edmlib.StubEdm
         public IEdmType Type { get; set; }
 
         /// <summary>
+        /// Gets the entity type of the navigation source. Can be null.
+        /// </summary>
+        public IEdmEntityType EntityType
+        {
+            get { return this.Type.AsElementType() as IEdmEntityType; }
+        }
+
+        /// <summary>
         /// Gets or sets the name
         /// </summary>
         public string Name { get; set; }

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/AmbiguousTypeTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/AmbiguousTypeTests.cs
@@ -62,7 +62,7 @@ namespace EdmLibTests.FunctionalTests
             Assert.AreEqual(EdmContainerElementKind.EntitySet, ambiguous.ContainerElementKind, "Correct container element kind");
             Assert.AreEqual("NS1.Baz", ambiguous.Container.FullName(), "Correct container name");
             Assert.AreEqual("Foo", ambiguous.Name, "Correct Name");
-            Assert.IsTrue(ambiguous.EntityType().IsBad(), "Association is bad.");
+            Assert.IsTrue(ambiguous.EntityType.IsBad(), "Association is bad.");
         }
 
         [TestMethod]

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ConstructibleModelTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ConstructibleModelTests.cs
@@ -543,8 +543,8 @@ namespace EdmLibTests.FunctionalTests
             E2.AddNavigationTarget(p201, E1);
             E2.AddNavigationTarget(p203, E1);
 
-            Assert.IsTrue(E1.EntityType() == t1, "EntitySet element type");
-            Assert.IsTrue(E2.EntityType() == t2, "EntitySet element type");
+            Assert.IsTrue(E1.EntityType == t1, "EntitySet element type");
+            Assert.IsTrue(E2.EntityType == t2, "EntitySet element type");
         }
 
         [TestMethod]
@@ -596,8 +596,8 @@ namespace EdmLibTests.FunctionalTests
             E1.AddNavigationTarget(p201, S1);
             E1.AddNavigationTarget(p203, S1);
 
-            Assert.IsTrue(S1.EntityType() == t1, "EntitySet element type");
-            Assert.IsTrue(S2.EntityType() == t2, "EntitySet element type");
+            Assert.IsTrue(S1.EntityType == t1, "EntitySet element type");
+            Assert.IsTrue(S2.EntityType == t2, "EntitySet element type");
         }
 
         [TestMethod]

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/CsdlParsingTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/CsdlParsingTests.cs
@@ -158,15 +158,15 @@ namespace EdmLibTests.FunctionalTests
             Assert.IsNotNull(model.FindType("NS.Ref1.VipCustomer"), "referenced type should be found");
             IEdmEntitySet entitySet = model.EntityContainer.EntitySets().First<IEdmEntitySet>(s => s.Name == "VipCustomers");
             Assert.IsNotNull(entitySet, "should not be null");
-            Assert.IsNotNull(entitySet.EntityType(), "should not be null");
+            Assert.IsNotNull(entitySet.EntityType, "should not be null");
 
             // verify property type in ref1 model
-            IEdmProperty referencedEntityTypeProp1 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipCustomerID");
+            IEdmProperty referencedEntityTypeProp1 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipCustomerID");
             Assert.AreEqual("Edm.String", referencedEntityTypeProp1.Type.Definition.FullTypeName(), "referenced property type is incorrect");
             Assert.AreEqual(EdmTypeKind.Primitive, referencedEntityTypeProp1.Type.Definition.TypeKind, "referenced property type is incorrect");
 
             // verify property type in main model
-            IEdmProperty referencedEntityTypeProp2 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipAddress");
+            IEdmProperty referencedEntityTypeProp2 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipAddress");
             Assert.AreEqual("NS1.Address", referencedEntityTypeProp2.Type.Definition.FullTypeName(), "referenced property type is incorrect");
             Assert.AreEqual(EdmTypeKind.Complex, referencedEntityTypeProp2.Type.Definition.TypeKind, "referenced property type is incorrect");
 
@@ -291,20 +291,20 @@ namespace EdmLibTests.FunctionalTests
             Assert.IsNotNull(model.FindType("NS.Ref1.VipCustomer"), "referenced type should be found");
             IEdmEntitySet entitySet = model.EntityContainer.EntitySets().First<IEdmEntitySet>(s => s.Name == "VipCustomers");
             Assert.IsNotNull(entitySet, "should not be null");
-            Assert.IsNotNull(entitySet.EntityType(), "should not be null");
+            Assert.IsNotNull(entitySet.EntityType, "should not be null");
 
             // verify property type in ref1 model
-            IEdmProperty referencedEntityTypeProp1 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipCustomerID");
+            IEdmProperty referencedEntityTypeProp1 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipCustomerID");
             Assert.AreEqual("Edm.String", referencedEntityTypeProp1.Type.Definition.FullTypeName(), "referenced property type is incorrect");
             Assert.AreEqual(EdmTypeKind.Primitive, referencedEntityTypeProp1.Type.Definition.TypeKind, "referenced property type is incorrect");
 
             // verify property type in main model
-            IEdmProperty referencedEntityTypeProp2 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipAddress");
+            IEdmProperty referencedEntityTypeProp2 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipAddress");
             Assert.AreEqual("NS1.Address", referencedEntityTypeProp2.Type.Definition.FullTypeName(), "referenced property type is incorrect");
             Assert.AreEqual(EdmTypeKind.Complex, referencedEntityTypeProp2.Type.Definition.TypeKind, "referenced property type is incorrect");
 
             // verify property type in ref2 model
-            IEdmProperty referencedEntityTypeProp3 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipCards");
+            IEdmProperty referencedEntityTypeProp3 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipCards");
             Assert.IsTrue(referencedEntityTypeProp3.Type.IsCollection(), "referenced property type is incorrect");
             IEdmEntityType VipCardEntityType = (IEdmEntityType)referencedEntityTypeProp3.Type.AsCollection().ElementType().Definition;
             Assert.AreEqual("NS.Ref2.VipCard", VipCardEntityType.FullName(), "referenced property type is incorrect");
@@ -312,7 +312,7 @@ namespace EdmLibTests.FunctionalTests
             Assert.AreEqual(EdmTypeKind.Collection, referencedEntityTypeProp3.Type.Definition.TypeKind, "referenced property type is incorrect");
 
             // verify bad property type referencing ref2 model
-            IEdmProperty referencedEntityTypeProp4 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "BadTypeVipCards");
+            IEdmProperty referencedEntityTypeProp4 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "BadTypeVipCards");
             IEdmEntityType badVipCardType = (IEdmEntityType)referencedEntityTypeProp4.Type.AsCollection().ElementType().Definition;
             Assert.AreEqual("VPCD.VipCard", badVipCardType.FullName(), "The alias in VPCD.VipCard shouldn't be resolved, so this bad name is expected to be returned.");
 
@@ -328,7 +328,7 @@ namespace EdmLibTests.FunctionalTests
             IEdmEntitySet cardEntitySet = model.EntityContainer.EntitySets().First<IEdmEntitySet>(s => s.Name == "VipCards");
 
             // verify property type in ref2 model
-            IEdmProperty cardEntitySetProp1 = cardEntitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipCardID");
+            IEdmProperty cardEntitySetProp1 = cardEntitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipCardID");
             Assert.AreEqual("Edm.Int32", cardEntitySetProp1.Type.Definition.FullTypeName(), "referenced property type is incorrect");
             Assert.AreEqual(EdmTypeKind.Primitive, cardEntitySetProp1.Type.Definition.TypeKind, "referenced property type is incorrect");
         }
@@ -440,20 +440,20 @@ namespace EdmLibTests.FunctionalTests
             Assert.IsNotNull(model.FindType("NS.Ref1.VipCustomer"), "referenced type should be found");
             IEdmEntitySet entitySet = model.EntityContainer.EntitySets().First<IEdmEntitySet>(s => s.Name == "VipCustomers");
             Assert.IsNotNull(entitySet, "should not be null");
-            Assert.IsNotNull(entitySet.EntityType(), "should not be null");
+            Assert.IsNotNull(entitySet.EntityType, "should not be null");
 
             // verify property type in ref1 model
-            IEdmProperty referencedEntityTypeProp1 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipCustomerID");
+            IEdmProperty referencedEntityTypeProp1 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipCustomerID");
             Assert.AreEqual("Edm.String", referencedEntityTypeProp1.Type.Definition.FullTypeName(), "referenced property type is incorrect");
             Assert.AreEqual(EdmTypeKind.Primitive, referencedEntityTypeProp1.Type.Definition.TypeKind, "referenced property type is incorrect");
 
             // verify property type in main model (circle reference not resolved)
-            IEdmProperty referencedEntityTypeProp2 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipAddress");
+            IEdmProperty referencedEntityTypeProp2 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipAddress");
             Assert.AreEqual("NS1.Address", referencedEntityTypeProp2.Type.Definition.FullTypeName(), "referenced property type is incorrect");
             Assert.AreEqual(EdmTypeKind.None, referencedEntityTypeProp2.Type.Definition.TypeKind, "referenced property type is incorrect");
 
             // verify property type in ref2 model
-            IEdmProperty referencedEntityTypeProp3 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipCards");
+            IEdmProperty referencedEntityTypeProp3 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipCards");
             Assert.IsTrue(referencedEntityTypeProp3.Type.IsCollection(), "referenced property type is incorrect");
             IEdmEntityType VipCardEntityType = (IEdmEntityType)referencedEntityTypeProp3.Type.AsCollection().ElementType().Definition;
             Assert.AreEqual("NS.Ref2.VipCard", VipCardEntityType.FullName(), "referenced property type is incorrect");
@@ -461,7 +461,7 @@ namespace EdmLibTests.FunctionalTests
             Assert.AreEqual(EdmTypeKind.Collection, referencedEntityTypeProp3.Type.Definition.TypeKind, "referenced property type is incorrect");
 
             // verify bad property type referencing ref2 model
-            IEdmProperty referencedEntityTypeProp4 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "BadTypeVipCards");
+            IEdmProperty referencedEntityTypeProp4 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "BadTypeVipCards");
             IEdmEntityType badVipCardType = (IEdmEntityType)referencedEntityTypeProp4.Type.AsCollection().ElementType().Definition;
             Assert.AreEqual("VPCD.VipCard", badVipCardType.FullName(), "The alias in VPCD.VipCard shouldn't be resolved, so this bad name is expected to be returned.");
 
@@ -477,7 +477,7 @@ namespace EdmLibTests.FunctionalTests
             IEdmEntitySet cardEntitySet = model.EntityContainer.EntitySets().First<IEdmEntitySet>(s => s.Name == "VipCards");
 
             // verify property type in ref2 model
-            IEdmProperty cardEntitySetProp1 = cardEntitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipCardID");
+            IEdmProperty cardEntitySetProp1 = cardEntitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipCardID");
             Assert.AreEqual("Edm.Int32", cardEntitySetProp1.Type.Definition.FullTypeName(), "referenced property type is incorrect");
             Assert.AreEqual(EdmTypeKind.Primitive, cardEntitySetProp1.Type.Definition.TypeKind, "referenced property type is incorrect");
         }
@@ -549,15 +549,15 @@ namespace EdmLibTests.FunctionalTests
             Assert.IsNotNull(model.FindType("NS.Ref1.VipCustomer"), "referenced type should be found");
             IEdmEntitySet entitySet = model.EntityContainer.EntitySets().First<IEdmEntitySet>(s => s.Name == "VipCustomers");
             Assert.IsNotNull(entitySet, "should not be null");
-            Assert.IsNotNull(entitySet.EntityType(), "should not be null");
+            Assert.IsNotNull(entitySet.EntityType, "should not be null");
 
             // verify property type in ref1 model
-            IEdmProperty referencedEntityTypeProp1 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipCustomerID");
+            IEdmProperty referencedEntityTypeProp1 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipCustomerID");
             Assert.AreEqual("Edm.String", referencedEntityTypeProp1.Type.Definition.FullTypeName(), "referenced property type is incorrect");
             Assert.AreEqual(EdmTypeKind.Primitive, referencedEntityTypeProp1.Type.Definition.TypeKind, "referenced property type is incorrect");
 
             // verify property type in main model
-            IEdmProperty referencedEntityTypeProp2 = entitySet.EntityType().Properties().First<IEdmProperty>(s => s.Name == "VipAddress");
+            IEdmProperty referencedEntityTypeProp2 = entitySet.EntityType.Properties().First<IEdmProperty>(s => s.Name == "VipAddress");
             Assert.AreEqual("NS1.Address", referencedEntityTypeProp2.Type.Definition.FullTypeName(), "referenced property type is incorrect");
 
             //  Reverse reference does not work using old approach.
@@ -1142,7 +1142,7 @@ namespace EdmLibTests.FunctionalTests
             Assert.IsNotNull(model.FindType("NS.Ref1.VipCustomer"), "referenced type should be found");
             IEdmEntitySet entitySet = model.EntityContainer.EntitySets().First<IEdmEntitySet>(s => s.Name == "VipCustomers");
             Assert.IsNotNull(entitySet, "should not be null");
-            Assert.IsNotNull(entitySet.EntityType(), "should not be null");
+            Assert.IsNotNull(entitySet.EntityType, "should not be null");
         }
 
         [TestMethod]
@@ -1409,7 +1409,7 @@ namespace EdmLibTests.FunctionalTests
             Assert.IsNotNull(model.FindType("NS.Ref1.VipCustomer"), "referenced type should be found");
             IEdmEntitySet entitySet = model.EntityContainer.EntitySets().First<IEdmEntitySet>(s => s.Name == "VipCustomers");
             Assert.IsNotNull(entitySet, "should not be null");
-            Assert.IsNotNull(entitySet.EntityType(), "should not be null");
+            Assert.IsNotNull(entitySet.EntityType, "should not be null");
 
             settings = new CsdlReaderSettings()
             {

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ParserTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ParserTests.cs
@@ -213,11 +213,11 @@ namespace EdmLibTests.FunctionalTests
             
             IEdmEntitySet entitySet = entityContainer.FindEntitySet("EntityTypeWithoutKey");
             Assert.AreEqual("EntityTypeWithoutKey", entitySet.Name, "Invalid entity set name");
-            Assert.AreEqual("TestModel.EntityTypeWithoutKey", entitySet.EntityType().FullName(), "Invalid entity set element type");
+            Assert.AreEqual("TestModel.EntityTypeWithoutKey", entitySet.EntityType.FullName(), "Invalid entity set element type");
 
             IEdmSingleton singleton = entityContainer.FindSingleton("SingletonWhoseEntityTypeWithoutKey");
             Assert.AreEqual("SingletonWhoseEntityTypeWithoutKey", singleton.Name, "Invalid singleton name");
-            Assert.AreEqual("TestModel.EntityTypeWithoutKey", singleton.EntityType().FullName(), "Invalid singleton element type");
+            Assert.AreEqual("TestModel.EntityTypeWithoutKey", singleton.EntityType.FullName(), "Invalid singleton element type");
             
             var expectedErrors = new EdmLibTestErrors()
             {
@@ -243,11 +243,11 @@ namespace EdmLibTests.FunctionalTests
 
             IEdmEntitySet entitySetElement1 = (IEdmEntitySet)entityContainer.Elements.ElementAt(0);
             Assert.AreEqual("DuplicateEntityType", entitySetElement1.Name, "Invalid entity set name");
-            Assert.AreEqual("TestModel.DuplicateEntityType", entitySetElement1.EntityType().FullName(), "Invalid entity set element type");
+            Assert.AreEqual("TestModel.DuplicateEntityType", entitySetElement1.EntityType.FullName(), "Invalid entity set element type");
 
             IEdmEntitySet entitySetElement2 = (IEdmEntitySet)entityContainer.Elements.ElementAt(1);
             Assert.AreEqual("DuplicateEntityType", entitySetElement2.Name, "Invalid entity set name");
-            Assert.AreEqual("TestModel.DuplicateEntityType", entitySetElement2.EntityType().FullName(), "Invalid entity set element type");
+            Assert.AreEqual("TestModel.DuplicateEntityType", entitySetElement2.EntityType.FullName(), "Invalid entity set element type");
 
             Assert.IsTrue(model.SchemaElements.Count() == 3, "Invalid schema element count");
             Assert.AreEqual(EdmSchemaElementKind.TypeDefinition, model.SchemaElements.ElementAt(0).SchemaElementKind, "Invalid schema element kind");
@@ -362,7 +362,7 @@ namespace EdmLibTests.FunctionalTests
 
             IEdmEntitySet entitySet = (IEdmEntitySet)entityContainer.Elements.Single();
             Assert.AreEqual("DuplicatePropertiesEntityType", entitySet.Name, "Invalid entity set name");
-            Assert.AreEqual("TestModel.DuplicatePropertiesEntityType", entitySet.EntityType().FullName(), "Invalid entity set element type");
+            Assert.AreEqual("TestModel.DuplicatePropertiesEntityType", entitySet.EntityType.FullName(), "Invalid entity set element type");
 
             Assert.IsTrue(model.SchemaElements.Count() == 2, "Invalid schema element count");
 

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ParsingValidation.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ParsingValidation.cs
@@ -1303,7 +1303,7 @@ namespace EdmLibTests.FunctionalTests
 
             var openEntitySet = model.EntityContainer.FindEntitySet("OpenEntityType");
             Assert.IsNotNull(openEntityType, "Invalid entity set.");
-            Assert.AreEqual(openEntityType, openEntitySet.EntityType(), "Invalid entity set type.");
+            Assert.AreEqual(openEntityType, openEntitySet.EntityType, "Invalid entity set type.");
         }
 
         [TestMethod]
@@ -1329,7 +1329,7 @@ namespace EdmLibTests.FunctionalTests
 
             var streamSet = model.EntityContainer.FindEntitySet("NamedStreamEntityType");
             Assert.IsNotNull(streamSet, "Invalid entity set.");
-            Assert.AreEqual(streamEntityType, streamSet.EntityType(), "Invalid element type.");
+            Assert.AreEqual(streamEntityType, streamSet.EntityType, "Invalid element type.");
         }
 
         private void CheckImmediateAnnotation(IEdmDirectValueAnnotation immediateAnnotation, string termName, string value)

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/SchemaParsingTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/SchemaParsingTests.cs
@@ -324,11 +324,11 @@ namespace EdmLibTests.FunctionalTests
             Assert.IsTrue(wild.Elements.Count() == 2, "Wild: correct number of Elements");
             Assert.AreEqual("Pets", wild.Elements.First().Name, "Wild: correct first element");
             Assert.AreEqual(EdmContainerElementKind.EntitySet, wild.Elements.First().ContainerElementKind, "Wild: first element type");
-            Assert.AreEqual("Hot.Pet", ((IEdmEntitySet)wild.Elements.First()).EntityType().FullName(), "Wild: element type for first entityset");
+            Assert.AreEqual("Hot.Pet", ((IEdmEntitySet)wild.Elements.First()).EntityType.FullName(), "Wild: element type for first entityset");
 
             Assert.AreEqual("People", wild.Elements.ElementAt(1).Name, "Wild: correct second element");
             Assert.AreEqual(EdmContainerElementKind.EntitySet, wild.Elements.ElementAt(1).ContainerElementKind, "Zero: second element type");
-            Assert.AreEqual("Hot.Person", ((IEdmEntitySet)wild.Elements.ElementAt(1)).EntityType().FullName(), "Zero: element type for second entityset");
+            Assert.AreEqual("Hot.Person", ((IEdmEntitySet)wild.Elements.ElementAt(1)).EntityType.FullName(), "Zero: element type for second entityset");
 
             IEdmEntityType person = (IEdmEntityType)model.FindType("Hot.Person");
             IEdmEntityType pet = (IEdmEntityType)model.FindType("Hot.Pet");
@@ -529,13 +529,13 @@ namespace EdmLibTests.FunctionalTests
 
             Assert.AreEqual("AnotherSingletonPeople", wild.Elements.ElementAt(1).Name, "AnotherSingletonPeople: correct second element");
             Assert.AreEqual(EdmContainerElementKind.Singleton, wild.Elements.ElementAt(1).ContainerElementKind, "Wild: second element type");
-            Assert.AreEqual("Hot.Person", ((IEdmSingleton)wild.Elements.ElementAt(1)).EntityType().FullName(), "Wild: type for first singleton");
+            Assert.AreEqual("Hot.Person", ((IEdmSingleton)wild.Elements.ElementAt(1)).EntityType.FullName(), "Wild: type for first singleton");
 
             IEdmEntityType person = (IEdmEntityType)model.FindType("Hot.Person");
             IEdmEntityType pet = (IEdmEntityType)model.FindType("Hot.Pet");
             IEdmSingleton singletonPeople = wild.FindSingleton("SingletonPeople");
             Assert.IsNotNull(singletonPeople, "singletonPeople singleton is not null");
-            Assert.AreEqual(person, singletonPeople.EntityType(), "the type of singletonPeople is Person");
+            Assert.AreEqual(person, singletonPeople.EntityType, "the type of singletonPeople is Person");
             IEdmSingleton anotherPeople = wild.FindSingleton("AnotherSingletonPeople");
             Assert.IsNotNull(anotherPeople, "anotherPeople singleton is not null");
             Assert.AreEqual(person, singletonPeople.Type, "the type of singletonPeople is Person");
@@ -1443,7 +1443,7 @@ namespace EdmLibTests.FunctionalTests
             Assert.AreEqual(peopleSet, eset, "Return EntitySet name is correct");
             IEdmEntitySetBase fiEntitySet;
             Assert.IsTrue(peopleWhoAreAwesome.TryGetStaticEntitySet(model, out fiEntitySet), "peopleWhoAreAwesome.TryGetStaticEntitySet");
-            Assert.AreEqual(personType, fiEntitySet.EntityType(), "Return EntitySet type is correct");
+            Assert.AreEqual(personType, fiEntitySet.EntityType, "Return EntitySet type is correct");
             Assert.AreEqual("peopleWhoAreAwesomeAction", peopleWhoAreAwesome.Name, "FunctionImport name is correct");
             Assert.AreEqual(EdmTypeKind.Collection, peopleWhoAreAwesome.Operation.ReturnType.Definition.TypeKind, "Return typekind is correct");
             Assert.AreEqual(personType, peopleWhoAreAwesome.Operation.ReturnType.AsCollection().ElementType().Definition, "Return entitytype is correct");
@@ -1573,8 +1573,8 @@ namespace EdmLibTests.FunctionalTests
             Assert.IsTrue(validated, "validate");
 
             var people = model.EntityContainer.FindEntitySet("People");
-            Assert.AreEqual("Person", people.EntityType().Name, "people.ElementType.Name");
-            Assert.IsFalse(((IEdmNavigationProperty)people.EntityType().FindProperty("Orders")).ContainsTarget, "Orders.ContainsTarget");
+            Assert.AreEqual("Person", people.EntityType.Name, "people.ElementType.Name");
+            Assert.IsFalse(((IEdmNavigationProperty)people.EntityType.FindProperty("Orders")).ContainsTarget, "Orders.ContainsTarget");
 
             var operationImports = model.EntityContainer.OperationImports().ToArray();
             Assert.AreEqual(11, operationImports.Length, "# of operation imports");

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalUtilities/InterfaceCriticalModelBuilder.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalUtilities/InterfaceCriticalModelBuilder.cs
@@ -765,6 +765,10 @@ namespace EdmLibTests.FunctionalUtilities
             {
                 get { return type; }
             }
+            public IEdmEntityType EntityType
+            {
+                get { return this.Type.AsElementType() as IEdmEntityType; }
+            }
 
             public bool IncludeInServiceDocument
             {

--- a/test/FunctionalTests/Tests/DataEdmLib/StubEdm/StubEdmEntitySet.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/StubEdm/StubEdmEntitySet.cs
@@ -74,6 +74,14 @@ namespace EdmLibTests.StubEdm
         public IEdmType Type { get; set; }
 
         /// <summary>
+        /// Gets the entity type of the navigation source. Can be null.
+        /// </summary>
+        public IEdmEntityType EntityType
+        {
+            get { return this.Type.AsElementType() as IEdmEntityType; }
+        }
+
+        /// <summary>
         /// Gets or sets whether to include in service doucment
         /// </summary>
         public bool IncludeInServiceDocument

--- a/test/FunctionalTests/Tests/DataEdmLib/UnitTests/ExtensionMethodsTests.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/UnitTests/ExtensionMethodsTests.cs
@@ -18,9 +18,9 @@ namespace EdmLibTests.UnitTests
             var container = new EdmEntityContainer("NS", "C");
             var entityType = new EdmEntityType("NS", "People");
             var entitySet = new EdmEntitySet(container, "Peoples", entityType);
-            Assert.AreEqual(entityType, entitySet.EntityType());
+            Assert.AreEqual(entityType, entitySet.EntityType);
             var singleton = new EdmSingleton(container, "Boss", entityType);
-            Assert.AreEqual(entityType, singleton.EntityType());
+            Assert.AreEqual(entityType, singleton.EntityType);
         }
     }
 }

--- a/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/CreateHandler.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/CreateHandler.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Test.Taupo.OData.WCFService
             using (var messageReader = new ODataMessageReader(message, this.GetDefaultReaderSettings(), this.Model))
             {
                 var odataItemStack = new Stack<ODataItem>();
-                var entryReader = messageReader.CreateODataResourceReader(entitySet.EntityType());
+                var entryReader = messageReader.CreateODataResourceReader(entitySet.EntityType);
                 IEdmEntitySet currentTargetEntitySet = entitySet;
 
                 while (entryReader.Read())
@@ -131,10 +131,10 @@ namespace Microsoft.Test.Taupo.OData.WCFService
                             {
                                 odataItemStack.Push(entryReader.Item);
                                 var navigationLink = (ODataNestedResourceInfo)entryReader.Item;
-                                var navigationProperty = (IEdmNavigationProperty)currentTargetEntitySet.EntityType().FindProperty(navigationLink.Name);
+                                var navigationProperty = (IEdmNavigationProperty)currentTargetEntitySet.EntityType.FindProperty(navigationLink.Name);
 
                                 // Current model implementation doesn't expose associations otherwise this would be much cleaner.
-                                currentTargetEntitySet = this.Model.EntityContainer.EntitySets().Single(s => s.EntityType() == navigationProperty.Type.Definition);
+                                currentTargetEntitySet = this.Model.EntityContainer.EntitySets().Single(s => s.EntityType == navigationProperty.Type.Definition);
                             }
 
                             break;

--- a/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/ODataObjectModelConverter.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/ODataObjectModelConverter.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Test.Taupo.OData.WCFService
         /// <returns>The converted ODataResource.</returns>
         public static ODataResource ConvertToODataEntry(object element, IEdmEntitySet entitySet, ODataVersion targetVersion)
         {
-            IEdmEntityType entityType = entitySet.EntityType();
+            IEdmEntityType entityType = entitySet.EntityType;
 
             Uri entryUri = BuildEntryUri(element, entitySet, targetVersion);
 
@@ -96,7 +96,7 @@ namespace Microsoft.Test.Taupo.OData.WCFService
         /// <returns>The generated URI.</returns>
         public static Uri BuildEntryUri(object entry, IEdmEntitySet entitySet, ODataVersion targetVersion)
         {
-            string keySegment = BuildKeyString(entry, entitySet.EntityType(), targetVersion);
+            string keySegment = BuildKeyString(entry, entitySet.EntityType, targetVersion);
             return new Uri(ServiceConstants.ServiceBaseUri, entitySet.Name + "(" + keySegment + ")");
         }
 

--- a/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/ResponseWriter.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/ResponseWriter.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Test.Taupo.OData.WCFService
             writer.WriteStart(entry);
 
             // Here, we write out the links for the navigation properties off of the entity type
-            WriteNavigationLinks(writer, element, entry.ReadLink, entitySet.EntityType(), model, targetVersion, expandedNavigationProperties);
+            WriteNavigationLinks(writer, element, entry.ReadLink, entitySet.EntityType, model, targetVersion, expandedNavigationProperties);
 
             writer.WriteEnd();
         }
@@ -84,7 +84,7 @@ namespace Microsoft.Test.Taupo.OData.WCFService
                     if (propertyValue != null)
                     {
                         var propertyEntityType = propertyTypeReference.Definition as IEdmEntityType;
-                        IEdmEntitySet targetEntitySet = model.EntityContainer.EntitySets().Single(s => s.EntityType() == propertyEntityType);
+                        IEdmEntitySet targetEntitySet = model.EntityContainer.EntitySets().Single(s => s.EntityType == propertyEntityType);
 
                         if (isCollection)
                         {

--- a/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/UpdateHandler.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/UpdateHandler.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Test.Taupo.OData.WCFService
         {
             using (var messageReader = new ODataMessageReader(message, this.GetDefaultReaderSettings(), this.Model))
             {
-                var entryReader = messageReader.CreateODataResourceReader(entitySet.EntityType());
+                var entryReader = messageReader.CreateODataResourceReader(entitySet.EntityType);
 
                 while (entryReader.Read())
                 {

--- a/test/FunctionalTests/Tests/DataOData/Common/OData/Common/ODataPayloadElementExtensions.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData/Common/ODataPayloadElementExtensions.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Test.Taupo.OData.Common
         {
             ExceptionUtilities.CheckArgumentNotNull(entityInstance, "entityInstance");
             ExpectedTypeODataPayloadElementAnnotation annotation = ODataPayloadElementExtensions.AddExpectedTypeAnnotation(entityInstance);
-            entityType = entityType ?? (entitySet == null ? null : entitySet.EntityType().ToTypeReference());
+            entityType = entityType ?? (entitySet == null ? null : entitySet.EntityType.ToTypeReference());
             annotation.EdmExpectedType = entityType;
             annotation.EdmEntitySet = entitySet;
             return entityInstance;
@@ -260,7 +260,7 @@ namespace Microsoft.Test.Taupo.OData.Common
         {
             ExceptionUtilities.CheckArgumentNotNull(entitySetInstance, "entitySetInstance");
             ExpectedTypeODataPayloadElementAnnotation annotation = ODataPayloadElementExtensions.AddExpectedTypeAnnotation(entitySetInstance);
-            var entityType = baseEntityType ?? (entitySet == null ? null : entitySet.EntityType().ToTypeReference());
+            var entityType = baseEntityType ?? (entitySet == null ? null : entitySet.EntityType.ToTypeReference());
             annotation.EdmExpectedType = entityType;
             annotation.EdmEntitySet = entitySet;
             return entitySetInstance;

--- a/test/FunctionalTests/Tests/DataOData/Common/OData/Common/PayloadGeneratorExtensions.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData/Common/PayloadGeneratorExtensions.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Test.Taupo.OData.Common
                 var navProp = entityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo() { Name = "NavigationProp", Target = payloadEntityType, TargetMultiplicity = isSingletonRelationship ? EdmMultiplicity.One : EdmMultiplicity.Many });
                 model.AddElement(entityType);
                 var entitySet = container.AddEntitySet(entityTypeName, entityType);
-                var targetSet = container.EntitySets().Where(s => payloadEntityType.IsOrInheritsFrom(s.EntityType())).Single();
+                var targetSet = container.EntitySets().Where(s => payloadEntityType.IsOrInheritsFrom(s.EntityType)).Single();
                 entitySet.AddNavigationTarget(navProp, targetSet);
             }
             string fullTypeName = entityType == null ? null : entityType.FullName();
@@ -667,7 +667,7 @@ namespace Microsoft.Test.Taupo.OData.Common
                 }
                 else
                 {
-                    resultSet = container.EntitySets().Where(s => resultEntityType.IsOrInheritsFrom(s.EntityType())).Single() as EdmEntitySet;
+                    resultSet = container.EntitySets().Where(s => resultEntityType.IsOrInheritsFrom(s.EntityType)).Single() as EdmEntitySet;
                 }
                 foreach (var p in properties)
                 {
@@ -730,7 +730,7 @@ namespace Microsoft.Test.Taupo.OData.Common
                             navProp.SetAnnotation(navigationPropertyCardinality);
                         }
                         var resultNavProp = resultEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo() { Name = navProp.Name, Target = navigationPropertyType, TargetMultiplicity = isCollection ? EdmMultiplicity.Many : EdmMultiplicity.One });
-                        var targetSet = container.EntitySets().Where(s => navigationPropertyType.IsOrInheritsFrom(s.EntityType())).Single();
+                        var targetSet = container.EntitySets().Where(s => navigationPropertyType.IsOrInheritsFrom(s.EntityType)).Single();
                         resultSet.AddNavigationTarget(resultNavProp, targetSet);
                     }
                 }

--- a/test/FunctionalTests/Tests/DataOData/Common/OData/Contracts/JsonLight/JsonLightODataPayloadElementExtensions.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData/Contracts/JsonLight/JsonLightODataPayloadElementExtensions.cs
@@ -305,13 +305,13 @@ namespace Microsoft.Test.Taupo.OData.Contracts.JsonLight
             }
 
 
-            if (entitySet.EntityType() == entityDataType)
+            if (entitySet.EntityType == entityDataType)
             {
                 // same types; nothing to add to the context URI
                 return;
             }
 
-            if (entityDataType.InheritsFrom(entitySet.EntityType()))
+            if (entityDataType.InheritsFrom(entitySet.EntityType))
             {
                 // derived type; add the type cast segment
                 builder.Append("/");

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.Tests/MetadataBinder/EntitySetNode.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.Tests/MetadataBinder/EntitySetNode.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Test.Taupo.OData.Query.Tests.MetadataBinder
         {
             ExceptionUtils.CheckArgumentNotNull(entitySet, "entitySet");
             this.entitySet = entitySet;
-            this.entityType = new EdmEntityTypeReference(this.NavigationSource.EntityType(), false);
+            this.entityType = new EdmEntityTypeReference(this.NavigationSource.EntityType, false);
             this.collectionTypeReference = EdmCoreModel.GetCollection(this.entityType);
         }
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.Tests/MetadataBinder/FilterBinderFunctionalTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Query.Tests/MetadataBinder/FilterBinderFunctionalTests.cs
@@ -539,7 +539,7 @@ namespace Microsoft.Test.Taupo.OData.Query.Tests.MetadataBinder
                     CollectionResourceNode entityCollectionNode = new EntitySetNode(entitySet);
                     var expectedFilter = new FilterClause(
                         testCase.ExpectedFilterCondition,
-                        new ResourceRangeVariable(ExpressionConstants.It, entitySet.EntityType().ToTypeReference(false).AsEntity(), entityCollectionNode)
+                        new ResourceRangeVariable(ExpressionConstants.It, entitySet.EntityType.ToTypeReference(false).AsEntity(), entityCollectionNode)
                         );
 
                     QueryNodeUtils.VerifyFilterClausesAreEqual(

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/JsonLightPayloadElementFixup.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/JsonLight/JsonLightPayloadElementFixup.cs
@@ -560,7 +560,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.JsonLight
 
         private static IEdmEntitySet FindEntitySet(IEdmModel model, IEdmSchemaType entityType)
         {
-            var entitySets = model.EntityContainer.EntitySets().Where(s => entityType.IsOrInheritsFrom(s.EntityType()));
+            var entitySets = model.EntityContainer.EntitySets().Where(s => entityType.IsOrInheritsFrom(s.EntityType));
             ExceptionUtilities.Assert(entitySets.Count() == 1, "Expected one entity set for entity type {0}. Found: {1}", entityType.Name, entitySets.Count());
             return entitySets.Single();
         }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/PayloadReaderTestDescriptor.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/PayloadReaderTestDescriptor.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests
                 if (typeAnnotation != null)
                 {
                     var edmEntityType = typeAnnotation.EdmModelType;
-                    return model.EntityContainersAcrossModels().First().EntitySets().SingleOrDefault(es => es.EntityType().FullName() == edmEntityType.FullName());
+                    return model.EntityContainersAcrossModels().First().EntitySets().SingleOrDefault(es => es.EntityType.FullName() == edmEntityType.FullName());
                 }
 
                 return null;

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataClientTemplateUnitTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/DesignT4UnitTests/ODataClientTemplateUnitTests.cs
@@ -1454,10 +1454,10 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
             foreach (var edmEntitySet in entitySets)
             {
                 List<IEdmNavigationSource> navigationSourceList = null;
-                if (!Context.ElementTypeToNavigationSourceMap.TryGetValue(edmEntitySet.EntityType(), out navigationSourceList))
+                if (!Context.ElementTypeToNavigationSourceMap.TryGetValue(edmEntitySet.EntityType, out navigationSourceList))
                 {
                     navigationSourceList = new List<IEdmNavigationSource>();
-                    Context.ElementTypeToNavigationSourceMap.Add(edmEntitySet.EntityType(), navigationSourceList);
+                    Context.ElementTypeToNavigationSourceMap.Add(edmEntitySet.EntityType, navigationSourceList);
                 }
 
                 navigationSourceList.Add(edmEntitySet);
@@ -1571,10 +1571,10 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
             foreach (var edmEntitySet in entitySets)
             {
                 List<IEdmNavigationSource> navigationSourceList = null;
-                if (!Context.ElementTypeToNavigationSourceMap.TryGetValue(edmEntitySet.EntityType(), out navigationSourceList))
+                if (!Context.ElementTypeToNavigationSourceMap.TryGetValue(edmEntitySet.EntityType, out navigationSourceList))
                 {
                     navigationSourceList = new List<IEdmNavigationSource>();
-                    Context.ElementTypeToNavigationSourceMap.Add(edmEntitySet.EntityType(), navigationSourceList);
+                    Context.ElementTypeToNavigationSourceMap.Add(edmEntitySet.EntityType, navigationSourceList);
                 }
 
                 navigationSourceList.Add(edmEntitySet);
@@ -1617,10 +1617,10 @@ namespace Microsoft.OData.Client.Design.T4.UnitTests
             foreach (var edmEntitySet in entitySets)
             {
                 List<IEdmNavigationSource> navigationSourceList = null;
-                if (!Context.ElementTypeToNavigationSourceMap.TryGetValue(edmEntitySet.EntityType(), out navigationSourceList))
+                if (!Context.ElementTypeToNavigationSourceMap.TryGetValue(edmEntitySet.EntityType, out navigationSourceList))
                 {
                     navigationSourceList = new List<IEdmNavigationSource>();
-                    Context.ElementTypeToNavigationSourceMap.Add(edmEntitySet.EntityType(), navigationSourceList);
+                    Context.ElementTypeToNavigationSourceMap.Add(edmEntitySet.EntityType, navigationSourceList);
                 }
 
                 navigationSourceList.Add(edmEntitySet);

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Data/ServiceModelData.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Data/ServiceModelData.cs
@@ -406,7 +406,7 @@ namespace AstoriaUnitTests.Data
             // Simplification: no MEST, no inheritance.
             IEdmEntityContainer container = this.model.EntityContainer;
             IEdmEntitySet entitySet = container.FindEntitySet(containerName);
-            return entitySet.EntityType().FullName();
+            return entitySet.EntityType.FullName();
         }
 
         /// <summary>Enumerates the properties that make up the ETag for the type.</summary>

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/TDDUnitTests/Tests/Server/Parsing/NodeToExpressionTranslatorTests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/TDDUnitTests/Tests/Server/Parsing/NodeToExpressionTranslatorTests.cs
@@ -686,7 +686,7 @@ namespace AstoriaUnitTests.TDD.Tests.Server.Parsing
 
         private SingleResourceNode EntityParameter<T>(string name)
         {
-            var entityRangeVariable = new ResourceRangeVariable(name, new EdmEntityTypeReference(this.entitySet.EntityType(), false), this.entitySet);
+            var entityRangeVariable = new ResourceRangeVariable(name, new EdmEntityTypeReference(this.entitySet.EntityType, false), this.entitySet);
             this.testSubject.ParameterExpressions[entityRangeVariable] = Expression.Parameter(typeof(T), name);
             return new ResourceRangeVariableReferenceNode(name, entityRangeVariable);
         }

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/ConstructableMetadata.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/ConstructableMetadata.cs
@@ -342,7 +342,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
         /// <param name="resourceSetReference">true if the property should be a entity set reference, false if it should be an entity reference.</param>
         private IEdmNavigationProperty AddReferenceProperty(IEdmEntityType entityType, string name, IEdmEntitySet targetEntitySet, IEdmEntityType targetEntityType, bool resourceSetReference, bool containsTarget)
         {
-            targetEntityType = targetEntityType ?? targetEntitySet.EntityType();
+            targetEntityType = targetEntityType ?? targetEntitySet.EntityType;
 
             IEdmTypeReference navPropertyTypeReference = resourceSetReference
                 ? new EdmCollectionType(targetEntityType.ToTypeReference(true)).ToTypeReference(true)

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/CsdlToEdmModelComparer.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/CsdlToEdmModelComparer.cs
@@ -446,7 +446,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
                 var entitySetName = entitySetElement.GetAttributeValue("Name");
                 var entitySet = entitySets.SingleOrDefault(e => e.Name == entitySetName);
                 ExceptionUtilities.Assert(entitySet != null, "Failed to find entity set " + entitySetName);
-                ExceptionUtilities.Assert(entitySetElement.GetAttributeValue("EntityType") == entitySet.EntityType().FullName(), "Unexpected type for entity set " + entitySetName);
+                ExceptionUtilities.Assert(entitySetElement.GetAttributeValue("EntityType") == entitySet.EntityType.FullName(), "Unexpected type for entity set " + entitySetName);
 
                 // Compare Navigation Property Bindings
                 var navigationPropertyBindingElements = entitySetElement.EdmElements("NavigationPropertyBinding").ToArray();
@@ -471,7 +471,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
                         var derivedType = entityTypes.SingleOrDefault(t => t.FullName() == splitPath.ElementAt(0));
                         ExceptionUtilities.Assert(derivedType != null, "Failed to find entity type " + derivedTypeName + " described in navigation property binding path");
                         ExceptionUtilities.Assert(derivedType.DeclaredNavigationProperties().SingleOrDefault(p => p.Name == propertyName) != null, "Failed to find nav property on derived type");
-                        EdmModelUtils.AssertEntityTypeIsDerivedFrom(derivedType, entitySet.EntityType());
+                        EdmModelUtils.AssertEntityTypeIsDerivedFrom(derivedType, entitySet.EntityType);
                     }
 
                     var navigationTarget = entitySet.NavigationPropertyBindings.SingleOrDefault(nt => nt.NavigationProperty.Name == propertyName && nt.Target.Name == targetValue);

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/EdmToStockModelConverter.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/EdmToStockModelConverter.cs
@@ -358,7 +358,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
 
             foreach (var edmNavigationSource in edmContainer.Elements.OfType<IEdmNavigationSource>())
             {
-                var stockEntityType = (EdmEntityType)stockModel.FindType(GetFullName(edmNavigationSource.EntityType()));
+                var stockEntityType = (EdmEntityType)stockModel.FindType(GetFullName(edmNavigationSource.EntityType));
                 if (edmNavigationSource is IEdmSingleton)
                 {
                     stockContainer.AddSingleton(edmNavigationSource.Name, stockEntityType);
@@ -371,7 +371,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
 
             foreach (var stockNavigationSource in stockContainer.Elements.OfType<EdmNavigationSource>())
             {
-                var stockEntityType = (EdmEntityType)stockModel.FindType(GetFullName(stockNavigationSource.EntityType()));
+                var stockEntityType = (EdmEntityType)stockModel.FindType(GetFullName(stockNavigationSource.EntityType));
                 IEdmNavigationSource edmNavigationSource = edmContainer.FindEntitySet(stockNavigationSource.Name);
                 if (edmNavigationSource == null)
                 {
@@ -393,7 +393,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
                             var targetEntitySetFromContainer = stockContainer.Elements.OfType<EdmEntitySet>().SingleOrDefault
                                 (
                                     n =>
-                                        GetBaseTypesAndSelf(((IEdmNavigationProperty)stockNavigationProperty).ToEntityType()).Select(m => GetFullName(m)).Contains(n.EntityType().FullName()) && n.Name == targetEdmEntitySet.Name
+                                        GetBaseTypesAndSelf(((IEdmNavigationProperty)stockNavigationProperty).ToEntityType()).Select(m => GetFullName(m)).Contains(n.EntityType.FullName()) && n.Name == targetEdmEntitySet.Name
                                 );
 
                             if (null == targetEntitySetFromContainer)
@@ -401,7 +401,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
                                 targetEntitySetFromContainer = stockContainer.Elements.OfType<EdmEntitySet>().SingleOrDefault
                                 (
                                     n =>
-                                        GetAllDerivedTypesAndSelf(((IEdmNavigationProperty)stockNavigationProperty).ToEntityType(), stockModel).Select(m => GetFullName(m)).Contains(n.EntityType().FullName()) && n.Name == targetEdmEntitySet.Name
+                                        GetAllDerivedTypesAndSelf(((IEdmNavigationProperty)stockNavigationProperty).ToEntityType(), stockModel).Select(m => GetFullName(m)).Contains(n.EntityType.FullName()) && n.Name == targetEdmEntitySet.Name
                                 );
                             }
 

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/PayloadGenerator.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/PayloadGenerator.cs
@@ -70,12 +70,12 @@ namespace Microsoft.Test.OData.Utils.Metadata
             // Create entity for each set in model.
             foreach (var set in sets)
             {
-                if (!set.EntityType().IsAbstract)
+                if (!set.EntityType.IsAbstract)
                 {
                     //create entity based on ElementType
-                    EntityInstance payload = this.AddIDAndLink(this.CreateEntityInstance(set.EntityType()));
+                    EntityInstance payload = this.AddIDAndLink(this.CreateEntityInstance(set.EntityType));
                     payload.WithDefaultAtomEntryAnnotations();
-                    payload.WithTypeAnnotation(set.EntityType());
+                    payload.WithTypeAnnotation(set.EntityType);
                     payload = (EntityInstance)this.normalizer.Visit(payload);
                     this.Assert.IsTrue(payload.Annotations.Count >= 2, "There should be a minimum of two annotations");
                     yield return payload;
@@ -97,9 +97,9 @@ namespace Microsoft.Test.OData.Utils.Metadata
             // Create entity for each set in model.
             foreach (var set in sets)
             {
-                if (!set.EntityType().IsAbstract)
+                if (!set.EntityType.IsAbstract)
                 {
-                    EntityInstance payload = this.AddIDAndLink(this.CreateEntityInstance(set.EntityType())).WithTypeAnnotation(set.EntityType());
+                    EntityInstance payload = this.AddIDAndLink(this.CreateEntityInstance(set.EntityType)).WithTypeAnnotation(set.EntityType);
                     this.Assert.IsTrue(payload.Annotations.Count == 2, "There should only be two annotations");
                     payload = (EntityInstance)this.normalizer.Visit(payload);
                     payloads.Add(payload);

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/ODataLibTest/ModelBuilder.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/ODataLibTest/ModelBuilder.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Test.OData.Utils.ODataLibTest
             ExceptionUtilities.CheckArgumentNotNull(container, "DefaultContainer");
 
             // create EntitySet
-            foreach (EdmEntityType entityType in model.SchemaElements.OfType<IEdmEntityType>().Where(e => e.BaseType == null && container.EntitySets().All(set => set.EntityType() != e)))
+            foreach (EdmEntityType entityType in model.SchemaElements.OfType<IEdmEntityType>().Where(e => e.BaseType == null && container.EntitySets().All(set => set.EntityType != e)))
             {
                 container.AddEntitySet(entityType.Name, entityType);
             }
@@ -483,7 +483,7 @@ namespace Microsoft.Test.OData.Utils.ODataLibTest
                     var searchType = entityType;
                     while (searchType != null)
                     {
-                        var entitySet = container.EntitySets().FirstOrDefault(s => s.EntityType() == searchType);
+                        var entitySet = container.EntitySets().FirstOrDefault(s => s.EntityType == searchType);
                         if (entitySet != null)
                         {
                             return entitySet;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2820.*

### Description

This pull request adds a `EntityType` property to `IEdmNavigationSource` interface to eliminate the constant type casting that happens when `EntityType(IEdmNavigationSource)` extension method is called.

The extension method is invoked very frequently and on hot paths in some cases.

Changes included implementing the property in classes that implement the `IEdmNavigationSource` interface.
In the crucial `EdmNavigationSource` class, the implementation looks as follows:
```csharp
// ...

private IEdmEntityType entityType;
private bool entityTypeSet = false;

// ...

public IEdmEntityType EntityType
{
    get
    {
        if (!this.entityTypeSet)
        {
            this.entityType = this.Type?.AsElementType() as IEdmEntityType;
            this.entityTypeSet = true;
        }

        return this.entityType;
    }
}
```

Since the `EntityType` extension method is public, I retained it but applied the `Obsolete` attribute.

Refactoring was also done to replace calls to the `EntityType` extension method with `IEdmNavigationSource.EntityType` property access.

**NOTE:**
The build pipeline for 8.x is not running the E2E tests currently.
A previous 8.x pull request got rid of `CreateODataDeltaReader` since it's deprecated and inadvertently forgot to update the tests in _/test/EndToEndTests/Tests/Client/Build.Desktop/DeltaTests/DeltaTests.cs_.
The E2E solution couldn't build locally so I fixed the delta tests in this pull request.
In addition, the tests had very few assert statements with little to no verification of the expected payload structure and data so I refactored them extensively.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
