### PR TITLE
Fix code coverage analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ obj/
 
 # Test results
 sln/TestResults/
+**/TestResults/
 test/packages/
 *BenchmarkDotNet.Artifacts*
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ obj/
 *.vspscc
 
 # Test results
-sln/TestResults/
 **/TestResults/
 test/packages/
 *BenchmarkDotNet.Artifacts*

--- a/buildandtest.yml
+++ b/buildandtest.yml
@@ -37,15 +37,15 @@ steps:
   displayName: 'Test'
   inputs:
     command: 'test'
-    arguments: '--configuration $(BuildConfiguration) --no-build --collect "Code coverage"'
+    arguments: '--configuration $(buildConfiguration) --settings $(Build.SourcesDirectory)\test.runsettings --no-build --collect "Code Coverage"'
     projects: |      
      $(Build.SourcesDirectory)\sln\OData.Pipeline.sln
 
 - task: DotNetCoreCLI@2
   condition: eq(variables.buildConfiguration, 'Release')
-  displayName: 'Test'
+  displayName: 'Test - Microsoft.OData.Client.E2E.Tests'
   inputs:
     command: 'test'
-    arguments: '--configuration $(buildConfiguration) --collect "Code coverage"'
+    arguments: '--configuration $(buildConfiguration) --settings $(Build.SourcesDirectory)\test.runsettings --collect "Code Coverage"'
     projects: |      
      $(Build.SourcesDirectory)\test\EndToEndTests\Tests\Client\Microsoft.OData.Client.E2E.Tests\Microsoft.OData.Client.E2E.Tests.csproj

--- a/test.runsettings
+++ b/test.runsettings
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <!-- Configurations that affect the Test Framework -->
+  <RunConfiguration>
+  </RunConfiguration>
+  <!-- Configurations for data collectors -->
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <Configuration>
+          <CodeCoverage>
+            <ModulePaths>
+              <Include>
+                <ModulePath>.*Microsoft\.OData\.Core\.dll$</ModulePath>
+                <ModulePath>.*Microsoft\.OData\.Edm\.dll$</ModulePath>
+                <ModulePath>.*Microsoft\.OData\.Client\.dll$</ModulePath>
+                <ModulePath>.*Microsoft\.Spatial\.dll$</ModulePath>
+              </Include>
+			  <Exclude>
+				<ModulePath>.*CPPUnitTestFramework.*</ModulePath>
+			  </Exclude>
+            </ModulePaths>
+            <!-- Match attributes on any code element: -->
+            <!-- https://docs.microsoft.com/en-us/visualstudio/test/customizing-code-coverage-analysis?#sample-runsettings-file -->
+            <Attributes>
+              <Exclude>
+                <!-- Don't forget "Attribute" at the end of the name -->
+                <Attribute>^System\.Diagnostics\.DebuggerHiddenAttribute$</Attribute>
+                <Attribute>^System\.Diagnostics\.DebuggerNonUserCodeAttribute$</Attribute>
+                <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+                <Attribute>^System\.Diagnostics\.CodeAnalysis\.ExcludeFromCodeCoverageAttribute$</Attribute>
+              </Exclude>
+            </Attributes>
+            <!-- We recommend you do not change the following values: -->
+            <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
+            <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
+            <CollectFromChildProcesses>True</CollectFromChildProcesses>
+            <CollectAspDotNet>False</CollectAspDotNet>
+          </CodeCoverage>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+  <!-- Parameters used by tests at runtime -->
+  <TestRunParameters>
+  </TestRunParameters>
+  <!-- Adapter Specific sections -->
+  <!-- MSTest adapter -->
+  <MSTest>
+    <!--<SettingsFile>test.testsettings</SettingsFile>-->
+    <InProcMode>false</InProcMode>
+    <ForcedLegacyMode>false</ForcedLegacyMode>
+    <MapInconclusiveToFailed>false</MapInconclusiveToFailed>
+    <CaptureTraceOutput>false</CaptureTraceOutput>
+    <DeleteDeploymentDirectoryAfterTestRunIsComplete>False</DeleteDeploymentDirectoryAfterTestRunIsComplete>
+  </MSTest>
+</RunSettings>

--- a/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat/Microsoft.Test.OData.PluggableFormat.csproj
+++ b/test/FunctionalTests/Tests/DataOData/Tests/OData.PluggableFormat/Microsoft.Test.OData.PluggableFormat.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="FluentAssertions" Version="4.1.0" />
     <PackageReference Include="EntityFramework" Version="5.0.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.TextTemplating.Interfaces.10.0" Version="10.0.30320" />    
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />

--- a/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DeepInsertE2ETests.cs
+++ b/test/FunctionalTests/Tests/DataServices/UnitTests/Client.TDD.Tests/Tests/DeepInsertE2ETests.cs
@@ -202,7 +202,7 @@ namespace Microsoft.OData.Client.TDDUnitTests.Tests
         [Fact]
         public async Task CallingDeepInsertAsyncRequest_WithUntrackedEntity_ShouldThrowAnInvalidException()
         {
-            Assert.Throws<InvalidOperationException>(delegate { this.context.DeepInsertAsync<Person>(this.person); });
+            await Assert.ThrowsAsync<InvalidOperationException>(() => this.context.DeepInsertAsync<Person>(this.person));
         }
 
         [Fact]

--- a/test/PublicApiTests/Microsoft.OData.PublicApi.Tests.csproj
+++ b/test/PublicApiTests/Microsoft.OData.PublicApi.Tests.csproj
@@ -27,6 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Description

Fix code coverage analysis

Restrict code coverage analysis to only the ODL libraries:
![{C2646442-5390-49A7-9FCA-C110E72E7C34}](https://github.com/user-attachments/assets/3218f113-3832-4824-9fba-a41fa44f4ee7)


### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*
