### PR TITLE
Port complex tests

### DIFF
--- a/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/HttpClientRequestMessage.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/HttpClientRequestMessage.cs
@@ -1,0 +1,186 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="HttpClientRequestMessage.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.E2E.TestCommon.Common
+{
+    /// <summary>
+    /// An implementation of <see cref="IODataRequestMessageAsync"/> that uses an <see cref="HttpRequestMessage"/> under the covers.
+    /// In OData library, a message is an abstraction which consists of stream and header interfaces that hides the details of stream-reading/writing.
+    /// </summary>
+    public class HttpClientRequestMessage : IODataRequestMessageAsync, IServiceCollectionProvider, IDisposable, IAsyncDisposable
+    {
+        private readonly HttpRequestMessage _request;
+        private readonly HttpClient _httpClient;
+        private HttpContent _content;
+        private Stream _stream;
+        private bool _disposed;
+
+        public HttpClientRequestMessage(Uri uri, HttpClient httpClient)
+        {
+            _httpClient = httpClient;
+            _stream = new MemoryStream();
+
+            _request = new HttpRequestMessage
+            {
+                RequestUri = uri
+            };
+        }
+
+        public string? GetHeader(string headerName)
+        {
+            if (_request.Headers.TryGetValues(headerName, out var values))
+            {
+                return string.Join(",", values);
+            }
+
+            if (_request.Content.Headers.TryGetValues(headerName, out values))
+            {
+                return string.Join(",", values);
+            }
+
+            return null;
+        }
+
+        public async Task<Stream> GetStreamAsync()
+        {
+            if (_stream == null)
+            {
+                _stream = new MemoryStream();
+                _content = new StreamContent(_stream);
+                _request.Content = _content;
+            }
+            else
+            {
+                _stream.Position = _stream.Length;
+            }
+
+            return await Task.FromResult<Stream>(_stream);
+        }
+
+        public IEnumerable<KeyValuePair<string, string>> Headers
+        {
+            get
+            {
+                if (_content != null)
+                {
+                    foreach (var contentHeader in _content.Headers)
+                    {
+                        yield return new KeyValuePair<string, string>(contentHeader.Key, string.Join(",", contentHeader.Value));
+                    }
+                }
+            }
+        }
+
+        public void SetHeader(string headerName, string headerValue)
+        {
+            if (!_request.Headers.TryAddWithoutValidation(headerName, headerValue))
+            {
+                if (_content == null)
+                {
+                    _content = new StreamContent(_stream);
+                    _request.Content = _content;
+                }
+                _content.Headers.TryAddWithoutValidation(headerName, headerValue);
+            }
+        }
+
+        public async Task<IODataResponseMessageAsync> GetResponseAsync()
+        {
+            HttpResponseMessage response;
+
+            try
+            {
+                response = await _httpClient.SendAsync(_request);
+            }
+            catch (HttpRequestException ex)
+            {
+                throw new Exception($"Request to {_request.RequestUri} failed: {ex.Message}", ex);
+            }
+
+            return new HttpClientResponseMessage(response)
+            {
+                ServiceProvider = ServiceProvider
+            };
+        }
+
+        public Stream GetStream()
+        {
+            if (_stream == null)
+            {
+                _stream = new MemoryStream();
+                _content = new StreamContent(_stream);
+                _request.Content = _content;
+            }
+            else
+            {
+                _stream.Position = _stream.Length;
+            }
+
+            return _stream;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _stream?.Dispose();
+                _content?.Dispose();
+                _request?.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore();
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (_stream != null)
+            {
+                await _stream.DisposeAsync();
+            }
+
+            _content?.Dispose();
+            _request?.Dispose();
+            _disposed = true;
+        }
+
+        public Uri Url
+        {
+            get => _request.RequestUri;
+            set => throw new InvalidOperationException("Request Uri cannot be changed");
+        }
+
+        public string Method
+        {
+            get => _request.Method.Method;
+            set => _request.Method = new HttpMethod(value);
+        }
+
+        public IServiceProvider ServiceProvider { get; set; }
+    }
+}

