### PR TITLE
Use ReadOnlySpan<char> to replace the 'new string(...)' to reduce memory allocation

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -596,7 +596,7 @@ namespace Microsoft.OData.UriParser
                         object result;
                         UriTemplateExpression expression;
 
-                        if (enableUriTemplateParsing && UriTemplateParser.TryParseLiteral(lexer.CurrentToken.Text, functionParameter.Type, out expression))
+                        if (enableUriTemplateParsing && UriTemplateParser.TryParseLiteral(lexer.CurrentToken.Span, functionParameter.Type, out expression))
                         {
                             result = expression;
                         }

--- a/src/Microsoft.OData.Core/UriParser/CustomUriLiteralPrefixes.cs
+++ b/src/Microsoft.OData.Core/UriParser/CustomUriLiteralPrefixes.cs
@@ -92,12 +92,13 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         /// <param name="literalPrefix">The literal prefix of the EdmType</param>
         /// <returns>Null if the custom literal prefix has no registered EdmType.</returns>
-        internal static IEdmTypeReference GetEdmTypeByCustomLiteralPrefix(string literalPrefix)
+        internal static IEdmTypeReference GetEdmTypeByCustomLiteralPrefix(ReadOnlySpan<char> literalPrefix)
         {
             lock (Locker)
             {
                 IEdmTypeReference edmTypeReference;
-                if (CustomLiteralPrefixesOfEdmTypes.TryGetValue(literalPrefix, out edmTypeReference))
+                string literal = literalPrefix.ToString();
+                if (CustomLiteralPrefixesOfEdmTypes.TryGetValue(literal, out edmTypeReference))
                 {
                     return edmTypeReference;
                 }

--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexerLiteralExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexerLiteralExtensions.cs
@@ -66,7 +66,7 @@ namespace Microsoft.OData.UriParser
                 return TryParseLiteral(expressionLexer);
             }
 
-            throw new ODataException(ODataErrorStrings.ExpressionLexer_ExpectedLiteralToken(expressionLexer.CurrentToken.Text));
+            throw new ODataException(ODataErrorStrings.ExpressionLexer_ExpectedLiteralToken(expressionLexer.CurrentToken.Text.ToString()));
         }
 
         /// <summary>
