### PR TITLE
Add ObjectPool dependency to nuget config

### DIFF
--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
@@ -23,6 +23,7 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
         <dependency id="Microsoft.Spatial" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
         <dependency id="Microsoft.OData.Edm" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
         <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
+        <dependency id="Microsoft.Extensions.ObjectPool" version="6.0.3" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
@@ -24,6 +24,7 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
         <dependency id="Microsoft.Spatial" version="[$VersionNuGetSemantic$]" />
         <dependency id="Microsoft.OData.Edm" version="[$VersionNuGetSemantic$]" />
         <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
+        <dependency id="Microsoft.Extensions.ObjectPool" version="6.0.3" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2950*

### Description

Adds the `Microsoft.Extension.ObjectPool` dependency to the NuGet config so that it can get installed on the customer's machine when they install our libraries.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
