### PR TITLE
Support Enums as Keys in OData Client

### DIFF
--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -321,7 +321,9 @@ namespace Microsoft.OData.Client.Metadata
                     throw c.Error.InvalidOperation(c.Strings.ClientType_KeysOnDifferentDeclaredType(typeName));
                 }
 
-                if (!PrimitiveType.IsKnownType(key.PropertyType) && !(key.PropertyType.GetGenericTypeDefinition() == typeof(System.Nullable<>) && key.PropertyType.GetGenericArguments().First().IsEnum()))
+                // Check if the key property's type is a known primitive, an enum, or a nullable generic.
+                // If it doesn't meet any of these conditions, throw an InvalidOperationException.
+                if (!PrimitiveType.IsKnownType(key.PropertyType) && !key.PropertyType.IsEnum() && !(key.PropertyType.IsGenericType() && key.PropertyType.GetGenericTypeDefinition() == typeof(System.Nullable<>)))
                 {
                     throw c.Error.InvalidOperation(c.Strings.ClientType_KeysMustBeSimpleTypes(key.Name, typeName, key.PropertyType.FullName));
                 }

--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -323,7 +323,7 @@ namespace Microsoft.OData.Client.Metadata
 
                 // Check if the key property's type is a known primitive, an enum, or a nullable generic.
                 // If it doesn't meet any of these conditions, throw an InvalidOperationException.
-                if (!PrimitiveType.IsKnownType(key.PropertyType) && !key.PropertyType.IsEnum() && !(key.PropertyType.IsGenericType() && key.PropertyType.GetGenericTypeDefinition() == typeof(System.Nullable<>)))
+                if (!PrimitiveType.IsKnownType(key.PropertyType) && !key.PropertyType.IsEnum() && !(key.PropertyType.IsGenericType() && key.PropertyType.GetGenericTypeDefinition() == typeof(System.Nullable<>) && key.PropertyType.GetGenericArguments().First().IsEnum()))
                 {
                     throw c.Error.InvalidOperation(c.Strings.ClientType_KeysMustBeSimpleTypes(key.Name, typeName, key.PropertyType.FullName));
                 }

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
@@ -7,6 +7,7 @@
 using Microsoft.OData.Client.Metadata;
 using System;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.OData.Client.Tests.Metadata
@@ -70,10 +71,10 @@ namespace Microsoft.OData.Client.Tests.Metadata
             //Arrange
             Type employee = typeof(Employee);
 
-            int expectedNumberOfKeyProperties = 4; // 2 Primitive Known Types, 1 Enum Type, 1 Nullable Generic Type
+            int expectedNumberOfKeyProperties = 4; // 2 Primitive Known Types, 1 Enum Type, 1 Enum Nullable Generic Type
 
             //Act
-            var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+            PropertyInfo[] keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
 
             //Assert
             Assert.Equal(expectedNumberOfKeyProperties, keyProperties.Length);
@@ -86,8 +87,8 @@ namespace Microsoft.OData.Client.Tests.Metadata
             Type employee = typeof(Employee);
 
             //Act
-            var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
-            var key = keyProperties.Single(k => k.Name == "EmpType");
+            PropertyInfo[] keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+            PropertyInfo key = keyProperties.Single(k => k.Name == "EmpType");
 
             //Assert
             Assert.True(key.PropertyType.IsEnum());
@@ -101,10 +102,10 @@ namespace Microsoft.OData.Client.Tests.Metadata
             Type employee = typeof(Employee);
 
             //Act
-            var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+            PropertyInfo[] keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
 
-            var empNumKey = keyProperties.Single(k => k.Name == "EmpNumber");
-            var deptNumKey = keyProperties.Single(k => k.Name == "DeptNumber");
+            PropertyInfo empNumKey = keyProperties.Single(k => k.Name == "EmpNumber");
+            PropertyInfo deptNumKey = keyProperties.Single(k => k.Name == "DeptNumber");
 
             //Assert
             Assert.True(PrimitiveType.IsKnownType(empNumKey.PropertyType) && empNumKey.PropertyType == typeof(int));