@@ -92,7 +92,8 @@ namespace Microsoft.OData.UriParser
         private static object ParseTypedLiteral(this ExpressionLexer expressionLexer, IEdmTypeReference targetTypeReference)
         {
             UriLiteralParsingException typeParsingException;
-            object targetValue = DefaultUriLiteralParser.Instance.ParseUriStringToType(expressionLexer.CurrentToken.Text, targetTypeReference, out typeParsingException);
+            string tokenText = expressionLexer.CurrentToken.Text.ToString();
+            object targetValue = DefaultUriLiteralParser.Instance.ParseUriStringToType(tokenText, targetTypeReference, out typeParsingException);
             if (targetValue == null)
             {
                 string message;
@@ -101,7 +102,7 @@ namespace Microsoft.OData.UriParser
                 {
                     message = ODataErrorStrings.UriQueryExpressionParser_UnrecognizedLiteral(
                         targetTypeReference.FullName(),
-                        expressionLexer.CurrentToken.Text,
+                        tokenText,
                         expressionLexer.CurrentToken.Position,
                         expressionLexer.ExpressionText);
 
@@ -111,7 +112,7 @@ namespace Microsoft.OData.UriParser
                 {
                     message = ODataErrorStrings.UriQueryExpressionParser_UnrecognizedLiteralWithReason(
                         targetTypeReference.FullName(),
-                        expressionLexer.CurrentToken.Text,
+                        tokenText,
                         expressionLexer.CurrentToken.Position,
                         expressionLexer.ExpressionText,
                         typeParsingException.Message);

--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexerUtils.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexerUtils.cs
@@ -46,7 +46,7 @@ namespace Microsoft.OData.Service.Parsing
         /// </summary>
         /// <param name="tokenText">Input token.</param>
         /// <returns>true if match found, false otherwise.</returns>
-        internal static bool IsInfinityOrNaNDouble(string tokenText)
+        internal static bool IsInfinityOrNaNDouble(ReadOnlySpan<char> tokenText)
         {
             Debug.Assert(tokenText != null, "tokenText != null");
 
@@ -62,7 +62,7 @@ namespace Microsoft.OData.Service.Parsing
                 {
                     if (tokenText[0] == ExpressionConstants.NaNLiteral[0])
                     {
-                        return String.CompareOrdinal(tokenText, 0, ExpressionConstants.NaNLiteral, 0, 3) == 0;
+                        return tokenText.Slice(0, 3).Equals(ExpressionConstants.NaNLiteral, StringComparison.Ordinal);
                     }
                 }
             }
@@ -76,13 +76,14 @@ namespace Microsoft.OData.Service.Parsing
         /// </summary>
         /// <param name="text">Text to look in.</param>
         /// <returns>true if the substring is equal using an ordinal comparison; false otherwise.</returns>
-        internal static bool IsInfinityLiteralDouble(string text)
+        internal static bool IsInfinityLiteralDouble(ReadOnlySpan<char> text)
         {
             Debug.Assert(text != null, "text != null");
 
             // COMPAT 30 - INFd/INFD and NaNd/NaND are rejected as Edm.Double literals
             // For now we behave exactly the same as WCF DS, we should consider "fixing" this bug in ODataLib, but it is technically a breaking change!
-            return String.CompareOrdinal(text, 0, ExpressionConstants.InfinityLiteral, 0, text.Length) == 0;
+
+            return text.Equals(ExpressionConstants.InfinityLiteral, StringComparison.Ordinal);
         }
 
         /// <summary>
@@ -91,7 +92,7 @@ namespace Microsoft.OData.Service.Parsing
         /// </summary>
         /// <param name="tokenText">Input token.</param>
         /// <returns>true if match found, false otherwise.</returns>
-        internal static bool IsInfinityOrNanSingle(string tokenText)
+        internal static bool IsInfinityOrNanSingle(ReadOnlySpan<char> tokenText)
         {
             Debug.Assert(tokenText != null, "tokenText != null");
 
@@ -104,7 +105,7 @@ namespace Microsoft.OData.Service.Parsing
                 else if (tokenText[0] == ExpressionConstants.NaNLiteral[0])
                 {
                     return (tokenText[3] == SingleSuffixLower || tokenText[3] == SingleSuffixUpper) &&
-                            String.CompareOrdinal(tokenText, 0, ExpressionConstants.NaNLiteral, 0, 3) == 0;
+                        tokenText.Slice(0, 3).Equals(ExpressionConstants.NaNLiteral, StringComparison.Ordinal);
                 }
             }
 
@@ -117,12 +118,12 @@ namespace Microsoft.OData.Service.Parsing
         /// </summary>
         /// <param name="text">Text to look in.</param>
         /// <returns>true if the substring is equal using an ordinal comparison; false otherwise.</returns>
-        internal static bool IsInfinityLiteralSingle(string text)
+        internal static bool IsInfinityLiteralSingle(ReadOnlySpan<char> text)
         {
             Debug.Assert(text != null, "text != null");
             return text.Length == 4 &&
                    (text[3] == SingleSuffixLower || text[3] == SingleSuffixUpper) &&
-                   String.CompareOrdinal(text, 0, ExpressionConstants.InfinityLiteral, 0, 3) == 0;
+                   text.Slice(0, 3).Equals(ExpressionConstants.InfinityLiteral, StringComparison.Ordinal);
         }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/CountSegmentParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/CountSegmentParser.cs
@@ -82,8 +82,8 @@ namespace Microsoft.OData.UriParser
                 while (this.lexer.CurrentToken.Kind != ExpressionTokenKind.CloseParen)
                 {
                     string text = this.UriQueryExpressionParser.EnableCaseInsensitiveBuiltinIdentifier
-                        ? this.lexer.CurrentToken.Text.ToLowerInvariant()
-                        : this.lexer.CurrentToken.Text;
+                        ? this.lexer.CurrentToken.Text.ToString().ToLowerInvariant()
+                        : this.lexer.CurrentToken.Text.ToString();
 
                     // Prepend '$' prefix if needed.
                     if (this.UriQueryExpressionParser.EnableNoDollarQueryOptions && !text.StartsWith(UriQueryConstants.DollarSign, StringComparison.Ordinal))

--- a/src/Microsoft.OData.Core/UriParser/Parsers/CountSegmentParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/CountSegmentParser.cs
@@ -78,33 +78,30 @@ namespace Microsoft.OData.UriParser
                     throw new ODataException(ODataErrorStrings.UriParser_EmptyParenthesis);
                 }
 
+                StringComparison comparison = this.UriQueryExpressionParser.EnableCaseInsensitiveBuiltinIdentifier ?
+                        StringComparison.OrdinalIgnoreCase :
+                        StringComparison.Ordinal;
+
                 // Look for all the supported query options
                 while (this.lexer.CurrentToken.Kind != ExpressionTokenKind.CloseParen)
                 {
-                    string text = this.UriQueryExpressionParser.EnableCaseInsensitiveBuiltinIdentifier
-                        ? this.lexer.CurrentToken.Text.ToString().ToLowerInvariant()
-                        : this.lexer.CurrentToken.Text.ToString();
+                    ReadOnlySpan<char> textSpan = this.lexer.CurrentToken.Span;
 
-                    // Prepend '$' prefix if needed.
-                    if (this.UriQueryExpressionParser.EnableNoDollarQueryOptions && !text.StartsWith(UriQueryConstants.DollarSign, StringComparison.Ordinal))
+                    if (textSpan.Equals(ExpressionConstants.QueryOptionFilter, comparison) ||
+                        (this.UriQueryExpressionParser.EnableNoDollarQueryOptions && textSpan.Equals("filter", comparison)))
                     {
-                        text = string.Format(CultureInfo.InvariantCulture, "{0}{1}", UriQueryConstants.DollarSign, text);
+                        // $filter within $count segment
+                        filterToken = ParseInnerFilter();
                     }
-
-                    switch (text)
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionSearch, comparison) ||
+                        (this.UriQueryExpressionParser.EnableNoDollarQueryOptions && textSpan.Equals("search", comparison)))
                     {
-                        case ExpressionConstants.QueryOptionFilter: // $filter within $count segment
-                            filterToken = ParseInnerFilter();
-                            break;
-
-                        case ExpressionConstants.QueryOptionSearch: // $search within $count segment
-                            searchToken = ParseInnerSearch();
-                            break;
-
-                        default:
-                            {
-                                throw new ODataException(ODataErrorStrings.UriQueryExpressionParser_IllegalQueryOptioninDollarCount);
-                            }
+                        // $search within $count segment
+                        searchToken = ParseInnerSearch();
+                    }
+                    else
+                    {
+                        throw new ODataException(ODataErrorStrings.UriQueryExpressionParser_IllegalQueryOptioninDollarCount);
                     }
                 }
             }

--- a/src/Microsoft.OData.Core/UriParser/Parsers/FunctionCallParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/FunctionCallParser.cs
@@ -85,7 +85,7 @@ namespace Microsoft.OData.UriParser
         public bool TryParseIdentifierAsFunction(QueryToken parent, out QueryToken result)
         {
             result = null;
-            string functionName;
+            ReadOnlySpan<char> functionName;
 
             ExpressionLexer.ExpressionLexerPosition position = lexer.SnapshotPosition();
 
@@ -97,14 +97,14 @@ namespace Microsoft.OData.UriParser
             else
             {
                 Debug.Assert(this.Lexer.CurrentToken.Kind == ExpressionTokenKind.Identifier, "Only identifier tokens can be treated as function calls.");
-                functionName = this.Lexer.CurrentToken.Text;
+                functionName = this.Lexer.CurrentToken.Span;
                 this.Lexer.NextToken();
             }
 
             FunctionParameterToken[] arguments = this.ParseArgumentListOrEntityKeyList(() => lexer.RestorePosition(position));
             if (arguments != null)
             {
-                result = new FunctionCallToken(functionName, arguments, parent);
+                result = new FunctionCallToken(functionName.ToString(), arguments, parent);
             }
 
             return result != null;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/FunctionParameterParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/FunctionParameterParser.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.OData.UriParser
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
@@ -78,7 +79,7 @@ namespace Microsoft.OData.UriParser
             while (currentToken.Kind != endTokenKind)
             {
                 lexer.ValidateToken(ExpressionTokenKind.Identifier);
-                string identifier = lexer.CurrentToken.GetIdentifier();
+                ReadOnlySpan<char> identifier = lexer.CurrentToken.GetIdentifier();
                 lexer.NextToken();
 
                 lexer.ValidateToken(ExpressionTokenKind.Equal);
@@ -89,7 +90,7 @@ namespace Microsoft.OData.UriParser
                 //      parameterValue = arrayOrObject
                 //                       / commonExpr
                 QueryToken parameterValue = parser.ParseExpression();
-                parameters.Add(new FunctionParameterToken(identifier, parameterValue));
+                parameters.Add(new FunctionParameterToken(identifier.ToString(), parameterValue));
 
                 // the above parser.ParseExpression() already moves to the next token, now get CurrentToken checking a comma followed by something
                 currentToken = lexer.CurrentToken;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/IdentifierTokenizer.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/IdentifierTokenizer.cs
@@ -68,7 +68,7 @@ namespace Microsoft.OData.UriParser
 
             if (this.lexer.PeekNextToken().Kind == ExpressionTokenKind.Dot)
             {
-                string fullIdentifier = this.lexer.ReadDottedIdentifier(false);
+                string fullIdentifier = this.lexer.ReadDottedIdentifier(false).ToString();
                 return new DottedIdentifierToken(fullIdentifier, parent);
             }
 
@@ -82,12 +82,12 @@ namespace Microsoft.OData.UriParser
         /// <returns>The lexical token representing the expression.</returns>
         public QueryToken ParseMemberAccess(QueryToken instance)
         {
-            if (this.lexer.CurrentToken.Text == UriQueryConstants.Star)
+            if (this.lexer.CurrentToken.Span.Equals(UriQueryConstants.Star, StringComparison.Ordinal))
             {
                 return this.ParseStarMemberAccess(instance);
             }
 
-            string identifier = this.lexer.CurrentToken.GetIdentifier();
+            string identifier = this.lexer.CurrentToken.GetIdentifier().ToString();
             if (instance == null && this.parameters.Contains(identifier))
             {
                 this.lexer.NextToken();
@@ -105,9 +105,9 @@ namespace Microsoft.OData.UriParser
         /// <returns>The lexical token representing the expression.</returns>
         public QueryToken ParseStarMemberAccess(QueryToken instance)
         {
-            if (this.lexer.CurrentToken.Text != UriQueryConstants.Star)
+            if (!this.lexer.CurrentToken.Span.Equals(UriQueryConstants.Star, StringComparison.Ordinal))
             {
-                throw ParseError(ODataErrorStrings.UriQueryExpressionParser_CannotCreateStarTokenFromNonStar(this.lexer.CurrentToken.Text));
+                throw ParseError(ODataErrorStrings.UriQueryExpressionParser_CannotCreateStarTokenFromNonStar(this.lexer.CurrentToken.Text.ToString()));
             }
 
             this.lexer.NextToken();

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SearchParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SearchParser.cs
@@ -163,7 +163,7 @@ namespace Microsoft.OData.UriParser
                     expr = this.ParseParenExpression();
                     break;
                 case ExpressionTokenKind.StringLiteral:
-                    expr = new StringLiteralToken(this.lexer.CurrentToken.Text);
+                    expr = new StringLiteralToken(this.lexer.CurrentToken.Text.ToString());
                     this.lexer.NextToken();
                     break;
                 default:

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
@@ -137,8 +137,8 @@ namespace Microsoft.OData.UriParser
                 while (this.lexer.CurrentToken.Kind != ExpressionTokenKind.CloseParen)
                 {
                     string text = this.enableCaseInsensitiveBuiltinIdentifier
-                        ? this.lexer.CurrentToken.Text.ToLowerInvariant()
-                        : this.lexer.CurrentToken.Text;
+                        ? this.lexer.CurrentToken.Text.ToString().ToLowerInvariant()
+                        : this.lexer.CurrentToken.Text.ToString();
 
                     // Prepend '$' prefix if needed.
                     if (this.enableNoDollarQueryOptions && !text.StartsWith(UriQueryConstants.DollarSign, StringComparison.Ordinal))
@@ -243,8 +243,8 @@ namespace Microsoft.OData.UriParser
                 while (this.lexer.CurrentToken.Kind != ExpressionTokenKind.CloseParen)
                 {
                     string text = this.enableCaseInsensitiveBuiltinIdentifier
-                        ? this.lexer.CurrentToken.Text.ToLowerInvariant()
-                        : this.lexer.CurrentToken.Text;
+                        ? this.lexer.CurrentToken.Text.ToString().ToLowerInvariant()
+                        : this.lexer.CurrentToken.Text.ToString();
 
                     // Prepend '$' prefix if needed.
                     if (this.enableNoDollarQueryOptions && !text.StartsWith(UriQueryConstants.DollarSign, StringComparison.Ordinal))
@@ -371,8 +371,8 @@ namespace Microsoft.OData.UriParser
                 while (this.lexer.CurrentToken.Kind != ExpressionTokenKind.CloseParen)
                 {
                     string text = this.enableCaseInsensitiveBuiltinIdentifier
-                        ? this.lexer.CurrentToken.Text.ToLowerInvariant()
-                        : this.lexer.CurrentToken.Text;
+                        ? this.lexer.CurrentToken.Text.ToString().ToLowerInvariant()
+                        : this.lexer.CurrentToken.Text.ToString();
                     switch (text)
                     {
                         case ExpressionConstants.QueryOptionLevels:

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandOptionParser.cs
@@ -133,55 +133,56 @@ namespace Microsoft.OData.UriParser
                     throw new ODataException(ODataErrorStrings.UriParser_MissingSelectOption(pathToken.Identifier));
                 }
 
+                StringComparison comparison = this.enableCaseInsensitiveBuiltinIdentifier ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
                 // Look for all the supported query options
                 while (this.lexer.CurrentToken.Kind != ExpressionTokenKind.CloseParen)
                 {
-                    string text = this.enableCaseInsensitiveBuiltinIdentifier
-                        ? this.lexer.CurrentToken.Text.ToString().ToLowerInvariant()
-                        : this.lexer.CurrentToken.Text.ToString();
+                    ReadOnlySpan<char> textSpan = this.lexer.CurrentToken.Span;
 
-                    // Prepend '$' prefix if needed.
-                    if (this.enableNoDollarQueryOptions && !text.StartsWith(UriQueryConstants.DollarSign, StringComparison.Ordinal))
+                    if (textSpan.Equals(ExpressionConstants.QueryOptionFilter, comparison) ||
+                       (this.enableNoDollarQueryOptions && textSpan.Equals("filter", comparison)))
                     {
-                        text = string.Format(CultureInfo.InvariantCulture, "{0}{1}", UriQueryConstants.DollarSign, text);
+                        filterOption = ParseInnerFilter();
                     }
-
-                    switch (text)
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionOrderby, comparison) ||
+                       (this.enableNoDollarQueryOptions && textSpan.Equals("orderby", comparison)))
                     {
-                        case ExpressionConstants.QueryOptionFilter: // inner $filter
-                            filterOption = ParseInnerFilter();
-                            break;
-
-                        case ExpressionConstants.QueryOptionOrderby: // inner $orderby
-                            orderByOptions = ParseInnerOrderBy();
-                            break;
-
-                        case ExpressionConstants.QueryOptionTop: // inner $top
-                            topOption = ParseInnerTop();
-                            break;
-
-                        case ExpressionConstants.QueryOptionSkip: // innner $skip
-                            skipOption = ParseInnerSkip();
-                            break;
-
-                        case ExpressionConstants.QueryOptionCount: // inner $count
-                            countOption = ParseInnerCount();
-                            break;
-
-                        case ExpressionConstants.QueryOptionSearch: // inner $search
-                            searchOption = ParseInnerSearch();
-                            break;
-
-                        case ExpressionConstants.QueryOptionSelect: // inner $select
-                            selectOption = ParseInnerSelect(pathToken);
-                            break;
-
-                        case ExpressionConstants.QueryOptionCompute: // inner $compute
-                            computeOption = ParseInnerCompute();
-                            break;
-
-                        default:
-                            throw new ODataException(ODataErrorStrings.UriSelectParser_TermIsNotValid(this.lexer.ExpressionText));
+                        orderByOptions = ParseInnerOrderBy();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionTop, comparison) ||
+                       (this.enableNoDollarQueryOptions && textSpan.Equals("top", comparison)))
+                    {
+                        topOption = ParseInnerTop();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionSkip, comparison) ||
+                       (this.enableNoDollarQueryOptions && textSpan.Equals("skip", comparison)))
+                    {
+                        skipOption = ParseInnerSkip();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionCount, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("count", comparison)))
+                    {
+                        countOption = ParseInnerCount();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionSearch, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("search", comparison)))
+                    {
+                        searchOption = ParseInnerSearch();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionSelect, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("select", comparison)))
+                    {
+                        selectOption = ParseInnerSelect(pathToken);
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionCompute, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("compute", comparison)))
+                    {
+                        computeOption = ParseInnerCompute();
+                    }
+                    else
+                    {
+                        throw new ODataException(ODataErrorStrings.UriSelectParser_TermIsNotValid(this.lexer.ExpressionText));
                     }
                 }
 
@@ -239,69 +240,71 @@ namespace Microsoft.OData.UriParser
                     throw new ODataException(ODataErrorStrings.UriParser_MissingExpandOption(pathToken.Identifier));
                 }
 
