### PR TITLE
Isolate scoped settings in default OData services

### DIFF
--- a/src/Microsoft.OData.Core/ODataServiceCollectionExtensions.cs
+++ b/src/Microsoft.OData.Core/ODataServiceCollectionExtensions.cs
@@ -55,15 +55,15 @@ namespace Microsoft.Extensions.DependencyInjection
             // Finally, register configurable settings.
             var readerSettings = new ODataMessageReaderSettings(odataVersion);
             configureReaderAction?.Invoke(readerSettings);
-            services.AddScoped(sp => readerSettings);
+            services.AddScoped(sp => readerSettings.Clone());
 
             var writerSettings = new ODataMessageWriterSettings(odataVersion);
             configureWriterAction?.Invoke(writerSettings);
-            services.AddScoped(sp => writerSettings);
+            services.AddScoped(sp => writerSettings.Clone());
 
             var parserSettings = new ODataUriParserSettings();
             configureUriParserAction?.Invoke(parserSettings);
-            services.AddScoped(sp => parserSettings);
+            services.AddScoped(sp => parserSettings.Clone());
 
             return services;
         }

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
@@ -91,7 +91,7 @@ namespace Microsoft.OData.UriParser
 
         internal ODataUriParserSettings Clone()
         {
-            ODataUriParserSettings copy = new()
+            return new()
             {
                 FilterLimit = this.FilterLimit,
                 OrderByLimit = this.OrderByLimit,
@@ -101,8 +101,6 @@ namespace Microsoft.OData.UriParser
                 MaximumExpansionCount = this.MaximumExpansionCount,
                 EnableParsingKeyAsSegment = this.EnableParsingKeyAsSegment
             };
-
-            return copy;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
@@ -91,14 +91,17 @@ namespace Microsoft.OData.UriParser
 
         internal ODataUriParserSettings Clone()
         {
-            ODataUriParserSettings copy = new ODataUriParserSettings();
-            copy.FilterLimit = this.FilterLimit;
-            copy.OrderByLimit = this.OrderByLimit;
-            copy.PathLimit = this.PathLimit;
-            copy.SearchLimit = this.SearchLimit;
-            copy.MaximumExpansionDepth = this.MaximumExpansionDepth;
-            copy.MaximumExpansionCount = this.MaximumExpansionCount;
-            copy.EnableParsingKeyAsSegment = this.EnableParsingKeyAsSegment;
+            ODataUriParserSettings copy = new()
+            {
+                FilterLimit = this.FilterLimit,
+                OrderByLimit = this.OrderByLimit,
+                PathLimit = this.PathLimit,
+                SearchLimit = this.SearchLimit,
+                MaximumExpansionDepth = this.MaximumExpansionDepth,
+                MaximumExpansionCount = this.MaximumExpansionCount,
+                EnableParsingKeyAsSegment = this.EnableParsingKeyAsSegment
+            };
+
             return copy;
         }
 

--- a/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
+++ b/src/Microsoft.OData.Core/UriParser/ODataUriParserSettings.cs
@@ -89,6 +89,19 @@ namespace Microsoft.OData.UriParser
             this.EnableParsingKeyAsSegment = true;
         }
 
+        internal ODataUriParserSettings Clone()
+        {
+            ODataUriParserSettings copy = new ODataUriParserSettings();
+            copy.FilterLimit = this.FilterLimit;
+            copy.OrderByLimit = this.OrderByLimit;
+            copy.PathLimit = this.PathLimit;
+            copy.SearchLimit = this.SearchLimit;
+            copy.MaximumExpansionDepth = this.MaximumExpansionDepth;
+            copy.MaximumExpansionCount = this.MaximumExpansionCount;
+            copy.EnableParsingKeyAsSegment = this.EnableParsingKeyAsSegment;
+            return copy;
+        }
+
         /// <summary>
         /// Gets or sets the maximum depth of the tree that results from parsing $expand.
         /// </summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataServiceCollectionExtensionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataServiceCollectionExtensionTests.cs
