### PR TITLE
Support net8.0 - Avoid evaluating Current on an empty enumerator

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
@@ -17,25 +17,21 @@ namespace Microsoft.OData.UriParser
 
         public ODataPathInfo(ODataPath odataPath)
         {
-            ODataPathSegment lastSegment = odataPath.LastSegment;
-            ODataPathSegment previous = null;
-            var segs = odataPath.GetEnumerator();
-            int count = 0;
-            while (++count < odataPath.Count && segs.MoveNext())
-            {
-            }
+            ODataPathSegment targetSegment = odataPath.LastSegment;
 
-            previous = (odataPath.Count > 0) ? segs.Current : null;
-            if (lastSegment != null)
+            if (targetSegment != null)
             {
-                // use previous segment if the last one is Key or Count Segment
-                if (lastSegment is KeySegment || lastSegment is CountSegment)
+                // use next to last segment if the last one is Key or Count Segment
+                if (targetSegment is KeySegment || targetSegment is CountSegment)
                 {
-                    lastSegment = previous;
+                    if (odataPath.Count > 1)
+                    {
+                        targetSegment = odataPath.Segments[odataPath.Count - 2];
+                    }
                 }
 
-                this.targetNavigationSource = lastSegment.TargetEdmNavigationSource;
-                this.targetEdmType = lastSegment.EdmType;
+                this.targetNavigationSource = targetSegment.TargetEdmNavigationSource;
+                this.targetEdmType = targetSegment.EdmType;
                 if (this.targetEdmType != null)
                 {
                     IEdmCollectionType collectionType = this.targetEdmType as IEdmCollectionType;

--- a/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataPathInfo.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData.UriParser
             {
             }
 
-            previous = segs.Current;
+            previous = (odataPath.Count > 0) ? segs.Current : null;
             if (lastSegment != null)
             {
                 // use previous segment if the last one is Key or Count Segment


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2796*

### Description

Avoid calling .Current on an empty enumerator.  Calling Current is not valid unless MoveNext() has returned true and in net8.0 this was enforced.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
