### PR TITLE
Set `ODataUtf8JsonWriter` as default `JsonWriter`

### DIFF
--- a/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
+++ b/src/Microsoft.OData.Core/Json/JsonValueUtils.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData.Json
         /// <summary>
         /// Characters which, if found inside a number, indicate that the number is a double when no other type information is available.
         /// </summary>
-        private static readonly char[] DoubleIndicatingCharacters = new char[] { '.', 'e', 'E' };
+        internal static readonly char[] DoubleIndicatingCharacters = new char[] { '.', 'e', 'E' };
 
         /// <summary>
         /// Map of special characters to strings.

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterFactory.cs
@@ -11,26 +11,26 @@ using System.Text;
 namespace Microsoft.OData.Json
 {
     /// <summary>
-    /// Default JSON writer factory
+    /// JSON writer factory
     /// </summary>
     [CLSCompliant(false)]
-    public sealed class DefaultJsonWriterFactory : IJsonWriterFactory
+    public sealed class ODataJsonWriterFactory : IJsonWriterFactory
     {
         private ODataStringEscapeOption stringEscapeOption;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultJsonWriterFactory" />.
+        /// Initializes a new instance of the <see cref="ODataJsonWriterFactory" />.
         /// </summary>
-        public DefaultJsonWriterFactory()
+        public ODataJsonWriterFactory()
             : this(ODataStringEscapeOption.EscapeNonAscii)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DefaultJsonWriterFactory" />.
+        /// Initializes a new instance of the <see cref="ODataJsonWriterFactory" />.
         /// </summary>
         /// <param name="stringEscapeOption">The string escape option.</param>
-        public DefaultJsonWriterFactory(ODataStringEscapeOption stringEscapeOption)
+        public ODataJsonWriterFactory(ODataStringEscapeOption stringEscapeOption)
         {
             this.stringEscapeOption = stringEscapeOption;
         }

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
@@ -60,9 +60,11 @@ namespace Microsoft.OData.Json
         /// <returns>A task representing the asynchronous operation. The task result contains a stream for writing the stream value.</returns>
         public async Task<Stream> StartStreamValueScopeAsync()
         {
-            this.WriteSeparatorIfNecessary();
+            this.CommitUtf8JsonWriterContentsToBuffer();
+
+            this.WriteItemWithSeparatorIfNeeded();
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.FlushAsync().ConfigureAwait(false);
 
             this.binaryValueStream = new ODataUtf8JsonWriteStream(this);
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -202,6 +202,24 @@ namespace Microsoft.OData.Json
             }
 
             /// <summary>
+            /// Writes the specifid character to the ODataUtf8JsonWriter.
+            /// </summary>
+            /// <param name="value">The character to write.</param>
+            public override void Write(char value)
+            {
+                if (!this.jsonWriter.isWritingJson)
+                {
+                    ReadOnlySpan<char> charToWrite = stackalloc char[1] { value };
+                    this.WriteCharsInChunks(charToWrite);
+                }
+                else
+                {
+                    ReadOnlySpan<char> charToWrite = stackalloc char[1] { value };
+                    this.WriteCharsInChunksWithoutEscaping(charToWrite);
+                }
+            }
+
+            /// <summary>
             /// Writes a specified number of characters from the given character array to the ODataUtf8JsonWriter.
             /// </summary>
             /// <param name="value">The character array from which to write characters.</param>

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -140,13 +140,13 @@ namespace Microsoft.OData.Json
         internal sealed class ODataUtf8JsonTextWriter : TextWriter
         {
             private readonly ODataUtf8JsonWriter jsonWriter = null;
-            // Buffer used to store chars that were could not be encoded due to
+            // Buffer used to store chars that could not be encoded due to
             // insufficient data in the input buffer. The chars will be prepended
             // to the next chunk of input.
             private char[] buffer;
-            // Number of chars in the buffer that are left over frevious chunk.
+            // Number of chars in the buffer that are left over from the previous chunk.
             private int numOfCharsNotWrittenFromPreviousChunk = 0;
-            // This buffer is used to by Write(char) to store the char so
+            // This buffer is used by Write(char) to store the char so
             // that we can re-use our Write(char[], ...) method.
             private char[] singleCharBuffer;
 
@@ -217,19 +217,18 @@ namespace Microsoft.OData.Json
             }
 
             /// <summary>
-            /// Writes the specifid character to the ODataUtf8JsonWriter.
+            /// Writes the specified character to the ODataUtf8JsonWriter.
             /// </summary>
             /// <param name="value">The character to write.</param>
             public override void Write(char value)
             {
+                ReadOnlySpan<char> charToWrite = stackalloc char[1] { value };
                 if (!this.jsonWriter.isWritingJson)
                 {
-                    ReadOnlySpan<char> charToWrite = stackalloc char[1] { value };
                     this.WriteCharsInChunks(charToWrite);
                 }
                 else
                 {
-                    ReadOnlySpan<char> charToWrite = stackalloc char[1] { value };
                     this.WriteCharsInChunksWithoutEscaping(charToWrite);
                 }
             }
@@ -246,7 +245,6 @@ namespace Microsoft.OData.Json
 
                 if (!this.jsonWriter.isWritingJson)
                 {
-                
                     await this.WriteCharsInChunksAsync(input).ConfigureAwait(false);
                 }
                 else

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -9,12 +9,10 @@ namespace Microsoft.OData.Json
 {
     using System;
     using System.Buffers;
-    using System.Diagnostics;
     using System.IO;
     using System.Text;
     using System.Text.Unicode;
     using System.Threading.Tasks;
-    using static System.Net.Mime.MediaTypeNames;
 
     internal sealed partial class ODataUtf8JsonWriter
     {

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -142,8 +142,15 @@ namespace Microsoft.OData.Json
         internal sealed class ODataUtf8JsonTextWriter : TextWriter
         {
             private readonly ODataUtf8JsonWriter jsonWriter = null;
+            // Buffer used to store chars that were could not be encoded due to
+            // insufficient data in the input buffer. The chars will be prepended
+            // to the next chunk of input.
             private char[] buffer;
+            // Number of chars in the buffer that are left over frevious chunk.
             private int numOfCharsNotWrittenFromPreviousChunk = 0;
+            // This buffer is used to by Write(char) to store the char so
+            // that we can re-use our Write(char[], ...) method.
+            private char[] singleCharBuffer;
 
             public ODataUtf8JsonTextWriter(ODataUtf8JsonWriter jsonWriter)
             {
@@ -183,6 +190,11 @@ namespace Microsoft.OData.Json
                     ArrayPool<char>.Shared.Return(this.buffer);
                 }
 
+                if (this.singleCharBuffer != null)
+                {
+                    ArrayPool<char>.Shared.Return(this.singleCharBuffer);
+                }
+
                 this.Flush();
                 base.Dispose(disposing);
             }
@@ -196,6 +208,11 @@ namespace Microsoft.OData.Json
                 if (this.buffer != null)
                 {
                     ArrayPool<char>.Shared.Return(this.buffer);
+                }
+
+                if (this.singleCharBuffer != null)
+                {
+                    ArrayPool<char>.Shared.Return(this.singleCharBuffer);
                 }
 
                 await this.FlushAsync().ConfigureAwait(false);
@@ -216,6 +233,27 @@ namespace Microsoft.OData.Json
                 {
                     ReadOnlySpan<char> charToWrite = stackalloc char[1] { value };
                     this.WriteCharsInChunksWithoutEscaping(charToWrite);
+                }
+            }
+
+            /// <summary>
+            /// Writes the specifid character to the ODataUtf8JsonWriter.
+            /// </summary>
+            /// <param name="value">The character to write.</param>
+            public override async Task WriteAsync(char value)
+            {
+                this.singleCharBuffer ??= ArrayPool<char>.Shared.Rent(1);
+                this.singleCharBuffer[0] = value;
+                ReadOnlyMemory<char> input = this.singleCharBuffer.AsMemory().Slice(0, 1);
+
+                if (!this.jsonWriter.isWritingJson)
+                {
+                
+                    await this.WriteCharsInChunksAsync(input).ConfigureAwait(false);
+                }
+                else
+                {
+                    await this.WriteCharsInChunksWithoutEscapingAsync(input).ConfigureAwait(false);
                 }
             }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -323,7 +323,7 @@ namespace Microsoft.OData.Json
                 // dropping this in the future (potentially behind a compatibility flag) to avoid
                 // the cost of converting to a string and checking whether a decimal point is needed.
                 bool needsFractionalPart = valueToWrite.IndexOfAny(JsonValueUtils.DoubleIndicatingCharacters) == -1;
-                this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: false);
+                this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: true);
             }
 
             this.FlushIfBufferThresholdReached();
