### PR TITLE
Fix nuget config and update to preview.2

### DIFF
--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
@@ -23,6 +23,7 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
         <dependency id="Microsoft.Spatial" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
         <dependency id="Microsoft.OData.Edm" version="[$VersionFullSemantic$-Nightly$NightlyBuildVersion$]" />
         <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
+        <dependency id="Microsoft.Extensions.ObjectPool" version="6.0.3" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
@@ -24,6 +24,7 @@ OData .NET library is open source at http://github.com/OData/odata.net. Document
         <dependency id="Microsoft.Spatial" version="[$VersionNuGetSemantic$]" />
         <dependency id="Microsoft.OData.Edm" version="[$VersionNuGetSemantic$]" />
         <dependency id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" />
+         <dependency id="Microsoft.Extensions.ObjectPool" version="6.0.3" />
       </group>
     </dependencies>
   </metadata>

--- a/tools/CustomMSBuild/Versioning.props
+++ b/tools/CustomMSBuild/Versioning.props
@@ -5,7 +5,7 @@
     <VersionMajor Condition="'$(VersionMajor)' == ''">8</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
     <VersionBuildNumber Condition="'$(VersionBuildNumber)' == ''">0</VersionBuildNumber>
-    <VersionRelease Condition="'$(VersionRelease)' == ''">preview.1</VersionRelease>
+    <VersionRelease Condition="'$(VersionRelease)' == ''">preview.2</VersionRelease>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
Fixes #2950 for ODL 8.

Without this fix, the Microsoft.Extensions.ObjectPool package is not installed automatically when you add OData library packages to your project. Without that package, a `TypeLoadException` will be raised when you try to write a resource with duplicate name checker validation enabled (which is the default).

And upgrades the version to `8.0.0-preview.2`.

Note: This fix has already been shipped in `7.21.1`. See: https://github.com/OData/odata.net/pull/2954