+                StringComparison comparison = this.enableCaseInsensitiveBuiltinIdentifier ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
                 // Look for all the supported query options
                 while (this.lexer.CurrentToken.Kind != ExpressionTokenKind.CloseParen)
                 {
-                    string text = this.enableCaseInsensitiveBuiltinIdentifier
-                        ? this.lexer.CurrentToken.Text.ToString().ToLowerInvariant()
-                        : this.lexer.CurrentToken.Text.ToString();
+                    ReadOnlySpan<char> textSpan = this.lexer.CurrentToken.Span;
 
-                    // Prepend '$' prefix if needed.
-                    if (this.enableNoDollarQueryOptions && !text.StartsWith(UriQueryConstants.DollarSign, StringComparison.Ordinal))
+                    if (textSpan.Equals(ExpressionConstants.QueryOptionFilter, comparison) ||
+                       (this.enableNoDollarQueryOptions && textSpan.Equals("filter", comparison)))
                     {
-                        text = string.Format(CultureInfo.InvariantCulture, "{0}{1}", UriQueryConstants.DollarSign, text);
+                        filterOption = ParseInnerFilter();
                     }
-
-                    switch (text)
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionOrderby, comparison) ||
+                       (this.enableNoDollarQueryOptions && textSpan.Equals("orderby", comparison)))
                     {
-                        case ExpressionConstants.QueryOptionFilter: // inner $filter
-                            filterOption = ParseInnerFilter();
-                            break;
-
-                        case ExpressionConstants.QueryOptionOrderby: // inner $orderby
-                            orderByOptions = ParseInnerOrderBy();
-                            break;
-
-                        case ExpressionConstants.QueryOptionTop: // inner $top
-                            topOption = ParseInnerTop();
-                            break;
-
-                        case ExpressionConstants.QueryOptionSkip: // inner $skip
-                            skipOption = ParseInnerSkip();
-                            break;
-
-                        case ExpressionConstants.QueryOptionCount: // inner $count
-                            countOption = ParseInnerCount();
-                            break;
-
-                        case ExpressionConstants.QueryOptionSearch: // inner $search
-                            searchOption = ParseInnerSearch();
-                            break;
-
-                        case ExpressionConstants.QueryOptionLevels: // inner $level
-                            levelsOption = ParseInnerLevel();
-                            break;
-
-                        case ExpressionConstants.QueryOptionSelect: // inner $select
-                            selectOption = ParseInnerSelect(pathToken);
-                            break;
-
-                        case ExpressionConstants.QueryOptionExpand: // inner $expand
-                            expandOption = ParseInnerExpand(pathToken);
-                            break;
-
-                        case ExpressionConstants.QueryOptionCompute: // inner $compute
-                            computeOption = ParseInnerCompute();
-                            break;
-
-                        case ExpressionConstants.QueryOptionApply: // inner $apply
-                            applyOptions = ParseInnerApply();
-                            break;
-
-                        default:
-                            {
-                                throw new ODataException(ODataErrorStrings.UriSelectParser_TermIsNotValid(this.lexer.ExpressionText));
-                            }
+                        orderByOptions = ParseInnerOrderBy();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionTop, comparison) ||
+                       (this.enableNoDollarQueryOptions && textSpan.Equals("top", comparison)))
+                    {
+                        topOption = ParseInnerTop();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionSkip, comparison) ||
+                       (this.enableNoDollarQueryOptions && textSpan.Equals("skip", comparison)))
+                    {
+                        skipOption = ParseInnerSkip();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionCount, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("count", comparison)))
+                    {
+                        countOption = ParseInnerCount();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionSearch, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("search", comparison)))
+                    {
+                        searchOption = ParseInnerSearch();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionLevels, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("levels", comparison)))
+                    {
+                        levelsOption = ParseInnerLevel();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionSelect, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("select", comparison)))
+                    {
+                        selectOption = ParseInnerSelect(pathToken);
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionExpand, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("expand", comparison)))
+                    {
+                        expandOption = ParseInnerExpand(pathToken);
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionCompute, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("compute", comparison)))
+                    {
+                        computeOption = ParseInnerCompute();
+                    }
+                    else if (textSpan.Equals(ExpressionConstants.QueryOptionApply, comparison) ||
+                      (this.enableNoDollarQueryOptions && textSpan.Equals("apply", comparison)))
+                    {
+                        applyOptions = ParseInnerApply();
+                    }
+                    else
+                    {
+                        throw new ODataException(ODataErrorStrings.UriSelectParser_TermIsNotValid(this.lexer.ExpressionText));
                     }
                 }
 

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriTemplateParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriTemplateParser.cs
@@ -26,6 +26,13 @@ namespace Microsoft.OData.UriParser
                 && literalText.EndsWith("}", StringComparison.Ordinal));
         }
 