@@ -1034,7 +1034,7 @@ namespace Microsoft.OData.Json
                 // dropping this in the future (potentially behind a compatibility flag) to avoid
                 // the cost of converting to a string and checking whether a decimal point is needed.
                 bool needsFractionalPart = valueToWrite.IndexOfAny(JsonValueUtils.DoubleIndicatingCharacters) == -1;
-                this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: false);
+                this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: true);
             }
 
             await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -312,11 +312,16 @@ namespace Microsoft.OData.Json
             }
             else
             {
-                // We write doubles like 100 as 100.0 (with .0 decimal point) to distinguish from ints when round-tripping.
-                // double.ToString() supports a max scale of 14,
                 // whereas double.MinValue and double.MaxValue have 16 digits scale. Hence we need
                 // to use XmlConvert in all other cases, except infinity
                 string valueToWrite = XmlConvert.ToString(value);
+
+                // We write doubles like 100 as 100.0 (with .0 decimal point).
+                // We do this to retain consistency with the legacy JsonWriter and with older
+                // versions. However, it's not a hard requirement. Clients should not rely on the .0
+                // to decide whether a value is an integer or double. We should consider
+                // dropping this in the future (potentially behind a compatibility flag) to avoid
+                // the cost of converting to a string and checking whether a decimal point is needed.
                 bool needsFractionalPart = valueToWrite.IndexOfAny(JsonValueUtils.DoubleIndicatingCharacters) == -1;
                 this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: false);
             }

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -1023,7 +1023,18 @@ namespace Microsoft.OData.Json
             }
             else
             {
-                this.utf8JsonWriter.WriteNumberValue(value);
+                // whereas double.MinValue and double.MaxValue have 16 digits scale. Hence we need
+                // to use XmlConvert in all other cases, except infinity
+                string valueToWrite = XmlConvert.ToString(value);
+
+                // We write doubles like 100 as 100.0 (with .0 decimal point).
+                // We do this to retain consistency with the legacy JsonWriter and with older
+                // versions. However, it's not a hard requirement. Clients should not rely on the .0
+                // to decide whether a value is an integer or double. We should consider
+                // dropping this in the future (potentially behind a compatibility flag) to avoid
+                // the cost of converting to a string and checking whether a decimal point is needed.
+                bool needsFractionalPart = valueToWrite.IndexOfAny(JsonValueUtils.DoubleIndicatingCharacters) == -1;
+                this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: false);
             }
 
             await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -252,7 +252,23 @@ namespace Microsoft.OData.Json
         public void WriteValue(float value)
         {
             this.WriteSeparatorIfNecessary();
-            this.utf8JsonWriter.WriteNumberValue(value);
+            if (float.IsNaN(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(nanValue.Span);
+            }
+            else if (float.IsPositiveInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(positiveInfinityValue.Span);
+            }
+            else if (float.IsNegativeInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(negativeInfinityValue.Span);
+            }
+            else
+            {
+                this.utf8JsonWriter.WriteNumberValue(value);
+            }
+
             this.FlushIfBufferThresholdReached();
         }
 
@@ -936,7 +952,23 @@ namespace Microsoft.OData.Json
         public async Task WriteValueAsync(float value)
         {
             this.WriteSeparatorIfNecessary();
-            this.utf8JsonWriter.WriteNumberValue(value);
+            if (float.IsNaN(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(nanValue.Span);
+            }
+            else if (float.IsPositiveInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(positiveInfinityValue.Span);
+            }
+            else if (float.IsNegativeInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(negativeInfinityValue.Span);
+            }
+            else
+            {
+                this.utf8JsonWriter.WriteNumberValue(value);
+            }
+
             await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -123,7 +123,7 @@ namespace Microsoft.OData.Json
             this.bufferFlushThreshold = 0.9f * this.bufferSize;
             this.leaveStreamOpen = leaveStreamOpen;
             this.outputEncoding = encoding;
-            this.encoder = encoder ?? JavaScriptEncoder.Default;
+            this.encoder = encoder ?? JavaScriptEncoder.UnsafeRelaxedJsonEscaping;
 
             if (this.outputEncoding.CodePage == Encoding.UTF8.CodePage)
             {

--- a/src/Microsoft.OData.Core/ODataServiceCollectionExtensions.cs
+++ b/src/Microsoft.OData.Core/ODataServiceCollectionExtensions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Start by registering services that do not require execution state.
             services.AddSingleton<IJsonReaderFactory, DefaultJsonReaderFactory>();
-            services.AddSingleton<IJsonWriterFactory, DefaultJsonWriterFactory>();
+            services.AddSingleton<IJsonWriterFactory, ODataUtf8JsonWriterFactory>();
             services.AddSingleton(sp => ODataMediaTypeResolver.GetMediaTypeResolver(null));
             services.AddSingleton(sp => ODataPayloadValueConverter.GetPayloadValueConverter(null));
             services.AddSingleton<IEdmModel>(sp => EdmCoreModel.Instance);

--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,7 +1,6 @@
 Microsoft.Extensions.DependencyInjection.ODataServiceCollectionExtensions
 Microsoft.OData.IServiceCollectionProvider
 Microsoft.OData.IServiceCollectionProvider.ServiceProvider.get -> System.IServiceProvider
-Microsoft.OData.Json.DefaultJsonWriterFactory.CreateJsonWriter(System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding) -> Microsoft.OData.Json.IJsonWriter
 Microsoft.OData.Json.IJsonWriter.EndArrayScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.EndObjectScopeAsync() -> System.Threading.Tasks.Task
 Microsoft.OData.Json.IJsonWriter.EndPaddingFunctionScopeAsync() -> System.Threading.Tasks.Task
@@ -46,6 +45,10 @@ Microsoft.OData.Json.IJsonReader.CreateTextReaderAsync() -> System.Threading.Tas
 Microsoft.OData.Json.IJsonReader.GetValue() -> object
 Microsoft.OData.Json.IJsonReader.GetValueAsync() -> System.Threading.Tasks.Task<object>
 Microsoft.OData.Json.IJsonReader.ReadAsync() -> System.Threading.Tasks.Task<bool>
+Microsoft.OData.Json.ODataJsonWriterFactory
+Microsoft.OData.Json.ODataJsonWriterFactory.CreateJsonWriter(System.IO.Stream stream, bool isIeee754Compatible, System.Text.Encoding encoding) -> Microsoft.OData.Json.IJsonWriter
+Microsoft.OData.Json.ODataJsonWriterFactory.ODataJsonWriterFactory() -> void
+Microsoft.OData.Json.ODataJsonWriterFactory.ODataJsonWriterFactory(Microsoft.OData.Json.ODataStringEscapeOption stringEscapeOption) -> void
 Microsoft.OData.ODataAsynchronousResponseMessage.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataBatchOperationRequestMessage.ServiceProvider.get -> System.IServiceProvider
 Microsoft.OData.ODataBatchOperationResponseMessage.ServiceProvider.get -> System.IServiceProvider
@@ -259,9 +262,6 @@ Microsoft.OData.IODataResponseMessage.StatusCode.get -> int
 Microsoft.OData.IODataResponseMessage.StatusCode.set -> void
 Microsoft.OData.IODataResponseMessageAsync
 Microsoft.OData.IODataResponseMessageAsync.GetStreamAsync() -> System.Threading.Tasks.Task<System.IO.Stream>
-Microsoft.OData.Json.DefaultJsonWriterFactory
-Microsoft.OData.Json.DefaultJsonWriterFactory.DefaultJsonWriterFactory() -> void
-Microsoft.OData.Json.DefaultJsonWriterFactory.DefaultJsonWriterFactory(Microsoft.OData.Json.ODataStringEscapeOption stringEscapeOption) -> void
 Microsoft.OData.Json.IJsonReader
 Microsoft.OData.Json.IJsonReader.IsIeee754Compatible.get -> bool
 Microsoft.OData.Json.IJsonReader.NodeType.get -> Microsoft.OData.Json.JsonNodeType

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/ODataJsonWriterShortSpanIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/ODataJsonWriterShortSpanIntegrationTests.cs
@@ -382,7 +382,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
             var property = new ODataProperty { Name = "OpenStringProperty", Value = new ODataPrimitiveValue(String.Empty + "K\uFFFF") };
             property.SetSerializationInfo(new ODataPropertySerializationInfo { PropertyKind = ODataPropertyKind.Open });
             var entry = new ODataResource { TypeName = "NS.MyDerivedEntityType", Properties = new[] { property } };
-            const string expectedPayload = "{\"@odata.context\":\"http://odata.org/test/$metadata#MySet/NS.MyDerivedEntityType/$entity\",\"OpenStringProperty\":\"K\\uffff\"}";
+            const string expectedPayload = "{\"@odata.context\":\"http://odata.org/test/$metadata#MySet/NS.MyDerivedEntityType/$entity\",\"OpenStringProperty\":\"K\\uFFFF\"}";
             this.WriteNestedItemsAndValidatePayload(entitySetFullName: "MySet", derivedEntityTypeFullName: "NS.MyDerivedEntityType", nestedItemToWrite: new[] { entry }, expectedPayload: expectedPayload, writingResponse: true);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/PropertyAndValueJsonWriterIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/PropertyAndValueJsonWriterIntegrationTests.cs
@@ -451,6 +451,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
             EdmEntityType entityType = new EdmEntityType("NS", "Person");
             entityType.AddKeys(entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
             entityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            entityType.AddStructuralProperty("Amount", EdmPrimitiveTypeKind.Double);
             model.AddElement(entityType);
 
             EdmEntityContainer container = new EdmEntityContainer("Ns", "MyContainer");
@@ -463,35 +464,95 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
                 Properties = new[]
                 {
                     new ODataProperty { Name = "Id", Value = 1 },
-                    new ODataProperty { Name = "Name", Value = "и\nя" }
+                    new ODataProperty { Name = "Name", Value = "и\nя" },
+                    new ODataProperty { Name = "Amount", Value = 300.0 }
                 }
             };
 
-            // 1. without string escape option
-            string outputPayload = this.WriterEntry(model, entry, entitySet, entityType, false, null, encoder: null);
-
-            const string expectedEscapedNonAsciiPayload =
-                "{" +
-                "\"@odata.context\":\"http://www.example.com/$metadata#People/$entity\"," +
-                "\"Id\":1," +
-                "\"Name\":\"\\u0438\\n\\u044F\"" +
-                "}";
-            Assert.Equal(expectedEscapedNonAsciiPayload, outputPayload);
-
-            // 2. With EscapeNonAscii escape option
-            outputPayload = this.WriterEntry(model, entry, entitySet, entityType, false, null, JavaScriptEncoder.Default);
-
-            Assert.Equal(expectedEscapedNonAsciiPayload, outputPayload);
-
-            // 3. With EscapeOnlyControls escape option
-            outputPayload = this.WriterEntry(model, entry, entitySet, entityType,
-                false, null, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+            // 1. without specifying JavaScriptEncoder
+            string outputPayload = this.WriterEntry(model, entry, entitySet, entityType, false, null, jsonWriterFactory: null);
 
             const string expectedEscapedOnlyControlPayload =
                 "{" +
                 "\"@odata.context\":\"http://www.example.com/$metadata#People/$entity\"," +
                 "\"Id\":1," +
-                "\"Name\":\"и\\nя\"" +
+                "\"Name\":\"и\\nя\"," +
+                "\"Amount\":300.0" +
+                "}";
+            Assert.Equal(expectedEscapedOnlyControlPayload, outputPayload);
+
+
+            // 2. With JavaScriptEncoder.Default (escapes non-ascii character)
+            const string expectedEscapedNonAsciiPayload =
+                "{" +
+                "\"@odata.context\":\"http://www.example.com/$metadata#People/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"\\u0438\\n\\u044F\"," +
+                "\"Amount\":300.0" +
+                "}";
+            outputPayload = this.WriterEntry(model, entry, entitySet, entityType, false, null, new ODataUtf8JsonWriterFactory(JavaScriptEncoder.Default));
+
+            Assert.Equal(expectedEscapedNonAsciiPayload, outputPayload);
+
+            // 3. With JavaScriptEncoder.UnsafeRelaxedJsonEscaping, escapes control control characters
+            outputPayload = this.WriterEntry(model, entry, entitySet, entityType,
+                false, null, new ODataUtf8JsonWriterFactory(JavaScriptEncoder.UnsafeRelaxedJsonEscaping));
+            Assert.Equal(expectedEscapedOnlyControlPayload, outputPayload);
+        }
+
+        [Fact]
+        public void WriteEntryWithStringEscapeOptionShouldWorkUsingODataJsonWriterFactory()
+        {
+            EdmModel model = new EdmModel();
+
+            EdmEntityType entityType = new EdmEntityType("NS", "Person");
+            entityType.AddKeys(entityType.AddStructuralProperty("Id", EdmPrimitiveTypeKind.Int32));
+            entityType.AddStructuralProperty("Name", EdmPrimitiveTypeKind.String);
+            entityType.AddStructuralProperty("Amount", EdmPrimitiveTypeKind.Double);
+            model.AddElement(entityType);
+
+            EdmEntityContainer container = new EdmEntityContainer("Ns", "MyContainer");
+            EdmEntitySet entitySet = container.AddEntitySet("People", entityType);
+            model.AddElement(container);
+
+            ODataResource entry = new ODataResource()
+            {
+                TypeName = "NS.Person",
+                Properties = new[]
+                {
+                    new ODataProperty { Name = "Id", Value = 1 },
+                    new ODataProperty { Name = "Name", Value = "и\nя" },
+                    new ODataProperty { Name = "Amount", Value = 300.0 }
+                }
+            };
+
+            // 1. without string escape option
+            string outputPayload = this.WriterEntry(model, entry, entitySet, entityType, false, null, new ODataJsonWriterFactory());
+
+            const string expectedEscapedNonAsciiPayload =
+                "{" +
+                "\"@odata.context\":\"http://www.example.com/$metadata#People/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"\\u0438\\n\\u044f\"," +
+                "\"Amount\":300.0" +
+                "}";
+            Assert.Equal(expectedEscapedNonAsciiPayload, outputPayload);
+
+            // 2. With EscapeNonAscii escape option
+            outputPayload = this.WriterEntry(model, entry, entitySet, entityType, false, null, new ODataJsonWriterFactory(ODataStringEscapeOption.EscapeNonAscii));
+
+            Assert.Equal(expectedEscapedNonAsciiPayload, outputPayload);
+
+            // 3. With EscapeOnlyControls escape option
+            outputPayload = this.WriterEntry(model, entry, entitySet, entityType,
+                false, null, new ODataJsonWriterFactory(ODataStringEscapeOption.EscapeOnlyControls));
+
+            const string expectedEscapedOnlyControlPayload =
+                "{" +
+                "\"@odata.context\":\"http://www.example.com/$metadata#People/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"и\\nя\"," +
+                 "\"Amount\":300.0" +
                 "}";
             Assert.Equal(expectedEscapedOnlyControlPayload, outputPayload);
         }
@@ -521,7 +582,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
             };
 
             string outputPayload = this.WriterEntry(model, entry, entitySet, entityType,
-                false, null, JavaScriptEncoder.UnsafeRelaxedJsonEscaping);
+                false, null, new ODataUtf8JsonWriterFactory(JavaScriptEncoder.UnsafeRelaxedJsonEscaping));
 
             const string expectedMinimalPayload =
                 "{" +
@@ -561,13 +622,13 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         }
 
         private string WriterEntry(IEdmModel userModel, ODataResource entry, EdmEntitySet entitySet, IEdmEntityType entityType,
-            bool fullMetadata = false, Action<ODataWriter> writeAction = null, JavaScriptEncoder encoder = null)
+            bool fullMetadata = false, Action<ODataWriter> writeAction = null, IJsonWriterFactory jsonWriterFactory = null)
         {
             var message = new InMemoryMessage() { Stream = new MemoryStream() };
-            if (encoder != null)
+            if (jsonWriterFactory != null)
             {
                 IServiceCollection services = new ServiceCollection().AddDefaultODataServices();
-                services.AddSingleton<IJsonWriterFactory>(sp => new ODataUtf8JsonWriterFactory(encoder));
+                services.AddSingleton<IJsonWriterFactory>(sp => jsonWriterFactory);
                 message.ServiceProvider = services.BuildServiceProvider();
             }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/PropertyAndValueJsonWriterIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/PropertyAndValueJsonWriterIntegrationTests.cs
@@ -566,7 +566,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
             if (stringEscapeOption != null)
             {
                 IServiceCollection services = new ServiceCollection().AddDefaultODataServices();
-                services.AddSingleton<IJsonWriterFactory>(sp => new DefaultJsonWriterFactory(stringEscapeOption.Value));
+                services.AddSingleton<IJsonWriterFactory>(sp => new ODataJsonWriterFactory(stringEscapeOption.Value));
                 message.ServiceProvider = services.BuildServiceProvider();
             }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncBaseTests.cs
@@ -968,6 +968,86 @@ namespace Microsoft.OData.Tests.Json
             }
         }
 
