### PR TITLE
Fixes #2293: Enable DateOnly and TimeOnly

### DIFF
--- a/src/Microsoft.OData.Client/Serialization/PrimitiveType.cs
+++ b/src/Microsoft.OData.Client/Serialization/PrimitiveType.cs
@@ -370,10 +370,10 @@ namespace Microsoft.OData.Client
             RegisterKnownType(typeof(Date), XmlConstants.EdmDateTypeName, EdmPrimitiveTypeKind.Date, new DateTypeConverter(), true);
             RegisterKnownType(typeof(TimeOfDay), XmlConstants.EdmTimeOfDayTypeName, EdmPrimitiveTypeKind.TimeOfDay, new TimeOfDayConverter(), true);
 
-            RegisterKnownType(typeof(DateOnly), XmlConstants.EdmDateTypeName, EdmPrimitiveTypeKind.Date, new DateOnlyTypeConverter(), true);
-            RegisterKnownType(typeof(TimeOnly), XmlConstants.EdmTimeOfDayTypeName, EdmPrimitiveTypeKind.TimeOfDay, new TimeOnlyConverter(), true);
-
             // Following are known types are mapped to existing Edm type
+            RegisterKnownType(typeof(DateOnly), XmlConstants.EdmDateTypeName, EdmPrimitiveTypeKind.Date, new DateOnlyTypeConverter(), false);
+            RegisterKnownType(typeof(TimeOnly), XmlConstants.EdmTimeOfDayTypeName, EdmPrimitiveTypeKind.TimeOfDay, new TimeOnlyConverter(), false);
+
             RegisterKnownType(typeof(Char), XmlConstants.EdmStringTypeName, EdmPrimitiveTypeKind.String, new CharTypeConverter(), false);
             RegisterKnownType(typeof(Char[]), XmlConstants.EdmStringTypeName, EdmPrimitiveTypeKind.String, new CharArrayTypeConverter(), false);
             RegisterKnownType(typeof(Type), XmlConstants.EdmStringTypeName, EdmPrimitiveTypeKind.String, new ClrTypeConverter(), false);

--- a/src/Microsoft.OData.Client/Serialization/PrimitiveType.cs
+++ b/src/Microsoft.OData.Client/Serialization/PrimitiveType.cs
@@ -8,6 +8,7 @@ namespace Microsoft.OData.Client
 {
     using System;
     using System.Collections.Generic;
+    using System.ComponentModel;
     using System.Diagnostics;
     using System.Linq;
 
@@ -367,7 +368,10 @@ namespace Microsoft.OData.Client
             RegisterKnownType(typeof(GeometryMultiPolygon), XmlConstants.EdmGeometryMultiPolygonTypeName, EdmPrimitiveTypeKind.GeometryMultiPolygon, new GeometryTypeConverter(), true);
             RegisterKnownType(typeof(DataServiceStreamLink), XmlConstants.EdmStreamTypeName, EdmPrimitiveTypeKind.Stream, new NamedStreamTypeConverter(), false);
             RegisterKnownType(typeof(Date), XmlConstants.EdmDateTypeName, EdmPrimitiveTypeKind.Date, new DateTypeConverter(), true);
-            RegisterKnownType(typeof(TimeOfDay), XmlConstants.EdmTimeOfDayTypeName, EdmPrimitiveTypeKind.TimeOfDay, new TimeOfDayConvert(), true);
+            RegisterKnownType(typeof(TimeOfDay), XmlConstants.EdmTimeOfDayTypeName, EdmPrimitiveTypeKind.TimeOfDay, new TimeOfDayConverter(), true);
+
+            RegisterKnownType(typeof(DateOnly), XmlConstants.EdmDateTypeName, EdmPrimitiveTypeKind.Date, new DateOnlyTypeConverter(), true);
+            RegisterKnownType(typeof(TimeOnly), XmlConstants.EdmTimeOfDayTypeName, EdmPrimitiveTypeKind.TimeOfDay, new TimeOnlyConverter(), true);
 
             // Following are known types are mapped to existing Edm type
             RegisterKnownType(typeof(Char), XmlConstants.EdmStringTypeName, EdmPrimitiveTypeKind.String, new CharTypeConverter(), false);

--- a/src/Microsoft.OData.Client/Serialization/PrimitiveXmlConverter.cs
+++ b/src/Microsoft.OData.Client/Serialization/PrimitiveXmlConverter.cs
@@ -859,9 +859,35 @@ namespace Microsoft.OData.Client
     }
 
     /// <summary>
+    /// Convert between primitive types Edm.Date and string
+    /// </summary>
+    internal sealed class DateOnlyTypeConverter : PrimitiveTypeConverter
+    {
+        /// <summary>
+        /// Create an instance of primitive type from a string representation
+        /// </summary>
+        /// <param name="text">The string representation</param>
+        /// <returns>An instance of primitive type</returns>
+        internal override object Parse(string text)
+        {
+            return PlatformHelper.ConvertStringToDateOnly(text);
+        }
+
+        /// <summary>
+        /// Convert an instance of primitive type to string
+        /// </summary>
+        /// <param name="instance">The instance</param>
+        /// <returns>The string representation of the instance</returns>
+        internal override string ToString(object instance)
+        {
+            return ((Date)(DateOnly)instance).ToString();
+        }
+    }
+
+    /// <summary>
     /// Convert between primitive types Edm.TimeOfDay and string
     /// </summary>