+        internal static bool IsValidTemplateLiteral(ReadOnlySpan<char> literalText)
+        {
+            return !literalText.IsEmpty
+                && literalText.StartsWith("{", StringComparison.Ordinal)
+                && literalText.EndsWith("}", StringComparison.Ordinal);
+        }
+
         /// <summary>
         /// Parse a literal as Uri template.
         /// </summary>
@@ -38,6 +45,18 @@ namespace Microsoft.OData.UriParser
             if (IsValidTemplateLiteral(literalText))
             {
                 expression = new UriTemplateExpression { LiteralText = literalText, ExpectedType = expectedType };
+                return true;
+            }
+
+            expression = null;
+            return false;
+        }
+
+        internal static bool TryParseLiteral(ReadOnlySpan<char> literalText, IEdmTypeReference expectedType, out UriTemplateExpression expression)
+        {
+            if (IsValidTemplateLiteral(literalText))
+            {
+                expression = new UriTemplateExpression { LiteralText = literalText.ToString(), ExpectedType = expectedType };
                 return true;
             }
 

--- a/src/PlatformHelper.cs
+++ b/src/PlatformHelper.cs
@@ -208,7 +208,7 @@ namespace Microsoft.OData.Edm
         /// <param name="text">String to be converted.</param>
         /// <param name="date">The converted date value</param>
         /// <returns>if parsing was successful</returns>
-        internal static bool TryConvertStringToDate(string text, out Date date)
+        internal static bool TryConvertStringToDate(ReadOnlySpan<char> text, out Date date)
         {
             date = default(Date);
             if (text == null || !PlatformHelper.DateValidator.IsMatch(text))
@@ -216,7 +216,9 @@ namespace Microsoft.OData.Edm
                 return false;
             }
 
-            return Date.TryParse(text, CultureInfo.InvariantCulture, out date);
+            bool b = DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateTime);
+            date = dateTime;
+            return b;
         }
 
         /// <summary>
