### PR TITLE
Fix for Error occurs when you check whether a string or integer literal is in an enum collection

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.OData.UriParser
 
             // If the left operand is either an integral or a string type and the right operand is a collection of enums,
             // Calls the MetadataBindingUtils.ConvertToTypeIfNeeded() method to convert the left operand to the same enum type as the right operand.
-            if ((right is CollectionPropertyAccessNode && right.ItemType.IsEnum()) && (left.TypeReference.IsString() || left.TypeReference.IsIntegral()))
+            if ((right is CollectionPropertyAccessNode && right.ItemType.IsEnum()) && (left.TypeReference != null && (left.TypeReference.IsString() || left.TypeReference.IsIntegral())))
             {
                 left = MetadataBindingUtils.ConvertToTypeIfNeeded(left, right.ItemType);
             }

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -58,14 +58,25 @@ namespace Microsoft.OData.UriParser
                     inToken.Right, new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetUntyped())), state.Model);
             }
 
-            // If the left operand is either an integral or a string type and the right operand is a collection of enums,
-            // Calls the MetadataBindingUtils.ConvertToTypeIfNeeded() method to convert the left operand to the same enum type as the right operand.
-            if ((right is CollectionPropertyAccessNode && right.ItemType.IsEnum()) && (left.TypeReference.IsString() || left.TypeReference.IsIntegral()))
+            if (ShouldConvertLeftOperand(left, right))
             {
                 left = MetadataBindingUtils.ConvertToTypeIfNeeded(left, right.ItemType);
             }
 
             return new InNode(left, right);
+        }
+
+        /// <summary>
+        /// Checks if the left operand is either an integral or a string type and the right operand is a collection of enums.
+        /// </summary>
+        /// <param name="leftNode">The left operand.</param>
+        /// <param name="rightNode">The right operand.</param>
+        /// <returns>True if the condition is met, otherwise false.</returns>
+        private static bool ShouldConvertLeftOperand(SingleValueNode leftNode, CollectionNode rightNode)
+        {
+            // If the left operand is either an integral or a string type and the right operand is a collection of enums,
+            // Calls the MetadataBindingUtils.ConvertToTypeIfNeeded() method to convert the left operand to the same enum type as the right operand.
+            return (rightNode is CollectionPropertyAccessNode && rightNode.ItemType.IsEnum()) && (leftNode.TypeReference.IsString() || leftNode.TypeReference.IsIntegral());
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -58,6 +58,13 @@ namespace Microsoft.OData.UriParser
                     inToken.Right, new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetUntyped())), state.Model);
             }
 
+            // If the left operand is either an integral or a string type and the right operand is a collection of enums,
+            // Calls the MetadataBindingUtils.ConvertToTypeIfNeeded() method to convert the left operand to the same enum type as the right operand.
+            if ((right is CollectionPropertyAccessNode && right.ItemType.IsEnum()) && (left.TypeReference.IsString() || left.TypeReference.IsIntegral()))
+            {
+                left = MetadataBindingUtils.ConvertToTypeIfNeeded(left, right.ItemType);
+            }
+
             return new InNode(left, right);
         }
 

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -58,25 +58,14 @@ namespace Microsoft.OData.UriParser
                     inToken.Right, new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetUntyped())), state.Model);
             }
 
-            if (ShouldConvertLeftOperand(left, right))
+            // If the left operand is either an integral or a string type and the right operand is a collection of enums,
+            // Calls the MetadataBindingUtils.ConvertToTypeIfNeeded() method to convert the left operand to the same enum type as the right operand.
+            if ((right is CollectionPropertyAccessNode && right.ItemType.IsEnum()) && (left.TypeReference.IsString() || left.TypeReference.IsIntegral()))
             {
                 left = MetadataBindingUtils.ConvertToTypeIfNeeded(left, right.ItemType);
             }
 
             return new InNode(left, right);
