### PR TITLE
Add support for Enums as Key in OData Client and Allow $filter with integer value in squote and without squote

### DIFF
--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -321,7 +321,9 @@ namespace Microsoft.OData.Client.Metadata
                     throw c.Error.InvalidOperation(c.Strings.ClientType_KeysOnDifferentDeclaredType(typeName));
                 }
 
-                if (!PrimitiveType.IsKnownType(key.PropertyType) && !(key.PropertyType.GetGenericTypeDefinition() == typeof(System.Nullable<>) && key.PropertyType.GetGenericArguments().First().IsEnum()))
+                // Check if the key property's type is a known primitive, an enum, or a nullable generic.
+                // If it doesn't meet any of these conditions, throw an InvalidOperationException.
+                if (!PrimitiveType.IsKnownType(key.PropertyType) && !key.PropertyType.IsEnum() && !(key.PropertyType.IsGenericType() && key.PropertyType.GetGenericTypeDefinition() == typeof(System.Nullable<>) && key.PropertyType.GetGenericArguments().First().IsEnum()))
                 {
                     throw c.Error.InvalidOperation(c.Strings.ClientType_KeysMustBeSimpleTypes(key.Name, typeName, key.PropertyType.FullName));
                 }

--- a/src/Microsoft.OData.Core/EdmExtensionMethods.cs
+++ b/src/Microsoft.OData.Core/EdmExtensionMethods.cs
@@ -122,5 +122,47 @@ namespace Microsoft.OData
 
             return false;
         }