@@ -241,7 +243,7 @@ namespace Microsoft.OData.Edm
         /// <param name="text">String to be converted.</param>
         /// <param name="timeOfDay">Time of the day</param>
         /// <returns>Whether the value is a valid time of day</returns>
-        internal static bool TryConvertStringToTimeOfDay(string text, out TimeOfDay timeOfDay)
+        internal static bool TryConvertStringToTimeOfDay(ReadOnlySpan<char> text, out TimeOfDay timeOfDay)
         {
             timeOfDay = default(TimeOfDay);
             if (text == null || !PlatformHelper.TimeOfDayValidator.IsMatch(text))
@@ -249,7 +251,15 @@ namespace Microsoft.OData.Edm
                 return false;
             }
 
-            return TimeOfDay.TryParse(text, CultureInfo.InvariantCulture, out timeOfDay);
+            TimeSpan time;
+            bool b = TimeSpan.TryParse(text, CultureInfo.InvariantCulture, out time);
+            if (b && time.Ticks >= TimeOfDay.MinTickValue && time.Ticks <= TimeOfDay.MaxTickValue)
+            {
+                timeOfDay = new TimeOfDay(time.Ticks);
+                return true;
+            }
+
+            return false;
         }
 
         /// <summary>
@@ -274,13 +284,13 @@ namespace Microsoft.OData.Edm
         /// </summary>
         /// <param name="text">String to be converted.</param>
         /// <returns>See documentation for method being accessed in the body of the method.</returns>
-        internal static DateTimeOffset ConvertStringToDateTimeOffset(string text)
+        internal static DateTimeOffset ConvertStringToDateTimeOffset(ReadOnlySpan<char> text)
         {
-            text = AddSecondsPaddingIfMissing(text);
-            DateTimeOffset dateTimeOffset = XmlConvert.ToDateTimeOffset(text);
+            string updatedText = AddSecondsPaddingIfMissing(text);
+            DateTimeOffset dateTimeOffset = XmlConvert.ToDateTimeOffset(updatedText);
 
             // Validate the time zone after we know that the text is a valid date time offset string.
-            ValidateTimeZoneInformationInDateTimeOffsetString(text);
+            ValidateTimeZoneInformationInDateTimeOffsetString(updatedText);
 
             return dateTimeOffset;
         }
@@ -322,7 +332,7 @@ namespace Microsoft.OData.Edm
         /// </summary>
         /// <param name="text">String to be validated.</param>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Code is shared among multiple assemblies and this method should be available as a helper in case it is needed in new code.")]
-        private static void ValidateTimeZoneInformationInDateTimeOffsetString(string text)
+        private static void ValidateTimeZoneInformationInDateTimeOffsetString(ReadOnlySpan<char> text)
         {
 
             // The XML DateTime pattern is described here: http://www.w3.org/TR/xmlschema-2/#dateTime
@@ -342,7 +352,7 @@ namespace Microsoft.OData.Edm
             }
 
             // No timezone specified, for example: "2012-12-21T15:01:23.1234567"
