### PR TITLE
Fix CA1002 violiation on ODataUrlValidationContext class

### DIFF
--- a/src/Microsoft.OData.Core/GlobalSuppressions.cs
+++ b/src/Microsoft.OData.Core/GlobalSuppressions.cs
@@ -58,5 +58,3 @@ using System.Diagnostics.CodeAnalysis;
 [assembly: SuppressMessage("Microsoft.Naming", "CA1704:IdentifiersShouldBeSpelledCorrectly", MessageId = "Utils", Scope = "type", Target = "Microsoft.OData.Buffers.BufferUtils")]
 [assembly: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Microsoft.OData.UriParser.CountSegmentParser.#CreateCountSegmentToken(Microsoft.OData.UriParser.QueryToken)")]
 [assembly: SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase", Scope = "member", Target = "Microsoft.OData.UriParser.SelectExpandOptionParser.#BuildSelectTermToken(Microsoft.OData.UriParser.PathSegmentToken,System.String)")]
-
-[assembly: SuppressMessage("Design", "CA1002:Do not expose generic lists", Justification = "Fix in next major release", Scope = "member", Target = "~P:Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Messages")]

--- a/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -68,6 +68,8 @@ Microsoft.OData.ODataMessageWriterSettings.BufferSize.get -> int
 Microsoft.OData.ODataMessageWriterSettings.BufferSize.set -> void
 Microsoft.OData.UriParser.ODataUriParserSettings.EnableParsingKeyAsSegment.get -> bool
 Microsoft.OData.UriParser.ODataUriParserSettings.EnableParsingKeyAsSegment.set -> void
+Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.AddMessage(Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage odataUrlValidationMessage) -> void
+Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Messages.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage>
 static Microsoft.Extensions.DependencyInjection.ODataServiceCollectionExtensions.AddDefaultODataServices(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.OData.ODataVersion odataVersion = Microsoft.OData.ODataVersion.V4, System.Action<Microsoft.OData.ODataMessageReaderSettings> configureReaderAction = null, System.Action<Microsoft.OData.ODataMessageWriterSettings> configureWriterAction = null, System.Action<Microsoft.OData.UriParser.ODataUriParserSettings> configureUriParserAction = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static Microsoft.OData.UriParser.ODataPathExtensions.TrimEndingTypeAndKeySegments(this Microsoft.OData.UriParser.ODataPath path) -> Microsoft.OData.UriParser.ODataPath
 override Microsoft.OData.ODataEnumValue.ToString() -> string
@@ -1899,7 +1901,6 @@ Microsoft.OData.UriParser.UriTemplateExpression.LiteralText.get -> string
 Microsoft.OData.UriParser.UriTemplateExpression.UriTemplateExpression() -> void
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.AddMessage(string code, string message, Microsoft.OData.UriParser.Validation.Severity severity) -> void
-Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Messages.get -> System.Collections.Generic.List<Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage>
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Model.get -> Microsoft.OData.Edm.IEdmModel
 Microsoft.OData.UriParser.Validation.ODataUrlValidationExtensions
 Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage

--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -71,6 +71,8 @@ Microsoft.OData.Json.IJsonWriterFactory.CreateJsonWriter(System.IO.Stream stream
 Microsoft.OData.Json.ODataUtf8JsonWriterFactory
 Microsoft.OData.Json.ODataUtf8JsonWriterFactory.CreateJsonWriter(System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding) -> Microsoft.OData.Json.IJsonWriter
 Microsoft.OData.Json.ODataUtf8JsonWriterFactory.ODataUtf8JsonWriterFactory(System.Text.Encodings.Web.JavaScriptEncoder encoder = null) -> void
+Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.AddMessage(Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage odataUrlValidationMessage) -> void
+Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Messages.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage>
 static Microsoft.Extensions.DependencyInjection.ODataServiceCollectionExtensions.AddDefaultODataServices(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.OData.ODataVersion odataVersion = Microsoft.OData.ODataVersion.V4, System.Action<Microsoft.OData.ODataMessageReaderSettings> configureReaderAction = null, System.Action<Microsoft.OData.ODataMessageWriterSettings> configureWriterAction = null, System.Action<Microsoft.OData.UriParser.ODataUriParserSettings> configureUriParserAction = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static Microsoft.OData.Json.ODataUtf8JsonWriterFactory.Default.get -> Microsoft.OData.Json.ODataUtf8JsonWriterFactory
 static Microsoft.OData.UriParser.ODataPathExtensions.TrimEndingTypeAndKeySegments(this Microsoft.OData.UriParser.ODataPath path) -> Microsoft.OData.UriParser.ODataPath
@@ -1910,7 +1912,6 @@ Microsoft.OData.UriParser.UriTemplateExpression.LiteralText.get -> string
 Microsoft.OData.UriParser.UriTemplateExpression.UriTemplateExpression() -> void
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.AddMessage(string code, string message, Microsoft.OData.UriParser.Validation.Severity severity) -> void
-Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Messages.get -> System.Collections.Generic.List<Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage>
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Model.get -> Microsoft.OData.Edm.IEdmModel
 Microsoft.OData.UriParser.Validation.ODataUrlValidationExtensions
 Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage

--- a/src/Microsoft.OData.Core/UrlValidation/ODataUrlValidationContext.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ODataUrlValidationContext.cs
@@ -18,7 +18,18 @@ namespace Microsoft.OData.UriParser.Validation
         /// <summary>
         /// List of <see cref="ODataUrlValidationMessage"/>s discovered while validating the OData Url.
         /// </summary>
-        public List<ODataUrlValidationMessage> Messages { get; private set; }
+        private List<ODataUrlValidationMessage> messages;
+
+        /// <summary>
+        /// List of <see cref="ODataUrlValidationMessage"/>s discovered while validating the OData Url.
+        /// </summary>
+        public IReadOnlyList<ODataUrlValidationMessage> Messages
+        {
+            get
+            {
+                return this.messages;
+            }
+        }
 
         /// <summary>
         /// The model against which the OData Url is to be validated.
@@ -53,7 +64,7 @@ namespace Microsoft.OData.UriParser.Validation
         internal ODataUrlValidationContext(IEdmModel model, ODataUrlValidator urlValidator)
         {
             this.Model = model;
-            this.Messages = new List<ODataUrlValidationMessage>();
+            this.messages = new List<ODataUrlValidationMessage>();
             this.UrlValidator = urlValidator;
             this.ExpressionValidator = new ExpressionValidator((item) => urlValidator.ValidateItem(item, this));
             this.PathValidator = new PathSegmentValidator(this);
@@ -61,14 +72,23 @@ namespace Microsoft.OData.UriParser.Validation
         }
 
         /// <summary>
-        /// Add an <see cref="ODataUrlValidationMessage"/> to the collection of validation messages.
+        /// Adds an <see cref="ODataUrlValidationMessage"/> to the collection of validation messages.
         /// </summary>
         /// <param name="code">The message code of the message.</param>
         /// <param name="message">The human readable message.</param>
         /// <param name="severity">The severity of the message.</param>
         public void AddMessage(string code, string message, Severity severity)
         {
-            this.Messages.Add(new ODataUrlValidationMessage(code, message, severity));
+            this.AddMessage(new ODataUrlValidationMessage(code, message, severity));
+        }
+
+        /// <summary>
+        /// Adds an <see cref="ODataUrlValidationMessage"/> to the collection of validation messages.
+        /// </summary>
+        /// <param name="ODataUrlValidationMessage">The <see cref="ODataUrlValidationMessage"/> to add.</param>
+        public void AddMessage(ODataUrlValidationMessage odataUrlValidationMessage)
+        {
+            this.messages.Add(odataUrlValidationMessage);
         }
     }
 }

--- a/src/Microsoft.OData.Core/UrlValidation/Rules/DeprecationRules.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/Rules/DeprecationRules.cs
@@ -62,7 +62,7 @@ namespace Microsoft.OData.UriParser.Validation.Rules
             Date? removalDate;
             if (IsDeprecated(context.Model, edmType, out message, out version, out date, out removalDate))
             {
-                context.Messages.Add(CreateUrlValidationMessage(edmType.FullTypeName(), message, version, date, removalDate));
+                context.AddMessage(CreateUrlValidationMessage(edmType.FullTypeName(), message, version, date, removalDate));
             }
         },
         /*includeImpliedProperties*/ true);
@@ -116,7 +116,7 @@ namespace Microsoft.OData.UriParser.Validation.Rules
             Date? removalDate;
             if (IsDeprecated(context.Model, element, out message, out version, out date, out removalDate))
             {
-                context.Messages.Add(CreateUrlValidationMessage(element.Name, message, version, date, removalDate));
+                context.AddMessage(CreateUrlValidationMessage(element.Name, message, version, date, removalDate));
             }
         }
 