+
+        /// <summary>
+        /// Parse an enum integral value to enum member.
+        /// </summary>
+        /// <param name="enumType">edm enum type</param>
+        /// <param name="value">input integral value.</param>
+        /// <param name="enumMember">parsed result.</param>
+        /// <returns>true if parse succeeds, false if parse fails.</returns>
+        public static bool TryParse(this IEdmEnumType enumType, long value, out IEdmEnumMember enumMember)
+        {
+            enumMember = null;
+            foreach (IEdmEnumMember member in enumType.Members)
+            {
+                if (member.Value.Value == value)
+                {
+                    enumMember = member;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the given member name exists in the enum type.
+        /// </summary>
+        /// <param name="enumType">The enum type.</param>
+        /// <param name="memberName">The member name to check.</param>
+        /// <param name="comparison">The comparison type to use for string comparison. Default is Ordinal.</param>
+        /// <returns>True if the member name exists in the enum type; otherwise, false.</returns>
+        public static bool ContainsMember(this IEdmEnumType enumType, string memberName, StringComparison comparison = StringComparison.Ordinal)
+        {
+            foreach (IEdmEnumMember member in enumType.Members)
+            {
+                if (string.Equals(member.Name, memberName, comparison))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/TypePromotionUtils.cs
@@ -267,14 +267,15 @@ namespace Microsoft.OData.UriParser
                     return true;
                 }
 
-                // Comparing an enum with a string is valid
-                if (left != null && right != null && left.IsEnum() && right.IsString())
+                // Comparing an enum with a string or int is valid
+                if (left != null && right != null && left.IsEnum() && (right.IsString() || right.IsIntegral()))
                 {
                     right = left;
                     return true;
                 }
 
-                if (left != null && right != null && right.IsEnum() && left.IsString())
+                // Comparing an enum with a string or int is valid
+                if (left != null && right != null && right.IsEnum() && (left.IsString() || left.IsIntegral()))
                 {
                     left = right;
                     return true;

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
@@ -6,6 +6,8 @@
 
 using Microsoft.OData.Client.Metadata;
 using System;
+using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.OData.Client.Tests.Metadata
@@ -50,6 +52,99 @@ namespace Microsoft.OData.Client.Tests.Metadata
             Assert.True(actualResult);
         }
 
+        [Fact]
+        public void IFType_HasMultipleKeyAttributesWhereOneIsEnum_TypeIsEntityAndDoesNotThrowException()
+        {
+            //Arrange
+            Type employee = typeof(Employee);
+
+            //Act
+            bool actualResult = ClientTypeUtil.TypeOrElementTypeIsEntity(employee);
+
+            //Assert
+            Assert.True(actualResult);
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasMultipleKeyAttributes_GetKeyPropertiesOnType_DoesNotThrowException()
+        {
+            //Arrange
+            Type employee = typeof(Employee);
+
+            int expectedNumberOfKeyProperties = 4; // 2 Primitive Known Types, 1 Enum Type, 1 Enum Nullable Generic Type
+
+            //Act
+            PropertyInfo[] keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+
+            //Assert
+            Assert.Equal(expectedNumberOfKeyProperties, keyProperties.Length);
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasEnumTypeKeyAttribute_GetKeyPropertiesOnType_DoesNotThrowException()
+        {
+            // Arrange
+            Type employee = typeof(Employee);
+
+            //Act
+            PropertyInfo[] keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+            PropertyInfo key = keyProperties.Single(k => k.Name == "EmpType");
+
+            //Assert
+            Assert.True(key.PropertyType.IsEnum());
+            Assert.True(key.PropertyType == typeof(EmployeeType));
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasKnownPrimitiveTypesKeyAttributes_GetKeyPropertiesOnType_DoesNotThrowException()
+        {
+            // Arrange
+            Type employee = typeof(Employee);
+
+            //Act
+            PropertyInfo[] keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+
+            PropertyInfo empNumKey = keyProperties.Single(k => k.Name == "EmpNumber");
+            PropertyInfo deptNumKey = keyProperties.Single(k => k.Name == "DeptNumber");
+
+            //Assert
+            Assert.True(PrimitiveType.IsKnownType(empNumKey.PropertyType) && empNumKey.PropertyType == typeof(int));
+            Assert.True(PrimitiveType.IsKnownType(deptNumKey.PropertyType) && deptNumKey.PropertyType == typeof(string));
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasNullableGenericTypeKeyAttribute_OfTypeEnum_GetKeyPropertiesOnType_DoesNotThrowException()
+        {
+            // Arrange
+            Type employee = typeof(Employee);
+
+            //Act
+            PropertyInfo[] keyProperties = ClientTypeUtil.GetKeyPropertiesOnType(employee);
+            PropertyInfo key = keyProperties.Single(k => k.Name == "NullableEmpType");
+
+            //Assert
+            Assert.True(key.PropertyType.IsGenericType);
+            Assert.True(key.PropertyType == typeof(System.Nullable<EmployeeType>));
+        }
+
+        [Fact]
+        public void IFTypeProperty_HasNullableGenericTypeKey_OfTypeStruct_GetKeyPropertiesOnType_ThrowsException()
+        {
+            // Arrange
+            Type employee = typeof(EmployeeWithNullableStruct);
+
+            PropertyInfo empTypeStructKey = employee.GetProperty("EmpTypeStruct");
+
+            InvalidOperationException expectedException = Error.InvalidOperation(Strings.ClientType_KeysMustBeSimpleTypes(empTypeStructKey.Name, employee.ToString(), empTypeStructKey.PropertyType.FullName));
+
+            //Act
+            InvalidOperationException actualException = Assert.Throws<InvalidOperationException>(() => ClientTypeUtil.GetKeyPropertiesOnType(employee));
+
+            //Assert
+            Assert.NotNull(actualException);
+            Assert.Equal(expectedException.Message, actualException.Message);
+        }
+
         public class Person
         {
             [System.ComponentModel.DataAnnotations.Key]
@@ -67,6 +162,56 @@ namespace Microsoft.OData.Client.Tests.Metadata
         {
             [System.ComponentModel.DataAnnotations.Key]
             public int NonStandardId { get; set; }
+        }
+
+        public class Employee
+        {
+            [System.ComponentModel.DataAnnotations.Key]
+            public int EmpNumber { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Key]
+            public string DeptNumber { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Key]
+            public EmployeeType EmpType { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Key]
+            public EmployeeType? NullableEmpType { get; set; }
+
+            public string Name { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Schema.ForeignKey("DeptNumber")]
+            public Department Department { get; set; }
+        }
+
+        public class EmployeeWithNullableStruct
+        {
+            [System.ComponentModel.DataAnnotations.Key]
+            public int EmpNumber { get; set; }
+
+            [System.ComponentModel.DataAnnotations.Key]
+            public EmployeeTypeStruct? EmpTypeStruct { get; set; }
+
+            public string Name { get; set; }
+        }
+
+        public enum EmployeeType
+        {
+            None = 1,
+            FullTime = 2,
+            PartTime = 3
+        }
+
+        public class Department
+        {
+            [System.ComponentModel.DataAnnotations.Key]
+            public string DeptId { get; set; }
+            public string Name { get; set; }
+        }
+
+        public struct EmployeeTypeStruct
+        {
+            public int EmpTypeId { get; set; }
         }
 
     }

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
@@ -1,0 +1,321 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="DataServiceContextQueryTests.cs" company="Microsoft">
+// Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm.Csdl;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml;
+using Xunit;
+
+namespace Microsoft.OData.Client.Tests.Tracking
+{
+    public class DataServiceContextQueryTests
+    {
+        private const string ServiceRoot = "http://localhost:8007";
+        private readonly Container _defaultContext;
+
+        #region Test Edmx
+        private const string Edmx = @"<edmx:Edmx xmlns:edmx=""http://docs.oasis-open.org/odata/ns/edmx"" Version=""4.0"">
+    <edmx:DataServices>
+        <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Sample.API.Models"">
+            <EntityType Name=""Employee"">
+                <Key>
+                    <PropertyRef Name=""EmpNumber"" />
+                    <PropertyRef Name=""EmpType"" />
+                    <PropertyRef Name=""OrgId"" />
+                </Key>
+                <Property Name=""EmpNumber"" Type=""Edm.Int32"" Nullable=""false"" />
+                <Property Name=""EmpType"" Type=""Sample.API.Models.Enums.EmployeeType"" Nullable=""false"" />
+                <Property Name=""OrgId"" Type=""Edm.Int32"" Nullable=""false"" />
+                <Property Name=""Name"" Type=""Edm.String"" Nullable=""false"" />
+                <Property Name=""Salary"" Type=""Edm.Decimal"" Nullable=""false"" Scale=""Variable"" />
+                <NavigationProperty Name=""Organization"" Type=""Sample.API.Models.Organization"" Nullable=""false"">
+                    <ReferentialConstraint Property=""OrgId"" ReferencedProperty=""Id"" />
+                </NavigationProperty>
+            </EntityType>
+            <EntityType Name=""Organization"">
+                <Key>
+                    <PropertyRef Name=""Id"" />
+                </Key>
+                <Property Name=""Id"" Type=""Edm.Int32"" Nullable=""false"" />
+                <Property Name=""Name"" Type=""Edm.String"" Nullable=""false"" />
+            </EntityType>
+        </Schema>
+        <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm""
+            Namespace=""Sample.API.Models.Enums"">
+            <EnumType Name=""EmployeeType"">
+                <Member Name=""None"" Value=""1"" />
+                <Member Name=""FullTime"" Value=""2"" />
+                <Member Name=""PartTime"" Value=""3"" />
+            </EnumType>
+        </Schema>
+        <Schema xmlns=""http://docs.oasis-open.org/odata/ns/edm"" Namespace=""Default"">
+            <EntityContainer Name=""Container"">
+                <EntitySet Name=""Employees"" EntityType=""Sample.API.Models.Employee"" />
+            </EntityContainer>
+        </Schema>
+    </edmx:DataServices>
+</edmx:Edmx>";
+        #endregion
+
+        public DataServiceContextQueryTests()
+        {
+            var uri = new Uri(ServiceRoot);
+            _defaultContext = new Container(uri);
+        }
+
+        [Fact]
+        public async Task SelectEntities_WithEnumAsKey_DoNotThrowException()
+        {
+            // Arrange
+            var expectedUri = $"{ServiceRoot}/Employees";
+
+            string response = @"{
+    ""@odata.context"": ""http://localhost:8007/$metadata#Employees"",
+    ""value"": [
+        {
+            ""EmpNumber"": 1,
+            ""EmpType"": ""FullTime"",
+            ""OrgId"": 1,
+            ""Name"": ""John Doe""
+        },
+        {
+            ""EmpNumber"": 2,
+            ""EmpType"": ""PartTime"",
+            ""OrgId"": 1,
+            ""Name"": ""Jane Doe""
+        }
+    ]
+}";
+            SetupContextWithRequestPipeline(_defaultContext, response, "Employees");
+            _defaultContext.SendingRequest2 += (sender, args) =>
+            {
+                Assert.Equal(expectedUri, args.RequestMessage.Url.ToString());
+            };
+
+            // Act
+            DataServiceQuery<Employee> query = _defaultContext.Employees;
+            IEnumerable<Employee> employees = await query.ExecuteAsync();
+
+            // Assert
+            Assert.Equal(expectedUri, query.ToString());
+            Assert.Equal(2, employees.Count());
+        }
+
+        [Fact]
+        public void UseWhereToFilterByOtherKeyOtherThanEnumKey_WithEnumAsKey_DoNotThrowException()
+        {
+            // Arrange
+            string expectedUri = $"{ServiceRoot}/Employees?$filter=EmpNumber eq 8";
+
+            string response = @"{
+    ""@odata.context"": ""http://localhost:8007/$metadata#Employees"",
+    ""value"": [
+        {
+            ""EmpNumber"": 8,
+            ""EmpType"": ""PartTime"",
+            ""OrgId"": 1,
+            ""Name"": ""Employee Two""
+        }
+    ]
+}";
+            SetupContextWithRequestPipeline(_defaultContext, response, "Employees");
+            _defaultContext.SendingRequest2 += (sender, args) =>
+            {
+                Assert.Equal($"{expectedUri}&$top=1", args.RequestMessage.Url.ToString());
+            };
+
+            // Act
+            IQueryable<Employee> query = _defaultContext.Employees.Where(e => e.EmpNumber == 8);
+            Employee employee = query.First();
+
+            // Assert
+            Assert.Equal(expectedUri, query.ToString());
+            Assert.Equal(EmployeeType.PartTime, employee.EmpType);
+            Assert.Equal("Employee Two", employee.Name);
+        }
+
+        [Fact]
+        public void UseWhereToFilterByEnumKey_WithEnumAsKey_DoNotThrowException()
+        {
+            // Arrange
+            string expectedUri = $"{ServiceRoot}/Employees?$filter=EmpType eq Microsoft.OData.Client.Tests.Tracking.EmployeeType'PartTime'";
+
+            string response = @"{
+    ""@odata.context"": ""http://localhost:8007/$metadata#Employees"",
+    ""value"": [
+        {
+            ""EmpNumber"": 8,
+            ""EmpType"": ""PartTime"",
+            ""OrgId"": 1,
+            ""Name"": ""Employee 45""
+        }
+    ]
+}";
+            SetupContextWithRequestPipeline(_defaultContext, response, "Employees");
+            _defaultContext.SendingRequest2 += (sender, args) =>
+            {
+                Assert.Equal($"{expectedUri}&$top=1", args.RequestMessage.Url.ToString());
+            };
+
+            // Act
+            var query = _defaultContext.Employees.Where(e => e.EmpType == EmployeeType.PartTime);
+            Employee employee = query.First();
+
+            // Assert
+            Assert.Equal(expectedUri, query.ToString());
+            Assert.Equal(8, employee.EmpNumber);
+            Assert.Equal(EmployeeType.PartTime, employee.EmpType);
+        }
+
+        [Fact]
+        public async Task FilterByCompositeKeys_WithEnumAsKey_DoNotThrowException()
+        {
+            // Arrange
+            string expectedUri = $"{ServiceRoot}/Employees(EmpNumber=8,EmpType=Microsoft.OData.Client.Tests.Tracking.EmployeeType'PartTime',OrgId=1)";
+
+            string response = @"{
+    ""@odata.context"": ""http://localhost:8007/$metadata#Employees"",
+    ""value"": [
+        {
+            ""EmpNumber"": 8,
+            ""EmpType"": ""PartTime"",
+            ""OrgId"": 1,
+            ""Name"": ""Employee 24""
+        }
+    ]
+}";
+            SetupContextWithRequestPipeline(_defaultContext, response, "Employees");
+            _defaultContext.SendingRequest2 += (sender, args) =>
+            {
+                Assert.Equal(expectedUri, args.RequestMessage.Url.ToString());
+            };
+
+            // Act
+            EmployeeSingle query = _defaultContext.Employees.ByKey(
+                new Dictionary<string, object>() { { "EmpNumber", 8 }, { "EmpType", EmployeeType.PartTime }, { "OrgId", 1 } });
+
+            Employee employee = await query.GetValueAsync().ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(expectedUri, query.Query.ToString());
+            Assert.Equal("Employee 24", employee.Name);
+            Assert.Equal(EmployeeType.PartTime, employee.EmpType);
+        }
+
+        [Fact]
+        public void FilterByEnumKey_WithEnumAsKey_DoNotThrowException()
+        {
+            // Arrange
+            string expectedUri = $"{ServiceRoot}/Employees(Microsoft.OData.Client.Tests.Tracking.EmployeeType'FullTime')";
+
+            string response = @"{
+        ""@odata.context"": ""http://localhost:8007/$metadata#Employees"",
+        ""value"": [
+        {
+            ""EmpNumber"": 9,
+            ""EmpType"": ""FullTime"",
+            ""OrgId"": 1,
+            ""Name"": ""John Doe""
+        }
+    ]
+}";
+            SetupContextWithRequestPipeline(_defaultContext, response, "Employees");
+            _defaultContext.SendingRequest2 += (sender, args) =>
+            {
+                Assert.Equal(expectedUri, args.RequestMessage.Url.ToString());
+            };
+
+            // Act
+            EmployeeSingle query = _defaultContext.Employees.ByKey(
+                new Dictionary<string, object>() { { "EmpType", EmployeeType.FullTime } });
+
+            Employee employee = query.GetValue();
+
+            // Assert
+            Assert.Equal(expectedUri, query.Query.ToString());
+            Assert.Equal(9, employee.EmpNumber);
+            Assert.Equal(EmployeeType.FullTime, employee.EmpType);
+        }
+
+        private void SetupContextWithRequestPipeline(DataServiceContext context, string response, string path)
+        {
+            string location = $"{ServiceRoot}/{path}";
+
+            context.Configurations.RequestPipeline.OnMessageCreating = (args) => new CustomizedRequestMessage(
+                args,
+                response,
+                new Dictionary<string, string>()
+                {
+                    { "Content-Type", "application/json;charset=utf-8" },
+                    { "Location", location },
+                });
+        }
+
+        class Container : DataServiceContext
+        {
+            public Container(Uri serviceRoot) :
+                base(serviceRoot, ODataProtocolVersion.V4)
+            {
+                Format.LoadServiceModel = () => CsdlReader.Parse(XmlReader.Create(new StringReader(Edmx)));
+                Format.UseJson();
+                Employees = base.CreateQuery<Employee>("Employees");
+            }
+
+            public DataServiceQuery<Employee> Employees { get; private set; }
+        }
+    }
+
+    [Key("EmpNumber", "EmpType", "OrgId")]
+    public class Employee : BaseEntityType
+    {
+        public int EmpNumber { get; set; }
+
+        // Enum - Employee Type Key
+        public EmployeeType EmpType { get; set; }
+
+        public int OrgId { get; set; }
+
+        public string Name { get; set; }
+
+        [ForeignKey("OrgId")]
+        public virtual Organization Organization { get; set; }
+    }
+
+    public class Organization
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+    }
+
+    public enum EmployeeType
+    {
+        None = 1,
+        FullTime = 2,
+        PartTime = 3
+    }
+
+    public partial class EmployeeSingle : DataServiceQuerySingle<Employee>
+    {
+        /// <summary>
+        /// Initialize a new EmployeeSingle object.
+        /// </summary>
+        public EmployeeSingle(DataServiceContext context, string path)
+            : base(context, path) { }
+    }
+
+    public static class ExtensionMethods
+    {
+        public static EmployeeSingle ByKey(this DataServiceQuery<Employee> _source, IDictionary<string, object> _keys)
+        {
+            return new EmployeeSingle(_source.Context, _source.GetKeyPath(Serializer.GetKeyString(_source.Context, _keys)));
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/MetadataBindingUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/MetadataBindingUtilsTests.cs
@@ -9,6 +9,7 @@ using Microsoft.OData.UriParser;
 using Microsoft.OData.Edm;
 using Xunit;
 using ODataErrorStrings = Microsoft.OData.Strings;
+using System.Linq;
 
 namespace Microsoft.OData.Tests.UriParser.Binders
 {
@@ -49,6 +50,199 @@ namespace Microsoft.OData.Tests.UriParser.Binders
             var targetType = EdmCoreModel.Instance.GetSpatial(EdmPrimitiveTypeKind.GeographyMultiLineString, false);
             Action convertMethod = () => MetadataBindingUtils.ConvertToTypeIfNeeded(node, targetType);
             convertMethod.Throws<ODataException>(ODataErrorStrings.MetadataBinder_CannotConvertToType(node.TypeReference.FullName(), targetType.FullName()));
+        }
+
+        [Fact]
+        public void IfTypePromotionNeeded_SourceIsIntegerMemberValueAndTargetIsEnum_ConstantNodeIsCreated()
+        {
+            // Arrange
+            int enumValue = 3;
+            bool success = WeekDayEmumType.TryParse(enumValue, out IEdmEnumMember expectedMember);
+
+            SingleValueNode source = new ConstantNode(enumValue);
+            IEdmTypeReference targetTypeReference = new EdmEnumTypeReference(WeekDayEmumType, false);
+
+            // Act
+            ConstantNode result = MetadataBindingUtils.ConvertToTypeIfNeeded(source, targetTypeReference) as ConstantNode;
+
+            // Assert
+            Assert.True(success);
+            result.ShouldBeEnumNode(WeekDayEmumType, expectedMember.Name);
+            Assert.Equal(expectedMember.Name, result.Value.ToString());
+        }
+
+        [Fact]
+        public void IfTypePromotionNeeded_SourceIsLongMemberValueAndTargetIsEnum_ConstantNodeIsCreated()
+        {
+            // Arrange
+            long enumValue = 7L;
+            bool success = WeekDayEmumType.TryParse(enumValue, out IEdmEnumMember expectedMember);
+
+            SingleValueNode source = new ConstantNode(enumValue);
+            IEdmTypeReference targetTypeReference = new EdmEnumTypeReference(WeekDayEmumType, false);
+
+            // Act
+            ConstantNode result = MetadataBindingUtils.ConvertToTypeIfNeeded(source, targetTypeReference) as ConstantNode;
+
+            // Assert
+            Assert.True(success);
+            result.ShouldBeEnumNode(WeekDayEmumType, expectedMember.Name);
+            Assert.Equal(expectedMember.Name, result.Value.ToString()); // Compare the enum member name
+        }
+
+        [Fact]
+        public void IfTypePromotionNeeded_SourceIsHugeLongMemberValueAndTargetIsEnum_ConstantNodeIsCreated()
+        {
+            // Arrange
+            long enumValue = 2147483657; // ((long)int.MaxValue + 10L).ToString()
+            bool success = EmployeeType.TryParse(enumValue, out IEdmEnumMember expectedMember);
+
+            SingleValueNode source = new ConstantNode(enumValue);
+            IEdmTypeReference targetTypeReference = new EdmEnumTypeReference(EmployeeType, false);
+
+            // Act
+            ConstantNode result = MetadataBindingUtils.ConvertToTypeIfNeeded(source, targetTypeReference) as ConstantNode;
+
+            // Assert
+            Assert.True(success);
+            result.ShouldBeEnumNode(EmployeeType, expectedMember.Name);
+            Assert.Equal(expectedMember.Name, result.Value.ToString()); // Compare the enum member name
+        }
+
+        [Fact]
+        public void IfTypePromotionNeeded_SourceIsLongAsStringMemberValueAndTargetIsEnum_ConstantNodeIsCreated()
+        {
+            // Arrange
+            string enumValue = "4294967294"; // ((long)int.MaxValue + (long)int.MaxValue).ToString();
+            bool success = EmployeeType.TryParse(long.Parse(enumValue), out IEdmEnumMember expectedMember);
+
+            SingleValueNode source = new ConstantNode(enumValue);
+            IEdmTypeReference targetTypeReference = new EdmEnumTypeReference(EmployeeType, false);
+
+            // Act
+            ConstantNode result = MetadataBindingUtils.ConvertToTypeIfNeeded(source, targetTypeReference) as ConstantNode;
+
+            // Assert
+            Assert.True(success);
+            result.ShouldBeEnumNode(EmployeeType, expectedMember.Name);
+            Assert.Equal(expectedMember.Name, result.Value.ToString()); // Compare the enum member name
+        }
+
+        [Fact]
+        public void IfTypePromotionNeededForEnum_SourceIsIntegralMemberValueInStringAndTargetIsEnumType_ConstantNodeIsCreated()
+        {
+            // Arrange
+            string enumValue = "5";
+            bool success = WeekDayEmumType.TryParse(long.Parse(enumValue), out IEdmEnumMember expectedMember);
+
+            SingleValueNode source = new ConstantNode(enumValue);
+            IEdmTypeReference targetTypeReference = new EdmEnumTypeReference(WeekDayEmumType, false);
+
+            // Act
+            ConstantNode result = MetadataBindingUtils.ConvertToTypeIfNeeded(source, targetTypeReference) as ConstantNode;
+
+            // Assert
+            Assert.True(success);
+            result.ShouldBeEnumNode(WeekDayEmumType, expectedMember.Name);
+            Assert.Equal(expectedMember.Name, result.Value.ToString()); // compare the enum member name
+        }
+
+        [Fact]
+        public void IfTypePromotionNeededForEnum_SourceIsMemberName_ConstantNodeIsCreated()
+        {
+            // Arrange
+            string enumValue = "Monday";
+            SingleValueNode source = new ConstantNode(enumValue);
+            IEdmTypeReference targetTypeReference = new EdmEnumTypeReference(WeekDayEmumType, false);
+            // Act
+            ConstantNode result = MetadataBindingUtils.ConvertToTypeIfNeeded(source, targetTypeReference) as ConstantNode;
+
+            // Assert
+            result.ShouldBeEnumNode(WeekDayEmumType, enumValue);
+            Assert.Equal(enumValue, result.Value.ToString());
+        }
+
+        [Fact]
+        public void IfTypePromotionNeededForEnum_SourceIsIntegerExceedingDefinedIntegralLimits_ValueIsNotValidEnumConstantExceptionIsThrown()
+        {
+            // Arrange
+            int enumValue = 10;
+            SingleValueNode source = new ConstantNode(enumValue);
+            IEdmTypeReference targetTypeReference = new EdmEnumTypeReference(WeekDayEmumType, false);
+
+            // Act
+            Action convertIfNeeded = () => MetadataBindingUtils.ConvertToTypeIfNeeded(source, targetTypeReference);
+
+            // Assert
+            convertIfNeeded.Throws<ODataException>(ODataErrorStrings.Binder_IsNotValidEnumConstant(enumValue.ToString()));
+        }
+
+        [Fact]
+        public void IfTypePromotionNeeded_SourceIsFloatMemberValuesAndTargetIsEnum_CannotConvertToTypeExceptionIsThrown()
+        {
+            // Arrange
+            float[] floatValues = new float[] { 1.0F, 3.3F, 5.0F, 6.0F };
+
+            foreach (float enumValue in floatValues)
+            {
+                SingleValueNode source = new ConstantNode(enumValue);
+                IEdmTypeReference targetTypeReference = new EdmEnumTypeReference(WeekDayEmumType, false);
+
+                // Act
+                Action convertIfNeeded = () => MetadataBindingUtils.ConvertToTypeIfNeeded(source, targetTypeReference);
+
+                // Assert
+                convertIfNeeded.Throws<ODataException>(ODataErrorStrings.MetadataBinder_CannotConvertToType(source.TypeReference.FullName(), targetTypeReference.FullName()));
+            }
+        }
+
+        [Fact]
+        public void IfTypePromotionNeeded_SourceIsFloatMemberValuesInStringAndTargetIsEnum_ValueIsNotValidEnumConstantExceptionIsThrown()
+        {
+            // Arrange
+            string[] floatValues = new string[] { "1.0", "3.1", "5.5", "7.0" };
+
+            foreach (string enumValue in floatValues)
+            {
+                SingleValueNode source = new ConstantNode(enumValue);
+                IEdmTypeReference targetTypeReference = new EdmEnumTypeReference(WeekDayEmumType, false);
+
+                // Act
+                Action convertIfNeeded = () => MetadataBindingUtils.ConvertToTypeIfNeeded(source, targetTypeReference);
+
+                // Assert
+                convertIfNeeded.Throws<ODataException>(ODataErrorStrings.Binder_IsNotValidEnumConstant(enumValue));
+            }
+        }
+
+        private static EdmEnumType WeekDayEmumType
+        {
+            get
+            {
+                EdmEnumType weekDayType = new EdmEnumType("NS", "WeekDay");
+                weekDayType.AddMember("Monday", new EdmEnumMemberValue(1L));
+                weekDayType.AddMember("Tuesday", new EdmEnumMemberValue(2L));
+                weekDayType.AddMember("Wednesday", new EdmEnumMemberValue(3L));
+                weekDayType.AddMember("Thursday", new EdmEnumMemberValue(4L));
+                weekDayType.AddMember("Friday", new EdmEnumMemberValue(5L));
+                weekDayType.AddMember("Saturday", new EdmEnumMemberValue(6L));
+                weekDayType.AddMember("Sunday", new EdmEnumMemberValue(7L));
+
+                return weekDayType;
+            }
+        }
+
+        private static EdmEnumType EmployeeType
+        {
+            get
+            {
+                EdmEnumType employeeType = new EdmEnumType("NS", "EmployeeType");
+                employeeType.AddMember("FullTime", new EdmEnumMemberValue((long)int.MaxValue));
+                employeeType.AddMember("PartTime", new EdmEnumMemberValue((long)int.MaxValue + 10L));
+                employeeType.AddMember("Contractor", new EdmEnumMemberValue((long)int.MaxValue + (long)int.MaxValue));
+
+                return employeeType;
+            }
         }
         #endregion
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/TypePromotionUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/TypePromotionUtilsTests.cs
@@ -326,6 +326,24 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.True(left.IsEquivalentTo(HardCodedTestModel.GetPet2PetColorPatternProperty().Type));
             Assert.True(right.IsEquivalentTo(HardCodedTestModel.GetPet2PetColorPatternProperty().Type));
         }
+
+        [Fact]
+        public void EqualsOnEnumAndIntegralMemberValueIsSupported()
+        {
+            // Arrange
+            IEdmTypeReference left = HardCodedTestModel.GetPet2PetColorPatternProperty().Type;
+            IEdmTypeReference right = EdmCoreModel.Instance.GetInt32(true);
+            SingleValueNode leftNode = new SingleValuePropertyAccessNode(new ConstantNode(null)/*parent*/, new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", left));
+            SingleValueNode rightNode = new SingleValuePropertyAccessNode(new ConstantNode(null)/*parent*/, new EdmStructuralProperty(new EdmEntityType("MyNamespace", "MyEntityType"), "myPropertyName", right));
+            
+            // Act
+            bool result = TypePromotionUtils.PromoteOperandTypes(BinaryOperatorKind.Equal, leftNode, rightNode, out left, out right, new TypeFacetsPromotionRules());
+
+            // Assert
+            Assert.True(result);
+            Assert.True(left.IsEquivalentTo(HardCodedTestModel.GetPet2PetColorPatternProperty().Type));
+            Assert.True(right.IsEquivalentTo(HardCodedTestModel.GetPet2PetColorPatternProperty().Type));
+        }
         #endregion
 
         #region PromoteOperandType Tests (For Unary Operators)


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Cherry-pick https://github.com/OData/odata.net/commit/c313eae66a2cb42a1b8e4e5bed1a6b3b9a448068 and https://github.com/OData/odata.net/commit/3080ebc49f97c71c4a0642e25af986f73c6011f6 into dev-8.x branch

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Test case modified*
- [x] *Build and test with one-click build and test script passed*