-            throw new FormatException(Strings.PlatformHelper_DateTimeOffsetMustContainTimeZone(text));
+            throw new FormatException(Strings.PlatformHelper_DateTimeOffsetMustContainTimeZone(text.ToString()));
         }
 
         /// <summary>
@@ -350,9 +360,9 @@ namespace Microsoft.OData.Edm
         /// </summary>
         /// <param name="text">String that needs seconds padding</param>
         /// <returns>DateTime string after adding seconds padding</returns>
-        internal static string AddSecondsPaddingIfMissing(string text)
+        internal static string AddSecondsPaddingIfMissing(ReadOnlySpan<char> text)
         {
-            int indexOfT = text.IndexOf("T", System.StringComparison.Ordinal);
+            int indexOfT = text.IndexOf("T", StringComparison.Ordinal);
             const int ColonBeforeSecondsOffset = 6;
             int indexOfColonBeforeSeconds = indexOfT + ColonBeforeSecondsOffset;
 
@@ -360,10 +370,10 @@ namespace Microsoft.OData.Edm
             if (indexOfT > 0 &&
                 (text.Length == indexOfColonBeforeSeconds || text.Length > indexOfColonBeforeSeconds && text[indexOfColonBeforeSeconds] != ':'))
             {
-                text = text.Insert(indexOfColonBeforeSeconds, ":00");
+                return text.ToString().Insert(indexOfColonBeforeSeconds, ":00");
             }
 
-            return text;
+            return text.ToString();
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -17,19 +17,19 @@ namespace Microsoft.OData.Tests.UriParser
 {
     public class ExpressionLexerTests
     {
-        private static readonly ExpressionToken CommaToken = new ExpressionToken() { Kind = ExpressionTokenKind.Comma, Text = "," };
-        private static readonly ExpressionToken OpenParenToken = new ExpressionToken() { Kind = ExpressionTokenKind.OpenParen, Text = "(" };
-        private static readonly ExpressionToken CloseParenToken = new ExpressionToken() { Kind = ExpressionTokenKind.CloseParen, Text = ")" };
-        private static readonly ExpressionToken EqualsToken = new ExpressionToken() { Kind = ExpressionTokenKind.Equal, Text = "=" };
-        private static readonly ExpressionToken SemiColonToken = new ExpressionToken() { Kind = ExpressionTokenKind.SemiColon, Text = ";" };
-        private static readonly ExpressionToken MinusToken = new ExpressionToken() { Kind = ExpressionTokenKind.Minus, Text = "-" };
-        private static readonly ExpressionToken SlashToken = new ExpressionToken() { Kind = ExpressionTokenKind.Slash, Text = "/" };
-        private static readonly ExpressionToken QuestionToken = new ExpressionToken() { Kind = ExpressionTokenKind.Question, Text = "?" };
-        private static readonly ExpressionToken DotToken = new ExpressionToken() { Kind = ExpressionTokenKind.Dot, Text = "." };
-        private static readonly ExpressionToken StarToken = new ExpressionToken() { Kind = ExpressionTokenKind.Star, Text = "*" };
-        private static readonly ExpressionToken ColonToken = new ExpressionToken() { Kind = ExpressionTokenKind.Colon, Text = ":" };
-        private static readonly ExpressionToken ItToken = new ExpressionToken() { Kind = ExpressionTokenKind.Identifier, Text = "$it" };
-        private static readonly ExpressionToken NullLiteralToken = new ExpressionToken() { Kind = ExpressionTokenKind.NullLiteral, Text = "null" };
+        private static readonly ExpressionToken CommaToken = new ExpressionToken() { Kind = ExpressionTokenKind.Comma, Text = ",".AsMemory() };
+        private static readonly ExpressionToken OpenParenToken = new ExpressionToken() { Kind = ExpressionTokenKind.OpenParen, Text = "(".AsMemory() };
+        private static readonly ExpressionToken CloseParenToken = new ExpressionToken() { Kind = ExpressionTokenKind.CloseParen, Text = ")".AsMemory() };
+        private static readonly ExpressionToken EqualsToken = new ExpressionToken() { Kind = ExpressionTokenKind.Equal, Text = "=".AsMemory() };
+        private static readonly ExpressionToken SemiColonToken = new ExpressionToken() { Kind = ExpressionTokenKind.SemiColon, Text = ";".AsMemory() };
+        private static readonly ExpressionToken MinusToken = new ExpressionToken() { Kind = ExpressionTokenKind.Minus, Text = "-".AsMemory() };
+        private static readonly ExpressionToken SlashToken = new ExpressionToken() { Kind = ExpressionTokenKind.Slash, Text = "/".AsMemory() };
+        private static readonly ExpressionToken QuestionToken = new ExpressionToken() { Kind = ExpressionTokenKind.Question, Text = "?".AsMemory() };
+        private static readonly ExpressionToken DotToken = new ExpressionToken() { Kind = ExpressionTokenKind.Dot, Text = ".".AsMemory() };
+        private static readonly ExpressionToken StarToken = new ExpressionToken() { Kind = ExpressionTokenKind.Star, Text = "*".AsMemory() };
+        private static readonly ExpressionToken ColonToken = new ExpressionToken() { Kind = ExpressionTokenKind.Colon, Text = ":".AsMemory() };
+        private static readonly ExpressionToken ItToken = new ExpressionToken() { Kind = ExpressionTokenKind.Identifier, Text = "$it".AsMemory() };
+        private static readonly ExpressionToken NullLiteralToken = new ExpressionToken() { Kind = ExpressionTokenKind.NullLiteral, Text = "null".AsMemory() };
 
         // internal static bool IsNumeric(ExpressionTokenKind id) tests
         [Fact]
@@ -233,7 +233,7 @@ namespace Microsoft.OData.Tests.UriParser
             ExpressionToken result = lexer.NextToken();
             Assert.Equal(ExpressionTokenKind.IntegerLiteral, result.Kind);
             Assert.Equal(result, lexer.CurrentToken);
-            Assert.Equal("5", result.Text);
+            Assert.Equal("5", result.Span.ToString());
         }
 
         [Fact]
@@ -341,7 +341,7 @@ namespace Microsoft.OData.Tests.UriParser
         public void ShouldReturnStringIdentifierWhenGivenIdentifierToken()
         {
             ExpressionLexer lexer = new ExpressionLexer("misomethingk", true, false);
-            string result = lexer.ReadDottedIdentifier(false);
+            string result = lexer.ReadDottedIdentifier(false).ToString();
             Assert.Equal("misomethingk", result);
         }
 
@@ -349,7 +349,7 @@ namespace Microsoft.OData.Tests.UriParser
         public void ShouldReturnStringIdentifierWhenGivenIdentifierTokenContainingDot()
         {
             ExpressionLexer lexer = new ExpressionLexer("m.i.something.k", true, false);
-            string result = lexer.ReadDottedIdentifier(false);
+            string result = lexer.ReadDottedIdentifier(false).ToString();
             Assert.Equal("m.i.something.k", result);
         }
 
@@ -357,7 +357,7 @@ namespace Microsoft.OData.Tests.UriParser
         public void ShouldReturnStringIdentifierWhenGivenIdentifierTokenContainingWhitespace()
         {
             ExpressionLexer lexer = new ExpressionLexer("    m.i.something.k", true, false);
-            string result = lexer.ReadDottedIdentifier(false);
+            string result = lexer.ReadDottedIdentifier(false).ToString();
             Assert.Equal("m.i.something.k", result);
         }
 
@@ -373,7 +373,7 @@ namespace Microsoft.OData.Tests.UriParser
         public void ShouldNotThrowWhenGivenStarInAcceptStarMode()
         {
             ExpressionLexer lexer = new ExpressionLexer("m.*", true, false);
-            string result = lexer.ReadDottedIdentifier(true);
+            string result = lexer.ReadDottedIdentifier(true).ToString();
             Assert.Equal("m.*", result);
         }
 
@@ -532,7 +532,7 @@ namespace Microsoft.OData.Tests.UriParser
         {
             ExpressionLexer l = new ExpressionLexer("id1.id2.id3(", moveToFirstToken: true, useSemicolonDelimiter: false);
             Assert.True(l.ExpandIdentifierAsFunction());
-            Assert.Equal("id1.id2.id3", l.CurrentToken.Text);
+            Assert.Equal("id1.id2.id3", l.CurrentToken.Span.ToString());
             Assert.Equal(0, l.CurrentToken.Position);
         }
 
@@ -541,7 +541,7 @@ namespace Microsoft.OData.Tests.UriParser
         {
             ExpressionLexer l = new ExpressionLexer("id1(", moveToFirstToken: true, useSemicolonDelimiter: false);
             Assert.True(l.ExpandIdentifierAsFunction());
-            Assert.Equal("id1", l.CurrentToken.Text);
+            Assert.Equal("id1", l.CurrentToken.Span.ToString());
             Assert.Equal(0, l.CurrentToken.Position);
         }
 
@@ -550,7 +550,7 @@ namespace Microsoft.OData.Tests.UriParser
         {
             ExpressionLexer l = new ExpressionLexer("id1.(", moveToFirstToken: true, useSemicolonDelimiter: false);
             Assert.False(l.ExpandIdentifierAsFunction());
-            Assert.Equal("id1", l.CurrentToken.Text);
+            Assert.Equal("id1", l.CurrentToken.Span.ToString());
             Assert.Equal(0, l.CurrentToken.Position);
         }
 
@@ -559,7 +559,7 @@ namespace Microsoft.OData.Tests.UriParser
         {
             ExpressionLexer l = new ExpressionLexer("id1.id2.id3", moveToFirstToken: true, useSemicolonDelimiter: false);
             Assert.False(l.ExpandIdentifierAsFunction());
-            Assert.Equal("id1", l.CurrentToken.Text);
+            Assert.Equal("id1", l.CurrentToken.Span.ToString());
             Assert.Equal(0, l.CurrentToken.Position);
         }
 
@@ -568,7 +568,7 @@ namespace Microsoft.OData.Tests.UriParser
         {
             ExpressionLexer l = new ExpressionLexer("id1.id2.id3 (", moveToFirstToken: true, useSemicolonDelimiter: false);
             Assert.False(l.ExpandIdentifierAsFunction());
-            Assert.Equal("id1", l.CurrentToken.Text);
+            Assert.Equal("id1", l.CurrentToken.Span.ToString());
             Assert.Equal(0, l.CurrentToken.Position);
         }
 
@@ -577,7 +577,7 @@ namespace Microsoft.OData.Tests.UriParser
         {
             ExpressionLexer l = new ExpressionLexer("id1.id2 .id3(", moveToFirstToken: true, useSemicolonDelimiter: false);
             Assert.False(l.ExpandIdentifierAsFunction());
-            Assert.Equal("id1", l.CurrentToken.Text);
+            Assert.Equal("id1", l.CurrentToken.Span.ToString());
             Assert.Equal(0, l.CurrentToken.Position);
         }
 
@@ -961,7 +961,7 @@ namespace Microsoft.OData.Tests.UriParser
             string result = lexer.AdvanceThroughExpandOption();
             Assert.Equal("'str with ; and () in it' eq StringProperty", result);
             Assert.Equal(43, lexer.Position);
-            Assert.StartsWith(")", lexer.CurrentToken.Text);
+            Assert.StartsWith(")", lexer.CurrentToken.Span.ToString());
         }
 
         // TODO: more unit tests for this method
@@ -973,7 +973,7 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal("(expression)", result);
             // TODO: the state of the lexer is weird right now, see note in AdvanceThroughBalancedParentheticalExpression.
 
-            Assert.Equal("next", lexer.NextToken().Text);
+            Assert.Equal("next", lexer.NextToken().Span.ToString());
         }
 
 #if !NETCOREAPP1_1 && !NETCOREAPP2_1&& !NETCOREAPP3_1