--- a/src/Microsoft.OData.Core/UrlValidation/Rules/RequireSelectRules.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/Rules/RequireSelectRules.cs
@@ -74,7 +74,7 @@ namespace Microsoft.OData.UriParser.Validation.Rules
 
         private static void AddError(string identifier, ODataUrlValidationContext validationContext)
         {
-            validationContext.Messages.Add(new ODataUrlValidationMessage(ODataUrlValidationMessageCodes.MissingSelect, Strings.ODataUrlValidationError_SelectRequired(identifier), Severity.Warning));
+            validationContext.AddMessage(new ODataUrlValidationMessage(ODataUrlValidationMessageCodes.MissingSelect, Strings.ODataUrlValidationError_SelectRequired(identifier), Severity.Warning));
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UrlValidation/ODataUrlValidatorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UrlValidation/ODataUrlValidatorTests.cs
@@ -152,6 +152,44 @@ namespace Microsoft.OData.Tests
             });
         }
 
+        public static IEnumerable<object[]> GetAddMessageTestData()
+        {
+            yield return new object[]
+            {
+                new Action<ODataUrlValidationContext>((odataUrlValidationContext) =>
+                {
+                    odataUrlValidationContext.AddMessage(new ODataUrlValidationMessage("dummyCode", "dummyMessage", OData.UriParser.Validation.Severity.Warning));
+                })
+            };
+
+            yield return new object[]
+            {
+                new Action<ODataUrlValidationContext>((odataUrlValidationContext) =>
+                {
+                    odataUrlValidationContext.AddMessage("dummyCode", "dummyMessage", OData.UriParser.Validation.Severity.Warning);
+                })
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetAddMessageTestData))]
+        public void CallingAddMessageAddsODataUrlValidationMessage(Action<ODataUrlValidationContext> addMessageAction)
+        {
+            // Arrange
+            var model = CreateModel();
+            var validator = new ODataUrlValidator(model, dummyRuleset);
+            var odataUrlValidationContext = new ODataUrlValidationContext(model, validator);
+
+            // Act
+            addMessageAction(odataUrlValidationContext);
+
+            // Assert
+            var odataUrlValidationMessage = Assert.Single(odataUrlValidationContext.Messages);
+            Assert.Equal("dummyCode", odataUrlValidationMessage.MessageCode);
+            Assert.Equal("dummyMessage", odataUrlValidationMessage.Message);
+            Assert.Equal(OData.UriParser.Validation.Severity.Warning, odataUrlValidationMessage.Severity);
+        }
+
         private static IEdmModel GetModel()
         {
             if (model == null)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #[2789](https://github.com/OData/odata.net/issues/2789).*

### Description

`ODataUrlValidationContext` public sealed class is used to store context when validating an OData URL.
The class has an internal constructor and currently the only means to instantiate the class is by calling `ODataUrlValidator.ValidateUrl` method.
The class has a `AddMessage` public message that should be the means through which `ODataUrlValidationMessage` should be added to the collection of validation messages.
However, the `Messages` collection property is exposed as a `List<ODataUrlValidationMessage>` and this makes it possible to circumvent the `AddMessage` method and add items to the collection directly.
This violates validation rule [CA1002: Do not expose generic lists](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1002).
This pull request fixes this violation in the following manner:
- Change the `Messages` property type from `List<ODataUrlValidationMessage>` to `IReadOnlyList<ODataUrlValidationMessage>` - Making the property read-only.
- Add an `AddMessage` overload that accepts an `ODataUrlValidationMessage>`
- Refactor `ODataUrlValidationContext.Messages.Add(ODataUrlValidationMessage)` calls to `ODataUrlValidationContext.AddMessage(ODataUrlValidationMessage)`.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
