### PR TITLE
Add public ShouldIncludeAnnotation property

### DIFF
--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -116,8 +116,8 @@ namespace Microsoft.OData
             this.message = new ODataRequestMessage(requestMessage, /*writing*/ true, this.settings.EnableMessageStreamDisposal, /*maxMessageSize*/ -1);
 
             // Always include all annotations when writing request message.
-            Debug.Assert(this.settings.ShouldIncludeAnnotation == null, "this.settings.ShouldIncludeAnnotation == null");
-            this.settings.ShouldIncludeAnnotation = AnnotationFilter.CreateIncludeAllFilter().Matches;
+            Debug.Assert(this.settings.IsAnnotationFiltered == null, "this.settings.ShouldIncludeAnnotation == null");
+            this.settings.IsAnnotationFiltered = AnnotationFilter.CreateIncludeAllFilter().Matches;
         }
 
         /// <summary> Creates a new <see cref="Microsoft.OData.ODataMessageWriter" /> for the given response message. </summary>
@@ -159,7 +159,7 @@ namespace Microsoft.OData
             string annotationFilter = responseMessage.PreferenceAppliedHeader().AnnotationFilter;
             if (!string.IsNullOrEmpty(annotationFilter))
             {
-                this.settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter(annotationFilter);
+                this.settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter(annotationFilter);
             }
         }
 

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -116,8 +116,8 @@ namespace Microsoft.OData
             this.message = new ODataRequestMessage(requestMessage, /*writing*/ true, this.settings.EnableMessageStreamDisposal, /*maxMessageSize*/ -1);
 
             // Always include all annotations when writing request message.
-            Debug.Assert(this.settings.IsAnnotationFiltered == null, "this.settings.IsAnnotationFiltered == null");
-            this.settings.IsAnnotationFiltered = AnnotationFilter.CreateIncludeAllFilter().Matches;
+            Debug.Assert(this.settings.ShouldIncludeAnnotationInternal == null, "this.settings.ShouldIncludeAnnotationInternal == null");
+            this.settings.ShouldIncludeAnnotationInternal = AnnotationFilter.CreateIncludeAllFilter().Matches;
         }
 
         /// <summary> Creates a new <see cref="Microsoft.OData.ODataMessageWriter" /> for the given response message. </summary>
@@ -159,7 +159,7 @@ namespace Microsoft.OData
             string annotationFilter = responseMessage.PreferenceAppliedHeader().AnnotationFilter;
             if (!string.IsNullOrEmpty(annotationFilter))
             {
-                this.settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter(annotationFilter);
+                this.settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter(annotationFilter);
             }
         }
 

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -116,7 +116,7 @@ namespace Microsoft.OData
             this.message = new ODataRequestMessage(requestMessage, /*writing*/ true, this.settings.EnableMessageStreamDisposal, /*maxMessageSize*/ -1);
 
             // Always include all annotations when writing request message.
-            Debug.Assert(this.settings.IsAnnotationFiltered == null, "this.settings.ShouldIncludeAnnotation == null");
+            Debug.Assert(this.settings.IsAnnotationFiltered == null, "this.settings.IsAnnotationFiltered == null");
             this.settings.IsAnnotationFiltered = AnnotationFilter.CreateIncludeAllFilter().Matches;
         }
 

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -53,12 +53,6 @@ namespace Microsoft.OData
         private ODataUri odataUri;
 
         /// <summary>
-        /// Func to evaluate whether an annotation should be written by the writer. The func should return true if the annotation should
-        /// be written and false if the annotation should be skipped.
-        /// </summary>
-        private Func<string, bool> isAnnotationFiltered;
-
-        /// <summary>
         /// true if the Format property should be used to compute the media type;
         /// false if AcceptableMediaTypes and AcceptableCharsets should be used.
         /// null if neither the format nor the acceptable media types/charsets have been set.
@@ -382,21 +376,10 @@ namespace Microsoft.OData
         /// be written and false if the annotation should be skipped.
         /// </summary>
         /// <remarks>
-        /// This property is internal and automatically set based on annotation filters. The developer can override this using the <see cref="ShouldIncludeAnnotation"/> property
+        /// This property is internal and automatically set based on annotation filters. The developer can use the <see cref="ShouldIncludeAnnotation"/> property
         /// to tell the writer to write annotations even if they were not included in the annotations filters.
         /// </remarks>
-        internal Func<string, bool> IsAnnotationFiltered
-        {
-            get
-            {
-                return this.isAnnotationFiltered;
-            }
-
-            set
-            {
-                this.isAnnotationFiltered = value;
-            }
-        }
+        internal Func<string, bool> ShouldIncludeAnnotationInternal { get; set; }
 
         /// <summary>
         /// Gets or sets a value that indicates whether the writer should put key values in their own URI segment when automatically building URIs.