@@ -1000,42 +1000,42 @@ namespace Microsoft.OData.Tests.UriParser
 
         private static ExpressionToken IdentifierToken(string id)
         {
-            return new ExpressionToken() { Kind = ExpressionTokenKind.Identifier, Text = id };
+            return new ExpressionToken() { Kind = ExpressionTokenKind.Identifier, Text = id.AsMemory() };
         }
 
         private static ExpressionToken IntegerToken(string integer)
         {
-            return new ExpressionToken() { Kind = ExpressionTokenKind.IntegerLiteral, Text = integer };
+            return new ExpressionToken() { Kind = ExpressionTokenKind.IntegerLiteral, Text = integer.AsMemory() };
         }
 
         private static ExpressionToken ParameterAliasToken(string text)
         {
-            return new ExpressionToken() { Kind = ExpressionTokenKind.ParameterAlias, Text = text };
+            return new ExpressionToken() { Kind = ExpressionTokenKind.ParameterAlias, Text = text.AsMemory() };
         }
 
         private static ExpressionToken SingleLiteralToken(string singleString )
         {
-            return new ExpressionToken() { Kind = ExpressionTokenKind.SingleLiteral, Text = singleString };
+            return new ExpressionToken() { Kind = ExpressionTokenKind.SingleLiteral, Text = singleString.AsMemory() };
         }
 
         private static ExpressionToken SpatialLiteralToken(string literal, bool geography = true)
         {
-            return new ExpressionToken() { Kind = geography ? ExpressionTokenKind.GeographyLiteral : ExpressionTokenKind.GeometryLiteral, Text = literal };
+            return new ExpressionToken() { Kind = geography ? ExpressionTokenKind.GeographyLiteral : ExpressionTokenKind.GeometryLiteral, Text = literal.AsMemory() };
         }
 
         private static ExpressionToken BracketToken(string text)
         {
-            return new ExpressionToken() { Kind = ExpressionTokenKind.BracketedExpression, Text = text };
+            return new ExpressionToken() { Kind = ExpressionTokenKind.BracketedExpression, Text = text.AsMemory() };
         }
 
         private static ExpressionToken BracedToken(string text)
         {
-            return new ExpressionToken() { Kind = ExpressionTokenKind.BracedExpression, Text = text };
+            return new ExpressionToken() { Kind = ExpressionTokenKind.BracedExpression, Text = text.AsMemory() };
         }
 
         private static ExpressionToken StringToken(string text)
         {
-            return new ExpressionToken() { Kind = ExpressionTokenKind.StringLiteral, Text = text };
+            return new ExpressionToken() { Kind = ExpressionTokenKind.StringLiteral, Text = text.AsMemory() };
         }
 
         private static void ValidateLexerException<T>(string expression, string message) where T : Exception
