### PR TITLE
Rename IBaseEntityType.Context to DataServiceContext

### DIFF
--- a/src/Microsoft.OData.Client/BaseEntityType.cs
+++ b/src/Microsoft.OData.Client/BaseEntityType.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.Client
         /// </summary>
         protected internal DataServiceContext Context { get; set; }
 
-        DataServiceContext IBaseEntityType.Context
+        DataServiceContext IBaseEntityType.DataServiceContext
         {
             get => Context;
             set => Context = value;

--- a/src/Microsoft.OData.Client/BaseEntityType.cs
+++ b/src/Microsoft.OData.Client/BaseEntityType.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.Client
         /// </summary>
         protected internal DataServiceContext Context { get; set; }
 
-        DataServiceContext IBaseEntityType.EntityTrackingContext
+        DataServiceContext IBaseEntityType.DataServiceContext
         {
             get => Context;
             set => Context = value;

--- a/src/Microsoft.OData.Client/BaseEntityType.cs
+++ b/src/Microsoft.OData.Client/BaseEntityType.cs
@@ -16,7 +16,7 @@ namespace Microsoft.OData.Client
         /// </summary>
         protected internal DataServiceContext Context { get; set; }
 
-        DataServiceContext IBaseEntityType.DataServiceContext
+        DataServiceContext IBaseEntityType.EntityTrackingContext
         {
             get => Context;
             set => Context = value;

--- a/src/Microsoft.OData.Client/IBaseEntityType.cs
+++ b/src/Microsoft.OData.Client/IBaseEntityType.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// DataServiceContext for query provider.
         /// </summary>
-        DataServiceContext Context { get; set; }
+        DataServiceContext DataServiceContext { get; set; }
 
         /// <summary>
         /// Entity descriptor containing entity stream links.

--- a/src/Microsoft.OData.Client/IBaseEntityType.cs
+++ b/src/Microsoft.OData.Client/IBaseEntityType.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// DataServiceContext for query provider.
         /// </summary>
-        DataServiceContext DataServiceContext { get; set; }
+        DataServiceContext EntityTrackingContext { get; set; }
 
         /// <summary>
         /// Entity descriptor containing entity stream links.

--- a/src/Microsoft.OData.Client/IBaseEntityType.cs
+++ b/src/Microsoft.OData.Client/IBaseEntityType.cs
@@ -15,7 +15,7 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// DataServiceContext for query provider.
         /// </summary>
-        DataServiceContext EntityTrackingContext { get; set; }
+        DataServiceContext DataServiceContext { get; set; }
 
         /// <summary>
         /// Entity descriptor containing entity stream links.

--- a/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
+++ b/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
@@ -682,7 +682,7 @@ namespace Microsoft.OData.Client.Materialization
 
             if (entry.ResolvedObject is IBaseEntityType entity)
             {
-                entity.EntityTrackingContext = this.EntityTrackingAdapter.Context;
+                entity.DataServiceContext = this.EntityTrackingAdapter.Context;
 
                 if (!entry.IsTracking)
                 {

--- a/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
+++ b/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
@@ -682,7 +682,7 @@ namespace Microsoft.OData.Client.Materialization
 
             if (entry.ResolvedObject is IBaseEntityType entity)
             {
-                entity.DataServiceContext = this.EntityTrackingAdapter.Context;
+                entity.EntityTrackingContext = this.EntityTrackingAdapter.Context;
 
                 if (!entry.IsTracking)
                 {

--- a/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
+++ b/src/Microsoft.OData.Client/Materialization/EntryValueMaterializationPolicy.cs
@@ -682,7 +682,7 @@ namespace Microsoft.OData.Client.Materialization
 
             if (entry.ResolvedObject is IBaseEntityType entity)
             {
-                entity.Context = this.EntityTrackingAdapter.Context;
+                entity.DataServiceContext = this.EntityTrackingAdapter.Context;
 
                 if (!entry.IsTracking)
                 {

--- a/src/Microsoft.OData.Client/MaterializeFromAtom.cs
+++ b/src/Microsoft.OData.Client/MaterializeFromAtom.cs
@@ -351,7 +351,7 @@ namespace Microsoft.OData.Client
                     {
                         if (this.materializer.CurrentValue is IBaseEntityType entity)
                         {
-                            entity.Context = this.responseInfo.Context;
+                            entity.DataServiceContext = this.responseInfo.Context;
                         }
 
                         this.current = this.materializer.CurrentValue;

--- a/src/Microsoft.OData.Client/MaterializeFromAtom.cs
+++ b/src/Microsoft.OData.Client/MaterializeFromAtom.cs
@@ -351,7 +351,7 @@ namespace Microsoft.OData.Client
                     {
                         if (this.materializer.CurrentValue is IBaseEntityType entity)
                         {
-                            entity.EntityTrackingContext = this.responseInfo.Context;
+                            entity.DataServiceContext = this.responseInfo.Context;
                         }
 
                         this.current = this.materializer.CurrentValue;

--- a/src/Microsoft.OData.Client/MaterializeFromAtom.cs
+++ b/src/Microsoft.OData.Client/MaterializeFromAtom.cs
@@ -351,7 +351,7 @@ namespace Microsoft.OData.Client
                     {
                         if (this.materializer.CurrentValue is IBaseEntityType entity)
                         {
-                            entity.DataServiceContext = this.responseInfo.Context;
+                            entity.EntityTrackingContext = this.responseInfo.Context;
                         }
 
                         this.current = this.materializer.CurrentValue;

--- a/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4,6 +4,8 @@ Microsoft.OData.Client.DataServiceClientRequestMessageArgs.DataServiceClientRequ
 Microsoft.OData.Client.DataServiceClientRequestMessageArgs.HttpClientFactory.get -> System.Net.Http.IHttpClientFactory
 Microsoft.OData.Client.DataServiceContext.HttpClientFactory.get -> System.Net.Http.IHttpClientFactory
 Microsoft.OData.Client.DataServiceContext.HttpClientFactory.set -> void
+Microsoft.OData.Client.IBaseEntityType.DataServiceContext.get -> Microsoft.OData.Client.DataServiceContext
+Microsoft.OData.Client.IBaseEntityType.DataServiceContext.set -> void
 Microsoft.OData.Client.UriFunctionAttribute
 Microsoft.OData.Client.UriFunctionAttribute.AllowClientSideEvaluation.get -> bool
 Microsoft.OData.Client.UriFunctionAttribute.UriFunctionAttribute(bool allowClientSideEvaluation = false) -> void
@@ -518,8 +520,6 @@ Microsoft.OData.Client.HttpWebResponseMessage
 Microsoft.OData.Client.HttpWebResponseMessage.Dispose() -> void
 Microsoft.OData.Client.HttpWebResponseMessage.HttpWebResponseMessage(System.Collections.Generic.IDictionary<string, string> headers, int statusCode, System.Func<System.IO.Stream> getResponseStream) -> void
 Microsoft.OData.Client.IBaseEntityType
-Microsoft.OData.Client.IBaseEntityType.Context.get -> Microsoft.OData.Client.DataServiceContext
-Microsoft.OData.Client.IBaseEntityType.Context.set -> void
 Microsoft.OData.Client.IBaseEntityType.EntityDescriptor.get -> Microsoft.OData.Client.EntityDescriptor
 Microsoft.OData.Client.IBaseEntityType.EntityDescriptor.set -> void
 Microsoft.OData.Client.IgnoreClientPropertyAttribute

--- a/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4,8 +4,8 @@ Microsoft.OData.Client.DataServiceClientRequestMessageArgs.DataServiceClientRequ
 Microsoft.OData.Client.DataServiceClientRequestMessageArgs.HttpClientFactory.get -> System.Net.Http.IHttpClientFactory
 Microsoft.OData.Client.DataServiceContext.HttpClientFactory.get -> System.Net.Http.IHttpClientFactory
 Microsoft.OData.Client.DataServiceContext.HttpClientFactory.set -> void
-Microsoft.OData.Client.IBaseEntityType.EntityTrackingContext.get -> Microsoft.OData.Client.DataServiceContext
-Microsoft.OData.Client.IBaseEntityType.EntityTrackingContext.set -> void
+Microsoft.OData.Client.IBaseEntityType.DataServiceContext.get -> Microsoft.OData.Client.DataServiceContext
+Microsoft.OData.Client.IBaseEntityType.DataServiceContext.set -> void
 Microsoft.OData.Client.UriFunctionAttribute
 Microsoft.OData.Client.UriFunctionAttribute.AllowClientSideEvaluation.get -> bool
 Microsoft.OData.Client.UriFunctionAttribute.UriFunctionAttribute(bool allowClientSideEvaluation = false) -> void

--- a/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4,8 +4,7 @@ Microsoft.OData.Client.DataServiceClientRequestMessageArgs.DataServiceClientRequ
 Microsoft.OData.Client.DataServiceClientRequestMessageArgs.HttpClientFactory.get -> System.Net.Http.IHttpClientFactory
 Microsoft.OData.Client.DataServiceContext.HttpClientFactory.get -> System.Net.Http.IHttpClientFactory
 Microsoft.OData.Client.DataServiceContext.HttpClientFactory.set -> void
-Microsoft.OData.Client.IBaseEntityType.DataServiceContext.get -> Microsoft.OData.Client.DataServiceContext
-Microsoft.OData.Client.IBaseEntityType.DataServiceContext.set -> void
+Microsoft.OData.Client.IBaseEntityType.EntityTrackingContext.get -> Microsoft.OData.Client.DataServiceContext
 Microsoft.OData.Client.UriFunctionAttribute
 Microsoft.OData.Client.UriFunctionAttribute.AllowClientSideEvaluation.get -> bool
 Microsoft.OData.Client.UriFunctionAttribute.UriFunctionAttribute(bool allowClientSideEvaluation = false) -> void

--- a/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -5,6 +5,7 @@ Microsoft.OData.Client.DataServiceClientRequestMessageArgs.HttpClientFactory.get
 Microsoft.OData.Client.DataServiceContext.HttpClientFactory.get -> System.Net.Http.IHttpClientFactory
 Microsoft.OData.Client.DataServiceContext.HttpClientFactory.set -> void
 Microsoft.OData.Client.IBaseEntityType.EntityTrackingContext.get -> Microsoft.OData.Client.DataServiceContext
+Microsoft.OData.Client.IBaseEntityType.EntityTrackingContext.set -> void
 Microsoft.OData.Client.UriFunctionAttribute
 Microsoft.OData.Client.UriFunctionAttribute.AllowClientSideEvaluation.get -> bool
 Microsoft.OData.Client.UriFunctionAttribute.UriFunctionAttribute(bool allowClientSideEvaluation = false) -> void


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2593 and fixes #2291 

### Description

This PR renames the `IBaseEntityType.Context` property to `DataServiceContext`. The name `Context` is a relatively common property name in customer schemas and this is therefore a common source of naming conflicts which result in compilation or runtime errors. We expect `DataServiceContext` to be less susceptible to conflicts, it's also more specific, so this doesn't hurt readability of the code.

The issue could be resolved by the customers by changing the generated property name manually to remove the conflict. But this would means they would have to make that change each time the regenerate the code (e.g. after an update to the CSDL). This leads to unfavorable developer experience.

We may also make changes to the code generation logic in the code gen tools such it generates a different property name when the customer CSDL contains property name that may conflict with built-in property names. That would be more work but definitely not unreasonable. In fact we have merged a pull request that changes generated property names if they would be invalid identifiers, so this is not far off. I'm not opposite to doing that if it's preferrable. But since this issue affects `Context` specifically, and since that not a far-fetched property name, I think it's safe to make change to the internal interface in this case.

Another approach that we have not discussed would be to provide a way for customers to inject custom scripts or hook that would apply user-defined transformations during code generations and these scripts could be saved along with the config so they would be re-applied automatically each time the code generator is executed. But this probably overkill and should be its own feature request that ought to be separately designed.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
