### PR TITLE
Update ODataTypeInfo.cs not correctly identifying entity keys by "Id" property

### DIFF
--- a/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
+++ b/src/Microsoft.OData.Client/Metadata/ClientTypeUtil.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ClientTypeUtil.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -18,6 +18,7 @@ namespace Microsoft.OData.Client.Metadata
     using Microsoft.OData.Metadata;
     using Microsoft.OData.Edm;
     using Client = Microsoft.OData.Client;
+    using System.Runtime.CompilerServices;
 
     #endregion Namespaces.
 
@@ -834,6 +835,21 @@ namespace Microsoft.OData.Client.Metadata
                 || assembly.Equals(typeof(ODataItem).Assembly) // OData core assembly
                 || assembly.Equals(typeof(EdmModel).Assembly) // OData Edm assembly
                 || assembly.Equals(typeof(Spatial.Geography).Assembly); // Spatial assembly
+        }
+
+
+        internal static bool IsAnonymousProperty(this PropertyInfo propertyInfo)
+        {
+            return propertyInfo.DeclaringType.IsAnonymousType();
+        }
+
+        internal static bool IsAnonymousType(this Type type)
+        {
+            return type.IsDefined(typeof(CompilerGeneratedAttribute), false)
+                && type.IsGenericType
+                && (type.Name.Contains("AnonymousType", StringComparison.Ordinal) || type.Name.Contains("AnonType", StringComparison.Ordinal))
+                && (type.Name.StartsWith("<>") || type.Name.StartsWith("VB$"))
+                && (type.Attributes & TypeAttributes.NotPublic) == TypeAttributes.NotPublic;
         }
     }
 }

--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -396,7 +396,7 @@ namespace Microsoft.OData.Client.Metadata
                 order = newOrder;
                 keyKind = newKind;
             }
-            else if (propertyName.EndsWith("ID", StringComparison.Ordinal))
+            else if (propertyName.EndsWith("ID", StringComparison.OrdinalIgnoreCase))
             {
                 string declaringTypeName = propertyInfo.DeclaringType.Name;
                 if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.Ordinal))

--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -396,7 +396,7 @@ namespace Microsoft.OData.Client.Metadata
                 order = newOrder;
                 keyKind = newKind;
             }
-            else if (propertyName.EndsWith("ID", StringComparison.OrdinalIgnoreCase))
+else if (propertyName.Equals(propertyInfo.DeclaringType.Name + "Id", StringComparison.OrdinalIgnoreCase) || propertyName.Equals("Id", StringComparison.OrdinalIgnoreCase))
             {
                 string declaringTypeName = propertyInfo.DeclaringType.Name;
                 if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.Ordinal))

--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -396,7 +396,7 @@ namespace Microsoft.OData.Client.Metadata
                 order = newOrder;
                 keyKind = newKind;
             }
-else if (propertyName.Equals(propertyInfo.DeclaringType.Name + "Id", StringComparison.OrdinalIgnoreCase) || propertyName.Equals("Id", StringComparison.OrdinalIgnoreCase))
+            else if (propertyName.Equals(propertyInfo.DeclaringType.Name + "Id", StringComparison.OrdinalIgnoreCase) || propertyName.Equals("Id", StringComparison.OrdinalIgnoreCase))
             {
                 string declaringTypeName = propertyInfo.DeclaringType.Name;
                 if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.Ordinal))

--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData.Client.Metadata
         public ODataTypeInfo(Type type)
         {
             this.type = type;
-            ServerSideNameDict = new ConcurrentDictionary<string, string>();                      
+            ServerSideNameDict = new ConcurrentDictionary<string, string>();
         }
 
         /// <summary>
@@ -84,8 +84,8 @@ namespace Microsoft.OData.Client.Metadata
         /// <summary>
         /// Sertver defined type name
         /// </summary>
-        public string ServerDefinedTypeName 
-        { 
+        public string ServerDefinedTypeName
+        {
             get
             {
                 if (_serverDefinedTypeName == null)
@@ -102,7 +102,7 @@ namespace Microsoft.OData.Client.Metadata
                     else
                     {
                         _serverDefinedTypeName = type.Name;
-                    }                    
+                    }
                 }
 
                 return _serverDefinedTypeName;
@@ -251,9 +251,9 @@ namespace Microsoft.OData.Client.Metadata
                     (typeof(UIntPtr) == propertyType))
                 {
                     continue;
-                }                    
+                }
 
-                Debug.Assert(!propertyType.ContainsGenericParameters(), "remove when test case is found that encounters this");                
+                Debug.Assert(!propertyType.ContainsGenericParameters(), "remove when test case is found that encounters this");
 
                 if (propertyInfo.CanRead &&
                     (!propertyType.IsValueType() || propertyInfo.CanWrite) &&
@@ -334,10 +334,10 @@ namespace Microsoft.OData.Client.Metadata
                 if (newKeyKind == KeyKind.AttributedKey && keyProperties.Count != dataServiceKeyAttribute?.KeyNames.Count)
                 {
                     var m = (from string a in dataServiceKeyAttribute.KeyNames
-                                where (from b in Properties
+                             where (from b in Properties
                                     where b.Name == a
                                     select b).FirstOrDefault() == null
-                                select a).First<string>();
+                             select a).First<string>();
                     throw Client.Error.InvalidOperation(Client.Strings.ClientType_MissingProperty(typeName, m));
                 }
             }