-        }
-
-        /// <summary>
-        /// Checks if the left operand is either an integral or a string type and the right operand is a collection of enums.
-        /// </summary>
-        /// <param name="leftNode">The left operand.</param>
-        /// <param name="rightNode">The right operand.</param>
-        /// <returns>True if the condition is met, otherwise false.</returns>
-        private static bool ShouldConvertLeftOperand(SingleValueNode leftNode, CollectionNode rightNode)
-        {
-            // If the left operand is either an integral or a string type and the right operand is a collection of enums,
-            // Calls the MetadataBindingUtils.ConvertToTypeIfNeeded() method to convert the left operand to the same enum type as the right operand.
-            return (rightNode is CollectionPropertyAccessNode && rightNode.ItemType.IsEnum()) && (leftNode.TypeReference.IsString() || leftNode.TypeReference.IsIntegral());
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/EnumFilterFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/EnumFilterFunctionalTests.cs
@@ -99,11 +99,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorType(this.userModel), (int)Color.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.Color"), (int)Color.Green);
         }
 
         [Fact]
@@ -121,11 +121,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorType(this.userModel), (int)Color.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.Color"), (int)Color.Green);
         }
 
         [Fact]
@@ -143,11 +143,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorFlagsType(this.userModel), (int)ColorFlags.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"), (int)ColorFlags.Green);
         }
 
         [Fact]
@@ -165,11 +165,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorFlagsType(this.userModel), (int)ColorFlags.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"), (int)ColorFlags.Green);
         }
 
         [Fact]
@@ -187,11 +187,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
             .Left
-            .ShouldBeEnumNode(this.GetColorFlagsType(this.userModel), (int)(ColorFlags.Green | ColorFlags.Red));
+            .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"), (int)(ColorFlags.Green | ColorFlags.Red));
 
             binaryNode
             .Right
-            .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+            .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
         }
 
         [Fact]
@@ -209,11 +209,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorType(this.userModel), (int)Color.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.Color"), (int)Color.Green);
         }
 
         [Fact]
@@ -231,12 +231,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorFlagsType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                 (int)(ColorFlags.Green | ColorFlags.Red));
         }
 
@@ -255,12 +255,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorFlagsType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                 (int)(ColorFlags.Green | ColorFlags.Red));
         }
 
@@ -279,12 +279,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                  .Right
                  .ShouldBeEnumNode(
-                 this.GetColorFlagsType(this.userModel),
+                 this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                  "Red");
         }
 
@@ -303,12 +303,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorFlagsType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                 (int)(ColorFlags.Green | ColorFlags.Red));
         }
 
@@ -327,12 +327,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorFlagsType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                 (int)(ColorFlags.Green | ColorFlags.Red));
         }
 
@@ -351,12 +351,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.Color"),
                 (int)(Color.White));
 
             var constantNode = Assert.IsType<ConstantNode>(binaryNode.Right);
@@ -379,12 +379,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.Color"),
                 -132534290);
 
             var constantNode = Assert.IsType<ConstantNode>(binaryNode.Right);
@@ -403,7 +403,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             var filterQueryNode = ParseFilter("Color eq null", this.userModel, this.entityType, this.entitySet);
             var binaryNode = filterQueryNode.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
-            binaryNode.Left.ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorProp(this.userModel));
+            binaryNode.Left.ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             var convertNode = Assert.IsType<ConvertNode>(binaryNode.Right);
             convertNode.Source.ShouldBeConstantQueryNode((object)null);
@@ -699,30 +699,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             // Assert
             action.Throws<ODataException>(Strings.Binder_IsNotValidEnumConstant(expectedExceptionParameter));
