### PR TITLE
Refactor ODataError, ODataErrorDetail and ODataInnerError classes

### DIFF
--- a/src/Microsoft.OData.Core/ErrorUtils.cs
+++ b/src/Microsoft.OData.Core/ErrorUtils.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OData
         {
             Debug.Assert(error != null, "error != null");
 
-            code = error.ErrorCode ?? string.Empty;
+            code = error.Code ?? string.Empty;
             message = error.Message ?? string.Empty;
         }
 

--- a/src/Microsoft.OData.Core/ErrorUtils.cs
+++ b/src/Microsoft.OData.Core/ErrorUtils.cs
@@ -4,9 +4,9 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System;
 using System.Diagnostics;
 using System.Xml;
+using Microsoft.OData.Json;
 using Microsoft.OData.Metadata;
 
 namespace Microsoft.OData
@@ -43,8 +43,12 @@ namespace Microsoft.OData
         /// <param name="writer">The Xml writer to write to.</param>
         /// <param name="error">The error instance to write.</param>
         /// <param name="includeDebugInformation">A flag indicating whether error details should be written (in debug mode only) or not.</param>
-        /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
-        internal static void WriteXmlError(XmlWriter writer, ODataError error, bool includeDebugInformation, int maxInnerErrorDepth)
+        /// <param name="messageWriterSettings">Configuration settings of the OData writer.</param>
+        internal static void WriteXmlError(
+            XmlWriter writer,
+            ODataError error,
+            bool includeDebugInformation,
+            ODataMessageWriterSettings messageWriterSettings)
         {
             Debug.Assert(writer != null, "writer != null");
             Debug.Assert(error != null, "error != null");
@@ -53,7 +57,7 @@ namespace Microsoft.OData
             ErrorUtils.GetErrorDetails(error, out code, out message);
 
             ODataInnerError innerError = includeDebugInformation ? error.InnerError : null;
-            WriteXmlError(writer, code, message, innerError, maxInnerErrorDepth);
+            WriteXmlError(writer, code, message, innerError, messageWriterSettings);
         }
 
         /// <summary>
@@ -63,8 +67,13 @@ namespace Microsoft.OData
         /// <param name="code">The code of the error.</param>
         /// <param name="message">The message of the error.</param>
         /// <param name="innerError">Inner error details that will be included in debug mode (if present).</param>
-        /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
-        private static void WriteXmlError(XmlWriter writer, string code, string message, ODataInnerError innerError, int maxInnerErrorDepth)
+        /// <param name="messageWriterSettings">Configuration settings of the OData writer.</param>
+        private static void WriteXmlError(
+            XmlWriter writer,
+            string code,
+            string message,
+            ODataInnerError innerError,
+            ODataMessageWriterSettings messageWriterSettings)
         {
             Debug.Assert(writer != null, "writer != null");
             Debug.Assert(code != null, "code != null");
@@ -81,7 +90,7 @@ namespace Microsoft.OData
 
             if (innerError != null)
             {
-                WriteXmlInnerError(writer, innerError, ODataMetadataConstants.ODataInnerErrorElementName, /* recursionDepth */ 0, maxInnerErrorDepth);
+                WriteXmlInnerError(writer, innerError, ODataMetadataConstants.ODataInnerErrorElementName, recursionDepth: 0, messageWriterSettings);
             }
 
             // </m:error>
@@ -95,11 +104,17 @@ namespace Microsoft.OData
         /// <param name="innerError">The inner error to write.</param>
         /// <param name="innerErrorElementName">The local name of the element representing the inner error.</param>
         /// <param name="recursionDepth">The number of times this method has been called recursively.</param>
-        /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
-        private static void WriteXmlInnerError(XmlWriter writer, ODataInnerError innerError, string innerErrorElementName, int recursionDepth, int maxInnerErrorDepth)
+        /// <param name="messageWriterSettings">Configuration settings of the OData writer.</param>
+        private static void WriteXmlInnerError(
+            XmlWriter writer,
+            ODataInnerError innerError,
+            string innerErrorElementName,
+            int recursionDepth,
+            ODataMessageWriterSettings messageWriterSettings)
         {
             Debug.Assert(writer != null, "writer != null");
 
+            int maxInnerErrorDepth = messageWriterSettings.MessageQuotas.MaxNestingDepth;
             recursionDepth++;
             if (recursionDepth > maxInnerErrorDepth)
             {
@@ -113,30 +128,48 @@ namespace Microsoft.OData
             // <m:innererror> or <m:internalexception>
             writer.WriteStartElement(ODataMetadataConstants.ODataMetadataNamespacePrefix, innerErrorElementName, ODataMetadataConstants.ODataMetadataNamespace);
 
-            //// NOTE: we add empty elements if no information is provided for the message, error type and stack trace
-            ////       to stay compatible with Astoria.
+            ODataValue propertyValue = null;
 
             // <m:message>...</m:message>
-            string errorMessage = innerError.Message ?? String.Empty;
-            writer.WriteStartElement(ODataMetadataConstants.ODataInnerErrorMessageElementName, ODataMetadataConstants.ODataMetadataNamespace);
-            writer.WriteString(errorMessage);
-            writer.WriteEndElement();
+            if (innerError.Properties.TryGetValue(ODataMetadataConstants.ODataInnerErrorMessageElementName, out propertyValue)
+                && propertyValue is ODataPrimitiveValue innerErrorMessage)
+            {
+                writer.WriteStartElement(ODataMetadataConstants.ODataInnerErrorMessageElementName, ODataMetadataConstants.ODataMetadataNamespace);
+                writer.WriteString((string)innerErrorMessage.Value);
+                writer.WriteEndElement();
+            }
 
             // <m:type>...</m:type>
-            string errorType = innerError.TypeName ?? string.Empty;
-            writer.WriteStartElement(ODataMetadataConstants.ODataInnerErrorTypeElementName, ODataMetadataConstants.ODataMetadataNamespace);
-            writer.WriteString(errorType);
-            writer.WriteEndElement();
+            if (innerError.Properties.TryGetValue(ODataMetadataConstants.ODataInnerErrorTypeElementName, out propertyValue)
+                && propertyValue is ODataPrimitiveValue innerErrorTypeName)
+            {
+                writer.WriteStartElement(ODataMetadataConstants.ODataInnerErrorTypeElementName, ODataMetadataConstants.ODataMetadataNamespace);
+                writer.WriteString((string)innerErrorTypeName.Value);
+                writer.WriteEndElement();
+            }
 
             // <m:stacktrace>...</m:stacktrace>
-            string errorStackTrace = innerError.StackTrace ?? String.Empty;
-            writer.WriteStartElement(ODataMetadataConstants.ODataInnerErrorStackTraceElementName, ODataMetadataConstants.ODataMetadataNamespace);
-            writer.WriteString(errorStackTrace);
-            writer.WriteEndElement();
+            if (innerError.Properties.TryGetValue(ODataMetadataConstants.ODataInnerErrorTypeElementName, out propertyValue)
+                && propertyValue is ODataPrimitiveValue innerErrorStackTrace)
+            {
+                writer.WriteStartElement(ODataMetadataConstants.ODataInnerErrorStackTraceElementName, ODataMetadataConstants.ODataMetadataNamespace);
+                writer.WriteString((string)innerErrorStackTrace.Value);
+                writer.WriteEndElement();
+            }
 
             if (innerError.InnerError != null)
             {
-                WriteXmlInnerError(writer, innerError.InnerError, ODataMetadataConstants.ODataInnerErrorInnerErrorElementName, recursionDepth, maxInnerErrorDepth);
+                string nestedInnerErrorPropertyName;
+                if (messageWriterSettings.LibraryCompatibility.HasFlag(ODataLibraryCompatibility.UseLegacyODataInnerErrorSerialization))
+                {
+                    nestedInnerErrorPropertyName = JsonConstants.ODataErrorInnerErrorInnerErrorName;
+                }
+                else
+                {
+                    nestedInnerErrorPropertyName = JsonConstants.ODataErrorInnerErrorName;
+                }
+
+                WriteXmlInnerError(writer, innerError.InnerError, nestedInnerErrorPropertyName, recursionDepth, messageWriterSettings);
             }
 
             // </m:innererror> or </m:internalexception>

--- a/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
@@ -520,7 +520,7 @@ namespace Microsoft.OData.Json
         /// The value of the TResult parameter contains a tuple comprising of:
         /// 1). A value of true if the current value is an in-stream error value; otherwise false.
         /// 2). An <see cref="ODataError"/> instance that was read from the payload.</returns>
-        internal async Task<Tuple<bool, ODataError>> StartBufferingAndTryToReadInStreamErrorPropertyValueAsync()
+        internal async Task<(bool IsReadSuccessfully, ODataError Error)> StartBufferingAndTryToReadInStreamErrorPropertyValueAsync()
         {
             this.AssertNotBuffering();
             this.AssertAsynchronous();
@@ -531,8 +531,9 @@ namespace Microsoft.OData.Json
 
             try
             {
-                Tuple<bool, ODataError> readInStreamErrorPropertyResult = await this.TryReadInStreamErrorPropertyValueAsync()
+                (bool IsReadSuccessfully, ODataError Error) readInStreamErrorPropertyResult = await this.TryReadInStreamErrorPropertyValueAsync()
                     .ConfigureAwait(false);
+
                 return readInStreamErrorPropertyResult;
             }
             finally
@@ -770,7 +771,7 @@ namespace Microsoft.OData.Json
 
                 // We only consider this to be an in-stream error if the object has a single 'error' property
                 bool errorPropertyFound = false;
-                Tuple<bool, ODataError> readInStreamErrorPropertyResult = null;
+                (bool IsReadSuccessfully, ODataError Error)? readInStreamErrorPropertyResult = null;
 
                 while (this.currentBufferedNode.NodeType == JsonNodeType.Property)
                 {
@@ -791,7 +792,7 @@ namespace Microsoft.OData.Json
 
                     readInStreamErrorPropertyResult = await this.TryReadInStreamErrorPropertyValueAsync()
                         .ConfigureAwait(false);
-                    if (!readInStreamErrorPropertyResult.Item1)
+                    if (readInStreamErrorPropertyResult?.IsReadSuccessfully == false)
                     {
                         // This means we thought we saw an in-stream error, but then
                         // we didn't see an intelligible error object, so we give up on reading the in-stream error
@@ -802,7 +803,7 @@ namespace Microsoft.OData.Json
 
                 if (errorPropertyFound)
                 {
-                    throw new ODataErrorException(readInStreamErrorPropertyResult.Item2);
+                    throw new ODataErrorException(readInStreamErrorPropertyResult?.Error);
                 }
             }
         }
@@ -1185,7 +1186,7 @@ namespace Microsoft.OData.Json
                         string message;
                         if (this.TryReadErrorStringPropertyValue(out message))
                         {
-                            innerError.Message = message;
+                            innerError.Properties.Add(JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue(message));
                         }
                         else
                         {
@@ -1203,7 +1204,7 @@ namespace Microsoft.OData.Json
                         string typeName;
                         if (this.TryReadErrorStringPropertyValue(out typeName))
                         {
-                            innerError.TypeName = typeName;
+                            innerError.Properties.Add(JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue(typeName));
                         }
                         else
                         {
@@ -1221,7 +1222,7 @@ namespace Microsoft.OData.Json
                         string stackTrace;
                         if (this.TryReadErrorStringPropertyValue(out stackTrace))
                         {
-                            innerError.StackTrace = stackTrace;
+                            innerError.Properties.Add(JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue(stackTrace));
                         }
                         else
                         {
@@ -1231,6 +1232,7 @@ namespace Microsoft.OData.Json
                         break;
 
                     case JsonConstants.ODataErrorInnerErrorInnerErrorName:
+                    case JsonConstants.ODataErrorInnerErrorName:
                         if (!ODataJsonReaderUtils.ErrorPropertyNotFound(ref propertiesFoundBitmask, ODataJsonReaderUtils.ErrorPropertyBitMask.InnerError))
                         {
                             return false;
@@ -1404,7 +1406,7 @@ namespace Microsoft.OData.Json
         /// The value of the TResult parameter contains a tuple comprising of:
         /// 1). A value of true if an <see cref="ODataError"/> instance that was read; otherwise false.
         /// 2). An <see cref="ODataError"/> instance that was read from the reader or null if none could be read.</returns>
-        private async Task<Tuple<bool, ODataError>> TryReadInStreamErrorPropertyValueAsync()
+        private async Task<(bool IsReadSuccessfully, ODataError Error)> TryReadInStreamErrorPropertyValueAsync()
         {
             Debug.Assert(this.parsingInStreamError, "this.parsingInStreamError");
             this.AssertBuffering();
@@ -1413,7 +1415,7 @@ namespace Microsoft.OData.Json
             // We expect a StartObject node here
             if (this.currentBufferedNode.NodeType != JsonNodeType.StartObject)
             {
-                return Tuple.Create(false, (ODataError)null);
+                return (false, (ODataError)null);
             }
 
             // Read the StartObject node
@@ -1435,17 +1437,17 @@ namespace Microsoft.OData.Json
                             ref propertiesFoundBitmask,
                             ODataJsonReaderUtils.ErrorPropertyBitMask.Code))
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
-                        Tuple<bool, string> readErrorCodePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
+                        (bool IsReadSuccessfully, string PropertyValue) readErrorCodePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorCodePropertyResult.Item1)
+                        if (!readErrorCodePropertyResult.IsReadSuccessfully)
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
-                        error.Code = readErrorCodePropertyResult.Item2;
+                        error.Code = readErrorCodePropertyResult.PropertyValue;
                         break;
 
                     case JsonConstants.ODataErrorMessageName:
@@ -1453,17 +1455,17 @@ namespace Microsoft.OData.Json
                             ref propertiesFoundBitmask,
                             ODataJsonReaderUtils.ErrorPropertyBitMask.Message))
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
-                        Tuple<bool, string> readErrorMessagePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
+                        (bool IsReadSuccessfully, string PropertyValue) readErrorMessagePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorMessagePropertyResult.Item1)
+                        if (!readErrorMessagePropertyResult.IsReadSuccessfully)
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
-                        error.Message = readErrorMessagePropertyResult.Item2;
+                        error.Message = readErrorMessagePropertyResult.PropertyValue;
                         break;
 
                     case JsonConstants.ODataErrorTargetName:
@@ -1471,14 +1473,14 @@ namespace Microsoft.OData.Json
                             ref propertiesFoundBitmask,
                             ODataJsonReaderUtils.ErrorPropertyBitMask.Target))
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
-                        Tuple<bool, string> readErrorTargetPropertyResult = await this.TryReadErrorStringPropertyValueAsync()
+                        (bool IsReadSuccessfully, string PropertyValue) readErrorTargetPropertyResult = await this.TryReadErrorStringPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorTargetPropertyResult.Item1)
+                        if (!readErrorTargetPropertyResult.IsReadSuccessfully)
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
                         error.Target = readErrorTargetPropertyResult.Item2;
@@ -1489,17 +1491,17 @@ namespace Microsoft.OData.Json
                                 ref propertiesFoundBitmask,
                                 ODataJsonReaderUtils.ErrorPropertyBitMask.Details))
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
-                        Tuple<bool, List<ODataErrorDetail>> readErrorDetailsPropertyResult = await this.TryReadErrorDetailsPropertyValueAsync()
+                        (bool IsReadSuccessfully, List<ODataErrorDetail> ErrorDetails) readErrorDetailsPropertyResult = await this.TryReadErrorDetailsPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorDetailsPropertyResult.Item1)
+                        if (!readErrorDetailsPropertyResult.IsReadSuccessfully)
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
-                        error.Details = readErrorDetailsPropertyResult.Item2;
+                        error.Details = readErrorDetailsPropertyResult.ErrorDetails;
                         break;
 
                     case JsonConstants.ODataErrorInnerErrorName:
@@ -1507,14 +1509,14 @@ namespace Microsoft.OData.Json
                             ref propertiesFoundBitmask,
                             ODataJsonReaderUtils.ErrorPropertyBitMask.InnerError))
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
                         Tuple<bool, ODataInnerError> readInnerErrorPropertyResult = await this.TryReadInnerErrorPropertyValueAsync(0 /*recursionDepth */)
                             .ConfigureAwait(false);
                         if (!readInnerErrorPropertyResult.Item1)
                         {
-                            return Tuple.Create(false, error);
+                            return (false, error);
                         }
 
                         error.InnerError = readInnerErrorPropertyResult.Item2;
@@ -1522,7 +1524,7 @@ namespace Microsoft.OData.Json
 
                     default:
                         // If we find a non-supported property we don't treat this as an error
-                        return Tuple.Create(false, error);
+                        return (false, error);
                 }
 
                 await this.ReadInternalAsync()
@@ -1538,8 +1540,7 @@ namespace Microsoft.OData.Json
                 .ConfigureAwait(false);
 
             // If we don't find any properties it is not a valid error object
-            return Tuple.Create(
-                propertiesFoundBitmask != ODataJsonReaderUtils.ErrorPropertyBitMask.None,
+            return (propertiesFoundBitmask != ODataJsonReaderUtils.ErrorPropertyBitMask.None,
                 error);
         }
 
@@ -1550,7 +1551,7 @@ namespace Microsoft.OData.Json
         /// The value of the TResult parameter contains a tuple comprising of:
         /// 1). A value of true if an <see cref="ODataErrorDetail"/> collection was read; otherwise false.
         /// 2). An <see cref="ODataErrorDetail"/> collection that was read from the reader or null if none could be read.</returns>
-        private async Task<Tuple<bool, List<ODataErrorDetail>>> TryReadErrorDetailsPropertyValueAsync()
+        private async Task<(bool IsReadSuccessfully, List<ODataErrorDetail> ErrorDetails)> TryReadErrorDetailsPropertyValueAsync()
         {
             Debug.Assert(
                 this.currentBufferedNode.NodeType == JsonNodeType.Property,
@@ -1566,7 +1567,7 @@ namespace Microsoft.OData.Json
             // We expect a StartArray node here
             if (this.currentBufferedNode.NodeType != JsonNodeType.StartArray)
             {
-                return Tuple.Create(false, (List<ODataErrorDetail>)null);
+                return (false, (List<ODataErrorDetail>)null);
             }
 
             // [
@@ -1577,22 +1578,22 @@ namespace Microsoft.OData.Json
 
             while (this.currentBufferedNode.NodeType != JsonNodeType.EndArray)
             {
-                Tuple<bool, ODataErrorDetail> readErrorDetailResult = await TryReadErrorDetailAsync()
+                (bool IsReadSuccessfully, ODataErrorDetail ErrorDetail) readErrorDetailResult = await TryReadErrorDetailAsync()
                     .ConfigureAwait(false);
 
-                if (!readErrorDetailResult.Item1)
+                if (!readErrorDetailResult.IsReadSuccessfully)
                 {
-                    return Tuple.Create(false, details);
+                    return (false, details);
                 }
 
-                details.Add(readErrorDetailResult.Item2);
+                details.Add(readErrorDetailResult.ErrorDetail);
 
                 // ] or { (next error detail object)
                 await ReadInternalAsync()
                     .ConfigureAwait(false);
             }
 
-            return Tuple.Create(true, details);
+            return (true, details);
         }
 
         /// <summary>
@@ -1602,7 +1603,7 @@ namespace Microsoft.OData.Json
         /// The value of the TResult parameter contains a tuple comprising of:
         /// 1). A value of true if an <see cref="ODataErrorDetail"/> instance was read; otherwise false.
         /// 2). An <see cref="ODataErrorDetail"/> instance that was read from the reader or null if none could be read.</returns>
-        private async Task<Tuple<bool, ODataErrorDetail>> TryReadErrorDetailAsync()
+        private async Task<(bool IsReadSuccessfully, ODataErrorDetail ErrorDetail)> TryReadErrorDetailAsync()
         {
             Debug.Assert(
                 this.currentBufferedNode.NodeType == JsonNodeType.StartObject,
@@ -1613,7 +1614,7 @@ namespace Microsoft.OData.Json
 
             if (this.currentBufferedNode.NodeType != JsonNodeType.StartObject)
             {
-                return Tuple.Create(false, (ODataErrorDetail)null);
+                return (false, (ODataErrorDetail)null);
             }
 
             // {
@@ -1635,17 +1636,17 @@ namespace Microsoft.OData.Json
                                 ref propertiesFoundBitmask,
                                 ODataJsonReaderUtils.ErrorPropertyBitMask.Code))
                         {
-                            return Tuple.Create(false, detail);
+                            return (false, detail);
                         }
 
-                        Tuple<bool, string> readErrorCodePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
+                        (bool IsReadSuccessfully, string PropertyValue) readErrorCodePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorCodePropertyResult.Item1)
+                        if (!readErrorCodePropertyResult.IsReadSuccessfully)
                         {
-                            return Tuple.Create(false, detail);
+                            return (false, detail);
                         }
 
-                        detail.Code = readErrorCodePropertyResult.Item2;
+                        detail.Code = readErrorCodePropertyResult.PropertyValue;
                         break;
 
                     case JsonConstants.ODataErrorTargetName:
@@ -1653,17 +1654,17 @@ namespace Microsoft.OData.Json
                                 ref propertiesFoundBitmask,
                                 ODataJsonReaderUtils.ErrorPropertyBitMask.Target))
                         {
-                            return Tuple.Create(false, detail);
+                            return (false, detail);
                         }
 
-                        Tuple<bool, string> readErrorTargetPropertyResult = await this.TryReadErrorStringPropertyValueAsync()
+                        (bool IsReadSuccessfully, string PropertyValue) readErrorTargetPropertyResult = await this.TryReadErrorStringPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorTargetPropertyResult.Item1)
+                        if (!readErrorTargetPropertyResult.IsReadSuccessfully)
                         {
-                            return Tuple.Create(false, detail);
+                            return (false, detail);
                         }
 
-                        detail.Target = readErrorTargetPropertyResult.Item2;
+                        detail.Target = readErrorTargetPropertyResult.PropertyValue;
                         break;
 
                     case JsonConstants.ODataErrorMessageName:
@@ -1671,17 +1672,17 @@ namespace Microsoft.OData.Json
                                 ref propertiesFoundBitmask,
                                 ODataJsonReaderUtils.ErrorPropertyBitMask.MessageValue))
                         {
-                            return Tuple.Create(false, detail);
+                            return (false, detail);
                         }
 
-                        Tuple<bool, string> readErrorMessagePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
+                        (bool IsReadSuccessfully, string PropertyValue) readErrorMessagePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorMessagePropertyResult.Item1)
+                        if (!readErrorMessagePropertyResult.IsReadSuccessfully)
                         {
-                            return Tuple.Create(false, detail);
+                            return (false, detail);
                         }
 
-                        detail.Message = readErrorMessagePropertyResult.Item2;
+                        detail.Message = readErrorMessagePropertyResult.PropertyValue;
                         break;
 
                     default:
@@ -1699,7 +1700,7 @@ namespace Microsoft.OData.Json
                 this.currentBufferedNode.NodeType == JsonNodeType.EndObject,
                 "this.currentBufferedNode.NodeType == JsonNodeType.EndObject");
 
-            return Tuple.Create(true, detail);
+            return (true, detail);
         }
 
         /// <summary>
@@ -1752,14 +1753,16 @@ namespace Microsoft.OData.Json
                             return Tuple.Create(false, innerError);
                         }
 
-                        Tuple<bool, string> readErrorMessagePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
+                        (bool IsReadSuccessfully, string PropertyValue) readErrorMessagePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorMessagePropertyResult.Item1)
+                        if (!readErrorMessagePropertyResult.IsReadSuccessfully)
                         {
                             return Tuple.Create(false, innerError);
                         }
 
-                        innerError.Message = readErrorMessagePropertyResult.Item2;
+                        innerError.Properties.Add(
+                            JsonConstants.ODataErrorInnerErrorMessageName,
+                            new ODataPrimitiveValue(readErrorMessagePropertyResult.PropertyValue));
                         break;
 
                     case JsonConstants.ODataErrorInnerErrorTypeNameName:
@@ -1770,14 +1773,16 @@ namespace Microsoft.OData.Json
                             return Tuple.Create(false, innerError);
                         }
 
-                        Tuple<bool, string> readErrorTypePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
+                        (bool IsReadSuccessfully, string PropertyValue) readErrorTypePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorTypePropertyResult.Item1)
+                        if (!readErrorTypePropertyResult.IsReadSuccessfully)
                         {
                             return Tuple.Create(false, innerError);
                         }
 
-                        innerError.TypeName = readErrorTypePropertyResult.Item2;
+                        innerError.Properties.Add(
+                            JsonConstants.ODataErrorInnerErrorTypeNameName,
+                            new ODataPrimitiveValue(readErrorTypePropertyResult.PropertyValue));
                         break;
 
                     case JsonConstants.ODataErrorInnerErrorStackTraceName:
@@ -1788,17 +1793,20 @@ namespace Microsoft.OData.Json
                             return Tuple.Create(false, innerError);
                         }
 