+        [Theory]
+        [InlineData("application/json", 'a', "a")]
+        [InlineData("text/html", 'a', "\"a\"")]
+        [InlineData("text/plain", 'a', "\"a\"")]
+        // JSON special char
+        [InlineData("application/json", '"', "\"")]
+        [InlineData("text/html", '"', "\"\\\"\"")]
+        [InlineData("text/plain", '"', "\"\\\"\"")]
+        // non-ascii
+        [InlineData("application/json", '你', "你")]
+        [InlineData("text/html", '你', "\"你\"")]
+        [InlineData("text/plain", '你', "\"你\"")]
+        public async Task TextWriter_CorrectlyWritesSingleCharacterAsync(string contentType, char value, string expectedOutput)
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            var tw = await jsonWriter.StartTextWriterValueScopeAsync(contentType);
+            await tw.WriteAsync(value);
+            await jsonWriter.EndTextWriterValueScopeAsync();
+            await jsonWriter.FlushAsync();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal(expectedOutput, rawOutput);
+        }
+
+        [Theory]
+        [InlineData(124.45, "124.45")]
+        // We write the .0 for doubles without a fractional part
+        // for consistency with the original JsonWriter implementation
+        // and with previous versions. However, it's not a hard requirement.
+        // Clients should not rely on the .0 to decide whether a value
+        // is an integer or double.
+        // In the future we can consider relaxing the need to add a .0 (possibly behind a feature flag).
+        [InlineData(124.0, "124.0")]
+        [InlineData(1.123456789012345, "1.123456789012345")]
+        [InlineData(1.245E+24, "1.245E+24")]
+        [InlineData(1.245E-24, "1.245E-24")]
+        [InlineData(double.PositiveInfinity, "\"INF\"")]
+        [InlineData(double.NegativeInfinity, "\"-INF\"")]
+        [InlineData(double.NaN, "\"NaN\"")]
+        public async Task WriteDoubleAsync(double value, string expectedOutput)
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            await jsonWriter.WriteValueAsync(value);
+            await jsonWriter.FlushAsync();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal(expectedOutput, rawOutput);
+        }
+
+        [Theory]
+        [InlineData(124.45f, "124.45")]
+        [InlineData(124.0f, "124")]
+        [InlineData(1.123456f, "1.123456")]
+        [InlineData(1.245E+10f, "1.245E+10")]
+        [InlineData(1.245E-10f, "1.245E-10")]
+        [InlineData(float.PositiveInfinity, "\"INF\"")]
+        [InlineData(float.NegativeInfinity, "\"-INF\"")]
+        [InlineData(float.NaN, "\"NaN\"")]
+        public async Task WriteFloatAsync(float value, string expectedOutput)
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            await jsonWriter.WriteValueAsync(value);
+            await jsonWriter.FlushAsync();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal(expectedOutput, rawOutput);
+        }
+
         /// <summary>
         /// Normalizes the differences between JSON text encoded
         /// by Utf8JsonWriter and OData's JsonWriter, to make

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
@@ -400,6 +400,28 @@ namespace Microsoft.OData.Tests.Json
                 (jsonWriter) => jsonWriter.WriteValueAsync("foo\tbar"));
         }
 