-        }
-
-        private IEdmStructuralProperty GetColorProp(IEdmModel model)
-        {
-            return (IEdmStructuralProperty)((IEdmStructuredType)model
-               .FindType("NS.MyEntityType"))
-               .FindProperty("Color");
-        }
-
-        private IEdmEnumType GetColorType(IEdmModel model)
-        {
-            return (IEdmEnumType)model.FindType("NS.Color");
-        }
-
-        private IEdmStructuralProperty GetColorFlagsProp(IEdmModel model)
-        {
-            return (IEdmStructuralProperty)((IEdmStructuredType)model
-                .FindType("NS.MyEntityType"))
-                .FindProperty("ColorFlags");
-        }
-
-        private IEdmEnumType GetColorFlagsType(IEdmModel model)
-        {
-            return (IEdmEnumType)model.FindType("NS.ColorFlags");
         }
 
         private T GetIEdmType<T>(string typeName) where T : IEdmType

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/EnumFilterFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/EnumFilterFunctionalTests.cs
@@ -42,8 +42,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             // set up the edm model etc
             this.userModel = new EdmModel();
 
-            EdmEnumType enumType = new EdmEnumType("NS", "Color", EdmPrimitiveTypeKind.Int32, false);
-            EdmEnumMember red = new EdmEnumMember(enumType, "Red", new EdmEnumMemberValue(1));
+            var enumType = new EdmEnumType("NS", "Color", EdmPrimitiveTypeKind.Int32, false);
+            var red = new EdmEnumMember(enumType, "Red", new EdmEnumMemberValue(1));
             enumType.AddMember(red);
             enumType.AddMember("Green", new EdmEnumMemberValue(2));
             enumType.AddMember("Blue", new EdmEnumMemberValue(3));
@@ -54,11 +54,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             // add enum property
             this.entityType = new EdmEntityType("NS", "MyEntityType", isAbstract: false, isOpen: true, baseType: null);
-            EdmEnumTypeReference enumTypeReference = new EdmEnumTypeReference(enumType, true);
+            var enumTypeReference = new EdmEnumTypeReference(enumType, true);
             this.entityType.AddProperty(new EdmStructuralProperty(this.entityType, "Color", enumTypeReference));
 
             // enum with flags
-            EdmEnumType enumFlagsType = new EdmEnumType("NS", "ColorFlags", EdmPrimitiveTypeKind.Int64, true);
+            var enumFlagsType = new EdmEnumType("NS", "ColorFlags", EdmPrimitiveTypeKind.Int64, true);
             enumFlagsType.AddMember("Red", new EdmEnumMemberValue(1L));
             enumFlagsType.AddMember("Green", new EdmEnumMemberValue(2L));
             enumFlagsType.AddMember("Blue", new EdmEnumMemberValue(4L));
@@ -68,7 +68,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             this.userModel.AddElement(enumFlagsType);
 
             // add enum with flags
-            EdmEnumTypeReference enumFlagsTypeReference = new EdmEnumTypeReference(enumFlagsType, true);
+            var enumFlagsTypeReference = new EdmEnumTypeReference(enumFlagsType, true);
             this.entityType.AddProperty(new EdmStructuralProperty(this.entityType, "ColorFlags", enumFlagsTypeReference));
 
             // add colors collection
@@ -682,13 +682,27 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             // Arrange
             string filterQuery = $"{floatString} in Colors";
 
-            IEdmEnumType colorType = this.GetColorType(this.userModel);
-
             // Act
             Action test = () => ParseFilter(filterQuery, this.userModel, this.entityType, this.entitySet);
 
             // Assert
             test.Throws<ArgumentException>(Strings.Nodes_InNode_CollectionItemTypeMustBeSameAsSingleItemType("NS.Color", "Edm.Single")); // Float are of Type Edm.Single
+        }
+
+        [Theory]
+        [InlineData(-20)]
+        [InlineData("-20")]
+        [InlineData("'-20'")]
+        public void ParseFilterWithInOperatorWithEnumsMemberInvalidIntegralValue(object integralValue)
+        {
+            // Arrange
+            string filterQuery = $"{integralValue} in Colors";
+
+            // Act
+            Action action = () => ParseFilter(filterQuery, this.userModel, this.entityType, this.entitySet);
+
+            // Assert
+            action.Throws<ODataException>(Strings.Binder_IsNotValidEnumConstant("-20"));
         }
 
         private IEdmStructuralProperty GetColorProp(IEdmModel model)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/EnumFilterFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/EnumFilterFunctionalTests.cs
