### PR TITLE
Throw an ODataException with helpful message when type name in context URL is not qualified

### DIFF
--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.cs
@@ -854,6 +854,7 @@ namespace Microsoft.OData
         internal const string JsonReaderExtensions_UnexpectedInstanceAnnotationName = "JsonReaderExtensions_UnexpectedInstanceAnnotationName";
         internal const string BufferUtils_InvalidBufferOrSize = "BufferUtils_InvalidBufferOrSize";
         internal const string ServiceProviderExtensions_NoServiceRegistered = "ServiceProviderExtensions_NoServiceRegistered";
+        internal const string TypeUtils_TypeNameIsNotQualified = "TypeUtils_TypeNameIsNotQualified";
 
         static TextRes loader = null;
         ResourceManager resources;

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.txt
@@ -997,3 +997,5 @@ JsonReaderExtensions_UnexpectedInstanceAnnotationName=An unexpected instance ann
 BufferUtils_InvalidBufferOrSize=The buffer from pool cannot be null or less than the required minimal size '{0}'.
 
 ServiceProviderExtensions_NoServiceRegistered=No service for type '{0}' has been registered.
+
+TypeUtils_TypeNameIsNotQualified=The value '{0}' is not a qualified type name. A qualified type name is expected.

--- a/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
+++ b/src/Microsoft.OData.Core/Parameterized.Microsoft.OData.Core.cs
@@ -7481,6 +7481,14 @@ namespace Microsoft.OData {
             return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.ServiceProviderExtensions_NoServiceRegistered, p0);
         }
 
+        /// <summary>
+        /// A string like "The value '{0}' is not a qualified type name. A qualified type name is expected."
+        /// </summary>
+        internal static string TypeUtils_TypeNameIsNotQualified(object p0)
+        {
+            return Microsoft.OData.TextRes.GetString(Microsoft.OData.TextRes.TypeUtils_TypeNameIsNotQualified, p0);
+        }
+
     }
 
     /// <summary>

--- a/src/Microsoft.OData.Core/TypeUtils.cs
+++ b/src/Microsoft.OData.Core/TypeUtils.cs
@@ -103,6 +103,11 @@ namespace Microsoft.OData
             }
 
             int separator = qualifiedTypeName.LastIndexOf(".", StringComparison.Ordinal);
+            if (separator == -1)
+            {
+                throw new ODataException(Strings.TypeUtils_TypeNameIsNotQualified(qualifiedTypeName));
+            }
+
             namespaceName = qualifiedTypeName.Substring(0, separator);
             typeName = qualifiedTypeName.Substring(separator == 0 ? 0 : separator + 1);
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/TypeUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/TypeUtilsTests.cs
@@ -1,0 +1,39 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="TypeUtilsTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Xunit;
+
+namespace Microsoft.OData.Tests
+{
+    public class TypeUtilsTests
+    {
+        [Theory]
+        [InlineData("Ns.TypeName", false)]
+        [InlineData("Collection(Ns.TypeName)", true)]
+        public void ParseQualifiedTypeNameSplitsInputIntoNamespaceAndUnqualifiedTypeName(string input, bool isCollection)
+        {
+            // Act
+            TypeUtils.ParseQualifiedTypeName(input, out string namespaceName, out string typeName, out bool outIsCollection);
+
+            // Assert
+            Assert.Equal("Ns", namespaceName);
+            Assert.Equal("TypeName", typeName);
+            Assert.Equal(isCollection, outIsCollection);
+        }
+
+        [Theory]
+        [InlineData("TypeName")]
+        [InlineData("Collection(TypeName)")]
+        public void ParseQualifiedTypeNameThrowsExceptionForTypeNameNotQualified(string input)
+        {
+            // Arrange & Act
+            var exception = Assert.Throws<ODataException>(() => TypeUtils.ParseQualifiedTypeName(input, out _, out _, out _));
+
+            // Assert
+            Assert.Equal("The value 'TypeName' is not a qualified type name. A qualified type name is expected.", exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
Cherry-pick [Throw an ODataException with helpful message when type name in context URL is not qualified](https://github.com/OData/odata.net/pull/2892) into dev-8.x

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*