-                        Tuple<bool, string> readErrorStackTracePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
+                        (bool IsReadSuccessfully, string PropertyValue) readErrorStackTracePropertyResult = await this.TryReadErrorStringPropertyValueAsync()
                             .ConfigureAwait(false);
-                        if (!readErrorStackTracePropertyResult.Item1)
+                        if (!readErrorStackTracePropertyResult.IsReadSuccessfully)
                         {
                             return Tuple.Create(false, innerError);
                         }
 
-                        innerError.StackTrace = readErrorStackTracePropertyResult.Item2;
+                        innerError.Properties.Add(
+                            JsonConstants.ODataErrorInnerErrorStackTraceName,
+                            new ODataPrimitiveValue(readErrorStackTracePropertyResult.PropertyValue));
                         break;
 
                     case JsonConstants.ODataErrorInnerErrorInnerErrorName:
+                    case JsonConstants.ODataErrorInnerErrorName:
                         if (!ODataJsonReaderUtils.ErrorPropertyNotFound(
                             ref propertiesFoundBitmask,
                             ODataJsonReaderUtils.ErrorPropertyBitMask.InnerError))
@@ -1841,7 +1849,7 @@ namespace Microsoft.OData.Json
         /// The value of the TResult parameter contains a tuple comprising of:
         /// 1). A value of true if a string value (or null) was read as property value of the current property; otherwise false.
         /// 2). The string value read if the method returns true; otherwise null.</returns>
-        private async Task<Tuple<bool, string>> TryReadErrorStringPropertyValueAsync()
+        private async Task<(bool IsReadSuccessfully, string PropertyValue)> TryReadErrorStringPropertyValueAsync()
         {
             Debug.Assert(this.currentBufferedNode.NodeType == JsonNodeType.Property, "this.currentBufferedNode.NodeType == JsonNodeType.Property");
             Debug.Assert(this.parsingInStreamError, "this.parsingInStreamError");
@@ -1853,7 +1861,7 @@ namespace Microsoft.OData.Json
 
             // We expect a string value
             string stringValue = this.currentBufferedNode.Value as string;
-            return Tuple.Create(
+            return (
                 this.currentBufferedNode.NodeType == JsonNodeType.PrimitiveValue && (this.currentBufferedNode.Value == null || stringValue != null),
                 stringValue);
         }

--- a/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/BufferingJsonReader.cs
@@ -901,7 +901,7 @@ namespace Microsoft.OData.Json
                         string errorCode;
                         if (this.TryReadErrorStringPropertyValue(out errorCode))
                         {
-                            error.ErrorCode = errorCode;
+                            error.Code = errorCode;
                         }
                         else
                         {
@@ -1073,7 +1073,7 @@ namespace Microsoft.OData.Json
                         string code;
                         if (this.TryReadErrorStringPropertyValue(out code))
                         {
-                            detail.ErrorCode = code;
+                            detail.Code = code;
                         }
                         else
                         {
@@ -1445,7 +1445,7 @@ namespace Microsoft.OData.Json
                             return Tuple.Create(false, error);
                         }
 
-                        error.ErrorCode = readErrorCodePropertyResult.Item2;
+                        error.Code = readErrorCodePropertyResult.Item2;
                         break;
 
                     case JsonConstants.ODataErrorMessageName:
@@ -1645,7 +1645,7 @@ namespace Microsoft.OData.Json
                             return Tuple.Create(false, detail);
                         }
 
-                        detail.ErrorCode = readErrorCodePropertyResult.Item2;
+                        detail.Code = readErrorCodePropertyResult.Item2;
                         break;
 
                     case JsonConstants.ODataErrorTargetName:

--- a/src/Microsoft.OData.Core/Json/ODataJsonErrorDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonErrorDeserializer.cs
@@ -307,18 +307,31 @@ namespace Microsoft.OData.Json
             switch (propertyName)
             {
                 case JsonConstants.ODataErrorInnerErrorMessageName:
-                    innerError.Message = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorInnerErrorMessageName);
+                    string innerErrorMessage = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorInnerErrorMessageName);
+
+                    innerError.Properties.Add(
+                        JsonConstants.ODataErrorInnerErrorMessageName,
+                        new ODataPrimitiveValue(innerErrorMessage));
                     break;
 
                 case JsonConstants.ODataErrorInnerErrorTypeNameName:
-                    innerError.TypeName = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorInnerErrorTypeNameName);
+                    string innerErrorTypeName = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorInnerErrorTypeNameName);
+
+                    innerError.Properties.Add(
+                        JsonConstants.ODataErrorInnerErrorTypeNameName,
+                        new ODataPrimitiveValue(innerErrorTypeName));
                     break;
 
                 case JsonConstants.ODataErrorInnerErrorStackTraceName:
-                    innerError.StackTrace = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorInnerErrorStackTraceName);
+                    string innerErrorStackTrace = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorInnerErrorStackTraceName);
+
+                    innerError.Properties.Add(
+                        JsonConstants.ODataErrorInnerErrorStackTraceName,
+                        new ODataPrimitiveValue(innerErrorStackTrace));
                     break;
 
                 case JsonConstants.ODataErrorInnerErrorInnerErrorName:
+                case JsonConstants.ODataErrorInnerErrorName:
                     innerError.InnerError = this.ReadInnerError(recursionDepth);
                     break;
 
@@ -686,21 +699,34 @@ namespace Microsoft.OData.Json
             switch (propertyName)
             {
                 case JsonConstants.ODataErrorInnerErrorMessageName:
-                    innerError.Message = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorInnerErrorMessageName)
+                    string innerErrorMessage = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorInnerErrorMessageName)
                         .ConfigureAwait(false);
+
+                    innerError.Properties.Add(
+                        JsonConstants.ODataErrorInnerErrorMessageName,
+                        new ODataPrimitiveValue(innerErrorMessage));
                     break;
 
                 case JsonConstants.ODataErrorInnerErrorTypeNameName:
-                    innerError.TypeName = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorInnerErrorTypeNameName)
+                    string innerErrorTypeName = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorInnerErrorTypeNameName)
                         .ConfigureAwait(false);
+
+                    innerError.Properties.Add(
+                        JsonConstants.ODataErrorInnerErrorTypeNameName,
+                        new ODataPrimitiveValue(innerErrorTypeName));
                     break;
 
                 case JsonConstants.ODataErrorInnerErrorStackTraceName:
-                    innerError.StackTrace = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorInnerErrorStackTraceName)
+                    string innerErrorStackTrace = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorInnerErrorStackTraceName)
                         .ConfigureAwait(false);
+
+                    innerError.Properties.Add(
+                        JsonConstants.ODataErrorInnerErrorStackTraceName,
+                        new ODataPrimitiveValue(innerErrorStackTrace));
                     break;
 
                 case JsonConstants.ODataErrorInnerErrorInnerErrorName:
+                case JsonConstants.ODataErrorInnerErrorName:
                     innerError.InnerError = await this.ReadInnerErrorAsync(recursionDepth)
                         .ConfigureAwait(false);
                     break;

--- a/src/Microsoft.OData.Core/Json/ODataJsonErrorDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonErrorDeserializer.cs
@@ -354,7 +354,7 @@ namespace Microsoft.OData.Json
             switch (propertyName)
             {
                 case JsonConstants.ODataErrorCodeName:
-                    error.ErrorCode = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorCodeName);
+                    error.Code = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorCodeName);
                     break;
 
                 case JsonConstants.ODataErrorMessageName:
@@ -441,7 +441,7 @@ namespace Microsoft.OData.Json
             switch (propertyName)
             {
                 case JsonConstants.ODataErrorCodeName:
-                    detail.ErrorCode = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorCodeName);
+                    detail.Code = this.JsonReader.ReadStringValue(JsonConstants.ODataErrorCodeName);
                     break;
 
                 case JsonConstants.ODataErrorMessageName:
@@ -739,7 +739,7 @@ namespace Microsoft.OData.Json
             switch (propertyName)
             {
                 case JsonConstants.ODataErrorCodeName:
-                    error.ErrorCode = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorCodeName)
+                    error.Code = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorCodeName)
                         .ConfigureAwait(false);
                     break;
 
@@ -835,7 +835,7 @@ namespace Microsoft.OData.Json
             switch (propertyName)
             {
                 case JsonConstants.ODataErrorCodeName:
-                    errorDetail.ErrorCode = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorCodeName)
+                    errorDetail.Code = await this.JsonReader.ReadStringValueAsync(JsonConstants.ODataErrorCodeName)
                         .ConfigureAwait(false);
                     break;
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonOutputContext.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonOutputContext.cs
@@ -1033,7 +1033,11 @@ namespace Microsoft.OData.Json
             }
 
             JsonInstanceAnnotationWriter instanceAnnotationWriter = new JsonInstanceAnnotationWriter(new ODataJsonValueSerializer(this), this.TypeNameOracle);
-            ODataJsonWriterUtils.WriteError(this.JsonWriter, instanceAnnotationWriter.WriteInstanceAnnotationsForError, error, includeDebugInformation, this.MessageWriterSettings.MessageQuotas.MaxNestingDepth);
+            ODataJsonWriterUtils.WriteError(
+                this.JsonWriter,
+                instanceAnnotationWriter.WriteInstanceAnnotationsForError,
+                error, includeDebugInformation,
+                this.MessageWriterSettings);
         }
 
         /// <summary>
@@ -1059,7 +1063,7 @@ namespace Microsoft.OData.Json
                 instanceAnnotationWriter.WriteInstanceAnnotationsForErrorAsync,
                 error,
                 includeDebugInformation,
-                this.MessageWriterSettings.MessageQuotas.MaxNestingDepth).ConfigureAwait(false);
+                this.MessageWriterSettings).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/Json/ODataJsonPayloadKindDetectionDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonPayloadKindDetectionDeserializer.cs
@@ -232,15 +232,14 @@ namespace Microsoft.OData.Json
                             }
                             else
                             {
-                                Tuple<bool, ODataError> readInStreamErrorPropertyResult = await this.JsonReader.StartBufferingAndTryToReadInStreamErrorPropertyValueAsync()
+                                (bool IsReadSuccessfully, ODataError Error) readInStreamErrorPropertyResult = await this.JsonReader.StartBufferingAndTryToReadInStreamErrorPropertyValueAsync()
                                     .ConfigureAwait(false);
-                                bool readInStreamError = readInStreamErrorPropertyResult.Item1;
-                                if (!readInStreamError)
+                                if (!readInStreamErrorPropertyResult.IsReadSuccessfully)
                                 {
                                     return Enumerable.Empty<ODataPayloadKind>();
                                 }
 
-                                error = readInStreamErrorPropertyResult.Item2;
+                                error = readInStreamErrorPropertyResult.Error;
                             }
 
                             // At this point we successfully read the first error property.

--- a/src/Microsoft.OData.Core/Json/ODataJsonSerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonSerializer.cs
@@ -215,7 +215,11 @@ namespace Microsoft.OData.Json
         {
             Debug.Assert(error != null, "error != null");
 
-            this.WriteTopLevelPayload(() => ODataJsonWriterUtils.WriteError(this.JsonOutputContext.JsonWriter, this.InstanceAnnotationWriter.WriteInstanceAnnotationsForError, error, includeDebugInformation, this.MessageWriterSettings.MessageQuotas.MaxNestingDepth));
+            this.WriteTopLevelPayload(() => ODataJsonWriterUtils.WriteError(
+                this.JsonOutputContext.JsonWriter,
+                this.InstanceAnnotationWriter.WriteInstanceAnnotationsForError,
+                error, includeDebugInformation,
+                this.MessageWriterSettings));
         }
 
         /// <summary>
@@ -321,7 +325,7 @@ namespace Microsoft.OData.Json
                     thisParam.InstanceAnnotationWriter.WriteInstanceAnnotationsForErrorAsync,
                     errorParam,
                     includeDebugInformationParam,
-                    thisParam.MessageWriterSettings.MessageQuotas.MaxNestingDepth),
+                    thisParam.MessageWriterSettings),
                 this,
                 error,
                 includeDebugInformation);

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
@@ -325,25 +325,11 @@ namespace Microsoft.OData.Json
             jsonWriter.WriteName(innerErrorPropertyName);
             jsonWriter.StartObjectScope();
 
-            if (innerError.Properties != null)
+            foreach (KeyValuePair<string, ODataValue> pair in innerError.Properties)
             {
-                foreach (KeyValuePair<string, ODataValue> pair in innerError.Properties)
-                {
-                    jsonWriter.WriteName(pair.Key);
+                jsonWriter.WriteName(pair.Key);
 
-                    if (pair.Value is ODataNullValue &&
-                        (pair.Key == JsonConstants.ODataErrorInnerErrorMessageName ||
-                        pair.Key == JsonConstants.ODataErrorInnerErrorStackTraceName ||
-                        pair.Key == JsonConstants.ODataErrorInnerErrorTypeNameName))
-                    {
-                        // Write empty string for null values in stacktrace, type and message properties of inner error.
-                        jsonWriter.WriteODataValue(new ODataPrimitiveValue(string.Empty));
-                    }
-                    else
-                    {
-                        jsonWriter.WriteODataValue(pair.Value);
-                    }
-                }
+                jsonWriter.WriteODataValue(pair.Value);
             }
 
             if (innerError.InnerError != null)
@@ -567,25 +553,11 @@ namespace Microsoft.OData.Json
             await jsonWriter.WriteNameAsync(innerErrorPropertyName).ConfigureAwait(false);
             await jsonWriter.StartObjectScopeAsync().ConfigureAwait(false);
 
-            if (innerError.Properties != null)
+            foreach (KeyValuePair<string, ODataValue> pair in innerError.Properties)
             {
-                foreach (KeyValuePair<string, ODataValue> pair in innerError.Properties)
-                {
-                    await jsonWriter.WriteNameAsync(pair.Key).ConfigureAwait(false);
+                await jsonWriter.WriteNameAsync(pair.Key).ConfigureAwait(false);
 
-                    if (pair.Value is ODataNullValue &&
-                        (pair.Key == JsonConstants.ODataErrorInnerErrorMessageName ||
-                        pair.Key == JsonConstants.ODataErrorInnerErrorStackTraceName ||
-                        pair.Key == JsonConstants.ODataErrorInnerErrorTypeNameName))
-                    {
-                        // Write empty string for null values in stacktrace, type and message properties of inner error.
-                        await jsonWriter.WriteODataValueAsync(new ODataPrimitiveValue(string.Empty)).ConfigureAwait(false);
-                    }
-                    else
-                    {
-                        await jsonWriter.WriteODataValueAsync(pair.Value).ConfigureAwait(false);
-                    }
-                }
+                await jsonWriter.WriteODataValueAsync(pair.Value).ConfigureAwait(false);
             }
 
             if (innerError.InnerError != null)

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
@@ -13,6 +13,7 @@ namespace Microsoft.OData.Json
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
+    using Microsoft.OData.Edm;
     using ODataErrorStrings = Microsoft.OData.Strings;
     #endregion Namespaces
 
@@ -28,13 +29,13 @@ namespace Microsoft.OData.Json
         /// <param name="writeInstanceAnnotationsDelegate">Action to write the instance annotations.</param>
         /// <param name="error">The error instance to write.</param>
         /// <param name="includeDebugInformation">A flag indicating whether error details should be written (in debug mode only) or not.</param>
-        /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
+        /// <param name="messageWriterSettings">Configuration settings of the OData writer.</param>
         internal static void WriteError(
             IJsonWriter jsonWriter,
             Action<ICollection<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate,
             ODataError error,
             bool includeDebugInformation,
-            int maxInnerErrorDepth)
+            ODataMessageWriterSettings messageWriterSettings)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
             Debug.Assert(error != null, "error != null");
@@ -53,7 +54,7 @@ namespace Microsoft.OData.Json
                 innerError,
                 error.GetInstanceAnnotations(),
                 writeInstanceAnnotationsDelegate,
-                maxInnerErrorDepth);
+                messageWriterSettings);
         }
 
         /// <summary>
@@ -94,32 +95,52 @@ namespace Microsoft.OData.Json
             if (value == null || value is ODataNullValue)
             {
                 sb.Append("null");
+                return;
             }
 
-            ODataCollectionValue collectionValue = value as ODataCollectionValue;
-            if (collectionValue != null)
+            if (value is ODataCollectionValue collectionValue)
             {
                 ODataCollectionValueToString(sb, collectionValue);
+                return;
             }
 
-            ODataResourceValue resourceValue = value as ODataResourceValue;
-            if (resourceValue != null)
+            if (value is ODataResourceValue resourceValue)
             {
                 ODataResourceValueToString(sb, resourceValue);
+                return;
             }
 
-            ODataPrimitiveValue primitiveValue = value as ODataPrimitiveValue;
-            if (primitiveValue != null)
+            if (value is ODataPrimitiveValue primitiveValue)
             {
-                if (primitiveValue.FromODataValue() is string)
+                object valueAsObject = primitiveValue.FromODataValue();
+                string valueAsString;
+                if (ODataRawValueUtils.TryConvertPrimitiveToString(valueAsObject, out valueAsString))
                 {
-                    sb.Append(string.Concat("\"", JsonValueUtils.GetEscapedJsonString(value.FromODataValue()?.ToString()), "\""));
+                    if (valueAsObject is string)
+                    {
+                        valueAsString = JsonValueUtils.GetEscapedJsonString(valueAsString);
+                        sb.Append('"').Append(valueAsString).Append('"');
+                    }
+                    else if (valueAsObject is byte[] || valueAsObject is DateTimeOffset || valueAsObject is Guid || valueAsObject is TimeSpan | valueAsObject is Date || valueAsObject is TimeOfDay)
+                    {
+                        sb.Append('"').Append(valueAsString).Append('"');
+                    }
+                    else
+                    {
+                        sb.Append(valueAsString);
+                    }
                 }
                 else
                 {
-                    sb.Append(JsonValueUtils.GetEscapedJsonString(value.FromODataValue()?.ToString()));
+                    // For unsupported primitive values (e.g. spatial values)
+                    sb.Append('"').Append(JsonValueUtils.GetEscapedJsonString(ODataErrorStrings.ODataJsonWriter_UnsupportedValueType(valueAsObject.GetType().FullName))).Append('"');
                 }
+
+                return;
             }
+
+            // Subclasses of ODataValue that are not supported in ODataInnerError.Properties dictionary
+            sb.Append('"').Append(JsonValueUtils.GetEscapedJsonString(ODataErrorStrings.ODataJsonWriter_UnsupportedValueType(value.GetType().FullName))).Append('"');
         }
 
         /// <summary>
@@ -129,14 +150,14 @@ namespace Microsoft.OData.Json
         /// <param name="writeInstanceAnnotationsDelegate">Delegate to write the instance annotations.</param>
         /// <param name="error">The error instance to write.</param>
         /// <param name="includeDebugInformation">A flag indicating whether error details should be written (in debug mode only) or not.</param>
-        /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
+        /// <param name="messageWriterSettings">Configuration settings of the OData writer.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         internal static Task WriteErrorAsync(
             IJsonWriter jsonWriter,
             Func<ICollection<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate,
             ODataError error,
             bool includeDebugInformation,
-            int maxInnerErrorDepth)
+            ODataMessageWriterSettings messageWriterSettings)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
             Debug.Assert(error != null, "error != null");
@@ -157,7 +178,7 @@ namespace Microsoft.OData.Json
                 innerError,
                 error.GetInstanceAnnotations(),
                 writeInstanceAnnotationsDelegate,
-                maxInnerErrorDepth);
+                messageWriterSettings);
         }
 
         /// <summary>
@@ -171,7 +192,7 @@ namespace Microsoft.OData.Json
         /// <param name="innerError">Inner error details that will be included in debug mode (if present).</param>
         /// <param name="instanceAnnotations">Instance annotations for this error.</param>
         /// <param name="writeInstanceAnnotationsDelegate">Action to write the instance annotations.</param>
-        /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
+        /// <param name="messageWriterSettings">Configuration settings of the OData writer.</param>
         private static void WriteError(
             IJsonWriter jsonWriter,
             string code,
@@ -181,7 +202,7 @@ namespace Microsoft.OData.Json
             ODataInnerError innerError,
             ICollection<ODataInstanceAnnotation> instanceAnnotations,
             Action<ICollection<ODataInstanceAnnotation>> writeInstanceAnnotationsDelegate,
-            int maxInnerErrorDepth)
+            ODataMessageWriterSettings messageWriterSettings)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
             Debug.Assert(code != null, "code != null");
@@ -223,7 +244,12 @@ namespace Microsoft.OData.Json
 
             if (innerError != null)
             {
-                WriteInnerError(jsonWriter, innerError, JsonConstants.ODataErrorInnerErrorName, /* recursionDepth */ 0, maxInnerErrorDepth);
+                WriteInnerError(
+                    jsonWriter,
+                    innerError,
+                    JsonConstants.ODataErrorInnerErrorName,
+                    recursionDepth: 0,
+                    messageWriterSettings);
             }
 
             Debug.Assert(writeInstanceAnnotationsDelegate != null, "writeInstanceAnnotationsDelegate != null");
@@ -254,7 +280,11 @@ namespace Microsoft.OData.Json
 
                 // "code": "301",
                 jsonWriter.WriteName(JsonConstants.ODataErrorCodeName);
-                jsonWriter.WriteValue(detail.ErrorCode ?? string.Empty);
+                jsonWriter.WriteValue(detail.Code ?? string.Empty);
+
+                // "message": "$search query option not supported",
+                jsonWriter.WriteName(JsonConstants.ODataErrorMessageName);
+                jsonWriter.WriteValue(detail.Message ?? string.Empty);
 
                 if (detail.Target != null)
                 {
@@ -262,10 +292,6 @@ namespace Microsoft.OData.Json
                     jsonWriter.WriteName(JsonConstants.ODataErrorTargetName);
                     jsonWriter.WriteValue(detail.Target);
                 }
-
-                // "message": "$search query option not supported",
-                jsonWriter.WriteName(JsonConstants.ODataErrorMessageName);
-                jsonWriter.WriteValue(detail.Message ?? string.Empty);
 
                 // }
                 jsonWriter.EndObjectScope();
@@ -282,18 +308,18 @@ namespace Microsoft.OData.Json
         /// <param name="innerError">Inner error details.</param>
         /// <param name="innerErrorPropertyName">The property name for the inner error property.</param>
         /// <param name="recursionDepth">The number of times this method has been called recursively.</param>
-        /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
+        /// <param name="messageWriterSettings">Configuration settings of the OData writer.</param>
         private static void WriteInnerError(
             IJsonWriter jsonWriter,
             ODataInnerError innerError,
             string innerErrorPropertyName,
             int recursionDepth,
-            int maxInnerErrorDepth)
+            ODataMessageWriterSettings messageWriterSettings)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
             Debug.Assert(innerErrorPropertyName != null, "innerErrorPropertyName != null");
 
-            ValidationUtils.IncreaseAndValidateRecursionDepth(ref recursionDepth, maxInnerErrorDepth);
+            ValidationUtils.IncreaseAndValidateRecursionDepth(ref recursionDepth, messageWriterSettings.MessageQuotas.MaxNestingDepth);
 
             // "innererror":
             jsonWriter.WriteName(innerErrorPropertyName);
@@ -322,8 +348,18 @@ namespace Microsoft.OData.Json
 
             if (innerError.InnerError != null)
             {
-                // "internalexception": { <nested inner error> }
-                WriteInnerError(jsonWriter, innerError.InnerError, JsonConstants.ODataErrorInnerErrorInnerErrorName, recursionDepth, maxInnerErrorDepth);
+                string nestedInnerErrorPropertyName;
+                if (messageWriterSettings.LibraryCompatibility.HasFlag(ODataLibraryCompatibility.UseLegacyODataInnerErrorSerialization))
+                {
+                    nestedInnerErrorPropertyName = JsonConstants.ODataErrorInnerErrorInnerErrorName;
+                }
+                else
+                {
+                    nestedInnerErrorPropertyName = JsonConstants.ODataErrorInnerErrorName;
+                }
+
+                // "internalexception": { <nested inner error> } or "innererror": { <nested inner error> }
+                WriteInnerError(jsonWriter, innerError.InnerError, nestedInnerErrorPropertyName, recursionDepth, messageWriterSettings);
             }
 
             // }
@@ -333,7 +369,7 @@ namespace Microsoft.OData.Json
         private static void ODataCollectionValueToString(StringBuilder sb, ODataCollectionValue value)
         {
             bool isFirst = true;
-            sb.Append("[");
+            sb.Append('[');
             foreach (object item in value.Items)
             {
                 if (isFirst)
@@ -342,43 +378,42 @@ namespace Microsoft.OData.Json
                 }
                 else
                 {
-                    sb.Append(",");
+                    sb.Append(',');
                 }
 
-                ODataValue odataValue = item as ODataValue;
-                if (odataValue != null)
+                if (item is ODataValue odataValue)
                 {
                     ODataValueToString(sb, odataValue);
                 }
                 else
                 {
-                    throw new ODataException(ODataErrorStrings.ODataJsonWriter_UnsupportedValueInCollection);
+                    sb.Append('"').Append(JsonValueUtils.GetEscapedJsonString(ODataErrorStrings.ODataJsonWriter_UnsupportedValueType(item.GetType().FullName))).Append('"');
                 }
             }
 