@@ -99,11 +99,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorType(this.userModel), (int)Color.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.Color"), (int)Color.Green);
         }
 
         [Fact]
@@ -121,11 +121,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorType(this.userModel), (int)Color.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.Color"), (int)Color.Green);
         }
 
         [Fact]
@@ -143,11 +143,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorFlagsType(this.userModel), (int)ColorFlags.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"), (int)ColorFlags.Green);
         }
 
         [Fact]
@@ -165,11 +165,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorFlagsType(this.userModel), (int)ColorFlags.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"), (int)ColorFlags.Green);
         }
 
         [Fact]
@@ -187,11 +187,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
             .Left
-            .ShouldBeEnumNode(this.GetColorFlagsType(this.userModel), (int)(ColorFlags.Green | ColorFlags.Red));
+            .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"), (int)(ColorFlags.Green | ColorFlags.Red));
 
             binaryNode
             .Right
-            .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+            .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
         }
 
         [Fact]
@@ -209,11 +209,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
-                .ShouldBeEnumNode(this.GetColorType(this.userModel), (int)Color.Green);
+                .ShouldBeEnumNode(this.GetIEdmType<IEdmEnumType>("NS.Color"), (int)Color.Green);
         }
 
         [Fact]
@@ -231,12 +231,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorFlagsType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                 (int)(ColorFlags.Green | ColorFlags.Red));
         }
 
@@ -255,12 +255,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorFlagsType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                 (int)(ColorFlags.Green | ColorFlags.Red));
         }
 
@@ -279,12 +279,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
          
             binaryNode
                  .Right
                  .ShouldBeEnumNode(
-                 this.GetColorFlagsType(this.userModel),
+                 this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                  "Red");
         }
 
@@ -303,12 +303,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorFlagsType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                 (int)(ColorFlags.Green | ColorFlags.Red));
         }
 
@@ -327,12 +327,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorFlagsProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("ColorFlags"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorFlagsType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.ColorFlags"),
                 (int)(ColorFlags.Green | ColorFlags.Red));
         }
 
@@ -351,12 +351,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.Color"),
                 (int)(Color.White));
 
             var constantNode = Assert.IsType<ConstantNode>(binaryNode.Right);
@@ -379,12 +379,12 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             binaryNode
                 .Left
-                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorProp(this.userModel));
+                .ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             binaryNode
                 .Right
                 .ShouldBeEnumNode(
-                this.GetColorType(this.userModel),
+                this.GetIEdmType<IEdmEnumType>("NS.Color"),
                 -132534290);
 
             var constantNode = Assert.IsType<ConstantNode>(binaryNode.Right);
@@ -403,7 +403,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             var filterQueryNode = ParseFilter("Color eq null", this.userModel, this.entityType, this.entitySet);
             var binaryNode = filterQueryNode.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
-            binaryNode.Left.ShouldBeSingleValuePropertyAccessQueryNode(this.GetColorProp(this.userModel));
+            binaryNode.Left.ShouldBeSingleValuePropertyAccessQueryNode(this.GetIEdmProperty("Color"));
 
             var convertNode = Assert.IsType<ConvertNode>(binaryNode.Right);
             convertNode.Source.ShouldBeConstantQueryNode((object)null);
@@ -528,7 +528,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             string filterQuery = $"NS.Color'{enumValue}' in Colors"; // "NS.Color'White' in Colors"
             string expectedLiteral = "NS.Color'White'";
 
-            IEdmEnumType colorType = this.GetColorType(this.userModel);
+            IEdmEnumType colorType = this.GetIEdmType<IEdmEnumType>("NS.Color");
             IEdmEnumMember enumMember = colorType.Members.Single(m => m.Name == enumValue);
 
             // Act
@@ -546,7 +546,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal(expectedLiteral, leftNode.LiteralText);
 
             CollectionPropertyAccessNode rightNode = Assert.IsType<CollectionPropertyAccessNode>(inNode.Right);
