### PR TITLE
Port client tests

### DIFF
--- a/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/TestStartupBase.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/TestStartupBase.cs
@@ -7,6 +7,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.OData;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.OData.Client.E2E.TestCommon
@@ -23,6 +24,8 @@ namespace Microsoft.OData.Client.E2E.TestCommon
         public virtual void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             ConfigureBeforeRouting(app, env);
+
+            app.UseODataBatching();
 
             app.UseRouting();
 

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/ClientQueryTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/ClientQueryTestsController.cs
@@ -1,0 +1,186 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ClientQueryTestsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
+{
+    public class ClientQueryTestsController : ODataController
+    {
+        private static CommonEndToEndDataSource _dataSource;
+
+        [EnableQuery]
+        [HttpGet("odata/People")]
+        public IActionResult Get()
+        {
+            var people = _dataSource.People;
+
+            return Ok(people);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/People/$count")]
+        public IActionResult GetPeopleCount()
+        {
+            var people = _dataSource.People;
+
+            return Ok(people);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/People({key})")]
+        public IActionResult Get(int key)
+        {
+            var person = _dataSource.People?.FirstOrDefault(a => a.PersonId == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(person);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Logins")]
+        public IActionResult GetLogins()
+        {
+            var logins = _dataSource.Logins;
+
+            return Ok(logins);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Logins({key})")]
+        public IActionResult GetLogin(string key)
+        {
+            var login = _dataSource.Logins?.FirstOrDefault(a => a.Username == key);
+            
+            if (login == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(login);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Logins({key})/SentMessages(fromUsername={fromUsername},messageId={messageId})")]
+        public IActionResult GetLoginSentMessages([FromODataUri] string key, [FromODataUri] string fromUsername, [FromODataUri] int messageId)
+        {
+            var login = _dataSource.Logins?.SingleOrDefault(a => a.Username == key);
+
+            if (login == null)
+            {
+                return NotFound();
+            }
+
+            Message sentMessage = login.SentMessages.SingleOrDefault(a => a.FromUsername == fromUsername && a.MessageId == messageId);
+
+            return Ok(sentMessage);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Logins({key})/SentMessages(messageId={messageId})")]
+        public IActionResult GetLoginSentMessage([FromODataUri] string key, [FromODataUri] int messageId)
+        {
+            return BadRequest("Key Mismatch");
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Logins({key})/SentMessages({messageId})")]
+        public IActionResult GetLoginSentMessageWithKeyMismatch([FromODataUri] string key, [FromODataUri] int messageId)
+        {
+            return BadRequest("Key Mismatch");
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Cars")]
+        public IActionResult GetCars()
+        {
+            var cars = _dataSource.Cars;
+
+            return Ok(cars);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Cars({key})")]
+        public IActionResult GetCar(int key)
+        {
+            var car = _dataSource.Cars?.FirstOrDefault(a => a.VIN == key);
+            
+            if (car == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(car);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Customers")]
+        public IActionResult GetCustomers()
+        {
+            var customers = _dataSource.Customers;
+
+            return Ok(customers);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Customers/$count")]
+        public IActionResult GetCustomersCount()
+        {
+            var customers = _dataSource.Customers;
+
+            return Ok(customers);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Customers({key})/Orders")]
+        public IActionResult GetCustomerOrders(int key)
+        {
+            var customer = _dataSource.Customers.SingleOrDefault(a => a.CustomerId == key);
+            
+            if (customer == null)
+            {
+                return NotFound();
+            }
+
+            var customerOrders = customer.Orders;
+
+            return Ok(customerOrders);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Customers({key})/Orders/$count")]
+        public IActionResult GetCustomerOrdersCount(int key)
+        {
+            var customer = _dataSource.Customers.SingleOrDefault(a => a.CustomerId == key);
+
+            if (customer == null)
+            {
+                return NotFound();
+            }
+
+            var customerOrders = customer.Orders;
+
+            return Ok(customerOrders);
+        }
+
+        [HttpPost("odata/clientquery/Default.ResetDataSource")]
+        public IActionResult ResetDataSource()
+        {
+            _dataSource = CommonEndToEndDataSource.CreateInstance();
+
+            return Ok();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/ClientTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/ClientTestsController.cs
@@ -1,0 +1,154 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ClientTestsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.Default;
+
+namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
+{
+    public class ClientTestsController : ODataController
+    {
+        private static DefaultDataSource _dataSource;
+
+        [EnableQuery]
+        [HttpGet("odata/People")]
+        public IActionResult Get()
+        {
+            var people = _dataSource.People;
+
+            return Ok(people);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/People({key})")]
+        public IActionResult Get([FromRoute] int key)
+        {
+            var person = _dataSource.People?.FirstOrDefault(a => a.PersonID == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(person);
+        }
+
+        [HttpDelete("odata/People({key})")]
+        public IActionResult DeletePerson(int key)
+        {
+            var person = _dataSource.People.SingleOrDefault(a => a.PersonID == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            _dataSource.People.Remove(person);
+
+            return NoContent();
+        }
+
+        [HttpDelete("odata/People({key})/Parent")]
+        public IActionResult DeleteParent(int key)
+        {
+            var person = _dataSource.People.SingleOrDefault(a => a.PersonID == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            _dataSource.People.Remove(person);
+
+            return NoContent();
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Products")]
+        public IActionResult GetProducts()
+        {
+            var products = _dataSource.Products;
+
+            return Ok(products);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Orders")]
+        public IActionResult GetOrders()
+        {
+            var orders = _dataSource.Orders;
+
+            return Ok(orders);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Customers")]
+        public IActionResult GetCustomers()
+        {
+            var customers = _dataSource.Customers;
+
+            return Ok(customers);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Customers({key})")]
+        public IActionResult GetCustomer(int key)
+        {
+            var customer = _dataSource.Customers.SingleOrDefault(a => a.PersonID == key);
+
+            if (customer == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(customer);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/ProductDetails")]
+        public IActionResult GetProductDetails()
+        {
+            var productDetails = _dataSource.ProductDetails;
+
+            return Ok(productDetails);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/OrderDetails")]
+        public IActionResult GetOrderDetails()
+        {
+            var orderDetails = _dataSource.OrderDetails;
+
+            return Ok(orderDetails);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/OrderDetails(orderId={orderId},productId={productId})")]
+        public IActionResult GetOrderDetail([FromODataUri] int orderId, [FromODataUri] int productId)
+        {
+            var orderDetail = _dataSource.OrderDetails.SingleOrDefault(a => a.OrderID == orderId && a.ProductID == productId);
+            
+            if (orderDetail == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(orderDetail);
+        }
+
+        [HttpPost("odata/clienttests/Default.ResetDefaultDataSource")]
+        public IActionResult ResetDefaultDataSource()
+        {
+            _dataSource = DefaultDataSource.CreateInstance();
+
+            return Ok();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/ClientUpdateTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/ClientUpdateTestsController.cs
@@ -1,0 +1,100 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ClientUpdateTestsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
+{
+    public class ClientUpdateTestsController : ODataController
+    {
+        private static CommonEndToEndDataSource _dataSource;
+
+        [EnableQuery]
+        [HttpGet("odata/Customers")]
+        public IActionResult GetCustomers()
+        {
+            var customers = _dataSource.Customers;
+
+            return Ok(customers);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Customers/$count")]
+        public IActionResult GetCustomersCount()
+        {
+            var customers = _dataSource.Customers;
+
+            return Ok(customers);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Products")]
+        public IActionResult Get()
+        {
+            var products = _dataSource.Products;
+
+            return Ok(products);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Products({key})")]
+        public IActionResult Get(int key)
+        {
+            var product = _dataSource.Products?.FirstOrDefault(a => a.ProductId == key);
+
+            if (product == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(product);
+        }
+
+        [HttpPatch("odata/Customers({key})")]
+        public IActionResult Patch([FromODataUri] int key, [FromBody] Delta<Customer> customer)
+        {
+            var existingCustomer = _dataSource.Customers.FirstOrDefault(c => c.CustomerId == key);
+            
+            if (existingCustomer == null)
+            {
+                return NotFound();
+            }
+
+            customer.Patch(existingCustomer);
+
+            return Updated(existingCustomer);
+        }
+
+        [HttpPatch("odata/Products({key})")]
+        public IActionResult PatchProducts([FromODataUri] int key, [FromBody] Delta<Product> product)
+        {
+            var existingProduct = _dataSource.Products.FirstOrDefault(c => c.ProductId == key);
+
+            if (existingProduct == null)
+            {
+                return NotFound();
+            }
+
+            product.Patch(existingProduct);
+
+            return Updated(existingProduct);
+        }
+
+        [HttpPost("odata/clientupdate/Default.ResetDataSource")]
+        public IActionResult ResetDataSource()
+        {
+            _dataSource = CommonEndToEndDataSource.CreateInstance();
+
+            return Ok();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/OpenTypesTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Server/OpenTypesTestsController.cs
@@ -1,0 +1,71 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="OpenTypesTestsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.OpenTypes;
+
+namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Server
+{
+    public class OpenTypesTestsController : ODataController
+    {
+        private static OpenTypesDataSource _dataSource;
+
+        [EnableQuery]
+        [HttpGet("odata/Rows")]
+        public IActionResult Get()
+        {
+            var row = _dataSource.Rows;
+
+            return Ok(row);
+        }
+
+        [HttpPatch("odata/Rows({key})")]
+        public IActionResult Patch([FromODataUri] Guid key, Delta<Row> row)
+        {
+            var rowToUpdate = _dataSource.Rows.SingleOrDefault(a => a.Id == key);
+
+            if (rowToUpdate == null)
+            {
+                return NotFound();
+            }
+
+            var updatedRow = row.Patch(rowToUpdate);
+
+            return Updated(updatedRow);
+        }
+
+        [HttpPost("odata/Rows")]
+        public IActionResult Post([FromBody] Row row)
+        {
+            _dataSource.Rows.Add(row);
+
+            return Created(row);
+        }
+
+
+        [EnableQuery]
+        [HttpGet("odata/RowIndices")]
+        public IActionResult RowIndex()
+        {
+            var rowIndex = _dataSource.RowIndices;
+
+            return Ok(rowIndex);
+        }
+
+        [HttpPost("odata/clientopentypeupdate/Default.ResetOpenTypesDataSource")]
+        public IActionResult ResetOpenTypesDataSource()
+        {
+            _dataSource = OpenTypesDataSource.CreateInstance();
+
+            return Ok();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientDeleteTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientDeleteTests.cs
@@ -1,0 +1,72 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ClientDeleteTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.TestCommon;
+using Microsoft.OData.Client.E2E.Tests.ClientTests.Server;
+using Microsoft.OData.Client.E2E.Tests.Common.Client.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.Default;
+using Xunit;
+
+namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
+{
+    public class ClientDeleteTests : EndToEndTestBase<ClientDeleteTests.TestsStartup>
+    {
+        private readonly Container _context;
+        private readonly Uri _baseUri;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(ClientTestsController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                    .AddRouteComponents("odata", DefaultEdmModel.GetEdmModel()));
+            }
+        }
+
+        public ClientDeleteTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory,
+            };
+
+            ResetDefaultDataSource();
+        }
+
+        [Fact]
+        public async Task DeletingANavigationProperty_ExecutesSuccessfully()
+        {
+            var query = _context.People.ByKey(1).Select(p => p.Parent);
+            Assert.Equal("http://localhost/odata/People(1)/Parent", query.RequestUri.ToString());
+            var response = await _context.ExecuteAsync(query.RequestUri, HttpMethod.Delete.Method);
+            Assert.Equal(204, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task DeletingAnEntity_ExecutesSuccessfully()
+        {
+            var query = _context.People.ByKey(2);
+            Assert.Equal("http://localhost/odata/People(2)", query.RequestUri.ToString());
+            var response = await _context.ExecuteAsync(query.RequestUri, HttpMethod.Delete.Method);
+            Assert.Equal(204, response.StatusCode);
+        }
+
+        private void ResetDefaultDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "clienttests/Default.ResetDefaultDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientEntityDescriptorTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientEntityDescriptorTests.cs
@@ -1,0 +1,268 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ClientEntityDescriptorTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.TestCommon;
+using Microsoft.OData.Client.E2E.Tests.ClientTests.Server;
+using Microsoft.OData.Client.E2E.Tests.Common.Client.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.Default;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
+{
+    public class ClientEntityDescriptorTests : EndToEndTestBase<ClientEntityDescriptorTests.TestsStartup>
+    {
+        private readonly Uri _baseUri;
+        private readonly Container _context;
+        private readonly IEdmModel _model;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(ClientTestsController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                    .AddRouteComponents("odata", DefaultEdmModel.GetEdmModel()));
+            }
+        }
+
+        public ClientEntityDescriptorTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+            _model = DefaultEdmModel.GetEdmModel();
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+
+            ResetDefaultDataSource();
+        }
+
+        private static readonly List<string> entitySetsList = ["People", "Orders", "ProductDetails"];
+
+        public static IEnumerable<object[]> GetEntitySetData()
+        {
+            foreach (var entitySetKey in entitySetsList)
+            {
+                yield return new object[] { entitySetKey };
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetEntitySetData))]
+        public void EntityDescriptor_LinksAndIdentity_AreNotNull_ForAllEntities(string entitySetKey)
+        {
+            IQueryable iqueryableProperty = typeof(Container).GetProperty(entitySetKey).GetValue(_context, null) as IQueryable;
+            foreach (var entity in iqueryableProperty)
+            {
+                EntityDescriptor eDescriptor = _context.GetEntityDescriptor(entity);
+
+                Assert.NotNull(eDescriptor.SelfLink);
+                Assert.NotNull(eDescriptor.EditLink);
+                Assert.NotNull(eDescriptor.Identity);
+            }
+        }
+
+        [Fact]
+        public async Task TopQuery_ExecutesSuccessfully()
+        {
+            var person = _context.People.Take(1);
+            Assert.Equal("http://localhost/odata/People?$top=1", person.ToString());
+
+            var topPerson = (await ((DataServiceQuery<Common.Client.Default.Person>)person).ExecuteAsync()).Single();
+
+            Assert.Equal("Bob", topPerson.FirstName);
+        }
+
+        [Fact]
+        public async Task SkipOption_ExecutesSuccessfully()
+        {
+            var allPeople = (await _context.People.ExecuteAsync()).ToList();
+            var skipFirstPersonQuery = _context.People.Skip(1);
+            var peopleAfterSkippingFirstPerson = (await ((DataServiceQuery<Common.Client.Default.Person>)skipFirstPersonQuery).ExecuteAsync()).ToList();
+
+            Assert.Equal("http://localhost/odata/People?$skip=1", skipFirstPersonQuery.ToString());
+            Assert.Equal(5, allPeople.Count);
+            Assert.Equal(4, peopleAfterSkippingFirstPerson.Count);
+        }
+
+        [Fact]
+        public async Task OrderByOption_ExecutesSuccessfully()
+        {
+            var orderByQuery = from p in _context.People 
+                         orderby p.FirstName 
+                         select p;
+
+            Assert.Equal("http://localhost/odata/People?$orderby=FirstName", orderByQuery.ToString());
+
+            var peopleList = (await ((DataServiceQuery<Common.Client.Default.Person>)orderByQuery).ExecuteAsync()).ToList();
+
+            var firstPerson = peopleList.First();
+            Assert.Equal("Bob", firstPerson.FirstName);
+
+            var lastPerson = peopleList.Last();
+            Assert.Equal("Peter", lastPerson.FirstName);
+        }
+
+        [Fact]
+        public async Task OrderByDescendingOption_ExecutesSuccessfully()
+        {
+            var orderByDescQuery = from p in _context.People
+                         orderby p.FirstName descending
+                         select p;
+
+            Assert.Equal("http://localhost/odata/People?$orderby=FirstName desc", orderByDescQuery.ToString());
+
+            var peopleList = (await ((DataServiceQuery<Common.Client.Default.Person>)orderByDescQuery).ExecuteAsync()).ToList();
+            var firstPerson = peopleList.First();
+
+            Assert.Equal("Peter", firstPerson.FirstName);
+
+            var lastPerson = peopleList.Last();
+
+            Assert.Equal("Bob", lastPerson.FirstName);
+        }
+
+        [Fact]
+        public async Task FilterByBooleanProperty_ExecutesSuccessfully()
+        {
+            var filterByBoolQuery = from product in _context.Products
+                                       where product.Discontinued
+                                       select product;
+
+            Assert.Equal("http://localhost/odata/Products?$filter=Discontinued", filterByBoolQuery.ToString());
+
+            var discontinuedProducts = (await ((DataServiceQuery<Common.Client.Default.Product>)filterByBoolQuery).ExecuteAsync()).ToList();
+
+            Assert.Single(discontinuedProducts);
+            Assert.True(discontinuedProducts.Single().Discontinued);
+        }
+
+        [Fact]
+        public async Task FilterByNegatedBooleanProperty_ExecutesSuccessfully()
+        {
+            var filterByBoolQuery = from product in _context.Products
+                                    where !product.Discontinued
+                                    select product;
+
+            Assert.Equal("http://localhost/odata/Products?$filter=not Discontinued", filterByBoolQuery.ToString());
+
+            var productsInCirculation = (await ((DataServiceQuery<Common.Client.Default.Product>)filterByBoolQuery).ExecuteAsync()).ToList();
+
+            Assert.Equal(4, productsInCirculation.Count);
+
+            foreach (var product in productsInCirculation)
+            {
+                Assert.False(product.Discontinued);
+            }
+        }
+
+        [Fact]
+        public async Task FilterByDayAndMonthOfDateProperty_ExecutesSuccessfully()
+        {
+            var dateTimeType = new DateTime?(DateTime.Now).GetType();
+            var filterByDateTimeQuery = from order in _context.Orders
+                                     where order.OrderDate.Day == 29 && order.OrderDate.Month == 5
+                                     select order;
+
+            Assert.Equal("http://localhost/odata/Orders?$filter=day(OrderDate) eq 29 and month(OrderDate) eq 5", filterByDateTimeQuery.ToString());
+
+            var ordersOnMyBirthday = (await ((DataServiceQuery<Common.Client.Default.Order>)filterByDateTimeQuery).ExecuteAsync()).ToList();
+
+            Assert.Single(ordersOnMyBirthday);
+            Assert.Equal("5/29/2011 12:00:00 AM", ordersOnMyBirthday.Single().OrderDate.Date.ToString());
+        }
+
+        [Fact]
+        public async Task FilterByStringProperty_ExecutesSuccessfully()
+        {
+            var filterByStringQuery = from customer in _context.Customers
+                                    where customer.City == "London"
+                                    select customer;
+
+            Assert.Equal("http://localhost/odata/Customers?$filter=City eq 'London'", filterByStringQuery.ToString());
+
+            var customersInLondon = (await ((DataServiceQuery<Common.Client.Default.Customer>)filterByStringQuery).ExecuteAsync()).ToList();
+
+            Assert.Single(customersInLondon);
+            Assert.Equal("London", customersInLondon.Single().City);
+        }
+
+        [Fact]
+        public async Task FilterByKeyProperty_UsingWhereClause_ExecutesSuccessfully()
+        {
+            IQueryable<Common.Client.Default.Customer> filterByWhereClauseQuery = _context.Customers.Where(c => c.PersonID == 1);
+
+            Assert.Equal("http://localhost/odata/Customers?$filter=PersonID eq 1", filterByWhereClauseQuery.ToString());
+
+            var customer = (await ((DataServiceQuery<Common.Client.Default.Customer>)filterByWhereClauseQuery).ExecuteAsync()).Single();
+
+            Assert.Equal("Bob", customer.FirstName);
+        }
+
+        [Fact]
+        public async Task FilterByKeyProperty_UsingByKey_ExecutesSuccessfully()
+        {
+            var filterByKeyQuery = _context.Customers.ByKey(1);
+
+            Assert.Equal("http://localhost/odata/Customers(1)", filterByKeyQuery.RequestUri.ToString());
+
+            var customer = await filterByKeyQuery.GetValueAsync();
+            Assert.Equal("Bob", customer.FirstName);
+        }
+
+        [Fact]
+        public async Task FilterByCompositeKey_UsingWhereClause_ExecutesSuccessfully()
+        {
+            IQueryable<Common.Client.Default.OrderDetail> filterByWhereClauseQuery = _context.OrderDetails.Where(c => c.OrderID == 7 && c.ProductID == 5);
+
+            Assert.Equal("http://localhost/odata/OrderDetails?$filter=OrderID eq 7 and ProductID eq 5", filterByWhereClauseQuery.ToString());
+
+            var orderDetail = (await ((DataServiceQuery<Common.Client.Default.OrderDetail>)filterByWhereClauseQuery).ExecuteAsync()).Single();
+            Assert.Equal(7, orderDetail.OrderID);
+            Assert.Equal(5, orderDetail.ProductID);
+        }
+
+        [Fact]
+        public void ParseServiceDocument()
+        {
+            var args = new DataServiceClientRequestMessageArgs(
+                "GET",
+                new Uri(_baseUri.AbsoluteUri, UriKind.Absolute),
+                usePostTunneling: false,
+                new Dictionary<string, string>(),
+                HttpClientFactory);
+
+            var requestMessage = new HttpClientRequestMessage(args);
+            var webResponse = requestMessage.GetResponse();
+
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = _baseUri };
+
+            using (var messageReader = new ODataMessageReader(webResponse, readerSettings, _model))
+            {
+                ODataServiceDocument workSpace = messageReader.ReadServiceDocument();
+
+                foreach (var entitySetName in entitySetsList)
+                {
+                    Assert.NotNull(workSpace.EntitySets.Single(c => c.Name == entitySetName));
+                }
+            }
+        }
+
+        private void ResetDefaultDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "clienttests/Default.ResetDefaultDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientOpenTypeUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientOpenTypeUpdateTests.cs
@@ -1,0 +1,122 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ClientOpenTypeUpdateTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.TestCommon;
+using Microsoft.OData.Client.E2E.Tests.ClientTests.Server;
+using Microsoft.OData.Client.E2E.Tests.Common.Clients.OpenTypes.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.OpenTypes;
+using Xunit;
+
+namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
+{
+    public class ClientOpenTypeUpdateTests : EndToEndTestBase<ClientOpenTypeUpdateTests.TestsStartup>
+    {
+        private readonly Uri _baseUri;
+        private readonly Container _context;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(OpenTypesTestsController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                    .AddRouteComponents("odata", OpenTypesEdmModel.GetEdmModel()));
+            }
+        }
+        public ClientOpenTypeUpdateTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+
+            ResetOpenTypesDataSource();
+        }
+
+        [Fact]
+        public async Task UpdatingOpenTypeWithUndeclaredProperties_AddsDynamicProperty_ToDynamicPropertiesDict()
+        {
+            // Arrange
+            _context.MergeOption = MergeOption.PreserveChanges;
+            _context.Configurations.RequestPipeline.OnEntryStarting(ea => EntryStarting(ea));
+
+            // Retrieve the row by its Id
+            var rowId = Guid.Parse("814d505b-6b6a-45a0-9de0-153b16149d56");
+            var row = (await ((DataServiceQuery<Common.Clients.OpenTypes.Row>)_context.Rows.Where(r => r.Id == rowId)).ExecuteAsync()).First();
+
+            // Verify that initially there is only one dynamic property
+            Assert.Single(row.DynamicProperties);
+
+            // Act
+            _context.UpdateObject(row);
+            await _context.SaveChangesAsync();
+
+            // Retrieve the updated row
+            var updatedRow = (await ((DataServiceQuery<Common.Clients.OpenTypes.Row>)_context.Rows.Where(r => r.Id == rowId)).ExecuteAsync()).First();
+
+            // Assert
+            // Verify that the dynamic properties now contain two items
+            Assert.Equal(2, updatedRow.DynamicProperties.Count);
+
+            // Verify the added dynamic property is present and has the correct value
+            Assert.True(updatedRow.DynamicProperties.TryGetValue("dynamicPropertyKey", out object keyValue));
+            Assert.Equal("dynamicPropertyValue", keyValue);
+        }
+
+        [Fact]
+        public async Task AddOpenTypeWithUndeclaredProperties_DoesNotThrowException()
+        {
+            var rowId = Guid.NewGuid();
+            var row = Common.Clients.OpenTypes.Row.CreateRow(rowId);
+
+            _context.Configurations.RequestPipeline.OnEntryStarting(ea => EntryStarting(ea));
+
+            _context.AddObject("Rows", row);
+            await _context.SaveChangesAsync();
+
+            // Get the created row;
+            var createdRow = (await ((DataServiceQuery<Common.Clients.OpenTypes.Row>)_context.Rows.Where(r => r.Id == rowId)).ExecuteAsync()).First(); ;
+
+            Assert.Equal(rowId, createdRow.Id);
+            Assert.Single(createdRow.DynamicProperties);
+
+            // Verify the added dynamic property is present and has the correct value
+            Assert.True(createdRow.DynamicProperties.TryGetValue("dynamicPropertyKey", out object keyValue));
+            Assert.Equal("dynamicPropertyValue", keyValue);
+        }
+
+        private void EntryStarting(WritingEntryArgs ea)
+        {
+            var odataProps = ea.Entry.Properties as List<ODataProperty>;
+
+            var entityState = _context.Entities.First(e => e.Entity == ea.Entity).State;
+
+            // Send up an undeclared property on an Open Type.
+            if (entityState == EntityStates.Modified || entityState == EntityStates.Added)
+            {
+                if (ea.Entity.GetType() == typeof(Common.Clients.OpenTypes.Row))
+                {
+                    // In practice, the data from this undeclared property would probably be stored in a transient property of the partial companion class to the client proxy.
+                    var undeclaredOdataProperty = new ODataProperty() { Name = "dynamicPropertyKey", Value = "dynamicPropertyValue" };
+                    odataProps.Add(undeclaredOdataProperty);
+                }
+            }
+        }
+
+        private void ResetOpenTypesDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "clientopentypeupdate/Default.ResetOpenTypesDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientQueryTests.cs
@@ -1,0 +1,412 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ClientQueryTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.TestCommon;
+using Microsoft.OData.Client.E2E.Tests.ClientTests.Server;
+using Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd;
+using Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
+using Xunit;
+
+namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
+{
+    public class ClientQueryTests : EndToEndTestBase<ClientQueryTests.TestsStartup>
+    {
+        private readonly Uri _baseUri;
+        private readonly Container _context;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(ClientQueryTestsController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.EnableQueryFeatures()
+                    .AddRouteComponents("odata", CommonEndToEndEdmModel.GetEdmModel()));
+            }
+        }
+
+        public ClientQueryTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+
+            ResetDataSource();
+        }
+
+        [Theory]
+        [InlineData("People?$filter=contains(Name, 'm')", 10)]
+        [InlineData("People?$filter=contains('m', Name)", 0)]
+        [InlineData("People?$filter=not contains(Name, 'm')", 3)]
+        [InlineData("People?$filter=contains(Name, 'm') eq true", 10)]
+        [InlineData("People?$filter=false eq contains(Name, 'm')", 3)]
+        [InlineData("People?$filter=contains(Name, substring('name',  2, 1))", 10)]
+        [InlineData("People?$filter=contains(concat('User','name'), 'name')", 13)]
+        [InlineData("People?$filter=contains(concat('User','name'), substring('name',  2, 1))", 13)]
+        public async Task DollarFilter_UsingContains_ExecutesSuccessfully(string query, int expectedCount)
+        {
+            // Act
+            var result = (await _context.ExecuteAsync<Common.Clients.EndToEnd.Person>(new Uri(_baseUri.OriginalString + query))).ToArray();
+
+            // Assert
+            Assert.Equal(expectedCount, result.Length);
+        }
+
+        [Fact]
+        public async Task Using_LinqContains_ExecutesSuccessfully()
+        {
+            var result = (from c in _context.People
+                          where c.Name.Contains("m")
+                          select new Common.Clients.EndToEnd.Person() { Name = c.Name }) as DataServiceQuery<Common.Clients.EndToEnd.Person>;
+
+            Assert.Equal("http://localhost/odata/People?$filter=contains(Name,'m')&$select=Name", result.ToString());
+            Assert.Equal(10, (await result.ExecuteAsync()).Count());
+
+            result = (DataServiceQuery<Common.Clients.EndToEnd.Person>)_context.People.Where(c => c.Name.Contains("m"));
+
+            Assert.Equal("http://localhost/odata/People?$filter=contains(Name,'m')", result.ToString());
+            Assert.Equal(10, (await result.ExecuteAsync()).Count());
+        }
+
+        [Fact]
+        public async Task Using_PrimitiveTypeInRequestUrl_ExecutesSuccessfully()
+        {
+            const string stringOfCast = "cast(PersonId,Edm.Byte)";
+
+            //GET http://localhost/odata/People?$filter=cast(cast(PersonId,Edm.Byte),Edm.Int32) gt 0 HTTP/1.1
+            //all the IDs in [-10, 2] except 0 are counted in.
+            var result = _context.People.Where(c => (Byte)c.PersonId > 0);
+            var stringOfQuery = result.ToString();
+            Assert.Equal("http://localhost/odata/People?$filter=cast(cast(PersonId,Edm.Byte),Edm.Int32) gt 0", stringOfQuery);
+            Assert.Contains(stringOfCast, stringOfQuery);
+            Assert.Equal(12, (await ((DataServiceQuery<Common.Clients.EndToEnd.Person>)result).ExecuteAsync()).Count());
+
+            //GET http://localhost/odata/People?$filter=PersonId gt 0 HTTP/1.1
+            //all the IDs in [1, 2] are counted in.
+            result = _context.People.Where(c => c.PersonId > 0);
+            Assert.Equal("http://localhost/odata/People?$filter=PersonId gt 0", result.ToString());
+            Assert.Equal(2, (await ((DataServiceQuery<Common.Clients.EndToEnd.Person>)result).ExecuteAsync()).Count());
+        }
+
+        [Theory]
+        [InlineData("Logins?$filter=contains(Username, 1)")]
+        [InlineData("People?$filter=contains(Name, \"m\")")]
+        [InlineData("Cars?$filter=contains(VIN, '12')")]
+        public async Task InvalidDollarFilter_UsingContains_ThrowsExceptions(string errorUrl)
+        {
+            // Act & Assert
+            var exception = await Assert.ThrowsAsync<DataServiceQueryException>(async () =>
+                await _context.ExecuteAsync<Common.Clients.EndToEnd.Person>(new Uri(_baseUri.OriginalString + errorUrl))
+            );
+
+            // Verify that the exception contains a 400 status code
+            Assert.Equal(400, exception.Response.StatusCode);
+        }
+
+        [Fact]
+        public async Task GetAllPages_WithPaging_VerifiesPagingRequests()
+        {
+            // Arrange
+            int expectedCount = (await _context.Customers.ExecuteAsync()).Count();
+            bool checkNextLink = false;
+            Uri nextPageLink = null;
+
+            EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
+            {
+                if (checkNextLink)
+                {
+                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                }
+
+                checkNextLink = true;
+            };
+
+            _context.Configurations.ResponsePipeline.OnFeedEnded((args) =>
+            {
+                nextPageLink = args.Feed.NextPageLink;
+            });
+
+            _context.SendingRequest2 += sendRequestEvent;
+
+            // Act
+            int resultCount = (await _context.Customers.GetAllPagesAsync()).Count();
+
+            // Assert
+            Assert.Equal(expectedCount, resultCount);
+
+            _context.SendingRequest2 -= sendRequestEvent;
+        }
+
+        [Fact]
+        public async Task GetAllPages_WithFilterAndPaging_VerifiesPagingRequests()
+        {
+            // Arrange
+            int expectedCount = _context.Customers.Where(c => c.CustomerId > -5).Count();
+            bool checkNextLink = false;
+            Uri nextPageLink = null;
+
+            EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
+            {
+                if (checkNextLink)
+                {
+                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                }
+
+                checkNextLink = true;
+            };
+
+            _context.Configurations.ResponsePipeline.OnFeedEnded((args) =>
+            {
+                nextPageLink = args.Feed.NextPageLink;
+            });
+
+            _context.SendingRequest2 += sendRequestEvent;
+
+            // Act
+            int resultCount = (await ((DataServiceQuery<Common.Clients.EndToEnd.Customer>)_context.Customers.Where(c => c.CustomerId > -5)).ExecuteAsync()).Count();
+
+            // Assert
+            Assert.Equal(expectedCount, resultCount);
+
+            _context.SendingRequest2 -= sendRequestEvent;
+        }
+
+        [Fact]
+        public void GetAllPages_WithSelectAndPaging_VerifiesPagingRequests()
+        {
+            // Arrange
+            int expectedCount = _context.Customers.Count();
+            bool checkNextLink = false;
+            Uri nextPageLink = null;
+
+            EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
+            {
+                if (checkNextLink)
+                {
+                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                }
+
+                checkNextLink = true;
+            };
+
+            _context.Configurations.ResponsePipeline.OnFeedEnded((args) =>
+            {
+                nextPageLink = args.Feed.NextPageLink;
+            });
+
+            _context.SendingRequest2 += sendRequestEvent;
+
+            // Act
+            int resultCount = ((DataServiceQuery<Common.Clients.EndToEnd.Customer>)_context.Customers.Select(c => new Common.Clients.EndToEnd.Customer() { CustomerId = c.CustomerId, Name = c.Name })).GetAllPages().Count();
+
+            // Assert
+            Assert.Equal(expectedCount, resultCount);
+
+            _context.SendingRequest2 -= sendRequestEvent;
+        }
+
+        [Fact]
+        public void GetAllPages_WithExpandAndPaging_VerifiesPagingRequests()
+        {
+            // Arrange
+            int expectedCount = _context.Customers.Count();
+            bool checkNextLink = false;
+            Uri nextPageLink = null;
+
+            EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
+            {
+                if (checkNextLink)
+                {
+                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                }
+
+                checkNextLink = true;
+            };
+
+            _context.Configurations.ResponsePipeline.OnFeedEnded((args) =>
+            {
+                nextPageLink = args.Feed.NextPageLink;
+            });
+
+            _context.SendingRequest2 += sendRequestEvent;
+
+            // Act
+            int resultCount = _context.Customers.Expand(c => c.Orders).GetAllPages().Count();
+
+            // Assert
+            Assert.Equal(expectedCount, resultCount);
+
+            _context.SendingRequest2 -= sendRequestEvent;
+        }
+
+        [Fact]
+        public void GetAllPages_WithTopAndPaging_VerifiesPagingRequests()
+        {
+            // Arrange
+            int expectedCount = 4;
+            bool checkNextLink = false;
+            Uri nextPageLink = null;
+
+            EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
+            {
+                if (checkNextLink)
+                {
+                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                }
+
+                checkNextLink = true;
+            };
+
+            _context.Configurations.ResponsePipeline.OnFeedEnded((args) =>
+            {
+                nextPageLink = args.Feed.NextPageLink;
+            });
+
+            _context.SendingRequest2 += sendRequestEvent;
+
+            // Act
+            int resultCount = ((DataServiceQuery<Common.Clients.EndToEnd.Customer>)_context.Customers.Take(4)).GetAllPages().Count();
+
+            // Assert
+            Assert.Equal(expectedCount, resultCount);
+
+            _context.SendingRequest2 -= sendRequestEvent;
+        }
+
+        [Fact]
+        public void GetAllPages_WithOrderByAndPaging_VerifiesPagingRequests()
+        {
+            // Arrange
+            int expectedCount = _context.Customers.Count();
+            bool checkNextLink = false;
+            Uri nextPageLink = null;
+
+            EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
+            {
+                if (checkNextLink)
+                {
+                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                }
+
+                checkNextLink = true;
+            };
+
+            _context.Configurations.ResponsePipeline.OnFeedEnded((args) =>
+            {
+                nextPageLink = args.Feed.NextPageLink;
+            });
+
+            _context.SendingRequest2 += sendRequestEvent;
+
+            // Act
+            int resultCount = ((DataServiceQuery<Common.Clients.EndToEnd.Customer>)_context.Customers.OrderBy(c => c.Name)).GetAllPages().Count();
+
+            // Assert
+            Assert.Equal(expectedCount, resultCount);
+
+            _context.SendingRequest2 -= sendRequestEvent;
+        }
+
+        [Fact]
+        public void GetAllPages_WithSkipByAndPaging_VerifiesPagingRequests()
+        {
+            // Arrange
+            int expectedCount = 6;
+            bool checkNextLink = false;
+            Uri nextPageLink = null;
+
+            EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
+            {
+                if (checkNextLink)
+                {
+                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                }
+
+                checkNextLink = true;
+            };
+
+            _context.Configurations.ResponsePipeline.OnFeedEnded((args) =>
+            {
+                nextPageLink = args.Feed.NextPageLink;
+            });
+
+            _context.SendingRequest2 += sendRequestEvent;
+
+            // Act
+            int resultCount = ((DataServiceQuery<Common.Clients.EndToEnd.Customer>)_context.Customers.Skip(4)).GetAllPages().Count();
+
+            // Assert
+            Assert.Equal(expectedCount, resultCount);
+
+            _context.SendingRequest2 -= sendRequestEvent;
+        }
+
+        [Fact]
+        public void PagingOnNavigationProperty()
+        {
+            int allOrdersCount = _context.Customers.ByKey(new Dictionary<string, object> { { "CustomerId", -10 } }).Orders.Count();
+            bool CheckNextLink = false;
+            Uri nextPageLink = null;
+
+            EventHandler<SendingRequest2EventArgs> sendRequestEvent = (sender, args) =>
+            {
+                //The first request should not be checked.
+                if (CheckNextLink)
+                {
+                    Assert.Equal(nextPageLink.AbsoluteUri, args.RequestMessage.Url.AbsoluteUri);
+                }
+                CheckNextLink = true;
+            };
+
+            _context.Configurations.ResponsePipeline.OnFeedEnded((args) =>
+            {
+                nextPageLink = args.Feed.NextPageLink;
+            });
+
+            _context.SendingRequest2 += sendRequestEvent;
+            //Navigation Property
+            CheckNextLink = false;
+            var queryOrderCount = _context.Customers.ByKey(new Dictionary<string, object> { { "CustomerId", -10 } }).Orders.GetAllPages().ToList().Count();
+            Assert.Equal(allOrdersCount, queryOrderCount);
+        }
+
+        [Fact]
+        public void DuplicateQueryTest()
+        {
+            // Assert that a DataServiceQueryException is thrown for duplicate OData query options.
+            var exception = Assert.Throws<DataServiceQueryException>(() =>
+            {
+                _context.Execute<Common.Clients.EndToEnd.Person>(
+                    new Uri(_baseUri.OriginalString + "People?$orderby=PersonId&$orderby=PersonId")
+                );
+            });
+
+            // Verify that the exception is due to a 400 Bad Request.
+            Assert.Equal(400, exception.Response.StatusCode);
+
+            // Execute a valid query with non-OData query options and verify the result.
+            var entryResults = _context.Execute<Common.Clients.EndToEnd.Person>(
+                new Uri(_baseUri.OriginalString + "People?nonODataQuery=foo&$filter=PersonId%20eq%200&nonODataQuery=bar")
+            );
+
+            Assert.Single(entryResults);
+        }
+
+        private void ResetDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "clientquery/Default.ResetDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientUpdateTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientUpdateTests.cs
@@ -1,0 +1,105 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ClientUpdateTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Batch;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.TestCommon;
+using Microsoft.OData.Client.E2E.Tests.ClientTests.Server;
+using Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
+using Xunit;
+
+namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
+{
+    public class ClientUpdateTests : EndToEndTestBase<ClientUpdateTests.TestsStartup>
+    {
+        private readonly Uri _baseUri;
+        private readonly Container _context;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(ClientUpdateTestsController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.EnableQueryFeatures()
+                    .AddRouteComponents("odata", CommonEndToEndEdmModel.GetEdmModel(), new DefaultODataBatchHandler()));
+            }
+        }
+
+        public ClientUpdateTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+
+            ResetDataSource();
+        }
+
+        [Fact]
+        public async Task UpdateObject_ExecutesSuccessfully()
+        { 
+            _context.MergeOption = MergeOption.PreserveChanges;
+            var product1 = (await _context.Products.ExecuteAsync()).First();
+            var product2 = (await ((DataServiceQuery<Common.Clients.EndToEnd.Product>)_context.Products.Skip(1)).ExecuteAsync()).First();
+
+            product1.Description = "New Description 1";
+            product2.Description = "New Description 2";
+
+            _context.UpdateObject(product1);
+            _context.UpdateObject(product2);
+
+            await _context.SaveChangesAsync(SaveChangesOptions.BatchWithIndependentOperations);
+
+            var product1AterUpdate = (await _context.Products.ExecuteAsync()).First();
+            Assert.Equal("New Description 1", product1AterUpdate.Description);
+
+            var product2AfterUpdate = (await ((DataServiceQuery<Common.Clients.EndToEnd.Product>)_context.Products.Skip(1)).ExecuteAsync()).First();
+            Assert.Equal("New Description 2", product2AfterUpdate.Description);
+        }
+
+        [Fact]
+        public async Task TrackingAndValidatingEntitiesAcrossAllPages_ExecutesSuccessfully()
+        {
+            var customerCount = (await _context.Customers.ExecuteAsync()).Count();
+            var customers = new DataServiceCollection<Common.Clients.EndToEnd.Customer>(_context, await _context.Customers.GetAllPagesAsync(), TrackingMode.AutoChangeTracking, null, null, null);
+
+            Assert.Equal(customerCount, customers.Count);
+
+            _context.Configurations.RequestPipeline.OnEntryEnding((args) =>
+            {
+                Assert.Equal(1, args.Entry.Properties.Count());
+            });
+
+            for (int i = 0; i < customers.Count; i++)
+            {
+                Assert.NotEqual(customers[i].Name, "Customer" + i.ToString());
+                customers[i].Name = "Customer" + i.ToString();
+            }
+
+            await _context.SaveChangesAsync();
+
+            var updatedCustomers = new DataServiceCollection<Common.Clients.EndToEnd.Customer>(_context, await _context.Customers.GetAllPagesAsync(), TrackingMode.AutoChangeTracking, null, null, null);
+
+            for (int i = 0; i < updatedCustomers.Count; i++)
+            {
+                customers[i].Name = "Customer" + i.ToString();
+            }
+        }
+
+        private void ResetDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "clientupdate/Default.ResetDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

This PR ports E2E client tests from depending on WCF services to use Microsoft.AspNetCore.OData. Here is a link to the tests that need porting: 
These tests test different OData Client features like: the different query options like `$filter`, `$top`, `$expand`, `$skip`, the various methods used to delete, add and update objects from OData Client.  
https://github.com/OData/odata.net/tree/main/test/EndToEndTests/Tests/Client/Build.Desktop/ClientTests

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
