### PR TITLE
Commit Utf8JsonWriter contents to buffer before writing directly to b…

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
@@ -64,7 +64,7 @@ namespace Microsoft.OData.Json
             this.WriteItemWithSeparatorIfNeeded();
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            await this.FlushAsync().ConfigureAwait(false);
+            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
 
             this.binaryValueStream = new ODataUtf8JsonWriteStream(this);
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
@@ -60,9 +60,11 @@ namespace Microsoft.OData.Json
         /// <returns>A task representing the asynchronous operation. The task result contains a stream for writing the stream value.</returns>
         public async Task<Stream> StartStreamValueScopeAsync()
         {
-            this.WriteSeparatorIfNecessary();
+            this.CommitUtf8JsonWriterContentsToBuffer();
+            this.WriteItemWithSeparatorIfNeeded();
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+
+            await this.FlushAsync().ConfigureAwait(false);
 
             this.binaryValueStream = new ODataUtf8JsonWriteStream(this);
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -142,14 +142,20 @@ namespace Microsoft.OData.Json
         internal sealed class ODataUtf8JsonTextWriter : TextWriter
         {
             private readonly ODataUtf8JsonWriter jsonWriter = null;
-            // Buffer used to store chars that were could not be encoded due to
-            // insufficient data in the input buffer. The chars will be prepended
-            // to the next chunk of input.
+            /// <summary>
+            /// Buffer used to store characters that could not be encoded due to
+            /// insufficient data in the input buffer. These characters will be prepended
+            /// to the next chunk of input.
+            /// </summary>
             private char[] buffer;
-            // Number of chars in the buffer that are left over frevious chunk.
+            /// <summary>
+            /// Number of characters in the buffer that are left over from the previous chunk.
+            /// </summary>
             private int numOfCharsNotWrittenFromPreviousChunk = 0;
-            // This buffer is used to by Write(char) to store the char so
-            // that we can re-use our Write(char[], ...) method.
+            /// <summary>
+            /// This buffer is used by the Write(char) method to store a single character,
+            /// that we can reuse the methods for writing chars in chunks.
+            /// </summary>
             private char[] singleCharBuffer;
 
             public ODataUtf8JsonTextWriter(ODataUtf8JsonWriter jsonWriter)
@@ -219,7 +225,7 @@ namespace Microsoft.OData.Json
             }
 
             /// <summary>
-            /// Writes the specifid character to the ODataUtf8JsonWriter.
+            /// Writes the specified character to the ODataUtf8JsonWriter.
             /// </summary>
             /// <param name="value">The character to write.</param>
             public override void Write(char value)
@@ -237,7 +243,7 @@ namespace Microsoft.OData.Json
             }
 
             /// <summary>
-            /// Writes the specifid character to the ODataUtf8JsonWriter.
+            /// Asynchronously writes the specified character to the ODataUtf8JsonWriter.
             /// </summary>
             /// <param name="value">The character to write.</param>
             public override async Task WriteAsync(char value)

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -18,6 +18,7 @@ using System.Runtime.CompilerServices;
 using Microsoft.OData.Edm;
 using System.Text.Unicode;
 using System.Buffers.Text;
