### PR TITLE
Add INavigationSourceSegment interface for navigation source segments

### DIFF
--- a/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -63,11 +63,15 @@ Microsoft.OData.ODataMessageWriterSettings.ODataMessageWriterSettings(Microsoft.
 Microsoft.OData.ODataMessageWriterSettings.SetOmitODataPrefix(bool value) -> void
 Microsoft.OData.ODataMessageWriterSettings.SetOmitODataPrefix(bool value, Microsoft.OData.ODataVersion version) -> void
 Microsoft.OData.Json.IJsonWriterFactory.CreateJsonWriter(System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding) -> Microsoft.OData.Json.IJsonWriter
+Microsoft.OData.UriParser.EntitySetSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
+Microsoft.OData.UriParser.INavigationSourceSegment
+Microsoft.OData.UriParser.INavigationSourceSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.UriParser.ODataPath.this[int index].get -> Microsoft.OData.UriParser.ODataPathSegment
 Microsoft.OData.ODataMessageWriterSettings.BufferSize.get -> int
 Microsoft.OData.ODataMessageWriterSettings.BufferSize.set -> void
 Microsoft.OData.UriParser.ODataUriParserSettings.EnableParsingKeyAsSegment.get -> bool
 Microsoft.OData.UriParser.ODataUriParserSettings.EnableParsingKeyAsSegment.set -> void
+Microsoft.OData.UriParser.SingletonSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.AddMessage(Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage odataUrlValidationMessage) -> void
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Messages.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage>
 static Microsoft.Extensions.DependencyInjection.ODataServiceCollectionExtensions.AddDefaultODataServices(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.OData.ODataVersion odataVersion = Microsoft.OData.ODataVersion.V4, System.Action<Microsoft.OData.ODataMessageReaderSettings> configureReaderAction = null, System.Action<Microsoft.OData.ODataMessageWriterSettings> configureWriterAction = null, System.Action<Microsoft.OData.UriParser.ODataUriParserSettings> configureUriParserAction = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection

--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -62,6 +62,9 @@ Microsoft.OData.ODataMessageWriterSettings.GetOmitODataPrefix(Microsoft.OData.OD
 Microsoft.OData.ODataMessageWriterSettings.ODataMessageWriterSettings(Microsoft.OData.ODataVersion? version) -> void
 Microsoft.OData.ODataMessageWriterSettings.SetOmitODataPrefix(bool value) -> void
 Microsoft.OData.ODataMessageWriterSettings.SetOmitODataPrefix(bool value, Microsoft.OData.ODataVersion version) -> void
+Microsoft.OData.UriParser.EntitySetSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
+Microsoft.OData.UriParser.INavigationSourceSegment
+Microsoft.OData.UriParser.INavigationSourceSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.UriParser.ODataPath.this[int index].get -> Microsoft.OData.UriParser.ODataPathSegment
 Microsoft.OData.ODataMessageWriterSettings.BufferSize.get -> int
 Microsoft.OData.ODataMessageWriterSettings.BufferSize.set -> void
@@ -71,6 +74,7 @@ Microsoft.OData.Json.IJsonWriterFactory.CreateJsonWriter(System.IO.Stream stream
 Microsoft.OData.Json.ODataUtf8JsonWriterFactory
 Microsoft.OData.Json.ODataUtf8JsonWriterFactory.CreateJsonWriter(System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding) -> Microsoft.OData.Json.IJsonWriter
 Microsoft.OData.Json.ODataUtf8JsonWriterFactory.ODataUtf8JsonWriterFactory(System.Text.Encodings.Web.JavaScriptEncoder encoder = null) -> void
+Microsoft.OData.UriParser.SingletonSegment.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.AddMessage(Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage odataUrlValidationMessage) -> void
 Microsoft.OData.UriParser.Validation.ODataUrlValidationContext.Messages.get -> System.Collections.Generic.IReadOnlyList<Microsoft.OData.UriParser.Validation.ODataUrlValidationMessage>
 static Microsoft.Extensions.DependencyInjection.ODataServiceCollectionExtensions.AddDefaultODataServices(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.OData.ODataVersion odataVersion = Microsoft.OData.ODataVersion.V4, System.Action<Microsoft.OData.ODataMessageReaderSettings> configureReaderAction = null, System.Action<Microsoft.OData.ODataMessageWriterSettings> configureWriterAction = null, System.Action<Microsoft.OData.UriParser.ODataUriParserSettings> configureUriParserAction = null) -> Microsoft.Extensions.DependencyInjection.IServiceCollection

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/EntitySetSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/EntitySetSegment.cs
@@ -12,7 +12,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// A segment representing an EntitySet in a path.
     /// </summary>
-    public sealed class EntitySetSegment : ODataPathSegment
+    public sealed class EntitySetSegment : ODataPathSegment, INavigationSourceSegment
     {
         /// <summary>
         /// The entity set represented by this segment.
@@ -60,6 +60,14 @@ namespace Microsoft.OData.UriParser
         public override IEdmType EdmType
         {
             get { return this.type; }
+        }
+
+        /// <summary>
+        /// The navigation source targeted by this segment.
+        /// </summary>
+        public IEdmNavigationSource NavigationSource
+        {
+            get { return this.entitySet; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/INavigationSourceSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/INavigationSourceSegment.cs
@@ -1,0 +1,23 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="INavigationSourceSegment.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.UriParser
+{
+    #region Namespaces
+
+    using Microsoft.OData.Edm;
+
+    #endregion Namespaces
+
+    /// <summary>
+    /// Represents a navigation source segment.
+    /// </summary>
+    public interface INavigationSourceSegment
+    {
+        /// <summary>The navigation source targeted by this segment.</summary>
+        IEdmNavigationSource NavigationSource { get; }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/NavigationPropertySegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/NavigationPropertySegment.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// A segment representing a navigation property
     /// </summary>
-    public sealed class NavigationPropertySegment : ODataPathSegment
+    public sealed class NavigationPropertySegment : ODataPathSegment, INavigationSourceSegment
     {
         /// <summary>
         /// The navigation property this segment represents.

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SingletonSegment.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SingletonSegment.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.UriParser
     /// <summary>
     /// A segment representing an singleton in a path.
     /// </summary>
-    public sealed class SingletonSegment : ODataPathSegment
+    public sealed class SingletonSegment : ODataPathSegment, INavigationSourceSegment
     {
         /// <summary>
         /// The singleton represented by this segment.
@@ -55,6 +55,14 @@ namespace Microsoft.OData.UriParser
         public override IEdmType EdmType
         {
             get { return this.singleton.EntityType; }
+        }
+
+        /// <summary>
+        /// The navigation source targeted by this segment.
+        /// </summary>
+        public IEdmNavigationSource NavigationSource
+        {
+            get { return this.singleton; }
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/EntitySetSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/EntitySetSegmentTests.cs
@@ -87,5 +87,13 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
             Assert.False(segment1.Equals(segment2));
             Assert.False(segment1.Equals(segment3));
         }
+
+        [Fact]
+        public void NavigationSourceIsCorrect()
+        {
+            IEdmEntitySet peopleEntitySet = HardCodedTestModel.GetPeopleSet();
+            EntitySetSegment segment = new EntitySetSegment(peopleEntitySet);
+            Assert.Same(peopleEntitySet, segment.NavigationSource);
+        }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/NavigationPropertySegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/NavigationPropertySegmentTests.cs
@@ -5,6 +5,7 @@
 //---------------------------------------------------------------------
 
 using System;
+using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
 using Xunit;
 
@@ -72,6 +73,14 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
             CountSegment segment = CountSegment.Instance;
             Assert.False(navigationPropertySegment1.Equals(navigationPropertySegment2));
             Assert.False(navigationPropertySegment1.Equals(segment));
+        }
+
+        [Fact]
+        public void NavigationSourceIsCorrect()
+        {
+            IEdmEntitySet dogsEntitySet = HardCodedTestModel.GetDogsSet();
+            NavigationPropertySegment navigationPropertySegment = new NavigationPropertySegment(HardCodedTestModel.GetPersonMyDogNavProp(), dogsEntitySet);
+            Assert.Same(dogsEntitySet, navigationPropertySegment.NavigationSource);
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/SingletonSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SemanticAst/SingletonSegmentTests.cs
@@ -40,5 +40,13 @@ namespace Microsoft.OData.Tests.UriParser.SemanticAst
             SingletonSegment segment2 = new SingletonSegment(HardCodedTestModel.GetBossSingleton());
             Assert.True(segment1.Equals(segment2));
         }
+
+        [Fact]
+        public void NavigationSourceIsCorrect()
+        {
+            IEdmSingleton singleton = HardCodedTestModel.GetBossSingleton();
+            SingletonSegment segment = new SingletonSegment(singleton);
+            Assert.Same(singleton, segment.NavigationSource);
+        }
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2528.*

### Description

Adds `INavigationSourceSegment` interface that `EntitySetSegment`, `SingletonSegment` and `NavigationPropertySegment` implement so that there is a consistent way to retrieve the "navigation source" from those segments.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
