### PR TITLE
Fixes #3068: Throws ResourceTypeAnnotationNotFirst error when payload…

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataJsonResourceDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonResourceDeserializer.cs
@@ -100,6 +100,14 @@ namespace Microsoft.OData.Json
             Debug.Assert(resourceState != null, "resourceState != null");
             this.AssertJsonCondition(JsonNodeType.Property, JsonNodeType.EndObject);
 
+            object value;
+            if (this.JsonReader.TryGetValueFromBuffered(ODataJsonConstants.PrefixedODataTypePropertyName, true, out value) ||
+                this.JsonReader.TryGetValueFromBuffered(ODataJsonConstants.SimplifiedODataTypePropertyName, true, out value))
+            {
+                resourceState.Resource.TypeName = ReaderUtils.AddEdmPrefixOfTypeName(ReaderUtils.RemovePrefixOfTypeName(value as string));
+                return;
+            }
+
             // If the current node is the odata.type property - read it.
             if (this.JsonReader.NodeType == JsonNodeType.Property)
             {
@@ -114,6 +122,8 @@ namespace Microsoft.OData.Json
 
                     // Read the annotation value.
                     resourceState.Resource.TypeName = this.ReadODataTypeAnnotationValue();
+
+                 //   resourceState.TypeAnnotationFound = true;
                 }
             }
 
@@ -821,9 +831,15 @@ namespace Microsoft.OData.Json
                     return this.ReadAndValidateAnnotationStringValue(annotationName);
 
                 case ODataAnnotationNames.ODataRemoved: // 'odata.removed'
+                    // If the value of 'odata.removed' is an object, let's throw exception since it should be not read here.
+                    if (this.JsonReader.NodeType == JsonNodeType.StartObject)
                     {
                         throw new ODataException(ODataErrorStrings.ODataJsonResourceDeserializer_UnexpectedDeletedEntryInResponsePayload);
                     }
+
+                    // for others, let's skip it
+                    this.JsonReader.SkipValue();
+                    return null;
 
                 default:
                     ODataAnnotationNames.ValidateIsCustomAnnotationName(annotationName);
@@ -903,6 +919,9 @@ namespace Microsoft.OData.Json
                 case ODataAnnotationNames.ODataMediaETag:  // 'odata.mediaEtag'
                     ODataJsonReaderUtils.EnsureInstance(ref mediaResource);
                     mediaResource.ETag = (string)annotationValue;
+                    break;
+
+                case ODataAnnotationNames.ODataRemoved: // 'odata.removed'
                     break;
 
                 default:

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -1358,6 +1358,159 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             return model;
         }
 