+using System.Xml;
 
 namespace Microsoft.OData.Json
 {
@@ -252,7 +253,24 @@ namespace Microsoft.OData.Json
         public void WriteValue(float value)
         {
             this.WriteSeparatorIfNecessary();
-            this.utf8JsonWriter.WriteNumberValue(value);
+
+            if (float.IsNaN(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(nanValue.Span);
+            }
+            else if (float.IsPositiveInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(positiveInfinityValue.Span);
+            }
+            else if (float.IsNegativeInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(negativeInfinityValue.Span);
+            }
+            else
+            {
+                this.utf8JsonWriter.WriteNumberValue(value);
+            }
+
             this.FlushIfBufferThresholdReached();
         }
 
@@ -936,7 +954,23 @@ namespace Microsoft.OData.Json
         public async Task WriteValueAsync(float value)
         {
             this.WriteSeparatorIfNecessary();
-            this.utf8JsonWriter.WriteNumberValue(value);
+            if (float.IsNaN(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(nanValue.Span);
+            }
+            else if (float.IsPositiveInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(positiveInfinityValue.Span);
+            }
+            else if (float.IsNegativeInfinity(value))
+            {
+                this.utf8JsonWriter.WriteStringValue(negativeInfinityValue.Span);
+            }
+            else
+            {
+                this.utf8JsonWriter.WriteNumberValue(value);
+            }
+
             await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncBaseTests.cs
@@ -630,6 +630,342 @@ namespace Microsoft.OData.Tests.Json
             }
         }
 
+        [Fact]
+        public async Task WriteMixedJsonWithStreamingDataLargeValues()
+        {
+            byte[] largeBinaryData = GenerateByteArray(256 * 1024);
+            string largeBase64Data = Convert.ToBase64String(largeBinaryData);
+
+            string largeStringData = new string('a', 256 * 1024);
+
+            string streamLargeStringData = new string('a', 1024 * 1024);
+
+            //Returns a string with special characters (in this case emoji) at different sections of the string
+            string streamLargeStringDataWithSpecialChars = ExpectedOutPutStringWithSpecialCharacters(streamLargeStringData);
+
+            byte[] inputLargeByteArray = GenerateByteArray(1024 * 1024);
+            string largeByteArray = Convert.ToBase64String(inputLargeByteArray);
+
+            string expectedJson =
+                $"{{\"s1\":\"test\"," +
+                $"\"lgS1\":\"{streamLargeStringData}\"," +
+                $"\"i1\":10," +
+                $"\"lgB641\":\"{largeBase64Data}\"," +
+                $"\"b1\":true," +
+                $"\"obj1\":{{\"lgB64AtObjStart\":\"{largeBase64Data}\",\"s2\":\"test\"}}," +
+                $"\"lgStreamLargeBytes\":\"{largeByteArray}\"," +
+                $"\"obj2\":{{\"dtProp\":\"2014-12-31\",\"lgB64AtObjEnd\":\"{largeBase64Data}\"}}," +
+                $"\"obj3\":{{\"lgB64BeforeRawVal\":\"{largeBase64Data}\",\"raw1\":\"foobar\"}}," +
+                $"\"obj4\":{{\"raw2\":\"foobar\",\"lgB64AfterRawVal\":\"{largeBase64Data}\"}}," +
+                $"\"arrWithStreamLgB64\":[\"{largeByteArray}\"]," +
+                $"\"arrWithStreamLgB64AtStart\":[\"{largeByteArray}\",\"test\",\"test\"]," +
+                $"\"arrWithStreamLgB64AtEnd\":[1,2,\"{largeByteArray}\"]," +
+                $"\"arrWithManyStreamLgB64AtStart\":[\"{largeByteArray}\",\"{largeByteArray}\",\"{largeByteArray}\",1,\"test\"]," +
+                $"\"arrWithManyStreamLgB64AtEnd\":[1,\"test\",\"{largeByteArray}\",\"{largeByteArray}\",\"{largeByteArray}\"]," +
+                $"\"arrWithManyStreamLgB64Only\":[\"{largeByteArray}\",\"{largeByteArray}\",\"{largeByteArray}\"]," +
+                $"\"obj5\":{{\"lgSAtObjStart\":\"{streamLargeStringDataWithSpecialChars}\",\"s2\":\"test\"}}," +
+                $"\"obj6\":{{\"dtProp\":\"2014-12-31\",\"lgSAtObjEnd\":\"{streamLargeStringData}\"}}," +
+                $"\"obj7\":{{\"lgSBeforeRawVal\":\"{largeStringData}\",\"raw1\":\"foobar\"}}," +
+                $"\"obj8\":{{\"raw2\":\"foobar\",\"lgSAfterRawVal\":\"{streamLargeStringData}\"}}," +
+                $"\"arrWithLgS\":[\"{streamLargeStringData}\"]," +
+                $"\"arrWithLgSAtStart\":[\"{streamLargeStringData}\",\"test\",\"test\"]," +
+                $"\"arrWithLgSAtEnd\":[1,2,\"{streamLargeStringData}\"]," +
+                $"\"arrWithManyLgSAtStart\":[\"{streamLargeStringData}\",\"{streamLargeStringDataWithSpecialChars}\",\"{streamLargeStringData}\",1,\"test\"]," +
+                $"\"arrWithManyLgSAtEnd\":[1,\"test\",\"{streamLargeStringData}\",\"{streamLargeStringData}\",\"{streamLargeStringData}\"]," +
+                $"\"arrWithManyLgSOnly\":[\"{streamLargeStringData}\",\"{streamLargeStringData}\",\"{streamLargeStringData}\"]," +
+                $"\"arrWithLgSAndLgB64Mix1\":[\"{largeByteArray}\",\"{streamLargeStringData}\",\"{largeBase64Data}\",\"{largeStringData}\"]," +
+                $"\"arrWithLgSAndLgB64Mix2\":[\"{largeStringData}\",\"{largeBase64Data}\",\"{largeStringData}\",\"{largeBase64Data}\"]," +
+                $"\"arrWithLgSAndLgB64Mix3\":[\"{largeStringData}\",\"raw\",\"{largeBase64Data}\",\"raw\",\"{largeStringData}\",\"{largeBase64Data}\",\"raw\",\"raw\"]," +
+                $"\"arrWithLgSAndLgB64Mix4\":[\"raw\",\"raw\",\"{largeStringData}\",\"raw\",\"{largeBase64Data}\",\"{largeStringData}\",\"{largeBase64Data}\"]" +
+                $"}}";
+
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonStreamWriterAsync jsonWriter = CreateJsonWriterAsync(stream, false, Encoding.UTF8) as IJsonStreamWriterAsync;
+                await jsonWriter.StartObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("s1");
+                await jsonWriter.WriteValueAsync("test");
+                await jsonWriter.WriteNameAsync("lgS1");
+                var tw = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(tw, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.WriteNameAsync("i1");
+                await jsonWriter.WriteValueAsync(10);
+                await jsonWriter.WriteNameAsync("lgB641");
+                await jsonWriter.WriteValueAsync(largeBinaryData);
+                await jsonWriter.WriteNameAsync("b1");
+                await jsonWriter.WriteValueAsync(true);
+
+                await jsonWriter.WriteNameAsync("obj1");
+                await jsonWriter.StartObjectScopeAsync();
+                await jsonWriter.WriteNameAsync("lgB64AtObjStart");
+                await jsonWriter.WriteValueAsync(largeBinaryData);
+                await jsonWriter.WriteNameAsync("s2");
+                await jsonWriter.WriteValueAsync("test");
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("lgStreamLargeBytes");
+                var st = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+
+                await jsonWriter.WriteNameAsync("obj2");
+                await jsonWriter.StartObjectScopeAsync();
+                await jsonWriter.WriteNameAsync("dtProp");
+                await jsonWriter.WriteValueAsync(new Date(2014, 12, 31));
+                await jsonWriter.WriteNameAsync("lgB64AtObjEnd");
+                await jsonWriter.WriteValueAsync(largeBinaryData);
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("obj3");
+                await jsonWriter.StartObjectScopeAsync();
+                await jsonWriter.WriteNameAsync("lgB64BeforeRawVal");
+                await jsonWriter.WriteValueAsync(largeBinaryData);
+                await jsonWriter.WriteNameAsync("raw1");
+                await jsonWriter.WriteRawValueAsync("\"foobar\"");
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("obj4");
+                await jsonWriter.StartObjectScopeAsync();
+                await jsonWriter.WriteNameAsync("raw2");
+                await jsonWriter.WriteRawValueAsync("\"foobar\"");
+                await jsonWriter.WriteNameAsync("lgB64AfterRawVal");
+                await jsonWriter.WriteValueAsync(largeBinaryData);
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithStreamLgB64");
+                await jsonWriter.StartArrayScopeAsync();
+                var st1 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st1, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithStreamLgB64AtStart");
+                await jsonWriter.StartArrayScopeAsync();
+                var st2 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st2, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                await jsonWriter.WriteValueAsync("test");
+                await jsonWriter.WriteValueAsync("test");
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithStreamLgB64AtEnd");
+                await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteValueAsync(1);
+                await jsonWriter.WriteValueAsync(2);
+                var st3 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st3, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithManyStreamLgB64AtStart");
+                await jsonWriter.StartArrayScopeAsync();
+                var st4 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st4, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                var st5 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st5, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                var st6 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st6, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                await jsonWriter.WriteValueAsync(1);
+                await jsonWriter.WriteValueAsync("test");
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithManyStreamLgB64AtEnd");
+                await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteValueAsync(1);
+                await jsonWriter.WriteValueAsync("test");
+                var st7 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st7, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                var st8 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st8, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                var st9 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st9, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithManyStreamLgB64Only");
+                await jsonWriter.StartArrayScopeAsync();
+                var sta = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(sta, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                var stb = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(stb, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                var stc = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(stc, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("obj5");
+                await jsonWriter.StartObjectScopeAsync();
+                await jsonWriter.WriteNameAsync("lgSAtObjStart");
+                var tw1 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringsWithSpecialCharactersInChunksAsync(tw1, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.WriteNameAsync("s2");
+                await jsonWriter.WriteValueAsync("test");
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("obj6");
+                await jsonWriter.StartObjectScopeAsync();
+                await jsonWriter.WriteNameAsync("dtProp");
+                await jsonWriter.WriteValueAsync(new Date(2014, 12, 31));
+                await jsonWriter.WriteNameAsync("lgSAtObjEnd");
+                var tw3 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(tw3, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("obj7");
+                await jsonWriter.StartObjectScopeAsync();
+                await jsonWriter.WriteNameAsync("lgSBeforeRawVal");
+                await jsonWriter.WriteValueAsync(largeStringData);
+                await jsonWriter.WriteNameAsync("raw1");
+                await jsonWriter.WriteRawValueAsync("\"foobar\"");
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("obj8");
+                await jsonWriter.StartObjectScopeAsync();
+                await jsonWriter.WriteNameAsync("raw2");
+                await jsonWriter.WriteRawValueAsync("\"foobar\"");
+                await jsonWriter.WriteNameAsync("lgSAfterRawVal");
+                var tw4 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(tw4, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithLgS");
+                await jsonWriter.StartArrayScopeAsync();
+                var tw5 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(tw5, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithLgSAtStart");
+                await jsonWriter.StartArrayScopeAsync();
+                var twa = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(twa, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.WriteValueAsync("test");
+                await jsonWriter.WriteValueAsync("test");
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithLgSAtEnd");
+                await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteValueAsync(1);
+                await jsonWriter.WriteValueAsync(2);
+                var twb = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(twb, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithManyLgSAtStart");
+                await jsonWriter.StartArrayScopeAsync();
+                var twa1 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(twa1, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                var twb1 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringsWithSpecialCharactersInChunksAsync(twb1, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                var twc1 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(twc1, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.WriteValueAsync(1);
+                await jsonWriter.WriteValueAsync("test");
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithManyLgSAtEnd");
+                await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteValueAsync(1);
+                await jsonWriter.WriteValueAsync("test");
+                var twc = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(twc, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                var twd = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(twd, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                var twe = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(twe, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithManyLgSOnly");
+                await jsonWriter.StartArrayScopeAsync();
+                var tw11 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(tw11, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                var tw12 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(tw12, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                var tw13 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(tw13, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.EndArrayScopeAsync();
+
+                // mixed scenarios
+                await jsonWriter.WriteNameAsync("arrWithLgSAndLgB64Mix1");
+                await jsonWriter.StartArrayScopeAsync();
+                var st11 = await jsonWriter.StartStreamValueScopeAsync();
+                await WriteByteArrayInChunksAsync(st11, inputLargeByteArray);
+                await jsonWriter.EndStreamValueScopeAsync();
+                var tw33 = await jsonWriter.StartTextWriterValueScopeAsync("text/plain");
+                await WriteLargeStringInChunksAsync(tw33, streamLargeStringData);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.WriteValueAsync(largeBase64Data);
+                await jsonWriter.WriteValueAsync(largeStringData);
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithLgSAndLgB64Mix2");
+                await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteValueAsync(largeStringData);
+                await jsonWriter.WriteValueAsync(largeBase64Data);
+                await jsonWriter.WriteValueAsync(largeStringData);
+                await jsonWriter.WriteValueAsync(largeBase64Data);
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithLgSAndLgB64Mix3");
+                await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteValueAsync(largeStringData);
+                await jsonWriter.WriteRawValueAsync("\"raw\"");
+                await jsonWriter.WriteValueAsync(largeBase64Data);
+                await jsonWriter.WriteRawValueAsync("\"raw\"");
+                await jsonWriter.WriteValueAsync(largeStringData);
+                await jsonWriter.WriteValueAsync(largeBase64Data);
+                await jsonWriter.WriteRawValueAsync("\"raw\"");
+                await jsonWriter.WriteRawValueAsync("\"raw\"");
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.WriteNameAsync("arrWithLgSAndLgB64Mix4");
+                await jsonWriter.StartArrayScopeAsync();
+                await jsonWriter.WriteRawValueAsync("\"raw\"");
+                await jsonWriter.WriteRawValueAsync("\"raw\"");
+                await jsonWriter.WriteValueAsync(largeStringData);
+                await jsonWriter.WriteRawValueAsync("\"raw\"");
+                await jsonWriter.WriteValueAsync(largeBase64Data);
+                await jsonWriter.WriteValueAsync(largeStringData);
+                await jsonWriter.WriteValueAsync(largeBase64Data);
+                await jsonWriter.EndArrayScopeAsync();
+
+                await jsonWriter.EndObjectScopeAsync();
+
+                await jsonWriter.FlushAsync();
+                stream.Seek(0, SeekOrigin.Begin);
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    string normalizedOutput = NormalizeJsonText(rawOutput);
+                    string normalizedExpectedOutput = NormalizeJsonText(expectedJson);
+                    Assert.Equal(normalizedExpectedOutput, normalizedOutput);
+                }
+            }
+        }
+
         /// <summary>
         /// Normalizes the differences between JSON text encoded
         /// by Utf8JsonWriter and OData's JsonWriter, to make
@@ -692,6 +1028,53 @@ namespace Microsoft.OData.Tests.Json
                 chunk += "\n\n\n\n\"\"\n\n\n\n\"\"";
                 await tw.WriteAsync(chunk);
             }
+        }
+
+        internal static async Task WriteLargeStringInChunksAsync(TextWriter tw, string input)
+        {
+            // Define chunk size.
+            int chunkSize = 4096;
+
+            // Stream the string to the output stream in chunks.
+            for (int i = 0; i < input.Length; i += chunkSize)
+            {
+                int remainingLength = Math.Min(chunkSize, input.Length - i);
+                string chunk = input.Substring(i, remainingLength);
+                await tw.WriteAsync(chunk);
+            }
+        }
+
+        private static async Task WriteByteArrayInChunksAsync(Stream streamWriter, byte[] input)
+        {
+            const int chunkSize = 4096;
+            int bytesWritten = 0;
+
+            // Stream the byte array and write it in chunks
+            while (bytesWritten < input.Length)
+            {
+                int remainingBytes = input.Length - bytesWritten;
+                int bytesToWrite = Math.Min(chunkSize, remainingBytes);
+                await streamWriter.WriteAsync(input, bytesWritten, bytesToWrite); // Write the chunk to the stream
+                bytesWritten += bytesToWrite;
+            }
+        }
+
+        internal static string ExpectedOutPutStringWithSpecialCharacters(string input)
+        {
+            string s = "";
+            // Define chunk size
+            int chunkSize = 4096;
+
+            // Stream the string to the output stream in chunks
+            for (int i = 0; i < input.Length; i += chunkSize)
+            {
+                int remainingLength = Math.Min(chunkSize, input.Length - i);
+                string chunk = input.Substring(i, remainingLength);
+                s += chunk;
+                s += "\\n\\n\\n\\n\\\"\\\"\\n\\n\\n\\n\\\"\\\"";
+            }
+
+            return s;
         }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
@@ -383,6 +383,39 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal(expected, this.builder.ToString());
         }
 
+        [Theory]
+        [InlineData(124.45, "124.45")]
+        // We write the .0 for doubles without a fractional part
+        // for consistency with the original JsonWriter implementation
+        // and with previous versions. However, it's not a hard requirement.
+        // Clients should not rely on the .0 to decide whether a value
+        // is an integer or double.
+        // In the future we can consider relaxing the need to add a .0 (possibly behind a feature flag).
+        [InlineData(124.0, "124.0")]
+        [InlineData(1.123456789012345, "1.123456789012345")]
+        [InlineData(1.245E+24, "1.245E+24")]
+        [InlineData(1.245E-24, "1.245E-24")]
+        [InlineData(double.PositiveInfinity, "\"INF\"")]
+        [InlineData(double.NegativeInfinity, "\"-INF\"")]
+        [InlineData(double.NaN, "\"NaN\"")]
+        public async Task WriteDoubleAsync(double value, string expectedOutput)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriterAsync jsonWriter = CreateJsonWriterAsync(stream, false, Encoding.UTF8);
+                await jsonWriter.WriteValueAsync(value);
+                await jsonWriter.FlushAsync();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal(expectedOutput, rawOutput);
+                }
+            }
+        }
+
         #endregion
 
         [Fact]
@@ -399,6 +432,38 @@ namespace Microsoft.OData.Tests.Json
         {
             return SetupJsonWriterRunTestAndVerifyRentAsync(
                 (jsonWriter) => jsonWriter.WriteValueAsync("foo\tbar"));
+        }
+
+        [Theory]
+        [InlineData("application/json", 'a', "a")]
+        [InlineData("text/html", 'a', "\"a\"")]
+        [InlineData("text/plain", 'a', "\"a\"")]
+        // JSON special char
+        [InlineData("application/json", '"', "\"")]
+        [InlineData("text/html", '"', "\"\\\"\"")]
+        [InlineData("text/plain", '"', "\"\\\"\"")]
+        // non-ascii
+        [InlineData("application/json", '你', "你")]
+        [InlineData("text/html", '你', "\"你\"")]
+        [InlineData("text/plain", '你', "\"你\"")]
+        public async Task TextWriter_CorrectlyWritesSingleCharacterAsync(string contentType, char value, string expectedOutput)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonStreamWriterAsync jsonWriter = CreateJsonWriterAsync(stream, false, Encoding.UTF8) as IJsonStreamWriterAsync;
+                var tw = await jsonWriter.StartTextWriterValueScopeAsync(contentType);
+                await tw.WriteAsync(value);
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.FlushAsync();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = await reader.ReadToEndAsync();
+                    Assert.Equal(expectedOutput, rawOutput);
+                }
+            }
         }
 
         private async Task SetupJsonWriterRunTestAndVerifyRentAsync(Func<JsonWriter, Task> func)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -1017,7 +1017,34 @@ namespace Microsoft.OData.Tests.Json
                 }
             }
         }
-        
+
+        [Theory]
+        [InlineData(124.45f, "124.45")]
+        [InlineData(124.0f, "124")]
+        [InlineData(1.123456f, "1.123456")]
+        [InlineData(1.245E+10f, "1.245E+10")]
+        [InlineData(1.245E-10f, "1.245E-10")]
+        [InlineData(float.PositiveInfinity, "\"INF\"")]
+        [InlineData(float.NegativeInfinity, "\"-INF\"")]
+        [InlineData(float.NaN, "\"NaN\"")]
+        public void WriteFloat(float value, string expectedOutput)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+                jsonWriter.WriteValue(value);
+                jsonWriter.Flush();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal(expectedOutput, rawOutput);
+                }
+            }
+        }
+
         /// <summary>
         /// Normalizes the differences between JSON text encoded
         /// by Utf8JsonWriter and OData's JsonWriter, to make

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -174,6 +174,39 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal("null", this.builder.ToString());
         }
 
+        [Theory]
+        [InlineData(124.45, "124.45")]
+        // We write the .0 for doubles without a fractional part
+        // for consistency with the original JsonWriter implementation
+        // and with previous versions. However, it's not a hard requirement.
+        // Clients should not rely on the .0 to decide whether a value
+        // is an integer or double.
+        // In the future we can consider relaxing the need to add a .0 (possibly behind a feature flag).
+        [InlineData(124.0, "124.0")]
+        [InlineData(1.123456789012345, "1.123456789012345")]
+        [InlineData(1.245E+24, "1.245E+24")]
+        [InlineData(1.245E-24, "1.245E-24")]
+        [InlineData(double.PositiveInfinity, "\"INF\"")]
+        [InlineData(double.NegativeInfinity, "\"-INF\"")]
+        [InlineData(double.NaN, "\"NaN\"")]
+        public void WriteDouble(double value, string expectedOutput)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+                jsonWriter.WriteValue(value);
+                jsonWriter.Flush();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal(expectedOutput, rawOutput);
+                }
+            }
+        }
+
         [Fact]
         public void WritePrimitiveValueDateTimeOffset()
         {
@@ -480,6 +513,38 @@ namespace Microsoft.OData.Tests.Json
                 {
                     string rawOutput = reader.ReadToEnd();
                     Assert.Equal($"\"{expectedOutput}\"", rawOutput);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("application/json", 'a', "a")]
+        [InlineData("text/html", 'a', "\"a\"")]
+        [InlineData("text/plain", 'a', "\"a\"")]
+        // JSON special char
+        [InlineData("application/json", '"', "\"")]
+        [InlineData("text/html", '"', "\"\\\"\"")]
+        [InlineData("text/plain", '"', "\"\\\"\"")]
+        // non-ascii
+        [InlineData("application/json", '你', "你")]
+        [InlineData("text/html", '你', "\"你\"")]
+        [InlineData("text/plain", '你', "\"你\"")]
+        public void TextWriter_CorrectlyWritesSingleCharacter(string contentType, char value, string expectedOutput)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonStreamWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8) as IJsonStreamWriter;
+                var tw = jsonWriter.StartTextWriterValueScope(contentType);
+                tw.Write(value);
+                jsonWriter.EndTextWriterValueScope();
+                jsonWriter.Flush();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal(expectedOutput, rawOutput);
                 }
             }
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -127,6 +127,24 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public async Task WritePrimitiveValueAsyncFloatNaN()
+        {
+            await this.VerifyWritePrimitiveValueAsync(float.NaN, "\"NaN\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncFloatPositiveInfinity()
+        {
+            await this.VerifyWritePrimitiveValueAsync(float.PositiveInfinity, "\"INF\"");
+        }
+
+        [Fact]
+        public async Task WritePrimitiveValueAsyncFloatNegativeInfinity()
+        {
+            await this.VerifyWritePrimitiveValueAsync(float.NegativeInfinity, "\"-INF\"");
+        }
+
+        [Fact]
         public async Task WritePrimitiveValueAsync_Int16()
         {
             await this.VerifyWritePrimitiveValueAsync((short)876, "876");
@@ -247,6 +265,39 @@ namespace Microsoft.OData.Tests.Json
             this.writer = new ODataUtf8JsonWriter(this.stream, isIeee754Compatible, Encoding.UTF8);
             await this.writer.WritePrimitiveValueAsync(parameter);
             Assert.Equal(expected, await this.ReadStreamAsync());
+        }
+
+        [Theory]
+        [InlineData(124.45, "124.45")]
+        // We write the .0 for doubles without a fractional part
+        // for consistency with the original JsonWriter implementation
+        // and with previous versions. However, it's not a hard requirement.
+        // Clients should not rely on the .0 to decide whether a value
+        // is an integer or double.
+        // In the future we can consider relaxing the need to add a .0 (possibly behind a feature flag).
+        [InlineData(124.0, "124")]
+        [InlineData(1.123456789012345, "1.123456789012345")]
+        [InlineData(1.245E+24, "1.245E+24")]
+        [InlineData(1.245E-24, "1.245E-24")]
+        [InlineData(double.PositiveInfinity, "\"INF\"")]
+        [InlineData(double.NegativeInfinity, "\"-INF\"")]
+        [InlineData(double.NaN, "\"NaN\"")]
+        public async Task WriteDoubleAsync(double value, string expectedOutput)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriterAsync jsonWriter = CreateJsonWriterAsync(stream, false, Encoding.UTF8);
+                await jsonWriter.WriteValueAsync(value);
+                await jsonWriter.FlushAsync();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = await reader.ReadToEndAsync();
+                    Assert.Equal(expectedOutput, rawOutput);
+                }
+            }
         }
 
         #endregion
