### PR TITLE
Add ODataPathInfo tests

### DIFF
--- a/buildandtest.yml
+++ b/buildandtest.yml
@@ -4,10 +4,12 @@ steps:
     versionSpec: '6.5.0'
 
 - task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 1.0.4'
   inputs:
     version: '1.0.4'
     
 - task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 2.1.3'
   inputs:
     version: '2.1.3'
  
@@ -22,13 +24,14 @@ steps:
       $publish.GacInstall("$(gacUtil)")
 
 - task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 2.1.x'
   inputs:
     version: '2.1.x'
 
 - task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 3.1.x'
   inputs:
     version: '3.1.x'
-
 
 - task: DotNetCoreCLI@2
   displayName: 'Build'  
@@ -54,3 +57,16 @@ steps:
     arguments: '--configuration $(buildConfiguration) --collect "Code coverage"'
     projects: |      
       $(Build.SourcesDirectory)\test\EndToEndTests\Tests\Client\Build.Desktop\Microsoft.Test.OData.Tests.Client.csproj
+
+- task: UseDotNet@2
+  displayName: 'Use .NET Core SDK 8.x'
+  inputs:
+    version: '8.x'
+
+- task: DotNetCoreCLI@2
+  displayName: 'Microsoft.OData.Core.Tests for NET 8.0'
+  inputs:
+    command: 'test'
+    arguments: '--configuration $(buildConfiguration) --collect "Code coverage"'
+    projects: |      
+      $(Build.SourcesDirectory)\test\FunctionalTests\Microsoft.OData.Core.Tests\Microsoft.OData.Core.Tests.Net8.csproj

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <DefineConstants>$(DefineConstants);NETCOREAPP3_1_OR_GREATER;NETCOREAPP;NETCOREAPP3_1</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP3_1_OR_GREATER;NETCOREAPP</DefineConstants>
   </PropertyGroup>
  
   <Import Project="..\Build.props" />

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/JsonLight/PropertyAndValueJsonLightWriterIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/JsonLight/PropertyAndValueJsonLightWriterIntegrationTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.JsonLight
                 "]," +
                 "\"FloatNumbers\":[" +
                 "1," +
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
                 "-3.4028235E+38," +
                 "3.4028235E+38," +
 #else

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataAnnotationNamesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataAnnotationNamesTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData.Tests.JsonLight
             .Where(f => f.FieldType == typeof(string))
             .Select(f => (string)f.GetValue(null)).ToArray();
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1&& !NETCOREAPP3_1
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1&& !NETCOREAPP3_1_OR_GREATER
         // Not applicable to .NET Core due to changes in framework
         [Fact]
         public void ReservedODataAnnotationNamesHashSetShouldContainAllODataAnnotationNamesSpecialToODataLib()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.Net8.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Microsoft.OData.Core.Tests.Net8.csproj
@@ -3,7 +3,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <AssemblyName>Microsoft.OData.Core.Tests</AssemblyName>
-    <TargetFrameworks>net452;netcoreapp1.1;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <FileUpgradeFlags>40</FileUpgradeFlags>
     <OldToolsVersion>2.0</OldToolsVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -20,16 +20,12 @@
     <DefineConstants>TRACE</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <PropertyGroup>
     <DefineConstants>$(DefineConstants);NETCOREAPP3_1_OR_GREATER;NETCOREAPP</DefineConstants>
   </PropertyGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <Import Project="..\Build.props"/>
@@ -79,19 +75,7 @@
     <ProjectReference Include="..\Microsoft.OData.TestCommon\Microsoft.OData.TestCommon.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>8.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces">
-      <Version>8.0.0</Version>
-    </PackageReference>
-  </ItemGroup>
-
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(TargetFramework)' == 'net452'">
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(TargetFramework)' == 'net48'">
     <Exec Command="&quot;$([System.Environment]::GetFolderPath(SpecialFolder.ProgramFilesX86))\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe&quot; /Vr $(OutputPath)\Microsoft.OData.Core.dll" />
   </Target>
 </Project>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
@@ -154,7 +154,7 @@ namespace Microsoft.OData.Tests
             copyOfSettings = settings.Clone();
             this.CompareMessageReaderSettings(settings, copyOfSettings);
         }
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void ODataMessageReaderSettingsErrorTest()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderTests.cs
@@ -258,7 +258,7 @@ namespace Microsoft.OData.Tests
             responseMessage.SetHeader("Content-Type", "application/json");
             ODataMessageReader reader = new ODataMessageReader(responseMessage, new ODataMessageReaderSettings(), new EdmModel());
 
