### PR TITLE
Fix grouping by nested dynamic property to behave like grouping by nested standard property

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -230,30 +230,23 @@ namespace Microsoft.OData.UriParser.Aggregation
             foreach (EndPathToken propertyToken in token.Properties)
             {
                 QueryNode bindResult = this.bindMethod(propertyToken);
-                SingleValuePropertyAccessNode property = bindResult as SingleValuePropertyAccessNode;
-                SingleComplexNode complexProperty = bindResult as SingleComplexNode;
 
-                if (property != null)
+                if (bindResult is SingleValuePropertyAccessNode property)
                 {
                     RegisterProperty(properties, ReversePropertyPath(property));
                 }
-                else if (complexProperty != null)
+                else if (bindResult is SingleComplexNode complexProperty)
                 {
                     RegisterProperty(properties, ReversePropertyPath(complexProperty));
                 }
+                else if (bindResult is SingleValueOpenPropertyAccessNode openProperty)
+                {
+                    RegisterProperty(properties, ReversePropertyPath(openProperty));
+                }
                 else
                 {
-                    SingleValueOpenPropertyAccessNode openProperty = bindResult as SingleValueOpenPropertyAccessNode;
-                    if (openProperty != null)
-                    {
-                        IEdmTypeReference type = GetTypeReferenceByPropertyName(openProperty.Name);
-                        properties.Add(new GroupByPropertyNode(openProperty.Name, openProperty, type));
-                    }
-                    else
-                    {
-                        throw new ODataException(
-                            ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue(propertyToken.Identifier));
-                    }
+                    throw new ODataException(
+                        ODataErrorStrings.ApplyBinder_GroupByPropertyNotPropertyAccessValue(propertyToken.Identifier));
                 }
             }
 
@@ -305,6 +298,10 @@ namespace Microsoft.OData.UriParser.Aggregation
                 {
                     node = ((SingleNavigationNode)node).Source as SingleValueNode;
                 }
+                else if (node.Kind == QueryNodeKind.SingleValueOpenPropertyAccess)
+                {
+                    node = ((SingleValueOpenPropertyAccessNode)node).Source;
+                }
             }
             while (node != null && IsPropertyNode(node));
 
@@ -349,6 +346,10 @@ namespace Microsoft.OData.UriParser.Aggregation
             else if (property.Kind == QueryNodeKind.SingleNavigationNode)
             {
                 return ((SingleNavigationNode)property).NavigationProperty.Name;
+            }
+            else if (property.Kind == QueryNodeKind.SingleValueOpenPropertyAccess)
+            {
+                return ((SingleValueOpenPropertyAccessNode)property).Name;
             }
             else
             {


### PR DESCRIPTION
### Issues

#2963

### Description

For the following group by : `groupby((Address/DynamicCity))`

The response was :
```json
[
    { "DynamicCity": "City 2" },
    { "DynamicCity": "City 1" }
]
```

Now, the response is :
```json
[
    { "Address": { "DynamicCity": "City 2" } },
    { "Address": { "DynamicCity": "City 1" } }
]
```

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*