@@ -1063,7 +1063,7 @@ namespace Microsoft.OData.Tests.UriParser
             for (int i = 0; i < expectTokens.Length; ++i)
             {
                 Assert.Equal(expectTokens[i].Kind, l.CurrentToken.Kind);
-                Assert.Equal(expectTokens[i].Text, l.CurrentToken.Text);
+                Assert.Equal(expectTokens[i].Text.ToString(), l.CurrentToken.Text.ToString());
                 l.NextToken();
             }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SearchLexerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/SearchLexerTests.cs
@@ -143,14 +143,14 @@ namespace Microsoft.OData.Tests.UriParser
         private static void ValidateStringLiteralToken(ExpressionLexer lexer, string text)
         {
             Assert.Equal(ExpressionTokenKind.StringLiteral, lexer.CurrentToken.Kind);
-            Assert.Equal(text, lexer.CurrentToken.Text);
+            Assert.Equal(text, lexer.CurrentToken.Span.ToString());
             lexer.NextToken();
         }
 
         private static void ValidateIdentifierToken(ExpressionLexer lexer, string text)
         {
             Assert.Equal(ExpressionTokenKind.Identifier, lexer.CurrentToken.Kind);
-            Assert.Equal(text, lexer.CurrentToken.Text);
+            Assert.Equal(text, lexer.CurrentToken.Span.ToString());
             lexer.NextToken();
         }
 


### PR DESCRIPTION
Use ExpressionLexer to do ReadOnlySpan investigation and seek feebacks to move forward to all other ODL parts.

### Be noted, 

1) the ReadOnlySpan<char> doesn't override the operator == and != for string. Remember to use 'Equals(...)' to replace them.

```C#
ReadOnlySpan<char> s1 = "nav/$ref".AsSpan().Slice(4,4);

Console.WriteLine(s1.ToString());
Console.WriteLine(s1 == "$ref");
Console.WriteLine(s1 != "$ref");
Console.WriteLine(s1.Equals("$ref", StringComparison.Ordinal));
```

It outputs
```cmd
$ref
False
True
True
```

2) Anytime to call 'ToString()' on ReadOnlySpan<char> will do the 'new string(...)', so be noted, not to call it multiple times until you need the string and remember to cache it.

### Benchmark:

![image](https://github.com/user-attachments/assets/78ff31ec-eb88-4bc7-9f3e-5bd942490b09)

See the allocated, using 'ReadOnlySpan<char>' is 1/3 memory allocation comparing to the 'new string(...)'.

#### Codes

```C#
   int NumberOfItems = 100000;
   public string expression = "abc(2014-09-19T12:13:14+00:00)/3258.678765765489753678965390/SRID=1234(POINT(10 20))/Function(foo=@x,bar=1,baz=@y)";

    [Benchmark]
    public void ExpressionLexerUsingNewStringSingleRun()
    {
        ExpressionLexer2 lexer = new Microsoft.OData.UriParser.ExpressionLexer2(expression, true, false);
        while (lexer.CurrentToken.Kind != ExpressionTokenKind.End)
        {
            lexer.NextToken();
        }
    }

    [Benchmark]
    public void ExpressionLexerUsingReadOnlySingleRun()
    {

        ExpressionLexer lexer = new Microsoft.OData.UriParser.ExpressionLexer(expression, true, false);
        while (lexer.CurrentToken.Kind != ExpressionTokenKind.End)
        {
            lexer.NextToken();
        }
    }

    [Benchmark]
    public void ExpressionLexerUsingNewString()
    {
        for (int i = 0; i < NumberOfItems; i++)
        {
            ExpressionLexer2 lexer = new Microsoft.OData.UriParser.ExpressionLexer2(expression, true, false);
            while (lexer.CurrentToken.Kind != ExpressionTokenKind.End)
            {
                lexer.NextToken();
            }
        }
    }

    [Benchmark]
    public void ExpressionLexerUsingReadOnly()
    {
        for (int i = 0; i < NumberOfItems; i++)
        {
            ExpressionLexer lexer = new Microsoft.OData.UriParser.ExpressionLexer(expression, true, false);
            while (lexer.CurrentToken.Kind != ExpressionTokenKind.End)
            {
                lexer.NextToken();
            }
        }
    }
```

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