+
+        [Theory]
+        [InlineData("application/json", "🐂")]
+        [InlineData("text/html", "\"🐂\"")]
+        [InlineData("text/plain", "\"🐂\"")]
+        public async Task TextWriter_CorrectlyHandlesSurrogatePairsAsync(string contentType, string expectedOutput)
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            var tw = await jsonWriter.StartTextWriterValueScopeAsync(contentType);
+            await tw.WriteAsync('\ud83d');
+            await tw.WriteAsync('\udc02');
+            await jsonWriter.EndTextWriterValueScopeAsync();
+            await jsonWriter.FlushAsync();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal(expectedOutput, rawOutput);
+        }
+
         private async Task SetupJsonWriterRunTestAndVerifyRentAsync(Func<JsonWriter, Task> func)
         {
             var jsonWriter = new JsonWriter(new StringWriter(builder), isIeee754Compatible: true);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -1047,6 +1047,52 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal(expectedOutput, rawOutput);
         }
 
+        [Theory]
+        [InlineData(124.45, "124.45")]
+        [InlineData(124.0, "124.0")]
+        [InlineData(1.123456789012345, "1.123456789012345")]
+        [InlineData(1.245E+24, "1.245E+24")]
+        [InlineData(1.245E-24, "1.245E-24")]
+        [InlineData(double.PositiveInfinity, "\"INF\"")]
+        [InlineData(double.NegativeInfinity, "\"-INF\"")]
+        [InlineData(double.NaN, "\"NaN\"")]
+        public void WriteDouble(double value, string expectedOutput)
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            jsonWriter.WriteValue(value);
+            jsonWriter.Flush();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal(expectedOutput, rawOutput);
+        }
+
+        [Theory]
+        [InlineData(124.45f, "124.45")]
+        [InlineData(124.0f, "124")]
+        [InlineData(1.123456f, "1.123456")]
+        [InlineData(1.245E+10f, "1.245E+10")]
+        [InlineData(1.245E-10f, "1.245E-10")]
+        [InlineData(float.PositiveInfinity, "\"INF\"")]
+        [InlineData(float.NegativeInfinity, "\"-INF\"")]
+        [InlineData(float.NaN, "\"NaN\"")]
+        public void WriteFloat(float value, string expectedOutput)
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            jsonWriter.WriteValue(value);
+            jsonWriter.Flush();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal(expectedOutput, rawOutput);
+        }
+
         /// <summary>
         /// Normalizes the differences between JSON text encoded
         /// by Utf8JsonWriter and OData's JsonWriter, to make

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -1155,7 +1155,7 @@ namespace Microsoft.OData.Tests.Json
                 int remainingLength = Math.Min(chunkSize, input.Length - i);
                 string chunk = input.Substring(i, remainingLength);
                 s += chunk;