-#if NETCOREAPP3_1 || NETCOREAPP2_1
+#if NETCOREAPP3_1_OR_GREATER || NETCOREAPP2_1
             IEdmModel model = reader.ReadMetadataDocument();
 
             IEdmEntityType customerType = model.FindDeclaredType("NS.Customer") as IEdmEntityType;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -851,7 +851,7 @@ namespace Microsoft.OData.Tests
 
             string contentType = "application/json";
 
-#if NETCOREAPP3_1 || NETCOREAPP2_1
+#if NETCOREAPP3_1_OR_GREATER || NETCOREAPP2_1
             // Act
             string payload = this.WriteAndGetPayload(edmModel, contentType, omWriter =>
             {
@@ -893,7 +893,7 @@ namespace Microsoft.OData.Tests
 #endif
         }
 
-#if NETCOREAPP3_1 || NETCOREAPP2_1
+#if NETCOREAPP3_1_OR_GREATER || NETCOREAPP2_1
         [Fact]
         public async Task WriteMetadataDocumentAsync_WorksForJsonCsdl()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataPreferenceHeaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataPreferenceHeaderTests.cs
@@ -73,7 +73,7 @@ namespace Microsoft.OData.Tests
             Assert.Equal(ReturnRepresentationPreference, this.requestMessage.GetHeader(PreferHeaderName));
         }
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void SetAnnotationFilterToEmptyShouldThrow()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
@@ -171,7 +171,7 @@ namespace Microsoft.OData.Tests
             this.odataEntry.InstanceAnnotations.Add(new ODataInstanceAnnotation("namespace.name", new ODataPrimitiveValue("value")));
             Assert.Single(this.odataEntry.InstanceAnnotations);
         }
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void SetNullValueToInstanceAnnotationsPropertyShouldThrow()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
@@ -63,7 +63,7 @@ namespace Microsoft.OData.Tests.Query
         public void TestDecimalConvertFromUriLiteral(string value)
         {
             object dec = ODataUriUtils.ConvertFromUriLiteral(value, ODataVersion.V4);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.True(dec is double || dec is decimal);
 #else
             Assert.True(dec is decimal);
@@ -97,13 +97,13 @@ namespace Microsoft.OData.Tests.Query
         public void TestSingleConvertToUriLiteral()
         {
             string singleString = ODataUriUtils.ConvertToUriLiteral(float.MaxValue, ODataVersion.V4);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.Equal("3.4028235E+38", singleString);
 #else
             Assert.Equal("3.40282347E+38", singleString);
 #endif 
             singleString = ODataUriUtils.ConvertToUriLiteral(float.MinValue, ODataVersion.V4);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.Equal("-3.4028235E+38", singleString);
 #else
             Assert.Equal("-3.40282347E+38", singleString);
@@ -119,7 +119,7 @@ namespace Microsoft.OData.Tests.Query
         public void TestSingleConvertFromUriLiteral(string value)
         {
             object singleNumber = ODataUriUtils.ConvertFromUriLiteral(value, ODataVersion.V4);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.True(singleNumber is float || singleNumber is double);
 #else
             Assert.True(singleNumber is float);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Evaluation/KeyGenerationPinningTest.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Evaluation/KeyGenerationPinningTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Evaluation
 {
     public class KeyGenerationPinningTest
     {
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void DoublePinning()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/MetadataUriRoundTripTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonLight/MetadataUriRoundTripTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.JsonLight
             this.organizationsSet = this.defaultContainer.FindEntitySet("Organizations");
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void EntryMetadataUrlRoundTrip()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/PathBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/PathBuilderTests.cs
@@ -409,7 +409,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
             Assert.Equal(new Uri("http://gobbledygook/GetPet4(id=102.0)"), actualUri);
         }
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void FunctionParameterDoublePrecision()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -136,7 +136,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             parse.Throws<ODataException>(ODataErrorStrings.MetadataBinder_IncompatibleOperandsError("Edm.Double", "Edm.Decimal", "Equal"));
         }
 
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void ParseFilterDecimalValuesWithOptionalSuffix()
         {
@@ -324,7 +324,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
         }
 
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void ParseFilterNodeInComplexExpression()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/PathFunctionalTests.cs
@@ -887,7 +887,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             PathFunctionalTestsUtil.RunParsePath("Pet4Set(102m)/").LastSegment.ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 102M));
         }
 
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void EntitySetKeyWithUnmatchType()
         {
@@ -950,7 +950,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             PathFunctionalTestsUtil.RunParsePath("GetPet3(id=1.0099999904632568)").LastSegment.ShouldBeOperationImportSegment(HardCodedTestModel.GetFunctionImportForGetPet3()).ShouldHaveParameterCount(1).ShouldHaveConstantParameter("id", 1.0099999904632568D);
         }
 