-            sb.Append("]");
+            sb.Append(']');
         }
 
         private static void ODataResourceValueToString(StringBuilder sb, ODataResourceValue value)
         {
-            bool isFirst = true;
-            sb.Append("{");
+            bool firstProperty = true;
+            sb.Append('{');
             foreach (ODataProperty property in value.Properties)
             {
-                if (isFirst)
+                if (firstProperty)
                 {
-                    isFirst = false;
+                    firstProperty = false;
                 }
                 else
                 {
-                    sb.Append(",");
+                    sb.Append(',');
                 }
 
-                sb.Append("\"").Append(property.Name).Append("\"").Append(":");
+                sb.Append("\"").Append(property.Name).Append("\"").Append(':');
                 ODataValueToString(sb, property.ODataValue);
             }
 
-            sb.Append("}");
+            sb.Append('}');
         }
 
         /// <summary>
@@ -392,7 +427,7 @@ namespace Microsoft.OData.Json
         /// <param name="innerError">Inner error details that will be included in debug mode (if present).</param>
         /// <param name="instanceAnnotations">Instance annotations for this error.</param>
         /// <param name="writeInstanceAnnotationsDelegate">Delegate to write the instance annotations.</param>
-        /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
+        /// <param name="messageWriterSettings">Configuration settings of the OData writer.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         private static async Task WriteErrorAsync(
             IJsonWriter jsonWriter,
@@ -403,12 +438,13 @@ namespace Microsoft.OData.Json
             ODataInnerError innerError,
             ICollection<ODataInstanceAnnotation> instanceAnnotations,
             Func<ICollection<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate,
-            int maxInnerErrorDepth)
+            ODataMessageWriterSettings messageWriterSettings)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
             Debug.Assert(code != null, "code != null");
             Debug.Assert(message != null, "message != null");
             Debug.Assert(instanceAnnotations != null, "instanceAnnotations != null");
+            Debug.Assert(messageWriterSettings != null, "messageWriterSettings != null");
 
             ExceptionUtils.CheckArgumentNotNull(writeInstanceAnnotationsDelegate, "writeInstanceAnnotationsDelegate");
 
@@ -445,8 +481,12 @@ namespace Microsoft.OData.Json
 
             if (innerError != null)
             {
-                await WriteInnerErrorAsync(jsonWriter, innerError, JsonConstants.ODataErrorInnerErrorName,
-                    /* recursionDepth */ 0, maxInnerErrorDepth).ConfigureAwait(false);
+                await WriteInnerErrorAsync(
+                    jsonWriter,
+                    innerError,
+                    JsonConstants.ODataErrorInnerErrorName,
+                    recursionDepth: 0,
+                    messageWriterSettings).ConfigureAwait(false);
             }
 
             await writeInstanceAnnotationsDelegate(instanceAnnotations).ConfigureAwait(false);
@@ -481,7 +521,11 @@ namespace Microsoft.OData.Json
 
                 // "code": "301",
                 await jsonWriter.WriteNameAsync(JsonConstants.ODataErrorCodeName).ConfigureAwait(false);
-                await jsonWriter.WriteValueAsync(detail.ErrorCode ?? string.Empty).ConfigureAwait(false);
+                await jsonWriter.WriteValueAsync(detail.Code ?? string.Empty).ConfigureAwait(false);
+
+                // "message": "$search query option not supported",
+                await jsonWriter.WriteNameAsync(JsonConstants.ODataErrorMessageName).ConfigureAwait(false);
+                await jsonWriter.WriteValueAsync(detail.Message ?? string.Empty).ConfigureAwait(false);
 
                 if (detail.Target != null)
                 {
@@ -489,10 +533,6 @@ namespace Microsoft.OData.Json
                     await jsonWriter.WriteNameAsync(JsonConstants.ODataErrorTargetName).ConfigureAwait(false);
                     await jsonWriter.WriteValueAsync(detail.Target).ConfigureAwait(false);
                 }
-
-                // "message": "$search query option not supported",
-                await jsonWriter.WriteNameAsync(JsonConstants.ODataErrorMessageName).ConfigureAwait(false);
-                await jsonWriter.WriteValueAsync(detail.Message ?? string.Empty).ConfigureAwait(false);
 
                 // }
                 await jsonWriter.EndObjectScopeAsync().ConfigureAwait(false);
@@ -509,15 +549,19 @@ namespace Microsoft.OData.Json
         /// <param name="innerError">Inner error details.</param>
         /// <param name="innerErrorPropertyName">The property name for the inner error property.</param>
         /// <param name="recursionDepth">The number of times this method has been called recursively.</param>
-        /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
+        /// <param name="messageWriterSettings">Configuration settings of the OData writer.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
-        private static async Task WriteInnerErrorAsync(IJsonWriter jsonWriter, ODataInnerError innerError,
-            string innerErrorPropertyName, int recursionDepth, int maxInnerErrorDepth)
+        private static async Task WriteInnerErrorAsync(
+            IJsonWriter jsonWriter,
+            ODataInnerError innerError,
+            string innerErrorPropertyName,
+            int recursionDepth,
+            ODataMessageWriterSettings messageWriterSettings)
         {
             Debug.Assert(jsonWriter != null, "jsonWriter != null");
             Debug.Assert(innerErrorPropertyName != null, "innerErrorPropertyName != null");
 
-            ValidationUtils.IncreaseAndValidateRecursionDepth(ref recursionDepth, maxInnerErrorDepth);
+            ValidationUtils.IncreaseAndValidateRecursionDepth(ref recursionDepth, messageWriterSettings.MessageQuotas.MaxNestingDepth);
 
             // "innererror":
             await jsonWriter.WriteNameAsync(innerErrorPropertyName).ConfigureAwait(false);
@@ -546,9 +590,23 @@ namespace Microsoft.OData.Json
 
             if (innerError.InnerError != null)
             {
-                // "internalexception": { <nested inner error> }
-                await WriteInnerErrorAsync(jsonWriter, innerError.InnerError, JsonConstants.ODataErrorInnerErrorInnerErrorName,
-                    recursionDepth, maxInnerErrorDepth).ConfigureAwait(false);
+                string nestedInnerErrorPropertyName;
+                if (messageWriterSettings.LibraryCompatibility.HasFlag(ODataLibraryCompatibility.UseLegacyODataInnerErrorSerialization))
+                {
+                    nestedInnerErrorPropertyName = JsonConstants.ODataErrorInnerErrorInnerErrorName;
+                }
+                else
+                {
+                    nestedInnerErrorPropertyName = JsonConstants.ODataErrorInnerErrorName;
+                }
+
+                // "internalexception": { <nested inner error> } or "innererror": { <nested inner error> }
+                await WriteInnerErrorAsync(
+                    jsonWriter,
+                    innerError.InnerError,
+                    nestedInnerErrorPropertyName,
+                    recursionDepth,
+                    messageWriterSettings).ConfigureAwait(false);
             }
 
             // }

--- a/src/Microsoft.OData.Core/Metadata/ODataAtomErrorDeserializer.cs
+++ b/src/Microsoft.OData.Core/Metadata/ODataAtomErrorDeserializer.cs
@@ -241,7 +241,10 @@ namespace Microsoft.OData.Metadata
                                             ref elementsReadBitmask,
                                             DuplicateInnerErrorElementPropertyBitMask.Message,
                                             ODataMetadataConstants.ODataInnerErrorMessageElementName);
-                                        innerError.Message = xmlReader.ReadElementValue();
+
+                                        innerError.Properties.Add(
+                                            ODataMetadataConstants.ODataInnerErrorMessageElementName,
+                                            new ODataPrimitiveValue(xmlReader.ReadElementValue()));
                                         continue;
 
                                     // <m:type>
@@ -250,7 +253,10 @@ namespace Microsoft.OData.Metadata
                                             ref elementsReadBitmask,
                                             DuplicateInnerErrorElementPropertyBitMask.TypeName,
                                             ODataMetadataConstants.ODataInnerErrorTypeElementName);
-                                        innerError.TypeName = xmlReader.ReadElementValue();
+
+                                        innerError.Properties.Add(
+                                            ODataMetadataConstants.ODataInnerErrorTypeElementName,
+                                            new ODataPrimitiveValue(xmlReader.ReadElementValue()));
                                         continue;
 
                                     // <m:stacktrace>
@@ -259,11 +265,16 @@ namespace Microsoft.OData.Metadata
                                             ref elementsReadBitmask,
                                             DuplicateInnerErrorElementPropertyBitMask.StackTrace,
                                             ODataMetadataConstants.ODataInnerErrorStackTraceElementName);
-                                        innerError.StackTrace = xmlReader.ReadElementValue();
+
+                                        innerError.Properties.Add(
+                                            ODataMetadataConstants.ODataInnerErrorStackTraceElementName,
+                                            new ODataPrimitiveValue(xmlReader.ReadElementValue()));
                                         continue;
 
                                     // <m:internalexception>
                                     case ODataMetadataConstants.ODataInnerErrorInnerErrorElementName:
+                                    // <m:innererror>
+                                    case ODataMetadataConstants.ODataInnerErrorElementName:
                                         VerifyInnerErrorElementNotFound(
                                             ref elementsReadBitmask,
                                             DuplicateInnerErrorElementPropertyBitMask.InternalException,

--- a/src/Microsoft.OData.Core/Metadata/ODataAtomErrorDeserializer.cs
+++ b/src/Microsoft.OData.Core/Metadata/ODataAtomErrorDeserializer.cs
@@ -104,7 +104,7 @@ namespace Microsoft.OData.Metadata
                                             ref elementsReadBitmask,
                                             DuplicateErrorElementPropertyBitMask.Code,
                                             ODataMetadataConstants.ODataErrorCodeElementName);
-                                        error.ErrorCode = xmlReader.ReadElementValue();
+                                        error.Code = xmlReader.ReadElementValue();
                                         continue;
 
                                     // <m:message >

--- a/src/Microsoft.OData.Core/Metadata/ODataMetadataWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Metadata/ODataMetadataWriterUtils.cs
@@ -53,9 +53,9 @@ namespace Microsoft.OData.Metadata
         /// <param name="error">The error instance to write.</param>
         /// <param name="includeDebugInformation">A flag indicating whether error details should be written (in debug mode only) or not.</param>
         /// <param name="maxInnerErrorDepth">The maximum number of nested inner errors to allow.</param>
-        internal static void WriteError(XmlWriter writer, ODataError error, bool includeDebugInformation, int maxInnerErrorDepth)
+        internal static void WriteError(XmlWriter writer, ODataError error, bool includeDebugInformation, ODataMessageWriterSettings messageWriterSettings)
         {
-            ErrorUtils.WriteXmlError(writer, error, includeDebugInformation, maxInnerErrorDepth);
+            ErrorUtils.WriteXmlError(writer, error, includeDebugInformation, messageWriterSettings);
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataErrorDetail.cs
+++ b/src/Microsoft.OData.Core/ODataErrorDetail.cs
@@ -8,7 +8,7 @@
 namespace Microsoft.OData
 {
     #region Namespaces
-    using System.Globalization;
+    using System.Text;
     using Microsoft.OData.Json;
     #endregion Namespaces
 
@@ -19,7 +19,7 @@ namespace Microsoft.OData
     {
         /// <summary>Gets or sets the error code to be used in payloads.</summary>
         /// <returns>The error code to be used in payloads.</returns>
-        public string ErrorCode { get; set; }
+        public string Code { get; set; }
 
         /// <summary>Gets or sets the error message.</summary>
         /// <returns>The error message.</returns>
@@ -33,13 +33,29 @@ namespace Microsoft.OData
         /// Serialization to Json format string.
         /// </summary>
         /// <returns>The string in Json format</returns>
-        internal string ToJson()
+        internal string ToJsonString()
         {
-            return string.Format(CultureInfo.InvariantCulture,
-                "{{ \"errorcode\": \"{0}\", \"message\": \"{1}\", \"target\": \"{2}\" }}",
-                this.ErrorCode == null ? "" : JsonValueUtils.GetEscapedJsonString(this.ErrorCode), 
-                this.Message == null ? "" : JsonValueUtils.GetEscapedJsonString(this.Message), 
-                this.Target == null ? "" : JsonValueUtils.GetEscapedJsonString(this.Target));
+            StringBuilder builder = new StringBuilder();
+
+            // `code` and `message` must be included
+            string code = this.Code == null ? string.Empty : JsonValueUtils.GetEscapedJsonString(this.Code);
+            string message = this.Message == null ? string.Empty : JsonValueUtils.GetEscapedJsonString(this.Message);
+
+            builder.Append('{');
+            builder.Append('"').Append(JsonConstants.ODataErrorCodeName).Append("\":");
+            builder.Append('"').Append(code).Append('"');
+            builder.Append(",\"").Append(JsonConstants.ODataErrorMessageName).Append("\":");
+            builder.Append('"').Append(message).Append('"');
+
+            if (this.Target != null)
+            {
+                builder.Append(",\"").Append(JsonConstants.ODataErrorTargetName).Append("\":");
+                builder.Append("\"").Append(JsonValueUtils.GetEscapedJsonString(this.Target)).Append('"');
+            }
+
+            builder.Append('}');
+
+            return builder.ToString();
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataInnerError.cs
+++ b/src/Microsoft.OData.Core/ODataInnerError.cs
@@ -7,9 +7,7 @@
 namespace Microsoft.OData
 {
     #region Namespaces
-    using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Text;
     using Microsoft.OData.Json;
     #endregion Namespaces
@@ -17,41 +15,12 @@ namespace Microsoft.OData
     /// <summary>
     /// Class representing implementation specific debugging information to help determine the cause of the error.
     /// </summary>
-    [DebuggerDisplay("{Message}")]
     public sealed class ODataInnerError
     {
-        /// <summary>Initializes a new instance of the <see cref="ODataInnerError" /> class with default values.</summary>
+        /// <summary>Initializes a new instance of the <see cref="ODataInnerError" /> class.</summary>
         public ODataInnerError()
         {
-            Properties = new Dictionary<string, ODataValue>
-            {
-                //// NOTE: we add empty elements if no information is provided for the message, error type and stack trace
-                ////       to stay compatible with Astoria.
-                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataNullValue() },
-                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataNullValue() },
-                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataNullValue() }
-            };
-        }
-
-        /// <summary>Initializes a new instance of the <see cref="ODataInnerError" /> class with exception object.</summary>
-        /// <param name="exception">The <see cref="System.Exception" /> used to create the inner error.</param>
-        public ODataInnerError(Exception exception)
-        {
-            ExceptionUtils.CheckArgumentNotNull(exception, "exception");
-
-            if (exception.InnerException != null)
-            {
-                this.InnerError = new ODataInnerError(exception.InnerException);
-            }
-
-            Properties = new Dictionary<string, ODataValue>
-            {
-                //// NOTE: we add empty elements if no information is provided for the message, error type and stack trace
-                ////       to stay compatible with Astoria.
-                { JsonConstants.ODataErrorInnerErrorMessageName, exception.Message.ToODataValue() ?? new ODataNullValue() },
-                { JsonConstants.ODataErrorInnerErrorTypeNameName, exception.GetType().FullName.ToODataValue() ?? new ODataNullValue() },
-                { JsonConstants.ODataErrorInnerErrorStackTraceName, exception.StackTrace.ToODataValue() ?? new ODataNullValue() }
-            };
+            Properties = new Dictionary<string, ODataValue>();
         }
 
         /// <summary>
@@ -72,33 +41,6 @@ namespace Microsoft.OData
         {
             get;
             private set;
-        }
-
-        /// <summary>Gets or sets the error message.</summary>
-        /// <returns>The error message.</returns>
-        [Obsolete("This will be dropped in the 9.x release. The contents of inner error object should be service-defined. There are no required properties.")]
-        public string Message
-        {
-            get { return GetStringValue(JsonConstants.ODataErrorInnerErrorMessageName); }
-            set { SetStringValue(JsonConstants.ODataErrorInnerErrorMessageName, value); }
-        }
-
-        /// <summary>Gets or sets the type name of this error, for example, the type name of an exception.</summary>
-        /// <returns>The type name of this error.</returns>
-        [Obsolete("This will be dropped in the 9.x release. The contents of inner error object should be service-defined. There are no required properties.")]
-        public string TypeName
-        {
-            get { return GetStringValue(JsonConstants.ODataErrorInnerErrorTypeNameName); }
-            set { SetStringValue(JsonConstants.ODataErrorInnerErrorTypeNameName, value); }
-        }
-
-        /// <summary>Gets or sets the stack trace for this error.</summary>
-        /// <returns>The stack trace for this error.</returns>
-        [Obsolete("This will be dropped in the 9.x release. The contents of inner error object should be service-defined. There are no required properties.")]
-        public string StackTrace
-        {
-            get { return GetStringValue(JsonConstants.ODataErrorInnerErrorStackTraceName); }
-            set { SetStringValue(JsonConstants.ODataErrorInnerErrorStackTraceName, value); }
         }
 
         /// <summary>Gets or sets the nested implementation specific debugging information. </summary>
@@ -123,14 +65,6 @@ namespace Microsoft.OData
             // Write some properties to enforce an order. 
             foreach (KeyValuePair<string, ODataValue> keyValuePair in Properties)
             {
-                if (keyValuePair.Key == JsonConstants.ODataErrorInnerErrorMessageName ||
-                    keyValuePair.Key == JsonConstants.ODataErrorInnerErrorStackTraceName ||
-                    keyValuePair.Key == JsonConstants.ODataErrorInnerErrorTypeNameName ||
-                    keyValuePair.Key == JsonConstants.ODataErrorInnerErrorInnerErrorName)
-                {
-                    continue;
-                }
-
                 if (!firstProperty)
                 {
                     builder.Append(',');
@@ -140,62 +74,28 @@ namespace Microsoft.OData
                     firstProperty = false;
                 }
 
-                builder.Append('"').Append(keyValuePair.Key).Append('"').Append(':');
+                builder.Append('"').Append(JsonValueUtils.GetEscapedJsonString(keyValuePair.Key)).Append('"').Append(':');
                 ODataJsonWriterUtils.ODataValueToString(builder, keyValuePair.Value);
             }
-
-            if (!firstProperty)
-            {
-                builder.Append(',');
-            }
-
-            string message = this.Message == null ? string.Empty : JsonValueUtils.GetEscapedJsonString(this.Message);
-            string typeName = this.TypeName == null ? string.Empty : JsonValueUtils.GetEscapedJsonString(this.TypeName);
-            string stackTrace = this.StackTrace == null ? string.Empty : JsonValueUtils.GetEscapedJsonString(this.StackTrace);
-
-            builder.Append('"').Append(JsonConstants.ODataErrorInnerErrorMessageName).Append("\":");
-            builder.Append('"').Append(message).Append('"');
-
-            builder.Append(",\"").Append(JsonConstants.ODataErrorInnerErrorTypeNameName).Append("\":");
-            builder.Append('"').Append(typeName).Append('"');
-
-            builder.Append(",\"").Append(JsonConstants.ODataErrorInnerErrorStackTraceName).Append("\":");
-            builder.Append('"').Append(stackTrace).Append('"');
 
             if (this.InnerError != null)
             {
                 string innerErrorJsonString = this.InnerError.ToJsonString();
-                builder.Append(",\"").Append(JsonConstants.ODataErrorInnerErrorName).Append("\":");
-                builder.Append(innerErrorJsonString);
+                if (!string.IsNullOrEmpty(innerErrorJsonString))
+                {
+                    if (!firstProperty)
+                    {
+                        builder.Append(',');
+                    }
+                    
+                    builder.Append('"').Append(JsonConstants.ODataErrorInnerErrorName).Append("\":");
+                    builder.Append(innerErrorJsonString);
+                }
             }
 
             builder.Append('}');
 
             return builder.ToString();
-        }
-
-        private string GetStringValue(string propertyKey)
-        {
-            if (Properties.ContainsKey(propertyKey))
-            {
-                return Properties[propertyKey].FromODataValue()?.ToString();
-            }
-
-            return string.Empty;
-        }
-
-        private void SetStringValue(string propertyKey, string value)
-        {
-            ODataValue odataValue = value == null ? new ODataNullValue() : value.ToODataValue();
-
-            if (!Properties.ContainsKey(propertyKey))
-            {
-                Properties.Add(propertyKey, odataValue);
-            }
-            else
-            {
-                Properties[propertyKey] = odataValue;
-            }
         }
     }
 }

--- a/src/Microsoft.OData.Core/ODataLibraryCompatibility.cs
+++ b/src/Microsoft.OData.Core/ODataLibraryCompatibility.cs
@@ -40,13 +40,19 @@ namespace Microsoft.OData
         DoNotThrowExceptionForTopLevelNullProperty = 1 << 3,
 
         /// <summary>
+        /// When enabled, OData inner error is serialized with "message", "type", and "stacktrace" properties irrespective of whether
+        /// they are null or empty. Also, nested inner error is serialized with property name as "internalexception".
+        /// </summary>
+        UseLegacyODataInnerErrorSerialization = 1 << 4,
+
+        /// <summary>
         /// Version 6.x
         /// </summary>
-        Version6 = UseLegacyVariableCasing | WriteTopLevelODataNullAnnotation | WriteODataContextAnnotationForNavProperty | DoNotThrowExceptionForTopLevelNullProperty,
+        Version6 = UseLegacyVariableCasing | WriteTopLevelODataNullAnnotation | WriteODataContextAnnotationForNavProperty | DoNotThrowExceptionForTopLevelNullProperty | UseLegacyODataInnerErrorSerialization,
 
         /// <summary>
         /// Version 7.x
         /// </summary>
-        Version7 = UseLegacyVariableCasing
+        Version7 = UseLegacyVariableCasing | UseLegacyODataInnerErrorSerialization
     }
 }

--- a/src/Microsoft.OData.Core/ODataLibraryCompatibility.cs
+++ b/src/Microsoft.OData.Core/ODataLibraryCompatibility.cs
@@ -40,8 +40,7 @@ namespace Microsoft.OData
         DoNotThrowExceptionForTopLevelNullProperty = 1 << 3,
 
         /// <summary>
-        /// When enabled, OData inner error is serialized with "message", "type", and "stacktrace" properties irrespective of whether
-        /// they are null or empty. Also, nested inner error is serialized with property name as "internalexception".
+        /// When enabled, OData nested inner error is serialized with property name as "internalexception".
         /// </summary>
         UseLegacyODataInnerErrorSerialization = 1 << 4,
 

--- a/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
@@ -108,7 +108,7 @@ namespace Microsoft.OData
             return TaskUtils.GetTaskForSynchronousOperationReturningTask(
                 () =>
                 {
-                    ODataMetadataWriterUtils.WriteError(this.xmlWriter, error, includeDebugInformation, this.MessageWriterSettings.MessageQuotas.MaxNestingDepth);
+                    ODataMetadataWriterUtils.WriteError(this.xmlWriter, error, includeDebugInformation, this.MessageWriterSettings);
                     return this.FlushAsync();
                 });
         }
@@ -161,7 +161,7 @@ namespace Microsoft.OData
         {
             this.AssertSynchronous();
 
-            ODataMetadataWriterUtils.WriteError(this.xmlWriter, error, includeDebugInformation, this.MessageWriterSettings.MessageQuotas.MaxNestingDepth);
+            ODataMetadataWriterUtils.WriteError(this.xmlWriter, error, includeDebugInformation, this.MessageWriterSettings);
             this.Flush();
         }
 

--- a/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net48/PublicAPI.Unshipped.txt
@@ -514,8 +514,8 @@ Microsoft.OData.ODataEnumValue.Value.get -> string
 Microsoft.OData.ODataError
 Microsoft.OData.ODataError.Details.get -> System.Collections.Generic.ICollection<Microsoft.OData.ODataErrorDetail>
 Microsoft.OData.ODataError.Details.set -> void
-Microsoft.OData.ODataError.ErrorCode.get -> string
-Microsoft.OData.ODataError.ErrorCode.set -> void
+Microsoft.OData.ODataError.Code.get -> string
+Microsoft.OData.ODataError.Code.set -> void
 Microsoft.OData.ODataError.InnerError.get -> Microsoft.OData.ODataInnerError
 Microsoft.OData.ODataError.InnerError.set -> void
 Microsoft.OData.ODataError.InstanceAnnotations.get -> System.Collections.Generic.ICollection<Microsoft.OData.ODataInstanceAnnotation>
@@ -526,8 +526,8 @@ Microsoft.OData.ODataError.ODataError() -> void
 Microsoft.OData.ODataError.Target.get -> string
 Microsoft.OData.ODataError.Target.set -> void
 Microsoft.OData.ODataErrorDetail