-    internal sealed class TimeOfDayConvert : PrimitiveTypeConverter
+    internal sealed class TimeOfDayConverter : PrimitiveTypeConverter
     {
         /// <summary>
         /// Create an instance of primitive type from a string representation
@@ -881,6 +907,32 @@ namespace Microsoft.OData.Client
         internal override string ToString(object instance)
         {
             return ((TimeOfDay)instance).ToString();
+        }
+    }
+
+    /// <summary>
+    /// Convert between primitive types Edm.TimeOfDay and string
+    /// </summary>
+    internal sealed class TimeOnlyConverter : PrimitiveTypeConverter
+    {
+        /// <summary>
+        /// Create an instance of primitive type from a string representation
+        /// </summary>
+        /// <param name="text">The string representation</param>
+        /// <returns>An instance of primitive type</returns>
+        internal override object Parse(string text)
+        {
+            return PlatformHelper.ConvertStringToTimeOnly(text);
+        }
+
+        /// <summary>
+        /// Convert an instance of primitive type to string
+        /// </summary>
+        /// <param name="instance">The instance</param>
+        /// <returns>The string representation of the instance</returns>
+        internal override string ToString(object instance)
+        {
+            return ((TimeOfDay)(TimeOnly)instance).ToString();
         }
     }
 }

--- a/src/Microsoft.OData.Client/Serialization/PrimitiveXmlConverter.cs
+++ b/src/Microsoft.OData.Client/Serialization/PrimitiveXmlConverter.cs
@@ -859,7 +859,7 @@ namespace Microsoft.OData.Client
     }
 
     /// <summary>
-    /// Convert between primitive types Edm.Date and string
+    /// Convert between primitive types Edm.Date (using DateOnly) and string
     /// </summary>
     internal sealed class DateOnlyTypeConverter : PrimitiveTypeConverter
     {
@@ -911,7 +911,7 @@ namespace Microsoft.OData.Client
     }
 
     /// <summary>
-    /// Convert between primitive types Edm.TimeOfDay and string
+    /// Convert between primitive types Edm.TimeOfDay (using TimeOnly) and string
     /// </summary>
     internal sealed class TimeOnlyConverter : PrimitiveTypeConverter
     {

--- a/src/Microsoft.OData.Core/Evaluation/EdmValueUtils.cs
+++ b/src/Microsoft.OData.Core/Evaluation/EdmValueUtils.cs
@@ -283,6 +283,12 @@ namespace Microsoft.OData.Evaluation
                 return new EdmDateConstant(dateType, (Date)primitiveValue);
             }
 
+            if (primitiveValue is DateOnly dateOnly)
+            {
+                IEdmPrimitiveTypeReference dateType = EnsurePrimitiveType(type, EdmPrimitiveTypeKind.Date);
+                return new EdmDateConstant(dateType, dateOnly);
+            }
+
             if (primitiveValue is DateTimeOffset)
             {
                 IEdmTemporalTypeReference dateTimeOffsetType = (IEdmTemporalTypeReference)EnsurePrimitiveType(type, EdmPrimitiveTypeKind.DateTimeOffset);
@@ -299,6 +305,12 @@ namespace Microsoft.OData.Evaluation
             {
                 IEdmTemporalTypeReference timeOfDayType = (IEdmTemporalTypeReference)EnsurePrimitiveType(type, EdmPrimitiveTypeKind.TimeOfDay);
                 return new EdmTimeOfDayConstant(timeOfDayType, (TimeOfDay)primitiveValue);
+            }
+
+            if (primitiveValue is TimeOnly timeOnly)
+            {
+                IEdmTemporalTypeReference timeOfDayType = (IEdmTemporalTypeReference)EnsurePrimitiveType(type, EdmPrimitiveTypeKind.TimeOfDay);
+                return new EdmTimeOfDayConstant(timeOfDayType, timeOnly);
             }
 
             if (primitiveValue is TimeSpan)

--- a/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
+++ b/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
@@ -21,20 +21,19 @@ namespace Microsoft.OData.Evaluation
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
     using System.Text;
     using System.Linq;
     using System.Xml;
 #if ODATA_CORE
     using Microsoft.OData.Edm;
     using Microsoft.Spatial;
-    using System.Globalization;
 #else
     using System.Xml.Linq;
     using Microsoft.OData;
     using Microsoft.OData.Edm;
     using Microsoft.Spatial;
     using ExpressionConstants = XmlConstants;
-    using System.Globalization;
 #endif
 
     /// <summary>

--- a/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
+++ b/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
@@ -27,12 +27,14 @@ namespace Microsoft.OData.Evaluation
 #if ODATA_CORE
     using Microsoft.OData.Edm;
     using Microsoft.Spatial;
+    using System.Globalization;
 #else
     using System.Xml.Linq;
     using Microsoft.OData;
     using Microsoft.OData.Edm;
     using Microsoft.Spatial;
     using ExpressionConstants = XmlConstants;
+    using System.Globalization;
 #endif
 
     /// <summary>
@@ -223,6 +225,11 @@ namespace Microsoft.OData.Evaluation
                 return value.ToString();
             }
 