-                s += "\\n\\n\\n\\n\\u0022\\u0022\\n\\n\\n\\n\\u0022\\u0022";
+                s += "\\n\\n\\n\\n\\\"\\\"\\n\\n\\n\\n\\\"\\\"";
             }
 
             return s;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -1049,6 +1049,12 @@ namespace Microsoft.OData.Tests.Json
 
         [Theory]
         [InlineData(124.45, "124.45")]
+        // We write the .0 for doubles without a fractional part
+        // for consistency with the original JsonWriter implementation
+        // and with previous versions. However, it's not a hard requirement.
+        // Clients should not rely on the .0 to decide whether a value
+        // is an integer or double.
+        // In the future we can consider relaxing the need to add a .0 (possibly behind a feature flag).
         [InlineData(124.0, "124.0")]
         [InlineData(1.123456789012345, "1.123456789012345")]
         [InlineData(1.245E+24, "1.245E+24")]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -484,6 +484,27 @@ namespace Microsoft.OData.Tests.Json
             }
         }
 
+        [Theory]
+        [InlineData("application/json", "🐂")]
+        [InlineData("text/html", "\"🐂\"")]
+        [InlineData("text/plain", "\"🐂\"")]
+        public void TextWriter_CorrectlyHandlesSurrogatePairs(string contentType, string expectedOutput)
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            var tw = jsonWriter.StartTextWriterValueScope(contentType);
+            tw.Write('\ud83d');
+            tw.Write('\udc02');
+            jsonWriter.EndTextWriterValueScope();
+            jsonWriter.Flush();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal(expectedOutput, rawOutput);
+        }
+
         private void SetupJsonWriterRunTestAndVerifyRent(Action<JsonWriter> action)
         {
             var jsonWriter = new JsonWriter(new StringWriter(builder), isIeee754Compatible: true);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -370,8 +370,8 @@ namespace Microsoft.OData.Tests.Json
         [InlineData("text/html")]
         public void CorrectlyStreams_NonAsciiCharacters_ToOutput(string contentType)
         {
-            string input = "😊😊😊😊😊😊😊😊";
-            string expectedOutput = "😊😊😊😊😊😊😊😊";
+            string input = "😊😊😊😊😊😊😊";
+            string expectedOutput = "😊😊😊😊😊😊😊";
 
             using (MemoryStream stream = new MemoryStream())
             {
@@ -403,7 +403,7 @@ namespace Microsoft.OData.Tests.Json
             string input = new string('a', inputLength);
 
             // Append special characters to the input string
-            input += "U+1F600";
+            input += "😊";
 
             using (MemoryStream stream = new MemoryStream())
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextTests.cs
@@ -555,7 +555,7 @@ namespace Microsoft.OData.Tests.Json
             var messageInfo = CreateMessageInfo(this.model, /*synchronous*/ true, /*writingResponse*/ true);
             messageInfo.ServiceProvider = ServiceProviderHelper.BuildServiceProvider(builder =>
             {
-                builder.AddSingleton<IJsonWriterFactory>(_ => new DefaultJsonWriterFactory());
+                builder.AddSingleton<IJsonWriterFactory>(_ => new ODataJsonWriterFactory());
             });
 
             var jsonOutputContext = new ODataJsonOutputContext(messageInfo, this.messageWriterSettings);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonServiceDocumentSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonServiceDocumentSerializerTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     FunctionImports = new ODataFunctionImportInfo[] {new ODataFunctionImportInfo() {Name = "name1", Url = new Uri("http://Service/FunctionImport")}}
                 },
-                @"﻿{""value"":[{""name"":""name1"",""kind"":""FunctionImport"",""url"":""http://service/FunctionImport""}]}");
+                @"{""value"":[{""name"":""name1"",""kind"":""FunctionImport"",""url"":""http://service/FunctionImport""}]}");
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace Microsoft.OData.Tests.Json
                         new ODataFunctionImportInfo() { Name = "name1", Url = new Uri("http://Service/FunctionImport") }
                     }
                 },