-Microsoft.OData.ODataErrorDetail.ErrorCode.get -> string
-Microsoft.OData.ODataErrorDetail.ErrorCode.set -> void
+Microsoft.OData.ODataErrorDetail.Code.get -> string
+Microsoft.OData.ODataErrorDetail.Code.set -> void
 Microsoft.OData.ODataErrorDetail.Message.get -> string
 Microsoft.OData.ODataErrorDetail.Message.set -> void
 Microsoft.OData.ODataErrorDetail.ODataErrorDetail() -> void

--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -51,11 +51,16 @@ Microsoft.OData.ODataBatchOperationRequestMessage.ServiceProvider.get -> System.
 Microsoft.OData.ODataBatchOperationResponseMessage.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataLibraryCompatibility.DoNotThrowExceptionForTopLevelNullProperty = 8 -> Microsoft.OData.ODataLibraryCompatibility
 Microsoft.OData.ODataLibraryCompatibility.None = 0 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.UseLegacyODataInnerErrorSerialization = 16 -> Microsoft.OData.ODataLibraryCompatibility
 Microsoft.OData.ODataLibraryCompatibility.UseLegacyVariableCasing = 1 -> Microsoft.OData.ODataLibraryCompatibility
-Microsoft.OData.ODataLibraryCompatibility.Version6 = Microsoft.OData.ODataLibraryCompatibility.UseLegacyVariableCasing | Microsoft.OData.ODataLibraryCompatibility.WriteTopLevelODataNullAnnotation | Microsoft.OData.ODataLibraryCompatibility.WriteODataContextAnnotationForNavProperty | Microsoft.OData.ODataLibraryCompatibility.DoNotThrowExceptionForTopLevelNullProperty -> Microsoft.OData.ODataLibraryCompatibility
-Microsoft.OData.ODataLibraryCompatibility.Version7 = 1 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.Version6 = Microsoft.OData.ODataLibraryCompatibility.WriteTopLevelODataNullAnnotation | Microsoft.OData.ODataLibraryCompatibility.WriteODataContextAnnotationForNavProperty | Microsoft.OData.ODataLibraryCompatibility.DoNotThrowExceptionForTopLevelNullProperty | Microsoft.OData.ODataLibraryCompatibility.Version7 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataLibraryCompatibility.Version7 = Microsoft.OData.ODataLibraryCompatibility.UseLegacyVariableCasing | Microsoft.OData.ODataLibraryCompatibility.UseLegacyODataInnerErrorSerialization -> Microsoft.OData.ODataLibraryCompatibility
 Microsoft.OData.ODataLibraryCompatibility.WriteODataContextAnnotationForNavProperty = 4 -> Microsoft.OData.ODataLibraryCompatibility
 Microsoft.OData.ODataLibraryCompatibility.WriteTopLevelODataNullAnnotation = 2 -> Microsoft.OData.ODataLibraryCompatibility
+Microsoft.OData.ODataError.Code.get -> string
+Microsoft.OData.ODataError.Code.set -> void
+Microsoft.OData.ODataErrorDetail.Code.get -> string
+Microsoft.OData.ODataErrorDetail.Code.set -> void
 Microsoft.OData.ODataMessageInfo.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataMessageInfo.ServiceProvider.set -> void
 Microsoft.OData.ODataMessageReaderSettings.EnableReadingKeyAsSegment.get -> bool
@@ -523,8 +528,6 @@ Microsoft.OData.ODataEnumValue.Value.get -> string
 Microsoft.OData.ODataError
 Microsoft.OData.ODataError.Details.get -> System.Collections.Generic.ICollection<Microsoft.OData.ODataErrorDetail>
 Microsoft.OData.ODataError.Details.set -> void
-Microsoft.OData.ODataError.ErrorCode.get -> string
-Microsoft.OData.ODataError.ErrorCode.set -> void
 Microsoft.OData.ODataError.InnerError.get -> Microsoft.OData.ODataInnerError
 Microsoft.OData.ODataError.InnerError.set -> void
 Microsoft.OData.ODataError.InstanceAnnotations.get -> System.Collections.Generic.ICollection<Microsoft.OData.ODataInstanceAnnotation>
@@ -535,8 +538,6 @@ Microsoft.OData.ODataError.ODataError() -> void
 Microsoft.OData.ODataError.Target.get -> string
 Microsoft.OData.ODataError.Target.set -> void
 Microsoft.OData.ODataErrorDetail
-Microsoft.OData.ODataErrorDetail.ErrorCode.get -> string
-Microsoft.OData.ODataErrorDetail.ErrorCode.set -> void
 Microsoft.OData.ODataErrorDetail.Message.get -> string
 Microsoft.OData.ODataErrorDetail.Message.set -> void
 Microsoft.OData.ODataErrorDetail.ODataErrorDetail() -> void

--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -564,16 +564,9 @@ Microsoft.OData.ODataFunctionImportInfo.ODataFunctionImportInfo() -> void
 Microsoft.OData.ODataInnerError
 Microsoft.OData.ODataInnerError.InnerError.get -> Microsoft.OData.ODataInnerError
 Microsoft.OData.ODataInnerError.InnerError.set -> void
-Microsoft.OData.ODataInnerError.Message.get -> string
-Microsoft.OData.ODataInnerError.Message.set -> void
 Microsoft.OData.ODataInnerError.ODataInnerError() -> void
 Microsoft.OData.ODataInnerError.ODataInnerError(System.Collections.Generic.IDictionary<string, Microsoft.OData.ODataValue> properties) -> void
-Microsoft.OData.ODataInnerError.ODataInnerError(System.Exception exception) -> void
 Microsoft.OData.ODataInnerError.Properties.get -> System.Collections.Generic.IDictionary<string, Microsoft.OData.ODataValue>
-Microsoft.OData.ODataInnerError.StackTrace.get -> string
-Microsoft.OData.ODataInnerError.StackTrace.set -> void
-Microsoft.OData.ODataInnerError.TypeName.get -> string
-Microsoft.OData.ODataInnerError.TypeName.set -> void
 Microsoft.OData.ODataInputContext
 Microsoft.OData.ODataInputContext.Dispose() -> void
 Microsoft.OData.ODataInputContext.MessageReaderSettings.get -> Microsoft.OData.ODataMessageReaderSettings

--- a/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/ErrorHandler.cs
+++ b/test/EndToEndTests/Services/ODataWCFLibrary/Handlers/ErrorHandler.cs
@@ -82,9 +82,9 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
             {
                 error = this.BuildODataError(statusCode, this.HandledException);
 
-                if (!string.IsNullOrEmpty(oee.Error.ErrorCode))
+                if (!string.IsNullOrEmpty(oee.Error.Code))
                 {
-                    error.ErrorCode = oee.Error.ErrorCode;
+                    error.Code = oee.Error.Code;
                 }
 
                 if (!string.IsNullOrEmpty(oee.Error.Message))
@@ -108,7 +108,7 @@ namespace Microsoft.Test.OData.Services.ODataWCFService.Handlers
         {
             return new ODataError()
             {
-                ErrorCode = statusCode.ToString(),
+                Code = statusCode.ToString(),
                 Message = exception.Message,
                 InnerError = this.BuildODataInnerError(exception),
             };

--- a/test/EndToEndTests/Tests/Client/Build.Desktop/DisableAtomTests/DisableAtomTests.cs
+++ b/test/EndToEndTests/Tests/Client/Build.Desktop/DisableAtomTests/DisableAtomTests.cs
@@ -352,7 +352,7 @@ namespace Microsoft.Test.OData.Tests.Client.DisableAtomTests
             {
                 var error = messageReader.ReadError();
                 Assert.Equal(typeof(Microsoft.OData.ODataError), error.GetType());
-                Assert.Equal("UnsupportedMediaType", error.ErrorCode);
+                Assert.Equal("UnsupportedMediaType", error.Code);
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
@@ -101,9 +101,12 @@ namespace Microsoft.OData.Tests.Json
                 Assert.Equal(ErrorTarget, error.Target);
                 var innerError = error.InnerError;
                 Assert.NotNull(innerError);
-                Assert.Equal(InnerErrorMessage, innerError.Message);
-                Assert.Equal(InnerErrorTypeName, innerError.TypeName);
-                Assert.Equal(InnerErrorStackTrace.Replace("\\\\", "\\"), innerError.StackTrace);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorMessageName, out ODataValue innerErrorMessage));
+                Assert.Equal(InnerErrorMessage, Assert.IsType<ODataPrimitiveValue>(innerErrorMessage).Value);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorTypeNameName, out ODataValue innerErrorTypeName));
+                Assert.Equal(InnerErrorTypeName, Assert.IsType<ODataPrimitiveValue>(innerErrorTypeName).Value);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorStackTraceName, out ODataValue innerErrorStackTrace));
+                Assert.Equal(InnerErrorStackTrace.Replace("\\\\", "\\"), Assert.IsType<ODataPrimitiveValue>(innerErrorStackTrace).Value);
                 Assert.NotNull(innerError.InnerError);
                 Assert.NotNull(error.Details);
                 Assert.Equal(2, error.Details.Count);
@@ -146,9 +149,12 @@ namespace Microsoft.OData.Tests.Json
                 Assert.Equal(ErrorTarget, error.Target);
                 var innerError = error.InnerError;
                 Assert.NotNull(innerError);
-                Assert.Equal(InnerErrorMessage, innerError.Message);
-                Assert.Equal(InnerErrorTypeName, innerError.TypeName);
-                Assert.Equal(InnerErrorStackTrace.Replace("\\\\", "\\"), innerError.StackTrace);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorMessageName, out ODataValue innerErrorMessage));
+                Assert.Equal(InnerErrorMessage, Assert.IsType<ODataPrimitiveValue>(innerErrorMessage).Value);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorTypeNameName, out ODataValue innerErrorTypeName));
+                Assert.Equal(InnerErrorTypeName, Assert.IsType<ODataPrimitiveValue>(innerErrorTypeName).Value);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorStackTraceName, out ODataValue innerErrorStackTrace));
+                Assert.Equal(InnerErrorStackTrace.Replace("\\\\", "\\"), Assert.IsType<ODataPrimitiveValue>(innerErrorStackTrace).Value);
                 Assert.NotNull(innerError.InnerError);
                 Assert.NotNull(error.Details);
                 var errorDetail = Assert.Single(error.Details);
@@ -184,18 +190,21 @@ namespace Microsoft.OData.Tests.Json
 
                 // Assert
                 Assert.True(result1);
-                Assert.True(result2.Item1);
+                Assert.True(result2.IsReadSuccessfully);
 
-                var error = result2.Item2;
+                var error = result2.Error;
                 Assert.NotNull(error);
                 Assert.Equal(ErrorCode, error.Code);
                 Assert.Equal(ErrorMessage, error.Message);
                 Assert.Equal(ErrorTarget, error.Target);
                 var innerError = error.InnerError;
                 Assert.NotNull(innerError);
-                Assert.Equal(InnerErrorMessage, innerError.Message);
-                Assert.Equal(InnerErrorTypeName, innerError.TypeName);
-                Assert.Equal(InnerErrorStackTrace.Replace("\\\\", "\\"), innerError.StackTrace);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorMessageName, out ODataValue innerErrorMessage));
+                Assert.Equal(InnerErrorMessage, Assert.IsType<ODataPrimitiveValue>(innerErrorMessage).Value);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorTypeNameName, out ODataValue innerErrorTypeName));
+                Assert.Equal(InnerErrorTypeName, Assert.IsType<ODataPrimitiveValue>(innerErrorTypeName).Value);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorStackTraceName, out ODataValue innerErrorStackTrace));
+                Assert.Equal(InnerErrorStackTrace.Replace("\\\\", "\\"), Assert.IsType<ODataPrimitiveValue>(innerErrorStackTrace).Value);
                 Assert.NotNull(innerError.InnerError);
                 Assert.NotNull(error.Details);
                 var errorDetail = Assert.Single(error.Details);
@@ -433,18 +442,21 @@ namespace Microsoft.OData.Tests.Json
 
                 // Assert
                 Assert.True(result1);
-                Assert.True(result2.Item1);
+                Assert.True(result2.IsReadSuccessfully);
 
-                var error = result2.Item2;
+                var error = result2.Error;
                 Assert.NotNull(error);
                 Assert.Equal(ErrorCode, error.Code);
                 Assert.Equal(ErrorMessage, error.Message);
                 Assert.Equal(ErrorTarget, error.Target);
                 var innerError = error.InnerError;
                 Assert.NotNull(innerError);
-                Assert.Equal(InnerErrorMessage, innerError.Message);
-                Assert.Equal(InnerErrorTypeName, innerError.TypeName);
-                Assert.Equal(InnerErrorStackTrace.Replace("\\\\", "\\"), innerError.StackTrace);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorMessageName, out ODataValue innerErrorMessage));
+                Assert.Equal(InnerErrorMessage, Assert.IsType<ODataPrimitiveValue>(innerErrorMessage).Value);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorTypeNameName, out ODataValue innerErrorTypeName));
+                Assert.Equal(InnerErrorTypeName, Assert.IsType<ODataPrimitiveValue>(innerErrorTypeName).Value);
+                Assert.True(innerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorStackTraceName, out ODataValue innerErrorStackTrace));
+                Assert.Equal(InnerErrorStackTrace.Replace("\\\\", "\\"), Assert.IsType<ODataPrimitiveValue>(innerErrorStackTrace).Value);
                 Assert.NotNull(innerError.InnerError);
                 Assert.NotNull(error.Details);
                 Assert.Equal(2, error.Details.Count);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/BufferingJsonReaderTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal("any target", error.Target);
             Assert.Equal(1, error.Details.Count);
             var detail = error.Details.Single();
-            Assert.Equal("500", detail.ErrorCode);
+            Assert.Equal("500", detail.Code);
             Assert.Equal("another target", detail.Target);
             Assert.Equal("any msg", detail.Message);
         }
@@ -96,7 +96,7 @@ namespace Microsoft.OData.Tests.Json
                 Assert.True(result2);
 
                 Assert.NotNull(error);
-                Assert.Equal(ErrorCode, error.ErrorCode);
+                Assert.Equal(ErrorCode, error.Code);
                 Assert.Equal(ErrorMessage, error.Message);
                 Assert.Equal(ErrorTarget, error.Target);
                 var innerError = error.InnerError;
@@ -107,9 +107,9 @@ namespace Microsoft.OData.Tests.Json
                 Assert.NotNull(innerError.InnerError);
                 Assert.NotNull(error.Details);
                 Assert.Equal(2, error.Details.Count);
-                Assert.Equal("dxd1", error.Details.ElementAt(0).ErrorCode);
+                Assert.Equal("dxd1", error.Details.ElementAt(0).Code);
                 Assert.Equal("dmg1", error.Details.ElementAt(0).Message);
-                Assert.Equal("dxd2", error.Details.ElementAt(1).ErrorCode);
+                Assert.Equal("dxd2", error.Details.ElementAt(1).Code);
                 Assert.Equal("dmg2", error.Details.ElementAt(1).Message);
             }
         }
@@ -141,7 +141,7 @@ namespace Microsoft.OData.Tests.Json
                 // Assert
                 var error = exception.Error;
                 Assert.NotNull(error);
-                Assert.Equal(ErrorCode, error.ErrorCode);
+                Assert.Equal(ErrorCode, error.Code);
                 Assert.Equal(ErrorMessage, error.Message);
                 Assert.Equal(ErrorTarget, error.Target);
                 var innerError = error.InnerError;
@@ -152,7 +152,7 @@ namespace Microsoft.OData.Tests.Json
                 Assert.NotNull(innerError.InnerError);
                 Assert.NotNull(error.Details);
                 var errorDetail = Assert.Single(error.Details);
-                Assert.Equal(ErrorDetailErrorCode, errorDetail.ErrorCode);
+                Assert.Equal(ErrorDetailErrorCode, errorDetail.Code);
                 Assert.Equal(ErrorDetailErrorMessage, errorDetail.Message);
                 Assert.Null(errorDetail.Target);
             }
@@ -188,7 +188,7 @@ namespace Microsoft.OData.Tests.Json
 
                 var error = result2.Item2;
                 Assert.NotNull(error);
-                Assert.Equal(ErrorCode, error.ErrorCode);
+                Assert.Equal(ErrorCode, error.Code);
                 Assert.Equal(ErrorMessage, error.Message);
                 Assert.Equal(ErrorTarget, error.Target);
                 var innerError = error.InnerError;
@@ -199,7 +199,7 @@ namespace Microsoft.OData.Tests.Json
                 Assert.NotNull(innerError.InnerError);
                 Assert.NotNull(error.Details);
                 var errorDetail = Assert.Single(error.Details);
-                Assert.Equal(ErrorDetailErrorCode, errorDetail.ErrorCode);
+                Assert.Equal(ErrorDetailErrorCode, errorDetail.Code);
                 Assert.Equal(ErrorDetailErrorMessage, errorDetail.Message);
                 Assert.Null(errorDetail.Target);
             }
@@ -401,7 +401,7 @@ namespace Microsoft.OData.Tests.Json
                 Assert.Null(error.InnerError);
                 Assert.NotNull(error.Details);
                 var errorDetail = Assert.Single(error.Details);
-                Assert.Equal(ErrorDetailErrorCode, errorDetail.ErrorCode);
+                Assert.Equal(ErrorDetailErrorCode, errorDetail.Code);
                 Assert.Equal(ErrorDetailErrorMessage, errorDetail.Message);
                 Assert.Null(errorDetail.Target);
             }
@@ -437,7 +437,7 @@ namespace Microsoft.OData.Tests.Json
 
                 var error = result2.Item2;
                 Assert.NotNull(error);
-                Assert.Equal(ErrorCode, error.ErrorCode);
+                Assert.Equal(ErrorCode, error.Code);
                 Assert.Equal(ErrorMessage, error.Message);
                 Assert.Equal(ErrorTarget, error.Target);
                 var innerError = error.InnerError;
@@ -448,9 +448,9 @@ namespace Microsoft.OData.Tests.Json
                 Assert.NotNull(innerError.InnerError);
                 Assert.NotNull(error.Details);
                 Assert.Equal(2, error.Details.Count);
-                Assert.Equal("dxd1", error.Details.ElementAt(0).ErrorCode);
+                Assert.Equal("dxd1", error.Details.ElementAt(0).Code);
                 Assert.Equal("dmg1", error.Details.ElementAt(0).Message);
-                Assert.Equal("dxd2", error.Details.ElementAt(1).ErrorCode);
+                Assert.Equal("dxd2", error.Details.ElementAt(1).Code);
                 Assert.Equal("dmg2", error.Details.ElementAt(1).Message);
             }
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
@@ -140,14 +140,13 @@ namespace Microsoft.OData.Tests.Json
 
             //Assert Inner Error properties
             Assert.NotNull(error.InnerError);
-            Assert.True(error.InnerError.Properties.ContainsKey("innererror"));
-            var objectValue =
-                (error.InnerError.Properties["innererror"] as ODataResourceValue).Properties
-                .FirstOrDefault(p => p.Name == "MyNewObject").ODataValue as ODataResourceValue;
-            Assert.NotNull(objectValue);
+            var nestedInnerError = error.InnerError.InnerError;
+            Assert.NotNull(nestedInnerError);
+            ODataValue myNewObjectValue;
+            Assert.True(nestedInnerError.Properties.TryGetValue("MyNewObject", out myNewObjectValue));
+            Assert.NotNull(myNewObjectValue);
 
-            ODataResourceValue nestedInnerObject = error.InnerError.Properties["innererror"] as ODataResourceValue;
-            ODataResourceValue nestedMyNewObject = nestedInnerObject.Properties.FirstOrDefault(p => p.Name == "MyNewObject").ODataValue as ODataResourceValue;
+            ODataResourceValue nestedMyNewObject = Assert.IsType<ODataResourceValue>(myNewObjectValue);
 
             Assert.Equal(5, nestedMyNewObject.Properties.Count());
             Assert.Equal("StringProperty", nestedMyNewObject.Properties.ElementAt(0).Name);
@@ -194,8 +193,10 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal(3, (error.InnerError.Properties["CollectionValue"] as ODataCollectionValue).Items.Count());
         }
 
-        [Fact]
-        public async Task ReadTopLevelErrorAsync()
+        [Theory]
+        [InlineData(JsonConstants.ODataErrorInnerErrorInnerErrorName)]
+        [InlineData(JsonConstants.ODataErrorInnerErrorName)]
+        public async Task ReadTopLevelErrorAsync(string nestedInnerErrorName)
         {
             var payload = "{\"error\":{" +
                 "\"code\":\"forbidden\"," +
@@ -207,7 +208,7 @@ namespace Microsoft.OData.Tests.Json
                     "\"type\":\"\"," +
                     "\"stacktrace\":\"\"," +
                     "\"correlationId\":\"4784efae-d1c4-4f1f-baba-e811b3b0826c\"," +
-                    "\"internalexception\":{}}," +
+                    $"\"{nestedInnerErrorName}\":{{}}}}," +
                 "\"ns.workloadId@odata.type\":\"#Guid\"," +
                 "\"@ns.workloadId\":\"5a3c4b92-f401-416f-bf88-106cb03efaf4\"}}";
 
@@ -222,9 +223,12 @@ namespace Microsoft.OData.Tests.Json
                     Assert.Equal("Access to the resource is forbidden", error.Message);
                     Assert.Equal("Resource", error.Target);
                     Assert.NotNull(error.InnerError);
-                    Assert.Equal("Contact administrator", error.InnerError.Message);
-                    Assert.Equal("", error.InnerError.TypeName);
-                    Assert.Equal("", error.InnerError.StackTrace);
+                    Assert.True(error.InnerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorMessageName, out ODataValue innerErrorMessage));
+                    Assert.Equal("Contact administrator", Assert.IsType<ODataPrimitiveValue>(innerErrorMessage).Value);
+                    Assert.True(error.InnerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorTypeNameName, out ODataValue innerErrorTypeName));
+                    Assert.Equal("", Assert.IsType<ODataPrimitiveValue>(innerErrorTypeName).Value);
+                    Assert.True(error.InnerError.Properties.TryGetValue(JsonConstants.ODataErrorInnerErrorStackTraceName, out ODataValue innerErrorStackTrace));
+                    Assert.Equal("", Assert.IsType<ODataPrimitiveValue>(innerErrorStackTrace).Value);
                     Assert.NotNull(error.InnerError.InnerError);
                     Assert.True(error.InnerError.Properties.TryGetValue("correlationId", out ODataValue correlationIdValue));
                     var correlationId = Assert.IsType<ODataPrimitiveValue>(correlationIdValue);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonErrorDeserializerTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal("any target", error.Target);
             Assert.Equal(1, error.Details.Count);
             var detail = error.Details.Single();
-            Assert.Equal("500", detail.ErrorCode);
+            Assert.Equal("500", detail.Code);
             Assert.Equal("another target", detail.Target);
             Assert.Equal("any msg", detail.Message);
         }
@@ -134,7 +134,7 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal("any target", error.Target);
             Assert.Equal(1, error.Details.Count);
             var detail = error.Details.Single();
-            Assert.Equal("500", detail.ErrorCode);
+            Assert.Equal("500", detail.Code);
             Assert.Equal("any target", detail.Target);
             Assert.Equal("any msg", detail.Message);
 
@@ -218,7 +218,7 @@ namespace Microsoft.OData.Tests.Json
                     var error = await jsonErrorDeserializer.ReadTopLevelErrorAsync();
 
                     Assert.NotNull(error);
-                    Assert.Equal("forbidden", error.ErrorCode);
+                    Assert.Equal("forbidden", error.Code);
                     Assert.Equal("Access to the resource is forbidden", error.Message);
                     Assert.Equal("Resource", error.Target);
                     Assert.NotNull(error.InnerError);
@@ -231,7 +231,7 @@ namespace Microsoft.OData.Tests.Json
                     Assert.Equal("4784efae-d1c4-4f1f-baba-e811b3b0826c", correlationId.Value);
                     Assert.NotNull(error.Details);
                     var errorDetail = Assert.Single(error.Details);
-                    Assert.Equal("insufficientPrivileges", errorDetail.ErrorCode);
+                    Assert.Equal("insufficientPrivileges", errorDetail.Code);
                     Assert.Equal("You don't have the required privileges", errorDetail.Message);
                     Assert.Equal("", errorDetail.Target);
                     var nsWorkloadIdAnnotation = Assert.Single(error.GetInstanceAnnotations());

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextApiTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextApiTests.cs
@@ -2568,11 +2568,14 @@ POST http://tempuri.org/Customers HTTP/1.1
                 Code = "badRequest",
                 Message = "Object reference not set to an instance of an object",
                 Target = "ConApp",