+            if (value is DateOnly dateOnly)
+            {
+                return ((Date)dateOnly).ToString();
+            }
+
             if (value is DateTimeOffset)
             {
                 return XmlConvert.ToString((DateTimeOffset)value);
@@ -231,6 +238,11 @@ namespace Microsoft.OData.Evaluation
             if (value is TimeOfDay)
             {
                 return value.ToString();
+            }
+
+            if (value is TimeOnly timeOnly)
+            {
+                return ((TimeOfDay)timeOnly).ToString();
             }
 
             if (value is TimeSpan)

--- a/src/Microsoft.OData.Core/Json/JsonWriterExtensions.Async.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterExtensions.Async.cs
@@ -135,9 +135,19 @@ namespace Microsoft.OData.Json
                 return jsonWriter.WriteValueAsync((Date)value);
             }
 
+            if (value is DateOnly dateOnly)
+            {
+                return jsonWriter.WriteValueAsync(dateOnly); // will implicitly to call 'Date' version
+            }
+
             if (value is TimeOfDay)
             {
                 return jsonWriter.WriteValueAsync((TimeOfDay)value);
+            }
+
+            if (value is TimeOnly timeOnly)
+            {
+                return jsonWriter.WriteValueAsync(timeOnly); // will implicitly to call 'TimeOfDay' version
             }
 
             return TaskUtils.GetFaultedTask(

--- a/src/Microsoft.OData.Core/Json/JsonWriterExtensions.Async.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterExtensions.Async.cs
@@ -137,7 +137,8 @@ namespace Microsoft.OData.Json
 
             if (value is DateOnly dateOnly)
             {
-                return jsonWriter.WriteValueAsync(dateOnly); // will implicitly to call 'Date' version
+                // will call 'WriteValueAsync(Date)' version implicitly
+                return jsonWriter.WriteValueAsync(dateOnly);
             }
 
             if (value is TimeOfDay)
@@ -147,7 +148,8 @@ namespace Microsoft.OData.Json
 
             if (value is TimeOnly timeOnly)
             {
-                return jsonWriter.WriteValueAsync(timeOnly); // will implicitly to call 'TimeOfDay' version
+                // will call 'WriteValueAsync(TimeOfDay)' version implicitly
+                return jsonWriter.WriteValueAsync(timeOnly);
             }
 
             return TaskUtils.GetFaultedTask(

--- a/src/Microsoft.OData.Core/Json/JsonWriterExtensions.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriterExtensions.cs
@@ -147,9 +147,24 @@ namespace Microsoft.OData.Json
                 return;
             }
 
+            // Why don't merge 'DateOnly' into 'Date' if clause?
+            // Because 'value' is System.Object, it's a boxed of 'DateOnly' and will throw exception to cast it to 'Date'.
+            // It's same for TimeOnly
+            if (value is DateOnly dateOnly)
+            {
+                jsonWriter.WriteValue(dateOnly);
+                return;
+            }
+
             if (value is TimeOfDay)
             {
                 jsonWriter.WriteValue((TimeOfDay)value);
+                return;
+            }
+
+            if (value is TimeOnly timeOnly)
+            {
+                jsonWriter.WriteValue(timeOnly);
                 return;
             }
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
@@ -121,7 +121,9 @@ namespace Microsoft.OData.Json
                         valueAsString = JsonValueUtils.GetEscapedJsonString(valueAsString);
                         sb.Append('"').Append(valueAsString).Append('"');
                     }
-                    else if (valueAsObject is byte[] || valueAsObject is DateTimeOffset || valueAsObject is Guid || valueAsObject is TimeSpan | valueAsObject is Date || valueAsObject is TimeOfDay)
+                    else if (valueAsObject is byte[] || valueAsObject is DateTimeOffset || valueAsObject is Guid
+                        || valueAsObject is TimeSpan || valueAsObject is Date || valueAsObject is TimeOfDay
+                        || valueAsObject is DateOnly || valueAsObject is TimeOnly)
                     {
                         sb.Append('"').Append(valueAsString).Append('"');
                     }

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriterUtils.cs
@@ -121,9 +121,14 @@ namespace Microsoft.OData.Json
                         valueAsString = JsonValueUtils.GetEscapedJsonString(valueAsString);
                         sb.Append('"').Append(valueAsString).Append('"');
                     }