-                @"﻿{""value"":[{""name"":""name1"",""kind"":""FunctionImport"",""url"":""http://service/FunctionImport""}]}");
+                @"{""value"":[{""name"":""name1"",""kind"":""FunctionImport"",""url"":""http://service/FunctionImport""}]}");
         }
 
         [Fact]
@@ -51,7 +51,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Singletons = new[] { new ODataSingletonInfo { Name = "singleton", Url = new Uri("http://Service/Singleton"), Title = "Some Singleton" } }
                 },
-                @"﻿{""value"":[{""name"":""singleton"",""title"":""Some Singleton"",""kind"":""Singleton"",""url"":""http://service/Singleton""}]}");
+                @"{""value"":[{""name"":""singleton"",""title"":""Some Singleton"",""kind"":""Singleton"",""url"":""http://service/Singleton""}]}");
         }
 
         [Fact]
@@ -62,7 +62,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     EntitySets = new[] { new ODataEntitySetInfo { Name = "entityset", Url = new Uri("http://Service/EntitySet"), Title = "Some EntitySet" } }
                 },
-                @"﻿{""value"":[{""name"":""entityset"",""title"":""Some EntitySet"",""kind"":""EntitySet"",""url"":""http://service/EntitySet""}]}");
+                @"{""value"":[{""name"":""entityset"",""title"":""Some EntitySet"",""kind"":""EntitySet"",""url"":""http://service/EntitySet""}]}");
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     Singletons = new[] { new ODataSingletonInfo { Name = "someSingleton", Url = new Uri("http://Service/Singleton"), Title = "someSingleton" } }
                 },
-                @"﻿{""value"":[{""name"":""someSingleton"",""kind"":""Singleton"",""url"":""http://service/Singleton""}]}");
+                @"{""value"":[{""name"":""someSingleton"",""kind"":""Singleton"",""url"":""http://service/Singleton""}]}");
         }
 
         [Fact]
@@ -84,7 +84,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     EntitySets = new[] { new ODataEntitySetInfo { Name = "entityset", Url = new Uri("http://Service/EntitySet"), Title = null } }
                 },
-                @"﻿{""value"":[{""name"":""entityset"",""kind"":""EntitySet"",""url"":""http://service/EntitySet""}]}");
+                @"{""value"":[{""name"":""entityset"",""kind"":""EntitySet"",""url"":""http://service/EntitySet""}]}");
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace Microsoft.OData.Tests.Json
                 {
                     EntitySets = new[] { new ODataEntitySetInfo { Name = "entityset", Url = new Uri("http://Service/EntitySet"), Title = "" } }
                 },
-                @"﻿{""value"":[{""name"":""entityset"",""kind"":""EntitySet"",""url"":""http://service/EntitySet""}]}");
+                @"{""value"":[{""name"":""entityset"",""kind"":""EntitySet"",""url"":""http://service/EntitySet""}]}");
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -449,7 +449,7 @@ namespace Microsoft.OData.Tests.Json
 
             this.writer = new ODataUtf8JsonWriter(this.stream, false, encoding);
             await this.writer.WriteODataValueAsync(collectionValue);
-            Assert.Equal("[{\"Name\":\"Sue\\uD800\\uDC05 \\u00E4\",\"Age\":19},{\"Name\":\"Joe\",\"Age\":23}]", await this.ReadStreamAsync(encoding));
+            Assert.Equal("[{\"Name\":\"Sue\\uD800\\uDC05 ä\",\"Age\":19},{\"Name\":\"Joe\",\"Age\":23}]", await this.ReadStreamAsync(encoding));
         }
 
         #endregion Support for other Encodings

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -127,6 +127,24 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public async Task WritePrimitiveValueAsyncFloatNaN()
+        {
+            await this.VerifyWritePrimitiveValueAsync(float.NaN, "\"NaN\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncFloatPositiveInfinity()
+        {
+            await this.VerifyWritePrimitiveValueAsync(float.PositiveInfinity, "\"INF\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncFloatNegativeInfinity()
+        {
+            await this.VerifyWritePrimitiveValueAsync(float.NegativeInfinity, "\"-INF\"");
+        }
+
+        [Fact]
         public async Task WritePrimitiveValueAsync_Int16()
         {
             await this.VerifyWritePrimitiveValueAsync((short)876, "876");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -417,8 +417,7 @@ namespace Microsoft.OData.Tests.Json
                 new object[] { Encoding.UTF8 },
                 new object[] { Encoding.Unicode },
                 new object[] { Encoding.UTF32 },
-                new object[] { Encoding.BigEndianUnicode },
-                new object[] { Encoding.ASCII }
+                new object[] { Encoding.BigEndianUnicode }
            };
 
         [Theory]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -710,6 +710,29 @@ namespace Microsoft.OData.Tests.Json
             }
         }
 
+        [Theory]
+        // both the escaped and non-escaped versions are valid
+        // and compliant JSON parsers should be able to handle both
+        [InlineData("application/json", "🐂")]
+        [InlineData("text/html", "\"\\uD83D\\uDC02\"")]
+        [InlineData("text/plain", "\"\\uD83D\\uDC02\"")]
+        public async Task TextWriter_CorrectlyHandlesSurrogatePairsAsync(string contentType, string expectedOutput)
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            var tw = await jsonWriter.StartTextWriterValueScopeAsync(contentType);
+            await tw.WriteAsync('\ud83d');
+            await tw.WriteAsync('\udc02');
+            await jsonWriter.EndTextWriterValueScopeAsync();
+            await jsonWriter.FlushAsync();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal(expectedOutput, rawOutput);
+        }
+
         /// <summary>
         /// Reads the test class's default stream with UTF8 encoding.
         /// </summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -470,6 +470,38 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal("[{\"Name\":\"Sue\\uD800\\uDC05 ä\",\"Age\":19},{\"Name\":\"Joe\",\"Age\":23}]", await this.ReadStreamAsync(encoding));
         }
 