-            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetColorsProperty(this.userModel));
+            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetIEdmProperty("Colors"));
             Assert.Equal(colorType, rightNode.ItemType.Definition);
         }
 
@@ -558,7 +558,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             string filterQuery = $"'{enumValue}' in Colors"; // "'Green' in Colors"
             string expectedLiteral = "'Green'";
 
-            IEdmEnumType colorType = this.GetColorType(this.userModel);
+            IEdmEnumType colorType = this.GetIEdmType<IEdmEnumType>("NS.Color");
 
             // Act
             FilterClause filterQueryNode = ParseFilter(filterQuery, this.userModel, this.entityType, this.entitySet);
@@ -575,7 +575,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal(expectedLiteral, leftNode.LiteralText);
 
             CollectionPropertyAccessNode rightNode = Assert.IsType<CollectionPropertyAccessNode>(inNode.Right);
-            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetColorsProperty(this.userModel));
+            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetIEdmProperty("Colors"));
             Assert.Equal(colorType, rightNode.ItemType.Definition);
         }
 
@@ -587,7 +587,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             string filterQuery = $"'{enumValue}' in Colors"; // "'1' in Colors"
             string expectedLiteral = "'Red'";
 
-            IEdmEnumType colorType = this.GetColorType(this.userModel);
+            IEdmEnumType colorType = this.GetIEdmType<IEdmEnumType>("NS.Color");
             bool success = colorType.TryParse(enumValue, out IEdmEnumMember enumMember);
 
             // Act
@@ -606,7 +606,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal(expectedLiteral, leftNode.LiteralText);
 
             CollectionPropertyAccessNode rightNode = Assert.IsType<CollectionPropertyAccessNode>(inNode.Right);
-            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetColorsProperty(this.userModel));
+            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetIEdmProperty("Colors"));
             Assert.Equal(colorType, rightNode.ItemType.Definition);
         }
 
@@ -618,7 +618,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             string filterQuery = $"{enumValue} in Colors"; // "3 in Colors"
             string expectedLiteral = "'Blue'";
 
-            IEdmEnumType colorType = this.GetColorType(this.userModel);
+            IEdmEnumType colorType = this.GetIEdmType<IEdmEnumType>("NS.Color");
             bool success = colorType.TryParse(enumValue, out IEdmEnumMember enumMember);
 
             // Act
@@ -637,7 +637,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal(expectedLiteral, leftNode.LiteralText);
 
             CollectionPropertyAccessNode rightNode = Assert.IsType<CollectionPropertyAccessNode>(inNode.Right);
-            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetColorsProperty(this.userModel));
+            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetIEdmProperty("Colors"));
             Assert.Equal(colorType, rightNode.ItemType.Definition);
         }
 
@@ -649,7 +649,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             string filterQuery = $"{enumValue} in Colors"; // "3 in Colors"
             string expectedLiteral = "'Blue'";
 
-            IEdmEnumType colorType = this.GetColorType(this.userModel);
+            IEdmEnumType colorType = this.GetIEdmType<IEdmEnumType>("NS.Color");
             bool success = colorType.TryParse(enumValue, out IEdmEnumMember enumMember);
 
             // Act
@@ -668,7 +668,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal(expectedLiteral, leftNode.LiteralText);
 
             CollectionPropertyAccessNode rightNode = Assert.IsType<CollectionPropertyAccessNode>(inNode.Right);
-            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetColorsProperty(this.userModel));
+            rightNode.ShouldBeCollectionPropertyAccessQueryNode(this.GetIEdmProperty("Colors"));
             Assert.Equal(colorType, rightNode.ItemType.Definition);
         }
 
@@ -739,35 +739,26 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             action.Throws<ODataException>(Strings.Binder_IsNotValidEnumConstant(expectedExceptionParameter));
         }
 