-                    else if (valueAsObject is byte[] || valueAsObject is DateTimeOffset || valueAsObject is Guid
-                        || valueAsObject is TimeSpan || valueAsObject is Date || valueAsObject is TimeOfDay
-                        || valueAsObject is DateOnly || valueAsObject is TimeOnly)
+                    else if (valueAsObject is byte[]
+                        || valueAsObject is DateTimeOffset
+                        || valueAsObject is Guid
+                        || valueAsObject is TimeSpan
+                        || valueAsObject is Date
+                        || valueAsObject is TimeOfDay
+                        || valueAsObject is DateOnly
+                        || valueAsObject is TimeOnly)
                     {
                         sb.Append('"').Append(valueAsString).Append('"');
                     }

--- a/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
+++ b/src/Microsoft.OData.Core/Metadata/EdmLibraryExtensions.cs
@@ -140,6 +140,11 @@ namespace Microsoft.OData.Metadata
             PrimitiveTypeReferenceMap.Add(typeof(TimeOfDay), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), false));
             PrimitiveTypeReferenceMap.Add(typeof(TimeOfDay?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), true));
 
+            PrimitiveTypeReferenceMap.Add(typeof(DateOnly), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Date), false));
+            PrimitiveTypeReferenceMap.Add(typeof(DateOnly?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.Date), true));
+            PrimitiveTypeReferenceMap.Add(typeof(TimeOnly), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), false));
+            PrimitiveTypeReferenceMap.Add(typeof(TimeOnly?), ToTypeReference(EdmCoreModel.Instance.GetPrimitiveType(EdmPrimitiveTypeKind.TimeOfDay), true));
+
 #if !NETSTANDARD1_1
             // Pack type codes of supported primitive types in the bitmap
             // See the type codes here: https://learn.microsoft.com/en-us/dotnet/api/system.typecode

--- a/src/Microsoft.OData.Core/ODataPayloadValueConverter.cs
+++ b/src/Microsoft.OData.Core/ODataPayloadValueConverter.cs
@@ -174,6 +174,18 @@ namespace Microsoft.OData
                 return PlatformHelper.ConvertStringToTimeOfDay(stringValue);
             }
 
+            // DateOnly
+            if (targetType == typeof(DateOnly))
+            {
+                return PlatformHelper.ConvertStringToDateOnly(stringValue);
+            }
+
+            // TimeOnly
+            if (targetType == typeof(TimeOnly))
+            {
+                return PlatformHelper.ConvertStringToTimeOnly(stringValue);
+            }
+
             // DateTimeOffset needs to be read using the XML rules (as per the Json spec).
             if (targetType == typeof(DateTimeOffset))
             {

--- a/src/Microsoft.OData.Core/ODataPayloadValueConverter.cs
+++ b/src/Microsoft.OData.Core/ODataPayloadValueConverter.cs
@@ -162,25 +162,21 @@ namespace Microsoft.OData
                 return EdmValueParser.ParseDuration(stringValue);
             }
 
-            // Date
             if (targetType == typeof(Date))
             {
                 return PlatformHelper.ConvertStringToDate(stringValue);
             }
 
-            // Time
             if (targetType == typeof(TimeOfDay))
             {
                 return PlatformHelper.ConvertStringToTimeOfDay(stringValue);
             }
 
-            // DateOnly
             if (targetType == typeof(DateOnly))
             {
                 return PlatformHelper.ConvertStringToDateOnly(stringValue);
             }
 
-            // TimeOnly
             if (targetType == typeof(TimeOnly))
             {
                 return PlatformHelper.ConvertStringToTimeOnly(stringValue);

--- a/src/Microsoft.OData.Core/ODataRawValueUtils.cs
+++ b/src/Microsoft.OData.Core/ODataRawValueUtils.cs
@@ -123,10 +123,22 @@ namespace Microsoft.OData
                 return true;
             }
 
+            if ( value is DateOnly dateOnly)
+            {
+                result = ODataRawValueConverter.ToString(dateOnly);
+                return true;
+            }
+
             if (value is TimeOfDay)
             {
                 // Edm.TimeOfDay
                 result = ODataRawValueConverter.ToString((TimeOfDay)value);
+                return true;
+            }
+
+            if (value is TimeOnly timeOnly)
+            {
+                result = ODataRawValueConverter.ToString(timeOnly);
                 return true;
             }
 

--- a/src/Microsoft.OData.Core/ODataRawValueUtils.cs
+++ b/src/Microsoft.OData.Core/ODataRawValueUtils.cs
@@ -123,7 +123,7 @@ namespace Microsoft.OData
                 return true;
             }
 
-            if ( value is DateOnly dateOnly)
+            if (value is DateOnly dateOnly)
             {
                 result = ODataRawValueConverter.ToString(dateOnly);
                 return true;

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -512,6 +512,12 @@ namespace Microsoft.OData
                         return new DateTimeOffset(dateValue.Year, dateValue.Month, dateValue.Day, 0, 0, 0, new TimeSpan(0));
                     }
 