@@ -136,6 +136,29 @@ namespace Microsoft.OData.Tests
             Assert.True(readerSettings.EnableCharactersCheck);
         }
 
+        [Fact]
+        public void AddDefaultODataServices_ReaderSettings_InstancesAreScoped()
+        {
+            var services = new ServiceCollection();
+            services.AddDefaultODataServices();
+            var provider = services.BuildServiceProvider();
+            using var scope1 = provider.CreateScope();
+            var settings1 = scope1.ServiceProvider.GetRequiredService<ODataMessageReaderSettings>();
+            settings1.EnableCharactersCheck = true;
+
+            var settings2 = scope1.ServiceProvider.GetRequiredService<ODataMessageReaderSettings>();
+
+            using var scope2 = provider.CreateScope();
+            var settings3 = scope2.ServiceProvider.GetRequiredService<ODataMessageReaderSettings>();
+            
+            // Instances from the same scope should be the same
+            Assert.True(object.ReferenceEquals(settings1, settings2));
+            Assert.True(settings2.EnableCharactersCheck);
+            // Instances from different scopes should be different
+            Assert.False(object.ReferenceEquals(settings2, settings3));
+            Assert.False(settings2.EnableCharactersCheck);
+        }
+
         /// <summary>
         /// Tests whether the <see cref="ODataMessageReaderSettings" /> can be configured using the <see cref="Action{ODataMessageWriterSettings}" />.
         /// </summary>
@@ -160,6 +183,29 @@ namespace Microsoft.OData.Tests
             Assert.True(writerSettings.EnableCharactersCheck);
         }
 
+        [Fact]
+        public void AddDefaultODataServices_WriterSettings_InstancesAreScoped()
+        {
+            var services = new ServiceCollection();
+            services.AddDefaultODataServices();
+            var provider = services.BuildServiceProvider();
+            using var scope1 = provider.CreateScope();
+            var settings1 = scope1.ServiceProvider.GetRequiredService<ODataMessageWriterSettings>();
+            settings1.EnableCharactersCheck = true;
+
+            var settings2 = scope1.ServiceProvider.GetRequiredService<ODataMessageWriterSettings>();
+
+            using var scope2 = provider.CreateScope();
+            var settings3 = scope2.ServiceProvider.GetRequiredService<ODataMessageWriterSettings>();
+
+            // Instances from the same scope should be the same
+            Assert.True(object.ReferenceEquals(settings1, settings2));
+            Assert.True(settings2.EnableCharactersCheck);
+            // Instances from different scopes should be different
+            Assert.False(object.ReferenceEquals(settings2, settings3));
+            Assert.False(settings2.EnableCharactersCheck);
+        }
+
         /// <summary>
         /// Tests whether the <see cref="ODataUriParserSettings" /> can be configured using the <see cref="Action{ODataUriParserSettings}" />.
         /// </summary>
@@ -182,6 +228,29 @@ namespace Microsoft.OData.Tests
             var parserSettings = scope.ServiceProvider.GetService<ODataUriParserSettings>();
             Assert.NotNull(parserSettings);
             Assert.Equal(1, parserSettings.MaximumExpansionCount);