-        private IEdmStructuralProperty GetColorProp(IEdmModel model)
+        private T GetIEdmType<T>(string typeName) where T : IEdmType
         {
-            return (IEdmStructuralProperty)((IEdmStructuredType)model
-                .FindType("NS.MyEntityType"))
-                .FindProperty("Color");
+            return (T)this.userModel.FindType(typeName);
         }
 
-        private IEdmStructuralProperty GetColorsProperty(IEdmModel model)
+        private T GetIEdmType<T>(IEdmModel model, string typeName) where T : IEdmType
         {
-            return (IEdmStructuralProperty)((IEdmStructuredType)model
-                .FindType("NS.MyEntityType"))
-                .FindProperty("Colors");
+            return (T)model.FindType(typeName);
         }
 
-        private IEdmEnumType GetColorType(IEdmModel model)
+        private IEdmStructuralProperty GetIEdmProperty(string propertyName)
         {
-            return (IEdmEnumType)model.FindType("NS.Color");
+            return (IEdmStructuralProperty)this.GetIEdmType<IEdmStructuredType>("NS.MyEntityType")
+                .FindProperty(propertyName);
         }
 
-        private IEdmStructuralProperty GetColorFlagsProp(IEdmModel model)
+        private IEdmStructuralProperty GetIEdmProperty(string entityName, string propertyName)
         {
-            return (IEdmStructuralProperty)((IEdmStructuredType)model
-                .FindType("NS.MyEntityType"))
-                .FindProperty("ColorFlags");
-        }
-
-        private IEdmEnumType GetColorFlagsType(IEdmModel model)
-        {
-            return (IEdmEnumType)model.FindType("NS.ColorFlags");
+            return (IEdmStructuralProperty)this.GetIEdmType<IEdmStructuredType>(entityName)
+                .FindProperty(propertyName);
         }
 
         private FilterClause ParseFilter(string text, IEdmModel edmModel, IEdmEntityType edmEntityType, IEdmEntitySet edmEntitySet)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2070,7 +2070,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [Theory]
         [InlineData("53")]
         [InlineData("'53'")]
-        public void FilterWithInOperationWithEnumsInvalidMemberIntegralValue_ThrowsIsNotValidEnumConstantException(object integralValue)
+        public void FilterWithInOperationWithEnumsInvalidMemberIntegralValue_ThrowsIsNotValidEnumConstantException(string integralValue)
         {
             // Arrange
             string filterQuery = $"{integralValue} in FavoriteColors";

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2041,57 +2041,14 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal("FavoriteColors", Assert.IsType<CollectionPropertyAccessNode>(inNode.Right).Property.Name);
         }
 