+                    if (primitiveValue is DateOnly dateOnly)
+                    {
+                        var dateValue = (Date)dateOnly;
+                        return new DateTimeOffset(dateValue.Year, dateValue.Month, dateValue.Day, 0, 0, 0, new TimeSpan(0));
+                    }
+
                     break;
 
                 case EdmPrimitiveTypeKind.Date:

--- a/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriConversionUtils.cs
@@ -509,13 +509,13 @@ namespace Microsoft.OData
                     if (primitiveValue is Date)
                     {
                         var dateValue = (Date)primitiveValue;
-                        return new DateTimeOffset(dateValue.Year, dateValue.Month, dateValue.Day, 0, 0, 0, new TimeSpan(0));
+                        return new DateTimeOffset(dateValue.Year, dateValue.Month, dateValue.Day, 0, 0, 0, TimeSpan.Zero);
                     }
 
                     if (primitiveValue is DateOnly dateOnly)
                     {
                         var dateValue = (Date)dateOnly;
-                        return new DateTimeOffset(dateValue.Year, dateValue.Month, dateValue.Day, 0, 0, 0, new TimeSpan(0));
+                        return new DateTimeOffset(dateValue.Year, dateValue.Month, dateValue.Day, 0, 0, 0, TimeSpan.Zero);
                     }
 
                     break;

--- a/src/Microsoft.OData.Edm/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Edm/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,4 @@
-﻿
+﻿static Microsoft.OData.Edm.Date.implicit operator Microsoft.OData.Edm.Date(System.DateOnly operand) -> Microsoft.OData.Edm.Date
+static Microsoft.OData.Edm.Date.implicit operator System.DateOnly(Microsoft.OData.Edm.Date operand) -> System.DateOnly
+static Microsoft.OData.Edm.TimeOfDay.implicit operator Microsoft.OData.Edm.TimeOfDay(System.TimeOnly timeOnly) -> Microsoft.OData.Edm.TimeOfDay
+static Microsoft.OData.Edm.TimeOfDay.implicit operator System.TimeOnly(Microsoft.OData.Edm.TimeOfDay time) -> System.TimeOnly

--- a/src/Microsoft.OData.Edm/Schema/Date.cs
+++ b/src/Microsoft.OData.Edm/Schema/Date.cs
@@ -231,6 +231,26 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Convert Date to Clr DateOnly
+        /// </summary>
+        /// <param name="operand">Date Value</param>
+        /// <returns>DateTime Value which represent the Date</returns>
+        public static implicit operator DateOnly(Date operand)
+        {
+            return DateOnly.FromDateTime(operand.dateTime);
+        }
+
+        /// <summary>
+        /// Convert Clr DateOnly to Date
+        /// </summary>
+        /// <param name="operand">DateOnly Value</param>
+        /// <returns>Date Value from DateOnly</returns>
+        public static implicit operator Date(DateOnly operand)
+        {
+            return new Date(operand.Year, operand.Month, operand.Day);
+        }
+
+        /// <summary>
         /// Convert Date to String
         /// </summary>
         /// <returns>string value of Date</returns>

--- a/src/Microsoft.OData.Edm/Schema/TimeOfDay.cs
+++ b/src/Microsoft.OData.Edm/Schema/TimeOfDay.cs
@@ -254,6 +254,26 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Convert TimeOfDay to .Net TimeOnly
+        /// </summary>
+        /// <param name="time">TimeOfDay Value</param>
+        /// <returns>TimeOnly Value which represent the TimeOfDay</returns>
+        public static implicit operator TimeOnly(TimeOfDay time)
+        {
+            return TimeOnly.FromTimeSpan(time.timeSpan);
+        }
+
+        /// <summary>
+        /// Convert .Net Clr TimeOnly to TimeOfDay
+        /// </summary>
+        /// <param name="timeOnly">TimeOnly Value</param>
+        /// <returns>TimeOfDay Value from TimeOnly</returns>
+        public static implicit operator TimeOfDay(TimeOnly timeOnly)
+        {
+            return new TimeOfDay(timeOnly.Ticks);
+        }
+
+        /// <summary>
         /// Compares the value of this instance to a specified TimeOfDay value
         /// and returns an bool that indicates whether this instance is same as the specified TimeOfDay value.
         /// </summary>

--- a/src/PlatformHelper.cs
+++ b/src/PlatformHelper.cs
@@ -236,7 +236,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Converts a string to a DateOnly.
+        /// Converts a string to a <see cref="DateOnly"/>.
         /// </summary>
         /// <param name="text">String to be converted.</param>
         /// <returns>DateOnly value</returns>
@@ -252,7 +252,7 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
-        /// Converts a string to a TimeOfDay.
+        /// Converts a string to a <see cref="TimeOfDay">.
         /// </summary>
         /// <param name="text">String to be converted.</param>
         /// <param name="timeOfDay">Time of the day</param>

--- a/src/PlatformHelper.cs
+++ b/src/PlatformHelper.cs
@@ -236,6 +236,22 @@ namespace Microsoft.OData.Edm
         }
 
         /// <summary>