@@ -544,7 +527,7 @@ namespace Microsoft.OData
         /// <returns>Returns true to indicate that the annotation with the name <paramref name="annotationName"/> should not be written, false otherwise.</returns>
         internal bool ShouldSkipAnnotation(string annotationName)
         {
-            bool skipAnnotation = this.IsAnnotationFiltered == null || !this.IsAnnotationFiltered(annotationName);
+            bool skipAnnotation = this.ShouldIncludeAnnotationInternal == null || !this.ShouldIncludeAnnotationInternal(annotationName);
             // if annotation is not included by default, the caller ensure it's written using ShouldIncludeAnnotation
             if (skipAnnotation && this.ShouldIncludeAnnotation != null)
             {
@@ -567,7 +550,7 @@ namespace Microsoft.OData
             this.JsonPCallback = other.JsonPCallback;
             this.messageQuotas = new ODataMessageQuotas(other.MessageQuotas);
             this.ODataUri = other.ODataUri.Clone();
-            this.isAnnotationFiltered = other.isAnnotationFiltered;
+            this.ShouldIncludeAnnotationInternal = other.ShouldIncludeAnnotationInternal;
             this.useFormat = other.useFormat;
             this.Version = other.Version;
             this.LibraryCompatibility = other.LibraryCompatibility;

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -551,6 +551,7 @@ namespace Microsoft.OData
             this.messageQuotas = new ODataMessageQuotas(other.MessageQuotas);
             this.ODataUri = other.ODataUri.Clone();
             this.ShouldIncludeAnnotationInternal = other.ShouldIncludeAnnotationInternal;
+            this.ShouldIncludeAnnotation = other.ShouldIncludeAnnotation;
             this.useFormat = other.useFormat;
             this.Version = other.Version;
             this.LibraryCompatibility = other.LibraryCompatibility;

--- a/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriterSettings.cs
@@ -56,7 +56,7 @@ namespace Microsoft.OData
         /// Func to evaluate whether an annotation should be written by the writer. The func should return true if the annotation should
         /// be written and false if the annotation should be skipped.
         /// </summary>
-        private Func<string, bool> shouldIncludeAnnotation;
+        private Func<string, bool> isAnnotationFiltered;
 
         /// <summary>
         /// true if the Format property should be used to compute the media type;
@@ -241,6 +241,16 @@ namespace Microsoft.OData
         public bool AlwaysAddTypeAnnotationsForDerivedTypes { get; set; }
 
         /// <summary>
+        /// Func to evaluate whether an annotation should be written by the writer. This is useful when you want to force the writer
+        /// to write annotations that would have otherwise been skipped (e.g. writing annotations that are not part of the odata.include-annotations filter).
+        /// </summary>
+        /// <remarks>
+        /// Note that this returning false does not guarantee that the annotation will not be written. For example, if an annotation was included in the preference
+        /// header annotations filter, it may still be written even if this func returns false.
+        /// </remarks>
+        public Func<string, bool> ShouldIncludeAnnotation { get; set; }
+
+        /// <summary>
         /// Gets the validator corresponding to the validation settings.
         /// </summary>
         internal IWriterValidator Validator { get; private set; }
@@ -367,19 +377,24 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Func to evaluate whether an annotation should be written by the writer. The func should return true if the annotation should
+        /// Func to evaluate whether an annotation should be written by the writer based on the annotations filtered in the odata.include-annotations header and OData standard.
+        /// The func should return true if the annotation should
         /// be written and false if the annotation should be skipped.
         /// </summary>
-        internal Func<string, bool> ShouldIncludeAnnotation
+        /// <remarks>
+        /// This property is internal and automatically set based on annotation filters. The developer can override this using the <see cref="ShouldIncludeAnnotation"/> property
+        /// to tell the writer to write annotations even if they were not included in the annotations filters.
+        /// </remarks>
+        internal Func<string, bool> IsAnnotationFiltered
         {
             get
             {
-                return this.shouldIncludeAnnotation;
+                return this.isAnnotationFiltered;
             }
 
             set
             {
-                this.shouldIncludeAnnotation = value;
+                this.isAnnotationFiltered = value;
             }
         }
 
@@ -529,7 +544,14 @@ namespace Microsoft.OData
         /// <returns>Returns true to indicate that the annotation with the name <paramref name="annotationName"/> should not be written, false otherwise.</returns>
         internal bool ShouldSkipAnnotation(string annotationName)
         {
-            return this.ShouldIncludeAnnotation == null || !this.ShouldIncludeAnnotation(annotationName);
+            bool skipAnnotation = this.IsAnnotationFiltered == null || !this.IsAnnotationFiltered(annotationName);
+            // if annotation is not included by default, the caller ensure it's written using ShouldIncludeAnnotation
+            if (skipAnnotation && this.ShouldIncludeAnnotation != null)
+            {
+                return !this.ShouldIncludeAnnotation(annotationName);
+            }
+
+            return skipAnnotation;
         }
 
         private void CopyFrom(ODataMessageWriterSettings other)
@@ -545,7 +567,7 @@ namespace Microsoft.OData
             this.JsonPCallback = other.JsonPCallback;
             this.messageQuotas = new ODataMessageQuotas(other.MessageQuotas);
             this.ODataUri = other.ODataUri.Clone();
-            this.shouldIncludeAnnotation = other.shouldIncludeAnnotation;
+            this.isAnnotationFiltered = other.isAnnotationFiltered;
             this.useFormat = other.useFormat;
             this.Version = other.Version;
             this.LibraryCompatibility = other.LibraryCompatibility;

--- a/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -66,6 +66,8 @@ Microsoft.OData.Json.IJsonWriterFactory.CreateJsonWriter(System.IO.Stream stream
 Microsoft.OData.UriParser.EntitySetSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.UriParser.INavigationSourceSegment
 Microsoft.OData.UriParser.INavigationSourceSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
+Microsoft.OData.ODataMessageWriterSettings.ShouldIncludeAnnotation.get -> System.Func<string, bool>
+Microsoft.OData.ODataMessageWriterSettings.ShouldIncludeAnnotation.set -> void
 Microsoft.OData.UriParser.ODataPath.this[int index].get -> Microsoft.OData.UriParser.ODataPathSegment
 Microsoft.OData.ODataMessageWriterSettings.BufferSize.get -> int
 Microsoft.OData.ODataMessageWriterSettings.BufferSize.set -> void

--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -65,6 +65,8 @@ Microsoft.OData.ODataMessageWriterSettings.SetOmitODataPrefix(bool value, Micros
 Microsoft.OData.UriParser.EntitySetSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.UriParser.INavigationSourceSegment
 Microsoft.OData.UriParser.INavigationSourceSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
+Microsoft.OData.ODataMessageWriterSettings.ShouldIncludeAnnotation.get -> System.Func<string, bool>
+Microsoft.OData.ODataMessageWriterSettings.ShouldIncludeAnnotation.set -> void
 Microsoft.OData.UriParser.ODataPath.this[int index].get -> Microsoft.OData.UriParser.ODataPathSegment
 Microsoft.OData.ODataMessageWriterSettings.BufferSize.get -> int
 Microsoft.OData.ODataMessageWriterSettings.BufferSize.set -> void

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -253,7 +253,7 @@ namespace Microsoft.OData
                     Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType,
 
                     // Should write instance annotations for the literal
-                    IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*")
+                    ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*")
                 };
 
                 WriteJsonLightLiteral(
@@ -304,7 +304,7 @@ namespace Microsoft.OData
                     Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType,
 
                     // TBD: Should write instance annotations for the literal???
-                    IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*"),
+                    ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*"),
                     IsIeee754Compatible = isIeee754Compatible
                 };
 

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -253,7 +253,7 @@ namespace Microsoft.OData
                     Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType,
 
                     // Should write instance annotations for the literal
-                    ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*")
+                    IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*")
                 };
 
                 WriteJsonLightLiteral(
@@ -304,7 +304,7 @@ namespace Microsoft.OData
                     Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType,
 
                     // TBD: Should write instance annotations for the literal???
-                    ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*"),
+                    IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*"),
                     IsIeee754Compatible = isIeee754Compatible
                 };
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/JsonLight/ODataJsonLightWriterComplexIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/JsonLight/ODataJsonLightWriterComplexIntegrationTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.JsonLight
         private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream)
         {
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             settings.SetServiceDocumentUri(new Uri("http://example.com/"));
 
             var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/JsonLight/ODataJsonLightWriterComplexIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/JsonLight/ODataJsonLightWriterComplexIntegrationTests.cs
@@ -213,7 +213,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.JsonLight
         private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream)
         {
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             settings.SetServiceDocumentUri(new Uri("http://example.com/"));
 
             var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonLightInstanceAnnotationWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonLightInstanceAnnotationWriterAsyncTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public async Task WriteInstanceAnnotationsAsync_ForDeclaredProperty()
         {
-            this.settings.IsAnnotationFiltered = (annotation) => true; // Allow annotations to be written
+            this.settings.ShouldIncludeAnnotationInternal = (annotation) => true; // Allow annotations to be written
             var instanceAnnotations = new List<ODataInstanceAnnotation>
             {
                 new ODataInstanceAnnotation("favorite.Coffee", new ODataPrimitiveValue("Cappuccino")),
@@ -346,7 +346,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public async Task WriteInstanceAnnotationsAsync_ShouldWriteAnnotationThatDoesNotPassTheAnnotationFilterIfShouldIncludeAnnotationReturnsTrue()
         {
-            this.settings.IsAnnotationFiltered = (name) => false;
+            this.settings.ShouldIncludeAnnotationInternal = (name) => false;
             this.settings.ShouldIncludeAnnotation = (name) => name == "favorite.Day";
             var instanceAnnotations = new List<ODataInstanceAnnotation>
             {
@@ -368,7 +368,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public async Task WriteInstanceAnnotationsAsync_ShouldSkipAnnotationThatDoesNotPassTheAnnotationFilterIfShouldIncludeAnnotationReturnsFalse()
         {
-            this.settings.IsAnnotationFiltered = (name) => false;
+            this.settings.ShouldIncludeAnnotationInternal = (name) => false;
             this.settings.ShouldIncludeAnnotation = (name) => false;
             var instanceAnnotations = new List<ODataInstanceAnnotation>
             {
@@ -390,7 +390,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public async Task WriteInstanceAnnotationsAsync_ShouldWriteAnnotationThatPassesTheAnnotationFilterIfShouldIncludeAnnotationReturnsFalse()
         {
-            this.settings.IsAnnotationFiltered = (name) => name == "favorite.Day";
+            this.settings.ShouldIncludeAnnotationInternal = (name) => name == "favorite.Day";
             this.settings.ShouldIncludeAnnotation = (name) => false;
             var instanceAnnotations = new List<ODataInstanceAnnotation>
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonLightInstanceAnnotationWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonLightInstanceAnnotationWriterTests.cs
@@ -743,7 +743,7 @@ namespace Microsoft.OData.Tests.Json
                 using (var outputContext = new ODataJsonLightOutputContext(
                     stream,
                     new ODataMessageInfo { Model = model, IsResponse = false, IsAsync = false, Encoding = Encoding.UTF8 },
-                    new ODataMessageWriterSettings { Version = ODataVersion.V4, IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*") }))
+                    new ODataMessageWriterSettings { Version = ODataVersion.V4, ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*") }))
                 {
                     var valueSerializer = new ODataJsonLightValueSerializer(outputContext);
 
@@ -772,7 +772,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.jsonWriter.WriteNameVerifier = (name) => verifierCalls++;
             this.valueWriter.WritePrimitiveVerifier = (value, reference) => verifierCalls++;
-            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name == "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotationInternal = name => name == "ns1.name";
 
             this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
             Assert.Equal(2, verifierCalls);
@@ -786,7 +786,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.jsonWriter.WriteNameVerifier = (name) => verifierCalls++;
             this.valueWriter.WritePrimitiveVerifier = (value, reference) => verifierCalls++;
-            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name != "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotationInternal = name => name != "ns1.name";
 
             this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
             Assert.Equal(0, verifierCalls);
@@ -819,7 +819,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
             this.valueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
-            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name != "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotationInternal = name => name != "ns1.name";
             this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name == "ns1.name";
 
             this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
@@ -838,7 +838,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
             this.valueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
-            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name == "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotationInternal = name => name == "ns1.name";
             this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name == "ns1.name";
 
             this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
@@ -857,7 +857,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
             this.valueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
-            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name != "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotationInternal = name => name != "ns1.name";
             this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name != "ns1.name";
 
             this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
@@ -874,7 +874,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
             this.valueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
-            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name == "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotationInternal = name => name == "ns1.name";
             this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name != "ns1.name";
 
             this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
@@ -985,7 +985,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
                 settings.SetServiceDocumentUri(new Uri("http://example.com/"));
-                settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+                settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             }
 
             var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonLightInstanceAnnotationWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonLightInstanceAnnotationWriterTests.cs
@@ -743,7 +743,7 @@ namespace Microsoft.OData.Tests.Json
                 using (var outputContext = new ODataJsonLightOutputContext(
                     stream,
                     new ODataMessageInfo { Model = model, IsResponse = false, IsAsync = false, Encoding = Encoding.UTF8 },
-                    new ODataMessageWriterSettings { Version = ODataVersion.V4, ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*") }))
+                    new ODataMessageWriterSettings { Version = ODataVersion.V4, IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*") }))
                 {
                     var valueSerializer = new ODataJsonLightValueSerializer(outputContext);
 
@@ -772,7 +772,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.jsonWriter.WriteNameVerifier = (name) => verifierCalls++;
             this.valueWriter.WritePrimitiveVerifier = (value, reference) => verifierCalls++;
-            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name == "ns1.name";
+            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name == "ns1.name";
 
             this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
             Assert.Equal(2, verifierCalls);
@@ -786,10 +786,102 @@ namespace Microsoft.OData.Tests.Json
 
             this.jsonWriter.WriteNameVerifier = (name) => verifierCalls++;
             this.valueWriter.WritePrimitiveVerifier = (value, reference) => verifierCalls++;
-            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name != "ns1.name";
+            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name != "ns1.name";
 
             this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
             Assert.Equal(0, verifierCalls);
+        }
+
+        [Fact]
+        public void WriteInstanceAnnotationShouldWriteAnnotationIfShouldIncludeAnnotationReturnsTrue()
+        {
+            var annotation = new ODataInstanceAnnotation("ns1.name", new ODataPrimitiveValue(123));
+            var writtenNames = new List<string>();
+            var writtenValues = new List<object>();
+
+            this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
+            this.valueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name == "ns1.name";
+
+            this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
+            Assert.Single(writtenNames);
+            Assert.Single(writtenValues);
+            Assert.Equal("@ns1.name", writtenNames[0]);
+            Assert.Equal(123, (int)writtenValues[0]);
+        }
+
+        [Fact]
+        public void WriteInstanceAnnotationsShouldWriteAnnotationThatDoesNotPassTheAnnotationFilterIfShouldIncludeAnnotationReturnsTrue()
+        {
+            var annotation = new ODataInstanceAnnotation("ns1.name", new ODataPrimitiveValue(123));
+            var writtenNames = new List<string>();
+            var writtenValues = new List<object>();
+
+            this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
+            this.valueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
+            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name != "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name == "ns1.name";
+
+            this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
+            Assert.Single(writtenNames);
+            Assert.Single(writtenValues);
+            Assert.Equal("@ns1.name", writtenNames[0]);
+            Assert.Equal(123, (int)writtenValues[0]);
+        }
+
+        [Fact]
+        public void WriteInstanceAnnotationsShouldWriteAnnotationThatPassesTheAnnotationFilterIfShouldIncludeAnnotationReturnsTrue()
+        {
+            var annotation = new ODataInstanceAnnotation("ns1.name", new ODataPrimitiveValue(123));
+            var writtenNames = new List<string>();
+            var writtenValues = new List<object>();
+
+            this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
+            this.valueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
+            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name == "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name == "ns1.name";
+
+            this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
+            Assert.Single(writtenNames);
+            Assert.Single(writtenValues);
+            Assert.Equal("@ns1.name", writtenNames[0]);
+            Assert.Equal(123, (int)writtenValues[0]);
+        }
+
+        [Fact]
+        public void WriteInstanceAnnotationShouldSkipAnnotationThatDoesNotPassTheAnnotationFilterIfShouldIncludeAnnotationReturnsFalse()
+        {
+            var annotation = new ODataInstanceAnnotation("ns1.name", new ODataPrimitiveValue(123));
+            var writtenNames = new List<string>();
+            var writtenValues = new List<object>();
+
+            this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
+            this.valueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
+            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name != "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name != "ns1.name";
+
+            this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
+            Assert.Empty(writtenNames);
+            Assert.Empty(writtenValues);
+        }
+
+        [Fact]
+        public void WriteInstanceAnnotationShouldWriteAnnotationThatPassesTheAnnotationFilterIfShouldIncludeAnnotationReturnsFalse()
+        {
+            var annotation = new ODataInstanceAnnotation("ns1.name", new ODataPrimitiveValue(123));
+            var writtenNames = new List<string>();
+            var writtenValues = new List<object>();
+
+            this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
+            this.valueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
+            this.valueWriter.MessageWriterSettings.IsAnnotationFiltered = name => name == "ns1.name";
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = name => name != "ns1.name";
+
+            this.jsonLightInstanceAnnotationWriter.WriteInstanceAnnotation(annotation);
+            Assert.Single(writtenNames);
+            Assert.Single(writtenValues);
+            Assert.Equal("@ns1.name", writtenNames[0]);
+            Assert.Equal(123, (int)writtenValues[0]);
         }
 
         [Fact]
@@ -831,6 +923,44 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void ShouldWriteAnyAnnotationWithIgnoreFilterSetToTrueEvenIfShouldIncludeAnnotationsReturnsFalse()
+        {
+            var stream = new MemoryStream();
+            var defaultValueWriter = new MockJsonLightValueSerializer(CreateJsonLightOutputContext(stream, model, this.jsonWriter, new ODataMessageWriterSettings { Version = ODataVersion.V4 }));
+            var defaultAnnotationWriter = new JsonLightInstanceAnnotationWriter(defaultValueWriter, new JsonMinimalMetadataTypeNameOracle());
+
+            var annotations = new Collection<ODataInstanceAnnotation>
+            {
+                new ODataInstanceAnnotation("term.one", new ODataPrimitiveValue(123)),
+                new ODataInstanceAnnotation("term.two", new ODataPrimitiveValue("456"))
+            };
+
+            var writtenNames = new List<string>();
+            var writtenValues = new List<object>(); ;
+
+            this.jsonWriter.WriteNameVerifier = (name) => writtenNames.Add(name);
+            defaultValueWriter.WritePrimitiveVerifier = (value, reference) => writtenValues.Add(value);
+            this.valueWriter.MessageWriterSettings.ShouldIncludeAnnotation = (name) => false;
+
+            defaultAnnotationWriter.WriteInstanceAnnotations(annotations, new InstanceAnnotationWriteTracker(), true);
+            Assert.Collection(
+                writtenNames,
+                new Action<string>[]
+                {
+                    name => Assert.Equal("@term.one", name),
+                    name => Assert.Equal("@term.two", name)
+                });
+
+            Assert.Collection(
+                writtenValues,
+                new Action<object>[]
+                {
+                    value => Assert.Equal(123, (int)value),
+                    value => Assert.Equal("456", (string)value)
+                });
+        }
+
+        [Fact]
         public void TestWriteInstanceAnnotationsForError()
         {
             var stream = new MemoryStream();
@@ -855,7 +985,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
                 settings.SetServiceDocumentUri(new Uri("http://example.com/"));
-                settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+                settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             }
 
             var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaWriterTests.cs
@@ -3063,7 +3063,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
         private static ODataJsonLightOutputContext CreateJsonLightOutputContext(Stream stream, IEdmModel userModel, bool fullMetadata = false, ODataUri uri = null, ODataVersion version = ODataVersion.V4, bool isResponse = true, bool isAsync = false)
         {
-            var settings = new ODataMessageWriterSettings { Version = version, ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*") };
+            var settings = new ODataMessageWriterSettings { Version = version, IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*") };
             settings.SetServiceDocumentUri(new Uri("http://host/service"));
             if (uri != null)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightDeltaWriterTests.cs
@@ -3063,7 +3063,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
         private static ODataJsonLightOutputContext CreateJsonLightOutputContext(Stream stream, IEdmModel userModel, bool fullMetadata = false, ODataUri uri = null, ODataVersion version = ODataVersion.V4, bool isResponse = true, bool isAsync = false)
         {
-            var settings = new ODataMessageWriterSettings { Version = version, IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*") };
+            var settings = new ODataMessageWriterSettings { Version = version, ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*") };
             settings.SetServiceDocumentUri(new Uri("http://host/service"));
             if (uri != null)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
 
         private ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings
         {
-            IsAnnotationFiltered = (annotationName) => true,
+            ShouldIncludeAnnotationInternal = (annotationName) => true,
             Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType
         };
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightEntryAndFeedDeserializerUndeclaredAnnotationTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Reader.JsonLight
 
         private ODataMessageWriterSettings writerSettings = new ODataMessageWriterSettings
         {
-            ShouldIncludeAnnotation = (annotationName) => true,
+            IsAnnotationFiltered = (annotationName) => true,
             Validations = ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType
         };
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightOutputContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightOutputContextTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OData.Tests.JsonLight
             this.stream = new MemoryStream();
             this.messageWriterSettings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
             this.messageWriterSettings.SetServiceDocumentUri(new Uri(ServiceUri));
-            this.messageWriterSettings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            this.messageWriterSettings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             this.nullReferenceError = new ODataError
             {
                 ErrorCode = "NRE",
@@ -794,7 +794,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
             var settings = new ODataMessageWriterSettings { Version = version };
             settings.SetServiceDocumentUri(new Uri("http://odata.org/test"));
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             
             if (use6x)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightOutputContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightOutputContextTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OData.Tests.JsonLight
             this.stream = new MemoryStream();
             this.messageWriterSettings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
             this.messageWriterSettings.SetServiceDocumentUri(new Uri(ServiceUri));
-            this.messageWriterSettings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            this.messageWriterSettings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             this.nullReferenceError = new ODataError
             {
                 ErrorCode = "NRE",
@@ -794,7 +794,7 @@ namespace Microsoft.OData.Tests.JsonLight
 
             var settings = new ODataMessageWriterSettings { Version = version };
             settings.SetServiceDocumentUri(new Uri("http://odata.org/test"));
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             
             if (use6x)
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerAsyncTests.cs
@@ -355,7 +355,7 @@ namespace Microsoft.OData.Tests.JsonLight
         private ODataJsonLightOutputContext CreateJsonLightOutputContext(Stream stream, Action<IServiceCollection> configureServices = null)
         {
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             settings.SetServiceDocumentUri(new Uri("http://tempuri.org/"));
 
             var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerAsyncTests.cs
@@ -355,7 +355,7 @@ namespace Microsoft.OData.Tests.JsonLight
         private ODataJsonLightOutputContext CreateJsonLightOutputContext(Stream stream, Action<IServiceCollection> configureServices = null)
         {
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             settings.SetServiceDocumentUri(new Uri("http://tempuri.org/"));
 
             var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
@@ -654,7 +654,7 @@ namespace Microsoft.OData.Tests.JsonLight
         private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream, Action<IServiceCollection> configureServices = null)
         {
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             settings.SetServiceDocumentUri(new Uri("http://example.com/"));
 
             var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightPropertySerializerTests.cs
@@ -654,7 +654,7 @@ namespace Microsoft.OData.Tests.JsonLight
         private ODataJsonLightOutputContext CreateJsonLightOutputContext(MemoryStream stream, Action<IServiceCollection> configureServices = null)
         {
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             settings.SetServiceDocumentUri(new Uri("http://example.com/"));
 
             var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceSerializerTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.OData.Tests.JsonLight
             {
                 EnableMessageStreamDisposal = false,
                 Version = ODataVersion.V4,
-                ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*")
+                IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*")
             };
 
             this.messageWriterSettings.SetServiceDocumentUri(new Uri(ServiceUri));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightResourceSerializerTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.OData.Tests.JsonLight
             {
                 EnableMessageStreamDisposal = false,
                 Version = ODataVersion.V4,
-                IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*")
+                ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*")
             };
 
             this.messageWriterSettings.SetServiceDocumentUri(new Uri(ServiceUri));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightValueSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightValueSerializerTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.OData.Tests.JsonLight
             entityType.AddStructuralProperty("Location", new EdmComplexTypeReference(complexType, false));
             model.AddElement(entityType);
 
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue = new ODataResourceValue
@@ -190,7 +190,7 @@ namespace Microsoft.OData.Tests.JsonLight
             complexType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
             model.AddElement(complexType);
 
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue1 = new ODataResourceValue
@@ -231,7 +231,7 @@ namespace Microsoft.OData.Tests.JsonLight
             entityType.AddStructuralProperty("Location", new EdmComplexTypeReference(complexType, false));
             model.AddElement(entityType);
 
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue = new ODataResourceValue
@@ -264,7 +264,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             var complexType = new EdmComplexType("TestNamespace", "Address");
             model.AddElement(complexType);
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue = new ODataResourceValue
@@ -293,7 +293,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             var complexType = new EdmComplexType("NS", "Address");
             model.AddElement(complexType);
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter(filter);
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter(filter);
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue = new ODataResourceValue

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightValueSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightValueSerializerTests.cs
@@ -158,7 +158,7 @@ namespace Microsoft.OData.Tests.JsonLight
             entityType.AddStructuralProperty("Location", new EdmComplexTypeReference(complexType, false));
             model.AddElement(entityType);
 
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue = new ODataResourceValue
@@ -190,7 +190,7 @@ namespace Microsoft.OData.Tests.JsonLight
             complexType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String);
             model.AddElement(complexType);
 
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue1 = new ODataResourceValue
@@ -231,7 +231,7 @@ namespace Microsoft.OData.Tests.JsonLight
             entityType.AddStructuralProperty("Location", new EdmComplexTypeReference(complexType, false));
             model.AddElement(entityType);
 
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue = new ODataResourceValue
@@ -264,7 +264,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             var complexType = new EdmComplexType("TestNamespace", "Address");
             model.AddElement(complexType);
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue = new ODataResourceValue
@@ -293,7 +293,7 @@ namespace Microsoft.OData.Tests.JsonLight
         {
             var complexType = new EdmComplexType("NS", "Address");
             model.AddElement(complexType);
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter(filter);
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter(filter);
             var result = this.SetupSerializerAndRunTest(serializer =>
             {
                 var resourceValue = new ODataResourceValue

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
             {
                 EnableMessageStreamDisposal = false,
                 Version = ODataVersion.V4,
-                IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*")
+                ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*")
             };
             this.settings.SetServiceDocumentUri(new Uri(ServiceUri));
         }
@@ -891,7 +891,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                 {
                     EnableMessageStreamDisposal = false,
                     Version = ODataVersion.V4,
-                    IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*"),
+                    ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*"),
                     ODataUri = uriParser.ParseUri(),
                 };
                 var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightWriterTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
             {
                 EnableMessageStreamDisposal = false,
                 Version = ODataVersion.V4,
-                ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*")
+                IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*")
             };
             this.settings.SetServiceDocumentUri(new Uri(ServiceUri));
         }
@@ -891,7 +891,7 @@ namespace Microsoft.OData.Core.Tests.JsonLight
                 {
                     EnableMessageStreamDisposal = false,
                     Version = ODataVersion.V4,
-                    ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*"),
+                    IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*"),
                     ODataUri = uriParser.ParseUri(),
                 };
                 var messageInfo = new ODataMessageInfo

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
@@ -652,7 +652,7 @@ namespace Microsoft.OData.Tests
             };
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
             settings.SetServiceDocumentUri(new Uri("http://odata.org/test"));
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
             return new ODataJsonLightOutputContext(messageInfo, settings);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinkTests.cs
@@ -652,7 +652,7 @@ namespace Microsoft.OData.Tests
             };
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
             settings.SetServiceDocumentUri(new Uri("http://odata.org/test"));
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             return new ODataJsonLightOutputContext(messageInfo, settings);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinksTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinksTests.cs
@@ -460,7 +460,7 @@ namespace Microsoft.OData.Tests
         {
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
             settings.SetServiceDocumentUri(new Uri("http://odata.org/test"));
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
 
             var messageInfo = new ODataMessageInfo
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinksTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataEntityReferenceLinksTests.cs
@@ -460,7 +460,7 @@ namespace Microsoft.OData.Tests
         {
             var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4 };
             settings.SetServiceDocumentUri(new Uri("http://odata.org/test"));
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
 
             var messageInfo = new ODataMessageInfo
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -376,6 +376,14 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
+        public void CopyConstructorShouldCopyShouldIncludeAnnotation()
+        {
+            this.settings.ShouldIncludeAnnotation = name => true;
+            var newSettings = this.settings.Clone();
+            Assert.Equal(this.settings.ShouldIncludeAnnotation, newSettings.ShouldIncludeAnnotation);
+        }
+
+        [Fact]
         public void CopyConstructorShouldCopyAll()
         {
             this.settings.MetadataSelector = new TestMetadataSelector() { PropertyToOmit = "TestProperty" };
@@ -385,6 +393,7 @@ namespace Microsoft.OData.Tests
             this.settings.EnableMessageStreamDisposal = false;
             this.settings.EnableCharactersCheck = true;
             this.settings.BufferSize = 4096;
+            this.settings.ShouldIncludeAnnotation = name => true;
 
             var edmModel = new EdmModel();
             var defaultContainer = new EdmEntityContainer("TestModel", "DefaultContainer");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void AnnotationFilterShouldBeNullByDefault()
         {
-            Assert.Null(this.settings.ShouldIncludeAnnotation);
+            Assert.Null(this.settings.IsAnnotationFiltered);
         }
 
         [Fact]
@@ -35,8 +35,8 @@ namespace Microsoft.OData.Tests
         {
             Func<string, bool> filter = name => true;
 
-            this.settings.ShouldIncludeAnnotation = filter;
-            Assert.Same(this.settings.ShouldIncludeAnnotation, filter);
+            this.settings.IsAnnotationFiltered = filter;
+            Assert.Same(this.settings.IsAnnotationFiltered, filter);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Microsoft.OData.Tests
         public void ShouldHonorAnnotationFilterForV4()
         {
             this.settings.Version = ODataVersion.V4;
-            this.settings.ShouldIncludeAnnotation = name => name.StartsWith("ns1.");
+            this.settings.IsAnnotationFiltered = name => name.StartsWith("ns1.");
             Assert.True(this.settings.ShouldSkipAnnotation("any.any"));
             Assert.False(this.settings.ShouldSkipAnnotation("ns1.any"));
         }
@@ -296,8 +296,8 @@ namespace Microsoft.OData.Tests
         {
             Func<string, bool> filter = name => true;
 
-            this.settings.ShouldIncludeAnnotation = filter;
-            Assert.Same(this.settings.Clone().ShouldIncludeAnnotation, filter);
+            this.settings.IsAnnotationFiltered = filter;
+            Assert.Same(this.settings.Clone().IsAnnotationFiltered, filter);
         }
 
         [Fact]
@@ -410,7 +410,7 @@ namespace Microsoft.OData.Tests
             this.settings.Version = ODataVersion.V4;
 
             Func<string, bool> filter = name => true;
-            this.settings.ShouldIncludeAnnotation = filter;
+            this.settings.IsAnnotationFiltered = filter;
 
             var newSetting = this.settings.Clone();
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterSettingsTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void AnnotationFilterShouldBeNullByDefault()
         {
-            Assert.Null(this.settings.IsAnnotationFiltered);
+            Assert.Null(this.settings.ShouldIncludeAnnotationInternal);
         }
 
         [Fact]
@@ -35,8 +35,8 @@ namespace Microsoft.OData.Tests
         {
             Func<string, bool> filter = name => true;
 
-            this.settings.IsAnnotationFiltered = filter;
-            Assert.Same(this.settings.IsAnnotationFiltered, filter);
+            this.settings.ShouldIncludeAnnotationInternal = filter;
+            Assert.Same(this.settings.ShouldIncludeAnnotationInternal, filter);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Microsoft.OData.Tests
         public void ShouldHonorAnnotationFilterForV4()
         {
             this.settings.Version = ODataVersion.V4;
-            this.settings.IsAnnotationFiltered = name => name.StartsWith("ns1.");
+            this.settings.ShouldIncludeAnnotationInternal = name => name.StartsWith("ns1.");
             Assert.True(this.settings.ShouldSkipAnnotation("any.any"));
             Assert.False(this.settings.ShouldSkipAnnotation("ns1.any"));
         }
@@ -296,8 +296,8 @@ namespace Microsoft.OData.Tests
         {
             Func<string, bool> filter = name => true;
 
-            this.settings.IsAnnotationFiltered = filter;
-            Assert.Same(this.settings.Clone().IsAnnotationFiltered, filter);
+            this.settings.ShouldIncludeAnnotationInternal = filter;
+            Assert.Same(this.settings.Clone().ShouldIncludeAnnotationInternal, filter);
         }
 
         [Fact]
@@ -410,7 +410,7 @@ namespace Microsoft.OData.Tests
             this.settings.Version = ODataVersion.V4;
 
             Func<string, bool> filter = name => true;
-            this.settings.IsAnnotationFiltered = filter;
+            this.settings.ShouldIncludeAnnotationInternal = filter;
 
             var newSetting = this.settings.Clone();
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OData.Tests
         public void CreateMessageWriterShouldNotSetAnnotationFilterWhenODataAnnotationsIsNotSetOnPreferenceAppliedHeader()
         {
             ODataMessageWriter writer = new ODataMessageWriter((IODataResponseMessage)new InMemoryMessage(), new ODataMessageWriterSettings());
-            Assert.Null(writer.Settings.ShouldIncludeAnnotation);
+            Assert.Null(writer.Settings.IsAnnotationFiltered);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Microsoft.OData.Tests
             IODataResponseMessage responseMessage = new InMemoryMessage();
             responseMessage.PreferenceAppliedHeader().AnnotationFilter = "*";
             ODataMessageWriter writer = new ODataMessageWriter(responseMessage, new ODataMessageWriterSettings());
-            Assert.NotNull(writer.Settings.ShouldIncludeAnnotation);
+            Assert.NotNull(writer.Settings.IsAnnotationFiltered);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.OData.Tests
         public void CreateMessageWriterShouldNotSetAnnotationFilterWhenODataAnnotationsIsNotSetOnPreferenceAppliedHeader()
         {
             ODataMessageWriter writer = new ODataMessageWriter((IODataResponseMessage)new InMemoryMessage(), new ODataMessageWriterSettings());
-            Assert.Null(writer.Settings.IsAnnotationFiltered);
+            Assert.Null(writer.Settings.ShouldIncludeAnnotationInternal);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ namespace Microsoft.OData.Tests
             IODataResponseMessage responseMessage = new InMemoryMessage();
             responseMessage.PreferenceAppliedHeader().AnnotationFilter = "*";
             ODataMessageWriter writer = new ODataMessageWriter(responseMessage, new ODataMessageWriterSettings());
-            Assert.NotNull(writer.Settings.IsAnnotationFiltered);
+            Assert.NotNull(writer.Settings.ShouldIncludeAnnotationInternal);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
@@ -797,7 +797,7 @@ namespace Microsoft.OData.Tests.JsonLight
                     RequestUri = new Uri("http://testService/customers")
                 },
             };
-            settings.ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*");
+            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
 
             ODataMessageWriter messageWriter;
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Streaming/ODataJsonLightStreamWritingTests.cs
@@ -797,7 +797,7 @@ namespace Microsoft.OData.Tests.JsonLight
                     RequestUri = new Uri("http://testService/customers")
                 },
             };
-            settings.IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*");
+            settings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
 
             ODataMessageWriter messageWriter;
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightSingletonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightSingletonWriterTests.cs
@@ -335,7 +335,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
                 Model = userModel ?? EdmCoreModel.Instance
             };
 
-            var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4, ShouldIncludeAnnotation = ODataUtils.CreateAnnotationFilter("*") };
+            var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4, IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*") };
             if (serviceDocumentUri != null)
             {
                 settings.SetServiceDocumentUri(serviceDocumentUri);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightSingletonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/JsonLight/ODataJsonLightSingletonWriterTests.cs
@@ -335,7 +335,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.JsonLight
                 Model = userModel ?? EdmCoreModel.Instance
             };
 
-            var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4, IsAnnotationFiltered = ODataUtils.CreateAnnotationFilter("*") };
+            var settings = new ODataMessageWriterSettings { Version = ODataVersion.V4, ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*") };
             if (serviceDocumentUri != null)
             {
                 settings.SetServiceDocumentUri(serviceDocumentUri);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2844 

### Description

This PR adds a `ShouldIncludeAnnotation` property to the `ODataMessageWriterSettings` that allows developers to force a custom instance annotation to be written even if it was not included in the preference header annotation filters (`odata.include-annotations:`)

It works as follows:
- The property is a `Func<string, bool>` that receives an annotation name and returns true if the annotation should be written
- If the writer was going to skip a certain annotation (e.g. because it was not part of the annotations filter), it will check this delegate before skipping the annotation. If the delegate returns true, then the annotation will not be skipped.

Note that if the writer was going to write an annotation (e.g. because of it's part of the annotation filters), then the annotation will still be written even if this `ShouldIncludeAnnotation` delegate returns false. **That is to say, this property does not prevent an annotation from being written, it can only prevent an annotation from being skipped**.  I did this intentionally because I don't think this property should prevent writing annotations where the standard requires that they be written. However, if you have a contrary opinion, please share your thoughts in the discussion or review comments.

There was already an internal property called `ShouldIncludeAnnotation`, which is also a `Func<string, bool>`. This is generated automatically by `ODataMessageWriter` based on the annotations filter in the header. To avoid confusion, I renamed this property to `ShouldIncludeAnnotationInternal`.

The main logic of this PR is implemented in `ODataMessageWriterSettings.ShouldSkipAnnotation` method.


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