@@ -381,10 +381,16 @@ namespace Microsoft.OData.Client.Metadata
         private static KeyKind IsKeyProperty(PropertyInfo propertyInfo, KeyAttribute dataServiceKeyAttribute, out int order)
         {
             Debug.Assert(propertyInfo != null, "propertyInfo != null");
+            order = -1;
+
+            //If the property's declaring type is anonymous, it is not a key.
+            if (propertyInfo.IsAnonymousProperty())
+            {
+                return KeyKind.NotKey;
+            }
 
             string propertyName = ClientTypeUtil.GetServerDefinedName(propertyInfo);
 
-            order = -1;
             KeyKind keyKind = KeyKind.NotKey;
             if (dataServiceKeyAttribute != null && dataServiceKeyAttribute.KeyNames.Contains(propertyName))
             {
@@ -419,7 +425,7 @@ namespace Microsoft.OData.Client.Metadata
             order = -1;
             kind = KeyKind.NotKey;
             var attributes = propertyInfo.GetCustomAttributes();
-            if(!attributes.Any(a => a is System.ComponentModel.DataAnnotations.KeyAttribute))
+            if (!attributes.Any(a => a is System.ComponentModel.DataAnnotations.KeyAttribute))
             {
                 return false;
             }

--- a/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
+++ b/src/Microsoft.OData.Client/Metadata/ODataTypeInfo.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ODataTypeInfo.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -399,7 +399,7 @@ namespace Microsoft.OData.Client.Metadata
             else if (propertyName.Equals(propertyInfo.DeclaringType.Name + "Id", StringComparison.OrdinalIgnoreCase) || propertyName.Equals("Id", StringComparison.OrdinalIgnoreCase))
             {
                 string declaringTypeName = propertyInfo.DeclaringType.Name;
-                if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.Ordinal))
+                if ((propertyName.Length == (declaringTypeName.Length + 2)) && propertyName.StartsWith(declaringTypeName, StringComparison.OrdinalIgnoreCase))
                 {
                     // matched "DeclaringType.Name+ID" pattern
                     keyKind = KeyKind.TypeNameId;

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Metadata/ClientTypeUtilTests.cs
@@ -1,4 +1,4 @@
-﻿//---------------------------------------------------------------------
+//---------------------------------------------------------------------
 // <copyright file="ClientTypeUtilTests.cs" company="Microsoft">
 //      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
 // </copyright>
@@ -17,6 +17,19 @@ namespace Microsoft.OData.Client.Tests.Metadata
     /// </summary>
     public class ClientTypeUtilTests
     {
+        [Theory]
+        [InlineData(typeof(Giraffe), true)]
+        [InlineData(typeof(Hippo), true)]
+        [InlineData(typeof(Ferret), true)]
+        [InlineData(typeof(Lion), false)]
+        public void IfTypeProperty_HasConventionalKey_TypeIsEntity(Type entityType, bool isEntity)
+        {
+            //Act
+            bool actualResult = ClientTypeUtil.TypeOrElementTypeIsEntity(entityType);
+            //Assert
+            Assert.Equal(actualResult, isEntity);
+        }
+
         [Fact]
         public void IFTypeProperty_HasKeyAttribute_TypeIsEntity()
         {
@@ -214,5 +227,37 @@ namespace Microsoft.OData.Client.Tests.Metadata
             public int EmpTypeId { get; set; }
         }
 
+        public class Giraffe
+        {
+            /// <summary>
+            /// Conventional Id Key property
+            /// </summary>
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        public class Hippo
+        {
+            /// <summary>
+            /// Conventional {TypeName + Id} Key Property
+            /// </summary>
+            public int HippoId { get; set; }
+            public double Weight { get; set; }
+        }
+
+        public class Ferret
+        {
+            /// <summary>
+            /// Conventional {TypeName + Id} Key Property with odd casing
+            /// </summary>
+            public int FeRReTID { get; set; }
+            public double Weight { get; set; }
+        }
+
+        public class Lion
+        {
+            public int SomeId { get; set; }
+            public string Name { get; set; }
+        }
     }
 }


### PR DESCRIPTION
I found an issue where the Conventional Id fields are not recognized as key fields.  As the Property Name Ends with Id, rather than "ID".  The result is that the EdmModel is properly defining the key property, however on the client the EntityType is resolved as "ComplexType" and failures in tracking occur later on in the pipeline.

<!-- markdownlint-disable MD002 MD041 -->

### Issues
https://github.com/OData/odata.net/issues/3052

### Description

This change finds Id properties using Case Insensitivity for cases where the [Key()] attribute is not defined.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