-                InnerError = new ODataInnerError
+                InnerError = new ODataInnerError(
+                    new Dictionary<string, ODataValue>
+                    {
+                        { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("Exception thrown due to attempt to access a member on a variable that currently holds a null reference") },
+                        { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("System.NullReferenceException") },
+                        { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("   at ConApp.Program.Main(String[] args) in C:\\Projects\\ConApp\\ConApp\\Program.cs:line 10") },
+                    })
                 {
-                    TypeName = "System.NullReferenceException",
-                    Message = "Exception thrown due to attempt to access a member on a variable that currently holds a null reference",
-                    StackTrace = "   at ConApp.Program.Main(String[] args) in C:\\Projects\\ConApp\\ConApp\\Program.cs:line 10",
                     InnerError = new ODataInnerError()
                 },
                 InstanceAnnotations = new List<ODataInstanceAnnotation>
@@ -2619,7 +2622,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 "\"message\":\"Exception thrown due to attempt to access a member on a variable that currently holds a null reference\"," +
                 "\"type\":\"System.NullReferenceException\"," +
                 "\"stacktrace\":\"   at ConApp.Program.Main(String[] args) in C:\\\\Projects\\\\ConApp\\\\ConApp\\\\Program.cs:line 10\"," +
-                $"\"{nestedInnerErrorPropertyName}\":{{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"\"}}}}," +
+                $"\"{nestedInnerErrorPropertyName}\":{{}}}}," +
                 "\"@Is.Error\":true}}";
 
             Assert.Equal(expected, asyncResult);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextTests.cs
@@ -43,7 +43,7 @@ namespace Microsoft.OData.Tests.Json
             this.messageWriterSettings.ShouldIncludeAnnotationInternal = ODataUtils.CreateAnnotationFilter("*");
             this.nullReferenceError = new ODataError
             {
-                ErrorCode = "NRE",
+                Code = "NRE",
                 Message = "Object reference not set to an instance of an object",
                 InstanceAnnotations = new List<ODataInstanceAnnotation>
                 {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonSerializerTests.cs
@@ -393,10 +393,13 @@ namespace Microsoft.OData.Tests.Json
                         {
                             new ODataErrorDetail { Code = "insufficientPrivileges", Message = "You don't have the required privileges"}
                         },
-                        InnerError = new ODataInnerError
-                        {
-                            Message = "Contact administrator"
-                        },
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("Contact administrator") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("") }
+                            }),
                         InstanceAnnotations = new Collection<ODataInstanceAnnotation>
                         {
                             new ODataInstanceAnnotation("ns.workloadId", new ODataPrimitiveValue(new Guid("5a3c4b92-f401-416f-bf88-106cb03efaf4")))

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonSerializerTests.cs
@@ -58,7 +58,7 @@ namespace Microsoft.OData.Tests.Json
         {
             var result = SetupSerializerAndRunTest(null, serializer =>
             {
-                ODataError error = new ODataError { ErrorCode = "Error Code" };
+                ODataError error = new ODataError { Code = "Error Code" };
                 serializer.WriteTopLevelError(error, false);
             });
 
@@ -386,12 +386,12 @@ namespace Microsoft.OData.Tests.Json
                 {
                     ODataError error = new ODataError
                     {
-                        ErrorCode = "forbidden",
+                        Code = "forbidden",
                         Message = "Access to the resource is forbidden",
                         Target = "Resource",
                         Details = new Collection<ODataErrorDetail>
                         {
-                            new ODataErrorDetail { ErrorCode = "insufficientPrivileges", Message = "You don't have the required privileges"}
+                            new ODataErrorDetail { Code = "insufficientPrivileges", Message = "You don't have the required privileges"}
                         },
                         InnerError = new ODataInnerError
                         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
@@ -21,12 +21,14 @@ namespace Microsoft.OData.Tests.Json
         private StringWriter stringWriter;
         private IJsonWriter jsonWriter;
         private Func<ICollection<ODataInstanceAnnotation>, Task> writeInstanceAnnotationsDelegate;
+        private ODataMessageWriterSettings messageWriterSettings;
 
         public ODataJsonWriterUtilsAsyncTests()
         {
             this.stringWriter = new StringWriter();
             this.jsonWriter = new JsonWriter(this.stringWriter, isIeee754Compatible: true);
             this.writeInstanceAnnotationsDelegate = async (ICollection<ODataInstanceAnnotation> instanceAnnotations) => await TaskUtils.CompletedTask;
+            this.messageWriterSettings = new ODataMessageWriterSettings();
         }
 
         [Fact]
@@ -35,7 +37,7 @@ namespace Microsoft.OData.Tests.Json
             var error = new ODataError
             {
                 Target = "any target",
-                Details = new[] { new ODataErrorDetail { ErrorCode = "500", Target = "any target", Message = "any msg" } }
+                Details = new[] { new ODataErrorDetail { Code = "500", Target = "any target", Message = "any msg" } }
             };
 
             await ODataJsonWriterUtils.WriteErrorAsync(
@@ -43,13 +45,13 @@ namespace Microsoft.OData.Tests.Json
                 this.writeInstanceAnnotationsDelegate,
                 error,
                 includeDebugInformation: false,
-                maxInnerErrorDepth: 0);
+                this.messageWriterSettings);
             var result = stringWriter.GetStringBuilder().ToString();
             Assert.Equal("{\"error\":{" +
                 "\"code\":\"\"," +
                 "\"message\":\"\"," +
                 "\"target\":\"any target\"," +
-                "\"details\":[{\"code\":\"500\",\"target\":\"any target\",\"message\":\"any msg\"}]" +
+                "\"details\":[{\"code\":\"500\",\"message\":\"any msg\",\"target\":\"any target\"}]" +
             "}}", result);
         }
 
@@ -59,7 +61,7 @@ namespace Microsoft.OData.Tests.Json
             var error = new ODataError
             {
                 Target = "any target",
-                Details = new[] { new ODataErrorDetail { ErrorCode = "500", Target = "any target", Message = "any msg with \"escaped characters\"" } }
+                Details = new[] { new ODataErrorDetail { Code = "500", Target = "any target", Message = "any msg with \"escaped characters\"" } }
             };
 
             await ODataJsonWriterUtils.WriteErrorAsync(
@@ -67,26 +69,30 @@ namespace Microsoft.OData.Tests.Json
                 this.writeInstanceAnnotationsDelegate,
                 error,
                 includeDebugInformation: false,
-                maxInnerErrorDepth: 0);
+                this.messageWriterSettings);
             var result = stringWriter.GetStringBuilder().ToString();
             Assert.Equal("{\"error\":{" +
                 "\"code\":\"\"," +
                 "\"message\":\"\"," +
                 "\"target\":\"any target\"," +
-                "\"details\":[{\"code\":\"500\",\"target\":\"any target\",\"message\":\"any msg with \\\"escaped characters\\\"\"}]" +
+                "\"details\":[{\"code\":\"500\",\"message\":\"any msg with \\\"escaped characters\\\"\",\"target\":\"any target\"}]" +
             "}}", result);
         }
 
-
-        [Fact]
-        public async Task WriteErrorAsync_InnerErrorWithNestedNullValue()
+        [Theory]
+        [InlineData(ODataLibraryCompatibility.UseLegacyODataInnerErrorSerialization, JsonConstants.ODataErrorInnerErrorInnerErrorName)]
+        [InlineData(ODataLibraryCompatibility.None, JsonConstants.ODataErrorInnerErrorName)]
+        public async Task WriteErrorAsync_InnerErrorWithNestedNullValue(ODataLibraryCompatibility libraryCompatibility, string nestedInnerErrorPropertyName)
         {
-            IDictionary<string, ODataValue> properties = new Dictionary<string, ODataValue>();
-            properties.Add("stacktrace", "NormalString".ToODataValue());
-            properties.Add("MyNewObject", new ODataResourceValue()
+            IDictionary<string, ODataValue> properties = new Dictionary<string, ODataValue>
             {
-                TypeName = "ComplexValue",
-                Properties = new List<ODataProperty>()
+                { "stacktrace", "NormalString".ToODataValue() },
+                {
+                    "MyNewObject",
+                    new ODataResourceValue()
+                    {
+                        TypeName = "ComplexValue",
+                        Properties = new List<ODataProperty>()
                 {
                     new ODataProperty
                     {
@@ -104,47 +110,60 @@ namespace Microsoft.OData.Tests.Json
                         }
                     }
                 }
-            });
-            IDictionary<string, ODataValue> nestedDict = new Dictionary<string, ODataValue>();
-            nestedDict.Add("nested", null);
+                    }
+                }
+            };
+
+            IDictionary<string, ODataValue> nestedDict = new Dictionary<string, ODataValue>
+            {
+                { "nested", null }
+            };
+
             var error = new ODataError
             {
                 Target = "any target",
-                Details = new[] { new ODataErrorDetail { ErrorCode = "500", Target = "any target", Message = "any msg" } },
+                Details = new[] { new ODataErrorDetail { Code = "500", Target = "any target", Message = "any msg" } },
                 InnerError = new ODataInnerError(properties) { InnerError = new ODataInnerError(nestedDict)}
             };
 
+            this.messageWriterSettings.MessageQuotas.MaxNestingDepth = 5;
+            this.messageWriterSettings.LibraryCompatibility |= libraryCompatibility;
             await ODataJsonWriterUtils.WriteErrorAsync(
                 this.jsonWriter,
                 this.writeInstanceAnnotationsDelegate,
                 error,
                 includeDebugInformation: true,
-                maxInnerErrorDepth: 5);
+                this.messageWriterSettings);
              var result = stringWriter.GetStringBuilder().ToString();
              Assert.Equal("{\"error\":{" +
                  "\"code\":\"\"," +
                  "\"message\":\"\"," +
                  "\"target\":\"any target\"," +
-                 "\"details\":[{\"code\":\"500\",\"target\":\"any target\",\"message\":\"any msg\"}]," +
+                 "\"details\":[{\"code\":\"500\",\"message\":\"any msg\",\"target\":\"any target\"}]," +
                  "\"innererror\":{" +
                     "\"stacktrace\":\"NormalString\"," +
                     "\"MyNewObject\":{" +
                         "\"NestedResourcePropertyName\":{\"InnerMostPropertyName\":\"InnerMostPropertyValue\"}" +
                     "}," +
-                    "\"internalexception\":{\"nested\":null}" +
+                    $"\"{nestedInnerErrorPropertyName}\":{{\"nested\":null}}" +
                 "}" +
             "}}", result);
         }
 
-        [Fact]
-        public async Task WriteErrorAsync_InnerErrorWithNestedProperties()
+        [Theory]
+        [InlineData(ODataLibraryCompatibility.UseLegacyODataInnerErrorSerialization, JsonConstants.ODataErrorInnerErrorInnerErrorName)]
+        [InlineData(ODataLibraryCompatibility.None, JsonConstants.ODataErrorInnerErrorName)]
+        public async Task WriteErrorAsync_InnerErrorWithNestedProperties(ODataLibraryCompatibility libraryCompatibility, string nestedInnerErrorPropertyName)
         {
-            IDictionary<string, ODataValue> properties = new Dictionary<string, ODataValue>();
-            properties.Add("stacktrace", "NormalString".ToODataValue());
-            properties.Add("MyNewObject", new ODataResourceValue
-            { 
-                TypeName = "ComplexValue",
-                Properties = new List<ODataProperty>
+            IDictionary<string, ODataValue> properties = new Dictionary<string, ODataValue>
+            {
+                { "stacktrace", "NormalString".ToODataValue() },
+                {
+                    "MyNewObject",
+                    new ODataResourceValue
+                    {
+                        TypeName = "ComplexValue",
+                        Properties = new List<ODataProperty>
                 {
                     new ODataProperty
                     {
@@ -152,31 +171,35 @@ namespace Microsoft.OData.Tests.Json
                         Value = "NestedPropertyValue"
                     }
                 }
-            });
+                    }
+                }
+            };
 
             var error = new ODataError
             {
                 Target = "any target",
-                Details = new[] { new ODataErrorDetail { ErrorCode = "500", Target = "any target", Message = "any msg" } },
+                Details = new[] { new ODataErrorDetail { Code = "500", Target = "any target", Message = "any msg" } },
                 InnerError = new ODataInnerError(properties) { InnerError = new ODataInnerError(properties) }
             };
 
+            this.messageWriterSettings.MessageQuotas.MaxNestingDepth = 5;
+            this.messageWriterSettings.LibraryCompatibility |= libraryCompatibility;
             await ODataJsonWriterUtils.WriteErrorAsync(
                 this.jsonWriter,
                 this.writeInstanceAnnotationsDelegate,
                 error,
                 includeDebugInformation: true,
-                maxInnerErrorDepth: 5);
+                this.messageWriterSettings);
             var result = stringWriter.GetStringBuilder().ToString();
             Assert.Equal("{\"error\":{" +
                 "\"code\":\"\"," +
                 "\"message\":\"\"," +
                 "\"target\":\"any target\"," +
-                "\"details\":[{\"code\":\"500\",\"target\":\"any target\",\"message\":\"any msg\"}]," +
+                "\"details\":[{\"code\":\"500\",\"message\":\"any msg\",\"target\":\"any target\"}]," +
                 "\"innererror\":{" +
                     "\"stacktrace\":\"NormalString\"," +
                     "\"MyNewObject\":{\"NestedResourcePropertyName\":\"NestedPropertyValue\"}," +
-                    "\"internalexception\":{" +
+                    $"\"{nestedInnerErrorPropertyName}\":{{" +
                         "\"stacktrace\":\"NormalString\"," +
                         "\"MyNewObject\":{\"NestedResourcePropertyName\":\"NestedPropertyValue\"}" +
                     "}" +
@@ -190,25 +213,26 @@ namespace Microsoft.OData.Tests.Json
             var error = new ODataError
             {
                 Target = "any target",
-                Details = new[] { new ODataErrorDetail { ErrorCode = "500", Target = "any target", Message = "any msg" } },
+                Details = new[] { new ODataErrorDetail { Code = "500", Target = "any target", Message = "any msg" } },
                 InnerError = new ODataInnerError
                 {
                     Message = "The other properties on the inner error object should serialize as empty strings because of using this constructor."
                 }
             };
 
+            this.messageWriterSettings.MessageQuotas.MaxNestingDepth = 5;
             await ODataJsonWriterUtils.WriteErrorAsync(
                 this.jsonWriter,
                 this.writeInstanceAnnotationsDelegate,
                 error,
                 includeDebugInformation: true,
-                maxInnerErrorDepth: 5);
+                this.messageWriterSettings);
             var result = stringWriter.GetStringBuilder().ToString();
             Assert.Equal("{\"error\":{" +
                 "\"code\":\"\"," +
                 "\"message\":\"\"," +
                 "\"target\":\"any target\"," +
-                "\"details\":[{\"code\":\"500\",\"target\":\"any target\",\"message\":\"any msg\"}]," +
+                "\"details\":[{\"code\":\"500\",\"message\":\"any msg\",\"target\":\"any target\"}]," +
                 "\"innererror\":{" +
                     "\"message\":\"The other properties on the inner error object should serialize as empty strings because of using this constructor.\"," +
                     "\"type\":\"\"," +
@@ -242,22 +266,23 @@ namespace Microsoft.OData.Tests.Json
             var error = new ODataError
             {
                 Target = "any target",
-                Details = new[] { new ODataErrorDetail { ErrorCode = "500", Target = "any target", Message = "any msg" } },
+                Details = new[] { new ODataErrorDetail { Code = "500", Target = "any target", Message = "any msg" } },
                 InnerError = innerError
             };
 
+            this.messageWriterSettings.MessageQuotas.MaxNestingDepth = 5;
             await ODataJsonWriterUtils.WriteErrorAsync(
                 this.jsonWriter,
                 this.writeInstanceAnnotationsDelegate,
                 error,
                 includeDebugInformation: true,
-                maxInnerErrorDepth: 5);
+                this.messageWriterSettings);
             var result = stringWriter.GetStringBuilder().ToString();
             Assert.Equal("{\"error\":{" +
                 "\"code\":\"\"," +
                 "\"message\":\"\"," +
                 "\"target\":\"any target\"," +
-                "\"details\":[{\"code\":\"500\",\"target\":\"any target\",\"message\":\"any msg\"}]," +
+                "\"details\":[{\"code\":\"500\",\"message\":\"any msg\",\"target\":\"any target\"}]," +
                 "\"innererror\":{" +
                     "\"message\":\"\"," +
                     "\"type\":\"\"," +
@@ -287,7 +312,7 @@ namespace Microsoft.OData.Tests.Json
                 },
                 error,
                 includeDebugInformation: false,
-                maxInnerErrorDepth: 0);
+                this.messageWriterSettings);
             var result = stringWriter.GetStringBuilder().ToString();
             Assert.Equal("{\"error\":{" +
                 "\"code\":\"\"," +
@@ -311,7 +336,7 @@ namespace Microsoft.OData.Tests.Json
                     null,
                     error,
                     includeDebugInformation: false,
-                    maxInnerErrorDepth: 0);
+                    this.messageWriterSettings);
                 });
         }
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataErrorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataErrorTests.cs
@@ -4,8 +4,15 @@
 // </copyright>
 //---------------------------------------------------------------------
 
+using Microsoft.OData.Edm;
+using Microsoft.OData.Json;
+using Microsoft.Spatial;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.OData.Tests
@@ -64,6 +71,917 @@ namespace Microsoft.OData.Tests
             this.odataError.InstanceAnnotations.Add(instanceAnnotation);
             var annotation = Assert.Single(this.odataError.InstanceAnnotations);
             Assert.Same(annotation, instanceAnnotation);