+        [Fact]
+        public async Task SupportsAsciiEncodingWhenEscaped()
+        {
+            var collectionValue = new ODataCollectionValue
+            {
+                Items = new List<ODataResourceValue>
+                {
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Sue\uD800\udc05 \u00e4" },
+                            new ODataProperty { Name = "Age", Value = 19 }
+                        }
+                    },
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Joe" },
+                            new ODataProperty { Name = "Age", Value = 23 }
+                        }
+                    }
+                }
+            };
+
+            Encoding encoding = Encoding.ASCII;
+            this.writer = new ODataUtf8JsonWriter(this.stream, isIeee754Compatible: false, encoding: encoding, encoder: JavaScriptEncoder.Default);
+            await this.writer.WriteODataValueAsync(collectionValue);
+            Assert.Equal("[{\"Name\":\"Sue\\uD800\\uDC05 \\u00E4\",\"Age\":19},{\"Name\":\"Joe\",\"Age\":23}]", await this.ReadStreamAsync(encoding));
+        }
+
         #endregion Support for other Encodings
 
         #region Custom JavaScriptEncoder

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterFactoryAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterFactoryAsyncTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.OData.Tests.Json
             using StreamReader reader = new StreamReader(stream, encoding);
             stream.Seek(0, SeekOrigin.Begin);
             string contents = await reader.ReadToEndAsync();
-            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":15.0,""Buzz"":""\u003C\u0022\n""}", contents);
+            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":15.0,""Buzz"":""<\""\n""}", contents);
         }
 
         [Theory]
@@ -96,7 +96,7 @@ namespace Microsoft.OData.Tests.Json
             using StreamReader reader = new StreamReader(stream, encoding);
             stream.Seek(0, SeekOrigin.Begin);
             string contents = await reader.ReadToEndAsync();
-            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":""15.0"",""Buzz"":""\u003C\u0022\n""}", contents);
+            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":""15.0"",""Buzz"":""<\""\n""}", contents);
         }
 
         [Theory]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterFactoryTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterFactoryTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OData.Tests.Json
             using StreamReader reader = new StreamReader(stream, encoding);
             stream.Seek(0, SeekOrigin.Begin);
             string contents = reader.ReadToEnd();
-            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":15.0,""Buzz"":""\u003C\u0022\n""}", contents);
+            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":15.0,""Buzz"":""<\""\n""}", contents);
         }
 
         [Theory]
@@ -95,7 +95,7 @@ namespace Microsoft.OData.Tests.Json
             using StreamReader reader = new StreamReader(stream, encoding);
             stream.Seek(0, SeekOrigin.Begin);
             string contents = reader.ReadToEnd();
-            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":""15.0"",""Buzz"":""\u003C\u0022\n""}", contents);
+            Assert.Equal(@"{""Foo"":""Bar"",""Fizz"":""15.0"",""Buzz"":""<\""\n""}", contents);
         }
 
         [Theory]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -131,6 +131,24 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void WritePrimitiveValueFloatNaN()
+        {
+            this.VerifyWritePrimitiveValue(float.NaN, "\"NaN\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueFloatPositiveInfinity()
+        {
+            this.VerifyWritePrimitiveValue(float.PositiveInfinity, "\"INF\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueFloatNegativeInfinity()
+        {
+            this.VerifyWritePrimitiveValue(float.NegativeInfinity, "\"-INF\"");
+        }
+
+        [Fact]
         public void WritePrimitiveValueInt16()
         {
             this.VerifyWritePrimitiveValue((short)876, "876");
@@ -764,6 +782,30 @@ namespace Microsoft.OData.Tests.Json
                     Assert.Equal(expectedOutput, rawOutput);
                 }
             }
+        }
+
+
+        [Theory]
+        // both the escaped and non-escaped versions are valid
+        // and compliant JSON parsers should be able to handle both
+        [InlineData("application/json", "🐂")]
+        [InlineData("text/html", "\"\\uD83D\\uDC02\"")]
+        [InlineData("text/plain", "\"\\uD83D\\uDC02\"")]
+        public void TextWriter_CorrectlyHandlesSurrogatePairs(string contentType, string expectedOutput)
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            var tw = jsonWriter.StartTextWriterValueScope(contentType);
+            tw.Write('\ud83d');
+            tw.Write('\udc02');
+            jsonWriter.EndTextWriterValueScope();
+            jsonWriter.Flush();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal(expectedOutput, rawOutput);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -12,6 +12,7 @@ using System.Net.Mime;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Unicode;
+using System.Threading.Tasks;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Json;
 using Xunit;
@@ -481,6 +482,38 @@ namespace Microsoft.OData.Tests.Json
             this.writer = new ODataUtf8JsonWriter(this.stream, false, encoding);
             this.writer.WriteODataValue(collectionValue);
             Assert.Equal("[{\"Name\":\"Sue\\uD800\\uDC05 ä\",\"Age\":19},{\"Name\":\"Joe\",\"Age\":23}]", this.ReadStream(encoding));
+        }
+
+        [Fact]
+        public void SupportsAsciiEncodingWhenEscaped()
+        {
+            var collectionValue = new ODataCollectionValue
+            {
+                Items = new List<ODataResourceValue>
+                {
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Sue\uD800\udc05 \u00e4" },
+                            new ODataProperty { Name = "Age", Value = 19 }
+                        }
+                    },
+                    new ODataResourceValue
+                    {
+                        Properties = new List<ODataProperty>
+                        {
+                            new ODataProperty { Name = "Name", Value = "Joe" },
+                            new ODataProperty { Name = "Age", Value = 23 }
+                        }
+                    }
+                }
+            };
+
+            Encoding encoding = Encoding.ASCII;
+            this.writer = new ODataUtf8JsonWriter(this.stream, isIeee754Compatible: false, encoding: encoding, encoder: JavaScriptEncoder.Default);
+            this.writer.WriteODataValue(collectionValue);
+            Assert.Equal("[{\"Name\":\"Sue\\uD800\\uDC05 \\u00E4\",\"Age\":19},{\"Name\":\"Joe\",\"Age\":23}]", this.ReadStream(encoding));
         }
 
         #endregion Support for other Encodings

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -225,7 +225,7 @@ namespace Microsoft.OData.Tests
 
             IJsonWriterFactory factory = request.ServiceProvider.GetService<IJsonWriterFactory>();
             Assert.IsType<ODataUtf8JsonWriterFactory>(factory);
-            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
+            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test ия\"}", output);
         }
 
         [Theory]
@@ -261,7 +261,7 @@ namespace Microsoft.OData.Tests
             Assert.IsType<ODataUtf8JsonWriter>(writerFactory.CreatedWriter);
             Assert.Equal(encodingCharset, writerFactory.Encoding.WebName);
             Assert.Equal(1, writerFactory.NumCalls);
-            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
+            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test ия\"}", output);
         }
 
         [Fact]
@@ -312,7 +312,7 @@ namespace Microsoft.OData.Tests
                     containerBuilder.AddSingleton<IJsonWriterFactory>( sp => ODataUtf8JsonWriterFactory.Default);
                 });
 
-            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
+            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test ия\"}", output);
         }
 
         [Theory]
@@ -348,7 +348,7 @@ namespace Microsoft.OData.Tests
             Assert.IsType<ODataUtf8JsonWriter>(writerFactory.CreatedWriter);
             Assert.Equal(encodingCharset, writerFactory.Encoding.WebName);
             Assert.Equal(1, writerFactory.NumCalls);
