### PR TITLE
Port EdmDateAndTimeOfDayTests

### DIFF
--- a/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/TestHttpClientRequestMessage.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/TestHttpClientRequestMessage.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------------
-// <copyright file="HttpClientRequestMessage.cs" company=".NET Foundation">
+// <copyright file="TestHttpClientRequestMessage.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
@@ -11,7 +11,7 @@ namespace Microsoft.OData.Client.E2E.TestCommon.Common
     /// An implementation of <see cref="IODataRequestMessageAsync"/> that uses an <see cref="HttpRequestMessage"/> under the covers.
     /// In OData library, a message is an abstraction which consists of stream and header interfaces that hides the details of stream-reading/writing.
     /// </summary>
-    public class HttpClientRequestMessage : IODataRequestMessageAsync, IServiceCollectionProvider, IDisposable, IAsyncDisposable
+    public class TestHttpClientRequestMessage : IODataRequestMessageAsync, IServiceCollectionProvider, IDisposable, IAsyncDisposable
     {
         private readonly HttpRequestMessage _request;
         private readonly HttpClient _httpClient;
@@ -19,7 +19,7 @@ namespace Microsoft.OData.Client.E2E.TestCommon.Common
         private Stream _stream;
         private bool _disposed;
 
-        public HttpClientRequestMessage(Uri uri, HttpClient httpClient)
+        public TestHttpClientRequestMessage(Uri uri, HttpClient httpClient)
         {
             _httpClient = httpClient;
             _stream = new MemoryStream();
@@ -101,7 +101,7 @@ namespace Microsoft.OData.Client.E2E.TestCommon.Common
                 throw new Exception($"Request to {_request.RequestUri} failed: {ex.Message}", ex);
             }
 
-            return new HttpClientResponseMessage(response)
+            return new TestHttpClientResponseMessage(response)
             {
                 ServiceProvider = ServiceProvider
             };

--- a/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/TestHttpClientResponseMessage.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.Client.E2E.TestCommon/Common/TestHttpClientResponseMessage.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------------
-// <copyright file="HttpClientResponseMessage.cs" company=".NET Foundation">
+// <copyright file="TestHttpClientResponseMessage.cs" company=".NET Foundation">
 //      Copyright (c) .NET Foundation and Contributors. All rights reserved.
 //      See License.txt in the project root for license information.
 // </copyright>
@@ -11,12 +11,12 @@ namespace Microsoft.OData.Client.E2E.TestCommon.Common
     /// An implementation of <see cref="IODataResponseMessageAsync"/> that uses an <see cref="HttpResponseMessage"/> under the covers.
     /// In ODataLibrary, a message is an abstraction which consists of stream and header interfaces that hides the details of stream-reading/writing.
     /// </summary>
-    public class HttpClientResponseMessage : IODataResponseMessageAsync, IServiceCollectionProvider
+    public class TestHttpClientResponseMessage : IODataResponseMessageAsync, IServiceCollectionProvider
     {
         private readonly HttpResponseMessage _response;
         private bool _disposed;
 
-        public HttpClientResponseMessage(HttpResponseMessage response)
+        public TestHttpClientResponseMessage(HttpResponseMessage response)
         {
             _response = response;
         }

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ComplexTypeTests/Tests/ComplexTypeTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ComplexTypeTests/Tests/ComplexTypeTests.cs
@@ -72,7 +72,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             var requestUri = new Uri(_baseUri.AbsoluteUri + "People(1)", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -128,7 +128,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             Uri requestUri = new(_baseUri.AbsoluteUri + "People(1)/HomeAddress", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -163,7 +163,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             Uri requestUri = new(_baseUri.AbsoluteUri + "People(1)/HomeAddress/Microsoft.OData.Client.E2E.Tests.Common.Server.Default.HomeAddress/FamilyName", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -191,7 +191,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             Uri requestUri = new(_baseUri.AbsoluteUri + "People?$filter=HomeAddress/Microsoft.OData.Client.E2E.Tests.Common.Server.Default.HomeAddress/FamilyName eq 'Cats'", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -309,7 +309,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             var requestUrl = new Uri(_baseUri + "People(1)");
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, base.Client)
             {
                 Method = "PATCH"
             };
@@ -426,7 +426,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             var requestUrl = new Uri(_baseUri + "People");
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, base.Client)
             {
                 Method = "POST"
             };
@@ -456,7 +456,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             var deleteRequestUrl = new Uri(_baseUri + "People(101)");
 
-            var deleteRequestMessage = new TestCommon.Common.HttpClientRequestMessage(deleteRequestUrl, base.Client)
+            var deleteRequestMessage = new TestHttpClientRequestMessage(deleteRequestUrl, base.Client)
             {
                 Method = "DELETE"
             };
@@ -480,7 +480,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             Uri requestUri = new(_baseUri.AbsoluteUri + "People(1)/Default.GetHomeAddress", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -510,7 +510,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             requestUri = new Uri(_baseUri.AbsoluteUri + "People(3)/Default.GetHomeAddress", UriKind.Absolute);
 
-            requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -668,7 +668,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             Uri requestUri = new(_baseUri.AbsoluteUri + "Accounts(101)", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -730,7 +730,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             Uri requestUri = new(_baseUri.AbsoluteUri + "Accounts(101)/AccountInfo/MiddleName", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -756,7 +756,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             Uri requestUri = new(_baseUri.AbsoluteUri + "Accounts?$filter=AccountInfo/MiddleName eq 'Hood'", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client);
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
 
@@ -939,7 +939,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             var requestUri = new Uri(_baseUri + "Accounts");
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "POST"
             };
@@ -972,7 +972,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
             // delete the entry
             var deleteRequestUri = new Uri(_baseUri + "Accounts(10086)");
 
-            var deleteRequestMessage = new TestCommon.Common.HttpClientRequestMessage(deleteRequestUri, base.Client)
+            var deleteRequestMessage = new TestHttpClientRequestMessage(deleteRequestUri, base.Client)
             {
                 Method = "DELETE"
             };
@@ -993,7 +993,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             Uri requestUri = new(_baseUri + "Accounts(101)/Default.GetAccountInfo", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -1024,7 +1024,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             requestUri = new Uri(_baseUri.AbsoluteUri + "Accounts(103)/Default.GetAccountInfo", UriKind.Absolute);
 
-            requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            requestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "GET"
             };
@@ -1251,7 +1251,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
             // delete the entry
             Uri requestUri = new(_baseUri + "Accounts(101)");
 
-            var deleteRequestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUri, base.Client)
+            var deleteRequestMessage = new TestHttpClientRequestMessage(requestUri, base.Client)
             {
                 Method = "DELETE"
             };
@@ -1295,7 +1295,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             var reqUrl = new Uri(_baseUri + "Accounts");
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(reqUrl, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(reqUrl, base.Client)
             {
                 Method = "POST"
             };
@@ -1362,7 +1362,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             var requestUrl = new Uri(_baseUri + "Accounts(101)/AccountInfo");
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, base.Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, base.Client)
             {
                 Method = "PATCH"
             };
@@ -1409,7 +1409,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ComplexTypeTests.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + uri, UriKind.Absolute);
 
-            var queryRequestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, base.Client)
+            var queryRequestMessage = new TestHttpClientRequestMessage(requestUrl, base.Client)
             {
                 Method = "GET"
             };

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ContainmentTests/Tests/ContainmentTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ContainmentTests/Tests/ContainmentTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(101)/MyGiftCard", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
 
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await  requestMessage.GetResponseAsync();
@@ -103,7 +103,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
             var requestUrl = new Uri(_baseUri.AbsoluteUri +
                 "Accounts(101)/MyGiftCard/Default.GetActualAmount(bonusRate=0.2)", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
 
             requestMessage.SetHeader("Accept", "*/*");
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -124,7 +124,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(101)/Default.GetDefaultPI()", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
 
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -168,7 +168,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri + "Accounts(101)/Default.RefreshDefaultPI");
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client)
             {
                 Method = "POST"
             };
@@ -221,7 +221,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             Uri requestUrl = new(_baseUri.AbsoluteUri + "Accounts(103)/MyPaymentInstruments", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
 
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -265,7 +265,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(103)/MyPaymentInstruments(103902)", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
 
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -298,7 +298,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(103)/MyPaymentInstruments(103901)/BillingStatements(103901001)", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
 
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -331,7 +331,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(103)/MyPaymentInstruments(103901)/BillingStatements", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
 
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -371,7 +371,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(103)/MyPaymentInstruments(103901)/TheStoredPI", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
 
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -404,7 +404,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(101)/MyPaymentInstruments(101901)/BackupStoredPI", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
 
@@ -442,7 +442,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + string.Format("Accounts(101)/MyPaymentInstruments(101902)/{0}.CreditCardPI", TestModelNameSpace), UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
 
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -475,7 +475,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + string.Format("Accounts(101)/MyPaymentInstruments/{0}.CreditCardPI", TestModelNameSpace), UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
 
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -511,7 +511,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + string.Format("Accounts(101)/MyPaymentInstruments(101902)/{0}.CreditCardPI/CreditRecords", TestModelNameSpace), UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
 
@@ -547,7 +547,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(101)", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
 
             var responseMessage = await requestMessage.GetResponseAsync();
@@ -580,7 +580,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
 
@@ -621,7 +621,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(101)/MyPaymentInstruments(101902)/PaymentInstrumentID", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
 
@@ -643,7 +643,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(103)/MyPaymentInstruments?$filter=PaymentInstrumentID gt 103901", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
 
@@ -684,7 +684,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + "Accounts(103)/MyPaymentInstruments?$orderby=CreatedDate", UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
             Assert.Equal(200, responseMessage.StatusCode);
@@ -727,7 +727,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + query, UriKind.Absolute);
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             requestMessage.SetHeader("Accept", mimeType);
             var responseMessage = await requestMessage.GetResponseAsync();
 
@@ -786,7 +786,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri + "Accounts(101)/MyPaymentInstruments");
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client)
             {
                 Method = "POST"
             };
