### PR TITLE
update scale variable to lower case

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertySerializer.cs
@@ -646,8 +646,8 @@ namespace Microsoft.OData.JsonLight
 
             if (this.currentPropertyInfo.IsTopLevel)
             {
-                if (this.JsonLightOutputContext.MessageWriterSettings.LibraryCompatibility <
-                    ODataLibraryCompatibility.Version7 && this.JsonLightOutputContext.MessageWriterSettings.Version < ODataVersion.V401)
+                if (this.JsonLightOutputContext.MessageWriterSettings.LibraryCompatibility.HasFlag(ODataLibraryCompatibility.WriteTopLevelODataNullAnnotation)
+                    && this.JsonLightOutputContext.MessageWriterSettings.Version < ODataVersion.V401)
                 {
                     // The 6.x library used an OData 3.0 protocol element in this case: @odata.null=true
                     this.ODataAnnotationWriter.WriteInstanceAnnotationName(ODataAnnotationNames.ODataNull);
@@ -1085,8 +1085,8 @@ namespace Microsoft.OData.JsonLight
 
             if (this.currentPropertyInfo.IsTopLevel)
             {
-                if (this.JsonLightOutputContext.MessageWriterSettings.LibraryCompatibility <
-                    ODataLibraryCompatibility.Version7 && this.JsonLightOutputContext.MessageWriterSettings.Version < ODataVersion.V401)
+                if (this.JsonLightOutputContext.MessageWriterSettings.LibraryCompatibility.HasFlag(ODataLibraryCompatibility.WriteTopLevelODataNullAnnotation) && 
+                    this.JsonLightOutputContext.MessageWriterSettings.Version < ODataVersion.V401)
                 {
                     // The 6.x library used an OData 3.0 protocol element in this case: @odata.null=true
                     await this.ODataAnnotationWriter.WriteInstanceAnnotationNameAsync(ODataAnnotationNames.ODataNull)

--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightWriter.cs
@@ -980,7 +980,7 @@ namespace Microsoft.OData.JsonLight
                 // Write @odata.context annotation for navigation property
                 IEdmContainedEntitySet containedEntitySet = this.CurrentScope.NavigationSource as IEdmContainedEntitySet;
                 if (containedEntitySet != null
-                    && this.messageWriterSettings.LibraryCompatibility < ODataLibraryCompatibility.Version7
+                    && this.messageWriterSettings.LibraryCompatibility.HasFlag(ODataLibraryCompatibility.WriteODataContextAnnotationForNavProperty)
                     && this.messageWriterSettings.Version < ODataVersion.V401)
                 {
                     ODataContextUrlInfo info = ODataContextUrlInfo.Create(
@@ -2056,7 +2056,7 @@ namespace Microsoft.OData.JsonLight
                     // Write @odata.context annotation for navigation property
                     IEdmContainedEntitySet containedEntitySet = this.CurrentScope.NavigationSource as IEdmContainedEntitySet;
                     if (containedEntitySet != null
-                        && this.messageWriterSettings.LibraryCompatibility < ODataLibraryCompatibility.Version7
+                        && this.messageWriterSettings.LibraryCompatibility.HasFlag(ODataLibraryCompatibility.WriteODataContextAnnotationForNavProperty)
                         && this.messageWriterSettings.Version < ODataVersion.V401)
                     {
                         ODataContextUrlInfo info = ODataContextUrlInfo.Create(

--- a/src/Microsoft.OData.Core/ODataLibraryCompatibility.cs
+++ b/src/Microsoft.OData.Core/ODataLibraryCompatibility.cs
@@ -4,29 +4,49 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System.Diagnostics.CodeAnalysis;
+using System;
 
 namespace Microsoft.OData
 {
     /// <summary>
     /// Library compatibility levels.
     /// </summary>
-    [SuppressMessage("Microsoft.Design", "CA1008:EnumsShouldHaveZeroValue")]
+    [Flags]
     public enum ODataLibraryCompatibility
     {
         /// <summary>
+        /// No backward compatibility flag set.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// When enabled, the CSDL Scale and SRID "variable" value will be written "Variable" instead of "variable" for compatibility with older versions of the library.
+        /// </summary>
+        UseLegacyVariableCasing = 1 << 0,
+
+        /// <summary>
+        /// When enabled, writes '@odata.null=true' if a top-level property is single-valued and has null value.
+        /// </summary>
+        WriteTopLevelODataNullAnnotation = 1 << 1,
+
+        /// <summary>
+        /// When enabled, writes @odata.context annotation for navigation property.
+        /// </summary>
+        WriteODataContextAnnotationForNavProperty = 1 << 2,
+
+        /// <summary>
+        /// When enabled, validation for a single-valued top-level property that has a null value doesn't throw an exception.
+        /// </summary>
+        DoNotThrowExceptionForTopLevelNullProperty = 1 << 3,
+
+        /// <summary>
         /// Version 6.x
         /// </summary>
-        Version6 = 060000,
+        Version6 = UseLegacyVariableCasing | WriteTopLevelODataNullAnnotation | WriteODataContextAnnotationForNavProperty | DoNotThrowExceptionForTopLevelNullProperty,
 
         /// <summary>
         /// Version 7.x
         /// </summary>
-        Version7 = 070000,
-
-        /// <summary>
-        /// The latest version of the library.
-        /// </summary>
-        Latest = int.MaxValue
+        Version7 = UseLegacyVariableCasing
     }
 }

--- a/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageReaderSettings.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData
             this.EnableMessageStreamDisposal = true;
             this.EnableCharactersCheck = false;
             this.Version = odataVersion;
-            this.LibraryCompatibility = ODataLibraryCompatibility.Latest;
+            this.LibraryCompatibility = ODataLibraryCompatibility.None;
             this.EnablePropertyNameCaseInsensitive = false; // for back-compatible
 
             Validator = new ReaderValidator(this);

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -96,7 +96,7 @@ namespace Microsoft.OData
             this.EnableCharactersCheck = false;
             this.Validations = ValidationKinds.All;
             this.Validator = new WriterValidator(this);
-            this.LibraryCompatibility = ODataLibraryCompatibility.Latest;
+            this.LibraryCompatibility = ODataLibraryCompatibility.None;
             this.MultipartNewLine = "\r\n";
             this.AlwaysAddTypeAnnotationsForDerivedTypes = false;
             this.BufferSize = ODataConstants.DefaultOutputBufferSize;

--- a/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
@@ -14,6 +14,7 @@ using System.Xml;
 using Microsoft.OData.Metadata;
 using Microsoft.OData.Edm.Csdl;
 using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm;
 
 namespace Microsoft.OData
 {
@@ -267,7 +268,15 @@ namespace Microsoft.OData
         private void WriteMetadataDocumentImplementation()
         {
             IEnumerable<EdmError> errors;
-            if (!CsdlWriter.TryWriteCsdl(this.Model, this.xmlWriter, CsdlTarget.OData, out errors))
+
+            CsdlXmlWriterSettings writerSettings = new CsdlXmlWriterSettings();
+
+            if (this.MessageWriterSettings.LibraryCompatibility.HasFlag(ODataLibraryCompatibility.UseLegacyVariableCasing))
+            {
+                writerSettings.LibraryCompatibility |= EdmLibraryCompatibility.UseLegacyVariableCasing;
+            }
+
+            if (!CsdlWriter.TryWriteCsdl(this.Model, this.xmlWriter, CsdlTarget.OData, writerSettings, out errors))
             {
                 Debug.Assert(errors != null, "errors != null");
 

--- a/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -49,6 +49,13 @@ Microsoft.OData.Json.IJsonReader.ReadAsync() -> System.Threading.Tasks.Task<bool
 Microsoft.OData.ODataAsynchronousResponseMessage.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataBatchOperationRequestMessage.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataBatchOperationResponseMessage.ServiceProvider.get -> System.IServiceProvider
+Microsoft.OData.ODataLibraryCompatibility.None = 0 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.DoNotThrowExceptionForTopLevelNullProperty = 8 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.UseLegacyVariableCasing = 1 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.Version6 = Microsoft.OData.ODataLibraryCompatibility.UseLegacyVariableCasing | Microsoft.OData.ODataLibraryCompatibility.WriteTopLevelODataNullAnnotation | Microsoft.OData.ODataLibraryCompatibility.WriteODataContextAnnotationForNavProperty | Microsoft.OData.ODataLibraryCompatibility.DoNotThrowExceptionForTopLevelNullProperty -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.Version7 = 1 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.WriteODataContextAnnotationForNavProperty = 4 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.WriteTopLevelODataNullAnnotation = 2 -> Microsoft.OData.ODataLibraryCompatibility
 Microsoft.OData.ODataMessageInfo.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataMessageInfo.ServiceProvider.set -> void
 Microsoft.OData.ODataMessageReaderSettings.EnableReadingKeyAsSegment.get -> bool
@@ -572,9 +579,6 @@ Microsoft.OData.ODataInstanceAnnotation.Value.get -> Microsoft.OData.ODataValue
 Microsoft.OData.ODataItem
 Microsoft.OData.ODataItem.ODataItem() -> void
 Microsoft.OData.ODataLibraryCompatibility
-Microsoft.OData.ODataLibraryCompatibility.Latest = 2147483647 -> Microsoft.OData.ODataLibraryCompatibility
-Microsoft.OData.ODataLibraryCompatibility.Version6 = 60000 -> Microsoft.OData.ODataLibraryCompatibility
-Microsoft.OData.ODataLibraryCompatibility.Version7 = 70000 -> Microsoft.OData.ODataLibraryCompatibility
 Microsoft.OData.ODataMediaType
 Microsoft.OData.ODataMediaType.ODataMediaType(string type, string subType) -> void
 Microsoft.OData.ODataMediaType.ODataMediaType(string type, string subType, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> parameters) -> void

--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -49,6 +49,13 @@ Microsoft.OData.Json.IJsonReader.ReadAsync() -> System.Threading.Tasks.Task<bool
 Microsoft.OData.ODataAsynchronousResponseMessage.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataBatchOperationRequestMessage.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataBatchOperationResponseMessage.ServiceProvider.get -> System.IServiceProvider
+Microsoft.OData.ODataLibraryCompatibility.DoNotThrowExceptionForTopLevelNullProperty = 8 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.None = 0 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.UseLegacyVariableCasing = 1 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.Version6 = Microsoft.OData.ODataLibraryCompatibility.UseLegacyVariableCasing | Microsoft.OData.ODataLibraryCompatibility.WriteTopLevelODataNullAnnotation | Microsoft.OData.ODataLibraryCompatibility.WriteODataContextAnnotationForNavProperty | Microsoft.OData.ODataLibraryCompatibility.DoNotThrowExceptionForTopLevelNullProperty -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.Version7 = 1 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.WriteODataContextAnnotationForNavProperty = 4 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.WriteTopLevelODataNullAnnotation = 2 -> Microsoft.OData.ODataLibraryCompatibility
 Microsoft.OData.ODataMessageInfo.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataMessageInfo.ServiceProvider.set -> void
 Microsoft.OData.ODataMessageReaderSettings.EnableReadingKeyAsSegment.get -> bool
@@ -581,9 +588,6 @@ Microsoft.OData.ODataInstanceAnnotation.Value.get -> Microsoft.OData.ODataValue
 Microsoft.OData.ODataItem
 Microsoft.OData.ODataItem.ODataItem() -> void
 Microsoft.OData.ODataLibraryCompatibility
-Microsoft.OData.ODataLibraryCompatibility.Latest = 2147483647 -> Microsoft.OData.ODataLibraryCompatibility
-Microsoft.OData.ODataLibraryCompatibility.Version6 = 60000 -> Microsoft.OData.ODataLibraryCompatibility
-Microsoft.OData.ODataLibraryCompatibility.Version7 = 70000 -> Microsoft.OData.ODataLibraryCompatibility
 Microsoft.OData.ODataMediaType
 Microsoft.OData.ODataMediaType.ODataMediaType(string type, string subType) -> void
 Microsoft.OData.ODataMediaType.ODataMediaType(string type, string subType, System.Collections.Generic.IEnumerable<System.Collections.Generic.KeyValuePair<string, string>> parameters) -> void

--- a/src/Microsoft.OData.Core/WriterValidator.cs
+++ b/src/Microsoft.OData.Core/WriterValidator.cs
@@ -244,8 +244,8 @@ namespace Microsoft.OData
             }
 
             if (isTopLevel
-                && (this.settings.LibraryCompatibility >= ODataLibraryCompatibility.Version7
-                || this.settings.Version >= ODataVersion.V401))
+                && (!(this.settings.LibraryCompatibility.HasFlag(ODataLibraryCompatibility.DoNotThrowExceptionForTopLevelNullProperty)
+                || this.settings.Version >= ODataVersion.V401)))
             {
                 // From the spec:
                 // 11.2.3 Requesting Individual Properties

--- a/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlConstants.cs
@@ -180,6 +180,8 @@ namespace Microsoft.OData.Edm.Csdl
         internal const string Value_Ref = "Ref";
         internal const string Value_SridVariable = EdmConstants.Value_SridVariable;
         internal const string Value_ScaleVariable = EdmConstants.Value_ScaleVariable;
+        internal const string Value_SridVariable_Legacy = EdmConstants.Value_SridVariable_Legacy;
+        internal const string Value_ScaleVariable_Legacy = EdmConstants.Value_ScaleVariable_Legacy;
 
         internal const string TypeName_Untyped = "Edm.Untyped";
         internal const string TypeName_Untyped_Short = "Untyped";

--- a/src/Microsoft.OData.Edm/Csdl/CsdlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlWriter.cs
@@ -84,6 +84,18 @@ namespace Microsoft.OData.Edm.Csdl
         }
 #endif
 
+        /// <summary>
+        /// Outputs a CSDL XML artifact to the provided <see cref="XmlWriter"/>.
+        /// </summary>
+        /// <param name="model">Model to be written.</param>
+        /// <param name="writer">The XmlWriter the generated CSDL will be written to.</param>
+        /// <param name="target">Target implementation of the CSDL being generated.</param>
+        /// <param name="errors">Errors that prevented successful serialization, or no errors if serialization was successful. </param>
+        /// <returns>A value indicating whether serialization was successful.</returns>
+        public static bool TryWriteCsdl(IEdmModel model, XmlWriter writer, CsdlTarget target, out IEnumerable<EdmError> errors)
+        {
+            return TryWriteCsdl(model, writer, target, new CsdlXmlWriterSettings(), out errors);
+        }
 
         /// <summary>
         /// Outputs a CSDL XML artifact to the provided <see cref="XmlWriter"/>.
@@ -91,9 +103,10 @@ namespace Microsoft.OData.Edm.Csdl
         /// <param name="model">Model to be written.</param>
         /// <param name="writer">XmlWriter the generated CSDL will be written to.</param>
         /// <param name="target">Target implementation of the CSDL being generated.</param>
+        /// <param name="writerSettings">The CSDL xml writer settings.</param>
         /// <param name="errors">Errors that prevented successful serialization, or no errors if serialization was successful. </param>
         /// <returns>A value indicating whether serialization was successful.</returns>
-        public static bool TryWriteCsdl(IEdmModel model, XmlWriter writer, CsdlTarget target, out IEnumerable<EdmError> errors)
+        public static bool TryWriteCsdl(IEdmModel model, XmlWriter writer, CsdlTarget target, CsdlXmlWriterSettings writerSettings, out IEnumerable<EdmError> errors)
         {
             EdmUtil.CheckArgumentNull(model, "model");
             EdmUtil.CheckArgumentNull(writer, "writer");
@@ -104,7 +117,7 @@ namespace Microsoft.OData.Edm.Csdl
                 return false;
             }
 
-            CsdlWriter csdlWriter = new CsdlXmlWriter(model, writer, edmxVersion, target);
+            CsdlWriter csdlWriter = new CsdlXmlWriter(model, writer, edmxVersion, target, writerSettings);
             csdlWriter.WriteCsdl();
 
             errors = Enumerable.Empty<EdmError>();

--- a/src/Microsoft.OData.Edm/Csdl/CsdlXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlXmlWriter.cs
@@ -20,6 +20,7 @@ namespace Microsoft.OData.Edm.Csdl
         private readonly XmlWriter writer;
         private readonly string edmxNamespace;
         private readonly CsdlTarget target;
+        private readonly CsdlXmlWriterSettings writerSettings;
 
         /// <summary>
         /// Initializes a new instance of <see cref="CsdlXmlWriter"/> class.
@@ -29,12 +30,26 @@ namespace Microsoft.OData.Edm.Csdl
         /// <param name="edmxVersion">The Edmx version.</param>
         /// <param name="target">The CSDL target.</param>
         public CsdlXmlWriter(IEdmModel model, XmlWriter writer, Version edmxVersion, CsdlTarget target)
+            : this(model, writer, edmxVersion, target, new CsdlXmlWriterSettings())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="CsdlXmlWriter"/> class.
+        /// </summary>
+        /// <param name="model">The Edm model.</param>
+        /// <param name="writer">The XML writer.</param>
+        /// <param name="edmxVersion">The Edmx version.</param>
+        /// <param name="target">The CSDL target.</param>
+        /// <param name="writerSettings">The CSDL xml writer settings.</param>
+        public CsdlXmlWriter(IEdmModel model, XmlWriter writer, Version edmxVersion, CsdlTarget target, CsdlXmlWriterSettings writerSettings)
             : base(model, edmxVersion)
         {
             EdmUtil.CheckArgumentNull(writer, "writer");
 
             this.writer = writer;
             this.target = target;
+            this.writerSettings = writerSettings;
 
             Debug.Assert(CsdlConstants.SupportedEdmxVersions.ContainsKey(edmxVersion), "CsdlConstants.SupportedEdmxVersions.ContainsKey(edmxVersion)");
             this.edmxNamespace = CsdlConstants.SupportedEdmxVersions[edmxVersion];
@@ -120,7 +135,7 @@ namespace Microsoft.OData.Edm.Csdl
 
                 foreach (IEdmReference edmReference in references)
                 {
-                    visitor = new EdmModelReferenceElementsXmlVisitor(this.model, this.writer, this.edmxVersion);
+                    visitor = new EdmModelReferenceElementsXmlVisitor(this.model, this.writer, this.edmxVersion, this.writerSettings);
                     visitor.VisitEdmReferences(this.model, edmReference);
                 }
             }
@@ -138,7 +153,7 @@ namespace Microsoft.OData.Edm.Csdl
             Version edmVersion = this.model.GetEdmVersion() ?? EdmConstants.EdmVersionLatest;
             foreach (EdmSchema schema in this.schemas)
             {
-                var schemaWriter = new EdmModelCsdlSchemaXmlWriter(model, this.writer, edmVersion);
+                var schemaWriter = new EdmModelCsdlSchemaXmlWriter(model, this.writer, edmVersion, this.writerSettings);
                 visitor = new EdmModelCsdlSerializationVisitor(this.model, schemaWriter);
                 visitor.VisitEdmSchema(schema, this.model.GetNamespacePrefixMappings());
             }

--- a/src/Microsoft.OData.Edm/Csdl/CsdlXmlWriterSettings.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlXmlWriterSettings.cs
@@ -1,0 +1,19 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CsdlXmlWriterSettings.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Edm.Csdl
+{
+    /// <summary>
+    /// Provides settings to be used with <see cref="CsdlXmlWriter"/>.
+    /// </summary>
+    public sealed class CsdlXmlWriterSettings
+    {
+        /// <summary>
+        /// Gets or sets the compatibility flags for the <see cref="CsdlXmlWriter"/> to maintain compatibility with legacy functionality.
+        /// </summary>
+        public EdmLibraryCompatibility LibraryCompatibility { get; set; }
+    }
+}

--- a/src/Microsoft.OData.Edm/Csdl/SchemaWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/SchemaWriter.cs
@@ -81,7 +81,7 @@ namespace Microsoft.OData.Edm.Csdl
                 XmlWriter writer = writerProvider(schema.Namespace);
                 if (writer != null)
                 {
-                    var schemaWriter = new EdmModelCsdlSchemaXmlWriter(model, writer, edmVersion);
+                    var schemaWriter = new EdmModelCsdlSchemaXmlWriter(model, writer, edmVersion, new CsdlXmlWriterSettings());
                     visitor = new EdmModelCsdlSerializationVisitor(model, schemaWriter);
                     visitor.VisitEdmSchema(schema, model.GetNamespacePrefixMappings());
                 }

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
@@ -24,12 +24,17 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
     {
         protected XmlWriter xmlWriter;
         protected readonly string edmxNamespace;
+        private readonly CsdlXmlWriterSettings writerSettings;
 
-        internal EdmModelCsdlSchemaXmlWriter(IEdmModel model, XmlWriter xmlWriter, Version edmVersion)
+        internal EdmModelCsdlSchemaXmlWriter(IEdmModel model, XmlWriter xmlWriter, Version edmVersion, CsdlXmlWriterSettings csdlXmlWriterSettings)
             : base(model, edmVersion)
         {
             this.xmlWriter = xmlWriter;
             this.edmxNamespace = CsdlConstants.SupportedEdmxVersions[edmVersion];
+
+            Debug.Assert(csdlXmlWriterSettings != null, "Writer settings must be initialized.");
+
+            this.writerSettings = csdlXmlWriterSettings;
         }
 
         internal override void WriteReferenceElementHeader(IEdmReference reference)
@@ -826,14 +831,28 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             }
         }
 
-        private static string SridAsXml(int? i)
+        private string SridAsXml(int? i)
         {
-            return i.HasValue ? Convert.ToString(i.Value, CultureInfo.InvariantCulture) : CsdlConstants.Value_SridVariable;
+            if (this.writerSettings.LibraryCompatibility.HasFlag(EdmLibraryCompatibility.UseLegacyVariableCasing))
+            {
+                return i.HasValue ? Convert.ToString(i.Value, CultureInfo.InvariantCulture) : CsdlConstants.Value_SridVariable_Legacy;
+            }
+            else 
+            {
+                return i.HasValue ? Convert.ToString(i.Value, CultureInfo.InvariantCulture) : CsdlConstants.Value_SridVariable;
+            }
         }
 
-        private static string ScaleAsXml(int? i)
+        private string ScaleAsXml(int? i)
         {
-            return i.HasValue ? Convert.ToString(i.Value, CultureInfo.InvariantCulture) : CsdlConstants.Value_ScaleVariable;
+            if (this.writerSettings.LibraryCompatibility.HasFlag(EdmLibraryCompatibility.UseLegacyVariableCasing))
+            {
+                return i.HasValue ? Convert.ToString(i.Value, CultureInfo.InvariantCulture) : CsdlConstants.Value_ScaleVariable_Legacy;
+            }
+            else 
+            {
+                return i.HasValue ? Convert.ToString(i.Value, CultureInfo.InvariantCulture) : CsdlConstants.Value_ScaleVariable;
+            }
         }
 
         private static string GetCsdlNamespace(Version edmVersion)

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelReferenceElementsXmlVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelReferenceElementsXmlVisitor.cs
@@ -5,7 +5,6 @@
 //---------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Xml;
 using Microsoft.OData.Edm.Vocabularies;
 
@@ -18,9 +17,9 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
     {
         private readonly EdmModelCsdlSchemaXmlWriter schemaWriter;
 
-        internal EdmModelReferenceElementsXmlVisitor(IEdmModel model, XmlWriter xmlWriter, Version edmxVersion)
+        internal EdmModelReferenceElementsXmlVisitor(IEdmModel model, XmlWriter xmlWriter, Version edmxVersion, CsdlXmlWriterSettings writerSettings)
         {
-            this.schemaWriter = new EdmModelCsdlSchemaXmlWriter(model, xmlWriter, edmxVersion);
+            this.schemaWriter = new EdmModelCsdlSchemaXmlWriter(model, xmlWriter, edmxVersion, writerSettings);
         }
 
         #region write IEdmModel.References for referenced models.

--- a/src/Microsoft.OData.Edm/EdmLibraryCompatibility.cs
+++ b/src/Microsoft.OData.Edm/EdmLibraryCompatibility.cs
@@ -1,0 +1,27 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="EdmLibraryCompatibility.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.OData.Edm
+{
+    /// <summary>
+    /// Represents compatibility settings for the EDM (Entity Data Model) library.
+    /// </summary>
+    [Flags]
+    public enum EdmLibraryCompatibility
+    {
+        /// <summary>
+        /// No flags set. Represents the base or default state.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// When enabled, the CSDL Scale and SRID "variable" value will be written "Variable" instead of "variable" for compatibility with older versions of the library.
+        /// </summary>
+        UseLegacyVariableCasing = 1 << 0
+    }
+}

--- a/src/Microsoft.OData.Edm/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -60,6 +60,10 @@ Microsoft.OData.Edm.Csdl.CsdlTarget.EntityFramework = 0 -> Microsoft.OData.Edm.C
 Microsoft.OData.Edm.Csdl.CsdlTarget.OData = 1 -> Microsoft.OData.Edm.Csdl.CsdlTarget
 Microsoft.OData.Edm.Csdl.CsdlWriter
 Microsoft.OData.Edm.Csdl.CsdlWriter.CsdlWriter(Microsoft.OData.Edm.IEdmModel model, System.Version edmxVersion) -> void
+Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings
+Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings.CsdlXmlWriterSettings() -> void
+Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings.LibraryCompatibility.get -> Microsoft.OData.Edm.EdmLibraryCompatibility
+Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings.LibraryCompatibility.set -> void
 Microsoft.OData.Edm.Csdl.EdmParseException
 Microsoft.OData.Edm.Csdl.EdmParseException.EdmParseException(System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> parseErrors) -> void
 Microsoft.OData.Edm.Csdl.EdmParseException.Errors.get -> System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.OData.Edm.Validation.EdmError>
@@ -287,6 +291,9 @@ Microsoft.OData.Edm.EdmIncludeAnnotations.EdmIncludeAnnotations(string termNames
 Microsoft.OData.Edm.EdmIncludeAnnotations.Qualifier.get -> string
 Microsoft.OData.Edm.EdmIncludeAnnotations.TargetNamespace.get -> string
 Microsoft.OData.Edm.EdmIncludeAnnotations.TermNamespace.get -> string
+Microsoft.OData.Edm.EdmLibraryCompatibility
+Microsoft.OData.Edm.EdmLibraryCompatibility.None = 0 -> Microsoft.OData.Edm.EdmLibraryCompatibility
+Microsoft.OData.Edm.EdmLibraryCompatibility.UseLegacyVariableCasing = 1 -> Microsoft.OData.Edm.EdmLibraryCompatibility
 Microsoft.OData.Edm.EdmLocation
 Microsoft.OData.Edm.EdmLocation.EdmLocation() -> void
 Microsoft.OData.Edm.EdmModel
@@ -1446,6 +1453,7 @@ static Microsoft.OData.Edm.Csdl.CsdlReader.TryParse(System.Xml.XmlReader reader,
 static Microsoft.OData.Edm.Csdl.CsdlReader.TryParse(System.Xml.XmlReader reader, System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.IEdmModel> references, out Microsoft.OData.Edm.IEdmModel model, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
 static Microsoft.OData.Edm.Csdl.CsdlReader.TryParse(System.Xml.XmlReader reader, System.Func<System.Uri, System.Xml.XmlReader> getReferencedModelReaderFunc, out Microsoft.OData.Edm.IEdmModel model, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
 static Microsoft.OData.Edm.Csdl.CsdlWriter.GetVersionString(System.Version version) -> string
+static Microsoft.OData.Edm.Csdl.CsdlWriter.TryWriteCsdl(Microsoft.OData.Edm.IEdmModel model, System.Xml.XmlWriter writer, Microsoft.OData.Edm.Csdl.CsdlTarget target, Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings writerSettings, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
 static Microsoft.OData.Edm.Csdl.CsdlWriter.TryWriteCsdl(Microsoft.OData.Edm.IEdmModel model, System.Xml.XmlWriter writer, Microsoft.OData.Edm.Csdl.CsdlTarget target, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
 static Microsoft.OData.Edm.Csdl.SchemaReader.TryParse(System.Collections.Generic.IEnumerable<System.Xml.XmlReader> readers, Microsoft.OData.Edm.IEdmModel reference, out Microsoft.OData.Edm.IEdmModel model, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
 static Microsoft.OData.Edm.Csdl.SchemaReader.TryParse(System.Collections.Generic.IEnumerable<System.Xml.XmlReader> readers, out Microsoft.OData.Edm.IEdmModel model, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool

--- a/src/Microsoft.OData.Edm/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -77,6 +77,10 @@ Microsoft.OData.Edm.Csdl.CsdlTarget.EntityFramework = 0 -> Microsoft.OData.Edm.C
 Microsoft.OData.Edm.Csdl.CsdlTarget.OData = 1 -> Microsoft.OData.Edm.Csdl.CsdlTarget
 Microsoft.OData.Edm.Csdl.CsdlWriter
 Microsoft.OData.Edm.Csdl.CsdlWriter.CsdlWriter(Microsoft.OData.Edm.IEdmModel model, System.Version edmxVersion) -> void
+Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings
+Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings.CsdlXmlWriterSettings() -> void
+Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings.LibraryCompatibility.get -> Microsoft.OData.Edm.EdmLibraryCompatibility
+Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings.LibraryCompatibility.set -> void
 Microsoft.OData.Edm.Csdl.EdmParseException
 Microsoft.OData.Edm.Csdl.EdmParseException.EdmParseException(System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> parseErrors) -> void
 Microsoft.OData.Edm.Csdl.EdmParseException.Errors.get -> System.Collections.ObjectModel.ReadOnlyCollection<Microsoft.OData.Edm.Validation.EdmError>
@@ -304,6 +308,9 @@ Microsoft.OData.Edm.EdmIncludeAnnotations.EdmIncludeAnnotations(string termNames
 Microsoft.OData.Edm.EdmIncludeAnnotations.Qualifier.get -> string
 Microsoft.OData.Edm.EdmIncludeAnnotations.TargetNamespace.get -> string
 Microsoft.OData.Edm.EdmIncludeAnnotations.TermNamespace.get -> string
+Microsoft.OData.Edm.EdmLibraryCompatibility
+Microsoft.OData.Edm.EdmLibraryCompatibility.None = 0 -> Microsoft.OData.Edm.EdmLibraryCompatibility
+Microsoft.OData.Edm.EdmLibraryCompatibility.UseLegacyVariableCasing = 1 -> Microsoft.OData.Edm.EdmLibraryCompatibility
 Microsoft.OData.Edm.EdmLocation
 Microsoft.OData.Edm.EdmLocation.EdmLocation() -> void
 Microsoft.OData.Edm.EdmModel
@@ -1470,6 +1477,7 @@ static Microsoft.OData.Edm.Csdl.CsdlReader.TryParse(System.Xml.XmlReader reader,
 static Microsoft.OData.Edm.Csdl.CsdlWriter.GetVersionString(System.Version version) -> string
 static Microsoft.OData.Edm.Csdl.CsdlWriter.TryWriteCsdl(Microsoft.OData.Edm.IEdmModel model, System.Text.Json.Utf8JsonWriter writer, Microsoft.OData.Edm.Csdl.CsdlJsonWriterSettings settings, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
 static Microsoft.OData.Edm.Csdl.CsdlWriter.TryWriteCsdl(Microsoft.OData.Edm.IEdmModel model, System.Text.Json.Utf8JsonWriter writer, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
+static Microsoft.OData.Edm.Csdl.CsdlWriter.TryWriteCsdl(Microsoft.OData.Edm.IEdmModel model, System.Xml.XmlWriter writer, Microsoft.OData.Edm.Csdl.CsdlTarget target, Microsoft.OData.Edm.Csdl.CsdlXmlWriterSettings writerSettings, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
 static Microsoft.OData.Edm.Csdl.CsdlWriter.TryWriteCsdl(Microsoft.OData.Edm.IEdmModel model, System.Xml.XmlWriter writer, Microsoft.OData.Edm.Csdl.CsdlTarget target, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
 static Microsoft.OData.Edm.Csdl.SchemaReader.TryParse(System.Collections.Generic.IEnumerable<System.Xml.XmlReader> readers, Microsoft.OData.Edm.IEdmModel reference, out Microsoft.OData.Edm.IEdmModel model, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool
 static Microsoft.OData.Edm.Csdl.SchemaReader.TryParse(System.Collections.Generic.IEnumerable<System.Xml.XmlReader> readers, out Microsoft.OData.Edm.IEdmModel model, out System.Collections.Generic.IEnumerable<Microsoft.OData.Edm.Validation.EdmError> errors) -> bool

--- a/src/Microsoft.OData.Edm/Schema/EdmConstants.cs
+++ b/src/Microsoft.OData.Edm/Schema/EdmConstants.cs
@@ -62,8 +62,10 @@ namespace Microsoft.OData.Edm
         internal const string Value_UnknownType = "UnknownType";
         internal const string Value_UnnamedType = "UnnamedType";
         internal const string Value_Max = "max";
-        internal const string Value_SridVariable = "Variable";
-        internal const string Value_ScaleVariable = "Variable";
+        internal const string Value_SridVariable = "variable";
+        internal const string Value_ScaleVariable = "variable";
+        internal const string Value_SridVariable_Legacy = "Variable";
+        internal const string Value_ScaleVariable_Legacy = "Variable";
 
         internal const string Type_Collection = "Collection";
         internal const string Type_Complex = "Complex";

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightOutputContextApiTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightOutputContextApiTests.cs
@@ -986,7 +986,7 @@ namespace Microsoft.OData.Tests.JsonLight
         [Theory]
         [InlineData(ODataLibraryCompatibility.Version6, "\"Items@odata.context\":\"http://tempuri.org/$metadata#Orders(1)/Items\",")]
         [InlineData(ODataLibraryCompatibility.Version7, "")]
-        [InlineData(ODataLibraryCompatibility.Latest, "")]
+        [InlineData(ODataLibraryCompatibility.None, "")]
         public async Task WriteContainment_APIsShouldYieldSameResult(ODataLibraryCompatibility libraryCompatilibity, string containmentContextUrl)
         {
             this.writerSettings.ODataUri.Path = new ODataUriParser(this.model, new Uri(ServiceUri), new Uri(ServiceUri + "/Orders(1)")).ParsePath();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
@@ -1527,7 +1527,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
         [Theory]
         [InlineData(ODataLibraryCompatibility.Version6, "\"Products@odata.context\":\"http://tempuri.org/$metadata#Orders(1)/Products\",")]
         [InlineData(ODataLibraryCompatibility.Version7, "")]
-        [InlineData(ODataLibraryCompatibility.Latest, "")]
+        [InlineData(ODataLibraryCompatibility.None, "")]
         public async Task WriteContainmentAsync(ODataLibraryCompatibility libraryCompatilibity, string containmentContextUrl)
         {
             this.settings.LibraryCompatibility = libraryCompatilibity;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OData.Tests
             Assert.True(1000 == settings.MessageQuotas.MaxOperationsPerChangeset, "MaxOperationsPerChangeset should be int.MaxValue.");
             Assert.True(100 == settings.MessageQuotas.MaxNestingDepth, "The MaxNestingDepth should be set to 100 by default.");
             Assert.True(1024 * 1024 == settings.MessageQuotas.MaxReceivedMessageSize, "The MaxMessageSize should be set to 1024 * 1024 by default.");
-            Assert.True(ODataLibraryCompatibility.Latest == settings.LibraryCompatibility, "The LibraryCompatibility should be set to ODataLibraryCompatibility.Latest by default.");
+            Assert.True(ODataLibraryCompatibility.None == settings.LibraryCompatibility, "The LibraryCompatibility should be set to ODataLibraryCompatibility.None by default.");
             Assert.False(settings.EnableReadingODataAnnotationWithoutPrefix);
             Assert.False(settings.EnableReadingKeyAsSegment);
         }
@@ -63,7 +63,7 @@ namespace Microsoft.OData.Tests
             Assert.True(1000 == settings.MessageQuotas.MaxOperationsPerChangeset, "MaxOperationsPerChangeset should be int.MaxValue.");
             Assert.True(100 == settings.MessageQuotas.MaxNestingDepth, "The MaxNestingDepth should be set to 100 by default.");
             Assert.True(1024 * 1024 == settings.MessageQuotas.MaxReceivedMessageSize, "The MaxMessageSize should be set to 1024 * 1024 by default.");
-            Assert.True(ODataLibraryCompatibility.Latest == settings.LibraryCompatibility, "The LibraryCompatibility should be set to ODataLibraryCompatibility.Latest by default.");
+            Assert.True(ODataLibraryCompatibility.None == settings.LibraryCompatibility, "The LibraryCompatibility should be set to ODataLibraryCompatibility.None by default.");
             Assert.False(settings.EnableReadingKeyAsSegment);
             Assert.True(settings.EnableReadingODataAnnotationWithoutPrefix);
         }
@@ -89,7 +89,7 @@ namespace Microsoft.OData.Tests
             Assert.True(1000 == settings.MessageQuotas.MaxOperationsPerChangeset, "MaxOperationsPerChangeset should be int.MaxValue.");
             Assert.True(100 == settings.MessageQuotas.MaxNestingDepth, "The MaxNestingDepth should be set to 100 by default.");
             Assert.True(1024 * 1024 == settings.MessageQuotas.MaxReceivedMessageSize, "The MaxMessageSize should be set to 1024 * 1024 by default.");
-            Assert.True(ODataLibraryCompatibility.Latest == settings.LibraryCompatibility, "The LibraryCompatibility should be set to ODataLibraryCompatibility.Latest by default.");
+            Assert.True(ODataLibraryCompatibility.None == settings.LibraryCompatibility, "The LibraryCompatibility should be set to ODataLibraryCompatibility.None by default.");
             Assert.False(settings.EnableReadingODataAnnotationWithoutPrefix);
             Assert.False(settings.EnableReadingKeyAsSegment);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -122,9 +122,9 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
-        public void LibraryCompatibilityShouldBeLatestByDefault()
+        public void LibraryCompatibilityShouldBeNoneByDefault()
         {
-            Assert.Equal(ODataLibraryCompatibility.Latest, this.settings.LibraryCompatibility);
+            Assert.Equal(ODataLibraryCompatibility.None, this.settings.LibraryCompatibility);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSchemaWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSchemaWriterTests.cs
@@ -177,7 +177,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             var namespaceAliasMappings = model.GetNamespaceAliases();
             Version edmxVersion = model.GetEdmxVersion();
             xmlWriter = XmlWriter.Create(memoryStream);
-            return new EdmModelCsdlSchemaXmlWriter(model, xmlWriter, edmxVersion);
+            return new EdmModelCsdlSchemaXmlWriter(model, xmlWriter, edmxVersion, new CsdlXmlWriterSettings());
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
@@ -2037,7 +2037,13 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
                 Indent = indent,
                 ConformanceLevel = ConformanceLevel.Auto
             });
-            var schemaWriter = new EdmModelCsdlSchemaXmlWriter(model, xmlWriter, edmxVersion);
+
+            CsdlXmlWriterSettings writerSettings = new CsdlXmlWriterSettings
+            {
+                LibraryCompatibility = EdmLibraryCompatibility.UseLegacyVariableCasing
+            };
+
+            var schemaWriter = new EdmModelCsdlSchemaXmlWriter(model, xmlWriter, edmxVersion, writerSettings);
             var visitor = new EdmModelCsdlSerializationVisitor(model, schemaWriter);
 
             testAction(visitor);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.cs
@@ -86,7 +86,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
   <Term Name=""AllowedValues"" Type=""Collection(Validation.AllowedValue)"" AppliesTo=""Property Parameter TypeDefinition"" Nullable=""false"">
     <Annotation Term=""Core.Description"" String=""A collection of valid values for the annotated property, parameter, or type definition"" />
   </Term>
-  <Term Name=""MultipleOf"" Type=""Edm.Decimal"" AppliesTo=""Property Parameter Term"" Nullable=""false"" Scale=""Variable"">
+  <Term Name=""MultipleOf"" Type=""Edm.Decimal"" AppliesTo=""Property Parameter Term"" Nullable=""false"" Scale=""variable"">
     <Annotation Term=""Core.Description"" String=""The value of the annotated property, parameter, or term must be an integer multiple of this positive value. For temporal types, the value is measured in seconds."" />
   </Term>
   <Term Name=""Constraint"" Type=""Validation.ConstraintType"" AppliesTo=""Property EntityType ComplexType"" Nullable=""false"">


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### This PR fixes https://github.com/OData/odata.net/issues/1243
https://github.com/OData/odata.net/issues/2026
https://github.com/OData/odata.net/issues/2501

### Description

The library writes for example
`<Property Name="charge" Type="Edm.Decimal" Scale="Variable" /> `

but according to [4.01 sections 7.2.4 [Scale](https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Scale)] and the [edm.xsd](https://raw.githubusercontent.com/oasis-tcs/odata-csdl-schemas/7249db75c4ee31ac959fafb99da6a79e2c6b9e02/schemas/edm.xsd)

the XML string "Variable" should be "variable"

This PR ensures that the `Variable` is written as `variable`

@mikepizzo do we need a compatibility flag for this change in 8.x?

- [x] I have added a new flag enum `EdmLibraryCompatibility` that will contain all compatibility flags specific to the Edm library as this change affects how the CSDL is read or written. I've named the compatibility for this change: `UseLegacyVariableCasing`. It will be used to disable writing lower case variable for `Scale` and `SRID` This means that if this flag is not set then the lower case `variable` will be used. It will be the default. 
- [x] I've added the same compatibility; `UseLegacyVariableCasing` to `ODataLibraryCompatibility` and update this enum to be a flag enum. 
- [x] I've added a class `CsdlXmlWriterSettings` in this namespace: `Microsoft.OData.Edm.Csdl`. This class will contain the `UseLegacyVariableCasing` as well and it's instance is what will be passed around the various methods. I think it's better to have the class than pass the `EdmLibraryCompatibility` flag enum to the CsdlWriter Methods as the class can have other compatibilities that are no related to the `CsdlWriter` or `CsdlReader`
- [x] To the `CsdlWriter` class I've added another overload of `TryWriteCsdl` that takes the `CsdlXmlWriterSettings` as a param. 
- [x] I've also updated the WriteMetadataDocumentImplementation method to call the new overload of the `TryWriteCsdl` that takes the `CsdlXmlWriterSettings`. 
 
### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