+        [Fact]
+        public void ReadingResourceWithInstanceAnnotationAndODataTypeWorks1()
+        {
+            const string payload =
+ "{\"@odata.context\":\"http://svc/$metadata#EntitySet/$entity\"," +
+  "\"@odata.type\":\"#Namespace.EntityType\"," +
+  "\"Name\":\"SampleName\"," +
+  "\"@removed\":false," +
+  "\"ID\":89}";
+
+            EdmEntitySet entitySet = EntitySet;
+            IEdmModel model = Model;
+            IEdmEntityType entityType = EntitySet.EntityType;
+
+            InMemoryMessage message = new InMemoryMessage();
+            message.SetHeader("Content-Type", "application/json;odata.metadata=minimal");
+            message.Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+            ODataResource topLevelResource = null;
+            ODataMessageReaderSettings settings = new ODataMessageReaderSettings(ODataVersion.V401)
+            {
+            };
+
+            using (var messageReader = new ODataMessageReader((IODataResponseMessage)message, settings, model))
+            {
+                var reader = messageReader.CreateODataResourceReader(entitySet, entityType);
+                while (reader.Read())
+                {
+                    switch (reader.State)
+                    {
+                        case ODataReaderState.ResourceEnd:
+                            topLevelResource = (ODataResource)reader.Item;
+                            break;
+                    }
+                }
+            }
+
+            Assert.NotNull(topLevelResource);
+            Assert.Equal(new Uri("http://svc/EntitySet(89)"), topLevelResource.Id);
+
+            Assert.Equal("Namespace.EntityType", topLevelResource.TypeName);
+            Assert.Equal("SampleName", Assert.IsType<ODataProperty>(topLevelResource.Properties.First(p => p.Name == "Name")).Value);
+            Assert.Equal(89, Assert.IsType<ODataProperty>(topLevelResource.Properties.First(p => p.Name == "ID")).Value);
+        }
+
+        [Fact]
+        public void ReadingResourceWithInstanceAnnotationAndODataTypeWorks()
+        {
+            const string payload =
+ "{\"@odata.context\":\"http://svc/$metadata#EntitySet/$entity\"," +
+  "\"@odata.type\":\"#Namespace.EntityType\"," +
+  "\"Name\":\"SampleName\"," +
+  "\"@NS.removed\":false," +
+  "\"ID\":89}";
+
+            EdmEntitySet entitySet = EntitySet;
+            IEdmModel model = Model;
+            IEdmEntityType entityType = EntitySet.EntityType;
+
+            InMemoryMessage message = new InMemoryMessage();
+            message.SetHeader("Content-Type", "application/json;odata.metadata=minimal");
+            message.Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+            ODataResource topLevelResource = null;
+            ODataMessageReaderSettings settings = new ODataMessageReaderSettings(ODataVersion.V401)
+            {
+                ShouldIncludeAnnotation = (annotation) => true
+            };
+
+            using (var messageReader = new ODataMessageReader((IODataResponseMessage)message, settings, model))
+            {
+                var reader = messageReader.CreateODataResourceReader(entitySet, entityType);
+                while (reader.Read())
+                {
+                    switch (reader.State)
+                    {
+                        case ODataReaderState.ResourceEnd:
+                            topLevelResource = (ODataResource)reader.Item;
+                            break;
+                    }
+                }
+            }
+
+            Assert.NotNull(topLevelResource);
+            Assert.Equal(new Uri("http://svc/EntitySet(89)"), topLevelResource.Id);
+
+            Assert.Equal("Namespace.EntityType", topLevelResource.TypeName);
+            Assert.Equal("SampleName", Assert.IsType<ODataProperty>(topLevelResource.Properties.First(p => p.Name == "Name")).Value);
+            Assert.Equal(89, Assert.IsType<ODataProperty>(topLevelResource.Properties.First(p => p.Name == "ID")).Value);
+
+            ODataInstanceAnnotation annotation = Assert.Single(topLevelResource.InstanceAnnotations);
+            Assert.Equal("NS.removed", annotation.Name);
+            Assert.Equal(false, annotation.Value.FromODataValue());
+        }
+
+        [Fact]
+        public void ReadingDeletedResourceContainsODataTypeWorks()
+        {
+            const string payload =
+"{\"@odata.context\":\"http://svc/$metadata#EntitySet/$delta\"," +
+  "\"value\":[" +
+    "{" +
+      "\"@odata.type\":\"#Namespace.EntityType\"," +
+      "\"Name\":\"SampleName\"," +
+      "\"@removed\":{\"reason\":\"deleted\"}," +
+      "\"ID\":89" +
+    "}" +
+  "]" +
+"}";
+
+            EdmEntitySet entitySet = EntitySet;
+            IEdmModel model = Model;
+            IEdmEntityType entityType = EntitySet.EntityType;
+
+            InMemoryMessage message = new InMemoryMessage();
+            message.SetHeader("Content-Type", "application/json;odata.metadata=minimal");
+            message.Stream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+
+            ODataMessageReaderSettings settings = new ODataMessageReaderSettings(ODataVersion.V401);
+
+            ODataDeletedResource deletedResource = null;
+            using (var messageReader = new ODataMessageReader((IODataResponseMessage)message, settings, model))
+            {
+                var reader = messageReader.CreateODataDeltaResourceSetReader(entitySet, entityType);
+                while (reader.Read())
+                {
+                    switch (reader.State)
+                    {
+                        case ODataReaderState.DeltaResourceSetStart:
+                            break;
+
+                        case ODataReaderState.DeltaResourceSetEnd:
+                            break;
+
+                        case ODataReaderState.DeletedResourceStart:
+                            deletedResource = (ODataDeletedResource)reader.Item;
+                            break;
+                        case ODataReaderState.DeletedResourceEnd:
+                            break;
+                    }
+                }
+            }
+
+            Assert.NotNull(deletedResource);
+            Assert.Equal(new Uri("http://svc/EntitySet(89)"), deletedResource.Id);
+
+            Assert.Equal("Namespace.EntityType", deletedResource.TypeName);
+
+            Assert.Equal(2, deletedResource.Properties.Count());
+            Assert.Equal("SampleName", Assert.IsType<ODataProperty>(deletedResource.Properties.First(p => p.Name == "Name")).Value);
+            Assert.Equal(89, Assert.IsType<ODataProperty>(deletedResource.Properties.First(p => p.Name == "ID")).Value);
+        }
+
         [Theory]
         [InlineData("minimal")]
         [InlineData("full")]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ReorderingJsonReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ReorderingJsonReaderTests.cs