@@ -812,7 +812,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
             // delete the entry
             var deleteRequestUrl = new Uri(_baseUri + "Accounts(101)/MyPaymentInstruments(101904)");
 
-            var deleteRequestMessage = new TestCommon.Common.HttpClientRequestMessage(deleteRequestUrl, Client)
+            var deleteRequestMessage = new TestHttpClientRequestMessage(deleteRequestUrl, Client)
             {
                 Method = "DELETE"
             };
@@ -851,7 +851,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri + "Accounts(104)/MyGiftCard");
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client)
             {
                 // Use PATCH to upsert
                 Method = "PATCH"
@@ -900,7 +900,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri + "Accounts(101)/MyPaymentInstruments(101903)");
 
-            var requestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client)
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client)
             {
                 Method = "PATCH"
             };
@@ -1182,7 +1182,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ContainmentTest.Tests
 
             var requestUrl = new Uri(_baseUri.AbsoluteUri + uri, UriKind.Absolute);
 
-            var queryRequestMessage = new TestCommon.Common.HttpClientRequestMessage(requestUrl, Client);
+            var queryRequestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
             queryRequestMessage.SetHeader("Accept", MimeTypes.ApplicationJsonLight);
             var queryResponseMessage = await queryRequestMessage.GetResponseAsync();
 

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/EdmDateAndTimeOfDayTests/Server/EdmDateAndTimeOfDayTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/EdmDateAndTimeOfDayTests/Server/EdmDateAndTimeOfDayTestsController.cs
@@ -1,0 +1,213 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="EdmDateAndTimeOfDayTestsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.Default;
+using Microsoft.OData.Edm;
+
+namespace Microsoft.OData.Client.E2E.Tests.EdmDateAndTimeOfDayTests.Server
+{
+    public class EdmDateAndTimeOfDayTestsController : ODataController
+    {
+        private static DefaultDataSource _dataSource;
+
+        [EnableQuery]
+        [HttpGet("odata/Orders")]
+        public IActionResult GetOrders()
+        {
+            var orders = _dataSource.Orders;
+
+            return Ok(orders);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Orders({key})")]
+        public IActionResult GetOrder([FromRoute] int key)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Orders({key})/ShipDate")]
+        public IActionResult GetOrderShipDate([FromRoute] int key)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order.ShipDate);
+        }
+
+
+        [EnableQuery]
+        [HttpGet("odata/Orders({key})/ShipDate/$value")]
+        public IActionResult GetOrderShipDateRawValue([FromRoute] int key)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order.ShipDate);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Orders({key})/ShipTime")]
+        public IActionResult GetOrderShipTime([FromRoute] int key)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order.ShipTime);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Orders({key})/ShipTime/$value")]
+        public IActionResult GetOrderShipTimeRawValue([FromRoute] int key)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order.ShipTime);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Orders({key})/Default.GetShipDate()")]
+        public IActionResult GetShipDate([FromRoute] int key)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order.ShipDate);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Orders({key})/Default.CheckShipDate(date = {date})")]
+        public IActionResult CheckShipDate([FromRoute] int key, Date date)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order.ShipDate == date);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Orders({key})/Default.GetShipTime")]
+        public IActionResult GetShipTime([FromRoute] int key)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order.ShipTime);
+        }
+
+
+        [EnableQuery]
+        [HttpGet("odata/Orders({key})/Default.CheckShipTime(time = {time})")]
+        public IActionResult CheckShipTime([FromRoute] int key, TimeOfDay time)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order.ShipTime == time);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Calendars({key})")]
+        public IActionResult GetCalendar([FromRoute] Date key)
+        {
+            var calendar = _dataSource.Calendars.SingleOrDefault(a => a.Day == key);
+
+            if (calendar == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(calendar);
+        }
+
+        [HttpPost("odata/Orders({key})/Default.ChangeShipTimeAndDate")]
+        public IActionResult ChangeShipTimeAndDate([FromRoute] int key, ODataActionParameters parameters)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            order.ShipTime = (TimeOfDay)parameters["time"];
+            order.ShipDate = (Date)parameters["date"];
+
+            return Ok(order);
+        }
+
+
+        [HttpPatch("odata/Orders({key})")]
+        public IActionResult PatchOrder([FromRoute] int key, [FromBody] Delta<Order> delta)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderID == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            var updatedOrder = delta.Patch(order);
+
+            return Ok(updatedOrder);
+        }
+
+        [HttpPost("odata/edmdateandtimeofday/Default.ResetDefaultDataSource")]
+        public IActionResult ResetDefaultDataSource()
+        {
+            _dataSource = DefaultDataSource.CreateInstance();
+
+            return Ok();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/EdmDateAndTimeOfDayTests/Tests/EdmDateAndTimeOfDayTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/EdmDateAndTimeOfDayTests/Tests/EdmDateAndTimeOfDayTests.cs
@@ -1,0 +1,519 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="EdmDateAndTimeOfDayTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.TestCommon;
+using Microsoft.OData.Client.E2E.TestCommon.Common;
+using Microsoft.OData.Client.E2E.Tests.Common.Client.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Client.Default.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.Default;
+using Microsoft.OData.Client.E2E.Tests.EdmDateAndTimeOfDayTests.Server;
+using Microsoft.OData.Edm;
+using Xunit;
+
+namespace Microsoft.OData.Client.E2E.Tests.EdmDateAndTimeOfDayTests.Tests
+{
+    public class EdmDateAndTimeOfDayTests : EndToEndTestBase<EdmDateAndTimeOfDayTests.TestsStartup>
+    {
+        private readonly Uri _baseUri;
+        private readonly Container _context;
+        private readonly IEdmModel _model;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(EdmDateAndTimeOfDayTestsController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                    .AddRouteComponents("odata", DefaultEdmModel.GetEdmModel()));
+            }
+        }
+
+        public EdmDateAndTimeOfDayTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+
+            _model = DefaultEdmModel.GetEdmModel();
+            ResetDefaultDataSource();
+        }
+
+        public static IEnumerable<object[]> MimeTypesData
+        {
+            get
+            {
+                yield return new object[] { MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata };
+                yield return new object[] { MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata };
+                yield return new object[] { MimeTypes.ApplicationJson + MimeTypes.ODataParameterNoMetadata };
+            }
+        }
+
+        #region Query/Action/Function
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingAnEntityThatContainsDateAndTimeOfDay_WorksCorrectly(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model))
+                {
+                    var reader = await messageReader.CreateODataResourceReaderAsync();
+                    ODataResource entry = null;
+                    while (await reader.ReadAsync())
+                    {
+                        if (reader.State == ODataReaderState.ResourceEnd)
+                        {
+                            entry = reader.Item as ODataResource;
+                        }
+                    }
+
+                    // Verify Date Property
+                    Assert.Equal(new Date(2014, 8, 31), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipDate").Value);
+                    Assert.Equal(new TimeOfDay(12, 40, 5, 50), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipTime").Value);
+                    Assert.Equal(ODataReaderState.Completed, reader.State);
+                }
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingTopLevelDateProperies_WorksCorrectly(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/ShipDate", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                ODataProperty property = await messageReader.ReadPropertyAsync();
+                Assert.Equal(new Date(2014, 8, 31), property.Value);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingTopLevelTimeOfDayProperies_WorksCorrectly(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/ShipTime", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                ODataProperty property = await messageReader.ReadPropertyAsync();
+                Assert.Equal(new TimeOfDay(12, 40, 5, 50), property.Value);
+            }
+        }
+
+        [Fact]
+        public async Task QueryingRawDateAndTimeOfDayValues_WorkCorrectly()
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/ShipDate/$value", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            using (var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model))
+            {
+                var date = await messageReader.ReadValueAsync(EdmCoreModel.Instance.GetDate(false));
+                Assert.Equal(new Date(2014, 8, 31), date);
+            }
+
+            var todRequestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/ShipTime/$value", UriKind.Absolute);
+
+            var requestMessage2 = new TestHttpClientRequestMessage(todRequestUrl, Client);
+            var responseMessage2 = await requestMessage2.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage2.StatusCode);
+
+            using (var messageReader = new ODataMessageReader(responseMessage2, readerSettings, _model))
+            {
+                var date = await messageReader.ReadValueAsync(EdmCoreModel.Instance.GetTimeOfDay(false));
+                Assert.Equal(new TimeOfDay(12, 40, 5, 50), date);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingWithDateFilter_WorksCorrectly(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders?$filter=ShipDate eq 2014-08-31", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var reader = await messageReader.CreateODataResourceSetReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    if (reader.State == ODataReaderState.ResourceEnd)
+                    {
+                        ODataResource entry = reader.Item as ODataResource;
+                        if (entry != null && entry.TypeName.EndsWith("Order"))
+                        {
+                            // Verify Date Property
+                            Assert.Equal(new Date(2014, 8, 31), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipDate").Value);
+                            Assert.Equal(new TimeOfDay(12, 40, 5, 50), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipTime").Value);
+                        }
+                    }
+                }
+
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingWithTimeFilter_WorksCorrectly(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders?$filter=ShipTime eq 12:40:5.05", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var reader = await messageReader.CreateODataResourceSetReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    if (reader.State == ODataReaderState.ResourceEnd)
+                    {
+                        ODataResource entry = reader.Item as ODataResource;
+
+                        if (entry != null)
+                        {
+                            // Verify Date Property
+                            Assert.Equal(new Date(2014, 8, 31), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipDate").Value);
+                            Assert.Equal(new TimeOfDay(12, 40, 5, 50), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipTime").Value);
+                        }
+                    }
+                }
+
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+        }
+
+        [Fact]
+        public async Task InvokingAFunctionCorrectly_ReturnDates()
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/Default.GetShipDate()", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            requestMessage.SetHeader("Accept", "*/*");
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+            var date = (await messageReader.ReadPropertyAsync()).Value;
+            Assert.Equal(new Date(2014, 8, 31), date);
+        }
+
+        [Fact]
+        public async Task InvokingAFunctionWithDateParameter_WorksCorrectly()
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/Default.CheckShipDate(date = 2014-08-31)", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            requestMessage.SetHeader("Accept", "*/*");
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+            var result = (await messageReader.ReadPropertyAsync()).Value;
+            Assert.Equal(true, result);
+        }
+
+        [Fact]
+        public async Task InvokingAFunctionWithTimeReturnType_CorrectlyWorks()
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/Default.GetShipTime", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            requestMessage.SetHeader("Accept", "*/*");
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+            var time = (await messageReader.ReadPropertyAsync()).Value;
+
+            Assert.Equal(new TimeOfDay(12, 40, 5, 50), time);
+        }
+
+        [Fact]
+        public async Task InvokingAFunctionWithATimeParameter_WorksCorrectly()
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/Default.CheckShipTime(time = 12:40:5.5)", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+            requestMessage.SetHeader("Accept", "*/*");
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+            var result = (await messageReader.ReadPropertyAsync()).Value;
+
+            Assert.Equal(false, result);
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task QueryingByDateKey_WorksCorrectly(string mimeType)
+        {
+            ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Calendars(2015-11-11)", UriKind.Absolute);
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+
+            requestMessage.SetHeader("Accept", mimeType);
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var reader = await messageReader.CreateODataResourceReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    if (reader.State == ODataReaderState.ResourceEnd)
+                    {
+                        ODataResource entry = reader.Item as ODataResource;
+                        // Verify Date Property
+                        Assert.Equal(new Date(2015, 11, 11), entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "Day").Value);
+                    }
+                }
+
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(MimeTypesData))]
+        public async Task InvokingAnActionWithDateAndTimeParameters_WorksCorrectly(string mimeType)
+        {
+            var writerSettings = new ODataMessageWriterSettings
+            {
+                BaseUri = _baseUri,
+                EnableMessageStreamDisposal = false
+            };
+
+            var readerSettings = new ODataMessageReaderSettings
+            {
+                BaseUri = _baseUri
+            };
+
+            var requestUrl = new Uri(_baseUri + "Orders(7)/Default.ChangeShipTimeAndDate");
+
+            var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client)
+            {
+                Method = "POST"
+            };
+
+            requestMessage.SetHeader("Content-Type", mimeType);
+            requestMessage.SetHeader("Accept", mimeType);
+
+            Date newDate = Date.MinValue;
+            TimeOfDay newTime = TimeOfDay.MinValue;
+
+            await using (var messageWriter = new ODataMessageWriter(requestMessage, writerSettings, _model))
+            {
+                var odataWriter = await messageWriter.CreateODataParameterWriterAsync((IEdmOperation)null);
+                await odataWriter.WriteStartAsync();
+                await odataWriter.WriteValueAsync("date", newDate);
+                await odataWriter.WriteValueAsync("time", newTime);
+                await odataWriter.WriteEndAsync();
+            }
+
+            // send the http request
+            var responseMessage = await requestMessage.GetResponseAsync();
+
+            Assert.Equal(200, responseMessage.StatusCode);
+
+            if (!mimeType.Contains(MimeTypes.ODataParameterNoMetadata))
+            {
+                using var messageReader = new ODataMessageReader(responseMessage, readerSettings, _model);
+                var reader = await messageReader.CreateODataResourceReaderAsync();
+
+                while (await reader.ReadAsync())
+                {
+                    if (reader.State == ODataReaderState.ResourceEnd)
+                    {
+                        ODataResource entry = reader.Item as ODataResource;
+
+                        if (entry != null)
+                        {
+                            Assert.Equal(Date.MinValue, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipDate").Value);
+                            Assert.Equal(TimeOfDay.MinValue, entry.Properties.OfType<ODataProperty>().Single(p => p.Name == "ShipTime").Value);
+                        }
+                    }
+                }
+
+                Assert.Equal(ODataReaderState.Completed, reader.State);
+            }
+        }
+
+        #endregion
+
+        #region Client
+
+        [Fact]
+        public async Task SelectingAnEntitysDateOrTimeOfDayPropertiesFromODataClient_WorksCorrectly()
+        {
+            // Query Property
+            var shipDate = await _context.Orders.ByKey(7).Select(o => o.ShipDate).GetValueAsync();
+            Assert.Equal(new Date(2014, 8, 31), shipDate);
+
+            var shipTime = await _context.Orders.ByKey(7).Select(o => o.ShipTime).GetValueAsync();
+            Assert.Equal(new TimeOfDay(12, 40, 05, 50), shipTime);
+        }
+
+        [Fact]
+        public async Task AProjectionSelectForDateAndTimeOfDayProperties_WorksCorrectly()
+        {
+            // Projection Select
+            var projOrder = await _context.Orders.ByKey(7).Select(o => new Common.Client.Default.Order() { ShipDate = o.ShipDate, ShipTime = o.ShipTime }).GetValueAsync();
+            Assert.True(projOrder != null);
+            Assert.Equal(new Date(2014, 8, 31), projOrder.ShipDate);
+            Assert.Equal(new TimeOfDay(12, 40, 05, 50), projOrder.ShipTime);
+        }
+
+        [Fact]
+        public async Task UpdatingDateAndTimeOfDayPropertiesFromODataClient_WorksCorrectly()
+        {
+            _context.MergeOption = MergeOption.OverwriteChanges;
+
+            // Update Properties
+            var order = await _context.Orders.ByKey(7).GetValueAsync();
+            Assert.True(order != null);
+            Assert.Equal(new Date(2014, 8, 31), order.ShipDate);
+            Assert.Equal(new TimeOfDay(12, 40, 05, 50), order.ShipTime);
+
+            order.ShipDate = new Date(2014, 9, 30);
+            _context.UpdateObject(order);
+            await _context.SaveChangesAsync();
+
+            var updatedOrder = await _context.Orders.ByKey(7).GetValueAsync();
+            Assert.Equal(new Date(2014, 9, 30), updatedOrder.ShipDate);
+        }
+
+        [Fact]
+        public async Task InvokingAFunctionThatReturnsDateFromODataClient_WorksCorrectly()
+        {
+            // Function
+            var date = await _context.Orders.ByKey(7).GetShipDate().GetValueAsync();
+            Assert.Equal(new Date(2014, 8, 31), date);
+        }
+
+        [Fact]
+        public async Task InvokingAnActionThatTakesDateAndTimeOfDayAsParameters_WorksCorrectly()
+        {
+            _context.MergeOption = MergeOption.OverwriteChanges;
+
+            var order = await _context.Orders.ByKey(7).GetValueAsync();
+            Assert.Equal(new Date(2014, 8, 31), order.ShipDate);
+
+            // Action
+            await _context.Orders.ByKey(7).ChangeShipTimeAndDate(Date.MaxValue, TimeOfDay.MaxValue).GetValueAsync();
+            order =await _context.Orders.ByKey(7).GetValueAsync();
+            Assert.Equal(Date.MaxValue, order.ShipDate);
+            Assert.Equal(TimeOfDay.MaxValue, order.ShipTime);
+        }
+
+        [Fact]
+        public async Task InvokingAFunctionWithDateParameterFromODataClient_WorksCorrectly()
+        {
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/Default.CheckShipDate(date = 2014-08-31)", UriKind.Absolute);
+
+            var result =( await _context.ExecuteAsync<bool>(requestUrl)).Single();
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task InvokingAFunctionWithATimeParameterFromODataClient_WorksCorrectly()
+        {
+            var requestUrl = new Uri(_baseUri.AbsoluteUri + "Orders(7)/Default.CheckShipTime(time = 12:40:5.5)", UriKind.Absolute);
+
+            var result = (await _context.ExecuteAsync<bool>(requestUrl)).Single();
+
+            Assert.False(result);
+        }
+
+        #endregion
+
+        private void ResetDefaultDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "edmdateandtimeofday/Default.ResetDefaultDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This PR ports E2E client tests from depending on WCF services to use Microsoft.AspNetCore.OData. Here is a link to the tests that need porting: https://github.com/OData/odata.net/tree/release-7.x/test/EndToEndTests/Tests/Client/Build.Desktop/EdmDateAndTimeOfDay

These tests test the usage of Edm.Date and TimeOfDay in OData.Net

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