-            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test \\u0438\\u044F\"}", output);
+            Assert.Equal("{\"@odata.context\":\"http://www.example.com/$metadata#Edm.String\",\"value\":\"This is a test ия\"}", output);
         }
 
         #endregion "ODataUtf8JsonWriter support"

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -125,7 +125,7 @@ namespace Microsoft.OData.Tests
             {
                 IServiceProvider container = CreateTestServiceContainer(services =>
                 {
-                    services.AddSingleton(sp => new DefaultJsonWriterFactory(stringEscapeOption.Value));
+                    services.AddSingleton(sp => new ODataJsonWriterFactory(stringEscapeOption.Value));
                 });
 
                 request.ServiceProvider = container;
@@ -152,7 +152,7 @@ namespace Microsoft.OData.Tests
         {
             var settings = new ODataMessageWriterSettings();
             IServiceCollection services = new ServiceCollection().AddDefaultODataServices();
-            services.AddSingleton<IJsonWriterFactory>(sp => new DefaultJsonWriterFactory(ODataStringEscapeOption.EscapeOnlyControls));
+            services.AddSingleton<IJsonWriterFactory>(sp => new ODataJsonWriterFactory(ODataStringEscapeOption.EscapeOnlyControls));
 
             settings.ODataUri.ServiceRoot = new Uri("http://host/service");
             settings.SetContentType(ODataFormat.Json);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2822*

### Description

This PR:
- Sets `ODataUtf8JsonWriter` as the default `IJsonWriter` used in `ODataMessageWriter`.
- Sets `JavaScriptEncoder.UnsafeRelaxedJsonEscaping` as the default `JavaScriptEncoder` for `ODataUtf8JsonWriter`.
- Fixes some bugs with `ODataUtf8JsonWriter` streaming (see details at the end)
- Normalizes JSON output for some edge cases for better consistency with `JsonWriter` (see details at the end).

Both of these changes aim to improve _default_ serialization performance. `ODataUtf8JsonWriter` has demonstrated better performance and memory efficiency over the current default `JsonWriter` in benchmarks and in production workloads. One of the major blockers to it becoming the default was lack of support for streaming, but that has been addressed by #2880 

The main concern about this change is that the JSON is different between the different writers as far as character escaping is concerned.

In any case, while the output is different, both are valid JSON and semantically equivalent. Compliant JSON parsers should interpret them the same way.


Differences between `ODataUtf8JsonWriter` and `JsonWriter`

|  Category| Description |  Examples
-------|--------------|-------------
String Escaping | Utf8JsonWriter escapes more characters in a string than the default Jsonwriter. By default, Utf8JsonWriter escapes even HTML-unsafe characters like <. However, you can override that by using the UnsafeRelaxedJsonEscaping as documented here: https://learn.microsoft.com/en-us/odata/odatalib/using-ut8jsonwriter-for-better-performance#choosing-a-javascriptencoder. That said, even with this encoding, there will be some differences in character escaping, but all are valid UTF-8 encoded strings. | Utf8JsonWriter uses uppercase letters for unicode code points, JsonWriter uses lowercase letters: (`JsonWriter`: "Cust1 \ud800\udc05 \u00e4" vs `Utf8JsonWriter`: "Cust1 \uD800\uDC05 \u00E4"). Encoder differences `JsonWriter`: "CityA1 'A1' + 3 <>" vs `Utf8JsonWriter` with relaxed encoder: "CityA1 'A1' + 3 <>" vs `Utf8JsonWriter` with default encoder: "CityA1 \u0027A1\u0027 \u002B 3 \u003C\u003E")
Number formatting | `Utf8JsonWriter` serializes the decimal `1.0M` as `1.0`, but `JsonWriter` serializes it as `1` (the opposite of the previous scenario). | `JsonWriter`: `1` vs `Utf8JsonWriter`: `1.0`

We also used to have a difference in `DateTimeOffset` formatting because `Utf8JsonWriter` uses `+00:00` timezone suffix when the timezone offset is 0 (e.g. `2022-11-09T09:42:30+00:00`) whereas `JsonWriter` uses `Z`  (e.g. `2022-11-09T09:42:30Z`). However, we addressed this in a past PR because we got feedback that this one has higher chances of breaking clients (not following standards). This type of difference is also something customers have raised in the past. Now both `JsonWriter` and `ODataUtf8JsonWriter` use the `Z` suffix.

Justification for changing the default encoder to `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`:

- None of the built-in encoder matches exactly any of the `ODataStringEscapeOption` used by `JsonWriter`. So there's no reason to prefer `JavaScriptEncoder.Default` based on consistency. It escapes more characters than either of the string escape options available for `JsonWriter`.
- Performance: serializing strings that need to be escaped uses more CPU and allocates more memory than strings that don't need escaping. Therefore, an encoder that is less likely to escape strings is more efficient.
- This encoder is used by default in AspNetCore, therefore this is more consistent with JSON-based APIs written in modern ASP.NET Core.
- The security concerns that make `JavaScriptEncoder.Default` (e.g. escaping HTML special characters) do not apply if we don't dump the output directly in a HTML document. Since our use case is REST APIs, it's up to the client to escape the response if they intend to render their contents in a web page.


Main changes:
- Registered `ODataUtf8JsonWriterFactory` as the default implementation of `IJsonWriterFactory` in `AddDefaultODataServices` extension method.
- I've renamed `DefaultJsonWriterFactory` to `ODataJsonWriterFactory` since it's no longer the default.
- Changed the default `JavaScriptEncoder` of `ODataUtf8JsonWriter` to `JavaScriptEncoder.UnsafeRelaxedJsonEscaping`.
- Update strings in tests that were escaped using `JavaScriptEncoder.Default` to match the output returned by the new encoder
- Replaced `DefaultJsonWriterFactory` with `ODataUtf8JsonWriterFactory` in a few tests.
- Fix bug in `ODataUtf8JsonWriter.CreateStreamValueScopeAsync`. Writing to the stream asynchronously would overwrite the content previously written by the JsonWriter and result in jumbled corrupted output. I fixed this by making sure the contents of the `Utf8JsonWriter` are committed to the buffer before starting the stream scope. This was correctly implemented and tested in the sync version, but not the async version.
- Fixed a bug in `ODataUtf8JsonWriter.TextWriter`. The `TextWriter` did not override `Write(char)`, as a result calling `Write(char)` would not actually write the char. I've overridden both `TextWriter.Write(char)` and `TextWriter.WriteAsync(char)`.
- I've added support for `float.PositiveInfinity` ( -> `"INF"`), `float.NegativityInfinity (-> `"-INF"`) and `float.NaN` (-> `"NaN"`) to `ODataUtf8JsonWriter`. Support was already there for `double`, but not `float` (an exception would be thrown when `Utf8JsonWriter` tries to write `float.NaN` for example)
- I've changed the implementation of `ODataUtf8JsonWriter.WriteValue(double)` such that it adds a `.0` when the value does not have a decimal point (e.g. `234.0` gets written as `234.0` instead of `234`). This is not required by the spec, but it's consistent with `JsonWriter` current behaviour. I spoke to @mikepizzo and he suggested it could be a left-over of OData v3. We can drop the `.0`, potentially with a feature flag. I thought it wise to keep the behaviour consistent for now to avoid disruptions since it broke a lot of our internal tests that checked for the presense of `.0` in the output.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