+        }
+
+        [Fact]
+        public void AddDefaultODataServices_ODataUriParserSettings_InstancesAreScoped()
+        {
+            var services = new ServiceCollection();
+            services.AddDefaultODataServices();
+            var provider = services.BuildServiceProvider();
+            using var scope1 = provider.CreateScope();
+            var settings1 = scope1.ServiceProvider.GetRequiredService<ODataUriParserSettings>();
+            settings1.EnableParsingKeyAsSegment = false;
+
+            var settings2 = scope1.ServiceProvider.GetRequiredService<ODataUriParserSettings>();
+
+            using var scope2 = provider.CreateScope();
+            var settings3 = scope2.ServiceProvider.GetRequiredService<ODataUriParserSettings>();
+
+            // Instances from the same scope should be the same
+            Assert.True(object.ReferenceEquals(settings1, settings2));
+            Assert.False(settings2.EnableParsingKeyAsSegment);
+            // Instances from different scopes should be different
+            Assert.False(object.ReferenceEquals(settings2, settings3));
+            Assert.True(settings2.EnableParsingKeyAsSegment);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataServiceCollectionExtensionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataServiceCollectionExtensionTests.cs
@@ -155,7 +155,7 @@ namespace Microsoft.OData.Tests
             Assert.True(object.ReferenceEquals(settings, settingsFromSameScope));
             Assert.True(settingsFromSameScope.EnableCharactersCheck);
             // Instances from different scopes should be different
-            Assert.False(object.ReferenceEquals(settingsFromSameScope, settingsFromOtherScope));
+            Assert.False(object.ReferenceEquals(settings, settingsFromOtherScope));
             Assert.False(settingsFromOtherScope.EnableCharactersCheck);
         }
 
@@ -202,7 +202,7 @@ namespace Microsoft.OData.Tests
             Assert.True(object.ReferenceEquals(settings, settingsFromSameScope));
             Assert.True(settingsFromSameScope.EnableCharactersCheck);
             // Instances from different scopes should be different
-            Assert.False(object.ReferenceEquals(settingsFromSameScope, settingsFromOtherScope));
+            Assert.False(object.ReferenceEquals(settings, settingsFromOtherScope));
             Assert.False(settingsFromOtherScope.EnableCharactersCheck);
         }
 
@@ -249,7 +249,7 @@ namespace Microsoft.OData.Tests
             Assert.True(object.ReferenceEquals(settings, settingsFromSameScope));
             Assert.False(settingsFromSameScope.EnableParsingKeyAsSegment);
             // Instances from different scopes should be different
-            Assert.False(object.ReferenceEquals(settingsFromSameScope, settingsFromOtherScope));
+            Assert.False(object.ReferenceEquals(settings, settingsFromOtherScope));
             Assert.True(settingsFromOtherScope.EnableParsingKeyAsSegment);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataServiceCollectionExtensionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataServiceCollectionExtensionTests.cs
@@ -4,11 +4,11 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-using System;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Json;
 using Microsoft.OData.UriParser;
+using System;
 using Xunit;
 
 namespace Microsoft.OData.Tests
@@ -143,20 +143,20 @@ namespace Microsoft.OData.Tests
             services.AddDefaultODataServices();
             var provider = services.BuildServiceProvider();
             using var scope1 = provider.CreateScope();
-            var settings1 = scope1.ServiceProvider.GetRequiredService<ODataMessageReaderSettings>();
-            settings1.EnableCharactersCheck = true;
+            var settings = scope1.ServiceProvider.GetRequiredService<ODataMessageReaderSettings>();
+            settings.EnableCharactersCheck = true;
 
-            var settings2 = scope1.ServiceProvider.GetRequiredService<ODataMessageReaderSettings>();
+            var settingsFromSameScope = scope1.ServiceProvider.GetRequiredService<ODataMessageReaderSettings>();
 
             using var scope2 = provider.CreateScope();
-            var settings3 = scope2.ServiceProvider.GetRequiredService<ODataMessageReaderSettings>();
+            var settingsFromOtherScope = scope2.ServiceProvider.GetRequiredService<ODataMessageReaderSettings>();
             
             // Instances from the same scope should be the same
-            Assert.True(object.ReferenceEquals(settings1, settings2));
-            Assert.True(settings2.EnableCharactersCheck);
+            Assert.True(object.ReferenceEquals(settings, settingsFromSameScope));
+            Assert.True(settingsFromSameScope.EnableCharactersCheck);
             // Instances from different scopes should be different