+        /// Converts a string to a DateOnly.
+        /// </summary>
+        /// <param name="text">String to be converted.</param>
+        /// <returns>DateOnly value</returns>
+        internal static DateOnly ConvertStringToDateOnly(string text)
+        {
+            DateOnly date;
+            if (!DateOnly.TryParse(text, out date))
+            {
+                throw new FormatException(string.Format(CultureInfo.InvariantCulture, "String '{0}' was not recognized as a valid Edm.Date.", text));
+            }
+
+            return date;
+        }
+
+        /// <summary>
         /// Converts a string to a TimeOfDay.
         /// </summary>
         /// <param name="text">String to be converted.</param>
@@ -261,6 +277,22 @@ namespace Microsoft.OData.Edm
         {
             TimeOfDay timeOfDay;
             if (!PlatformHelper.TryConvertStringToTimeOfDay(text, out timeOfDay))
+            {
+                throw new FormatException(string.Format(CultureInfo.InvariantCulture, "String '{0}' was not recognized as a valid Edm.TimeOfDay.", text));
+            }
+
+            return timeOfDay;
+        }
+
+        /// <summary>
+        /// Converts a string to a TimeOnly.
+        /// </summary>
+        /// <param name="text">String to be converted.</param>
+        /// <returns>TimeOnly value</returns>
+        internal static TimeOnly ConvertStringToTimeOnly(string text)
+        {
+            TimeOnly timeOfDay;
+            if (!TimeOnly.TryParse(text, out timeOfDay))
             {
                 throw new FormatException(string.Format(CultureInfo.InvariantCulture, "String '{0}' was not recognized as a valid Edm.TimeOfDay.", text));
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -1099,6 +1099,36 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal(expectedOutput, rawOutput);
         }
 
+        [Fact]
+        public void WriteDateOnly()
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            jsonWriter.WriteValue(new DateOnly(2024,10,1));
+            jsonWriter.Flush();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal("\"2024-10-01\"", rawOutput);
+        }
+
+        [Fact]
+        public void WriteTimeOnly()
+        {
+            using MemoryStream stream = new MemoryStream();
+            IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
+            jsonWriter.WriteValue(new TimeOnly(4, 3, 2, 1));
+            jsonWriter.Flush();
+
+            stream.Seek(0, SeekOrigin.Begin);
+
+            using StreamReader reader = new StreamReader(stream, encoding: Encoding.UTF8);
+            string rawOutput = reader.ReadToEnd();
+            Assert.Equal("\"04:03:02.0010000\"", rawOutput);
+        }
+
         /// <summary>
         /// Normalizes the differences between JSON text encoded
         /// by Utf8JsonWriter and OData's JsonWriter, to make

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -1104,7 +1104,7 @@ namespace Microsoft.OData.Tests.Json
         {
             using MemoryStream stream = new MemoryStream();
             IJsonWriter jsonWriter = CreateJsonWriter(stream, isIeee754Compatible: false, Encoding.UTF8);
-            jsonWriter.WriteValue(new DateOnly(2024,10,1));
+            jsonWriter.WriteValue(new DateOnly(2024, 10, 1));
             jsonWriter.Flush();
 
             stream.Seek(0, SeekOrigin.Begin);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -205,9 +205,21 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public void WritePrimitiveValueDateOnly()
+        {
+            this.VerifyWritePrimitiveValue(new DateOnly(2024, 10, 1), "\"2024-10-01\"");
+        }
+
+        [Fact]
         public void WritePrimitiveValueTimeOfDay()
         {
             this.VerifyWritePrimitiveValue(new TimeOfDay(12, 30, 5, 10), "\"12:30:05.0100000\"");
+        }
+
+        [Fact]
+        public void WritePrimitiveValueTimeOnly()
+        {
+            this.VerifyWritePrimitiveValue(new TimeOnly(4, 3, 2, 1), "\"04:03:02.0010000\"");
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerAsyncTests.cs
@@ -426,6 +426,36 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
+        public async Task WriteDateOnlyValueAsync_WritesExpectedValue()
+        {
+            var date = new DateOnly(2024, 9, 17);
+            var dateEdmTypeReference = EdmCoreModel.Instance.GetDate(false);
+
+            var result = await SetupJsonValueSerializerAndRunTestAsync(
+                (jsonValueSerializer) =>
+                {
+                    return jsonValueSerializer.WritePrimitiveValueAsync(date, dateEdmTypeReference);
+                });
+
+            Assert.Equal("\"2024-09-17\"", result);
+        }
+
+        [Fact]
+        public async Task WriteTimeOnlyValueAsync_WritesExpectedValue()
+        {
+            var timeOnly = new TimeOfDay(14, 9, 17, 2);
+            var dateEdmTypeReference = EdmCoreModel.Instance.GetTimeOfDay(false);
+
+            var result = await SetupJsonValueSerializerAndRunTestAsync(
+                (jsonValueSerializer) =>
+                {
+                    return jsonValueSerializer.WritePrimitiveValueAsync(timeOnly, dateEdmTypeReference);
+                });
+
+            Assert.Equal("\"14:09:17.0020000\"", result);
+        }
+
+        [Fact]
         public async Task WriteUntypedValueAsync_ThrowsExceptionForRawValueNullOrEmpty()
         {
             var untypedValue = new ODataUntypedValue { RawValue = "" };

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Metadata/EdmLibraryExtensionsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Metadata/EdmLibraryExtensionsTests.cs
@@ -722,6 +722,11 @@ namespace Microsoft.OData.Tests.Metadata
         [InlineData(typeof(byte))]
         [InlineData(typeof(bool))]
         [InlineData(typeof(float))]
+        [InlineData(typeof(Date))]
+        [InlineData(typeof(DateOnly))]
+        [InlineData(typeof(DateOnly?))]
+        [InlineData(typeof(TimeOnly))]
+        [InlineData(typeof(TimeOnly?))]
         [InlineData(typeof(Geography))]
         [InlineData(typeof(Geometry))]
         public void IsPrimitiveTypeForSupportedTypesShouldBeTrue(Type type)
@@ -737,6 +742,22 @@ namespace Microsoft.OData.Tests.Metadata
         {
             bool result = EdmLibraryExtensions.IsPrimitiveType(type);
             Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData(typeof(Date), EdmPrimitiveTypeKind.Date, false)]
+        [InlineData(typeof(Date?), EdmPrimitiveTypeKind.Date, true)]
+        [InlineData(typeof(TimeOfDay), EdmPrimitiveTypeKind.TimeOfDay, false)]
+        [InlineData(typeof(TimeOfDay?), EdmPrimitiveTypeKind.TimeOfDay, true)]
+        [InlineData(typeof(DateOnly), EdmPrimitiveTypeKind.Date, false)]
+        [InlineData(typeof(DateOnly?), EdmPrimitiveTypeKind.Date, true)]
+        [InlineData(typeof(TimeOnly), EdmPrimitiveTypeKind.TimeOfDay, false)]
+        [InlineData(typeof(TimeOnly?), EdmPrimitiveTypeKind.TimeOfDay, true)]
+        public void GetPrimitiveTypeReferenceForDateOnlyTimeOnlyShouldReturnCorrectEdmType(Type clrType, EdmPrimitiveTypeKind kind, bool nullable)
+        {
+            IEdmPrimitiveTypeReference primitiveTypeRef = EdmLibraryExtensions.GetPrimitiveTypeReference(clrType);
+            Assert.Equal(kind, primitiveTypeRef.PrimitiveKind());
+            Assert.Equal(nullable, primitiveTypeRef.IsNullable);
         }
 
         [Theory]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderTests.cs
@@ -106,6 +106,7 @@ namespace Microsoft.OData.Tests
             ODataMessageReader reader = new ODataMessageReader(responseMessage, new ODataMessageReaderSettings(), new EdmModel());
             var result = reader.ReadValue(new EdmTypeDefinitionReference(new EdmTypeDefinition("NS", "TimeOfDayValue", EdmPrimitiveTypeKind.TimeOfDay), true));
             Assert.Equal(new TimeOfDay(12, 30, 4, 998), result);
+            Assert.Equal(new TimeOnly(12, 30, 4, 998), (TimeOnly)(TimeOfDay)result); // need to cast from object to 'TimeOfDay' first then cast to 'TimeOnly'
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Evaluation/KeyGenerationPinningTest.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Evaluation/KeyGenerationPinningTest.cs
@@ -105,6 +105,10 @@ namespace Microsoft.OData.Tests.ScenarioTests.Evaluation
             RunPinningTest(builder, DateTimeOffset.MaxValue, DateTimeOffset.MinValue, XmlConvert.ToDateTimeOffset("2012-11-16T10:54:13.5422534-08:00"), XmlConvert.ToDateTimeOffset("2012-11-16T18:54:13.5422534Z"));
             RunPinningTest(builder, Date.MinValue, new Date(2014, 12, 31), Date.MaxValue);
             RunPinningTest(builder, TimeOfDay.MinValue, new TimeOfDay(12, 20, 4, 123), new TimeOfDay(TimeOfDay.MaxTickValue));
+
+            RunPinningTest(builder, DateOnly.MinValue, new DateOnly(2024, 10, 1), DateOnly.MaxValue);
+            RunPinningTest(builder, TimeOnly.MinValue, new TimeOnly(4, 3, 2, 1), TimeOnly.MaxValue);
+
             RunPinningTest(builder, TimeSpan.MaxValue, TimeSpan.MinValue, TimeSpan.FromDays(1.5));
             RunPinningTest(builder, Guid.Empty, Guid.Parse("b467459e-1eb5-4598-8a63-2c40c6a2590c"));
             RunPinningTest(builder, "", "  \t \r\n", ".,();", "\r\n", "\r\n\r\n\r\n\r\n", "\r", "\n", "\n\r", "a\x0302e\x0327\x0627\x0654\x0655", "a surrogate pair: \xd800\xdc00", "left to right \x05d0\x05d1 \x05ea\x05e9 english", "\x1\x2\x3\x4\x5\x20");
@@ -175,6 +179,16 @@ namespace Microsoft.OData.Tests.ScenarioTests.Evaluation
 (12%3A20%3A04.1230000)
 (23%3A59%3A59.9999999)
 (prop0=00%3A00%3A00.0000000,prop1=12%3A20%3A04.1230000,prop2=23%3A59%3A59.9999999)
+
+(0001-01-01)
+(2024-10-01)
+(9999-12-31)
+(prop0=0001-01-01,prop1=2024-10-01,prop2=9999-12-31)
+
+(00%3A00%3A00.0000000)
+(04%3A03%3A02.0010000)
+(23%3A59%3A59.9999999)
+(prop0=00%3A00%3A00.0000000,prop1=04%3A03%3A02.0010000,prop2=23%3A59%3A59.9999999)
 
 (duration'P10675199DT2H48M5.4775807S')
 (duration'-P10675199DT2H48M5.4775808S')

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/BinaryValueEncodingTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/BinaryValueEncodingTests.cs
@@ -71,6 +71,28 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
             Assert.True(KeyAsSegmentsLiteralParser.TryParseLiteral(byteArray.GetType(), Uri.UnescapeDataString(keyAsSegmentFormattedByteArray), out keyAsSegmentParsedByteArray));
             Assert.Equal((byte[])keyAsSegmentParsedByteArray, byteArray);
         }
+
+        [Fact]
+        public void LiteralFormatterFormatDateOnlyLiteral()
+        {
+            DateOnly dateOnly = new DateOnly(2024, 10, 1);
+            string defaultFormattedDateOnly = DefaultLiteralFormatter.Format(dateOnly);
+            string keyAsSegmentFormattedDateOnly = KeyAsSegmentsLiteralFormatter.Format(dateOnly);
+
+            Assert.Equal("2024-10-01", defaultFormattedDateOnly);
+            Assert.Equal(defaultFormattedDateOnly, keyAsSegmentFormattedDateOnly);
+        }
+
+        [Fact]
+        public void LiteralFormatterFormatTimeOnlyLiteral()
+        {
+            TimeOnly timeOnly = new TimeOnly(4, 10, 1, 9);
+            string defaultFormattedTimeOnly = DefaultLiteralFormatter.Format(timeOnly);
+            string keyAsSegmentFormattedTimeOnly = KeyAsSegmentsLiteralFormatter.Format(timeOnly);
+
+            Assert.Equal("04%3A10%3A01.0090000", defaultFormattedTimeOnly);
+            Assert.Equal(defaultFormattedTimeOnly, keyAsSegmentFormattedTimeOnly);
+        }
     }
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2293.*

### Description

OData.Spec defines the following two primitive types:
![image](https://github.com/user-attachments/assets/58a97934-be94-4154-a610-2841f4b1b824)

From OData model perspective, it only knows `Edm.Date` and `Edm.TimeOfDay`. 

We'd resolve the mapping between the Edm types and C# types from the real value.

OData library maps 'Edm.Date' to '[Microsoft.OData.Edm.Date](https://github.com/OData/odata.net/blob/main/src/Microsoft.OData.Edm/Schema/Date.cs)' struct and 'Edm.TimeOfDay' to '[Microsoft.OData.Edm.TimeOfDay](https://github.com/OData/odata.net/blob/main/src/Microsoft.OData.Edm/Schema/TimeOfDay.cs)' struct. 

However, neither 'Date' type nor 'TimeOfDay' is supported in database side.

Now since .NET 6, two new primitive types have introduced into the 'System" namespace as:

### [System.TimeOnly](https://docs.microsoft.com/en-us/dotnet/api/system.timeonly)
### [System.DateOnly](https://docs.microsoft.com/en-us/dotnet/api/system.dateonly)

They are widely used in modern database side and EF core supports them. See at: https://github.com/dotnet/efcore/issues/24507
and Here: https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-8.0/breaking-changes

At OData side, we should support those two types as well.

1) At OData.Edm side, typically we don't need to change anything.  Because it only knows the 'Edm.Date' and 'Edm.TimeOfDay' primitive types. But for conversion, we'd update 'Date' and 'TimeOfDay' struct type to support convert to 'System.DateOnly' and 'System.TimeOnly' respectively, implicitly.

2) At OData.Core side, we'd support to write the 'DateOnly' and 'TimeOnly' values, same as 'Date' and 'TimeOfDay' respectively.
    For reading, suppose we have a property at model side as:
    
    ```xml
     <Property Name='ValidDate' Type='Edm.Date' />
    ```
   So, if ODL reads the value of 'ValidDate' property, we can continue to read it as 'Date' instance and it should be able to convert it to 'System.DateOnly' implicitly.

3) At OData.Client side, we should support to create the property using the correct C# types (Microsoft.OData.Edm.Date, or System.DateOnly) during code generation. I'd suggest to add a flag/configuration for the OData Connected service to switch between them. This part is not included in this PR.


### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