-        [Fact]
-        public void FilterWithInOperationWithEnumsMemberName_WithoutQualifiedNamespace()
+        [Theory]
+        [InlineData("'SolidYellow'")]
+        [InlineData("'12'")]
+        [InlineData("12")]
+        public void FilterWithInOperationWithEnumsMemberIntegralValue(string filterOptionValue)
         {
             // Arrange
-            string filterQuery = "'SolidYellow' in FavoriteColors";
-
-            string expectedLiteralText = "'SolidYellow'";
-            string expectedfullyQualifiedName = "Fully.Qualified.Namespace.ColorPattern'SolidYellow'";
-            string expectedCollectionPropertyName = "FavoriteColors";
-
-            // Act
-            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
-
-            // Assert
-            InNode inNode = Assert.IsType<InNode>(filter.Expression);
-            ConstantNode left = Assert.IsType<ConstantNode>(inNode.Left);
-            ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(left.Value);
-
-            Assert.Equal(expectedLiteralText, left.LiteralText);
-            Assert.Equal(expectedfullyQualifiedName, (enumValue.TypeName + left.LiteralText));
-            Assert.Equal(expectedCollectionPropertyName, Assert.IsType<CollectionPropertyAccessNode>(inNode.Right).Property.Name);
-        }
-
-        [Fact]
-        public void FilterWithInOperationWithEnumsMemberIntegralValue_WithSingleQuotes()
-        {
-            // Arrange
-            string filterQuery = "'12' in FavoriteColors";
-
-            string expectedLiteralText = "'SolidYellow'";
-            string expectedfullyQualifiedName = "Fully.Qualified.Namespace.ColorPattern'SolidYellow'";
-            string expectedCollectionPropertyName = "FavoriteColors";
-
-            // Act
-            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
-
-            // Assert
-            InNode inNode = Assert.IsType<InNode>(filter.Expression);
-            ConstantNode left = Assert.IsType<ConstantNode>(inNode.Left);
-            ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(left.Value);
-
-            Assert.Equal(expectedLiteralText, left.LiteralText);
-            Assert.Equal(expectedfullyQualifiedName, (enumValue.TypeName + left.LiteralText));
-            Assert.Equal(expectedCollectionPropertyName, Assert.IsType<CollectionPropertyAccessNode>(inNode.Right).Property.Name);
-        }
-
-        [Fact]
-        public void FilterWithInOperationWithEnumsMemberIntegralValue_WithoutSingleQuotes()
-        {
-            // Arrange
-            string filterQuery = "12 in FavoriteColors";
+            string filterQuery = $"{filterOptionValue} in FavoriteColors";
 
             string expectedLiteralText = "'SolidYellow'";
             string expectedfullyQualifiedName = "Fully.Qualified.Namespace.ColorPattern'SolidYellow'";
@@ -2111,7 +2068,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Theory]
-        [InlineData(53)]
         [InlineData("53")]
         [InlineData("'53'")]
         public void FilterWithInOperationWithEnumsInvalidMemberIntegralValue_ThrowsIsNotValidEnumConstantException(object integralValue)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2114,7 +2114,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [InlineData(53)]
         [InlineData("53")]
         [InlineData("'53'")]