+        }
+
+        public static IEnumerable<object[]> GetODataInnerErrorTestData()
+        {
+            return
+            [
+                [
+                    new ODataInnerError(),
+                    "{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"\"}"
+                ],
+                [
+                    new ODataInnerError { Message = "OIEM1" },
+                    "{\"message\":\"OIEM1\",\"type\":\"\",\"stacktrace\":\"\"}"
+                ],
+                [
+                    new ODataInnerError { TypeName = "OIET1" },
+                    "{\"message\":\"\",\"type\":\"OIET1\",\"stacktrace\":\"\"}"
+                ],
+                [
+                    new ODataInnerError { StackTrace = "OIES1" },
+                    "{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"OIES1\"}"
+                ],
+                [
+                    new ODataInnerError { Message = "OIEM1", TypeName = "OIET1" },
+                    "{\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"\"}"
+                ],
+                [
+                    new ODataInnerError { Message = "OIEM1", StackTrace = "OIES1" },
+                    "{\"message\":\"OIEM1\",\"type\":\"\",\"stacktrace\":\"OIES1\"}"
+                ],
+                [
+                    new ODataInnerError { TypeName = "OIET1", StackTrace = "OIES1" },
+                    "{\"message\":\"\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}"
+                ],
+                [
+                    new ODataInnerError { Message = "OIEM1", TypeName = "OIET1", StackTrace = "OIES1" },
+                    "{\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}"
+                ],
+                [
+                    new ODataInnerError(
+                        new Dictionary<string, ODataValue>
+                        {
+                            { "p1", new ODataPrimitiveValue(1) },
+                            { "p2", new ODataPrimitiveValue("SP") }
+                        })
+                    {
+                        Message = "OIEM1",
+                        TypeName = "OIET1",
+                        StackTrace = "OIES1"
+                    },
+                    "{\"p1\":1,\"p2\":\"SP\",\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}"
+                ],
+                [
+                    new ODataInnerError
+                    {
+                        Message = "OIEM1",
+                        TypeName = "OIET1",
+                        StackTrace = "OIES1",
+                        InnerError = new ODataInnerError()
+                    },
+                    "{\"message\":\"OIEM1\"," +
+                    "\"type\":\"OIET1\"," +
+                    "\"stacktrace\":\"OIES1\"," +
+                    "\"innererror\":{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"\"}}"
+                ],
+                [
+                    new ODataInnerError
+                    {
+                        Message = "OIEM1",
+                        TypeName = "OIET1",
+                        StackTrace = "OIES1",
+                        InnerError = new ODataInnerError { Message = "OIEM2", TypeName = "OIET2", StackTrace = "OIES2" }
+                    },
+                    "{\"message\":\"OIEM1\"," +
+                    "\"type\":\"OIET1\"," +
+                    "\"stacktrace\":\"OIES1\"," +
+                    "\"innererror\":{\"message\":\"OIEM2\",\"type\":\"OIET2\",\"stacktrace\":\"OIES2\"}}"
+                ],
+                [
+                    new ODataInnerError(
+                        new Dictionary<string, ODataValue>
+                        {
+                            { "p1", new ODataPrimitiveValue(1) },
+                            { "p2", new ODataPrimitiveValue("SP") }
+                        })
+                    {
+                        Message = "OIEM1",
+                        TypeName = "OIET1",
+                        StackTrace = "OIES1",
+                        InnerError = new ODataInnerError { Message = "OIEM2", TypeName = "OIET2", StackTrace = "OIES2" }
+                    },
+                    "{\"p1\":1," +
+                    "\"p2\":\"SP\"," +
+                    "\"message\":\"OIEM1\"," +
+                    "\"type\":\"OIET1\"," +
+                    "\"stacktrace\":\"OIES1\"," +
+                    "\"innererror\":{\"message\":\"OIEM2\",\"type\":\"OIET2\",\"stacktrace\":\"OIES2\"}}"
+                ],
+                [
+                    new ODataInnerError
+                    {
+                        Message = "OIEM1",
+                        TypeName = "OIET1",
+                        StackTrace = "OIES1",
+                        InnerError = new ODataInnerError
+                        {
+                            Message = "OIEM2",
+                            TypeName = "OIET2",
+                            StackTrace = "OIES2",
+                            InnerError = new ODataInnerError { Message = "OIEM3", TypeName = "OIET3", StackTrace = "OIES3" }
+                        }
+                    },
+                    "{\"message\":\"OIEM1\"," +
+                    "\"type\":\"OIET1\"," +
+                    "\"stacktrace\":\"OIES1\"," +
+                    "\"innererror\":{" +
+                    "\"message\":\"OIEM2\"," +
+                    "\"type\":\"OIET2\"," +
+                    "\"stacktrace\":\"OIES2\"," +
+                    "\"innererror\":{\"message\":\"OIEM3\",\"type\":\"OIET3\",\"stacktrace\":\"OIES3\"}}}"
+                ]
+            ];
+        }
+
+        [Theory]
+        [MemberData(nameof(GetODataInnerErrorTestData))]
+        public void TestODataInnerErrorToJsonString(ODataInnerError odataInnerError, string expectedJsonString)
+        {
+            // Arrange & Act
+            var jsonString = odataInnerError.ToJsonString();
+
+            // Assert
+            Assert.Equal(expectedJsonString, jsonString);
+        }
+
+        public static IEnumerable<object[]> GetODataErrorDetailTestData()
+        {
+            return
+            [
+                [
+                    new ODataErrorDetail(),
+                    "{\"code\":\"\",\"message\":\"\"}"
+                ],
+                [
+                    new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1" },
+                    "{\"code\":\"OEDC1\",\"message\":\"OEDM1\"}"
+                ],
+                [
+                    new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1", Target = "OEDT1" },
+                    "{\"code\":\"OEDC1\",\"message\":\"OEDM1\",\"target\":\"OEDT1\"}"
+                ],
+                [
+                    new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1", Target = "" },
+                    "{\"code\":\"OEDC1\",\"message\":\"OEDM1\",\"target\":\"\"}"
+                ]
+            ];
+        }
+
+        [Theory]
+        [MemberData(nameof(GetODataErrorDetailTestData))]
+        public void TestODataErrorDetailToJsonString(ODataErrorDetail odataErrorDetail, string expectedJsonString)
+        {
+            // Arrange & Act
+            var jsonString = odataErrorDetail.ToJsonString();
+
+            // Assert
+            Assert.Equal(expectedJsonString, jsonString);
+        }
+
+        [Fact]
+        public void TestODataInnerErrorToJsonStringForUnsupportedODataValues()
+        {
+            var jsonInputString = "{\"foo\":\"bar\"}";
+
+            using (var jsonDocument = JsonDocument.Parse(jsonInputString))
+            {
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new BinaryWriter(stream))
+                    {
+                        writer.Write("1234567890");
+                        writer.Flush();
+                        stream.Position = 0;
+
+                        // Arrange
+                        var odataInnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { "p1", new ODataEnumValue("Black") },
+                                { "p2", new ODataUntypedValue { RawValue = "\"roygbiv\"" } },
+                                { "p3", new ODataBinaryStreamValue(stream, leaveOpen: false) },
+                                { "p4", new ODataStreamReferenceValue() },
+                                { "p5", new ODataJsonElementValue(jsonDocument.RootElement) }
+                            });
+
+                        // Act
+                        var jsonString = odataInnerError.ToJsonString();
+
+                        // Assert
+                        Assert.Equal(
+                            "{" +
+                            "\"p1\":\"The value of type 'Microsoft.OData.ODataEnumValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"p2\":\"The value of type 'Microsoft.OData.ODataUntypedValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"p3\":\"The value of type 'Microsoft.OData.ODataBinaryStreamValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"p4\":\"The value of type 'Microsoft.OData.ODataStreamReferenceValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"p5\":\"The value of type 'Microsoft.OData.ODataJsonElementValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"message\":\"\"," +
+                            "\"type\":\"\"," +
+                            "\"stacktrace\":\"\"}",
+                            jsonString);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void TestODataInnerErrorToJsonStringForUnsupportedODataPrimitiveValues()
+        {
+            // Arrange
+            var odataInnerError = new ODataInnerError(
+                new Dictionary<string, ODataValue>
+                {
+                    { "p1", new ODataPrimitiveValue(GeographyPoint.Create(22.2, 22.2)) },
+                })
+            {
+                Message = "OIEM1",
+                TypeName = "OIET1",
+                StackTrace = "OIES1"
+            };
+
+            // Act
+            var jsonString = odataInnerError.ToJsonString();
+
+            // Assert
+            Assert.Equal(
+                "{" +
+                "\"p1\":\"The value of type 'Microsoft.Spatial.GeographyPointImplementation' is not supported and cannot be converted to a JSON representation.\"," +
+                "\"message\":\"OIEM1\"," +
+                "\"type\":\"OIET1\"," +
+                "\"stacktrace\":\"OIES1\"}",
+                jsonString);
+        }
+
+        [Fact]
+        public void TestODataInnerErrorToJsonStringForUnsupportedODataValuesInODataResourceValue()
+        {
+            var jsonInputString = "{\"foo\":\"bar\"}";
+
+            using (var jsonDocument = JsonDocument.Parse(jsonInputString))
+            {
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new BinaryWriter(stream))
+                    {
+                        writer.Write("1234567890");
+                        writer.Flush();
+                        stream.Position = 0;
+
+                        // Arrange
+                        var odataInnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                {
+                                    "p1",
+                                    new ODataResourceValue
+                                    {
+                                        Properties = new List<ODataProperty>
+                                        {
+                                            new ODataProperty { Name = "prop1", Value = new ODataEnumValue("Black") },
+                                            new ODataProperty { Name = "prop2", Value = new ODataUntypedValue { RawValue = "\"roygbiv\"" } },
+                                            new ODataProperty { Name = "prop3", Value = new ODataBinaryStreamValue(stream, leaveOpen: false) },
+                                            new ODataProperty { Name = "prop4", Value = new ODataStreamReferenceValue() },
+                                            new ODataProperty { Name = "prop5", Value = new ODataJsonElementValue(jsonDocument.RootElement) },
+                                        }
+                                    }
+                                }
+                            });
+
+                        // Act
+                        var jsonString = odataInnerError.ToJsonString();
+
+                        // Assert
+                        Assert.Equal(
+                            "{" +
+                            "\"p1\":{" +
+                            "\"prop1\":\"The value of type 'Microsoft.OData.ODataEnumValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"prop2\":\"The value of type 'Microsoft.OData.ODataUntypedValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"prop3\":\"The value of type 'Microsoft.OData.ODataBinaryStreamValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"prop4\":\"The value of type 'Microsoft.OData.ODataStreamReferenceValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"prop5\":\"The value of type 'Microsoft.OData.ODataJsonElementValue' is not supported and cannot be converted to a JSON representation.\"}," +
+                            "\"message\":\"\"," +
+                            "\"type\":\"\"," +
+                            "\"stacktrace\":\"\"}",
+                            jsonString);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void TestODataInnerErrorToJsonStringForUnsupportedODataValuesInODataCollectionValue()
+        {
+            var jsonInputString = "{\"foo\":\"bar\"}";
+
+            using (var jsonDocument = JsonDocument.Parse(jsonInputString))
+            {
+                using (var stream = new MemoryStream())
+                {
+                    using (var writer = new BinaryWriter(stream))
+                    {
+                        writer.Write("1234567890");
+                        writer.Flush();
+                        stream.Position = 0;
+
+                        // Arrange
+                        var odataInnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                {
+                                    "p1",
+                                    new ODataCollectionValue
+                                    {
+                                        Items = new Collection<object>
+                                        {
+                                            new ODataEnumValue("Black"),
+                                            new ODataUntypedValue { RawValue = "\"roygbiv\"" },
+                                            new ODataBinaryStreamValue(stream, leaveOpen: false),
+                                            new ODataStreamReferenceValue(),
+                                            new ODataJsonElementValue(jsonDocument.RootElement),
+                                            130M,
+                                            new object()
+                                        }
+                                    }
+                                }
+                            });
+
+                        // Act
+                        var jsonString = odataInnerError.ToJsonString();
+
+                        // Assert
+                        Assert.Equal(
+                            "{" +
+                            "\"p1\":[" +
+                            "\"The value of type 'Microsoft.OData.ODataEnumValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"The value of type 'Microsoft.OData.ODataUntypedValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"The value of type 'Microsoft.OData.ODataBinaryStreamValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"The value of type 'Microsoft.OData.ODataStreamReferenceValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"The value of type 'Microsoft.OData.ODataJsonElementValue' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"The value of type 'System.Decimal' is not supported and cannot be converted to a JSON representation.\"," +
+                            "\"The value of type 'System.Object' is not supported and cannot be converted to a JSON representation.\"]," +
+                            "\"message\":\"\"," +
+                            "\"type\":\"\"," +
+                            "\"stacktrace\":\"\"}",
+                            jsonString);
+                    }
+                }
+            }
+        }
+
+        public static IEnumerable<object[]> GetODataErrorTestData()
+        {
+            return
+            [
+                [
+                    new ODataError(),
+                    "{\"error\":{\"code\":\"\",\"message\":\"\"}}"
+                ],
+                [
+                    new ODataError { Code = "OEC1" },
+                    "{\"error\":{\"code\":\"OEC1\",\"message\":\"\"}}"
+                ],
+                [
+                    new ODataError { Message = "OEM1" },
+                    "{\"error\":{\"code\":\"\",\"message\":\"OEM1\"}}"
+                ],
+                [
+                    new ODataError { Code = "OEC1", Message = "OEM1" },
+                    "{\"error\":{\"code\":\"OEC1\",\"message\":\"OEM1\"}}"
+                ],
+                [
+                    new ODataError { Code = "OEC1", Message = "OEM1", Target = "OET1" },
+                    "{\"error\":{\"code\":\"OEC1\",\"message\":\"OEM1\",\"target\":\"OET1\"}}"
+                ],
+                [
+                    new ODataError { Code = "OEC1", Message = "OEM1", Target = "" },
+                    "{\"error\":{\"code\":\"OEC1\",\"message\":\"OEM1\",\"target\":\"\"}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError()
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError { Message = "OIEM1" }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{\"message\":\"OIEM1\",\"type\":\"\",\"stacktrace\":\"\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError { TypeName = "OIET1" }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{\"message\":\"\",\"type\":\"OIET1\",\"stacktrace\":\"\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError { StackTrace = "OIES1" }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"OIES1\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError { Message = "OIEM1", TypeName = "OIET1" }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError { Message = "OIEM1", StackTrace = "OIES1" }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{\"message\":\"OIEM1\",\"type\":\"\",\"stacktrace\":\"OIES1\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError { TypeName = "OIET1", StackTrace = "OIES1" }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{\"message\":\"\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError
+                        {
+                            Message = "OIEM1",
+                            TypeName = "OIET1",
+                            StackTrace = "OIES1"
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { "p1", new ODataPrimitiveValue(1) },
+                                { "p2", new ODataPrimitiveValue("SP") }
+                            })
+                        {
+                            Message = "OIEM1",
+                            TypeName = "OIET1",
+                            StackTrace = "OIES1"
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{\"p1\":1,\"p2\":\"SP\",\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError
+                        {
+                            Message = "OIEM1",
+                            TypeName = "OIET1",
+                            StackTrace = "OIES1",
+                            InnerError = new ODataInnerError { Message = "OIEM2", TypeName = "OIET2", StackTrace = "OIES2" }
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{" +
+                    "\"message\":\"OIEM1\"," +
+                    "\"type\":\"OIET1\"," +
+                    "\"stacktrace\":\"OIES1\"," +
+                    "\"innererror\":{\"message\":\"OIEM2\",\"type\":\"OIET2\",\"stacktrace\":\"OIES2\"}}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError
+                        {
+                            Message = "OIEM1",
+                            TypeName = "OIET1",
+                            StackTrace = "OIES1",
+                            InnerError = new ODataInnerError
+                            {
+                                Message = "OIEM2",
+                                TypeName = "OIET2",
+                                StackTrace = "OIES2",
+                                InnerError = new ODataInnerError { Message = "OIEM3", TypeName = "OIET3", StackTrace = "OIES3" }
+                            }
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{" +
+                    "\"message\":\"OIEM1\"," +
+                    "\"type\":\"OIET1\"," +
+                    "\"stacktrace\":\"OIES1\"," +
+                    "\"innererror\":{" +
+                    "\"message\":\"OIEM2\"," +
+                    "\"type\":\"OIET2\"," +
+                    "\"stacktrace\":\"OIES2\"," +
+                    "\"innererror\":{\"message\":\"OIEM3\",\"type\":\"OIET3\",\"stacktrace\":\"OIES3\"}}}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { "p1", new ODataPrimitiveValue(1) },
+                                { "p2", new ODataPrimitiveValue("SP") }
+                            })
+                        {
+                            Message = "OIEM1",
+                            TypeName = "OIET1",
+                            StackTrace = "OIES1",
+                            InnerError = new ODataInnerError { Message = "OIEM2", TypeName = "OIET2", StackTrace = "OIES2" }
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{" +
+                    "\"p1\":1," +
+                    "\"p2\":\"SP\"," +
+                    "\"message\":\"OIEM1\"," +
+                    "\"type\":\"OIET1\"," +
+                    "\"stacktrace\":\"OIES1\"," +
+                    "\"innererror\":{\"message\":\"OIEM2\",\"type\":\"OIET2\",\"stacktrace\":\"OIES2\"}}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        Details = new Collection<ODataErrorDetail>()
+                    },
+                    "{\"error\":{\"code\":\"OEC1\",\"message\":\"OEM1\",\"target\":\"OET1\",\"details\":[]}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        Details = new Collection<ODataErrorDetail> { null }
+                    },
+                    "{\"error\":{\"code\":\"OEC1\",\"message\":\"OEM1\",\"target\":\"OET1\",\"details\":[]}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        Details = new Collection<ODataErrorDetail>
+                        {
+                            new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1", Target = "OEDT1" }
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"details\":[{\"code\":\"OEDC1\",\"message\":\"OEDM1\",\"target\":\"OEDT1\"}]}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        Details = new Collection<ODataErrorDetail>
+                        {
+                            new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1", Target = "OEDT1" },
+                            new ODataErrorDetail { Code = "OEDC2", Message = "OEDM2", Target = "OEDT2" }
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"details\":[" +
+                    "{\"code\":\"OEDC1\",\"message\":\"OEDM1\",\"target\":\"OEDT1\"}," +
+                    "{\"code\":\"OEDC2\",\"message\":\"OEDM2\",\"target\":\"OEDT2\"}]}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError
+                        {
+                            Message = "OIEM1",
+                            TypeName = "OIET1",
+                            StackTrace = "OIES1"
+                        },
+                        Details = new Collection<ODataErrorDetail>
+                        {
+                            new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1", Target = "OEDT1" }
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"details\":[{\"code\":\"OEDC1\",\"message\":\"OEDM1\",\"target\":\"OEDT1\"}]," +
+                    "\"innererror\":{\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { "p1", new ODataPrimitiveValue(1) },
+                                { "p2", new ODataPrimitiveValue("SP") }
+                            })
+                        {
+                            Message = "OIEM1",
+                            TypeName = "OIET1",
+                            StackTrace = "OIES1",
+                            InnerError = new ODataInnerError(
+                                new Dictionary<string, ODataValue>
+                                {
+                                    { "p3", new ODataPrimitiveValue(13M) },
+                                    { "p4", new ODataPrimitiveValue(new DateTimeOffset(2024, 5, 2, 13, 27, 30, TimeSpan.Zero)) }
+                                })
+                            {
+                                Message = "OIEM2",
+                                TypeName = "OIET2",
+                                StackTrace = "OIES2",
+                            }
+                        },
+                        Details = new Collection<ODataErrorDetail>
+                        {
+                            new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1", Target = "OEDT1" }
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"details\":[{\"code\":\"OEDC1\",\"message\":\"OEDM1\",\"target\":\"OEDT1\"}]," +
+                    "\"innererror\":{" +
+                    "\"p1\":1," +
+                    "\"p2\":\"SP\"," +
+                    "\"message\":\"OIEM1\"," +
+                    "\"type\":\"OIET1\"," +
+                    "\"stacktrace\":\"OIES1\"," +
+                    "\"innererror\":{" +
+                    "\"p3\":13," +
+                    "\"p4\":\"2024-05-02T13:27:30Z\"," +
+                    "\"message\":\"OIEM2\"," +
+                    "\"type\":\"OIET2\"," +
+                    "\"stacktrace\":\"OIES2\"}}}}"
+                ],
+                [
+                    new ODataError
+                    {
+                        Code = "OEC1",
+                        Message = "OEM1",
+                        Target = "OET1",
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { "p1", null },
+                                { "p2", new ODataNullValue() },
+                                { "p3", new ODataPrimitiveValue(true) },
+                                { "p4", new ODataPrimitiveValue((byte)10) },
+                                { "p5", new ODataPrimitiveValue(130M) },
+                                { "p6", new ODataPrimitiveValue(3.14159265359d) },
+                                { "p7", new ODataPrimitiveValue((short)7) },
+                                { "p8", new ODataPrimitiveValue(13) },
+                                { "p9", new ODataPrimitiveValue(299792458L) },
+                                { "p10", new ODataPrimitiveValue((sbyte)-10) },
+                                { "p11", new ODataPrimitiveValue(3.142f) },
+                                { "p12", new ODataPrimitiveValue("foobar") },
+                                { "p13", new ODataPrimitiveValue(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 }) },
+                                { "p14", new ODataPrimitiveValue(new DateTimeOffset(2024, 5, 2, 13, 27, 30, TimeSpan.Zero)) },
+                                { "p15", new ODataPrimitiveValue(Guid.Parse("6693ceb2-5d47-45c7-b928-900ebdebe898")) },
+                                { "p16", new ODataPrimitiveValue(new TimeSpan(1, 12, 0)) },
+                                { "p17", new ODataPrimitiveValue(new Date(2024, 5, 2)) },
+                                { "p18", new ODataPrimitiveValue(new TimeOfDay(12, 42, 30, 100)) },
+                                { "p19", new ODataResourceValue
+                                    {
+                                        Properties = new List<ODataProperty>
+                                        {
+                                            new ODataProperty
+                                            {
+                                                Name = "DateOfBirth",
+                                                Value = new ODataPrimitiveValue(new DateTimeOffset(1980, 12, 13, 11, 1, 1, TimeSpan.Zero))
+                                            }
+                                        }
+                                    }
+                                },
+                                { "p20", new ODataCollectionValue
+                                    {
+                                        Items = new List<ODataPrimitiveValue>
+                                        {
+                                            new ODataPrimitiveValue(new DateTimeOffset(1990, 7, 17, 23, 59, 59, TimeSpan.Zero))
+                                        }
+                                    }
+                                },
+                                {
+                                    "p21", new ODataPrimitiveValue("foo\tbar")
+                                },
+                                {
+                                    "p22", new ODataPrimitiveValue("cA_Россия\r\n")
+                                },
+                                {
+                                    "p23", new ODataPrimitiveValue("Быстрая коричневая лиса прыгает через ленивую собаку")
+                                },
+                                {
+                                    "p24", new ODataPrimitiveValue("roygbiv\\\uD800\udc05 \u00e4")
+                                },
+                                {
+                                    "p25", new ODataPrimitiveValue("ボァゼあクゾ\"")
+                                },
+                                {
+                                    "p26", new ODataPrimitiveValue("😊😊😊")
+                                },
+                                { "p27", new ODataPrimitiveValue((DateTimeOffset?)new DateTimeOffset(2024, 5, 2, 13, 27, 30, TimeSpan.Zero)) },
+                                { "p28", new ODataPrimitiveValue((Guid?)Guid.Parse("6693ceb2-5d47-45c7-b928-900ebdebe898")) },
+                                { "p29", new ODataPrimitiveValue((TimeSpan?)new TimeSpan(1, 12, 0)) },
+                                { "p30", new ODataPrimitiveValue((Date?)new Date(2024, 5, 2)) },
+                                { "p31", new ODataPrimitiveValue((TimeOfDay?)new TimeOfDay(12, 42, 30, 100)) }
+                            })
+                        {
+                            Message = "OIEM1",
+                            TypeName = "OIET1",
+                            StackTrace = "OIES1"
+                        }
+                    },
+                    "{\"error\":{" +
+                    "\"code\":\"OEC1\"," +
+                    "\"message\":\"OEM1\"," +
+                    "\"target\":\"OET1\"," +
+                    "\"innererror\":{" +
+                    "\"p1\":null," +
+                    "\"p2\":null," +
+                    "\"p3\":true," +
+                    "\"p4\":10," +
+                    "\"p5\":130," +
+                    "\"p6\":3.14159265359," +
+                    "\"p7\":7," +
+                    "\"p8\":13," +
+                    "\"p9\":299792458," +
+                    "\"p10\":-10," +
+                    "\"p11\":3.142," +
+                    "\"p12\":\"foobar\"," +
+                    "\"p13\":\"AQIDBAUGBwgJAA==\"," +
+                    "\"p14\":\"2024-05-02T13:27:30Z\"," +
+                    "\"p15\":\"6693ceb2-5d47-45c7-b928-900ebdebe898\"," +
+                    "\"p16\":\"PT1H12M\"," +
+                    "\"p17\":\"2024-05-02\"," +
+                    "\"p18\":\"12:42:30.1000000\"," +
+                    "\"p19\":{\"DateOfBirth\":\"1980-12-13T11:01:01Z\"}," +
+                    "\"p20\":[\"1990-07-17T23:59:59Z\"]," +
+                    "\"p21\":\"foo\\tbar\"," +
+                    "\"p22\":\"cA_\\u0420\\u043e\\u0441\\u0441\\u0438\\u044f\\r\\n\"," +
+                    "\"p23\":\"\\u0411\\u044b\\u0441\\u0442\\u0440\\u0430\\u044f \\u043a\\u043e\\u0440\\u0438\\u0447\\u043d\\u0435\\u0432\\u0430\\u044f \\u043b\\u0438\\u0441\\u0430 \\u043f\\u0440\\u044b\\u0433\\u0430\\u0435\\u0442 \\u0447\\u0435\\u0440\\u0435\\u0437 \\u043b\\u0435\\u043d\\u0438\\u0432\\u0443\\u044e \\u0441\\u043e\\u0431\\u0430\\u043a\\u0443\"," +
+                    "\"p24\":\"roygbiv\\\\\\ud800\\udc05 \\u00e4\"," +
+                    "\"p25\":\"\\u30dc\\u30a1\\u30bc\\u3042\\u30af\\u30be\\\"\"," +
+                    "\"p26\":\"\\ud83d\\ude0a\\ud83d\\ude0a\\ud83d\\ude0a\"," +
+                    "\"p27\":\"2024-05-02T13:27:30Z\"," +
+                    "\"p28\":\"6693ceb2-5d47-45c7-b928-900ebdebe898\"," +
+                    "\"p29\":\"PT1H12M\"," +
+                    "\"p30\":\"2024-05-02\"," +
+                    "\"p31\":\"12:42:30.1000000\"," +
+                    "\"message\":\"OIEM1\"," +
+                    "\"type\":\"OIET1\"," +
+                    "\"stacktrace\":\"OIES1\"}}}"
+                ]
+            ];
+        }
+
+        [Theory]
+        [MemberData(nameof(GetODataErrorTestData))]
+        public void TestODataErrorToString(ODataError odataError, string expectedJsonString)
+        {
+            // Arrange
+            var stringWriter = new StringWriter();
+            var jsonWriter = new JsonWriter(stringWriter, isIeee754Compatible: false);
+
+            // Act
+            var jsonString = odataError.ToString();
+            ODataJsonWriterUtils.WriteError(
+                jsonWriter,
+                enumerable => { },
+                odataError,
+                includeDebugInformation: true,
+                new ODataMessageWriterSettings { MessageQuotas = new ODataMessageQuotas { MaxNestingDepth = 3 } });
+
+            // Assert
+            Assert.Equal(expectedJsonString, stringWriter.ToString());
+            Assert.Equal(expectedJsonString, jsonString);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetODataErrorTestData))]
+        public async Task TestODataErrorToStringAsync(ODataError odataError, string expectedJsonString)
+        {
+            // Arrange
+            var stringWriter = new StringWriter();
+            var jsonWriter = new JsonWriter(stringWriter, isIeee754Compatible: false);
+
+            // Act
+            var jsonString = odataError.ToString();
+            await ODataJsonWriterUtils.WriteErrorAsync(
+                jsonWriter,
+                enumerable => { return Task.CompletedTask; },
+                odataError,
+                includeDebugInformation: true,
+                new ODataMessageWriterSettings { MessageQuotas = new ODataMessageQuotas { MaxNestingDepth = 3 } });
+
+            // Assert
+            Assert.Equal(expectedJsonString, stringWriter.ToString());
+            Assert.Equal(expectedJsonString, jsonString);
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataErrorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataErrorTests.cs
@@ -4,15 +4,15 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using Microsoft.OData.Edm;
-using Microsoft.OData.Json;
-using Microsoft.Spatial;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.OData.Edm;
+using Microsoft.OData.Json;
+using Microsoft.Spatial;
 using Xunit;
 
 namespace Microsoft.OData.Tests
@@ -79,34 +79,60 @@ namespace Microsoft.OData.Tests
             [
                 [
                     new ODataInnerError(),
-                    "{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"\"}"
+                    "{}"
                 ],
                 [
-                    new ODataInnerError { Message = "OIEM1" },
-                    "{\"message\":\"OIEM1\",\"type\":\"\",\"stacktrace\":\"\"}"
+                    new ODataInnerError(new Dictionary<string, ODataValue>
+                    {
+                        { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") }
+                    }),
+                    "{\"message\":\"OIEM1\"}"
                 ],
                 [
-                    new ODataInnerError { TypeName = "OIET1" },
-                    "{\"message\":\"\",\"type\":\"OIET1\",\"stacktrace\":\"\"}"
+                    new ODataInnerError(new Dictionary<string, ODataValue>
+                    {
+                        { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") }
+                    }),
+                    "{\"type\":\"OIET1\"}"
                 ],
                 [
-                    new ODataInnerError { StackTrace = "OIES1" },
-                    "{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"OIES1\"}"
+                    new ODataInnerError(new Dictionary<string, ODataValue>
+                    {
+                        { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                    }),
+                    "{\"stacktrace\":\"OIES1\"}"
                 ],
                 [
-                    new ODataInnerError { Message = "OIEM1", TypeName = "OIET1" },
-                    "{\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"\"}"
+                    new ODataInnerError(new Dictionary<string, ODataValue>
+                    {
+                        { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                        { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") }
+                    }),
+                    "{\"message\":\"OIEM1\",\"type\":\"OIET1\"}"
                 ],
                 [
-                    new ODataInnerError { Message = "OIEM1", StackTrace = "OIES1" },
-                    "{\"message\":\"OIEM1\",\"type\":\"\",\"stacktrace\":\"OIES1\"}"
+                    new ODataInnerError(new Dictionary<string, ODataValue>
+                    {
+                        { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                        { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                    }),
+                    "{\"message\":\"OIEM1\",\"stacktrace\":\"OIES1\"}"
                 ],
                 [
-                    new ODataInnerError { TypeName = "OIET1", StackTrace = "OIES1" },
-                    "{\"message\":\"\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}"
+                    new ODataInnerError(new Dictionary<string, ODataValue>
+                    {
+                        { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                        { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                    }),
+                    "{\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}"
                 ],
                 [
-                    new ODataInnerError { Message = "OIEM1", TypeName = "OIET1", StackTrace = "OIES1" },
+                    new ODataInnerError(new Dictionary<string, ODataValue>
+                    {
+                        { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                        { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                        { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                    }),
                     "{\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}"
                 ],
                 [
@@ -115,34 +141,30 @@ namespace Microsoft.OData.Tests
                         {
                             { "p1", new ODataPrimitiveValue(1) },
                             { "p2", new ODataPrimitiveValue("SP") }
-                        })
-                    {
-                        Message = "OIEM1",
-                        TypeName = "OIET1",
-                        StackTrace = "OIES1"
-                    },
-                    "{\"p1\":1,\"p2\":\"SP\",\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}"
+                        }),
+                    "{\"p1\":1,\"p2\":\"SP\"}"
                 ],
                 [
                     new ODataInnerError
                     {
-                        Message = "OIEM1",
-                        TypeName = "OIET1",
-                        StackTrace = "OIES1",
                         InnerError = new ODataInnerError()
                     },
-                    "{\"message\":\"OIEM1\"," +
-                    "\"type\":\"OIET1\"," +
-                    "\"stacktrace\":\"OIES1\"," +
-                    "\"innererror\":{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"\"}}"
+                    "{\"innererror\":{}}"
                 ],
                 [
-                    new ODataInnerError
+                    new ODataInnerError(new Dictionary<string, ODataValue>
                     {
-                        Message = "OIEM1",
-                        TypeName = "OIET1",
-                        StackTrace = "OIES1",
-                        InnerError = new ODataInnerError { Message = "OIEM2", TypeName = "OIET2", StackTrace = "OIES2" }
+                        { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                        { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                        { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                    })
+                    {
+                        InnerError = new ODataInnerError(new Dictionary<string, ODataValue>
+                        {
+                            { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM2") },
+                            { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET2") },
+                            { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES2") }
+                        })
                     },
                     "{\"message\":\"OIEM1\"," +
                     "\"type\":\"OIET1\"," +
@@ -154,13 +176,18 @@ namespace Microsoft.OData.Tests
                         new Dictionary<string, ODataValue>
                         {
                             { "p1", new ODataPrimitiveValue(1) },
-                            { "p2", new ODataPrimitiveValue("SP") }
+                            { "p2", new ODataPrimitiveValue("SP") },
+                            { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                            { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                            { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
                         })
                     {
-                        Message = "OIEM1",
-                        TypeName = "OIET1",
-                        StackTrace = "OIES1",
-                        InnerError = new ODataInnerError { Message = "OIEM2", TypeName = "OIET2", StackTrace = "OIES2" }
+                        InnerError = new ODataInnerError(new Dictionary<string, ODataValue>
+                        {
+                            { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM2") },
+                            { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET2") },
+                            { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES2") }
+                        })
                     },
                     "{\"p1\":1," +
                     "\"p2\":\"SP\"," +
@@ -170,17 +197,26 @@ namespace Microsoft.OData.Tests
                     "\"innererror\":{\"message\":\"OIEM2\",\"type\":\"OIET2\",\"stacktrace\":\"OIES2\"}}"
                 ],
                 [
-                    new ODataInnerError
+                    new ODataInnerError(new Dictionary<string, ODataValue>
                     {
-                        Message = "OIEM1",
-                        TypeName = "OIET1",
-                        StackTrace = "OIES1",
-                        InnerError = new ODataInnerError
+                        { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                        { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                        { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                    })
+                    {
+                        InnerError = new ODataInnerError(new Dictionary<string, ODataValue>
                         {
-                            Message = "OIEM2",
-                            TypeName = "OIET2",
-                            StackTrace = "OIES2",
-                            InnerError = new ODataInnerError { Message = "OIEM3", TypeName = "OIET3", StackTrace = "OIES3" }
+                            { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM2") },
+                            { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET2") },
+                            { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES2") }
+                        })
+                        {
+                            InnerError = new ODataInnerError(new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM3") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET3") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES3") }
+                            })
                         }
                     },
                     "{\"message\":\"OIEM1\"," +
@@ -276,10 +312,7 @@ namespace Microsoft.OData.Tests
                             "\"p2\":\"The value of type 'Microsoft.OData.ODataUntypedValue' is not supported and cannot be converted to a JSON representation.\"," +
                             "\"p3\":\"The value of type 'Microsoft.OData.ODataBinaryStreamValue' is not supported and cannot be converted to a JSON representation.\"," +
                             "\"p4\":\"The value of type 'Microsoft.OData.ODataStreamReferenceValue' is not supported and cannot be converted to a JSON representation.\"," +
-                            "\"p5\":\"The value of type 'Microsoft.OData.ODataJsonElementValue' is not supported and cannot be converted to a JSON representation.\"," +
-                            "\"message\":\"\"," +
-                            "\"type\":\"\"," +
-                            "\"stacktrace\":\"\"}",
+                            "\"p5\":\"The value of type 'Microsoft.OData.ODataJsonElementValue' is not supported and cannot be converted to a JSON representation.\"}",
                             jsonString);
                     }
                 }
@@ -294,23 +327,14 @@ namespace Microsoft.OData.Tests
                 new Dictionary<string, ODataValue>
                 {
                     { "p1", new ODataPrimitiveValue(GeographyPoint.Create(22.2, 22.2)) },
-                })
-            {
-                Message = "OIEM1",
-                TypeName = "OIET1",
-                StackTrace = "OIES1"
-            };
+                });
 
             // Act
             var jsonString = odataInnerError.ToJsonString();
 
             // Assert
             Assert.Equal(
-                "{" +
-                "\"p1\":\"The value of type 'Microsoft.Spatial.GeographyPointImplementation' is not supported and cannot be converted to a JSON representation.\"," +
-                "\"message\":\"OIEM1\"," +
-                "\"type\":\"OIET1\"," +
-                "\"stacktrace\":\"OIES1\"}",
+                "{\"p1\":\"The value of type 'Microsoft.Spatial.GeographyPointImplementation' is not supported and cannot be converted to a JSON representation.\"}",
                 jsonString);
         }
 
@@ -360,10 +384,7 @@ namespace Microsoft.OData.Tests
                             "\"prop2\":\"The value of type 'Microsoft.OData.ODataUntypedValue' is not supported and cannot be converted to a JSON representation.\"," +
                             "\"prop3\":\"The value of type 'Microsoft.OData.ODataBinaryStreamValue' is not supported and cannot be converted to a JSON representation.\"," +
                             "\"prop4\":\"The value of type 'Microsoft.OData.ODataStreamReferenceValue' is not supported and cannot be converted to a JSON representation.\"," +
-                            "\"prop5\":\"The value of type 'Microsoft.OData.ODataJsonElementValue' is not supported and cannot be converted to a JSON representation.\"}," +
-                            "\"message\":\"\"," +
-                            "\"type\":\"\"," +
-                            "\"stacktrace\":\"\"}",
+                            "\"prop5\":\"The value of type 'Microsoft.OData.ODataJsonElementValue' is not supported and cannot be converted to a JSON representation.\"}}",
                             jsonString);
                     }
                 }
@@ -420,10 +441,7 @@ namespace Microsoft.OData.Tests
                             "\"The value of type 'Microsoft.OData.ODataStreamReferenceValue' is not supported and cannot be converted to a JSON representation.\"," +
                             "\"The value of type 'Microsoft.OData.ODataJsonElementValue' is not supported and cannot be converted to a JSON representation.\"," +
                             "\"The value of type 'System.Decimal' is not supported and cannot be converted to a JSON representation.\"," +
-                            "\"The value of type 'System.Object' is not supported and cannot be converted to a JSON representation.\"]," +
-                            "\"message\":\"\"," +
-                            "\"type\":\"\"," +
-                            "\"stacktrace\":\"\"}",
+                            "\"The value of type 'System.Object' is not supported and cannot be converted to a JSON representation.\"]}",
                             jsonString);
                     }
                 }
@@ -470,7 +488,7 @@ namespace Microsoft.OData.Tests
                     "\"code\":\"OEC1\"," +
                     "\"message\":\"OEM1\"," +
                     "\"target\":\"OET1\"," +
-                    "\"innererror\":{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"\"}}}"
+                    "\"innererror\":{}}}"
                 ],
                 [
                     new ODataError
@@ -478,13 +496,17 @@ namespace Microsoft.OData.Tests
                         Code = "OEC1",
                         Message = "OEM1",
                         Target = "OET1",
-                        InnerError = new ODataInnerError { Message = "OIEM1" }
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") }
+                            })
                     },
                     "{\"error\":{" +
                     "\"code\":\"OEC1\"," +
                     "\"message\":\"OEM1\"," +
                     "\"target\":\"OET1\"," +
-                    "\"innererror\":{\"message\":\"OIEM1\",\"type\":\"\",\"stacktrace\":\"\"}}}"
+                    "\"innererror\":{\"message\":\"OIEM1\"}}}"
                 ],
                 [
                     new ODataError
@@ -492,13 +514,17 @@ namespace Microsoft.OData.Tests
                         Code = "OEC1",
                         Message = "OEM1",
                         Target = "OET1",
-                        InnerError = new ODataInnerError { TypeName = "OIET1" }
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") }
+                            })
                     },
                     "{\"error\":{" +
                     "\"code\":\"OEC1\"," +
                     "\"message\":\"OEM1\"," +
                     "\"target\":\"OET1\"," +
-                    "\"innererror\":{\"message\":\"\",\"type\":\"OIET1\",\"stacktrace\":\"\"}}}"
+                    "\"innererror\":{\"type\":\"OIET1\"}}}"
                 ],
                 [
                     new ODataError
@@ -506,13 +532,17 @@ namespace Microsoft.OData.Tests
                         Code = "OEC1",
                         Message = "OEM1",
                         Target = "OET1",
-                        InnerError = new ODataInnerError { StackTrace = "OIES1" }
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                            })
                     },
                     "{\"error\":{" +
                     "\"code\":\"OEC1\"," +
                     "\"message\":\"OEM1\"," +
                     "\"target\":\"OET1\"," +
-                    "\"innererror\":{\"message\":\"\",\"type\":\"\",\"stacktrace\":\"OIES1\"}}}"
+                    "\"innererror\":{\"stacktrace\":\"OIES1\"}}}"
                 ],
                 [
                     new ODataError
@@ -520,13 +550,18 @@ namespace Microsoft.OData.Tests
                         Code = "OEC1",
                         Message = "OEM1",
                         Target = "OET1",
-                        InnerError = new ODataInnerError { Message = "OIEM1", TypeName = "OIET1" }
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") }
+                            })
                     },
                     "{\"error\":{" +
                     "\"code\":\"OEC1\"," +
                     "\"message\":\"OEM1\"," +
                     "\"target\":\"OET1\"," +
-                    "\"innererror\":{\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"\"}}}"
+                    "\"innererror\":{\"message\":\"OIEM1\",\"type\":\"OIET1\"}}}"
                 ],
                 [
                     new ODataError
@@ -534,13 +569,18 @@ namespace Microsoft.OData.Tests
                         Code = "OEC1",
                         Message = "OEM1",
                         Target = "OET1",
-                        InnerError = new ODataInnerError { Message = "OIEM1", StackTrace = "OIES1" }
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                            })
                     },
                     "{\"error\":{" +
                     "\"code\":\"OEC1\"," +
                     "\"message\":\"OEM1\"," +
                     "\"target\":\"OET1\"," +
-                    "\"innererror\":{\"message\":\"OIEM1\",\"type\":\"\",\"stacktrace\":\"OIES1\"}}}"
+                    "\"innererror\":{\"message\":\"OIEM1\",\"stacktrace\":\"OIES1\"}}}"
                 ],
                 [
                     new ODataError
@@ -548,13 +588,18 @@ namespace Microsoft.OData.Tests
                         Code = "OEC1",
                         Message = "OEM1",
                         Target = "OET1",
-                        InnerError = new ODataInnerError { TypeName = "OIET1", StackTrace = "OIES1" }
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                            })
                     },
                     "{\"error\":{" +
                     "\"code\":\"OEC1\"," +
                     "\"message\":\"OEM1\"," +
                     "\"target\":\"OET1\"," +
