### PR TITLE
Remove Credentials and ReadWriteTimeout deprecated overrides

### DIFF
--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/HttpClientRequestMessage.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/HttpClientRequestMessage.cs
@@ -9,13 +9,11 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
     using System;
     using System.Collections.Generic;
     using Microsoft.OData.Client;
-    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
-    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.OData;
 
@@ -107,38 +105,11 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
         }
 
         /// <summary>
-        ///  Gets or set the credentials for this request.
-        /// </summary>
-        public override ICredentials Credentials
-        {
-            get
-            {
-                return this.handler.Credentials;
-            }
-            set
-            {
-                this.handler.Credentials = value;
-            }
-        }
-
-        /// <summary>
         /// Gets or sets the timeout (in seconds) for this request.
         /// </summary>
 #if !(NETCOREAPP1_0 || NETCOREAPP2_0)
         public override int Timeout 
         { 
-            get
-            {
-                return (int)this.client.Timeout.TotalSeconds;
-            }
-            set
-            {
-                this.client.Timeout = new TimeSpan(0, 0, value);
-            }
-        }
-
-        public override int ReadWriteTimeout
-        {
             get
             {
                 return (int)this.client.Timeout.TotalSeconds;

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/HttpClientRequestMessage.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/HttpClientRequestMessage.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
 {
     using System;
     using System.Collections.Generic;
-    using Microsoft.OData.Client;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -16,6 +15,7 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
     using Microsoft.OData;
+    using Microsoft.OData.Client;
 
     /// <summary>
     /// HttpClient based implementation of DataServiceClientRequestMessage.

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/RequestMessageArgsTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests/RequestMessageArgsTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
                 {
                     if (args.Method == "MERGE")
                     {
-                        var newArgs = new DataServiceClientRequestMessageArgs("PATCH", args.RequestUri, true, args.UsePostTunneling, args.Headers);
+                        var newArgs = new DataServiceClientRequestMessageArgs("PATCH", args.RequestUri, args.UsePostTunneling, args.Headers);
 
                         // PATCH verb not supported in V1 or V2
                         newArgs.Headers.Remove("DataServiceVersion");
@@ -103,7 +103,7 @@ namespace Microsoft.Test.OData.Tests.Client.TransportLayerTests
                     if (args.Method == "PATCH")
                     {
                         // use Merge
-                        var newArgs = new DataServiceClientRequestMessageArgs("MERGE", args.RequestUri, true, args.UsePostTunneling, args.Headers);
+                        var newArgs = new DataServiceClientRequestMessageArgs("MERGE", args.RequestUri, args.UsePostTunneling, args.Headers);
                         // use V4 since Merge is removed only in V4
                         newArgs.Headers["DataServiceVersion"] = "4.0";
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request removes `Credentials` and `ReadWriteTimeout` deprecated overrides

### Description

This pull request removes `Credentials` and `ReadWriteTimeout` deprecated overrides inadvertently forgotten in a previous pull request

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