-#if !NETCOREAPP3_1
+#if !NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void FunctionParameterSinglePrecision()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -634,7 +634,7 @@ namespace Microsoft.OData.Tests.UriParser
             EdmValidNamesNotAllowedInUri("_some_name");
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void EdmValidNamesNotAllowedInUri_Combinations()
         {
@@ -976,7 +976,7 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal("next", lexer.NextToken().Text);
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1&& !NETCOREAPP3_1
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1&& !NETCOREAPP3_1_OR_GREATER
         private char FindMatchingChar(UnicodeCategory category)
         {
             for (int i = 0; i <= 0xffff; i++)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataPathInfoTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataPathInfoTests.cs
@@ -1,0 +1,101 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="ODataPathInfoTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OData.Edm;
+using Microsoft.OData.UriParser;
+using Xunit;
+
+namespace Microsoft.OData.Tests.UriParser
+{
+    public class ODataPathInfoTests
+    {
+        private readonly EdmEntityType personEntityType;
+        private readonly EdmNavigationProperty friendsNavigationProperty;
+        private readonly EdmEntitySet peopleEntitySet;
+
+        public ODataPathInfoTests()
+        {
+            var model = new EdmModel();
+            this.personEntityType = model.AddEntityType("NS", "Person");
+            this.personEntityType.AddKeys(personEntityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32, isNullable: false));
+
+            this.friendsNavigationProperty = this.personEntityType.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo
+            {
+                Name = "Friends",
+                Target = this.personEntityType,
+                TargetMultiplicity = EdmMultiplicity.Many
+            });
+
+            var entityContainer = model.AddEntityContainer("NS", "Default");
+            this.peopleEntitySet = entityContainer.AddEntitySet("People", personEntityType);
+        }
+
+        [Fact]
+        public void TestODataPathInfo()
+        {
+            var odataPathInfo = new ODataPathInfo(this.personEntityType, this.peopleEntitySet);
+
+            Assert.Equal(this.peopleEntitySet, odataPathInfo.TargetNavigationSource);
+            Assert.Equal(this.personEntityType, odataPathInfo.TargetEdmType);
+            Assert.Equal(this.personEntityType, odataPathInfo.TargetStructuredType);
+            Assert.Empty(odataPathInfo.Segments);
+        }
+
+        [Fact]
+        public void TestODataPathInfoForEmptySegmentsInODataPath()
+        {
+            var odataPathInfo = new ODataPathInfo(new ODataPath());
+
+            Assert.Null(odataPathInfo.TargetNavigationSource);
+            Assert.Null(odataPathInfo.TargetEdmType);
+            Assert.Null(odataPathInfo.TargetStructuredType);
+            Assert.Empty(odataPathInfo.Segments);
+        }
+
+        [Fact]
+        public void TestODataPathInfoForEntitySetSegmentInODataPath()
+        {
+            var odataPath = new ODataPath(new EntitySetSegment(this.peopleEntitySet));
+            var odataPathInfo = new ODataPathInfo(odataPath);
+
+            Assert.Equal(this.peopleEntitySet, odataPathInfo.TargetNavigationSource);
+            Assert.Equal(this.personEntityType, odataPathInfo.TargetEdmType);
+            Assert.Equal(this.personEntityType, odataPathInfo.TargetStructuredType);
+            Assert.Single(odataPathInfo.Segments);
+        }
+
+        [Fact]
+        public void TestODataPathInfoForKeySegmentInODataPath()
+        {
+            var odataPath = new ODataPath(
+                new EntitySetSegment(this.peopleEntitySet),
+                new KeySegment(new[] { new KeyValuePair<string, object>("Id", 1) }, this.personEntityType, this.peopleEntitySet));
+            var odataPathInfo = new ODataPathInfo(odataPath);
+
+            Assert.Equal(this.peopleEntitySet, odataPathInfo.TargetNavigationSource);
+            Assert.Equal(this.personEntityType, odataPathInfo.TargetEdmType);
+            Assert.Equal(this.personEntityType, odataPathInfo.TargetStructuredType);
+            Assert.Equal(2, odataPathInfo.Segments.Count());
+        }
+
+        [Fact]
+        public void TestODataPathInfoForNavigationPropertySegmentInODataPath()
+        {
+            var odataPath = new ODataPath(
+                new EntitySetSegment(this.peopleEntitySet),
+                new KeySegment(new[] { new KeyValuePair<string, object>("Id", 1) }, this.personEntityType, this.peopleEntitySet),
+                new NavigationPropertySegment(this.friendsNavigationProperty, this.peopleEntitySet));
+            var odataPathInfo = new ODataPathInfo(odataPath);
+
+            Assert.Equal(this.peopleEntitySet, odataPathInfo.TargetNavigationSource);
+            Assert.Equal(this.personEntityType, odataPathInfo.TargetEdmType);
+            Assert.Equal(this.personEntityType, odataPathInfo.TargetStructuredType);
+            Assert.Equal(3, odataPathInfo.Segments.Count());
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -939,7 +939,7 @@ namespace Microsoft.OData.Tests.UriParser
             Uri url = new Uri("http://host/Paintings?$compute=nonsense as");
             ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, url);
             Action action = () => parser.ParseCompute();
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             action.Throws<ArgumentNullException>("Value cannot be null or empty. (Parameter 'alias')");
 #else
              action.Throws<ArgumentNullException>("Value cannot be null or empty.\r\nParameter name: alias");

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderJsonTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderJsonTests.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlWriterTests.cs
@@ -10,7 +10,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
 using System.Text.Encodings.Web;
 using System.Text.Json;
 #endif
@@ -2853,7 +2853,7 @@ var v40Json =
 
         internal void WriteAndVerifyJson(IEdmModel model, string expected, bool indented = true, bool isIeee754Compatible = false)
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             using (MemoryStream memStream = new MemoryStream())
             {
                 JsonWriterOptions options = new JsonWriterOptions

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/EdmValueParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/EdmValueParserTests.cs
@@ -429,7 +429,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             double? result;
             Assert.True(EdmValueParser.TryParseFloat("1.7976931348623157E+308", out result));
             Assert.Equal(double.MaxValue, result);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.True(EdmValueParser.TryParseFloat("1.7976931348623157E+309", out result));
 #else
             Assert.False(EdmValueParser.TryParseFloat("1.7976931348623157E+309", out result));

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Parsing/AnnotationJsonParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Parsing/AnnotationJsonParserTests.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
 using System.Linq;
 using System.Text.Json;
 using Microsoft.OData.Edm.Csdl.Parsing;

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Parsing/CsdlJsonParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Parsing/CsdlJsonParserTests.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
 using System;
 using System.Text;
 using System.Text.Json;

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Parsing/SchemaJsonParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Parsing/SchemaJsonParserTests.cs
@@ -4,7 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
@@ -6,7 +6,7 @@
 
 using System;
 using System.IO;
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
 using System.Text.Json;
 using System.Text.Encodings.Web;
 #endif
@@ -1666,7 +1666,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             IEdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(complexType, term, new EdmFloatingConstant(3.14f));
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             // Act & Assert for XML
             VisitAndVerifyXml(v => v.VisitVocabularyAnnotation(annotation),
                 @"<Annotation Term=""UI.FloatWidth"" Float=""3.140000104904175"" />");
@@ -2052,7 +2052,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
         internal void VisitAndVerifyJson(Action<EdmModelCsdlSerializationVisitor> testAction, string expected, bool indent = true, bool wrapper = true)
         {
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Version edmxVersion = this.model.GetEdmxVersion();
 
             using (MemoryStream memStream = new MemoryStream())

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
@@ -38,6 +38,10 @@
     <ProjectReference Include="..\..\..\src\Microsoft.OData.Edm\Microsoft.OData.Edm.csproj" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <DefineConstants>$(DefineConstants);NETCOREAPP3_1_OR_GREATER;NETCOREAPP</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp3.1'">
      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
   </ItemGroup>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/DateAndTimeOfDayTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/DateAndTimeOfDayTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             Action test = () => date.AddYears(-5000);
 
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
 #else
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
@@ -67,7 +67,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             Date date = new Date(2013, 8, 12);
             Action test = () => date.AddYears(12000);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
 #else
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
@@ -88,7 +88,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             Date date = new Date(1, 1, 1);
             Action test = () => date.AddMonths(-5000);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
 #else
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
@@ -101,7 +101,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             Date date = new Date(1, 1, 1);
             Action test = () => date.AddMonths(120001);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
 #else
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
@@ -122,7 +122,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             Date date = new Date(1, 1, 1);
             Action test = () => date.AddDays(-2);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
 #else
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
@@ -135,7 +135,7 @@ namespace Microsoft.OData.Edm.Tests.Library
             Date date = new Date(1, 1, 1);
             Action test = () => date.AddDays(999999999);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
 #else
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/ForwardingSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/ForwardingSegmentTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Spatial.Tests
             Exception ex = SpatialTestUtils.RunCatching(() => this.testSubject.GeographyPipeline.SetCoordinateSystem(coordinateSystem));
             Assert.True(ex.GetType() == typeof(InvalidOperationException), "got the exception we threw");
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1_OR_GREATER
             // .NET Core does not appear to generate this stack trace
             Assert.True(ex.StackTrace.Contains("DoWhenNotCall"), "Lost the original stack trace");
 #endif
@@ -89,7 +89,7 @@ namespace Microsoft.Spatial.Tests
             Exception ex = SpatialTestUtils.RunCatching(() => this.testSubject.GeographyPipeline.EndFigure());
             Assert.True(ex.GetType() == typeof(InvalidOperationException), "got the exception we threw");
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1_OR_GREATER
             // .NET Core does not appear to generate this stack trace
             Assert.True(ex.StackTrace.Contains("DoWhenCall"), "Lost the original stack trace");
 #endif

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/Microsoft.Spatial.Tests.csproj
@@ -38,6 +38,10 @@
     <PackageReference Include="System.Xml.XPath" Version="4.3.0" />
   </ItemGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <DefineConstants>$(DefineConstants);NETCOREAPP3_1_OR_GREATER;NETCOREAPP</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp3.1'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
   </ItemGroup>

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/SpatialReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/SpatialReaderTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Spatial.Tests
         public void ErrorOnNullDestinationInCtor()
         {
             Action act = () => new TrivialReader(null);
-#if NETCOREAPP3_1            
+#if NETCOREAPP3_1_OR_GREATER            
             SpatialTestUtils.VerifyExceptionThrown<ArgumentNullException>(act, "Value cannot be null. (Parameter 'destination')");
 #else
             SpatialTestUtils.VerifyExceptionThrown<ArgumentNullException>(act, "Value cannot be null.\r\nParameter name: destination");
@@ -62,7 +62,7 @@ namespace Microsoft.Spatial.Tests
             var reader = new TrivialReader(new CallSequenceLoggingPipeline());
             Action[] acts = { () => reader.ReadGeography(null), () => reader.ReadGeometry(null) };
 
-#if NETCOREAPP3_1
+#if NETCOREAPP3_1_OR_GREATER
             foreach (var act in acts)
             {
                 SpatialTestUtils.VerifyExceptionThrown<ArgumentNullException>(act, "Value cannot be null. (Parameter 'input')");

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Stubs/AdHocModel.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/ServerUnitTests/Stubs/AdHocModel.cs
@@ -188,7 +188,7 @@ namespace AstoriaUnitTests.Stubs
 
     public class AdHocPrimitiveType : AdHocType
     {
-        private static Dictionary<Type, string> map = TestUtil.CreateDictionary(
+        private static Dictionary<Type, string> map = TestUtil.CreateDictionary<Type, string>(
             new KeyValuePair<Type, string>(typeof(int), "int"),
             new KeyValuePair<Type, string>(typeof(Guid), "uniqueidentifier"),
             new KeyValuePair<Type, string>(typeof(string), "nvarchar"));

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Common/ExceptionUtilities.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Common/ExceptionUtilities.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Test.OData.Utils.Common
         /// </returns>
         public static bool IsCatchable(Exception exception)
         {
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1_OR_GREATER
             if (exception is ThreadAbortException)
             {
                 return false;

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/TestModels.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/TestModels.cs
@@ -255,7 +255,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
             // Model with OData-specific attribute annotations
             yield return BuildODataAnnotationTestModel(true);
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1_OR_GREATER
             // Astoria Default Test Model
             yield return BuildDefaultAstoriaTestModel();
 #endif
@@ -339,7 +339,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
             return model;
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
+#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1_OR_GREATER
         /// <summary>
         /// Builds the Astoria default test model and applies necessary fixups for use in OData tests.
         /// </summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Related to #2974.
- Add tests for `ODataPathInfo` class.
- Add **net8.0** as a target framework for **Microsoft.OData.Core.Tests** test project - necessitated replacing `NETCOREAPP3_1` with `NETCOREAPP3_1_OR_GREATER` across test files.
- Added _Microsoft.OData.Core.Tests.Net8.csproj_ project file targeting net8.0 framework for the specific purpose of running tests against that framework

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
