### PR TITLE
Add UseDefault property to IEdmVocabularyAnnotation

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Semantics/CsdlSemanticsVocabularyAnnotation.cs
@@ -120,9 +120,9 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
         }
 
         /// <summary>
-        /// Gets whether the annotation uses a default value
+        /// Checks if the annotation uses a default value.
         /// </summary>
-        internal bool UseDefault
+        public bool UsesDefault
         {
             get { return this.Annotation.Expression == null; }
         }
@@ -134,7 +134,7 @@ namespace Microsoft.OData.Edm.Csdl.CsdlSemantics
 
         private IEdmExpression ComputeValue()
         {
-            if (this.UseDefault)
+            if (this.UsesDefault)
             {
                 return Term.GetDefaultValueExpression();
             }

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaXmlWriter.cs
@@ -446,23 +446,6 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             }
         }
 
-        internal static bool IsUsingDefaultValue(IEdmVocabularyAnnotation annotation)
-        {
-            EdmVocabularyAnnotation edmAnnotation = annotation as EdmVocabularyAnnotation;
-            if (edmAnnotation != null)
-            {
-                return edmAnnotation.UseDefault;
-            }
-
-            CsdlSemanticsVocabularyAnnotation csdlAnnotation = annotation as CsdlSemanticsVocabularyAnnotation;
-            if (csdlAnnotation != null)
-            {
-                return csdlAnnotation.UseDefault;
-            }
-
-            return false;
-        }
-
         internal override void WriteInlineExpression(IEdmExpression expression)
         {
             IEdmPathExpression pathExpression = expression as IEdmPathExpression;
@@ -530,7 +513,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.WriteRequiredAttribute(CsdlConstants.Attribute_Term, annotation.Term, this.TermAsXml);
             this.WriteOptionalAttribute(CsdlConstants.Attribute_Qualifier, annotation.Qualifier, EdmValueWriter.StringAsXml);
 
-            if (isInline && !IsUsingDefaultValue(annotation))
+            if (isInline && !annotation.UsesDefault)
             {
                 // in xml format, we can (should) skip writing the expression value if it matches the term default value.
                 this.WriteInlineExpression(annotation.Value);

--- a/src/Microsoft.OData.Edm/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -1266,6 +1266,8 @@ Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.EdmVocabularyAnnotation
 Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.Qualifier.get -> string
 Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.Target.get -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable
 Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.Term.get -> Microsoft.OData.Edm.Vocabularies.IEdmTerm
+Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.UsesDefault.get -> bool
+Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.UsesDefault.set -> void
 Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.Value.get -> Microsoft.OData.Edm.IEdmExpression
 Microsoft.OData.Edm.Vocabularies.IEdmApplyExpression
 Microsoft.OData.Edm.Vocabularies.IEdmApplyExpression.AppliedFunction.get -> Microsoft.OData.Edm.IEdmFunction
@@ -1372,6 +1374,7 @@ Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation
 Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.Qualifier.get -> string
 Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.Target.get -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable
 Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.Term.get -> Microsoft.OData.Edm.Vocabularies.IEdmTerm
+Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.UsesDefault.get -> bool
 Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.Value.get -> Microsoft.OData.Edm.IEdmExpression
 Microsoft.OData.Edm.Vocabularies.Measures.V1.MeasuresVocabularyModel
 Microsoft.OData.Edm.Vocabularies.TryCreateObjectInstance
@@ -1759,7 +1762,7 @@ static Microsoft.OData.Edm.Validation.ValidationRuleSet.GetEdmModelRuleSet(Syste
 static Microsoft.OData.Edm.Vocabularies.EdmExpressionEvaluator.FindEdmType(string edmTypeName, Microsoft.OData.Edm.IEdmModel edmModel) -> Microsoft.OData.Edm.IEdmType
 static Microsoft.OData.Edm.Vocabularies.EdmNullExpression.Instance -> Microsoft.OData.Edm.Vocabularies.EdmNullExpression
 static Microsoft.OData.Edm.Vocabularies.IEdmTermExtensions.CreateVocabularyAnnotation(this Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target) -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation
-static Microsoft.OData.Edm.Vocabularies.IEdmTermExtensions.CreateVocabularyAnnotation(this Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target, string qualifier) -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation
+static Microsoft.OData.Edm.Vocabularies.IEdmTermExtensions.CreateVocabularyAnnotation(this Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target, Microsoft.OData.Edm.IEdmExpression value) -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation
 static Microsoft.OData.Edm.Vocabularies.V1.VocabularyAnnotationExtensions.GetVocabularyStringCollection(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<string>
 static readonly Microsoft.OData.Edm.Csdl.CsdlConstants.EdmxVersion4 -> System.Version
 static readonly Microsoft.OData.Edm.Csdl.CsdlConstants.EdmxVersion401 -> System.Version

--- a/src/Microsoft.OData.Edm/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1283,6 +1283,8 @@ Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.EdmVocabularyAnnotation
 Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.Qualifier.get -> string
 Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.Target.get -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable
 Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.Term.get -> Microsoft.OData.Edm.Vocabularies.IEdmTerm
+Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.UsesDefault.get -> bool
+Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.UsesDefault.set -> void
 Microsoft.OData.Edm.Vocabularies.EdmVocabularyAnnotation.Value.get -> Microsoft.OData.Edm.IEdmExpression
 Microsoft.OData.Edm.Vocabularies.IEdmApplyExpression
 Microsoft.OData.Edm.Vocabularies.IEdmApplyExpression.AppliedFunction.get -> Microsoft.OData.Edm.IEdmFunction
@@ -1389,6 +1391,7 @@ Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation
 Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.Qualifier.get -> string
 Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.Target.get -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable
 Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.Term.get -> Microsoft.OData.Edm.Vocabularies.IEdmTerm
+Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.UsesDefault.get -> bool
 Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation.Value.get -> Microsoft.OData.Edm.IEdmExpression
 Microsoft.OData.Edm.Vocabularies.Measures.V1.MeasuresVocabularyModel
 Microsoft.OData.Edm.Vocabularies.TryCreateObjectInstance
@@ -1783,6 +1786,7 @@ static Microsoft.OData.Edm.Validation.ValidationRuleSet.GetEdmModelRuleSet(Syste
 static Microsoft.OData.Edm.Vocabularies.EdmExpressionEvaluator.FindEdmType(string edmTypeName, Microsoft.OData.Edm.IEdmModel edmModel) -> Microsoft.OData.Edm.IEdmType
 static Microsoft.OData.Edm.Vocabularies.EdmNullExpression.Instance -> Microsoft.OData.Edm.Vocabularies.EdmNullExpression
 static Microsoft.OData.Edm.Vocabularies.IEdmTermExtensions.CreateVocabularyAnnotation(this Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target) -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation
+static Microsoft.OData.Edm.Vocabularies.IEdmTermExtensions.CreateVocabularyAnnotation(this Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target, Microsoft.OData.Edm.IEdmExpression value, string qualifier = null) -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation
 static Microsoft.OData.Edm.Vocabularies.IEdmTermExtensions.CreateVocabularyAnnotation(this Microsoft.OData.Edm.Vocabularies.IEdmTerm term, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target, string qualifier) -> Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotation
 static Microsoft.OData.Edm.Vocabularies.V1.VocabularyAnnotationExtensions.GetVocabularyStringCollection(this Microsoft.OData.Edm.IEdmModel model, Microsoft.OData.Edm.Vocabularies.IEdmVocabularyAnnotatable target, Microsoft.OData.Edm.Vocabularies.IEdmTerm term) -> System.Collections.Generic.IEnumerable<string>
 static readonly Microsoft.OData.Edm.Csdl.CsdlConstants.EdmxVersion4 -> System.Version

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/EdmVocabularyAnnotation.cs
@@ -44,7 +44,7 @@ namespace Microsoft.OData.Edm.Vocabularies
             this.term = term;
             this.qualifier = qualifier;
             this.value = value;
-            UseDefault = false;
+            UsesDefault = false;
         }
 
         /// <summary>
@@ -81,8 +81,7 @@ namespace Microsoft.OData.Edm.Vocabularies
 
         /// <summary>
         /// Gets whether the annotation uses a default value.
-        /// In vNext, need refactor this.
         /// </summary>
-        internal bool UseDefault { get; set; }
+        public bool UsesDefault { get; set; }
     }
 }

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/IEdmTermExtensions.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/IEdmTermExtensions.cs
@@ -45,8 +45,25 @@ namespace Microsoft.OData.Edm.Vocabularies
 
             return new EdmVocabularyAnnotation(target, term, qualifier, value)
             {
-                UseDefault = true
+                UsesDefault = true
             };
+        }
+
+        /// <summary>
+        /// Creates an <see cref="IEdmVocabularyAnnotation"/> when the annotation value is provided.
+        /// </summary>
+        /// <param name="term">Term bound by the annotation.</param>
+        /// <param name="target">Element the annotation applies to.</param>
+        /// <param name="value">Expression producing the value of the annotation.</param>
+        /// <param name="qualifier">Qualifier used to discriminate between multiple bindings of the same property or type.</param>
+        /// <returns>The <see cref="IEdmVocabularyAnnotation"/> built.</returns>
+        public static IEdmVocabularyAnnotation CreateVocabularyAnnotation(this IEdmTerm term, IEdmVocabularyAnnotatable target, IEdmExpression value, string qualifier = null)
+        {
+            EdmUtil.CheckArgumentNull(target, "target");
+            EdmUtil.CheckArgumentNull(term, "term");
+            EdmUtil.CheckArgumentNull(value, "value");
+
+            return new EdmVocabularyAnnotation(target, term, qualifier, value);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Vocabularies/Annotations/IEdmVocabularyAnnotation.cs
+++ b/src/Microsoft.OData.Edm/Vocabularies/Annotations/IEdmVocabularyAnnotation.cs
@@ -30,5 +30,10 @@ namespace Microsoft.OData.Edm.Vocabularies
         /// Gets the expression producing the value of the annotation.
         /// </summary>
         IEdmExpression Value { get; }
+
+        /// <summary>
+        /// Gets whether the annotation uses a default value.
+        /// </summary>
+        bool UsesDefault { get; }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.VocabularyAnnotation.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.VocabularyAnnotation.cs
@@ -1,0 +1,184 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="CsdlWriterTests.VocabularyAnnotation.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm.Csdl;
+using Microsoft.OData.Edm.Validation;
+using Microsoft.OData.Edm.Vocabularies;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.OData.Edm.Tests.Csdl
+{
+    public partial class CsdlWriterTests
+    {
+        [Fact]
+        public void CanWriteAnnotationWithoutSpecifiedValue_UsingCustomIEdmVocabularyImplementation()
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+            EdmComplexType complex = new EdmComplexType("NS", "Complex");
+            EdmTerm term1 = new EdmTerm("NS", "MyAnnotationPathTerm", EdmCoreModel.Instance.GetAnnotationPath(false));
+            EdmTerm term2 = new EdmTerm("NS", "MyDefaultStringTerm", EdmCoreModel.Instance.GetString(false), "Property Term", "This is a test");
+            EdmTerm term3 = new EdmTerm("NS", "MyDefaultBoolTerm", EdmCoreModel.Instance.GetBoolean(false), "Property Term", "true");
+            model.AddElements(new IEdmSchemaElement[] { complex, term1, term2, term3 });
+
+            // annotation with value
+            IEdmVocabularyAnnotation annotation = new CustomEdmVocabularyAnnotation(complex, term1, new EdmAnnotationPathExpression("abc/efg"));
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+            model.SetVocabularyAnnotation(annotation);
+
+            // annotation without value
+            annotation = new CustomEdmVocabularyAnnotation(complex, term2, null);
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+            model.SetVocabularyAnnotation(annotation);
+
+            annotation = new CustomEdmVocabularyAnnotation(complex, term3, null);
+            annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
+            model.SetVocabularyAnnotation(annotation);
+
+            // Validate model
+            IEnumerable<EdmError> errors;
+            Assert.True(model.Validate(out errors));
+
+            // Act & Assert for XML
+            WriteAndVerifyXml(model, "<?xml version=\"1.0\" encoding=\"utf-16\"?>" +
+             "<edmx:Edmx Version=\"4.0\" xmlns:edmx=\"http://docs.oasis-open.org/odata/ns/edmx\">" +
+               "<edmx:DataServices>" +
+                 "<Schema Namespace=\"NS\" xmlns=\"http://docs.oasis-open.org/odata/ns/edm\">" +
+                   "<ComplexType Name=\"Complex\">" +
+                     "<Annotation Term=\"NS.MyAnnotationPathTerm\" AnnotationPath=\"abc/efg\" />" +
+                     "<Annotation Term=\"NS.MyDefaultStringTerm\" />" + // no longer has value
+                     "<Annotation Term=\"NS.MyDefaultBoolTerm\" />" + // no longer has value
+                   "</ComplexType>" +
+                   "<Term Name=\"MyAnnotationPathTerm\" Type=\"Edm.AnnotationPath\" Nullable=\"false\" />" +
+                   "<Term Name=\"MyDefaultStringTerm\" Type=\"Edm.String\" DefaultValue=\"This is a test\" AppliesTo=\"Property Term\" Nullable=\"false\" />" +
+                   "<Term Name=\"MyDefaultBoolTerm\" Type=\"Edm.Boolean\" DefaultValue=\"true\" AppliesTo=\"Property Term\" Nullable=\"false\" />" +
+                 "</Schema>" +
+               "</edmx:DataServices>" +
+             "</edmx:Edmx>");
+
+            // Act & Assert for JSON
+            WriteAndVerifyJson(model, @"{
+  ""$Version"": ""4.0"",
+  ""NS"": {
+    ""Complex"": {
+      ""$Kind"": ""ComplexType"",
+      ""@NS.MyAnnotationPathTerm"": ""abc/efg"",
+      ""@NS.MyDefaultStringTerm"": ""This is a test"",
+      ""@NS.MyDefaultBoolTerm"": true
+    },
+    ""MyAnnotationPathTerm"": {
+      ""$Kind"": ""Term"",
+      ""$Type"": ""Edm.AnnotationPath""
+    },
+    ""MyDefaultStringTerm"": {
+      ""$Kind"": ""Term"",
+      ""$AppliesTo"": [
+        ""Property Term""
+      ],
+      ""$DefaultValue"": ""This is a test""
+    },
+    ""MyDefaultBoolTerm"": {
+      ""$Kind"": ""Term"",
+      ""$Type"": ""Edm.Boolean"",
+      ""$AppliesTo"": [
+        ""Property Term""
+      ],
+      ""$DefaultValue"": ""true""
+    }
+  }
+}");
+        }
+
+    }
+
+    internal class CustomEdmVocabularyAnnotation : EdmElement, IEdmVocabularyAnnotation
+    {
+        private readonly IEdmVocabularyAnnotatable target;
+        private readonly IEdmTerm term;
+        private readonly string qualifier;
+        private readonly IEdmExpression value;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmVocabularyAnnotation"/> class.
+        /// </summary>
+        /// <param name="target">Element the annotation applies to.</param>
+        /// <param name="term">Term bound by the annotation.</param>
+        /// <param name="value">Expression producing the value of the annotation.</param>
+        public CustomEdmVocabularyAnnotation(IEdmVocabularyAnnotatable target, IEdmTerm term, IEdmExpression value)
+            : this(target, term, null, value)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EdmVocabularyAnnotation"/> class.
+        /// </summary>
+        /// <param name="target">Element the annotation applies to.</param>
+        /// <param name="term">Term bound by the annotation.</param>
+        /// <param name="qualifier">Qualifier used to discriminate between multiple bindings of the same property or type.</param>
+        /// <param name="value">Expression producing the value of the annotation.</param>
+        public CustomEdmVocabularyAnnotation(IEdmVocabularyAnnotatable target, IEdmTerm term, string qualifier, IEdmExpression value)
+        {
+            EdmUtil.CheckArgumentNull(target, "target");
+            EdmUtil.CheckArgumentNull(term, "term");
+
+            this.target = target;
+            this.term = term;
+            this.qualifier = qualifier;
+            this.value = value;
+            UsesDefault = false;
+
+            if (value == null)
+            {
+                this.value = term.GetDefaultValueExpression();
+                if (this.value == null)
+                {
+                    throw new InvalidOperationException(Strings.EdmVocabularyAnnotations_DidNotFindDefaultValue(term.Type));
+                }
+
+                UsesDefault = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets the element the annotation applies to.
+        /// </summary>
+        public IEdmVocabularyAnnotatable Target
+        {
+            get { return this.target; }
+        }
+
+        /// <summary>
+        /// Gets the term bound by the annotation.
+        /// </summary>
+        public IEdmTerm Term
+        {
+            get { return this.term; }
+        }
+
+        /// <summary>
+        /// Gets the qualifier used to discriminate between multiple bindings of the same property or type.
+        /// </summary>
+        public string Qualifier
+        {
+            get { return this.qualifier; }
+        }
+
+        /// <summary>
+        /// Gets the expression producing the value of the annotation.
+        /// </summary>
+        public IEdmExpression Value
+        {
+            get { return this.value; }
+        }
+
+        /// <summary>
+        /// Checks if the annotation uses a default value. </param>
+        /// </summary>
+        public bool UsesDefault { get; set; }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -2228,7 +2228,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             model.AddElements(new IEdmSchemaElement[] { complex, term1, term2, term3 });
 
             // annotation with value
-            IEdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(complex, term1, new EdmAnnotationPathExpression("abc/efg"));
+            IEdmVocabularyAnnotation annotation = term1.CreateVocabularyAnnotation(complex, new EdmAnnotationPathExpression("abc/efg"));
             annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
             model.SetVocabularyAnnotation(annotation);
 

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ConstructibleModelErrorCases.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ConstructibleModelErrorCases.cs
@@ -529,5 +529,11 @@ namespace EdmLibTests.FunctionalTests
             get;
             set;
         }
+
+        public bool UsesDefault
+        {
+            get;
+            set;
+        }
     }
 }

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ConstructibleVocabularyTestsUsingConverter.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalTests/ConstructibleVocabularyTestsUsingConverter.cs
@@ -98,6 +98,12 @@ namespace EdmLibTests.FunctionalTests
                 get;
                 set;
             }
+
+            public bool UsesDefault
+            {
+                get;
+                set;
+            }
         }
 
         [TestMethod]