-            Assert.False(object.ReferenceEquals(settings2, settings3));
-            Assert.False(settings2.EnableCharactersCheck);
+            Assert.False(object.ReferenceEquals(settingsFromSameScope, settingsFromOtherScope));
+            Assert.False(settingsFromOtherScope.EnableCharactersCheck);
         }
 
         /// <summary>
@@ -190,20 +190,20 @@ namespace Microsoft.OData.Tests
             services.AddDefaultODataServices();
             var provider = services.BuildServiceProvider();
             using var scope1 = provider.CreateScope();
-            var settings1 = scope1.ServiceProvider.GetRequiredService<ODataMessageWriterSettings>();
-            settings1.EnableCharactersCheck = true;
+            var settings = scope1.ServiceProvider.GetRequiredService<ODataMessageWriterSettings>();
+            settings.EnableCharactersCheck = true;
 
-            var settings2 = scope1.ServiceProvider.GetRequiredService<ODataMessageWriterSettings>();
+            var settingsFromSameScope = scope1.ServiceProvider.GetRequiredService<ODataMessageWriterSettings>();
 
             using var scope2 = provider.CreateScope();
-            var settings3 = scope2.ServiceProvider.GetRequiredService<ODataMessageWriterSettings>();
+            var settingsFromOtherScope = scope2.ServiceProvider.GetRequiredService<ODataMessageWriterSettings>();
 
             // Instances from the same scope should be the same
-            Assert.True(object.ReferenceEquals(settings1, settings2));
-            Assert.True(settings2.EnableCharactersCheck);
+            Assert.True(object.ReferenceEquals(settings, settingsFromSameScope));
+            Assert.True(settingsFromSameScope.EnableCharactersCheck);
             // Instances from different scopes should be different
-            Assert.False(object.ReferenceEquals(settings2, settings3));
-            Assert.False(settings2.EnableCharactersCheck);
+            Assert.False(object.ReferenceEquals(settingsFromSameScope, settingsFromOtherScope));
+            Assert.False(settingsFromOtherScope.EnableCharactersCheck);
         }
 
         /// <summary>
@@ -237,20 +237,20 @@ namespace Microsoft.OData.Tests
             services.AddDefaultODataServices();
             var provider = services.BuildServiceProvider();
             using var scope1 = provider.CreateScope();
-            var settings1 = scope1.ServiceProvider.GetRequiredService<ODataUriParserSettings>();
-            settings1.EnableParsingKeyAsSegment = false;
+            var settings = scope1.ServiceProvider.GetRequiredService<ODataUriParserSettings>();
+            settings.EnableParsingKeyAsSegment = false;
 
-            var settings2 = scope1.ServiceProvider.GetRequiredService<ODataUriParserSettings>();
+            var settingsFromSameScope = scope1.ServiceProvider.GetRequiredService<ODataUriParserSettings>();
 
             using var scope2 = provider.CreateScope();
-            var settings3 = scope2.ServiceProvider.GetRequiredService<ODataUriParserSettings>();
+            var settingsFromOtherScope = scope2.ServiceProvider.GetRequiredService<ODataUriParserSettings>();
 
             // Instances from the same scope should be the same
-            Assert.True(object.ReferenceEquals(settings1, settings2));
-            Assert.False(settings2.EnableParsingKeyAsSegment);
+            Assert.True(object.ReferenceEquals(settings, settingsFromSameScope));
+            Assert.False(settingsFromSameScope.EnableParsingKeyAsSegment);
             // Instances from different scopes should be different
-            Assert.False(object.ReferenceEquals(settings2, settings3));
-            Assert.True(settings2.EnableParsingKeyAsSegment);
+            Assert.False(object.ReferenceEquals(settingsFromSameScope, settingsFromOtherScope));
+            Assert.True(settingsFromOtherScope.EnableParsingKeyAsSegment);
         }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3070 *

### Description

Clones the reader, writer and URI parser settings when registering them as scoped services in `AddDefaultODataServices()` to ensure that different request scopes get different copies that can be independently modified.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