-        public void FilterWithInOperationWithEnumsInValidMemberIntegralValue_ThrowsIsNotValidEnumConstantException(object integralValue)
+        public void FilterWithInOperationWithEnumsInvalidMemberIntegralValue_ThrowsIsNotValidEnumConstantException(object integralValue)
         {
             // Arrange
             string filterQuery = $"{integralValue} in FavoriteColors";
@@ -2124,6 +2124,23 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             // Assert
             action.Throws<ODataException>(ODataErrorStrings.Binder_IsNotValidEnumConstant("53"));
+        }
+
+        [Theory]
+        [InlineData("'Teal'")]
+        [InlineData("NS.Color'Teal'")]
+        public void FilterWithInOperationWithEnumsInvalidMemberNames_ThrowsIsNotValidEnumConstantException(string memberName)
+        {
+            // Arrange
+            string filterQuery = $"{memberName} in FavoriteColors";
+
+            string expectedExceptionParameter = memberName.StartsWith("'") ? memberName.Trim('\'') : memberName; // Trim('\'') method removes any single quotes from the start and end of the string
+
+            // Act
+            Action action = () => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            // Assert
+            action.Throws<ODataException>(ODataErrorStrings.Binder_IsNotValidEnumConstant(expectedExceptionParameter));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2042,6 +2042,91 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void FilterWithInOperationWithEnumsMemberName_WithoutQualifiedNamespace()
+        {
+            // Arrange
+            string filterQuery = "'SolidYellow' in FavoriteColors";
+
+            string expectedLiteralText = "'SolidYellow'";
+            string expectedfullyQualifiedName = "Fully.Qualified.Namespace.ColorPattern'SolidYellow'";
+            string expectedCollectionPropertyName = "FavoriteColors";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            // Assert
+            InNode inNode = Assert.IsType<InNode>(filter.Expression);
+            ConstantNode left = Assert.IsType<ConstantNode>(inNode.Left);
+            ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(left.Value);
+
+            Assert.Equal(expectedLiteralText, left.LiteralText);
+            Assert.Equal(expectedfullyQualifiedName, (enumValue.TypeName + left.LiteralText));
+            Assert.Equal(expectedCollectionPropertyName, Assert.IsType<CollectionPropertyAccessNode>(inNode.Right).Property.Name);
+        }
+
+        [Fact]
+        public void FilterWithInOperationWithEnumsMemberIntegralValue_WithSingleQuotes()
+        {
+            // Arrange
+            string filterQuery = "'12' in FavoriteColors";
+
+            string expectedLiteralText = "'SolidYellow'";
+            string expectedfullyQualifiedName = "Fully.Qualified.Namespace.ColorPattern'SolidYellow'";
+            string expectedCollectionPropertyName = "FavoriteColors";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            // Assert
+            InNode inNode = Assert.IsType<InNode>(filter.Expression);
+            ConstantNode left = Assert.IsType<ConstantNode>(inNode.Left);
+            ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(left.Value);
+
+            Assert.Equal(expectedLiteralText, left.LiteralText);
+            Assert.Equal(expectedfullyQualifiedName, (enumValue.TypeName + left.LiteralText));
+            Assert.Equal(expectedCollectionPropertyName, Assert.IsType<CollectionPropertyAccessNode>(inNode.Right).Property.Name);
+        }
+
+        [Fact]
+        public void FilterWithInOperationWithEnumsMemberIntegralValue_WithoutSingleQuotes()
+        {
+            // Arrange
+            string filterQuery = "12 in FavoriteColors";
+
+            string expectedLiteralText = "'SolidYellow'";
+            string expectedfullyQualifiedName = "Fully.Qualified.Namespace.ColorPattern'SolidYellow'";
+            string expectedCollectionPropertyName = "FavoriteColors";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            // Assert
+            InNode inNode = Assert.IsType<InNode>(filter.Expression);
+            ConstantNode left = Assert.IsType<ConstantNode>(inNode.Left);
+            ODataEnumValue enumValue = Assert.IsType<ODataEnumValue>(left.Value);
+
+            Assert.Equal(expectedLiteralText, left.LiteralText);
+            Assert.Equal(expectedfullyQualifiedName, (enumValue.TypeName + left.LiteralText));
+            Assert.Equal(expectedCollectionPropertyName, Assert.IsType<CollectionPropertyAccessNode>(inNode.Right).Property.Name);
+        }
+
+        [Theory]
+        [InlineData(53)]
+        [InlineData("53")]
+        [InlineData("'53'")]
+        public void FilterWithInOperationWithEnumsInValidMemberIntegralValue_ThrowsIsNotValidEnumConstantException(object integralValue)
+        {
+            // Arrange
+            string filterQuery = $"{integralValue} in FavoriteColors";
+
+            // Act
+            Action action = () => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            // Assert
+            action.Throws<ODataException>(ODataErrorStrings.Binder_IsNotValidEnumConstant("53"));
+        }
+
+        [Fact]
         public void FilterWithInOperationWithAny()
         {
             // https://github.com/OData/odata.net/issues/1447


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2371.*

### Description

This change is to fix the issue raised where the `in` operator does not allow using a `string` or `integer` literal as left operand when comparing against a collection of enums.

The change involves:
- Checking if the` left operand` is either an `integral` or a `string` type and the `right operand` is a collection of enums. 
- If this is true, it calls `MetadataBindingUtils.ConvertToTypeIfNeeded()` method to try convert the left operand to the same enum type if possible. 
- If this is not possible, exception is thrown.

Assume you have the following entity:
```cs
public class Employee 
{
    public int Id { get; set; }
    public string Name { get; set; }
    public List<WeekDay> WorkingDays { get; set; }
}

public enum WeekDay
{
    Monday = 1,
    Tuesday = 2,
    Wednesday = 3,
    Thursday = 4,
    Friday = 5,
    Saturday = 6,
    Sunday = 7
}
```
This change enables support of the following scenarios for `$filter` with `In` Operator:

```cs
// left operand without fully qualified namespace
/Employees?$filter='Monday' in WorkingDays

// left operand with integral value in single quotes
/Employees?$filter='1' in WorkingDays

// left operand with integral value without single quotes
/Employees?$filter=1 in WorkingDays
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