--- a/test/FunctionalTests/Tests/DataEdmLib/FunctionalUtilities/InterfaceCriticalModelBuilder.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/FunctionalUtilities/InterfaceCriticalModelBuilder.cs
@@ -838,5 +838,11 @@ namespace EdmLibTests.FunctionalUtilities
             get;
             set;
         }
+
+        public bool UsesDefault
+        {
+            get;
+            set;
+        }
     }
 }

--- a/test/FunctionalTests/Tests/DataEdmLib/VocabularyStubs/StubVocabularyAnnotation.cs
+++ b/test/FunctionalTests/Tests/DataEdmLib/VocabularyStubs/StubVocabularyAnnotation.cs
@@ -10,7 +10,7 @@ namespace EdmLibTests.VocabularyStubs
     using Microsoft.OData.Edm.Vocabularies;
     using EdmLibTests.StubEdm;
 
-    public class StubVocabularyAnnotation : StubEdmElement, IEdmVocabularyAnnotation 
+    public class StubVocabularyAnnotation : StubEdmElement, IEdmVocabularyAnnotation
     {
         public string Qualifier { get; set; }
 
@@ -19,5 +19,7 @@ namespace EdmLibTests.VocabularyStubs
         public IEdmVocabularyAnnotatable Target { get; set; }
 
         public IEdmExpression Value { get; set; }
+
+        public bool UsesDefault { get; set; }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This PR fixes https://github.com/OData/odata.net/issues/2228

### Description

This PR adds the `UsesDefault` property to `IEdmVocabularyAnnotation`.  
We do not write an `EdmVocabularyAnnotation's` value if it has a default value. 
That's why we do the check and set the `UsesDefault` value to either true or false. 

When creating an `EdmVocabularyAnnotation` if the value is not provided, we check whether the EdmTerm has a default value or not. If the term has a default value and no value was provided, we set the `UsesDefault` to true, otherwise false. 

This PR already has this logic and tests. The only change that I made was: 
1. I added a new extension method for creating an `EdmVocabularyAnnotation` when a value is provided as we already have an extension method for creating an `EdmVocabularyAnnotation` when a value is not provided. 
2. I removed the logic that we were using to cast the `IEdmVocabularyAnnotation` to internal implementations of the interface and replaced it with a call to the interface's new added property `UsesDefault`. This now means that we can support any custom implementation of the `IEdmVocabularyAnnotation`. 
3. I added a test for a custom implementation of the `IEdmVocabularyAnnotation`. 
 ### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
