### PR TITLE
Fix async wrapper over sync API in reading nested property info

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightReader.cs
@@ -417,6 +417,17 @@ namespace Microsoft.OData.JsonLight
             return this.ReadAtNestedPropertyInfoSynchronously();
         }
 
+        /// <summary>
+        /// Asynchronous implementation of the reader logic when in state 'PropertyInfo'.
+        /// </summary>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains true if more items can be read from the reader; otherwise false
+        /// </returns>
+        protected override Task<bool> ReadAtNestedPropertyInfoImplementationAsync()
+        {
+            return this.ReadAtNestedPropertyInfoAsynchronously();
+        }
+
         #endregion
 
         #region Stream
@@ -1594,6 +1605,54 @@ namespace Microsoft.OData.JsonLight
 
                 // We are reading a next nested info.
                 return this.ReadNextNestedInfo();
+            }
+            else
+            {
+                this.StartNestedStreamInfo(
+                   new ODataJsonLightReaderStreamInfo(propertyInfo.PrimitiveTypeKind));
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Asynchronous implementation of the reader logic when in state 'PropertyInfo'.
+        /// </summary>
+        /// <returns>
+        /// A task that represents the asynchronous read operation.
+        /// The value of the TResult parameter contains true if more items can be read from the reader; otherwise false
+        /// </returns>
+        /// <remarks>
+        /// Pre-Condition:  JsonNodeType.Property:          there are more properties after the nested resource info in the owning resource
+        /// Post-Condition: JsonNodeType.StartObject        start of the expanded resource nested resource info to read next
+        ///                 JsonNodeType.StartArray         start of the expanded resource set nested resource info to read next
+        ///                 JsonNoteType.Primitive (null)   expanded null resource nested resource info to read next
+        ///                 JsonNoteType.Property           property after deferred link or entity reference link
+        ///                 JsonNodeType.EndObject          end of the parent resource
+        /// </remarks>
+        private async Task<bool> ReadAtNestedPropertyInfoAsynchronously()
+        {
+            Debug.Assert(this.CurrentScope.State == ODataReaderState.NestedProperty, "Must be on 'NestedProperty' scope.");
+            JsonLightNestedPropertyInfoScope nestedPropertyInfoScope = (JsonLightNestedPropertyInfoScope)this.CurrentScope;
+            ODataJsonLightReaderNestedPropertyInfo nestedPropertyInfo = nestedPropertyInfoScope.ReaderNestedPropertyInfo;
+            Debug.Assert(nestedPropertyInfo != null);
+
+            ODataPropertyInfo propertyInfo = this.CurrentScope.Item as ODataPropertyInfo;
+            Debug.Assert(propertyInfo != null, "Reading Nested Property Without an ODataPropertyInfo");
+
+            ODataStreamPropertyInfo streamPropertyInfo = propertyInfo as ODataStreamPropertyInfo;
+            if (streamPropertyInfo != null && !String.IsNullOrEmpty(streamPropertyInfo.ContentType))
+            {
+                this.StartNestedStreamInfo(new ODataJsonLightReaderStreamInfo(streamPropertyInfo.PrimitiveTypeKind, streamPropertyInfo.ContentType));
+            }
+            else if (!nestedPropertyInfo.WithValue)
+            {
+                // It's a nested non-stream property
+                this.PopScope(ODataReaderState.NestedProperty);
+
+                // We are reading a next nested info.
+                return await this.ReadNextNestedInfoAsync()
+                    .ConfigureAwait(false);
             }
             else
             {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/JsonLight/ODataJsonLightReaderTests.cs
@@ -1642,6 +1642,112 @@ namespace Microsoft.OData.Tests.JsonLight
         }
 
         [Fact]
+        public async Task ReadResourceWithNestedPropertyInfoAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Orders/$entity\"," +
+                "\"Id\":1," +
+                "\"Amount\":130," +
+                "\"ShippingAddress@odata.type\":\"#NS.Address\"}";
+
+            ODataResource orderResource = null;
+            ODataPropertyInfo shippingAddressPropertyInfo = null;
+
+            await SetupJsonLightReaderAndRunTestAsync(
+                payload,
+                this.orderEntitySet,
+                this.orderEntityType,
+                (jsonLightReader) => DoReadAsync(
+                    jsonLightReader,
+                    verifyResourceAction: (resource) =>
+                    {
+                        orderResource = resource;
+                    },
+                    verifyNestedPropertyInfoAction: (nestedPropertyInfo) =>
+                    {
+                        shippingAddressPropertyInfo = nestedPropertyInfo;
+                    }));
+
+            Assert.NotNull(orderResource);
+            Assert.Equal("NS.Order", orderResource.TypeName);
+            Assert.Equal(2, orderResource.Properties.Count());
+
+            var idProperty = orderResource.Properties.ElementAt(0);
+            var amountProperty = orderResource.Properties.ElementAt(1);
+
+            Assert.Equal("Id", idProperty.Name);
+            Assert.Equal(1, idProperty.Value);
+            Assert.Equal("Amount", amountProperty.Name);
+            Assert.Equal(130M, amountProperty.Value);
+
+            Assert.NotNull(shippingAddressPropertyInfo);
+            Assert.Equal("ShippingAddress", shippingAddressPropertyInfo.Name);
+        }
+
+        [Fact]
+        public async Task ReadResourceWithStreamPropertyContentTypeUnspecifiedAsync()
+        {
+            var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
+                "\"Id\":1," +
+                "\"Name\":\"Sue\"," +
+                "\"Photo@odata.mediaEditLink\":\"http://tempuri.org/Customers(1)/Photo/Edit\"," +
+                "\"Photo@odata.mediaReadLink\":\"http://tempuri.org/Customers(1)/Photo\"," +
+                "\"Photo@odata.mediaEtag\":\"media-etag\"," +
+                "\"Photo\":\"AQIDBAUGBwgJAA==\"}";
+
+            ODataResource customerResource = null;
+            ODataPropertyInfo photoPropertyInfo = null;
+            byte[] photoBuffer = null;
+            int bytesRead = 0;
+
+            await SetupJsonLightReaderAndRunTestAsync(
+                payload,
+                this.customerEntitySet,
+                this.customerEntityType,
+                (jsonLightReader) => DoReadAsync(
+                    jsonLightReader,
+                    verifyResourceAction: (resource) =>
+                    {
+                        customerResource = resource;
+                    },
+                    verifyNestedPropertyInfoAction: (nestedPropertyInfo) =>
+                    {
+                        photoPropertyInfo = nestedPropertyInfo;
+                    },
+                    verifyBinaryStreamAction: async (binaryStream) =>
+                    {
+                        var maxLength = 10;
+                        photoBuffer = new byte[maxLength];
+                        bytesRead = await binaryStream.ReadAsync(photoBuffer, 0, maxLength);
+                    }));
+
+            Assert.NotNull(customerResource);
+            Assert.Equal("NS.Customer", customerResource.TypeName);
+            Assert.Equal(3, customerResource.Properties.Count());
+
+            var idProperty = customerResource.Properties.ElementAt(0);
+            var nameProperty = customerResource.Properties.ElementAt(1);
+            var photoProperty = customerResource.Properties.ElementAt(2);
+
+            Assert.Equal("Id", idProperty.Name);
+            Assert.Equal(1, idProperty.Value);
+            Assert.Equal("Name", nameProperty.Name);
+            Assert.Equal("Sue", nameProperty.Value);
+            Assert.Equal("Photo", photoProperty.Name);
+
+            Assert.Equal(10, bytesRead);
+            Assert.NotNull(photoBuffer);
+            Assert.Equal(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 }, photoBuffer);
+
+            Assert.NotNull(photoPropertyInfo);
+            var photoStreamInfoProperty = Assert.IsType<ODataStreamPropertyInfo>(photoPropertyInfo);
+            Assert.Equal("Photo", photoStreamInfoProperty.Name);
+            Assert.Equal("http://tempuri.org/Customers(1)/Photo", photoStreamInfoProperty.ReadLink.OriginalString);
+            Assert.Equal("http://tempuri.org/Customers(1)/Photo/Edit", photoStreamInfoProperty.EditLink.OriginalString);
+            Assert.Null(photoStreamInfoProperty.ContentType);
+            Assert.Equal("media-etag", photoStreamInfoProperty.ETag);
+        }
+
+        [Fact]
         public async Task ReadNestedResourceSetAsync_ThrowsExceptionForInvalidItemsInResourceSet()
         {
             var payload = "{\"@odata.context\":\"http://tempuri.org/$metadata#Customers/$entity\"," +
@@ -1714,7 +1820,7 @@ namespace Microsoft.OData.Tests.JsonLight
             Action<ODataDeletedResource> verifyDeletedResourceAction = null,
             Action<ODataDeltaLinkBase> verifyDeltaLinkAction = null,
             Action<ODataEntityReferenceLink> verifyEntityReferenceLinkAction = null,
-            Action<ODataItem> verifyNestedPropertyInfoAction = null,
+            Action<ODataPropertyInfo> verifyNestedPropertyInfoAction = null,
             Action<Stream> verifyBinaryStreamAction = null,
             Action<TextReader> verifyTextStreamAction = null,
             Action<ODataPrimitiveValue> verifyPrimitiveAction = null)
@@ -1823,9 +1929,12 @@ namespace Microsoft.OData.Tests.JsonLight
 
                         break;
                     case ODataReaderState.NestedProperty:
+                        var nestedPropertyInfo = jsonLightReader.Item as ODataPropertyInfo;
+                        Assert.NotNull(nestedPropertyInfo);
+
                         if (verifyNestedPropertyInfoAction != null)
                         {
-                            verifyNestedPropertyInfoAction(jsonLightReader.Item);
+                            verifyNestedPropertyInfoAction(nestedPropertyInfo);
                         }
 
                         break;


### PR DESCRIPTION
### Description

Fix async wrapper over sync API in reading nested property info - prevent inadvertent sync IO

This is why/how the sync method was being called:
https://github.com/OData/odata.net/blob/383e29f3cb96eda22e76d19df7bdab11459377b8/src/Microsoft.OData.Core/ODataReaderCoreAsync.cs#L88-L91

The async methods are declared in the `ODataReaderCoreAsync` base class and their default implementation is to wrap the sync method.

If they're not overridden in the derived class, they'll do sync IO. The `ReadAtNestedPropertyInfoImplementationAsync` was inadvertently not overridden in `ODataJsonLightReader` class.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*