### PR TITLE
Set the version to 8.0.0-preview.1

### DIFF
--- a/buildandtest.yml
+++ b/buildandtest.yml
@@ -26,6 +26,11 @@ steps:
   inputs:
     version: '8.x'
 
+# .NET Core App 2.1 is required to run the ESRP code signing task
+- task: UseDotNet@2
+  inputs:
+    version: '2.1.x'
+
 
 - task: DotNetCoreCLI@2
   displayName: 'Build'  

--- a/tools/CustomMSBuild/Versioning.props
+++ b/tools/CustomMSBuild/Versioning.props
@@ -5,7 +5,7 @@
     <VersionMajor Condition="'$(VersionMajor)' == ''">8</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
     <VersionBuildNumber Condition="'$(VersionBuildNumber)' == ''">0</VersionBuildNumber>
-    <VersionRelease Condition="'$(VersionRelease)' == ''">dev</VersionRelease>
+    <VersionRelease Condition="'$(VersionRelease)' == ''">preview1</VersionRelease>
   </PropertyGroup>
 
   <!--

--- a/tools/CustomMSBuild/Versioning.props
+++ b/tools/CustomMSBuild/Versioning.props
@@ -5,7 +5,7 @@
     <VersionMajor Condition="'$(VersionMajor)' == ''">8</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
     <VersionBuildNumber Condition="'$(VersionBuildNumber)' == ''">0</VersionBuildNumber>
-    <VersionRelease Condition="'$(VersionRelease)' == ''">preview1</VersionRelease>
+    <VersionRelease Condition="'$(VersionRelease)' == ''">preview.1</VersionRelease>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Sets the version to `8.0.0-preview.1`.

Added .NET Core App 2.1 to the build pipeline because it's required by the ESRP codesigning task. We should consider updating the task.