@@ -307,6 +307,7 @@ namespace Microsoft.OData.Tests.Json
                         await reorderingReader.ReadPrimitiveValueAsync());
                 });
         }
+
         [Fact]
         public async Task ReadReorderedPayloadContainingSimplifiedODataAnnotationsAsync()
         {
@@ -342,6 +343,86 @@ namespace Microsoft.OData.Tests.Json
                     Assert.Equal(
                         "Sue",
                         await reorderingReader.ReadPrimitiveValueAsync());
+                });
+        }
+
+        [Fact]
+        public async Task ReadReorderedPayload_OrderingContextRemovedTypeIdAsync()
+        {
+            var payload = "{" +
+                "\"Id\":1," +
+                "\"@odata.id\":\"http://tempuri.org/Customers(1)\"," +
+                "\"Name\":\"Sue\"," +
+                "\"@odata.removed\":{\"reason\":\"deleted\"}," +
+                "\"@odata.type\":\"SomeEntityType\"," +
+                "\"@odata.context\":\"any\"" +
+              "}";
+
+            await SetupReorderingJsonReaderAndRunTestAsync(
+                payload,
+                async (reorderingReader) =>
+                {
+                    // 1. should be '@odata.context'
+                    Assert.Equal("@odata.context", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip context value
+
+                    // 2. should be '@odata.removed'
+                    Assert.Equal("@odata.removed", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip object value
+
+                    // 3. should be '@odata.type'
+                    Assert.Equal("@odata.type", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip object value
+
+                    // 4. should be '@odata.id'
+                    Assert.Equal("@odata.id", await reorderingReader.ReadPropertyNameAsync());
+                    Assert.Equal("http://tempuri.org/Customers(1)", await reorderingReader.ReadPrimitiveValueAsync());
+
+                    Assert.Equal("Id", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip object value
+
+                    Assert.Equal("Name", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip object value
+                });
+        }
+
+        [Fact]
+        public async Task ReadReorderedPayload_OrderingContextRemovedTypeId_ContainingSimplifiedAnnotationAsync()
+        {
+            var payload = "{" +
+                "\"Id\":1," +
+                "\"@id\":\"http://tempuri.org/Customers(1)\"," +
+                "\"Name\":\"Sue\"," +
+                "\"@removed\":{\"reason\":\"deleted\"}," +
+                "\"@context\":\"any\"," +
+                "\"@type\":\"SomeEntityType\""+
+              "}";
+
+            await SetupReorderingJsonReaderAndRunTestAsync(
+                payload,
+                async (reorderingReader) =>
+                {
+                    // 1. should be '@context'
+                    Assert.Equal("@context", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip context value
+
+                    // 2. should be '@removed'
+                    Assert.Equal("@removed", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip object value
+
+                    // 3. should be '@type'
+                    Assert.Equal("@type", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip object value
+
+                    // 4. should be '@id'
+                    Assert.Equal("@id", await reorderingReader.ReadPropertyNameAsync());
+                    Assert.Equal("http://tempuri.org/Customers(1)", await reorderingReader.ReadPrimitiveValueAsync());
+
+                    Assert.Equal("Id", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip object value
+
+                    Assert.Equal("Name", await reorderingReader.ReadPropertyNameAsync());
+                    await reorderingReader.SkipValueAsync(); // Skip object value
                 });
         }
 


### PR DESCRIPTION
… has both @removed and @odata.type

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3068.*

### Description

1) Make sure the reordering json reader reorder @context, @removed, @type, @id in this ordering.
   @mikepizzo, Why does @removed should be property before @type?

2) We cannot assume the end customer is reading the payload using delta reader or normal entity reader, so, we don't know whether the @type position is the first property or second property if it contains @context.  So, in this PR, try to retrieve the @type directly from the buffer.  But, we should make sure:
      a) Can a normal entity payload contain 'odata.removed'? 
      b) Can we allow use 'resource reader' to read the payload containing 'odata.removed'?
       @mikepizzo 
  
3) We can skip the value/validation if the 'odata.removed' has the wrong value. It's same concern that if we do like this solution? 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
