### PR TITLE
Fix ODL-8 E2E solution build failures

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
@@ -30,21 +30,20 @@ namespace Microsoft.OData.Client.Tests.Serialization
         }
 
         [Fact]
-        public void WhenHttpClientHandlerProviderIsSet_UsesReturnedHttpClientHandler_ToMakeRequest()
+        public void WhenHttpClientFactoryIsSet_UsesReturnedHttpClientHandler_ToMakeRequest()
         {
             // Arrange
             string expectedResponse = "Foo";
             using (var handler = new MockHttpClientHandler(expectedResponse))
             {
-
-                var httpClientHandlerProvider = new MockHttpClientFactory(handler);
+                var httpClientFactory = new MockHttpClientFactory(handler);
 
                 var args = new DataServiceClientRequestMessageArgs(
                     "GET",
                     new Uri("http://localhost"),
                     usePostTunneling: false,
-                    new Dictionary<string, string>(),
-                    httpClientHandlerProvider);
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
 
                 using (var request = new HttpClientRequestMessage(args))
                 {
@@ -61,7 +60,7 @@ namespace Microsoft.OData.Client.Tests.Serialization
                     Assert.Equal(expectedResponse, contents);
                     Assert.Equal(1, handler.Requests.Count);
                     Assert.Equal("GET http://localhost/", handler.Requests[0]);
-                    Assert.Equal(1, httpClientHandlerProvider.NumCalls);
+                    Assert.Equal(1, httpClientFactory.NumCalls);
                 }
             }
         }
@@ -74,14 +73,14 @@ namespace Microsoft.OData.Client.Tests.Serialization
             using (var handler = new MockHttpClientHandler(expectedResponse))
             {
 
-                var httpClientProvider = new MockHttpClientFactory(handler);
+                var httpClientFactory = new MockHttpClientFactory(handler);
 
                 var args = new DataServiceClientRequestMessageArgs(
                     "GET",
                     new Uri("http://localhost"),
                     usePostTunneling: false,
-                    new Dictionary<string, string>(),
-                    httpClientProvider);
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
 
                 //var request = new HttpClientRequestMessage(args);
 
@@ -118,14 +117,14 @@ namespace Microsoft.OData.Client.Tests.Serialization
             using (var handler = new MockUnresponsiveHttpClientHandler())
             {
 
-                var httpClientProvider = new MockHttpClientFactory(handler);
+                var httpClientFactory = new MockHttpClientFactory(handler);
 
                 var args = new DataServiceClientRequestMessageArgs(
                     "GET",
                     new Uri("http://localhost"),
                     usePostTunneling: false,
-                    new Dictionary<string, string>(),
-                    httpClientProvider);
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
 
                 using (var request = new HttpClientRequestMessage(args))
                 {
@@ -165,15 +164,15 @@ namespace Microsoft.OData.Client.Tests.Serialization
                     "GET",
                     new Uri("http://localhost/request1"),
                     usePostTunneling: false,
-                    new Dictionary<string, string>(),
-                    httpClientFactory);
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
 
                 var args2 = new DataServiceClientRequestMessageArgs(
                     "GET",
                     new Uri("http://localhost/request2"),
                     usePostTunneling: false,
-                    new Dictionary<string, string>(),
-                    httpClientFactory);
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
 
                 using (var request1 = new HttpClientRequestMessage(args1))
                 using (var request2 = new HttpClientRequestMessage(args2))
@@ -229,8 +228,8 @@ namespace Microsoft.OData.Client.Tests.Serialization
                     "GET",
                     new Uri("http://localhost"),
                     usePostTunneling: false,
-                    new Dictionary<string, string>(),
-                    httpClientFactory);
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
 
                 using (var request = new HttpClientRequestMessage(args))
                 {
@@ -262,20 +261,20 @@ namespace Microsoft.OData.Client.Tests.Serialization
             // Arrange
             using (var handler = new MockDelayedHttpClientHandler("Success", 5000))
             {
-                var httpClientProvider = new MockHttpClientFactory(handler);
+                var httpClientFactory = new MockHttpClientFactory(handler);
                 var args1 = new DataServiceClientRequestMessageArgs(
                     "GET",
                     new Uri("http://localhost/request1"),
                     usePostTunneling: false,
-                    new Dictionary<string, string>(),
-                    httpClientProvider);
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
 
                 var args2 = new DataServiceClientRequestMessageArgs(
                     "GET",
                     new Uri("http://localhost/request2"),
                     usePostTunneling: false,
-                    new Dictionary<string, string>(),
-                    httpClientProvider);
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
 
                 using (var request1 = new HttpClientRequestMessage(args1))
                 using (var request2 = new HttpClientRequestMessage(args2))
@@ -327,8 +326,8 @@ namespace Microsoft.OData.Client.Tests.Serialization
                     "GET",
                     new Uri("http://localhost"),
                     usePostTunneling: false,
-                    new Dictionary<string, string>(),
-                    httpClientFactory);
+                    headers: new Dictionary<string, string>(),
+                    httpClientFactory: httpClientFactory);
 
                 using (var request = new HttpClientRequestMessage(args))
                 {

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/MediaStreaming.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/MediaStreaming.vb
@@ -1322,7 +1322,6 @@ Partial Public Class ClientModule
                         ' Checks that streaming/non-streaming is OK with different content lengths, including 0 and unset
                         request.Content.Headers.ContentLength = content.Length
                     End If
-                    request.AllowWriteStreamBuffering = enableBuffering
                 End Sub
 
             Dim testHook = New HttpTestHookConsumer(ctx, False)

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/StateChange.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/StateChange.vb
@@ -733,7 +733,7 @@ Partial Public Class ClientModule
         End Sub
 
         Private Sub ValidateRequestMethods(ByVal ParamArray methods As String())
-            Dim x = String.Concat((From m In Me.sentRequests Select m.Method).ToArray())
+            Dim x = String.Concat((From m In Me.sentRequests Select m.Method.Method).ToArray())
             Assert.AreEqual(methods.Length, Me.sentRequests.Count, "SendingRequest count {0}", x)
             For i As Int32 = 0 To methods.Length - 1
                 Assert.AreEqual(methods(i), Me.sentRequests.Item(i).Method, "SendingRequest[{0}].Method", i)

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/UpdateTests.vb
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ClientUnitTests/UpdateTests.vb
@@ -12,6 +12,7 @@ Imports System.Collections.Generic
 Imports System.Data.Test.Astoria
 Imports System.IO
 Imports System.Net
+Imports System.Net.Http
 Imports System.Linq
 Imports System.Threading
 Imports System.Xml.Linq


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Fix ODL-8 E2E solution build failures. Some references in test code were not refactored.

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*