-                    "\"innererror\":{\"message\":\"\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}}}"
+                    "\"innererror\":{\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}}}"
                 ],
                 [
                     new ODataError
@@ -562,12 +607,13 @@ namespace Microsoft.OData.Tests
                         Code = "OEC1",
                         Message = "OEM1",
                         Target = "OET1",
-                        InnerError = new ODataInnerError
-                        {
-                            Message = "OIEM1",
-                            TypeName = "OIET1",
-                            StackTrace = "OIES1"
-                        }
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                            })
                     },
                     "{\"error\":{" +
                     "\"code\":\"OEC1\"," +
@@ -584,33 +630,18 @@ namespace Microsoft.OData.Tests
                         InnerError = new ODataInnerError(
                             new Dictionary<string, ODataValue>
                             {
-                                { "p1", new ODataPrimitiveValue(1) },
-                                { "p2", new ODataPrimitiveValue("SP") }
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
                             })
                         {
-                            Message = "OIEM1",
-                            TypeName = "OIET1",
-                            StackTrace = "OIES1"
-                        }
-                    },
-                    "{\"error\":{" +
-                    "\"code\":\"OEC1\"," +
-                    "\"message\":\"OEM1\"," +
-                    "\"target\":\"OET1\"," +
-                    "\"innererror\":{\"p1\":1,\"p2\":\"SP\",\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}}}"
-                ],
-                [
-                    new ODataError
-                    {
-                        Code = "OEC1",
-                        Message = "OEM1",
-                        Target = "OET1",
-                        InnerError = new ODataInnerError
-                        {
-                            Message = "OIEM1",
-                            TypeName = "OIET1",
-                            StackTrace = "OIES1",
-                            InnerError = new ODataInnerError { Message = "OIEM2", TypeName = "OIET2", StackTrace = "OIES2" }
+                            InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM2") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET2") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES2") }
+                            })
                         }
                     },
                     "{\"error\":{" +
@@ -629,17 +660,30 @@ namespace Microsoft.OData.Tests
                         Code = "OEC1",
                         Message = "OEM1",
                         Target = "OET1",
-                        InnerError = new ODataInnerError
-                        {
-                            Message = "OIEM1",
-                            TypeName = "OIET1",
-                            StackTrace = "OIES1",
-                            InnerError = new ODataInnerError
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
                             {
-                                Message = "OIEM2",
-                                TypeName = "OIET2",
-                                StackTrace = "OIES2",
-                                InnerError = new ODataInnerError { Message = "OIEM3", TypeName = "OIET3", StackTrace = "OIES3" }
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                            })
+                        {
+                            InnerError = new ODataInnerError(
+                                new Dictionary<string, ODataValue>
+                                {
+                                    { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM2") },
+                                    { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET2") },
+                                    { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES2") }
+                                })
+                            {
+                                InnerError = new ODataInnerError(
+                                    new Dictionary<string, ODataValue>
+                                    {
+                                        { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM3") },
+                                        { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET3") },
+                                        { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES3") }
+
+                                    })
                             }
                         }
                     },
@@ -667,26 +711,17 @@ namespace Microsoft.OData.Tests
                             new Dictionary<string, ODataValue>
                             {
                                 { "p1", new ODataPrimitiveValue(1) },
-                                { "p2", new ODataPrimitiveValue("SP") }
+                                { "p2", new ODataPrimitiveValue("SP") },
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
                             })
-                        {
-                            Message = "OIEM1",
-                            TypeName = "OIET1",
-                            StackTrace = "OIES1",
-                            InnerError = new ODataInnerError { Message = "OIEM2", TypeName = "OIET2", StackTrace = "OIES2" }
-                        }
                     },
                     "{\"error\":{" +
                     "\"code\":\"OEC1\"," +
                     "\"message\":\"OEM1\"," +
                     "\"target\":\"OET1\"," +
-                    "\"innererror\":{" +
-                    "\"p1\":1," +
-                    "\"p2\":\"SP\"," +
-                    "\"message\":\"OIEM1\"," +
-                    "\"type\":\"OIET1\"," +
-                    "\"stacktrace\":\"OIES1\"," +
-                    "\"innererror\":{\"message\":\"OIEM2\",\"type\":\"OIET2\",\"stacktrace\":\"OIES2\"}}}}"
+                    "\"innererror\":{\"p1\":1,\"p2\":\"SP\",\"message\":\"OIEM1\",\"type\":\"OIET1\",\"stacktrace\":\"OIES1\"}}}"
                 ],
                 [
                     new ODataError
@@ -751,12 +786,13 @@ namespace Microsoft.OData.Tests
                         Code = "OEC1",
                         Message = "OEM1",
                         Target = "OET1",
-                        InnerError = new ODataInnerError
-                        {
-                            Message = "OIEM1",
-                            TypeName = "OIET1",
-                            StackTrace = "OIES1"
-                        },
+                        InnerError = new ODataInnerError(
+                            new Dictionary<string, ODataValue>
+                            {
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
+                            }),
                         Details = new Collection<ODataErrorDetail>
                         {
                             new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1", Target = "OEDT1" }
@@ -779,23 +815,21 @@ namespace Microsoft.OData.Tests
                             new Dictionary<string, ODataValue>
                             {
                                 { "p1", new ODataPrimitiveValue(1) },
-                                { "p2", new ODataPrimitiveValue("SP") }
+                                { "p2", new ODataPrimitiveValue("SP") },
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
                             })
                         {
-                            Message = "OIEM1",
-                            TypeName = "OIET1",
-                            StackTrace = "OIES1",
                             InnerError = new ODataInnerError(
                                 new Dictionary<string, ODataValue>
                                 {
                                     { "p3", new ODataPrimitiveValue(13M) },
-                                    { "p4", new ODataPrimitiveValue(new DateTimeOffset(2024, 5, 2, 13, 27, 30, TimeSpan.Zero)) }
+                                    { "p4", new ODataPrimitiveValue(new DateTimeOffset(2024, 5, 2, 13, 27, 30, TimeSpan.Zero)) },
+                                    { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM2") },
+                                    { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET2") },
+                                    { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES2") }
                                 })
-                            {
-                                Message = "OIEM2",
-                                TypeName = "OIET2",
-                                StackTrace = "OIES2",
-                            }
                         },
                         Details = new Collection<ODataErrorDetail>
                         {
@@ -889,13 +923,11 @@ namespace Microsoft.OData.Tests
                                 { "p28", new ODataPrimitiveValue((Guid?)Guid.Parse("6693ceb2-5d47-45c7-b928-900ebdebe898")) },
                                 { "p29", new ODataPrimitiveValue((TimeSpan?)new TimeSpan(1, 12, 0)) },
                                 { "p30", new ODataPrimitiveValue((Date?)new Date(2024, 5, 2)) },
-                                { "p31", new ODataPrimitiveValue((TimeOfDay?)new TimeOfDay(12, 42, 30, 100)) }
+                                { "p31", new ODataPrimitiveValue((TimeOfDay?)new TimeOfDay(12, 42, 30, 100)) },
+                                { JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue("OIEM1") },
+                                { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("OIET1") },
+                                { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("OIES1") }
                             })
-                        {
-                            Message = "OIEM1",
-                            TypeName = "OIET1",
-                            StackTrace = "OIES1"
-                        }
                     },
                     "{\"error\":{" +
                     "\"code\":\"OEC1\"," +

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataRawOutputContextApiTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataRawOutputContextApiTests.cs
@@ -233,7 +233,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     }
 
                     await messageWriter.WriteErrorAsync(
-                        new ODataError { ErrorCode = "NRE", Message = "Object reference not set to an instance of an object." },
+                        new ODataError { Code = "NRE", Message = "Object reference not set to an instance of an object." },
                         /*includeDebugInformation*/ true);
                 }
             });
@@ -259,7 +259,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                         }
 
                         messageWriter.WriteError(
-                            new ODataError { ErrorCode = "NRE", Message = "Object reference not set to an instance of an object." },
+                            new ODataError { Code = "NRE", Message = "Object reference not set to an instance of an object." },
                             /*includeDebugInformation*/ true);
                     }
                 }));

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataRawOutputContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataRawOutputContextTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.OData.Tests
             this.settings.SetServiceDocumentUri(new Uri(ServiceUri));
             this.nullReferenceError = new ODataError
             {
-                ErrorCode = "NRE",
+                Code = "NRE",
                 Message = "Object reference not set to an instance of an object"
             };
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/CustomInstanceAnnotationAcceptanceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/CustomInstanceAnnotationAcceptanceTests.cs
@@ -356,7 +356,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader
             // Write payload
             using (var messageWriter = new ODataMessageWriter(messageToWrite, writerSettings, Model))
             {
-                ODataError error = new ODataError { ErrorCode = "400", Message = "Resource not found for the segment 'Address'." };
+                ODataError error = new ODataError { Code = "400", Message = "Resource not found for the segment 'Address'." };
                 error.InstanceAnnotations.Add(new ODataInstanceAnnotation("instance.annotation", new ODataPrimitiveValue("stringValue")));
                 messageWriter.WriteError(error, includeDebugInformation: true);
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/MetadataReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/MetadataReaderTests.cs
@@ -112,7 +112,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader
 
             ODataErrorException exception = Assert.Throws<ODataErrorException>(test);
             Assert.Equal("An error was read from the payload. See the 'Error' property for more details.", exception.Message);
-            Assert.Equal("code42", exception.Error.ErrorCode);
+            Assert.Equal("code42", exception.Error.Code);
             Assert.Equal("message text", exception.Error.Message);
         }
 
@@ -161,7 +161,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader
 
             ODataErrorException exception = Assert.Throws<ODataErrorException>(test);
             Assert.Equal("An error was read from the payload. See the 'Error' property for more details.", exception.Message);
-            Assert.Equal("code42", exception.Error.ErrorCode);
+            Assert.Equal("code42", exception.Error.Code);
             Assert.Equal("message text", exception.Error.Message);
             Assert.Equal("some inner error", exception.Error.InnerError.Message);
         }

--- a/test/FunctionalTests/Service/Microsoft/OData/Service/ErrorHandler.cs
+++ b/test/FunctionalTests/Service/Microsoft/OData/Service/ErrorHandler.cs
@@ -427,7 +427,7 @@ namespace Microsoft.OData.Service
                     var newErrorWriter = messageWriterBuilder.CreateWriter();
                     ODataError errorWhileWritingOtherError = new ODataError()
                     {
-                        ErrorCode = "500",
+                        Code = "500",
                         InnerError = new ODataInnerError(e),
                         Message = Strings.ErrorHandler_ErrorWhileWritingError
                     };