@@ -112,18 +113,18 @@ namespace Microsoft.OData.Client.Tests.Metadata
         }
 
         [Fact]
-        public void IFTypeProperty_HasNullableGenericTypeKeyAttribute_GetKeyPropertiesOnType_DoesNotThrowException()
+        public void IFTypeProperty_HasNullableGenericTypeKeyAttributeOfTypeEnum_GetKeyPropertiesOnType_DoesNotThrowException()
         {
             // Arrange
             Type employee = typeof(Employee);
 
             //Act
-            var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
-            var key = keyProperties.Single(k => k.Name == "NullableId");
+            PropertyInfo[] keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+            PropertyInfo key = keyProperties.Single(k => k.Name == "NullableEmpType");
 
             //Assert
             Assert.True(key.PropertyType.IsGenericType);
-            Assert.True(key.PropertyType == typeof(System.Nullable<int>));
+            Assert.True(key.PropertyType == typeof(System.Nullable<EmployeeType>));
         }
 
         public class Person
@@ -157,7 +158,7 @@ namespace Microsoft.OData.Client.Tests.Metadata
             public EmployeeType EmpType { get; set; }
 
             [System.ComponentModel.DataAnnotations.Key]
-            public int? NullableId { get; set; }
+            public EmployeeType? NullableEmpType { get; set; }
 
             public string Name { get; set; }
 

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
@@ -6,6 +6,7 @@
 
 using Microsoft.OData.Client.Metadata;
 using System;
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.OData.Client.Tests.Metadata
@@ -50,6 +51,86 @@ namespace Microsoft.OData.Client.Tests.Metadata
             Assert.True(actualResult);
         }
 