@@ -664,6 +715,38 @@ namespace Microsoft.OData.Tests.Json
 
                 await WriteSpecialCharsInChunksOfOddStringInChunksAsync(tw, input);
 
+                await jsonWriter.EndTextWriterValueScopeAsync();
+                await jsonWriter.FlushAsync();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = await reader.ReadToEndAsync();
+                    Assert.Equal(expectedOutput, rawOutput);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("application/json", 'a', "a")]
+        [InlineData("text/html", 'a', "\"a\"")]
+        [InlineData("text/plain", 'a', "\"a\"")]
+        // JSON special char
+        [InlineData("application/json", '"', "\"")]
+        [InlineData("text/html", '"', "\"\\u0022\"")]
+        [InlineData("text/plain", '"', "\"\\u0022\"")]
+        // non-ascii
+        [InlineData("application/json", '你', "你")]
+        [InlineData("text/html", '你', "\"\\u4F60\"")]
+        [InlineData("text/plain", '你', "\"\\u4F60\"")]
+        public async Task TextWriter_CorrectlyWritesSingleCharacterAsync(string contentType, char value, string expectedOutput)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonStreamWriterAsync jsonWriter = CreateJsonWriterAsync(stream, false, Encoding.UTF8) as IJsonStreamWriterAsync;
+                var tw = await jsonWriter.StartTextWriterValueScopeAsync(contentType);
+                await tw.WriteAsync(value);
                 await jsonWriter.EndTextWriterValueScopeAsync();
                 await jsonWriter.FlushAsync();
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -269,12 +269,6 @@ namespace Microsoft.OData.Tests.Json
 
         [Theory]
         [InlineData(124.45, "124.45")]