--- a/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/HttpClientResponseMessage.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/HttpClientResponseMessage.cs
@@ -1,0 +1,134 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="HttpClientResponseMessage.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.E2E.TestCommon.Common
+{
+    /// <summary>
+    /// An implementation of <see cref="IODataResponseMessageAsync"/> that uses an <see cref="HttpResponseMessage"/> under the covers.
+    /// In ODataLibrary, a message is an abstraction which consists of stream and header interfaces that hides the details of stream-reading/writing.
+    /// </summary>
+    public class HttpClientResponseMessage : IODataResponseMessageAsync, IServiceCollectionProvider, IDisposable, IAsyncDisposable
+    {
+        private readonly HttpResponseMessage _response;
+        private bool _disposed;
+
+        public HttpClientResponseMessage(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        public string? GetHeader(string headerName)
+        {
+            if (_response.Headers.TryGetValues(headerName, out var values))
+            {
+                return string.Join(",", values);
+            }
+
+            if (_response.Content.Headers.TryGetValues(headerName, out values))
+            {
+                return string.Join(",", values);
+            }
+
+            return null;
+        }
+
+        public async Task<Stream> GetStreamAsync()
+        {
+            return await _response.Content.ReadAsStreamAsync();
+        }
+
+        public IEnumerable<KeyValuePair<string, string>> Headers
+        {
+            get
+            {
+                foreach (var header in _response.Headers)
+                {
+                    yield return new KeyValuePair<string, string>(header.Key, string.Join(",", header.Value));
+                }
+
+                foreach (var contentHeader in _response.Content.Headers)
+                {
+                    yield return new KeyValuePair<string, string>(contentHeader.Key, string.Join(",", contentHeader.Value));
+                }
+            }
+        }
+
+        public void SetHeader(string headerName, string headerValue)
+        {
+            // HttpResponseMessage doesn't allow directly setting headers on the response, 
+            throw new NotSupportedException("Setting headers on HttpResponseMessage is not supported.");
+        }
+
+        public int StatusCode
+        {
+            get
+            {
+                return (int)_response.StatusCode;
+            }
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public string StatusDescription
+        {
+            get => _response.ReasonPhrase;
+            set
+            {
+                throw new NotSupportedException();
+            }
+        }
+
+        public Stream GetStream()
+        {
+            return _response.Content.ReadAsStream();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            if (disposing)
+            {
+                _response?.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await DisposeAsyncCore();
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual async ValueTask DisposeAsyncCore()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _response?.Dispose();
+            _disposed = true;
+
+            await ValueTask.CompletedTask;
+        }
+
+        public IServiceProvider ServiceProvider { get; set; }
+    }
+}

--- a/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/HttpClientResponseMessage.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/HttpClientResponseMessage.cs
@@ -11,7 +11,7 @@ namespace Microsoft.OData.Client.E2E.TestCommon.Common
     /// An implementation of <see cref="IODataResponseMessageAsync"/> that uses an <see cref="HttpResponseMessage"/> under the covers.
     /// In ODataLibrary, a message is an abstraction which consists of stream and header interfaces that hides the details of stream-reading/writing.
     /// </summary>
-    public class HttpClientResponseMessage : IODataResponseMessageAsync, IServiceCollectionProvider, IDisposable, IAsyncDisposable
+    public class HttpClientResponseMessage : IODataResponseMessageAsync, IServiceCollectionProvider
     {
         private readonly HttpResponseMessage _response;
         private bool _disposed;
@@ -87,46 +87,6 @@ namespace Microsoft.OData.Client.E2E.TestCommon.Common
         public Stream GetStream()
         {
             return _response.Content.ReadAsStream();
-        }
-
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual void Dispose(bool disposing)
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            if (disposing)
-            {
-                _response?.Dispose();
-            }
-
-            _disposed = true;
-        }
-
-        public async ValueTask DisposeAsync()
-        {
-            await DisposeAsyncCore();
-            GC.SuppressFinalize(this);
-        }
-
-        protected virtual async ValueTask DisposeAsyncCore()
-        {
-            if (_disposed)
-            {
-                return;
-            }
-
-            _response?.Dispose();
-            _disposed = true;
-
-            await ValueTask.CompletedTask;
         }
 
         public IServiceProvider ServiceProvider { get; set; }

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Common/Client/Default/DefaultContainer.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Common/Client/Default/DefaultContainer.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-// Generation date: 8/19/2024 6:14:16 PM
+// Generation date: 8/25/2024 6:54:52 PM
 namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default
 {
     /// <summary>
@@ -3730,6 +3730,427 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default
         }
     }
     /// <summary>
+    /// There are no comments for StoredPISingle in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("StoredPISingle")]
+    public partial class StoredPISingle : global::Microsoft.OData.Client.DataServiceQuerySingle<StoredPI>
+    {
+        /// <summary>
+        /// Initialize a new StoredPISingle object.
+        /// </summary>
+        public StoredPISingle(global::Microsoft.OData.Client.DataServiceContext context, string path)
+            : base(context, path) { }
+
+        /// <summary>
+        /// Initialize a new StoredPISingle object.
+        /// </summary>
+        public StoredPISingle(global::Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
+            : base(context, path, isComposable) { }
+
+        /// <summary>
+        /// Initialize a new StoredPISingle object.
+        /// </summary>
+        public StoredPISingle(global::Microsoft.OData.Client.DataServiceQuerySingle<StoredPI> query)
+            : base(query) { }
+
+    }
+    /// <summary>
+    /// There are no comments for StoredPI in the schema.
+    /// </summary>
+    /// <KeyProperties>
+    /// StoredPIID
+    /// </KeyProperties>
+    [global::Microsoft.OData.Client.Key("StoredPIID")]
+    [global::Microsoft.OData.Client.OriginalNameAttribute("StoredPI")]
+    public partial class StoredPI : global::Microsoft.OData.Client.BaseEntityType, global::System.ComponentModel.INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Create a new StoredPI object.
+        /// </summary>
+        /// <param name="storedPIID">Initial value of StoredPIID.</param>
+        /// <param name="createdDate">Initial value of CreatedDate.</param>
+        /// <param name="updatedTime">Initial value of UpdatedTime.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static StoredPI CreateStoredPI(int storedPIID, global::System.DateTimeOffset createdDate, global::System.DateTimeOffset updatedTime)
+        {
+            StoredPI storedPI = new StoredPI();
+            storedPI.StoredPIID = storedPIID;
+            storedPI.CreatedDate = createdDate;
+            storedPI.UpdatedTime = updatedTime;
+            return storedPI;
+        }
+        /// <summary>
+        /// There are no comments for Property StoredPIID in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("StoredPIID")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "StoredPIID is required.")]
+        public virtual int StoredPIID
+        {
+            get
+            {
+                return this._StoredPIID;
+            }
+            set
+            {
+                this.OnStoredPIIDChanging(value);
+                this._StoredPIID = value;
+                this.OnStoredPIIDChanged();
+                this.OnPropertyChanged("StoredPIID");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private int _StoredPIID;
+        partial void OnStoredPIIDChanging(int value);
+        partial void OnStoredPIIDChanged();
+        /// <summary>
+        /// There are no comments for Property PIName in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("PIName")]
+        public virtual string PIName
+        {
+            get
+            {
+                return this._PIName;
+            }
+            set
+            {
+                this.OnPINameChanging(value);
+                this._PIName = value;
+                this.OnPINameChanged();
+                this.OnPropertyChanged("PIName");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _PIName;
+        partial void OnPINameChanging(string value);
+        partial void OnPINameChanged();
+        /// <summary>
+        /// There are no comments for Property PIType in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("PIType")]
+        public virtual string PIType
+        {
+            get
+            {
+                return this._PIType;
+            }
+            set
+            {
+                this.OnPITypeChanging(value);
+                this._PIType = value;
+                this.OnPITypeChanged();
+                this.OnPropertyChanged("PIType");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _PIType;
+        partial void OnPITypeChanging(string value);
+        partial void OnPITypeChanged();
+        /// <summary>
+        /// There are no comments for Property CreatedDate in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("CreatedDate")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "CreatedDate is required.")]
+        public virtual global::System.DateTimeOffset CreatedDate
+        {
+            get
+            {
+                return this._CreatedDate;
+            }
+            set
+            {
+                this.OnCreatedDateChanging(value);
+                this._CreatedDate = value;
+                this.OnCreatedDateChanged();
+                this.OnPropertyChanged("CreatedDate");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.DateTimeOffset _CreatedDate;
+        partial void OnCreatedDateChanging(global::System.DateTimeOffset value);
+        partial void OnCreatedDateChanged();
+        /// <summary>
+        /// There are no comments for Property UpdatedTime in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("UpdatedTime")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "UpdatedTime is required.")]
+        public virtual global::System.DateTimeOffset UpdatedTime
+        {
+            get
+            {
+                return this._UpdatedTime;
+            }
+            set
+            {
+                this.OnUpdatedTimeChanging(value);
+                this._UpdatedTime = value;
+                this.OnUpdatedTimeChanged();
+                this.OnPropertyChanged("UpdatedTime");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.DateTimeOffset _UpdatedTime;
+        partial void OnUpdatedTimeChanging(global::System.DateTimeOffset value);
+        partial void OnUpdatedTimeChanged();
+        /// <summary>
+        /// This event is raised when the value of the property is changed
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        /// <summary>
+        /// The value of the property is changed
+        /// </summary>
+        /// <param name="property">property name</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        protected virtual void OnPropertyChanged(string property)
+        {
+            if ((this.PropertyChanged != null))
+            {
+                this.PropertyChanged(this, new global::System.ComponentModel.PropertyChangedEventArgs(property));
+            }
+        }
+    }
+    /// <summary>
+    /// There are no comments for SubscriptionSingle in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("SubscriptionSingle")]
+    public partial class SubscriptionSingle : global::Microsoft.OData.Client.DataServiceQuerySingle<Subscription>
+    {
+        /// <summary>
+        /// Initialize a new SubscriptionSingle object.
+        /// </summary>
+        public SubscriptionSingle(global::Microsoft.OData.Client.DataServiceContext context, string path)
+            : base(context, path) { }
+
+        /// <summary>
+        /// Initialize a new SubscriptionSingle object.
+        /// </summary>
+        public SubscriptionSingle(global::Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
+            : base(context, path, isComposable) { }
+
+        /// <summary>
+        /// Initialize a new SubscriptionSingle object.
+        /// </summary>
+        public SubscriptionSingle(global::Microsoft.OData.Client.DataServiceQuerySingle<Subscription> query)
+            : base(query) { }
+
+    }
+    /// <summary>
+    /// There are no comments for Subscription in the schema.
+    /// </summary>
+    /// <KeyProperties>
+    /// SubscriptionID
+    /// </KeyProperties>
+    [global::Microsoft.OData.Client.Key("SubscriptionID")]
+    [global::Microsoft.OData.Client.OriginalNameAttribute("Subscription")]
+    public partial class Subscription : global::Microsoft.OData.Client.BaseEntityType, global::System.ComponentModel.INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Create a new Subscription object.
+        /// </summary>
+        /// <param name="subscriptionID">Initial value of SubscriptionID.</param>
+        /// <param name="createdDate">Initial value of CreatedDate.</param>
+        /// <param name="qualifiedAccountID">Initial value of QualifiedAccountID.</param>
+        /// <param name="updatedTime">Initial value of UpdatedTime.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static Subscription CreateSubscription(int subscriptionID, global::System.DateTimeOffset createdDate, int qualifiedAccountID, global::System.DateTimeOffset updatedTime)
+        {
+            Subscription subscription = new Subscription();
+            subscription.SubscriptionID = subscriptionID;
+            subscription.CreatedDate = createdDate;
+            subscription.QualifiedAccountID = qualifiedAccountID;
+            subscription.UpdatedTime = updatedTime;
+            return subscription;
+        }
+        /// <summary>
+        /// There are no comments for Property SubscriptionID in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("SubscriptionID")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "SubscriptionID is required.")]
+        public virtual int SubscriptionID
+        {
+            get
+            {
+                return this._SubscriptionID;
+            }
+            set
+            {
+                this.OnSubscriptionIDChanging(value);
+                this._SubscriptionID = value;
+                this.OnSubscriptionIDChanged();
+                this.OnPropertyChanged("SubscriptionID");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private int _SubscriptionID;
+        partial void OnSubscriptionIDChanging(int value);
+        partial void OnSubscriptionIDChanged();
+        /// <summary>
+        /// There are no comments for Property TemplateGuid in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("TemplateGuid")]
+        public virtual string TemplateGuid
+        {
+            get
+            {
+                return this._TemplateGuid;
+            }
+            set
+            {
+                this.OnTemplateGuidChanging(value);
+                this._TemplateGuid = value;
+                this.OnTemplateGuidChanged();
+                this.OnPropertyChanged("TemplateGuid");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _TemplateGuid;
+        partial void OnTemplateGuidChanging(string value);
+        partial void OnTemplateGuidChanged();
+        /// <summary>
+        /// There are no comments for Property Title in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Title")]
+        public virtual string Title
+        {
+            get
+            {
+                return this._Title;
+            }
+            set
+            {
+                this.OnTitleChanging(value);
+                this._Title = value;
+                this.OnTitleChanged();
+                this.OnPropertyChanged("Title");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _Title;
+        partial void OnTitleChanging(string value);
+        partial void OnTitleChanged();
+        /// <summary>
+        /// There are no comments for Property Category in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Category")]
+        public virtual string Category
+        {
+            get
+            {
+                return this._Category;
+            }
+            set
+            {
+                this.OnCategoryChanging(value);
+                this._Category = value;
+                this.OnCategoryChanged();
+                this.OnPropertyChanged("Category");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _Category;
+        partial void OnCategoryChanging(string value);
+        partial void OnCategoryChanged();
+        /// <summary>
+        /// There are no comments for Property CreatedDate in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("CreatedDate")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "CreatedDate is required.")]
+        public virtual global::System.DateTimeOffset CreatedDate
+        {
+            get
+            {
+                return this._CreatedDate;
+            }
+            set
+            {
+                this.OnCreatedDateChanging(value);
+                this._CreatedDate = value;
+                this.OnCreatedDateChanged();
+                this.OnPropertyChanged("CreatedDate");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.DateTimeOffset _CreatedDate;
+        partial void OnCreatedDateChanging(global::System.DateTimeOffset value);
+        partial void OnCreatedDateChanged();
+        /// <summary>
+        /// There are no comments for Property QualifiedAccountID in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("QualifiedAccountID")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "QualifiedAccountID is required.")]
+        public virtual int QualifiedAccountID
+        {
+            get
+            {
+                return this._QualifiedAccountID;
+            }
+            set
+            {
+                this.OnQualifiedAccountIDChanging(value);
+                this._QualifiedAccountID = value;
+                this.OnQualifiedAccountIDChanged();
+                this.OnPropertyChanged("QualifiedAccountID");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private int _QualifiedAccountID;
+        partial void OnQualifiedAccountIDChanging(int value);
+        partial void OnQualifiedAccountIDChanged();
+        /// <summary>
+        /// There are no comments for Property UpdatedTime in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("UpdatedTime")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "UpdatedTime is required.")]
+        public virtual global::System.DateTimeOffset UpdatedTime
+        {
+            get
+            {
+                return this._UpdatedTime;
+            }
+            set
+            {
+                this.OnUpdatedTimeChanging(value);
+                this._UpdatedTime = value;
+                this.OnUpdatedTimeChanged();
+                this.OnPropertyChanged("UpdatedTime");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.DateTimeOffset _UpdatedTime;
+        partial void OnUpdatedTimeChanging(global::System.DateTimeOffset value);
+        partial void OnUpdatedTimeChanged();
+        /// <summary>
+        /// This event is raised when the value of the property is changed
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        /// <summary>
+        /// The value of the property is changed
+        /// </summary>
+        /// <param name="property">property name</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        protected virtual void OnPropertyChanged(string property)
+        {
+            if ((this.PropertyChanged != null))
+            {
+                this.PropertyChanged(this, new global::System.ComponentModel.PropertyChangedEventArgs(property));
+            }
+        }
+    }
+    /// <summary>
     /// There are no comments for Address in the schema.
     /// </summary>
     [global::Microsoft.OData.Client.OriginalNameAttribute("Address")]
@@ -5146,192 +5567,6 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default
         }
     }
     /// <summary>
-    /// There are no comments for StoredPISingle in the schema.
-    /// </summary>
-    [global::Microsoft.OData.Client.OriginalNameAttribute("StoredPISingle")]
-    public partial class StoredPISingle : global::Microsoft.OData.Client.DataServiceQuerySingle<StoredPI>
-    {
-        /// <summary>
-        /// Initialize a new StoredPISingle object.
-        /// </summary>
-        public StoredPISingle(global::Microsoft.OData.Client.DataServiceContext context, string path)
-            : base(context, path) { }
-
-        /// <summary>
-        /// Initialize a new StoredPISingle object.
-        /// </summary>
-        public StoredPISingle(global::Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
-            : base(context, path, isComposable) { }
-
-        /// <summary>
-        /// Initialize a new StoredPISingle object.
-        /// </summary>
-        public StoredPISingle(global::Microsoft.OData.Client.DataServiceQuerySingle<StoredPI> query)
-            : base(query) { }
-
-    }
-    /// <summary>
-    /// There are no comments for StoredPI in the schema.
-    /// </summary>
-    /// <KeyProperties>
-    /// StoredPIID
-    /// </KeyProperties>
-    [global::Microsoft.OData.Client.Key("StoredPIID")]
-    [global::Microsoft.OData.Client.OriginalNameAttribute("StoredPI")]
-    public partial class StoredPI : global::Microsoft.OData.Client.BaseEntityType, global::System.ComponentModel.INotifyPropertyChanged
-    {
-        /// <summary>
-        /// Create a new StoredPI object.
-        /// </summary>
-        /// <param name="storedPIID">Initial value of StoredPIID.</param>
-        /// <param name="createdDate">Initial value of CreatedDate.</param>
-        /// <param name="updatedTime">Initial value of UpdatedTime.</param>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public static StoredPI CreateStoredPI(int storedPIID, global::System.DateTimeOffset createdDate, global::System.DateTimeOffset updatedTime)
-        {
-            StoredPI storedPI = new StoredPI();
-            storedPI.StoredPIID = storedPIID;
-            storedPI.CreatedDate = createdDate;
-            storedPI.UpdatedTime = updatedTime;
-            return storedPI;
-        }
-        /// <summary>
-        /// There are no comments for Property StoredPIID in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("StoredPIID")]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "StoredPIID is required.")]
-        public virtual int StoredPIID
-        {
-            get
-            {
-                return this._StoredPIID;
-            }
-            set
-            {
-                this.OnStoredPIIDChanging(value);
-                this._StoredPIID = value;
-                this.OnStoredPIIDChanged();
-                this.OnPropertyChanged("StoredPIID");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private int _StoredPIID;
-        partial void OnStoredPIIDChanging(int value);
-        partial void OnStoredPIIDChanged();
-        /// <summary>
-        /// There are no comments for Property PIName in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("PIName")]
-        public virtual string PIName
-        {
-            get
-            {
-                return this._PIName;
-            }
-            set
-            {
-                this.OnPINameChanging(value);
-                this._PIName = value;
-                this.OnPINameChanged();
-                this.OnPropertyChanged("PIName");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private string _PIName;
-        partial void OnPINameChanging(string value);
-        partial void OnPINameChanged();
-        /// <summary>
-        /// There are no comments for Property PIType in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("PIType")]
-        public virtual string PIType
-        {
-            get
-            {
-                return this._PIType;
-            }
-            set
-            {
-                this.OnPITypeChanging(value);
-                this._PIType = value;
-                this.OnPITypeChanged();
-                this.OnPropertyChanged("PIType");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private string _PIType;
-        partial void OnPITypeChanging(string value);
-        partial void OnPITypeChanged();
-        /// <summary>
-        /// There are no comments for Property CreatedDate in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("CreatedDate")]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "CreatedDate is required.")]
-        public virtual global::System.DateTimeOffset CreatedDate
-        {
-            get
-            {
-                return this._CreatedDate;
-            }
-            set
-            {
-                this.OnCreatedDateChanging(value);
-                this._CreatedDate = value;
-                this.OnCreatedDateChanged();
-                this.OnPropertyChanged("CreatedDate");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.DateTimeOffset _CreatedDate;
-        partial void OnCreatedDateChanging(global::System.DateTimeOffset value);
-        partial void OnCreatedDateChanged();
-        /// <summary>
-        /// There are no comments for Property UpdatedTime in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("UpdatedTime")]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "UpdatedTime is required.")]
-        public virtual global::System.DateTimeOffset UpdatedTime
-        {
-            get
-            {
-                return this._UpdatedTime;
-            }
-            set
-            {
-                this.OnUpdatedTimeChanging(value);
-                this._UpdatedTime = value;
-                this.OnUpdatedTimeChanged();
-                this.OnPropertyChanged("UpdatedTime");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.DateTimeOffset _UpdatedTime;
-        partial void OnUpdatedTimeChanging(global::System.DateTimeOffset value);
-        partial void OnUpdatedTimeChanged();
-        /// <summary>
-        /// This event is raised when the value of the property is changed
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-        /// <summary>
-        /// The value of the property is changed
-        /// </summary>
-        /// <param name="property">property name</param>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        protected virtual void OnPropertyChanged(string property)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new global::System.ComponentModel.PropertyChangedEventArgs(property));
-            }
-        }
-    }
-    /// <summary>
     /// There are no comments for CreditCardPISingle in the schema.
     /// </summary>
     [global::Microsoft.OData.Client.OriginalNameAttribute("CreditCardPISingle")]
@@ -5761,241 +5996,6 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default
         private global::System.DateTimeOffset _CreatedDate;
         partial void OnCreatedDateChanging(global::System.DateTimeOffset value);
         partial void OnCreatedDateChanged();
-        /// <summary>
-        /// There are no comments for Property UpdatedTime in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("UpdatedTime")]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "UpdatedTime is required.")]
-        public virtual global::System.DateTimeOffset UpdatedTime
-        {
-            get
-            {
-                return this._UpdatedTime;
-            }
-            set
-            {
-                this.OnUpdatedTimeChanging(value);
-                this._UpdatedTime = value;
-                this.OnUpdatedTimeChanged();
-                this.OnPropertyChanged("UpdatedTime");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.DateTimeOffset _UpdatedTime;
-        partial void OnUpdatedTimeChanging(global::System.DateTimeOffset value);
-        partial void OnUpdatedTimeChanged();
-        /// <summary>
-        /// This event is raised when the value of the property is changed
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
-        /// <summary>
-        /// The value of the property is changed
-        /// </summary>
-        /// <param name="property">property name</param>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        protected virtual void OnPropertyChanged(string property)
-        {
-            if ((this.PropertyChanged != null))
-            {
-                this.PropertyChanged(this, new global::System.ComponentModel.PropertyChangedEventArgs(property));
-            }
-        }
-    }
-    /// <summary>
-    /// There are no comments for SubscriptionSingle in the schema.
-    /// </summary>
-    [global::Microsoft.OData.Client.OriginalNameAttribute("SubscriptionSingle")]
-    public partial class SubscriptionSingle : global::Microsoft.OData.Client.DataServiceQuerySingle<Subscription>
-    {
-        /// <summary>
-        /// Initialize a new SubscriptionSingle object.
-        /// </summary>
-        public SubscriptionSingle(global::Microsoft.OData.Client.DataServiceContext context, string path)
-            : base(context, path) { }
-
-        /// <summary>
-        /// Initialize a new SubscriptionSingle object.
-        /// </summary>
-        public SubscriptionSingle(global::Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
-            : base(context, path, isComposable) { }
-
-        /// <summary>
-        /// Initialize a new SubscriptionSingle object.
-        /// </summary>
-        public SubscriptionSingle(global::Microsoft.OData.Client.DataServiceQuerySingle<Subscription> query)
-            : base(query) { }
-
-    }
-    /// <summary>
-    /// There are no comments for Subscription in the schema.
-    /// </summary>
-    /// <KeyProperties>
-    /// SubscriptionID
-    /// </KeyProperties>
-    [global::Microsoft.OData.Client.Key("SubscriptionID")]
-    [global::Microsoft.OData.Client.OriginalNameAttribute("Subscription")]
-    public partial class Subscription : global::Microsoft.OData.Client.BaseEntityType, global::System.ComponentModel.INotifyPropertyChanged
-    {
-        /// <summary>
-        /// Create a new Subscription object.
-        /// </summary>
-        /// <param name="subscriptionID">Initial value of SubscriptionID.</param>
-        /// <param name="createdDate">Initial value of CreatedDate.</param>
-        /// <param name="qualifiedAccountID">Initial value of QualifiedAccountID.</param>
-        /// <param name="updatedTime">Initial value of UpdatedTime.</param>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        public static Subscription CreateSubscription(int subscriptionID, global::System.DateTimeOffset createdDate, int qualifiedAccountID, global::System.DateTimeOffset updatedTime)
-        {
-            Subscription subscription = new Subscription();
-            subscription.SubscriptionID = subscriptionID;
-            subscription.CreatedDate = createdDate;
-            subscription.QualifiedAccountID = qualifiedAccountID;
-            subscription.UpdatedTime = updatedTime;
-            return subscription;
-        }
-        /// <summary>
-        /// There are no comments for Property SubscriptionID in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("SubscriptionID")]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "SubscriptionID is required.")]
-        public virtual int SubscriptionID
-        {
-            get
-            {
-                return this._SubscriptionID;
-            }
-            set
-            {
-                this.OnSubscriptionIDChanging(value);
-                this._SubscriptionID = value;
-                this.OnSubscriptionIDChanged();
-                this.OnPropertyChanged("SubscriptionID");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private int _SubscriptionID;
-        partial void OnSubscriptionIDChanging(int value);
-        partial void OnSubscriptionIDChanged();
-        /// <summary>
-        /// There are no comments for Property TemplateGuid in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("TemplateGuid")]
-        public virtual string TemplateGuid
-        {
-            get
-            {
-                return this._TemplateGuid;
-            }
-            set
-            {
-                this.OnTemplateGuidChanging(value);
-                this._TemplateGuid = value;
-                this.OnTemplateGuidChanged();
-                this.OnPropertyChanged("TemplateGuid");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private string _TemplateGuid;
-        partial void OnTemplateGuidChanging(string value);
-        partial void OnTemplateGuidChanged();
-        /// <summary>
-        /// There are no comments for Property Title in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("Title")]
-        public virtual string Title
-        {
-            get
-            {
-                return this._Title;
-            }
-            set
-            {
-                this.OnTitleChanging(value);
-                this._Title = value;
-                this.OnTitleChanged();
-                this.OnPropertyChanged("Title");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private string _Title;
-        partial void OnTitleChanging(string value);
-        partial void OnTitleChanged();
-        /// <summary>
-        /// There are no comments for Property Category in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("Category")]
-        public virtual string Category
-        {
-            get
-            {
-                return this._Category;
-            }
-            set
-            {
-                this.OnCategoryChanging(value);
-                this._Category = value;
-                this.OnCategoryChanged();
-                this.OnPropertyChanged("Category");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private string _Category;
-        partial void OnCategoryChanging(string value);
-        partial void OnCategoryChanged();
-        /// <summary>
-        /// There are no comments for Property CreatedDate in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("CreatedDate")]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "CreatedDate is required.")]
-        public virtual global::System.DateTimeOffset CreatedDate
-        {
-            get
-            {
-                return this._CreatedDate;
-            }
-            set
-            {
-                this.OnCreatedDateChanging(value);
-                this._CreatedDate = value;
-                this.OnCreatedDateChanged();
-                this.OnPropertyChanged("CreatedDate");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private global::System.DateTimeOffset _CreatedDate;
-        partial void OnCreatedDateChanging(global::System.DateTimeOffset value);
-        partial void OnCreatedDateChanged();
-        /// <summary>
-        /// There are no comments for Property QualifiedAccountID in the schema.
-        /// </summary>
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        [global::Microsoft.OData.Client.OriginalNameAttribute("QualifiedAccountID")]
-        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "QualifiedAccountID is required.")]
-        public virtual int QualifiedAccountID
-        {
-            get
-            {
-                return this._QualifiedAccountID;
-            }
-            set
-            {
-                this.OnQualifiedAccountIDChanging(value);
-                this._QualifiedAccountID = value;
-                this.OnQualifiedAccountIDChanged();
-                this.OnPropertyChanged("QualifiedAccountID");
-            }
-        }
-        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
-        private int _QualifiedAccountID;
-        partial void OnQualifiedAccountIDChanging(int value);
-        partial void OnQualifiedAccountIDChanged();
         /// <summary>
         /// There are no comments for Property UpdatedTime in the schema.
         /// </summary>
@@ -6472,6 +6472,52 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default
             return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.PaymentInstrumentSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
         }
         /// <summary>
+        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle specified by key from an entity set
+        /// </summary>
+        /// <param name="_source">source entity set</param>
+        /// <param name="_keys">dictionary with the names and values of keys</param>
+        public static global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI> _source, global::System.Collections.Generic.IDictionary<string, object> _keys)
+        {
+            return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
+        }
+        /// <summary>
+        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle specified by key from an entity set
+        /// </summary>
+        /// <param name="_source">source entity set</param>
+        /// <param name="storedPIID">The value of storedPIID</param>
+        public static global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI> _source,
+            int storedPIID)
+        {
+            global::System.Collections.Generic.IDictionary<string, object> _keys = new global::System.Collections.Generic.Dictionary<string, object>
+            {
+                { "StoredPIID", storedPIID }
+            };
+            return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
+        }
+        /// <summary>
+        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle specified by key from an entity set
+        /// </summary>
+        /// <param name="_source">source entity set</param>
+        /// <param name="_keys">dictionary with the names and values of keys</param>
+        public static global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription> _source, global::System.Collections.Generic.IDictionary<string, object> _keys)
+        {
+            return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
+        }
+        /// <summary>
+        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle specified by key from an entity set
+        /// </summary>
+        /// <param name="_source">source entity set</param>
+        /// <param name="subscriptionID">The value of subscriptionID</param>
+        public static global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription> _source,
+            int subscriptionID)
+        {
+            global::System.Collections.Generic.IDictionary<string, object> _keys = new global::System.Collections.Generic.Dictionary<string, object>
+            {
+                { "SubscriptionID", subscriptionID }
+            };
+            return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
+        }
+        /// <summary>
         /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.GiftCard as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.GiftCardSingle specified by key from an entity set
         /// </summary>
         /// <param name="_source">source entity set</param>
@@ -6596,29 +6642,6 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default
             return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StatementSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
         }
         /// <summary>
-        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle specified by key from an entity set
-        /// </summary>
-        /// <param name="_source">source entity set</param>
-        /// <param name="_keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI> _source, global::System.Collections.Generic.IDictionary<string, object> _keys)
-        {
-            return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
-        }
-        /// <summary>
-        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle specified by key from an entity set
-        /// </summary>
-        /// <param name="_source">source entity set</param>
-        /// <param name="storedPIID">The value of storedPIID</param>
-        public static global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI> _source,
-            int storedPIID)
-        {
-            global::System.Collections.Generic.IDictionary<string, object> _keys = new global::System.Collections.Generic.Dictionary<string, object>
-            {
-                { "StoredPIID", storedPIID }
-            };
-            return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
-        }
-        /// <summary>
         /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.CreditCardPI as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.CreditCardPISingle specified by key from an entity set
         /// </summary>
         /// <param name="_source">source entity set</param>
@@ -6672,29 +6695,6 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default
                 { "CreditRecordID", creditRecordID }
             };
             return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.CreditRecordSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
-        }
-        /// <summary>
-        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle specified by key from an entity set
-        /// </summary>
-        /// <param name="_source">source entity set</param>
-        /// <param name="_keys">dictionary with the names and values of keys</param>
-        public static global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription> _source, global::System.Collections.Generic.IDictionary<string, object> _keys)
-        {
-            return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
-        }
-        /// <summary>
-        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription as global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle specified by key from an entity set
-        /// </summary>
-        /// <param name="_source">source entity set</param>
-        /// <param name="subscriptionID">The value of subscriptionID</param>
-        public static global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription> _source,
-            int subscriptionID)
-        {
-            global::System.Collections.Generic.IDictionary<string, object> _keys = new global::System.Collections.Generic.Dictionary<string, object>
-            {
-                { "SubscriptionID", subscriptionID }
-            };
-            return new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.SubscriptionSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
         }
     }
 }
@@ -6997,6 +6997,42 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Default
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
         private global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.PaymentInstrument> _PaymentInstruments;
         /// <summary>
+        /// There are no comments for StoredPIs in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("StoredPIs")]
+        public virtual global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI> StoredPIs
+        {
+            get
+            {
+                if ((this._StoredPIs == null))
+                {
+                    this._StoredPIs = base.CreateQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI>("StoredPIs");
+                }
+                return this._StoredPIs;
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI> _StoredPIs;
+        /// <summary>
+        /// There are no comments for SubscriptionTemplates in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("SubscriptionTemplates")]
+        public virtual global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription> SubscriptionTemplates
+        {
+            get
+            {
+                if ((this._SubscriptionTemplates == null))
+                {
+                    this._SubscriptionTemplates = base.CreateQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription>("SubscriptionTemplates");
+                }
+                return this._SubscriptionTemplates;
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription> _SubscriptionTemplates;
+        /// <summary>
         /// There are no comments for People in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
@@ -7093,6 +7129,22 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Default
             base.AddObject("PaymentInstruments", paymentInstrument);
         }
         /// <summary>
+        /// There are no comments for StoredPIs in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public virtual void AddToStoredPIs(global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPI storedPI)
+        {
+            base.AddObject("StoredPIs", storedPI);
+        }
+        /// <summary>
+        /// There are no comments for SubscriptionTemplates in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public virtual void AddToSubscriptionTemplates(global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Subscription subscription)
+        {
+            base.AddObject("SubscriptionTemplates", subscription);
+        }
+        /// <summary>
         /// There are no comments for Boss in the schema.
         /// </summary>
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
@@ -7182,6 +7234,24 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Default
         }
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
         private global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.LabourUnionSingle _LabourUnion;
+        /// <summary>
+        /// There are no comments for DefaultStoredPI in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("DefaultStoredPI")]
+        public virtual global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle DefaultStoredPI
+        {
+            get
+            {
+                if ((this._DefaultStoredPI == null))
+                {
+                    this._DefaultStoredPI = new global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle(this, "DefaultStoredPI");
+                }
+                return this._DefaultStoredPI;
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::Microsoft.OData.Client.E2E.Tests.Common.Client.Default.StoredPISingle _DefaultStoredPI;
         [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
         private abstract class GeneratedEdmModel
         {

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Common/Client/Default/DefaultServiceCsdl.xml
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Common/Client/Default/DefaultServiceCsdl.xml
@@ -146,9 +146,9 @@
         <Property Name="CountryRegion" Type="Edm.String" />
         <Property Name="AccountInfo" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.AccountInfo" />
         <Property Name="UpdatedTime" Type="Edm.DateTimeOffset" Nullable="false" />
-        <NavigationProperty Name="MyPaymentInstruments" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.PaymentInstrument)" />
-        <NavigationProperty Name="ActiveSubscriptions" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Subscription)" />
-        <NavigationProperty Name="MyGiftCard" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.GiftCard" />
+        <NavigationProperty Name="MyPaymentInstruments" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.PaymentInstrument)" ContainsTarget="true" />
+        <NavigationProperty Name="ActiveSubscriptions" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Subscription)" ContainsTarget="true" />
+        <NavigationProperty Name="MyGiftCard" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.GiftCard" ContainsTarget="true" />
       </EntityType>
       <EntityType Name="Order" BaseType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.AbstractEntity">
         <Key>
@@ -173,9 +173,31 @@
         <Property Name="FriendlyName" Type="Edm.String" />
         <Property Name="CreatedDate" Type="Edm.DateTimeOffset" Nullable="false" />
         <Property Name="UpdatedTime" Type="Edm.DateTimeOffset" Nullable="false" />
-        <NavigationProperty Name="BillingStatements" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Statement)" />
+        <NavigationProperty Name="BillingStatements" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Statement)" ContainsTarget="true" />
         <NavigationProperty Name="TheStoredPI" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.StoredPI" />
         <NavigationProperty Name="BackupStoredPI" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.StoredPI" />
+      </EntityType>
+      <EntityType Name="StoredPI">
+        <Key>
+          <PropertyRef Name="StoredPIID" />
+        </Key>
+        <Property Name="StoredPIID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="PIName" Type="Edm.String" />
+        <Property Name="PIType" Type="Edm.String" />
+        <Property Name="CreatedDate" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="UpdatedTime" Type="Edm.DateTimeOffset" Nullable="false" />
+      </EntityType>
+      <EntityType Name="Subscription">
+        <Key>
+          <PropertyRef Name="SubscriptionID" />
+        </Key>
+        <Property Name="SubscriptionID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="TemplateGuid" Type="Edm.String" />
+        <Property Name="Title" Type="Edm.String" />
+        <Property Name="Category" Type="Edm.String" />
+        <Property Name="CreatedDate" Type="Edm.DateTimeOffset" Nullable="false" />
+        <Property Name="QualifiedAccountID" Type="Edm.Int32" Nullable="false" />
+        <Property Name="UpdatedTime" Type="Edm.DateTimeOffset" Nullable="false" />
       </EntityType>
       <ComplexType Name="Address">
         <Property Name="Street" Type="Edm.String" />
@@ -207,8 +229,8 @@
       </ComplexType>
       <EntityType Name="PublicCompany" BaseType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Company" OpenType="true">
         <Property Name="StockExchange" Type="Edm.String" />
-        <NavigationProperty Name="Assets" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Asset)" />
-        <NavigationProperty Name="Club" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Club" />
+        <NavigationProperty Name="Assets" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Asset)" ContainsTarget="true" />
+        <NavigationProperty Name="Club" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Club" ContainsTarget="true" />
         <NavigationProperty Name="LabourUnion" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.LabourUnion" />
       </EntityType>
       <EntityType Name="Asset">
@@ -242,23 +264,13 @@
         <Property Name="Amount" Type="Edm.Double" Nullable="false" />
         <Property Name="UpdatedTime" Type="Edm.DateTimeOffset" Nullable="false" />
       </EntityType>
-      <EntityType Name="StoredPI">
-        <Key>
-          <PropertyRef Name="StoredPIID" />
-        </Key>
-        <Property Name="StoredPIID" Type="Edm.Int32" Nullable="false" />
-        <Property Name="PIName" Type="Edm.String" />
-        <Property Name="PIType" Type="Edm.String" />
-        <Property Name="CreatedDate" Type="Edm.DateTimeOffset" Nullable="false" />
-        <Property Name="UpdatedTime" Type="Edm.DateTimeOffset" Nullable="false" />
-      </EntityType>
       <EntityType Name="CreditCardPI" BaseType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.PaymentInstrument">
         <Property Name="CardNumber" Type="Edm.String" />
         <Property Name="CVV" Type="Edm.String" />
         <Property Name="HolderName" Type="Edm.String" />
         <Property Name="Balance" Type="Edm.Double" Nullable="false" />
         <Property Name="ExperationDate" Type="Edm.DateTimeOffset" Nullable="false" />
-        <NavigationProperty Name="CreditRecords" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.CreditRecord)" />
+        <NavigationProperty Name="CreditRecords" Type="Collection(Microsoft.OData.Client.E2E.Tests.Common.Server.Default.CreditRecord)" ContainsTarget="true" />
       </EntityType>
       <EntityType Name="CreditRecord">
         <Key>
@@ -268,18 +280,6 @@
         <Property Name="IsGood" Type="Edm.Boolean" Nullable="false" />
         <Property Name="Reason" Type="Edm.String" />
         <Property Name="CreatedDate" Type="Edm.DateTimeOffset" Nullable="false" />
-        <Property Name="UpdatedTime" Type="Edm.DateTimeOffset" Nullable="false" />
-      </EntityType>
-      <EntityType Name="Subscription">
-        <Key>
-          <PropertyRef Name="SubscriptionID" />
-        </Key>
-        <Property Name="SubscriptionID" Type="Edm.Int32" Nullable="false" />
-        <Property Name="TemplateGuid" Type="Edm.String" />
-        <Property Name="Title" Type="Edm.String" />
-        <Property Name="Category" Type="Edm.String" />
-        <Property Name="CreatedDate" Type="Edm.DateTimeOffset" Nullable="false" />
-        <Property Name="QualifiedAccountID" Type="Edm.Int32" Nullable="false" />
         <Property Name="UpdatedTime" Type="Edm.DateTimeOffset" Nullable="false" />
       </EntityType>
       <EnumType Name="AccessLevel" IsFlags="true">
@@ -461,15 +461,18 @@
           <NavigationPropertyBinding Path="ProductOrdered" Target="Products" />
         </EntitySet>
         <EntitySet Name="Departments" EntityType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Department" />
-        <EntitySet Name="Accounts" EntityType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Account">
-          <NavigationPropertyBinding Path="MyPaymentInstruments" Target="PaymentInstruments" />
-        </EntitySet>
+        <EntitySet Name="Accounts" EntityType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Account" />
         <EntitySet Name="Orders" EntityType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Order">
           <NavigationPropertyBinding Path="CustomerForOrder" Target="Customers" />
           <NavigationPropertyBinding Path="LoggedInEmployee" Target="Employees" />
           <NavigationPropertyBinding Path="OrderDetails" Target="OrderDetails" />
         </EntitySet>
-        <EntitySet Name="PaymentInstruments" EntityType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.PaymentInstrument" />
+        <EntitySet Name="PaymentInstruments" EntityType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.PaymentInstrument">
+          <NavigationPropertyBinding Path="BackupStoredPI" Target="StoredPIs" />
+          <NavigationPropertyBinding Path="TheStoredPI" Target="StoredPIs" />
+        </EntitySet>
+        <EntitySet Name="StoredPIs" EntityType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.StoredPI" />
+        <EntitySet Name="SubscriptionTemplates" EntityType="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Subscription" />
         <Singleton Name="Boss" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Person">
           <NavigationPropertyBinding Path="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Customer/Orders" Target="Orders" />
           <NavigationPropertyBinding Path="Parent" Target="People" />
@@ -491,6 +494,7 @@
           <NavigationPropertyBinding Path="VipCustomer" Target="Customers" />
         </Singleton>
         <Singleton Name="LabourUnion" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.LabourUnion" />
+        <Singleton Name="DefaultStoredPI" Type="Microsoft.OData.Client.E2E.Tests.Common.Server.Default.StoredPI" />
         <ActionImport Name="Discount" Action="Default.Discount" />
         <ActionImport Name="ResetBossEmail" Action="Default.ResetBossEmail" />
         <ActionImport Name="ResetBossAddress" Action="Default.ResetBossAddress" />

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ComplexTypeTests/Server/ComplexTypeTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ComplexTypeTests/Server/ComplexTypeTestsController.cs
@@ -1,0 +1,301 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ComplexTypeTestsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.Default;
+
+namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Server
+{
+    public class ComplexTypeTestsController : ODataController
+    {
+        private static DefaultDataSource _dataSource;
+
+        [EnableQuery]
+        [HttpGet("odata/People")]
+        public IActionResult Get()
+        {
+            var people = _dataSource.People;
+
+            return Ok(people);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/People({key})")]
+        public IActionResult Get(int key)
+        {
+            var person = _dataSource.People.FirstOrDefault(a => a.PersonID == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(person);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/People({key})/HomeAddress")]
+        public IActionResult GetPersonHomeAddress(int key)
+        {
+            var person = _dataSource.People.FirstOrDefault(a => a.PersonID == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            var personAddress = person.HomeAddress;
+
+            return Ok(personAddress);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/People({key})/HomeAddress/Microsoft.OData.Client.E2E.Tests.Common.Server.Default.HomeAddress/FamilyName")]
+        public IActionResult GetFamilyName(int key)
+        {
+            var person = _dataSource.People.FirstOrDefault(a => a.PersonID == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            var familyName = (person.HomeAddress as HomeAddress).FamilyName;
+
+            return Ok(familyName);
+        }
+
+        [HttpPatch("odata/People({key})")]
+        public IActionResult PatchPerson([FromRoute] int key, [FromBody] Delta<Person> delta)
+        {
+            var person = _dataSource.People.SingleOrDefault(a => a.PersonID == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            var updatedPerson = delta.Patch(person);
+
+            return Updated(updatedPerson);
+        }
+
+        [HttpPut("odata/People({key})/Microsoft.OData.Client.E2E.Tests.Common.Server.Default.Customer")]
+        public IActionResult PatchCustomerHomeAddress([FromRoute] int key, [FromBody] Person person)
+        {
+            var customer = _dataSource.People.SingleOrDefault(a => a.PersonID == key);
+
+            if (customer == null)
+            {
+                return NotFound();
+            }
+
+            var newCustomerAddress = customer.HomeAddress as HomeAddress;
+            var originalCustomerAddress = person.HomeAddress as HomeAddress;
+            newCustomerAddress.FamilyName = originalCustomerAddress.FamilyName;
+            newCustomerAddress.City = originalCustomerAddress.City;
+
+            return Updated(newCustomerAddress);
+        }
+
+        [HttpDelete("odata/People({key})")]
+        public IActionResult DeletePerson(int key)
+        {
+            var person = _dataSource.People.SingleOrDefault(a => a.PersonID == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            _dataSource.People.Remove(person);
+
+            return NoContent();
+        }
+
+        [HttpPost("odata/People")]
+        public IActionResult Post([FromBody] Person person)
+        {
+            _dataSource.People.Add(person);
+
+            return Created(person);
+        }
+
+        [HttpPost("odata/People({key})")]
+        public IActionResult PostPerson(int key, [FromBody] Person person)
+        {
+            _dataSource.People.Add(person);
+
+            return Created(person);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Accounts")]
+        public IActionResult GetAccounts()
+        {
+            var accounts = _dataSource.Accounts;
+
+            return Ok(accounts);
+        }
+
+        [HttpGet("odata/Accounts({key})")]
+        public IActionResult GetAccount([FromRoute] int key)
+        {
+            var account = _dataSource.Accounts.SingleOrDefault(a=>a.AccountID == key);
+
+            if (account == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(account);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Accounts({key})/AccountInfo")]
+        public IActionResult GetAccountInfo([FromRoute] int key)
+        {
+            var account = _dataSource.Accounts.SingleOrDefault(a => a.AccountID == key);
+
+            if (account == null)
+            {
+                return NotFound();
+            }
+
+            var accountInfo = account.AccountInfo;
+
+            return Ok(accountInfo);
+        }
+
+        [HttpGet("odata/Accounts({key})/AccountInfo/MiddleName")]
+        public IActionResult GetAccountInfoMiddleName([FromRoute] int key)
+        {
+            var account = _dataSource.Accounts.SingleOrDefault(a => a.AccountID == key);
+
+            if (account == null)
+            {
+                return NotFound();
+            }
+
+            var middleName = account.AccountInfo.DynamicProperties.FirstOrDefault(a=>a.Key == "MiddleName").Value;
+
+            return Ok(middleName);
+        }
+
+        [HttpPost("odata/Accounts")]
+        public IActionResult PostAccount([FromBody] Account account)
+        {
+            _dataSource.Accounts.Add(account);
+
+            return Created(account);
+        }
+
+        [HttpPatch("odata/Accounts({key})")]
+        public IActionResult PatchAccount([FromRoute] int key, [FromBody] Delta<Account> delta)
+        {
+            var account = _dataSource.Accounts.SingleOrDefault(a => a.AccountID == key);
+
+            if (account == null)
+            {
+                return NotFound();
+            }
+
+            var updatedAccount = delta.Patch(account);
+
+            return Updated(updatedAccount);
+        }
+
+        [HttpPatch("odata/Accounts({key})/AccountInfo")]
+        public IActionResult PatchAccountInfo([FromRoute] int key, [FromBody] Delta<AccountInfo> delta)
+        {
+            var account = _dataSource.Accounts.SingleOrDefault(a => a.AccountID == key);
+
+            if (account == null)
+            {
+                return NotFound();
+            }
+
+            var updatedAccountInfo = delta.Patch(account.AccountInfo);
+
+            return Updated(updatedAccountInfo);
+        }
+
+        [HttpPut("odata/Accounts({key})")]
+        public IActionResult UpdateAccount([FromRoute] int key, [FromBody] Account account)
+        {
+            var originalCustomer = _dataSource.Accounts.SingleOrDefault(a => a.AccountID == key);
+
+            if (originalCustomer == null)
+            {
+                return NotFound();
+            }
+
+            var updatedAccountInfo = originalCustomer.AccountInfo;
+            updatedAccountInfo.FirstName = account.AccountInfo.FirstName;
+            updatedAccountInfo.DynamicProperties = account.AccountInfo.DynamicProperties;
+
+            return Updated(updatedAccountInfo);
+        }
+
+        [HttpDelete("odata/Accounts({key})")]
+        public IActionResult DeleteAccount(int key)
+        {
+            var account = _dataSource.Accounts.SingleOrDefault(a => a.AccountID == key);
+
+            if (account == null)
+            {
+                return NotFound();
+            }
+
+            _dataSource.Accounts.Remove(account);
+
+            return NoContent();
+        }
+
+        [HttpGet("odata/People({key})/Default.GetHomeAddress")]
+        public IActionResult GetHomeAddress([FromODataUri] int key)
+        {
+            var person = _dataSource.People.SingleOrDefault(x => x.PersonID == key);
+
+            if (person == null)
+            {
+                return NotFound();
+            }
+
+            var homeAddress = person.HomeAddress;
+
+            return Ok(homeAddress);
+        }
+
+        [HttpGet("odata/Accounts({key})/Default.GetAccountInfo")]
+        public IActionResult GetAccountInfoFunc([FromODataUri] int key)
+        {
+            var account = _dataSource.Accounts.SingleOrDefault(x => x.AccountID == key);
+
+            if (account == null)
+            {
+                return NotFound();
+            }
+
+            var accountInfo = account.AccountInfo;
+
+            return Ok(accountInfo);
+        }
+
+        [HttpPost("odata/complextype/Default.ResetDefaultDataSource")]
+        public IActionResult ResetDefaultDataSource()
+        {
+            _dataSource = DefaultDataSource.CreateInstance();
+
+            return Ok();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ComplexTypeTests/Tests/ComplexTypeTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ComplexTypeTests/Tests/ComplexTypeTests.cs
@@ -1,0 +1,1480 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ComplexTypeTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.TestCommon;
+using Microsoft.OData.Client.E2E.TestCommon.Common;
+using Microsoft.OData.Client.E2E.Tests.Common.Client.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.Default;
+using Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Server;
+using Microsoft.OData.Edm;
+using Microsoft.Spatial;
+using Xunit;
+
+namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
+{
+    public class ComplexTypeTests : EndToEndTestBase<ComplexTypeTests.TestsStartup>
+    {
+        private readonly Uri _baseUri;
+        private readonly Container _context;
+        private readonly IEdmModel _model;
+        private const string NameSpacePrefix = "Microsoft.OData.Client.E2E.Tests.Common.Server.Default.";
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(ComplexTypeTestsController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                    .AddRouteComponents("odata", DefaultEdmModel.GetEdmModel()));
+            }
+        }
+
+        public ComplexTypeTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+
+            _model = DefaultEdmModel.GetEdmModel();
+            ResetDefaultDataSource();
+        }
+
+        public static IEnumerable<object[]> MimeTypesData
+        {
+            get
+            {
+                yield return new object[] { MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata };
+                yield return new object[] { MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata };
+                yield return new object[] { MimeTypes.ApplicationJson + MimeTypes.ODataParameterNoMetadata };
+            }
+        }
+
+        #region Complex type inheritance
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingAnEntityWithADerivedComplexTypeProperty_ExecutesSuccessfully(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUri = new Uri(_baseUri.AbsoluteUri + "People(1)", UriKind.Absolute);
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var reader = await messageReader.CreateODataResourceReaderAsync();
+                bool startHomeAddress = false;
+
+                while (await reader.ReadAsync())
+                {
+                    if (reader.State == ODataReaderState.NestedResourceInfoStart)
+                    {
+                        if (reader.Item is ODataNestedResourceInfo navigation && navigation.Name == "HomeAddress")
+                        {
+                            startHomeAddress = true;
+                        }
+                    }
+                    else if (reader.State == ODataReaderState.ResourceEnd)
+                    {
+                        ODataResource? entry = reader.Item as ODataResource;
+
+                        if (startHomeAddress)
+                        {
+                            Assert.NotNull(entry);
+                            string typeName = NameSpacePrefix + "HomeAddress";
+                            Assert.Equal(typeName, entry.TypeName);
+                            Assert.Equal("Cats", entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "FamilyName").Value);
+                            startHomeAddress = false;
+                        }
+                    }
+                }
+
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingADerivedComplexTypeProperty_ExecutesSuccessfully(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings()
+            {
+                BaseUri = _baseUri,
+                Validations = ValidationKinds.All & ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType
+            };
+
+            Uri requestUri = new(_baseUri.AbsoluteUri + "People(1)/HomeAddress", UriKind.Absolute);
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var resourceReader = await messageReader.CreateODataResourceReaderAsync();
+
+                while (await resourceReader.ReadAsync())
+                {
+                    if (resourceReader.State == ODataReaderState.ResourceEnd)
+                    {
+                        var homeAddress = resourceReader.Item as ODataResource;
+                        Assert.NotNull(homeAddress);
+                        Assert.Equal("Tokyo", homeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "City").Value);
+                    }
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingAPropertyOfADerivedComplexTypeProperty_ExecutesSuccessfully(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            Uri requestUri = new(_baseUri.AbsoluteUri + "People(1)/HomeAddress/Microsoft.OData.Client.E2E.Tests.Common.Server.Default.HomeAddress/FamilyName", UriKind.Absolute);
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                ODataProperty property = await messageReader.ReadPropertyAsync();
+
+                Assert.NotNull(property);
+                Assert.Equal("Cats", property.Value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task FilterByAPropertyOfADerivedComplexTypeProperty_ExecutesSuccessfully(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            Uri requestUri = new(_baseUri.AbsoluteUri + "People?$filter=HomeAddress/Microsoft.OData.Client.E2E.Tests.Common.Server.Default.HomeAddress/FamilyName eq 'Cats'", UriKind.Absolute);
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var reader = await messageReader.CreateODataResourceSetReaderAsync();
+                bool startHomeAddress = false;
+                int depth = 0;
+
+                while (await reader.ReadAsync())
+                {
+                    switch (reader.State)
+                    {
+                        case ODataReaderState.NestedResourceInfoStart:
+                            depth++;
+                            if (reader.Item is ODataNestedResourceInfo navigation && navigation.Name == "HomeAddress")
+                            {
+                                startHomeAddress = true;
+                            }
+                            break;
+                        case ODataReaderState.NestedResourceInfoEnd:
+                            depth--;
+                            break;
+                        case ODataReaderState.ResourceEnd:
+                            {
+                                if (reader.Item is ODataResource entry)
+                                {
+                                    if (startHomeAddress)
+                                    {
+                                        Assert.NotNull(entry);
+                                        string typeName = NameSpacePrefix + "HomeAddress";
+                                        Assert.Equal(typeName, entry.TypeName);
+                                        Assert.Equal("Cats", entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "FamilyName").Value);
+                                        startHomeAddress = false;
+                                    }
+                                    if (depth == 0)
+                                    {
+                                        Assert.Equal(1, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "PersonID").Value);
+                                    }
+                                }
+                                break;
+                            }
+                        default:
+                            break;
+                    }
+                }
+
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task UpdatingADerivedComplexTypeProperty_UpdatesSuccessfully(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+            (ODataResource entry, List<ODataResource> complexTypeResources) = await this.QueryEntryAsync("People(1)");
+
+            var homeAddress = complexTypeResources.Last(a => a.TypeName.EndsWith("HomeAddress"));
+
+            Assert.Equal("Cats", homeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "FamilyName").Value);
+
+            //update
+            var entryWrapper = new ODataResourceWrapper()
+            {
+                Resource = new ODataResource() { TypeName = NameSpacePrefix + "Person" },
+                NestedResourceInfoWrappers =
+                [
+                    new ODataNestedResourceInfoWrapper()
+                        {
+                            NestedResourceInfo = new ODataNestedResourceInfo()
+                            {
+                                Name = "HomeAddress",
+                                IsCollection = false
+                            },
+                            NestedResourceOrResourceSet = new ODataResourceWrapper()
+                            {
+                                Resource = new ODataResource()
+                                {
+                                    TypeName = NameSpacePrefix + "HomeAddress",
+                                    Properties =
+                                    [
+                                        new ODataProperty
+                                        {
+                                            Name = "City",
+                                            Value = "Chengdu"
+                                        },
+                                        new ODataProperty
+                                        {
+                                            Name = "FamilyName",
+                                            Value = "Tigers"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                ]
+            };
+
+            var settings = new ODataMessageWriterSettings
+            {
+                BaseUri = _baseUri,
+                EnableMessageStreamDisposal = false
+            };
+
+            var personType = _model.FindDeclaredType(NameSpacePrefix + "Person") as IEdmEntityType;
+            var personSet = _model.EntityContainer.FindEntitySet("People");
+
+            var requestUrl = new Uri(_baseUri + "People(1)");
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, base.Client)
+            {
+                Method = "PATCH"
+            };
+
+            requestMessage.SetHeader("Content-Type", mimeType);
+            requestMessage.SetHeader("Accept", mimeType);
+
+            using (var messageWriter = new ODataMessageWriter(requestMessage, settings, _model))
+            {
+                var odataWriter = await messageWriter.CreateODataResourceWriterAsync(personSet, personType);
+                await ODataWriterHelper.WriteResourceAsync(odataWriter, entryWrapper);
+            }
+
+            var responseMessage = await requestMessage.GetResponseAsync();
+            Assert.Equal(204, responseMessage.StatusCode);
+
+            // verify updated value
+            (entry, complexTypeResources) = await this.QueryEntryAsync("People(1)");
+            var updatedHomeAddress = complexTypeResources.Last(a => a.TypeName.EndsWith("HomeAddress"));
+            Assert.Equal("Chengdu", updatedHomeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "City").Value);
+            Assert.Equal("Tigers", updatedHomeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "FamilyName").Value);
+        }
+
+        [Fact]
+        public async Task InsertingAndDeletingAnEntityWithADerivedComplexTypeProperty_WorksCorrectly()
+        {
+            // insert
+            var entryWrapper = new ODataResourceWrapper()
+            {
+                Resource = new ODataResource()
+                {
+                    TypeName = NameSpacePrefix + "Person",
+                    Properties =
+                    [
+                        new ODataProperty { Name = "PersonID", Value = 101 },
+                        new ODataProperty { Name = "FirstName", Value = "Peter" },
+                        new ODataProperty { Name = "LastName", Value = "Zhang" },
+                        new ODataProperty
+                        {
+                            Name = "Home",
+                            Value = GeographyPoint.Create(32.1, 23.1)
+                        },
+                        new ODataProperty
+                        {
+                            Name = "Numbers",
+                            Value = new ODataCollectionValue
+                            {
+                                TypeName = "Collection(Edm.String)",
+                                Items = new string[] { "12345" }
+                            }
+                        },
+                        new ODataProperty
+                        {
+                            Name = "Emails",
+                            Value = new ODataCollectionValue
+                            {
+                                TypeName = "Collection(Edm.String)",
+                                Items = new string[] { "a@b.cc" }
+                            }
+                        }
+                    ]
+                },
+                NestedResourceInfoWrappers =
+                [
+                    new()
+                    {
+                        NestedResourceInfo = new ODataNestedResourceInfo()
+                        {
+                            Name = "HomeAddress",
+                            IsCollection = false
+                        },
+                        NestedResourceOrResourceSet = new ODataResourceWrapper()
+                        {
+                            Resource = new ODataResource()
+                            {
+                                TypeName = NameSpacePrefix + "HomeAddress",
+                                Properties =
+                                [
+                                    new ODataProperty
+                                    {
+                                        Name = "Street",
+                                        Value = "ZiXing Road"
+                                    },
+                                    new ODataProperty
+                                    {
+                                        Name = "City",
+                                        Value = "Chengdu"
+                                    },
+                                    new ODataProperty
+                                    {
+                                        Name = "PostalCode",
+                                        Value = "200241"
+                                    },
+                                    new ODataProperty
+                                    {
+                                        Name = "FamilyName",
+                                        Value = "Tigers"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ]
+            };
+
+            var settings = new ODataMessageWriterSettings
+            {
+                BaseUri = _baseUri,
+                EnableMessageStreamDisposal = false
+            };
+
+            var personType = _model.FindDeclaredType(NameSpacePrefix + "Person") as IEdmEntityType;
+            var peopleSet = _model.EntityContainer.FindEntitySet("People");
+
+            var requestUrl = new Uri(_baseUri + "People");
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, base.Client)
+            {
+                Method = "POST"
+            };
+
+            requestMessage.SetHeader("Content-Type", MimeTypes.ApplicationJson);
+            requestMessage.SetHeader("Accept", MimeTypes.ApplicationJson);
+
+            using (var messageWriter = new ODataMessageWriter(requestMessage, settings, _model))
+            {
+                var odataWriter = await messageWriter.CreateODataResourceWriterAsync(peopleSet, personType);
+                await ODataWriterHelper.WriteResourceAsync(odataWriter, entryWrapper);
+            }
+
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            // verify the insert
+            Assert.Equal(201, responseMessage.StatusCode);
+
+            (ODataResource entry, List<ODataResource> complexTypeResources) = await this.QueryEntryAsync("People(101)");
+
+            Assert.Equal(101, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "PersonID").Value);
+
+            var homeAddress = complexTypeResources.Single(r => r.TypeName.EndsWith("Address"));
+
+            Assert.Equal("Chengdu", homeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "City").Value);
+            Assert.Equal("Tigers", homeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "FamilyName").Value);
+
+            var deleteRequestUrl = new Uri(_baseUri + "People(101)");
+
+            var deleteRequestMessage = new TestCommon.Common.HttpClientRequestMessage(deleteRequestUrl, base.Client)
+            {
+                Method = "DELETE"
+            };
+
+            var deleteResponseMessage = await deleteRequestMessage.GetResponseAsync();
+
+            // verify the delete
+            Assert.Equal(204, deleteResponseMessage.StatusCode);
+
+            ODataResource deletedEntry = null;
+            (deletedEntry, complexTypeResources) = await this.QueryEntryAsync("People(101)", 404);
+
+            Assert.Null(deletedEntry);
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task FunctionReturns_DerivedComplexType_Successfully(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            Uri requestUri = new(_baseUri.AbsoluteUri + "People(1)/Default.GetHomeAddress", UriKind.Absolute);
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var odataReader = await messageReader.CreateODataResourceReaderAsync();
+
+                while (await odataReader.ReadAsync())
+                {
+                    if (odataReader.State == ODataReaderState.ResourceEnd)
+                    {
+                        var homeAddress = odataReader.Item as ODataResource;
+
+                        Assert.NotNull(homeAddress);
+                        Assert.Equal("Tokyo", homeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "City").Value);
+                        Assert.Equal("Cats", homeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "FamilyName").Value);
+                    }
+                }
+            }
+
+            requestUri = new Uri(_baseUri.AbsoluteUri + "People(3)/Default.GetHomeAddress", UriKind.Absolute);
+
+            requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var odataReader = await messageReader.CreateODataResourceReaderAsync();
+
+                while (await odataReader.ReadAsync())
+                {
+                    if (odataReader.State == ODataReaderState.ResourceEnd)
+                    {
+                        var homeAddress = odataReader.Item as ODataResource;
+                        Assert.NotNull(homeAddress);
+                        Assert.Equal("Sydney", homeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "City").Value);
+                        Assert.Equal("Zips", homeAddress.Properties.OfType<ODataProperty>().Single(p => p.Name == "FamilyName").Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task QueryingAPropertyOfADerivedComplexType_ExecutesSuccessfully()
+        {
+            _context.Format.UseJson(_model);
+            _context.MergeOption = MergeOption.OverwriteChanges;
+
+            var familyName = await _context.People.ByKey(1).Select(p => (p.HomeAddress as Common.Client.Default.HomeAddress).FamilyName).GetValueAsync();
+
+            Assert.NotNull(familyName);
+            Assert.Equal("Cats", familyName);
+        }
+
+        [Fact]
+        public async Task QueryingATopLevelDerivedComplexTypeProperty_ExecutesSuccessfully()
+        {
+            _context.Format.UseJson(_model);
+
+            var address = await _context.People.ByKey(1).GetValueAsync();
+            var homeAddress = address.HomeAddress as Common.Client.Default.HomeAddress;
+
+            Assert.NotNull(homeAddress);
+            Assert.Equal("Cats", homeAddress.FamilyName);
+        }
+
+        [Fact]
+        public async Task AFilterQueryOptionOnADerivedComplexTypeProperty_ExecutesSuccessfully()
+        {
+            _context.Format.UseJson(_model);
+
+            var queryable0 = _context.People.Where(p => (p.HomeAddress as Common.Client.Default.HomeAddress).FamilyName == "Cats");
+
+            Common.Client.Default.Person personResult = (await ((DataServiceQuery<Common.Client.Default.Person>)queryable0).ExecuteAsync()).Single();
+
+            Assert.NotNull(personResult);
+
+            Common.Client.Default.HomeAddress homeAddress = personResult.HomeAddress as Common.Client.Default.HomeAddress;
+
+            Assert.NotNull(homeAddress);
+            Assert.Equal(1, personResult.PersonID);
+            Assert.Equal("Cats", homeAddress.FamilyName);
+        }
+
+        [Fact]
+        public async Task UpdatingADerivedComplexType_ExecutesSuccessfully()
+        {
+            _context.Format.UseJson(_model);
+            _context.MergeOption = MergeOption.OverwriteChanges;
+
+            var people = (await _context.People.ExecuteAsync()).ToList();
+            var person = await _context.People.ByKey(1).GetValueAsync();
+
+            Assert.NotNull(person);
+
+            var homeAddress = person.HomeAddress as Common.Client.Default.HomeAddress;
+
+            Assert.NotNull(homeAddress);
+            Assert.Equal("Cats", homeAddress.FamilyName);
+
+            homeAddress.City = "Shanghai";
+            homeAddress.FamilyName = "Tigers";
+
+            _context.UpdateObject(person);
+            await _context.SaveChangesAsync(SaveChangesOptions.ReplaceOnUpdate);
+
+            var updatedPerson = await _context.People.ByKey(1).GetValueAsync();
+            var updatedHomeAddress = updatedPerson.HomeAddress as Common.Client.Default.HomeAddress;
+
+            Assert.NotNull(updatedHomeAddress);
+            Assert.Equal("Shanghai", updatedHomeAddress.City);
+            Assert.Equal("Tigers", updatedHomeAddress.FamilyName);
+        }
+
+        [Fact]
+        public async Task InsertingAndDeletingAnEntityWithADerivedComplexTypeProperty_ExecutesSuccessfully()
+        {
+            _context.Format.UseJson(_model);
+
+            // create an an account entity and a contained PI entity
+            Common.Client.Default.Person newPerson = new Common.Client.Default.Person()
+            {
+                PersonID = 10001,
+                FirstName = "New",
+                LastName = "Person",
+                MiddleName = "Guy",
+                Home = GeographyPoint.Create(32.1, 23.1),
+                HomeAddress = new Common.Client.Default.HomeAddress
+                {
+                    City = "Shanghai",
+                    Street = "Zixing Rd",
+                    PostalCode = "200241",
+                    FamilyName = "New"
+                }
+            };
+
+            _context.AddToPeople(newPerson);
+            await _context.SaveChangesAsync();
+
+            var queryable0 = _context.People.ByKey(10001);
+            var personResult = await queryable0.GetValueAsync();
+
+            Assert.NotNull(personResult);
+
+            var homeAddress = personResult.HomeAddress as Common.Client.Default.HomeAddress;
+
+            Assert.NotNull(homeAddress);
+            Assert.Equal("New", homeAddress.FamilyName);
+
+            // delete
+            var personToDelete =await _context.People.ByKey(10001).GetValueAsync();
+
+            _context.DeleteObject(personToDelete);
+            await _context.SaveChangesAsync();
+
+            var People = (await _context.People.ExecuteAsync()).ToList();
+            var queryDeletedPerson = People.Where(person => person.PersonID == 10001);
+
+            Assert.Empty(queryDeletedPerson);
+        }
+        #endregion
+
+        #region Open complex type
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingAnEntityWithAnOpenComplexTypeProperty_ExecutesSuccessfully(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = _baseUri };
+
+            Uri requestUri = new(_baseUri.AbsoluteUri + "Accounts(101)", UriKind.Absolute);
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var reader = await messageReader.CreateODataResourceReaderAsync();
+
+                ODataResource account = null;
+                ODataResource accountInfo = null;
+                ODataResource addressComplex1 = null;
+
+                while (await reader.ReadAsync())
+                {
+                    if (reader.State == ODataReaderState.ResourceStart)
+                    {
+                        if (account == null)
+                        {
+                            account = reader.Item as ODataResource;
+                        }
+                        else if (accountInfo == null)
+                        {
+                            accountInfo = reader.Item as ODataResource;
+                        }
+                        else if (addressComplex1 == null)
+                        {
+                            addressComplex1 = reader.Item as ODataResource;
+                        }
+                    }
+                }
+
+                Assert.NotNull(accountInfo);
+
+                string typeName = NameSpacePrefix + "AccountInfo";
+
+                Assert.Equal(typeName, accountInfo.TypeName);
+                Assert.Equal("\"Hood\"", (accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "MiddleName").Value as ODataUntypedValue).RawValue);
+
+                var colorODataEnumValue = accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "FavoriteColor").Value as ODataEnumValue;
+                string colorTypeName = NameSpacePrefix + "Color";
+
+                Assert.Equal(colorTypeName, colorODataEnumValue.TypeName);
+                Assert.Equal("Red", colorODataEnumValue.Value);
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingAnOpenPropertyOfAnOpenComplexType_ExecutesSuccessfully(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = _baseUri };
+
+            Uri requestUri = new(_baseUri.AbsoluteUri + "Accounts(101)/AccountInfo/MiddleName", UriKind.Absolute);
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                ODataProperty middleNameProperty = messageReader.ReadProperty();
+                Assert.Equal("Hood", middleNameProperty.Value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task FilteringByAnOpenProperty_ExecutesSuccessfully(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = _baseUri };
+
+            Uri requestUri = new(_baseUri.AbsoluteUri + "Accounts?$filter=AccountInfo/MiddleName eq 'Hood'", UriKind.Absolute);
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client);
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var reader = await messageReader.CreateODataResourceSetReaderAsync();
+
+                ODataResource account = null;
+                ODataResource accountInfo = null;
+                ODataResource addressComplex1 = null;
+
+                while (await reader.ReadAsync())
+                {
+                    if (reader.State == ODataReaderState.ResourceStart)
+                    {
+                        if (account == null)
+                        {
+                            account = reader.Item as ODataResource;
+                        }
+                        else if (accountInfo == null)
+                        {
+                            accountInfo = reader.Item as ODataResource;
+                        }
+                        else addressComplex1 ??= reader.Item as ODataResource;
+                    }
+                }
+
+                Assert.NotNull(account);
+                Assert.NotNull(accountInfo);
+
+                string typeName = NameSpacePrefix + "AccountInfo";
+
+                Assert.Equal(typeName, accountInfo.TypeName);
+                Assert.Equal("\"Hood\"", (accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "MiddleName").Value as ODataUntypedValue).RawValue);
+
+                int? accountID = account.Properties.OfType<ODataProperty>().Single(p => p.Name == "AccountID").Value as int?;
+
+                Assert.Equal(101, accountID);
+                Assert.NotNull(addressComplex1);
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+        }
+
+        [Fact]
+        public async Task UpdatingAnOpenComplexTypeProperty_ExecutesSuccessfully()
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            string[] types = new string[]
+            {
+                MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata,
+                MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata,
+                MimeTypes.ApplicationJson + MimeTypes.ODataParameterNoMetadata,
+            };
+
+            string[] middleNames = { "Hood", "MN1", "MN2", "MN3" };
+            for (int i = 0; i < types.Length; i++)
+            {
+                (ODataResource entry, List<ODataResource> complexTypeResources) = await this.QueryEntryAsync("Accounts(101)");
+
+                var accountInfo = complexTypeResources.Single(a => a.TypeName.EndsWith("AccountInfo"));
+                Assert.Equal("\"" + middleNames[i] + "\"", (accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "MiddleName").Value as ODataUntypedValue).RawValue);
+
+                // update
+                bool isPersonalAccount = (i % 2 == 0);
+                entry = new ODataResource() { TypeName = NameSpacePrefix + "Account" };
+                var accountInfo_NestedInfo = new ODataNestedResourceInfo() { Name = "AccountInfo" };
+                var accountInfo_Resource = new ODataResource()
+                {
+                    TypeName = NameSpacePrefix + "AccountInfo",
+                    Properties = new[]
+                    {
+                        new ODataProperty
+                        {
+                            Name = "FirstName",
+                            Value = "FN"
+                        },
+                        new ODataProperty
+                        {
+                            Name = "LastName",
+                            Value = "LN"
+                        },
+                        new ODataProperty
+                        {
+                            Name = "MiddleName",
+                            Value = middleNames[i+1]
+                        },
+                        new ODataProperty
+                        {
+                            Name = "IsPersonalAccount",
+                            Value = isPersonalAccount
+                        }
+                    }
+                };
+
+                var settings = new ODataMessageWriterSettings();
+                settings.BaseUri = _baseUri;
+                var accountType = _model.FindDeclaredType(NameSpacePrefix + "Account") as IEdmEntityType;
+                var accountSet = _model.EntityContainer.FindEntitySet("Accounts");
+
+                var args = new DataServiceClientRequestMessageArgs(
+                    "PATCH",
+                    new Uri(_baseUri + "Accounts(101)"),
+                    usePostTunneling: false,
+                    new Dictionary<string, string>(),
+                    HttpClientFactory);
+
+                var requestMessage = new HttpClientRequestMessage(args);
+                requestMessage.SetHeader("Content-Type", types[i]);
+                requestMessage.SetHeader("Accept", types[i]);
+
+                using (var messageWriter = new ODataMessageWriter(requestMessage, settings))
+                {
+                    var odataWriter = messageWriter.CreateODataResourceWriter(accountSet, accountType);
+                    odataWriter.WriteStart(entry);
+                    odataWriter.WriteStart(accountInfo_NestedInfo);
+                    odataWriter.WriteStart(accountInfo_Resource);
+                    odataWriter.WriteEnd();
+                    odataWriter.WriteEnd();
+                    odataWriter.WriteEnd();
+                }
+
+                var responseMessage = requestMessage.GetResponse();
+                Assert.Equal(204, responseMessage.StatusCode);
+
+                // verify updated value
+                (entry, complexTypeResources) = await this.QueryEntryAsync("Accounts(101)");
+                var updatedAccountInfo = complexTypeResources.Single(a => a.TypeName.EndsWith("AccountInfo"));
+                Assert.Equal("FN", updatedAccountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "FirstName").Value);
+                Assert.Equal("\"" + middleNames[i + 1] + "\"", (updatedAccountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "MiddleName").Value as ODataUntypedValue).RawValue);
+                Assert.Equal(isPersonalAccount, updatedAccountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "IsPersonalAccount").Value);
+            }
+        }
+
+        [Fact]
+        public async Task InsertingAndDeletingAnEntityWithAnOpenComplexTypeProperty_ExecutesSuccessfully()
+        {
+            var entry = new ODataResource() { TypeName = NameSpacePrefix + "Account" };
+            entry.Properties = new[]
+            {
+                    new ODataProperty { Name = "AccountID", Value = 10086 },
+                    new ODataProperty { Name = "CountryRegion", Value = "CN" },
+            };
+
+            var accountInfo_NestedInfo = new ODataNestedResourceInfo() { Name = "AccountInfo", IsCollection = false };
+            var accountInfoResource = new ODataResource
+            {
+                TypeName = NameSpacePrefix + "AccountInfo",
+                Properties = new[]
+                {
+                        new ODataProperty
+                        {
+                            Name = "FirstName",
+                            Value = "Peter"
+                        },
+                        new ODataProperty
+                        {
+                            Name = "LastName",
+                            Value = "Andy"
+                        },
+                        new ODataProperty
+                        {
+                            Name = "ShippingAddress",
+                            Value = "#999, ZiXing Road"
+                        }
+                    }
+            };
+
+            var settings = new ODataMessageWriterSettings
+            {
+                BaseUri = _baseUri,
+                EnableMessageStreamDisposal = false
+            };
+
+            var accountType = _model.FindDeclaredType(NameSpacePrefix + "Account") as IEdmEntityType;
+            var accountSet = _model.EntityContainer.FindEntitySet("Accounts");
+
+            var requestUri = new Uri(_baseUri + "Accounts");
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "POST"
+            };
+
+            requestMessage.SetHeader("Content-Type", MimeTypes.ApplicationJson);
+            requestMessage.SetHeader("Accept", MimeTypes.ApplicationJson);
+
+            using (var messageWriter = new ODataMessageWriter(requestMessage, settings))
+            {
+                var odataWriter = await messageWriter.CreateODataResourceWriterAsync(accountSet, accountType);
+                await odataWriter.WriteStartAsync(entry);
+                await odataWriter.WriteStartAsync(accountInfo_NestedInfo);
+                await odataWriter.WriteStartAsync(accountInfoResource);
+                await odataWriter.WriteEndAsync();
+                await odataWriter.WriteEndAsync();
+                await odataWriter.WriteEndAsync();
+            }
+
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            // verify the insert
+            Assert.Equal(201, responseMessage.StatusCode);
+            (entry, List<ODataResource> complexTypeResources) = await this.QueryEntryAsync("Accounts(10086)");
+            Assert.Equal(10086, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "AccountID").Value);
+
+            var accountInfo = complexTypeResources.Single(a => a.TypeName.EndsWith("AccountInfo"));
+            Assert.Equal("Peter", accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "FirstName").Value);
+            Assert.Equal("\"#999, ZiXing Road\"", (accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShippingAddress").Value as ODataUntypedValue).RawValue);
+
+            // delete the entry
+            var deleteRequestUri = new Uri(_baseUri + "Accounts(10086)");
+
+            var deleteRequestMessage = new TestCommon.Common.HttpClientRequestMessage(deleteRequestUri, base.Client)
+            {
+                Method = "DELETE"
+            };
+
+            var deleteResponseMessage = await deleteRequestMessage.GetResponseAsync();
+
+            // verify the delete
+            Assert.Equal(204, deleteResponseMessage.StatusCode);
+            (ODataResource deletedEntry, List<ODataResource> complexProperties) = await this.QueryEntryAsync("Accounts(10086)", 404);
+            Assert.Null(deletedEntry);
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task FunctionReturnsAnOpenComplexType_Correctly(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            Uri requestUri = new(_baseUri + "Accounts(101)/Default.GetAccountInfo", UriKind.Absolute);
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var odataReader = await messageReader.CreateODataResourceReaderAsync();
+                ODataResource accountInfo = null;
+
+                while (await odataReader.ReadAsync())
+                {
+                    if (odataReader.State == ODataReaderState.ResourceEnd)
+                    {
+                        accountInfo = odataReader.Item as ODataResource;
+                    }
+                }
+
+                Assert.NotNull(accountInfo);
+                Assert.Equal("Alex", accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "FirstName").Value);
+                Assert.Equal("\"Hood\"", (accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "MiddleName").Value as ODataUntypedValue).RawValue);
+            }
+
+            requestUri = new Uri(_baseUri.AbsoluteUri + "Accounts(103)/Default.GetAccountInfo", UriKind.Absolute);
+
+            requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "GET"
+            };
+
+            requestMessage.SetHeader("Accept", mimeType);
+            responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var odataReader = await messageReader.CreateODataResourceReaderAsync();
+                
+                while (await odataReader.ReadAsync())
+                {
+                    if (odataReader.State == ODataReaderState.ResourceEnd)
+                    {
+                        var accountInfo = odataReader.Item as ODataResource;
+
+                        Assert.NotNull(accountInfo);
+                        Assert.Equal("Adam", accountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "FirstName").Value);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public async Task QueryingAnOpenComplexType_WorksCorrectly()
+        {
+            _context.Format.UseJson(_model);
+            _context.MergeOption = MergeOption.OverwriteChanges;
+
+            var accountInfo = await _context.Accounts.ByKey(101).Select(a => a.AccountInfo).GetValueAsync();
+            Assert.NotNull(accountInfo);
+
+            accountInfo.DynamicProperties.TryGetValue("MiddleName", out var middleName);
+            Assert.Equal("Hood", middleName);
+
+            accountInfo.DynamicProperties.TryGetValue("Address", out var address);
+            Assert.NotNull(address);
+        }
+
+        [Fact]
+        public async Task UpdatingAnOpenComplexType_WorksCorrectly()
+        {
+            _context.Format.UseJson(_model);
+            _context.MergeOption = MergeOption.OverwriteChanges;
+            
+            var account = await _context.Accounts.ByKey(101).GetValueAsync();
+            Assert.NotNull(account);
+
+            var accountInfo = account.AccountInfo;
+            Assert.NotNull(accountInfo);
+
+            accountInfo.DynamicProperties.TryGetValue("MiddleName", out var middleName);
+            Assert.Equal("Hood", middleName);
+
+            accountInfo.FirstName = "Peter";
+            accountInfo.DynamicProperties["MiddleName"] = "White";
+
+            // verify: open type enum property from client side should be serialized with odata.type
+            accountInfo.DynamicProperties["FavoriteColor"] = Common.Client.Default.Color.Blue;
+            accountInfo.DynamicProperties["Address"] = new Common.Client.Default.Address
+            {
+                Street = "1",
+                City = "2",
+                PostalCode = "3"
+            };
+
+            _context.UpdateObject(account);
+            await _context.SaveChangesAsync(SaveChangesOptions.ReplaceOnUpdate);
+
+            var updatedAccount =await _context.Accounts.ByKey(101).GetValueAsync();
+            Assert.NotNull(updatedAccount);
+
+            var updatedAccountInfo = updatedAccount.AccountInfo;
+            Assert.NotNull(updatedAccountInfo);
+            Assert.Equal("Peter", updatedAccountInfo.FirstName);
+            accountInfo.DynamicProperties.TryGetValue("MiddleName", out var updatedMiddleName);
+            Assert.Equal("White", updatedMiddleName);
+
+            accountInfo.DynamicProperties.TryGetValue("FavoriteColor", out var updatedFavoriteColor);
+            Assert.Equal(Common.Client.Default.Color.Blue, updatedFavoriteColor);
+            accountInfo.DynamicProperties.TryGetValue("Address", out var updatedAddress);
+            Assert.Equal("2", (updatedAddress as Common.Client.Default.Address).City);
+            Assert.Equal("1", (updatedAddress as Common.Client.Default.Address).Street);
+            Assert.Equal("3", (updatedAddress as Common.Client.Default.Address).PostalCode);
+        }
+
+        [Fact]
+        public async Task UpdatingAnOpenComplexTypeWithUndeclaredProperties_WorksCorrectly()
+        {
+            _context.Format.UseJson(_model);
+            _context.MergeOption = MergeOption.OverwriteChanges;
+            _context.Configurations.RequestPipeline.OnEntryStarting(ea => EntryStarting(ea));
+
+            var account = await _context.Accounts.ByKey(101).GetValueAsync();
+            Assert.Equal(3, account.AccountInfo.DynamicProperties.Count);
+
+            // In practice, transient property data would be mutated here in the partial companion to the client proxy.
+
+            _context.UpdateObject(account);
+            await _context.SaveChangesAsync();
+
+            var updatedAccount =await _context.Accounts.ByKey(101).GetValueAsync();
+            Assert.Equal(4, account.AccountInfo.DynamicProperties.Count);
+
+            account.AccountInfo.DynamicProperties.TryGetValue("dynamicPropertyKey", out var addedDynamicPropertyValue);
+            Assert.Equal("dynamicPropertyValue", addedDynamicPropertyValue);
+        }
+
+        [Fact]
+        public async Task UpdatingAndReadingAnOpenComplexTypeWithUndeclaredProperties_WorksCorrectly()
+        {
+            _context.Format.UseJson(_model);
+            _context.MergeOption = MergeOption.OverwriteChanges;
+            _context.Configurations.RequestPipeline.OnMessageWriterSettingsCreated(wsa =>
+            {
+                // writer supports ODataUntypedValue
+                wsa.Settings.Validations &= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+            });
+
+            _context.Configurations.RequestPipeline.OnEntryStarting(ea =>
+            {
+                if (ea.Entity.GetType() == typeof(Common.Client.Default.AccountInfo))
+                {
+                    var undeclaredOdataProperty = new ODataProperty()
+                    {
+                        Name = "UndecalredOpenProperty1",
+                        Value = new ODataUntypedValue() { RawValue = "{ \"sender\": \"RSS\", \"senderImage\": \"https://exchangelabs.live-int.com/connectors/content/images/feed-icon-128px.png?upn=admin%40tenant-EXHR-3837dom.EXTEST.MICROSOFT.COM\", \"summary\": \"RSS is now connected to your mailbox\", \"title\": null }" }
+                    };
+                    var accountInfoComplexValueProperties = ea.Entry.Properties as List<ODataProperty>;
+                    accountInfoComplexValueProperties.Add(undeclaredOdataProperty);
+                }
+            });
+
+            var account = await _context.Accounts.ByKey(101).GetValueAsync();
+            _context.UpdateObject(account);
+            await _context.SaveChangesAsync();
+
+            _context.Configurations.ResponsePipeline.OnMessageReaderSettingsCreated(rsa =>
+            {
+                // reader supports undeclared property
+                rsa.Settings.Validations ^= ~ValidationKinds.ThrowOnUndeclaredPropertyForNonOpenType;
+            });
+
+            ODataUntypedValue undeclaredOdataPropertyValue = null;
+            _context.Configurations.ResponsePipeline.OnEntityMaterialized(rea =>
+            {
+                if (rea.Entity.GetType() == typeof(Common.Client.Default.AccountInfo))
+                {
+                    var undeclaredOdataProperty = rea.Entry.Properties.OfType<ODataProperty>().FirstOrDefault(s => s.Name == "UndecalredOpenProperty1");
+                    undeclaredOdataPropertyValue = (ODataUntypedValue)undeclaredOdataProperty.Value;
+                }
+            });
+
+            //There is a bug in OData Client that need fixing.OData Client cannot materialize ODataUntypedValues.
+            //var accountReturned = await _context.Accounts.ByKey(101).GetValueAsync();
+            /* Assert.Equal<string>(
+                 "{\"sender\":\"RSS\",\"senderImage\":\"https://exchangelabs.live-int.com/connectors/content/images/feed-icon-128px.png?upn=admin%40tenant-EXHR-3837dom.EXTEST.MICROSOFT.COM\",\"summary\":\"RSS is now connected to your mailbox\",\"title\":null}",
+                 undeclaredOdataPropertyValue.RawValue);*/
+        }
+
+        [Fact]
+        public async Task InsertingAndDeletingAnEntityWithAnOpenComplexTypeProperty_WorksCorrectly()
+        {
+            _context.Format.UseJson(_model);
+
+            Common.Client.Default.Account newAccount = new Common.Client.Default.Account()
+            {
+                AccountID = 110,
+                CountryRegion = "CN",
+                AccountInfo = new Common.Client.Default.AccountInfo()
+                {
+                    FirstName = "New",
+                    LastName = "Guy",
+                    DynamicProperties = new Dictionary<string, object>()
+                    {
+                        { "MiddleName", "Howard" },
+                        { "FavoriteColor", Common.Client.Default.Color.Red },
+                        { "Address", new Common.Client.Default.Address()
+                            {
+                                City = "Shanghai",
+                                PostalCode = "200001",
+                                Street = "ZiXing"
+                            }
+                        }
+                    }
+                }
+            };
+
+            _context.AddToAccounts(newAccount);
+            await _context.SaveChangesAsync();
+
+            var queryable0 = _context.Accounts.ByKey(110);
+            Common.Client.Default.Account accountResult = await queryable0.GetValueAsync();
+            Assert.NotNull(accountResult);
+            accountResult.AccountInfo.DynamicProperties.TryGetValue("MiddleName", out var middleName);
+            accountResult.AccountInfo.DynamicProperties.TryGetValue("Address", out var address);
+            accountResult.AccountInfo.DynamicProperties.TryGetValue("FavoriteColor", out var favoriteColor);
+            Assert.Equal("Howard", middleName);
+            Assert.NotNull(address);
+
+            Assert.Equal(Common.Client.Default.Color.Red, favoriteColor);
+
+            // delete
+            var accountToDelete = await _context.Accounts.ByKey(110).GetValueAsync();
+            _context.DeleteObject(accountToDelete);
+            await _context.SaveChangesAsync();
+
+            var accounts = (await _context.Accounts.ExecuteAsync()).ToList();
+            var queryDeletedAccount = accounts.Where(account => account.AccountID == 110);
+            Assert.Empty(queryDeletedAccount);
+        }
+
+        [Fact]
+        public async Task DeletingAndInsertingAnEntityWithAnOpenComplexTypeProperty_WorksCorrectly()
+        {
+            _context.Format.UseJson(_model);
+            _context.MergeOption = MergeOption.OverwriteChanges;
+            _ = await _context.Accounts.ByKey(101).GetValueAsync();
+
+            // delete the entry
+            Uri requestUri = new(_baseUri + "Accounts(101)");
+
+            var deleteRequestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            {
+                Method = "DELETE"
+            };
+
+            _ = await deleteRequestMessage.GetResponseAsync();
+
+            var entry = new ODataResource() { TypeName = NameSpacePrefix + "Account" };
+
+            entry.Properties = new[]
+            {
+                new ODataProperty { Name = "AccountID", Value = 101 },
+                new ODataProperty { Name = "CountryRegion", Value = "CN" }
+            };
+
+            var accountInfo_NestedInfo = new ODataNestedResourceInfo() { Name = "AccountInfo", IsCollection = false };
+            var accountInfo_Resource = new ODataResource
+            {
+                TypeName = NameSpacePrefix + "AccountInfo",
+                Properties = new[]
+                    {
+                        new ODataProperty
+                        {
+                            Name = "FirstName",
+                            Value = "Peter"
+                        },
+                        new ODataProperty
+                        {
+                            Name = "LastName",
+                            Value = "Andy"
+                        }
+                    }
+            };
+
+            var settings = new ODataMessageWriterSettings
+            {
+                EnableMessageStreamDisposal = false
+            };
+
+            var accountType = _model.FindDeclaredType(NameSpacePrefix + "Account") as IEdmEntityType;
+            var accountSet = _model.EntityContainer.FindEntitySet("Accounts");
+
+            var reqUrl = new Uri(_baseUri + "Accounts");
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(reqUrl, base.Client)
+            {
+                Method = "POST"
+            };
+
+            requestMessage.SetHeader("Content-Type", MimeTypes.ApplicationJson);
+            requestMessage.SetHeader("Accept", MimeTypes.ApplicationJson);
+
+            using (var messageWriter = new ODataMessageWriter(requestMessage, settings))
+            {
+                var odataWriter = await messageWriter.CreateODataResourceWriterAsync(accountSet, accountType);
+                await odataWriter.WriteStartAsync(entry);
+                await odataWriter.WriteStartAsync(accountInfo_NestedInfo);
+                await odataWriter.WriteStartAsync(accountInfo_Resource);
+                await odataWriter.WriteEndAsync();
+                await odataWriter.WriteEndAsync();
+                await odataWriter.WriteEndAsync();
+            }
+
+            _ = await requestMessage.GetResponseAsync();
+
+            var updatedAccount = await _context.Accounts.ByKey(101).GetValueAsync();
+            var info = updatedAccount.AccountInfo;
+            info.DynamicProperties.TryGetValue("MiddleName", out var middleName);
+
+            Assert.Null(middleName);
+        }
+        #endregion
+
+        #region open collection property
+
+        [Fact]
+        public async Task OpenCollectionPropertyRoundTrip()
+        {
+            var mimeType = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata;
+
+            // update
+            var accountInfo = new ODataResource
+            {
+                TypeName = NameSpacePrefix + "AccountInfo",
+                Properties =
+                [
+                    new ODataProperty
+                    {
+                        Name = "FirstName",
+                        Value = "FN"
+                    },
+                    new ODataProperty
+                    {
+                        Name = "FavoriteFood",
+                        Value = new ODataCollectionValue()
+                        {
+                            TypeName = "Collection(Edm.String)",
+                            Items = ["meat", "sea food", "apple"]
+                        }
+                    }
+                ]
+            };
+
+            var settings = new ODataMessageWriterSettings
+            {
+                BaseUri = _baseUri,
+                EnableMessageStreamDisposal = false
+            };
+
+            var requestUrl = new Uri(_baseUri + "Accounts(101)/AccountInfo");
+
+            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, base.Client)
+            {
+                Method = "PATCH"
+            };
+
+            requestMessage.SetHeader("Content-Type", mimeType);
+            requestMessage.SetHeader("Accept", mimeType);
+
+            using (var messageWriter = new ODataMessageWriter(requestMessage, settings, _model))
+            {
+                var odataWriter = await messageWriter.CreateODataResourceWriterAsync(null, null);
+                await odataWriter.WriteStartAsync(accountInfo);
+                await odataWriter.WriteEndAsync();
+            }
+
+            var responseMessage = await requestMessage.GetResponseAsync();
+            Assert.Equal(204, responseMessage.StatusCode);
+
+            // verify updated value
+            (ODataResource entry, List<ODataResource> complexProperties) = await this.QueryEntryAsync("Accounts(101)");
+            var updatedAccountInfo = complexProperties.Single(r => r.TypeName.EndsWith("AccountInfo"));
+
+            Assert.Equal("FN", updatedAccountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "FirstName").Value);
+            Assert.Equal("Green", updatedAccountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "LastName").Value);
+            Assert.Equal("\"Hood\"", (updatedAccountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "MiddleName").Value as ODataUntypedValue).RawValue);
+
+            var favoriteFood = updatedAccountInfo.Properties.OfType<ODataProperty>().Single(p => p.Name == "FavoriteFood").Value as ODataCollectionValue;
+            
+            // validate items of favoriteFood.
+            string[] expectedFavoriteFood = ["meat", "sea food", "apple"];
+            int index = 0;
+
+            foreach (var item in favoriteFood.Items)
+            {
+                Assert.Equal(expectedFavoriteFood[index++], item);
+            }
+
+            Assert.Equal(3, index);
+        }
+        #endregion
+
+        private async Task<(ODataResource entry, List<ODataResource> complexProperties)> QueryEntryAsync(string uri, int expectedStatusCode = 200)
+        {
+            ODataMessageReaderSettings readerSettings = new ODataMessageReaderSettings() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + uri, UriKind.Absolute);
+
+            var queryRequestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, base.Client)
+            {
+                Method = "GET"
+            };
+
+            queryRequestMessage.SetHeader("Accept", MimeTypes.ApplicationJsonLight);
+            var queryResponseMessage = await queryRequestMessage.GetResponseAsync();
+
+            Assert.Equal(expectedStatusCode, queryResponseMessage.StatusCode);
+
+            ODataResource entry = null;
+            List<ODataResource> complexProperties = [];
+
+            if (expectedStatusCode == 200)
+            {
+                using var messageReader = new ODataMessageReader(queryResponseMessage, readerSettings, _model);
+                var reader = await messageReader.CreateODataResourceReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    switch (reader.State)
+                    {
+                        case ODataReaderState.NestedResourceInfoStart:
+                            break;
+                        case ODataReaderState.NestedResourceInfoEnd:
+                            break;
+                        case ODataReaderState.ResourceSetStart:
+                            break;
+                        case ODataReaderState.ResourceStart:
+                            {
+                                if (entry == null)
+                                {
+                                    entry = reader.Item as ODataResource;
+                                }
+                                else
+                                {
+                                    complexProperties.Add(reader.Item as ODataResource);
+                                }
+
+                                break;
+                            }
+                        default:
+                            break;
+                    }
+                }
+
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+
+            return (entry, complexProperties);
+        }
+
+        private void EntryStarting(WritingEntryArgs ea)
+        {
+            if (ea.Entity.GetType() == typeof(Common.Client.Default.AccountInfo))
+            {
+                var properties = ea.Entry.Properties as List<ODataProperty>;
+                var undeclaredOdataProperty = new ODataProperty() { Name = "dynamicPropertyKey", Value = "dynamicPropertyValue" };
+                properties.Add(undeclaredOdataProperty);
+                ea.Entry.Properties = properties;
+            }
+        }
+
+        private void ResetDefaultDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "complextype/Default.ResetDefaultDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataItemWrapper.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataItemWrapper.cs
@@ -1,0 +1,14 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataItemWrapper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.E2E.Tests
+{
+    public abstract class ODataItemWrapper
+    {
+        public abstract ODataItem Item { get; }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataNestedResourceInfoWrapper.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataNestedResourceInfoWrapper.cs
@@ -1,0 +1,21 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataNestedResourceInfoWrapper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.E2E.Tests
+{
+    public class ODataNestedResourceInfoWrapper : ODataItemWrapper
+    {
+        public ODataNestedResourceInfo NestedResourceInfo { get; set; }
+
+        public ODataItemWrapper NestedResourceOrResourceSet { get; set; }
+
+        public override ODataItem Item
+        {
+            get { return this.NestedResourceInfo; }
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataResourceSetWrapper.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataResourceSetWrapper.cs
@@ -1,0 +1,21 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataResourceSetWrapper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.E2E.Tests
+{
+    public class ODataResourceSetWrapper : ODataItemWrapper
+    {
+        public ODataResourceSet ResourceSet { get; set; }
+
+        public IEnumerable<ODataResourceWrapper> Resources { get; set; }
+
+        public override ODataItem Item
+        {
+            get { return this.ResourceSet; }
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataResourceWrapper.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataResourceWrapper.cs
@@ -1,0 +1,23 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataResourceWrapper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.E2E.Tests
+{
+    public class ODataResourceWrapper : ODataItemWrapper
+    {
+        public ODataResource Resource { get; set; }
+
+        public IEnumerable<ODataNestedResourceInfoWrapper> NestedResourceInfoWrappers { get; set; }
+
+        public override ODataItem Item
+        {
+            get { return Resource; }
+        }
+
+        public object Instance { get; set; }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataWriterHelper.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ODataWriterHelper.cs
@@ -1,0 +1,126 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="ODataWriterHelper.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.E2E.Tests
+{
+    public static class ODataWriterHelper
+    {
+        public static void WriteResourceSet(ODataWriter writer, ODataResourceSetWrapper resourceSetWrapper)
+        {
+            writer.WriteStart(resourceSetWrapper.ResourceSet);
+
+            if (resourceSetWrapper.Resources != null)
+            {
+                foreach (var resourceWrapper in resourceSetWrapper.Resources)
+                {
+                    WriteResource(writer, resourceWrapper);
+                }
+            }
+
+            writer.WriteEnd();
+        }
+
+        public static async Task WriteResourceSetAsync(ODataWriter writer, ODataResourceSetWrapper resourceSetWrapper)
+        {
+            await writer.WriteStartAsync(resourceSetWrapper.ResourceSet);
+
+            if (resourceSetWrapper.Resources != null)
+            {
+                foreach (var resourceWrapper in resourceSetWrapper.Resources)
+                {
+                    await WriteResourceAsync(writer, resourceWrapper);
+                }
+            }
+
+            await writer.WriteEndAsync();
+        }
+
+        public static void WriteResource(ODataWriter writer, ODataResourceWrapper resourceWrapper)
+        {
+            writer.WriteStart(resourceWrapper.Resource);
+
+            if (resourceWrapper.NestedResourceInfoWrappers != null)
+            {
+                foreach (var nestedResourceInfoWrapper in resourceWrapper.NestedResourceInfoWrappers)
+                {
+                    WriteNestedResourceInfo(writer, nestedResourceInfoWrapper);
+                }
+            }
+
+            writer.WriteEnd();
+        }
+
+        public static async Task WriteResourceAsync(ODataWriter writer, ODataResourceWrapper resourceWrapper)
+        {
+            await writer.WriteStartAsync(resourceWrapper.Resource);
+
+            if (resourceWrapper.NestedResourceInfoWrappers != null)
+            {
+                foreach (var nestedResourceInfoWrapper in resourceWrapper.NestedResourceInfoWrappers)
+                {
+                    await WriteNestedResourceInfoAsync(writer, nestedResourceInfoWrapper);
+                }
+            }
+
+            await writer.WriteEndAsync();
+        }
+
+        public static void WriteNestedResourceInfo(ODataWriter writer, ODataNestedResourceInfoWrapper nestedResourceInfo)
+        {
+            writer.WriteStart(nestedResourceInfo.NestedResourceInfo);
+
+            if (nestedResourceInfo.NestedResourceOrResourceSet != null)
+            {
+                WriteItem(writer, nestedResourceInfo.NestedResourceOrResourceSet);
+            }
+
+            writer.WriteEnd();
+        }
+
+        public static async Task WriteNestedResourceInfoAsync(ODataWriter writer, ODataNestedResourceInfoWrapper nestedResourceInfo)
+        {
+            await writer.WriteStartAsync(nestedResourceInfo.NestedResourceInfo);
+
+            if (nestedResourceInfo.NestedResourceOrResourceSet != null)
+            {
+                await WriteItemAsync(writer, nestedResourceInfo.NestedResourceOrResourceSet);
+            }
+
+            await writer.WriteEndAsync();
+        }
+
+        private static void WriteItem(ODataWriter writer, ODataItemWrapper ODataItemWrapper)
+        {
+            var ODataResourceWrapper = ODataItemWrapper as ODataResourceWrapper;
+            if (ODataResourceWrapper != null)
+            {
+                WriteResource(writer, ODataResourceWrapper);
+            }
+
+            var ODataResourceSetWrapper = ODataItemWrapper as ODataResourceSetWrapper;
+            if (ODataResourceSetWrapper != null)
+            {
+                WriteResourceSet(writer, ODataResourceSetWrapper);
+            }
+        }
+
+        private static async Task WriteItemAsync(ODataWriter writer, ODataItemWrapper ODataItemWrapper)
+        {
+            var ODataResourceWrapper = ODataItemWrapper as ODataResourceWrapper;
+            if (ODataResourceWrapper != null)
+            {
+                await WriteResourceAsync(writer, ODataResourceWrapper);
+            }
+
+            var ODataResourceSetWrapper = ODataItemWrapper as ODataResourceSetWrapper;
+            if (ODataResourceSetWrapper != null)
+            {
+                await WriteResourceSetAsync(writer, ODataResourceSetWrapper);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

This PR ports E2E client tests from depending on WCF services to use Microsoft.AspNetCore.OData. Here is a link to the tests that need porting: https://github.com/OData/odata.net/blob/release-7.x/test/EndToEndTests/Tests/Client/Build.Desktop/ComplexTypeTests/ComplexTypeTests.cs

These tests test complex types in ODataNet. How they are read, written, how they work with the different OData query  options. How they work in open types, derived types etc. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