+        [Fact]
+        public void IFType_HasMultipleKeyAttributesWhereOneIsEnum_TypeIsEntityAndDoesNotThrowException()
+        {
+            //Arrange
+            Type employee = typeof(Employee);
+
+            //Act
+            bool actualResult = ClientTypeUtil.TypeOrElementTypeIsEntity(employee);
+
+            //Assert
+            Assert.True(actualResult);
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasMultipleKeyAttributes_GetKeyPropertiesOnType_DoesNotThrowException()
+        {
+            //Arrange
+            Type employee = typeof(Employee);
+
+            int expectedNumberOfKeyProperties = 4; // 2 Primitive Known Types, 1 Enum Type, 1 Nullable Generic Type
+
+            //Act
+            var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+
+            //Assert
+            Assert.Equal(expectedNumberOfKeyProperties, keyProperties.Length);
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasEnumTypeKeyAttribute_GetKeyPropertiesOnType_DoesNotThrowException()
+        {
+            // Arrange
+            Type employee = typeof(Employee);
+
+            //Act
+            var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+
+            //Assert
+            Assert.Equal("EmpType", keyProperties.Single(k => k.PropertyType == typeof(EmployeeType)).Name);
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasKnownPrimitiveTypesKeyAttributes_GetKeyPropertiesOnType_DoesNotThrowException()
+        {
+            // Arrange
+            Type employee = typeof(Employee);
+
+            //Act
+            var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+
+            //Assert
+            foreach (var keyProperty in keyProperties)
+            {
+                if (PrimitiveType.IsKnownType(keyProperty.PropertyType))
+                {
+                    if (keyProperty.PropertyType == typeof(int))
+                    {
+                        Assert.Equal("EmpNumber", keyProperty.Name);
+                    }
+                    else if (keyProperty.PropertyType == typeof(string))
+                    {
+                        Assert.Equal("DeptNumber", keyProperty.Name);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasNullableGenericTypeKeyAttribute_GetKeyPropertiesOnType_DoesNotThrowException()
+        {
+            // Arrange
+            Type employee = typeof(Employee);
+
+            //Act
+            var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+
+            //Assert
+            Assert.Equal("NullableId", keyProperties.Single(k => k.PropertyType == typeof(System.Nullable<int>)).Name);
+        }
+
         public class Person
         {
             [System.ComponentModel.DataAnnotations.Key]
@@ -67,6 +148,42 @@ namespace Microsoft.OData.Client.Tests.Metadata
         {
             [System.ComponentModel.DataAnnotations.Key]
             public int NonStandardId { get; set; }
+        }
+
+        public class Employee
+        {
+            [System.ComponentModel.DataAnnotations.Key]
+            public int EmpNumber { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Key]
+            public string DeptNumber { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Key]
+            public EmployeeType EmpType { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Key]
+            public int? NullableId { get; set; }
+
+            public string Name { get; set; }
+
+            public decimal Salary { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Schema.ForeignKey("DeptNumber")]
+            public Department Department { get; set; }
+        }
+
+        public enum EmployeeType
+        {
+            None = 1,
+            FullTime = 2,
+            PartTime = 3
+        }
+
+        public class Department
+        {
+            [System.ComponentModel.DataAnnotations.Key]
+            public string DeptId { get; set; }
+            public string Name { get; set; }
         }
 
     }

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.OData.Client.Tests.Metadata
         }
 
         [Fact]
-        public void IFTypeProperty_HasNullableGenericTypeKeyAttributeOfTypeEnum_GetKeyPropertiesOnType_DoesNotThrowException()
+        public void IFTypeProperty_HasNullableGenericTypeKeyAttribute_OfTypeEnum_GetKeyPropertiesOnType_DoesNotThrowException()
         {
             // Arrange
             Type employee = typeof(Employee);
@@ -125,6 +125,24 @@ namespace Microsoft.OData.Client.Tests.Metadata
             //Assert
             Assert.True(key.PropertyType.IsGenericType);
             Assert.True(key.PropertyType == typeof(System.Nullable<EmployeeType>));
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasNullableGenericTypeKey_OfTypeStruct_GetKeyPropertiesOnType_ThrowsException()
+        {
+            // Arrange
+            Type employee = typeof(EmployeeWithNullableStruct);
+
+            PropertyInfo empTypeStructKey = employee.GetProperty("EmpTypeStruct");
+
+            InvalidOperationException expectedException = Error.InvalidOperation(Strings.ClientType_KeysMustBeSimpleTypes(empTypeStructKey.Name, employee.ToString(), empTypeStructKey.PropertyType.FullName));
+
+            //Act
+            InvalidOperationException actualException = Assert.Throws<InvalidOperationException>(() => ClientTypeUtil.GetKeyPropertiesOnType(employee));
+
+            //Assert
+            Assert.NotNull(actualException);
+            Assert.Equal(expectedException.Message, actualException.Message);
         }
 
         public class Person
@@ -162,10 +180,19 @@ namespace Microsoft.OData.Client.Tests.Metadata
 
             public string Name { get; set; }
 
-            public decimal Salary { get; set; }
-
             [System.ComponentModel.DataAnnotations.Schema.ForeignKey("DeptNumber")]
             public Department Department { get; set; }
+        }
+
+        public class EmployeeWithNullableStruct
+        {
+            [System.ComponentModel.DataAnnotations.Key]
+            public int EmpNumber { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Key]
+            public EmployeeTypeStruct? EmpTypeStruct { get; set; }
+
+            public string Name { get; set; }
         }
 
         public enum EmployeeType
@@ -180,6 +207,11 @@ namespace Microsoft.OData.Client.Tests.Metadata
             [System.ComponentModel.DataAnnotations.Key]
             public string DeptId { get; set; }
             public string Name { get; set; }
+        }
+
+        public struct EmployeeTypeStruct
+        {
+            public int EmpTypeId { get; set; }
         }
 
     }

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
@@ -87,9 +87,11 @@ namespace Microsoft.OData.Client.Tests.Metadata
 
             //Act
             var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+            var key = keyProperties.Single(k => k.Name == "EmpType");
 
             //Assert
-            Assert.Equal("EmpType", keyProperties.Single(k => k.PropertyType == typeof(EmployeeType)).Name);
+            Assert.True(key.PropertyType.IsEnum());
+            Assert.True(key.PropertyType == typeof(EmployeeType));
         }
 
         [Fact]
@@ -101,21 +103,12 @@ namespace Microsoft.OData.Client.Tests.Metadata
             //Act
             var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
 
+            var empNumKey = keyProperties.Single(k => k.Name == "EmpNumber");
+            var deptNumKey = keyProperties.Single(k => k.Name == "DeptNumber");
+
             //Assert
-            foreach (var keyProperty in keyProperties)
-            {
-                if (PrimitiveType.IsKnownType(keyProperty.PropertyType))
-                {
-                    if (keyProperty.PropertyType == typeof(int))
-                    {
-                        Assert.Equal("EmpNumber", keyProperty.Name);
-                    }
-                    else if (keyProperty.PropertyType == typeof(string))
-                    {
-                        Assert.Equal("DeptNumber", keyProperty.Name);
-                    }
-                }
-            }
+            Assert.True(PrimitiveType.IsKnownType(empNumKey.PropertyType) && empNumKey.PropertyType == typeof(int));
+            Assert.True(PrimitiveType.IsKnownType(deptNumKey.PropertyType) && deptNumKey.PropertyType == typeof(string));
         }
 
         [Fact]
@@ -126,9 +119,11 @@ namespace Microsoft.OData.Client.Tests.Metadata
 
             //Act
             var keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+            var key = keyProperties.Single(k => k.Name == "NullableId");
 
             //Assert
-            Assert.Equal("NullableId", keyProperties.Single(k => k.PropertyType == typeof(System.Nullable<int>)).Name);
+            Assert.True(key.PropertyType.IsGenericType);
+            Assert.True(key.PropertyType == typeof(System.Nullable<int>));
         }
 
         public class Person

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
@@ -1,0 +1,161 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DataServiceContextDataSelectTests.cs" company="Microsoft">
+// Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm.Csdl;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.Tracking
+{
+    public class DataServiceContextQueryTests
+    {
+        private readonly Container _defaultContext;
+
+        #region Test Edmx
+        private const string Edmx = @"<edmx:Edmx xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"" Version=""4.0"">
+    <edmx:DataServices>
+        <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Sample.API.Models"">
+            <EntityType Name=""Employee"">
+                <Key>
+                    <PropertyRef Name=""EmpNumber"" />
+                    <PropertyRef Name=""EmpType"" />
+                    <PropertyRef Name=""OrgId"" />
+                </Key>
+                <Property Name=""EmpNumber"" Type=""Edm.Int32"" Nullable=""false"" />
+                <Property Name=""EmpType"" Type=""Sample.API.Models.Enums.EmployeeType"" Nullable=""false"" />
+                <Property Name=""OrgId"" Type=""Edm.Int32"" Nullable=""false"" />
+                <Property Name=""Name"" Type=""Edm.String"" Nullable=""false"" />
+                <Property Name=""Salary"" Type=""Edm.Decimal"" Nullable=""false"" Scale=""Variable"" />
+                <NavigationProperty Name=""Organization"" Type=""Sample.API.Models.Organization"" Nullable=""false"">
+                    <ReferentialConstraint Property=""OrgId"" ReferencedProperty=""Id"" />
+                </NavigationProperty>
+            </EntityType>
+            <EntityType Name=""Organization"">
+                <Key>
+                    <PropertyRef Name=""Id"" />
+                </Key>
+                <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+                <Property Name=""Name"" Type=""Edm.String"" Nullable=""false"" />
+            </EntityType>
+        </Schema>
+        <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm""
+            Namespace=""Sample.API.Models.Enums"">
+            <EnumType Name=""EmployeeType"">
+                <Member Name=""None"" Value=""1"" />
+                <Member Name=""FullTime"" Value=""2"" />
+                <Member Name=""PartTime"" Value=""3"" />
+            </EnumType>
+        </Schema>
+        <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Default"">
+            <EntityContainer Name=""Container"">
+                <EntitySet Name=""Employees"" EntityType=""Sample.API.Models.Employee"" />
+            </EntityContainer>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>";
+        #endregion
+
+        public DataServiceContextQueryTests()
+        {
+            var uri = new Uri("http://localhost:8000");
+            _defaultContext = new Container(uri);
+        }
+
+        [Fact]
+        public async Task SelectEntities_WithEnumAsKey_DoNotThrowException()
+        {
+            // Arrange
+            string response = @"{
+    ""@odata.context"": ""http://localhost:5128/$metadata#Employees"",
+    ""value"": [
+        {
+            ""EmpNumber"": 1,
+            ""EmpType"": ""FullTime"",
+            ""OrgId"": 1,
+            ""Name"": ""John Doe""
+        },
+        {
+            ""EmpNumber"": 2,
+            ""EmpType"": ""PartTime"",
+            ""OrgId"": 1,
+            ""Name"": ""Jane Doe""
+        }
+    ]
+}";
+            SetupContextWithRequestPipeline(new DataServiceContext[] { _defaultContext }, response, "http://localhost:8000/employees");
+
+            // Act
+            IEnumerable<Employee> employees = await _defaultContext.Employees.ExecuteAsync();
+
+            // Assert
+            Assert.Equal(2, employees.Count());
+        }
+
+        private void SetupContextWithRequestPipeline(DataServiceContext[] contexts, string response, string location)
+        {
+            foreach (var context in contexts)
+            {
+                context.Configurations.RequestPipeline.OnMessageCreating =
+                    (args) => new CustomizedRequestMessage(
+                        args,
+                        response,
+                        new Dictionary<string, string>()
+                        {
+                            { "Content-Type", "application/json;charset=utf-8" },
+                            { "Location", location },
+                        });
+            }
+        }
+
+        class Container : DataServiceContext
+        {
+            public Container(Uri serviceRoot) :
+                base(serviceRoot, ODataProtocolVersion.V4)
+            {
+                Format.LoadServiceModel = () => CsdlReader.Parse(XmlReader.Create(new StringReader(Edmx)));
+                Format.UseJson();
+                Employees = base.CreateQuery<Employee>("Employees");
+            }
+
+            public DataServiceQuery<Employee> Employees { get; private set; }
+        }
+    }
+
+    [Key("EmpNumber", "EmpType", "OrgId")]
+    public class Employee : BaseEntityType
+    {
+        public int EmpNumber { get; set; }
+
+        // Enum - Employee Type Key
+        public EmployeeType EmpType { get; set; }
+
+        public int OrgId { get; set; }
+
+        public string Name { get; set; }
+
+        [ForeignKey("OrgId")]
+        public virtual Organization Organization { get; set; }
+    }
+
+    public class Organization
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public enum EmployeeType
+    {
+        None = 1,
+        FullTime = 2,
+        PartTime = 3
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2964.*

### Description

*This change involves adding functionality to support the use of `enumeration types` as `keys`.*

Currently, attempting to query entities with `enums as keys` through `OData Client`, results in an error stating that the operation is not valid for non-generic types. 

**Exception**:
`This operation is only valid on generic types.`

**Change**:
This modification will address this issue, allowing `enums` as keys without causing exceptions.
For example, the below `Employee` `object` has `EmpType` which is a key of `Type Enum` and `NullableEmpType` which is `nullable generic Type with Enum as generic argument`.

```cs
public class Employee
{
    [System.ComponentModel.DataAnnotations.Key]
    public int EmpNumber { get; set; }

    // Enum - Employee Type Key
    [System.ComponentModel.DataAnnotations.Key]
    public EmployeeType EmpType { get; set; }

    [System.ComponentModel.DataAnnotations.Key]
    public EmployeeType? NullableEmpType { get; set; }

    public string Name { get; set; }

    public decimal Salary { get; set; }
}

public enum EmployeeType
{
    Hybrid = 1,
    FullTime = 2,
    PartTime = 3
}
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