-        // We write the .0 for doubles without a fractional part
-        // for consistency with the original JsonWriter implementation
-        // and with previous versions. However, it's not a hard requirement.
-        // Clients should not rely on the .0 to decide whether a value
-        // is an integer or double.
-        // In the future we can consider relaxing the need to add a .0 (possibly behind a feature flag).
         [InlineData(124.0, "124")]
         [InlineData(1.123456789012345, "1.123456789012345")]
         [InlineData(1.245E+24, "1.245E+24")]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -112,6 +112,39 @@ namespace Microsoft.OData.Tests.Json
             this.VerifyWritePrimitiveValue(42.2d, "42.2");
         }
 
+        [Theory]
+        [InlineData(124.45, "124.45")]
+        // We write the .0 for doubles without a fractional part
+        // for consistency with the original JsonWriter implementation
+        // and with previous versions. However, it's not a hard requirement.
+        // Clients should not rely on the .0 to decide whether a value
+        // is an integer or double.
+        // In the future we can consider relaxing the need to add a .0 (possibly behind a feature flag).
+        [InlineData(124.0, "124")]
+        [InlineData(1.123456789012345, "1.123456789012345")]
+        [InlineData(1.245E+24, "1.245E+24")]
+        [InlineData(1.245E-24, "1.245E-24")]
+        [InlineData(double.PositiveInfinity, "\"INF\"")]
+        [InlineData(double.NegativeInfinity, "\"-INF\"")]
+        [InlineData(double.NaN, "\"NaN\"")]
+        public void WriteDouble(double value, string expectedOutput)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+                jsonWriter.WriteValue(value);
+                jsonWriter.Flush();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal(expectedOutput, rawOutput);
+                }
+            }
+        }
+
         [Fact]
         public void WritePrimitiveValueDoubleNaN()
         {
@@ -128,6 +161,24 @@ namespace Microsoft.OData.Tests.Json
         public void WritePrimitiveValueDoubleNegativeInfinity()
         {
             this.VerifyWritePrimitiveValue(double.NegativeInfinity, "\"-INF\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueFloatNaN()
+        {
+            this.VerifyWritePrimitiveValue(float.NaN, "\"NaN\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueFloatPositiveInfinity()
+        {
+            this.VerifyWritePrimitiveValue(float.PositiveInfinity, "\"INF\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueFloatNegativeInfinity()
+        {
+            this.VerifyWritePrimitiveValue(float.NegativeInfinity, "\"-INF\"");
         }
 
         [Fact]
@@ -755,6 +806,38 @@ namespace Microsoft.OData.Tests.Json
 
                 WriteSpecialCharsInChunksOfOddStringInChunks(tw, input);
 
+                jsonWriter.EndTextWriterValueScope();
+                jsonWriter.Flush();
+
+                stream.Seek(0, SeekOrigin.Begin);
+
+                using (StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8))
+                {
+                    string rawOutput = reader.ReadToEnd();
+                    Assert.Equal(expectedOutput, rawOutput);
+                }
+            }
+        }
+
+        [Theory]
+        [InlineData("application/json", 'a', "a")]
+        [InlineData("text/html", 'a', "\"a\"")]
+        [InlineData("text/plain", 'a', "\"a\"")]
+        // JSON special char
+        [InlineData("application/json", '"', "\"")]
+        [InlineData("text/html", '"', "\"\\u0022\"")]
+        [InlineData("text/plain", '"', "\"\\u0022\"")]
+        // non-ascii
+        [InlineData("application/json", '你', "你")]
+        [InlineData("text/html", '你', "\"\\u4F60\"")]
+        [InlineData("text/plain", '你', "\"\\u4F60\"")]
+        public void TextWriter_CorrectlyWritesSingleCharacter(string contentType, char value, string expectedOutput)
+        {
+            using (MemoryStream stream = new MemoryStream())
+            {
+                IJsonStreamWriter jsonWriter = CreateJsonWriter(stream, false, Encoding.UTF8) as IJsonStreamWriter;
+                var tw = jsonWriter.StartTextWriterValueScope(contentType);
+                tw.Write(value);
                 jsonWriter.EndTextWriterValueScope();
                 jsonWriter.Flush();
 


### PR DESCRIPTION


<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

This PR fixes a bug in the ODataUtf8JsonWriter's `StartStreamValueScopeAsync` where the contents of the utf8jsonwriter are not committed to the buffer before writing stream content to the buffer directly. This leads to content previously written by the utf8jsonwriter being overwritten which leads to corrupt data. Committing utf8jsonwriter's content to buffer before streaming data to the buffer directly fixes this issue. 

The PR also has logic to  add support for float.PositiveInfinity ( -> "INF"), float.NegativityInfinity (-> "-INF") and float.NaN(->"NaN") to ODataUtf8JsonWriter. Support was already there for double, but not float(an exception would be thrown whenUtf8JsonWritertries to writefloat.NaN` for example)

The ODataUtf8JsonWriter.TextWriter did not override Write(char), This PR has changes to override both TextWriter.Write(char) and TextWriter.WriteAsync(char).

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