--- a/test/FunctionalTests/Service/Microsoft/OData/Service/HandleExceptionArgs.cs
+++ b/test/FunctionalTests/Service/Microsoft/OData/Service/HandleExceptionArgs.cs
@@ -126,7 +126,7 @@ namespace Microsoft.OData.Service
             DataServiceException dataException = this.Exception as DataServiceException;
             if (dataException == null)
             {
-                error.ErrorCode = String.Empty;
+                error.Code = String.Empty;
                 error.Message = Strings.DataServiceException_GeneralError;
 
                 if (this.UseVerboseErrors)
@@ -136,7 +136,7 @@ namespace Microsoft.OData.Service
             }
             else
             {
-                error.ErrorCode = dataException.ErrorCode ?? String.Empty;
+                error.Code = dataException.ErrorCode ?? String.Empty;
                 error.Message = dataException.Message ?? String.Empty;
 
                 if (this.UseVerboseErrors && dataException.InnerException != null)

--- a/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/RequestHandler.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData.WCFService/RequestHandler.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Test.Taupo.OData.WCFService
                     writer.WriteError(
                          new ODataError
                          {
-                             ErrorCode = errorCode.ToString(CultureInfo.InvariantCulture),
+                             Code = errorCode.ToString(CultureInfo.InvariantCulture),
                              Message = error.Message,
                              InnerError = new ODataInnerError
                              {

--- a/test/FunctionalTests/Tests/DataOData/Common/OData/Common/ODataObjectModelValidationUtils.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData/Common/ODataObjectModelValidationUtils.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Test.Taupo.OData.Common
             if (first == null && second == null) return true;
             if (first == null || second == null) return false;
 
-            if (string.CompareOrdinal(first.ErrorCode, second.ErrorCode) != 0) return false;
+            if (string.CompareOrdinal(first.Code, second.Code) != 0) return false;
             if (string.CompareOrdinal(first.Message, second.Message) != 0) return false;
             if (!AreEqual(first.InnerError, second.InnerError)) return false;
 

--- a/test/FunctionalTests/Tests/DataOData/Common/OData/Common/ODataPayloadElementToObjectModelConverter.cs
+++ b/test/FunctionalTests/Tests/DataOData/Common/OData/Common/ODataPayloadElementToObjectModelConverter.cs
@@ -593,7 +593,7 @@ namespace Microsoft.Test.Taupo.OData.Common
             ExceptionUtilities.Assert(this.items.Count == 0, "Error should only be top level");
             var error = new ODataError()
             {
-                ErrorCode = payloadElement.Code,
+                Code = payloadElement.Code,
                 Message = payloadElement.Message
             };
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/ObjectModelTests/ODataErrorTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/ObjectModelTests/ODataErrorTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Test.Taupo.OData.Common.Tests.ObjectModelTests
         public void DefaultValuesTest()
         {
             ODataError error = new ODataError();
-            this.Assert.IsNull(error.ErrorCode, "Expected null default value for property 'ErrorCode'.");
+            this.Assert.IsNull(error.Code, "Expected null default value for property 'Code'.");
             this.Assert.IsNull(error.Message, "Expected null default value for property 'Message'.");
             this.Assert.IsNull(error.Target, "Expected null default value for property 'Target'.");
             this.Assert.IsNull(error.Details, "Expected null default value for property 'Details'.");
@@ -39,20 +39,20 @@ namespace Microsoft.Test.Taupo.OData.Common.Tests.ObjectModelTests
             var target = "any target";
             var details = new List<ODataErrorDetail>
             {
-                new ODataErrorDetail { ErrorCode = "401", Message = "any msg", Target = "another target" }
+                new ODataErrorDetail { Code = "401", Message = "any msg", Target = "another target" }
             };
             ODataInnerError innerError = new ODataInnerError { Message = "No inner error" };
 
             ODataError error = new ODataError()
             {
-                ErrorCode = errorCode,
+                Code = errorCode,
                 Message = message,
                 Target = target,
                 Details = details,
                 InnerError = innerError
             };
 
-            this.Assert.AreEqual(errorCode, error.ErrorCode, "Expected equal error code values.");
+            this.Assert.AreEqual(errorCode, error.Code, "Expected equal error code values.");
             this.Assert.AreEqual(message, error.Message, "Expected equal message values.");
             this.Assert.AreEqual(target, error.Target, "Expected equal target values.");
             this.Assert.AreSame(details, error.Details, "Expected equal error detail values.");
@@ -64,24 +64,24 @@ namespace Microsoft.Test.Taupo.OData.Common.Tests.ObjectModelTests
         {
             ODataError error = new ODataError()
             {
-                ErrorCode = "500",
+                Code = "500",
                 Message = "Fehler! Bitte kontaktieren Sie den Administrator!",
                 Target = "any target",
                 Details =
                     new List<ODataErrorDetail>
                     {
-                        new ODataErrorDetail { ErrorCode = "401", Message = "any msg", Target = "another target" }
+                        new ODataErrorDetail { Code = "401", Message = "any msg", Target = "another target" }
                     },
                 InnerError = new ODataInnerError { Message = "No inner error" },
             };
 
-            error.ErrorCode = null;
+            error.Code = null;
             error.Message = null;
             error.Target = null;
             error.Details = null;
             error.InnerError = null;
 
-            this.Assert.IsNull(error.ErrorCode, "Expected null default value for property 'ErrorCode'.");
+            this.Assert.IsNull(error.Code, "Expected null default value for property 'Code'.");
             this.Assert.IsNull(error.Message, "Expected null default value for property 'Message'.");
             this.Assert.IsNull(error.Target, "Expected null default value for property 'Target'.");
             this.Assert.IsNull(error.Details, "Expected null default value for property 'Details'.");

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Common.Tests/PublicApi/PublicApi.bsl
@@ -5349,7 +5349,7 @@ public sealed class Microsoft.OData.ODataError : Microsoft.OData.ODataAnnotatabl
 	public ODataError ()
 
 	System.Collections.Generic.ICollection`1[[Microsoft.OData.ODataErrorDetail]] Details  { public get; public set; }
-	string ErrorCode  { public get; public set; }
+	string Code  { public get; public set; }
 	Microsoft.OData.ODataInnerError InnerError  { public get; public set; }
 	System.Collections.Generic.ICollection`1[[Microsoft.OData.ODataInstanceAnnotation]] InstanceAnnotations  { public get; public set; }
 	string Message  { public get; public set; }
@@ -5361,7 +5361,7 @@ public sealed class Microsoft.OData.ODataError : Microsoft.OData.ODataAnnotatabl
 public sealed class Microsoft.OData.ODataErrorDetail {
 	public ODataErrorDetail ()
 
-	string ErrorCode  { public get; public set; }
+	string Code  { public get; public set; }
 	string Message  { public get; public set; }
 	string Target  { public get; public set; }
 }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat.Tests/Avro/Test/ODataAvroScenarioTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat.Tests/Avro/Test/ODataAvroScenarioTests.cs
@@ -592,7 +592,7 @@ namespace Microsoft.Test.OData.PluggableFormat.Avro.Test
         {
             ODataError odataError = new ODataError()
             {
-                ErrorCode = "404",
+                Code = "404",
                 Message = "Not Found",
             };
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat.Tests/Avro/Test/ODataAvroWriterTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat.Tests/Avro/Test/ODataAvroWriterTests.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Test.OData.PluggableFormat.Avro.Test
         {
             ODataError error = new ODataError()
             {
-                ErrorCode = "32",
+                Code = "32",
                 Message = "msg1",
             };
 
@@ -367,7 +367,7 @@ namespace Microsoft.Test.OData.PluggableFormat.Avro.Test
             var records = results.Cast<AvroRecord>().ToList();
             Assert.AreEqual(1, records.Count());
             dynamic err = records[0];
-            Assert.AreEqual("32", err.ErrorCode);
+            Assert.AreEqual("32", err.Code);
             Assert.AreEqual("msg1", err.Message);
         }
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat/Avro/ODataAvroConvert.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat/Avro/ODataAvroConvert.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Test.OData.PluggableFormat.Avro
             if (error != null)
             {
                 var record = new AvroRecord(schema);
-                record["ErrorCode"] = error.ErrorCode;
+                record["ErrorCode"] = error.Code;
                 record["Message"] = error.Message;
                 return record;
             }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat/Avro/ODataAvroInputContext.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat/Avro/ODataAvroInputContext.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Test.OData.PluggableFormat.Avro
 
             return new ODataError
             {
-                ErrorCode = record.ErrorCode,
+                Code = record.ErrorCode,
                 Message = record.Message,
             };
         }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Json/InStreamErrorReaderJsonTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/Json/InStreamErrorReaderJsonTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.Json
                 new
                 {
                     Json = "{{ \"{0}\": {{ \"code\": \"my-error-code\" }} }}",
-                    ExpectedException = ODataExpectedExceptions.ODataErrorException(new ODataError { ErrorCode = "my-error-code" }) 
+                    ExpectedException = ODataExpectedExceptions.ODataErrorException(new ODataError { Code = "my-error-code" }) 
                 },
                 new
                 {
@@ -66,12 +66,12 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.Json
                 new
                 {
                     Json = "{{ \"{0}\": {{ \"code\": \"my-error-code\", \"message\": \"my-error-message\" }} }}",
-                    ExpectedException = ODataExpectedExceptions.ODataErrorException(new ODataError { ErrorCode = "my-error-code", Message = "my-error-message" }) 
+                    ExpectedException = ODataExpectedExceptions.ODataErrorException(new ODataError { Code = "my-error-code", Message = "my-error-message" }) 
                 },
                 new
                 {
                     Json = "{{ \"{0}\": {{ \"code\": \"my-error-code\", \"innererror\": {{ \"message\": \"my-inner-error\" }} }} }}",
-                    ExpectedException = ODataExpectedExceptions.ODataErrorException(new ODataError { ErrorCode = "my-error-code", InnerError = new ODataInnerError { Message = "my-inner-error" }}) 
+                    ExpectedException = ODataExpectedExceptions.ODataErrorException(new ODataError { Code = "my-error-code", InnerError = new ODataInnerError { Message = "my-inner-error" }}) 
                 },
                 new
                 {
@@ -86,7 +86,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests.Json
                 new
                 {
                     Json = "{{ \"{0}\": {{ \"code\": \"my-error-code\", \"message\": \"my-error-message\", \"innererror\": {{ \"message\": \"my-inner-error\" }} }} }}",
-                    ExpectedException = ODataExpectedExceptions.ODataErrorException(new ODataError { ErrorCode = "my-error-code", Message = "my-error-message", InnerError = new ODataInnerError { Message = "my-inner-error" }}) 
+                    ExpectedException = ODataExpectedExceptions.ODataErrorException(new ODataError { Code = "my-error-code", Message = "my-error-message", InnerError = new ODataInnerError { Message = "my-inner-error" }}) 
                 },
             };
 

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/ObjectModelToPayloadElementConverter.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/ObjectModelToPayloadElementConverter.cs
@@ -479,7 +479,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests
             protected override ODataPayloadElement VisitError(ODataError error)
             {
                 ExceptionUtilities.CheckArgumentNotNull(error, "error");
-                return PayloadBuilder.Error(error.ErrorCode)
+                return PayloadBuilder.Error(error.Code)
                     .Message(error.Message)
                     .InnerError(error.InnerError == null ? null : (ODataInternalExceptionPayload)this.Visit(error.InnerError));
             }

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/PayloadReaderTestDescriptorExtensions.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Reader.Tests/PayloadReaderTestDescriptorExtensions.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Test.Taupo.OData.Reader.Tests
         {
             ODataError error = new ODataError();
 
-            error.ErrorCode = errorPayload.Code;
+            error.Code = errorPayload.Code;
             error.Message = errorPayload.Message; ;
 
             ODataInternalExceptionPayload innerErrorPayload = errorPayload.InnerError;

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/CollectionWriter/CollectionWriterTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/CollectionWriter/CollectionWriterTests.cs
@@ -606,7 +606,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.CollectionWriter
                 {
                     Error = new ODataError()
                     {
-                        ErrorCode = "5555",
+                        Code = "5555",
                         Message = "Dummy error message",
                     }
                 },

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Common/ObjectModelUtils.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Common/ObjectModelUtils.cs
@@ -583,7 +583,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Common
         }
 
         /// <summary>
-        /// Creates an <see cref="ODataError"/> instance with the default value for 'ErrorCode' and 'Message'
+        /// Creates an <see cref="ODataError"/> instance with the default value for 'Code' and 'Message'
         /// that can be used and modified in tests.
         /// </summary>
         /// <returns>The newly created <see cref="ODataError"/> instance.</returns>
@@ -591,7 +591,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Common
         {
             ODataError error = new ODataError()
             {
-                ErrorCode = DefaultErrorCode,
+                Code = DefaultErrorCode,
                 Message = DefaultErrorMessage,
                 InnerError = includeDetails ? DefaultInnerError : null,
             };

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Writer/WriterErrorTests.cs
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.Writer.Tests/Writer/WriterErrorTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Writer
                     Code = string.Empty, Message = string.Empty, InnerError = (InnerError)null, ExpectedException = (ExpectedException) null
                 },
                 new {
-                    Error = new ODataAnnotatedError { Error = new ODataError() { ErrorCode = "code1" } },
+                    Error = new ODataAnnotatedError { Error = new ODataError() { Code = "code1" } },
                     Code = "code1", Message = string.Empty, InnerError = (InnerError)null, ExpectedException = (ExpectedException) null
                 },
                 new {
@@ -126,11 +126,11 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Writer
                     Code = string.Empty, Message = string.Empty, InnerError = new InnerError { Message = "some inner error" }, ExpectedException = (ExpectedException) null
                 },
                 new {
-                    Error = new ODataAnnotatedError { Error = new ODataError() { ErrorCode = "code42", Message = "message text", InnerError = new ODataInnerError { Message = "some inner error" } } },
+                    Error = new ODataAnnotatedError { Error = new ODataError() { Code = "code42", Message = "message text", InnerError = new ODataInnerError { Message = "some inner error" } } },
                     Code = "code42", Message = "message text", InnerError = (InnerError)null, ExpectedException = (ExpectedException) null
                 },
                 new {
-                    Error = new ODataAnnotatedError { Error = new ODataError() { ErrorCode = "code42", Message = "message text", InnerError = new ODataInnerError { Message = "some inner error" } }, IncludeDebugInformation = true },
+                    Error = new ODataAnnotatedError { Error = new ODataError() { Code = "code42", Message = "message text", InnerError = new ODataInnerError { Message = "some inner error" } }, IncludeDebugInformation = true },
                     Code = "code42", Message = "message text", InnerError = new InnerError { Message = "some inner error" }, ExpectedException = (ExpectedException) null
                 },
                 new {
@@ -138,7 +138,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Writer
                     {
                         Error = new ODataError()
                         {
-                            ErrorCode = "code42",
+                            Code = "code42",
                             Message = "message text",
                             InnerError = new ODataInnerError
                             {
@@ -164,7 +164,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Writer
                     {
                         Error = new ODataError()
                         {
-                            ErrorCode = "code42",
+                            Code = "code42",
                             Message = "message text",
                             InnerError = new ODataInnerError
                             {
@@ -210,7 +210,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Writer
                     ExpectedException = (ExpectedException) null
                 },
                 new {
-                    Error = new ODataAnnotatedError { Error = new ODataError() { ErrorCode = "code42", Message = "message text", InnerError = new ODataInnerError(new Exception("some inner error")) }, IncludeDebugInformation = true },
+                    Error = new ODataAnnotatedError { Error = new ODataError() { Code = "code42", Message = "message text", InnerError = new ODataInnerError(new Exception("some inner error")) }, IncludeDebugInformation = true },
                     Code = "code42", Message = "message text", InnerError = new InnerError { Message = "some inner error", TypeName = "System.Exception" }, ExpectedException = (ExpectedException) null
                 },
                 new {
@@ -218,7 +218,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Writer
                     {
                         Error = new ODataError()
                         {
-                            ErrorCode = "code42",
+                            Code = "code42",
                             Message = "message text",
                             InnerError = new ODataInnerError(
                                 new Exception("some inner error", new Exception("nested inner error", new Exception("nested nested inner error"))))
@@ -250,7 +250,7 @@ namespace Microsoft.Test.Taupo.OData.Writer.Tests.Writer
                     {
                         Error = new ODataError()
                         {
-                            ErrorCode = "code42",
+                            Code = "code42",
                             Message = "message text",
                             InnerError = new ODataInnerError
                             {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1421.*

### Description

Refactor `ODataError`, `ODataErrorDetail` and `ODataInnerError` classes

The OData standard provides the following guidance on error response - [19 Error Response](http://docs.oasis-open.org/odata/odata-json-format/v4.0/os/odata-json-format-v4.0-os.html#_Toc372793091):
- _The error response MUST be a single JSON object. This object MUST have a single name/value pair named `error`. The value must be a JSON object._
- _This object MUST contain name/value pairs with the names `code` and `message`, and it MAY contain name/value pairs with the names `target`, `details` and `innererror`._
- _The value for the `code` name/value pair is a language-independent string. Its value is a service-defined error code. This code serves as a sub-status for the HTTP error code specified in the response._
- _The value for the `message` name/value pair MUST be a human-readable, language-dependent representation of the error. The Content-Language header MUST contain the language code from [RFC5646] corresponding to the language in which the value for message is written._
- _The value for the `target` name/value pair is the target of the particular error (for example, the name of the property in error)._
- _The value for the `details` name/value pair MUST be an array of JSON objects that MUST contain name/value pairs for `code` and `message`, and MAY contain a name/value pair for target, as described above._
- _The value for the `innererror` name/value pair MUST be an object. The contents of this object are service-defined. Usually this object contains information that will help debug the service. The `innererror` name/value pair SHOULD only be used in development environments in order to guard against potential security concerns around information disclosure._

The differences between the OData spec guidance and the ODL implementation are summarized in the following comment https://github.com/OData/odata.net/issues/1421#issuecomment-1309673556

The existing implementation of `ODataError` `ToString` made an attempt to construct a JSON string representing the error response that ODL serializes an `ODataError` object into. The logic however falls short in several ways:
1. While `ODataInnerError`'s `ToJson` method skips any of the 3 string properties of `ODataInnerError` (i.e., `message`, `type`, and `stacktrace`) when the values are not provided, the OData serializers default to empty strings.

    For example,
    ```csharp
    new ODataInnerError()
    ```
    OData serializers produce:

    ```json
    {
        "message": "",
        "type": "",
        "stacktrace": ""
    }
    ```
    `odataInnerError.ToJson()`: `{}`

    In this pull request, I have made a change such that `ToJson` produces the same result as the ODL serializers do.
2. One of the `ODataInnerError`'s constructors accepts a `Dictionary<string, ODataValue>` parameter.
    The thing about `ODataValue` is that it has many subclasses, namely `ODataNullValue`, `ODataPrimitiveValue`, `ODataEnumValue`, `ODataBinaryStreamValue`, `ODataStreamReferenceValue`, `ODataResourceValue`, `ODataCollectionValue`, and `ODataUntypedValue`.
    Out of these, the OData serializers only handle `ODataNullValue`, `ODataPrimitiveValue`, `ODataResourceValue`, and `ODataCollectionValue`. If it finds an instance of any of the other subclasses when serializing, an exception is thrown.
    The problem with the `ToJson` method implementation however is that when an `ODataPrimitiveValue` containing primitive values like `byte[]`, `DateTimeOffset`, `Guid`, `TimeSpan`, `Microsoft.OData.Edm.Date`, and `Microsoft.OData.Edm.TimeOfDay` is present in the dictionary, such values not converted into the expected string literals and the converted value is also not enclosed in double quotes as would be expected.

    For example, the following `ODataInnerError` instance would yield the invalid JSON payload further below:

    ```csharp
    new ODataInnerError(
        new Dictionary<string, ODataValue>
        {
            { "p13", new ODataPrimitiveValue(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 }) },
            { "p14", new ODataPrimitiveValue(new DateTimeOffset(2024, 5, 2, 13, 27, 30, TimeSpan.Zero)) },
            { "p15", new ODataPrimitiveValue(Guid.Parse("6693ceb2-5d47-45c7-b928-900ebdebe898")) },
            { "p16", new ODataPrimitiveValue(new TimeSpan(1, 12, 0)) },
            { "p17", new ODataPrimitiveValue(new Microsoft.OData.Edm.Date(2024, 5, 2)) },
            { "p18", new ODataPrimitiveValue(new Microsoft.OData.Edm.TimeOfDay(12, 42, 30, 100)) }
        })
      ```
      `ToJson` result:

      ```json
      {
        "p13": System.Byte[],
        "p14": 02-May-24 1:27:30 PM +00:00,
        "p15": 6693ceb2-5d47-45c7-b928-900ebdebe89,
        "p16": 01:12:00,
        "p17": 2024-05-02,
        "p18": 12:42:30.1000000
      }
      ```
   The reason for this invalid result is because of the [buggy logic in `ODataValueToString`](https://github.com/OData/odata.net/blob/bbe2ac74487fb01fe14d97aeca131d0ca89d2452/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs#L124) that just calls `.ToString()` on the value before appending the result to the string builder.
    In this pull request, I have remedied this by making use of `ODataRawValueUtils.TryConvertPrimitiveToString(object, out string)` to convert the value to the expected string literals and also enclosing the converted value in double quotes.
4. When an `ODataInnerError` object has a nested `ODataInnerError`, the ODL serializers serializes the property as `internalexception` while `ToJson` method adopts `innererror`. In addition, `ToJson` always adds an `innererror` property with an empty object when the `InnerError` nested property is not initialized.

   For example, 
    ```csharp
    var odataError = new ODataError
    {
        InnerError = new ODataInnerError
        {
            InnerError = new ODataInnerError()
        }
    }
    ```
    `ODataJsonWriterUtils.WriteError(odataError, /* other parameters */)`:

    ```json
    {
        "error": {
            "code": "",
            "message": "",
            "innererror": {
                "message": "",
                "type": "",
                "stacktrace": "",
                "internalexception": {
                    "message": "",
                    "type": "",
                    "stacktrace": ""
                }
            }
        }
    }
    ```
    `odataError.ToString()`:

    ```json
    {
        "error": {
            "code": "",
            "message": "",
            "target": "",
            "details": {},
            "innererror": {
                "message": "",
                "type": "",
                "stacktrace": "",
                "innererror": {
                    "message": "",
                    "type": "",
                    "stacktrace": "",
                    "innererror": {}
                }
            }
        }
    }
    ```
    In this pull request, I have made a change such that the nested `ODataInnerError` is named `internalexception` when `ToJson` method is called. In addition, when the nested `InnerError` property is null, it doesn't get added as a property. This mirrors what is produced by ODL serializers.

#### Other changes:
- Renamed `ToJson` methods in `ODataInnerError` and `ODataErrorDetail` to `ToJsonString`.
- When serializing an `ODataErrorDetail` instance, the OData serializers would write the optional `target` property ahead of the required `message` property. I switched the order such that the required `message` property is written first. This makes logical sense and change of property order does not qualify as a breaking change.

    **Before:**

    ```csharp
    var odataError = new ODataError
    {
        Details = new Collection<ODataErrorDetail>
        {
            new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1", Target = "OEDT1" },
            new ODataErrorDetail { Code = "OEDC1", Message = "OEDM1" },
            new ODataErrorDetail {}
        }
    };
    ```
    `ODataJsonWriterUtils.WriteError(odataError, /* other parameters */)`:

    ```json
    {
        "error": {
            "code": "",
            "message": "",
            "details": [
                {
                    "code": "OEDC1",
                    "target": "OEDT1",
                    "message": "OEDM1"
                },
                {
                    "code": "OEDC1",
                    "message": "OEDM1"
                },
                {
                    "code": "",
                    "message": ""
                }
            ]
        }
    }
    ```
    `odataError.ToString()`:

    ```json
    {
      "error": {
        "code": "",
        "message": "",
        "target": "",
        "details": [
          {
            "errorcode": "OEDC1",
            "message": "OEDM1",
            "target": "OEDT1"
          },
          {
            "errorcode": "OEDC1",
            "message": "OEDM1",
            "target": ""
          },
          {
            "errorcode": "",
            "message": "",
            "target": ""
          }
        ],
        "innererror": {}
      }
    }
    ```
    **After:**

    Both `ODataJsonWriterUtils.WriteError(odataError, /* other parameters */)` and `odataError.ToString()`:

    ```json
    {
      "error": {
        "code": "",
        "message": "",
        "details": [
          {
            "code": "OEDC1",
            "message": "OEDM1",
            "target": "OEDT1"
          },
          {
            "code": "OEDC1",
            "message": "OEDM1"
          },
          {
            "code": "",
            "message": ""
          }
        ]
      }
    }
    ```
- Throwing an exception from `ToString()` is considered a very bad idea. For that reason, whenever an `ODataValue` that cannot be converted into a JSON representation is encountered in the `ODataInnerError` dictionary, an error message is written in its place:

    For example:
    ```csharp
    var odataInnerError = new ODataInnerError(
        new Dictionary<string, ODataValue>
        {
            { "p1", new ODataEnumValue("Black") },
            { "p2", new ODataUntypedValue { RawValue = "\"roygbiv\"" } },
            { "p3", new ODataBinaryStreamValue(stream, leaveOpen: false) },
            { "p4", new ODataStreamReferenceValue() },
            { "p5", new ODataJsonElementValue(jsonDocument.RootElement) }
        }
    ```
    `odataInnerError.ToJsonString()`:

    ```json
    {
        "p1": "The value of type 'Microsoft.OData.ODataEnumValue' is not supported and cannot be converted to a JSON representation.",
        "p2": "The value of type 'Microsoft.OData.ODataUntypedValue' is not supported and cannot be converted to a JSON representation.",
        "p3": "The value of type 'Microsoft.OData.ODataBinaryStreamValue' is not supported and cannot be converted to a JSON representation.",
        "p4": "The value of type 'Microsoft.OData.ODataStreamReferenceValue' is not supported and cannot be converted to a JSON representation.",
        "p5": "The value of type 'Microsoft.OData.ODataJsonElementValue' is not supported and cannot be converted to a JSON representation.",
        "message": "",
        "type": "",
        "stacktrace": ""
    }
    ```
    The option of validating that an unsupported `ODataValue` is not added to the dictionary and throwing an exception in such event was considered. However, since `ODataResourceValue` and `ODataCollectionValue` can be heavily nested, with `ODataValue` likely to be present at any level, the idea of such validation looks less attractive and potentially costly.
   Tests were added to confirm the output produced when unsupported values are encountered.
- The OData serializers write the properties in the `ODataInnerError` dictionary ahead of the declared properties. This behaviour was retained and this also meant a change to the `ToJsonString` method to produce a similar output.

    **Before:**
    ```csharp
    var odataInnerError = new ODataInnerError(
        new Dictionary<string, ODataValue>
        {
            { "p1", new ODataPrimitiveValue(1) }
        }
    ```
    `odataInnerError.ToJson()`:

    ```json
    {
        "message": "",
        "type": "",
        "stacktrace": "",
        "p1": 1
    }
    ```
    **After:**
    `odataInnerError.ToJsonString()`:

    ```json
    {
        "p1": 1,
        "message": "",
        "type": "",
        "stacktrace": ""
    }
    ```

#### Be noted
- As per the OData standard, the contents of the `innererror` object are service-defined. The sample in the OData spec has the following `innererror` object:
    ```json
    "innererror": {
        "trace": [...],
        "context": {...}
    }
    ```
    The two properties here are just sample properties. The OData spec doesn't designate them as required or optional properties.
    In ODL, the `ODataInnerError` class has 3 declared properties - `Message`, `Type` and `StackTrace`. ~The OData serializers always write those 3 properties. When any of their values are not provided, an empty string is written. This behaviour has been retained.~ The logic to support Astoria compatibility has been removed. If anyone needs `message`, `type` and `stacktrace` to be included in the serialized `ODataError`, they can add the properties to the `ODataInnerError`'s `Properties` dictionary explicitly.

    In addition, a nested inner error is an ODL implementation, not an OData standard requirement. Using `innerexception` for the nested inner error will be toggled using a compatibility flag - `ODataLibraryCompatibility.UseLegacyODataInnerErrorSerialization`. Going forward, `innererror` will be used by default.
### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
