### PR TITLE
fix ArgumentNullException exception when loading invalid CSDL

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
@@ -312,9 +312,9 @@ namespace Microsoft.OData.Edm.Csdl
             Version edmxVersion;
             CsdlModel astModel;
 
-            TryParseCsdlFileToCsdlModel(out edmxVersion, out astModel);
+            bool parsed = TryParseCsdlFileToCsdlModel(out edmxVersion, out astModel);
 
-            if (!this.HasIntolerableError())
+            if (!this.HasIntolerableError() && parsed)
             {
                 List<CsdlModel> referencedAstModels = this.LoadAndParseReferencedCsdlFiles(edmxVersion);
 


### PR DESCRIPTION
When loading invalid CSDL model via
**CsdlReader.Parse** we get correct exception **EdmException**. But if we do it via **CsdlReader.TryParse** with **ignoreUnexpectedAttributesAndElements** option enabled we get instead **System.ArgumentNullException: Value cannot be null. (Parameter 'key'**) because adding null version fails here https://github.com/OData/odata.net/blob/main/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs#L339 and as get no critical errors due to https://github.com/OData/odata.net/blob/main/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs#L483 