### PR TITLE
Remove .NET Framework 4.8 target framework

### DIFF
--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.OData.Client</AssemblyName>
     <RootNamespace>Microsoft.OData.Client</RootNamespace>
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
@@ -175,6 +175,9 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>Microsoft.OData.Client.cs</LastGenOutput>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
   </ItemGroup>
 
 </Project>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.OData.Core</AssemblyName>
     <RootNamespace>Microsoft.OData.Core</RootNamespace>
 

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.OData.Edm</AssemblyName>
     <RootNamespace>Microsoft.OData.Edm</RootNamespace>
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>

--- a/src/Microsoft.Spatial/Microsoft.Spatial.csproj
+++ b/src/Microsoft.Spatial/Microsoft.Spatial.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Microsoft.Spatial</AssemblyName>
     <RootNamespace>Microsoft.Spatial</RootNamespace>
 

--- a/test/Common/Microsoft.Test.OData.DependencyInjection/Microsoft.Test.OData.DependencyInjection.csproj
+++ b/test/Common/Microsoft.Test.OData.DependencyInjection/Microsoft.Test.OData.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.Test.OData.DependencyInjection</AssemblyName> 
-    <TargetFrameworks>net8.0;net48</TargetFrameworks> 
+    <TargetFramework>net8.0</TargetFramework> 
     <TestType Condition=" '$(TestType)' == '' ">Private</TestType>
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Microsoft.OData.Client.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Microsoft.OData.Client.Tests.csproj
@@ -4,7 +4,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <Optimize>false</Optimize>
     <AssemblyName>Microsoft.OData.Client.Tests</AssemblyName>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\..\sln\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.csproj
@@ -3,7 +3,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyName>Microsoft.OData.Core.Tests</AssemblyName>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <FileUpgradeFlags>40</FileUpgradeFlags>
     <OldToolsVersion>2.0</OldToolsVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
@@ -4,7 +4,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <Optimize>true</Optimize>
     <AssemblyName>Microsoft.OData.Edm.Tests</AssemblyName>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute> <!--check this in attributes-->

--- a/test/FunctionalTests/Microsoft.OData.TestCommon/Microsoft.OData.TestCommon.csproj
+++ b/test/FunctionalTests/Microsoft.OData.TestCommon/Microsoft.OData.TestCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Microsoft.OData.TestCommon</AssemblyName>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.csproj
@@ -4,7 +4,7 @@
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <Optimize>true</Optimize>
     <AssemblyName>Microsoft.Spatial.Tests</AssemblyName>
-    <TargetFrameworks>net8.0;net48</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RestorePackages>true</RestorePackages>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->


We are not planning to support .NET Framework in the first preview release. This PR therefore removes .net48 from target frameworks. This removes support, but it would be easy to add support again if we change our plan before the final release

Note that as a result of this change the **E2E test projects will not compile**.
