### PR TITLE
Fix issue #1320 metadata async issue

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/SchemaWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/SchemaWriter.cs
@@ -106,7 +106,7 @@ namespace Microsoft.OData.Edm.Csdl
                 return (false, errors);
             }
 
-            IEnumerable<EdmSchema> schemas = new EdmModelSchemaSeparationSerializationVisitor(model).GetSchemas();
+            IEnumerable<EdmSchema> schemas = await (new EdmModelSchemaSeparationSerializationVisitor(model)).GetSchemasAsync().ConfigureAwait(false);
             if (schemas.Count() > 1 && singleFileExpected)
             {
                 errors = new EdmError[] { new EdmError(new CsdlLocation(0, 0), EdmErrorCode.SingleFileExpected, Edm.Strings.Serializer_SingleFileExpected) };

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
@@ -191,7 +191,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             }
 
             // EntityContainers are excluded from the EdmSchema.SchemaElements property so they can be forced to the end.
-            VisitCollection(element.EntityContainers, async (e) => await this.ProcessEntityContainerAsync(e).ConfigureAwait(false));
+            await VisitCollectionAsync(element.EntityContainers, (e) => this.ProcessEntityContainerAsync(e)).ConfigureAwait(false);
 
             if (element.OutOfLineAnnotations.Any())
             {

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
@@ -180,13 +180,13 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
 
             await this.schemaWriter.WriteSchemaElementHeaderAsync(element, alias, mappings).ConfigureAwait(false);
 
-            VisitSchemaElements(element.SchemaElements);
+            await VisitSchemaElementsAsync(element.SchemaElements).ConfigureAwait(false);
 
             // process the functions/actions seperately
             foreach (var operation in element.SchemaOperations)
             {
                 await this.schemaWriter.WriteSchemaOperationsHeaderAsync(operation).ConfigureAwait(false);
-                VisitSchemaElements(operation.Value.AsEnumerable<IEdmSchemaElement>()); // Call AsEnumerable() to make .net 3.5 happy
+                await VisitSchemaElementsAsync(operation.Value.AsEnumerable<IEdmSchemaElement>()).ConfigureAwait(false); // Call AsEnumerable() to make .net 3.5 happy
                 await this.schemaWriter.WriteSchemaOperationsEndAsync(operation).ConfigureAwait(false);
             }
 
@@ -304,8 +304,8 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                 await this.VisitEntityTypeDeclaredKeyAsync(element.DeclaredKey).ConfigureAwait(false);
             }
 
-            this.VisitProperties(element.DeclaredStructuralProperties().Cast<IEdmProperty>());
-            this.VisitProperties(element.DeclaredNavigationProperties().Cast<IEdmProperty>());
+            await this.VisitPropertiesAsync(element.DeclaredStructuralProperties().Cast<IEdmProperty>()).ConfigureAwait(false);
+            await this.VisitPropertiesAsync(element.DeclaredNavigationProperties().Cast<IEdmProperty>()).ConfigureAwait(false);
             await this.EndElementAsync(element).ConfigureAwait(false);
         }
 
@@ -331,7 +331,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             await this.BeginElementAsync(element, (IEdmStructuralProperty t) =>  this.schemaWriter.WriteStructuralPropertyElementHeaderAsync(t, inlineType), e =>  this.ProcessFacetsAsync(e.Type, inlineType)).ConfigureAwait(false);
             if (!inlineType)
             {
-                VisitTypeReference(element.Type);
+                await VisitTypeReferenceAsync(element.Type).ConfigureAwait(false);
             }
 
             await this.EndElementAsync(element).ConfigureAwait(false);
@@ -558,7 +558,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             {
                 if (term.Type != null)
                 {
-                    VisitTypeReference(term.Type);
+                    await VisitTypeReferenceAsync(term.Type).ConfigureAwait(false);
                 }
             }
 
@@ -629,7 +629,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                 ).ConfigureAwait(false);
             if (!inlineType)
             {
-                VisitTypeReference(element.Type);
+                await VisitTypeReferenceAsync(element.Type).ConfigureAwait(false);
             }
 
             await this.VisitPrimitiveElementAnnotationsAsync(this.Model.DirectValueAnnotations(element)).ConfigureAwait(false);
@@ -691,7 +691,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                     }
                     else
                     {
-                        this.VisitTypeReference(type);
+                        await this.VisitTypeReferenceAsync(type).ConfigureAwait(false);
                     }
                 }).ConfigureAwait(false);
             await this.EndElementAsync(operationReturn).ConfigureAwait(false);
@@ -726,7 +726,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                 ).ConfigureAwait(false);
             if (!inlineType)
             {
-                VisitTypeReference(element.ElementType);
+                await VisitTypeReferenceAsync(element.ElementType).ConfigureAwait(false);
             }
 
             await this.EndElementAsync(element).ConfigureAwait(false);
@@ -1031,7 +1031,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
 
                 if (!inlineType)
                 {
-                    VisitTypeReference(expression.Type);
+                    await VisitTypeReferenceAsync(expression.Type).ConfigureAwait(false);    
                 }
 
                 this.VisitExpression(expression.Operand);
@@ -1279,7 +1279,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
 
                 if (!inlineType)
                 {
-                    VisitTypeReference(expression.Type);
+                    await VisitTypeReferenceAsync(expression.Type).ConfigureAwait(false);
                 }
 
                 this.VisitExpression(expression.Operand);
@@ -1412,7 +1412,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             await this.BeginElementAsync(operation, writeElementAction).ConfigureAwait(false);
 
             await this.schemaWriter.WriteOperationParametersBeginAsync(operation.Parameters).ConfigureAwait(false);
-            this.VisitOperationParameters(operation.Parameters);
+            await this.VisitOperationParametersAsync(operation.Parameters).ConfigureAwait(false);
             await this.schemaWriter.WriteOperationParametersEndAsync(operation.Parameters).ConfigureAwait(false);
 
             IEdmOperationReturn operationReturn = operation.GetReturn();
@@ -1501,12 +1501,12 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
                     {
                         IEdmCollectionTypeReference collectionElement = element.AsCollection();
                         await this.schemaWriter.WriteNullableAttributeAsync(collectionElement.CollectionDefinition().ElementType).ConfigureAwait(false);
-                        VisitTypeReference(collectionElement.CollectionDefinition().ElementType);
+                        await VisitTypeReferenceAsync(collectionElement.CollectionDefinition().ElementType).ConfigureAwait(false);
                     }
                     else
                     {
                         await this.schemaWriter.WriteNullableAttributeAsync(element).ConfigureAwait(false);
-                        VisitTypeReference(element);
+                        await VisitTypeReferenceAsync(element).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
@@ -186,7 +186,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             foreach (var operation in element.SchemaOperations)
             {
                 await this.schemaWriter.WriteSchemaOperationsHeaderAsync(operation).ConfigureAwait(false);
-                await VisitSchemaElementsAsync(operation.Value.AsEnumerable<IEdmSchemaElement>()).ConfigureAwait(false); // Call AsEnumerable() to make .net 3.5 happy
+                await VisitSchemaElementsAsync(operation.Value.AsEnumerable<IEdmSchemaElement>()).ConfigureAwait(false);
                 await this.schemaWriter.WriteSchemaOperationsEndAsync(operation).ConfigureAwait(false);
             }
 

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSerializationVisitor.cs
@@ -191,7 +191,7 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             }
 
             // EntityContainers are excluded from the EdmSchema.SchemaElements property so they can be forced to the end.
-            await VisitCollectionAsync(element.EntityContainers, (e) => this.ProcessEntityContainerAsync(e)).ConfigureAwait(false);
+            await VisitCollectionAsync(element.EntityContainers, this.ProcessEntityContainerAsync).ConfigureAwait(false);
 
             if (element.OutOfLineAnnotations.Any())
             {

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelSchemaSeparationSerializationVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelSchemaSeparationSerializationVisitor.cs
@@ -6,6 +6,7 @@
 
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.OData.Edm.Vocabularies;
 
 namespace Microsoft.OData.Edm.Csdl.Serialization
@@ -31,9 +32,25 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             return this.modelSchemas.Values;
         }
 
+        public async Task<IEnumerable<EdmSchema>> GetSchemasAsync()
+        {
+            if (!this.visitCompleted)
+            {
+                await this.VisitAsync().ConfigureAwait(false);
+            }
+
+            return this.modelSchemas.Values;
+        }
+
         protected void Visit()
         {
             this.VisitEdmModel();
+            this.visitCompleted = true;
+        }
+
+        protected async Task VisitAsync()
+        {
+            await this.VisitEdmModelAsync().ConfigureAwait(false);
             this.visitCompleted = true;
         }
 
@@ -44,10 +61,23 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.VisitVocabularyAnnotations(model.VocabularyAnnotations.Where(a => !a.IsInline(this.Model)));
         }
 
+        protected override async Task ProcessModelAsync(IEdmModel model)
+        {
+            await this.ProcessElementAsync(model).ConfigureAwait(false);
+            await this.VisitSchemaElementsAsync(model.SchemaElements).ConfigureAwait(false);
+            await this.VisitVocabularyAnnotationsAsync(model.VocabularyAnnotations.Where(a => !a.IsInline(this.Model))).ConfigureAwait(false);
+        }
+
         protected override void ProcessVocabularyAnnotatable(IEdmVocabularyAnnotatable element)
         {
             this.VisitAnnotations(this.Model.DirectValueAnnotations(element));
             this.VisitVocabularyAnnotations(this.Model.FindDeclaredVocabularyAnnotations(element).Where(a => a.IsInline(this.Model)));
+        }
+
+        protected override async Task ProcessVocabularyAnnotatableAsync(IEdmVocabularyAnnotatable element)
+        {
+            await this.VisitAnnotationsAsync(this.Model.DirectValueAnnotations(element)).ConfigureAwait(false);
+            await this.VisitVocabularyAnnotationsAsync(this.Model.FindDeclaredVocabularyAnnotations(element).Where(a => a.IsInline(this.Model))).ConfigureAwait(false);
         }
 
         protected override void ProcessSchemaElement(IEdmSchemaElement element)
@@ -71,6 +101,29 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.activeSchema = schema;
 
             base.ProcessSchemaElement(element);
+        }
+
+        protected override Task ProcessSchemaElementAsync(IEdmSchemaElement element)
+        {
+            string namespaceName = element.Namespace;
+
+            // Put all of the namespaceless stuff into one schema.
+            if (EdmUtil.IsNullOrWhiteSpaceInternal(namespaceName))
+            {
+                namespaceName = string.Empty;
+            }
+
+            EdmSchema schema;
+            if (!this.modelSchemas.TryGetValue(namespaceName, out schema))
+            {
+                schema = new EdmSchema(namespaceName);
+                this.modelSchemas.Add(namespaceName, schema);
+            }
+
+            schema.AddSchemaElement(element);
+            this.activeSchema = schema;
+
+            return base.ProcessSchemaElementAsync(element);
         }
 
         protected override void ProcessVocabularyAnnotation(IEdmVocabularyAnnotation annotation)
@@ -98,6 +151,31 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             base.ProcessVocabularyAnnotation(annotation);
         }
 
+        protected override async Task ProcessVocabularyAnnotationAsync(IEdmVocabularyAnnotation annotation)
+        {
+            if (!annotation.IsInline(this.Model))
+            {
+                var annotationSchemaNamespace = annotation.GetSchemaNamespace(this.Model) ?? this.modelSchemas.Select(s => s.Key).FirstOrDefault() ?? string.Empty;
+
+                EdmSchema annotationSchema;
+                if (!this.modelSchemas.TryGetValue(annotationSchemaNamespace, out annotationSchema))
+                {
+                    annotationSchema = new EdmSchema(annotationSchemaNamespace);
+                    this.modelSchemas.Add(annotationSchema.Namespace, annotationSchema);
+                }
+
+                annotationSchema.AddVocabularyAnnotation(annotation);
+                this.activeSchema = annotationSchema;
+            }
+
+            if (annotation.Term != null)
+            {
+                await this.CheckSchemaElementReferenceAsync(annotation.Term).ConfigureAwait(false);
+            }
+
+            await base.ProcessVocabularyAnnotationAsync(annotation).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// When we see an entity container, we see if it has <see cref="CsdlConstants.SchemaNamespaceAnnotation"/>.
         /// If it does, then we attach it to that schema, otherwise we attached to the first existing schema.
@@ -121,9 +199,38 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             base.ProcessEntityContainer(element);
         }
 
+        /// <summary>
+        /// When we see an entity container, we see if it has <see cref="CsdlConstants.SchemaNamespaceAnnotation"/>.
+        /// If it does, then we attach it to that schema, otherwise we attached to the first existing schema.
+        /// If there are no schemas, we create the one named "Default" and attach container to it.
+        /// </summary>
+        /// <param name="element">The entity container being processed.</param>
+        /// <returns>A task that represents the asynchronous operation.</returns>
+        protected override Task ProcessEntityContainerAsync(IEdmEntityContainer element)
+        {
+            var containerSchemaNamespace = element.Namespace;
+
+            EdmSchema containerSchema;
+            if (!this.modelSchemas.TryGetValue(containerSchemaNamespace, out containerSchema))
+            {
+                containerSchema = new EdmSchema(containerSchemaNamespace);
+                this.modelSchemas.Add(containerSchema.Namespace, containerSchema);
+            }
+
+            containerSchema.AddEntityContainer(element);
+            this.activeSchema = containerSchema;
+
+            return base.ProcessEntityContainerAsync(element);
+        }
+
         protected override void ProcessComplexTypeReference(IEdmComplexTypeReference element)
         {
             this.CheckSchemaElementReference(element.ComplexDefinition());
+        }
+
+        protected override Task ProcessComplexTypeReferenceAsync(IEdmComplexTypeReference element)
+        {
+            return this.CheckSchemaElementReferenceAsync(element.ComplexDefinition());
         }
 
         protected override void ProcessEntityTypeReference(IEdmEntityTypeReference element)
@@ -131,9 +238,19 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.CheckSchemaElementReference(element.EntityDefinition());
         }
 
+        protected override Task ProcessEntityTypeReferenceAsync(IEdmEntityTypeReference element)
+        {
+            return this.CheckSchemaElementReferenceAsync(element.EntityDefinition());
+        }
+
         protected override void ProcessEntityReferenceTypeReference(IEdmEntityReferenceTypeReference element)
         {
             this.CheckSchemaElementReference(element.EntityType());
+        }
+
+        protected override Task ProcessEntityReferenceTypeReferenceAsync(IEdmEntityReferenceTypeReference element)
+        {
+            return this.CheckSchemaElementReferenceAsync(element.EntityType());
         }
 
         protected override void ProcessEnumTypeReference(IEdmEnumTypeReference element)
@@ -141,9 +258,19 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.CheckSchemaElementReference(element.EnumDefinition());
         }
 
+        protected override Task ProcessEnumTypeReferenceAsync(IEdmEnumTypeReference element)
+        {
+            return this.CheckSchemaElementReferenceAsync(element.EnumDefinition());
+        }
+
         protected override void ProcessTypeDefinitionReference(IEdmTypeDefinitionReference element)
         {
             this.CheckSchemaElementReference(element.TypeDefinition());
+        }
+
+        protected override Task ProcessTypeDefinitionReferenceAsync(IEdmTypeDefinitionReference element)
+        {
+            return this.CheckSchemaElementReferenceAsync(element.TypeDefinition());
         }
 
         protected override void ProcessEntityType(IEdmEntityType element)
@@ -152,6 +279,15 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             if (element.BaseEntityType() != null)
             {
                 this.CheckSchemaElementReference(element.BaseEntityType());
+            }
+        }
+
+        protected override async Task ProcessEntityTypeAsync(IEdmEntityType element)
+        {
+            await base.ProcessEntityTypeAsync(element).ConfigureAwait(false);
+            if (element.BaseEntityType() != null)
+            {
+                await this.CheckSchemaElementReferenceAsync(element.BaseEntityType()).ConfigureAwait(false);
             }
         }
 
@@ -164,10 +300,25 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             }
         }
 
+        protected override async Task ProcessComplexTypeAsync(IEdmComplexType element)
+        {
+            await base.ProcessComplexTypeAsync(element).ConfigureAwait(false);
+            if (element.BaseComplexType() != null)
+            {
+                await this.CheckSchemaElementReferenceAsync(element.BaseComplexType()).ConfigureAwait(false);
+            }
+        }
+
         protected override void ProcessEnumType(IEdmEnumType element)
         {
             base.ProcessEnumType(element);
             this.CheckSchemaElementReference(element.UnderlyingType);
+        }
+
+        protected override async Task ProcessEnumTypeAsync(IEdmEnumType element)
+        {
+            await base.ProcessEnumTypeAsync(element).ConfigureAwait(false);
+            await this.CheckSchemaElementReferenceAsync(element.UnderlyingType).ConfigureAwait(false);
         }
 
         protected override void ProcessTypeDefinition(IEdmTypeDefinition element)
@@ -176,9 +327,20 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             this.CheckSchemaElementReference(element.UnderlyingType);
         }
 
+        protected override async Task ProcessTypeDefinitionAsync(IEdmTypeDefinition element)
+        {
+            await base.ProcessTypeDefinitionAsync(element).ConfigureAwait(false);
+            await this.CheckSchemaElementReferenceAsync(element.UnderlyingType).ConfigureAwait(false);
+        }
+
         private void CheckSchemaElementReference(IEdmSchemaElement element)
         {
             this.CheckSchemaElementReference(element.Namespace);
+        }
+
+        private Task CheckSchemaElementReferenceAsync(IEdmSchemaElement element)
+        {
+            return this.CheckSchemaElementReferenceAsync(element.Namespace);
         }
 
         private void CheckSchemaElementReference(string namespaceName)
@@ -187,6 +349,16 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
             {
                 this.activeSchema.AddNamespaceUsing(namespaceName);
             }
+        }
+
+        private Task CheckSchemaElementReferenceAsync(string namespaceName)
+        {
+            if (this.activeSchema != null)
+            {
+                this.activeSchema.AddNamespaceUsing(namespaceName);
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -766,8 +766,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessSchemaElementAsync(IEdmSchemaElement element)
         {
-            await this.ProcessVocabularyAnnotatableAsync(element);
-            await this.ProcessNamedElementAsync(element);
+            await this.ProcessVocabularyAnnotatableAsync(element).ConfigureAwait(false);
+            await this.ProcessNamedElementAsync(element).ConfigureAwait(false);
         }
 
         protected virtual void ProcessVocabularyAnnotatable(IEdmVocabularyAnnotatable annotatable)
@@ -811,8 +811,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessEntityReferenceTypeReferenceAsync(IEdmEntityReferenceTypeReference reference)
         {
-            await this.ProcessTypeReferenceAsync(reference);
-            await this.ProcessEntityReferenceTypeAsync(reference.EntityReferenceDefinition());
+            await this.ProcessTypeReferenceAsync(reference).ConfigureAwait(false);
+            await this.ProcessEntityReferenceTypeAsync(reference.EntityReferenceDefinition()).ConfigureAwait(false);
         }
 
         protected virtual void ProcessCollectionTypeReference(IEdmCollectionTypeReference reference)
@@ -823,8 +823,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessCollectionTypeReferenceAsync(IEdmCollectionTypeReference reference)
         {
-            await this.ProcessTypeReferenceAsync(reference);
-            await this.ProcessCollectionTypeAsync(reference.CollectionDefinition());
+            await this.ProcessTypeReferenceAsync(reference).ConfigureAwait(false);
+            await this.ProcessCollectionTypeAsync(reference.CollectionDefinition()).ConfigureAwait(false);
         }
 
         protected virtual void ProcessEnumTypeReference(IEdmEnumTypeReference reference)
@@ -1092,9 +1092,9 @@ namespace Microsoft.OData.Edm
             this.ProcessProperty(property);
         }
 
-        protected virtual async Task ProcessNavigationPropertyAsync(IEdmNavigationProperty property)
+        protected virtual Task ProcessNavigationPropertyAsync(IEdmNavigationProperty property)
         {
-            await this.ProcessPropertyAsync(property);
+            return this.ProcessPropertyAsync(property);
         }
 
         protected virtual void ProcessStructuralProperty(IEdmStructuralProperty property)
@@ -1102,9 +1102,9 @@ namespace Microsoft.OData.Edm
             this.ProcessProperty(property);
         }
 
-        protected virtual async Task ProcessStructuralPropertyAsync(IEdmStructuralProperty property)
+        protected virtual Task ProcessStructuralPropertyAsync(IEdmStructuralProperty property)
         {
-            await this.ProcessPropertyAsync(property);
+            return this.ProcessPropertyAsync(property);
         }
 
         protected virtual void ProcessProperty(IEdmProperty property)
@@ -1116,8 +1116,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessPropertyAsync(IEdmProperty property)
         {
-            await this.ProcessVocabularyAnnotatableAsync(property);
-            await this.ProcessNamedElementAsync(property);
+            await this.ProcessVocabularyAnnotatableAsync(property).ConfigureAwait(false);
+            await this.ProcessNamedElementAsync(property).ConfigureAwait(false);
             await this.VisitTypeReferenceAsync(property.Type).ConfigureAwait(false);
         }
 
@@ -1126,9 +1126,9 @@ namespace Microsoft.OData.Edm
             this.ProcessNamedElement(enumMember);
         }
 
-        protected virtual async Task ProcessEnumMemberAsync(IEdmEnumMember enumMember)
+        protected virtual Task ProcessEnumMemberAsync(IEdmEnumMember enumMember)
         {
-            await this.ProcessNamedElementAsync(enumMember);
+            return this.ProcessNamedElementAsync(enumMember);
         }
 
         #endregion
@@ -1140,9 +1140,9 @@ namespace Microsoft.OData.Edm
             this.ProcessElement(annotation);
         }
 
-        protected virtual async Task ProcessVocabularyAnnotationAsync(IEdmVocabularyAnnotation annotation)
+        protected virtual Task ProcessVocabularyAnnotationAsync(IEdmVocabularyAnnotation annotation)
         {
-            await this.ProcessElementAsync(annotation);
+            return this.ProcessElementAsync(annotation);
         }
 
         protected virtual void ProcessImmediateValueAnnotation(IEdmDirectValueAnnotation annotation)
@@ -1280,8 +1280,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessCollectionExpressionAsync(IEdmCollectionExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
-            await this.VisitExpressionsAsync(expression.Elements);
+            await this.ProcessExpressionAsync(expression).ConfigureAwait(false);
+            await this.VisitExpressionsAsync(expression.Elements).ConfigureAwait(false);
         }
 
         protected virtual void ProcessLabeledExpressionReferenceExpression(IEdmLabeledExpressionReferenceExpression expression)
@@ -1303,9 +1303,9 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessIsOfExpressionAsync(IEdmIsOfExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
-            await this.VisitTypeReferenceAsync(expression.Type);
-            await this.VisitExpressionAsync(expression.Operand);
+            await this.ProcessExpressionAsync(expression).ConfigureAwait(false);
+            await this.VisitTypeReferenceAsync(expression.Type).ConfigureAwait(false);
+            await this.VisitExpressionAsync(expression.Operand).ConfigureAwait(false);
         }
 
         protected virtual void ProcessIntegerConstantExpression(IEdmIntegerConstantExpression expression)
@@ -1476,9 +1476,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessNullConstantExpressionAsync(IEdmNullExpression expression)
+        protected virtual Task ProcessNullConstantExpressionAsync(IEdmNullExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         #endregion
@@ -1494,9 +1494,9 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessEntityContainerAsync(IEdmEntityContainer container)
         {
-            await this.ProcessVocabularyAnnotatableAsync(container);
-            await this.ProcessNamedElementAsync(container);
-            await this.VisitEntityContainerElementsAsync(container.Elements);
+            await this.ProcessVocabularyAnnotatableAsync(container).ConfigureAwait(false);
+            await this.ProcessNamedElementAsync(container).ConfigureAwait(false);
+            await this.VisitEntityContainerElementsAsync(container.Elements).ConfigureAwait(false);
         }
 
         protected virtual void ProcessEntityContainerElement(IEdmEntityContainerElement element)
@@ -1504,9 +1504,9 @@ namespace Microsoft.OData.Edm
             this.ProcessNamedElement(element);
         }
 
-        protected virtual async Task ProcessEntityContainerElementAsync(IEdmEntityContainerElement element)
+        protected virtual Task ProcessEntityContainerElementAsync(IEdmEntityContainerElement element)
         {
-            await this.ProcessNamedElementAsync(element);
+            return this.ProcessNamedElementAsync(element);
         }
 
         protected virtual void ProcessEntitySet(IEdmEntitySet set)
@@ -1514,9 +1514,9 @@ namespace Microsoft.OData.Edm
             this.ProcessEntityContainerElement(set);
         }
 
-        protected virtual async Task ProcessEntitySetAsync(IEdmEntitySet set)
+        protected virtual Task ProcessEntitySetAsync(IEdmEntitySet set)
         {
-            await this.ProcessEntityContainerElementAsync(set);
+            return this.ProcessEntityContainerElementAsync(set);
         }
 
         protected virtual void ProcessSingleton(IEdmSingleton singleton)
@@ -1524,9 +1524,9 @@ namespace Microsoft.OData.Edm
             this.ProcessEntityContainerElement(singleton);
         }
 
-        protected virtual async Task ProcessSingletonAsync(IEdmSingleton singleton)
+        protected virtual Task ProcessSingletonAsync(IEdmSingleton singleton)
         {
-            await this.ProcessEntityContainerElementAsync(singleton);
+            return this.ProcessEntityContainerElementAsync(singleton);
         }
 
         #endregion
@@ -1541,8 +1541,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessActionAsync(IEdmAction action)
         {
-            await this.ProcessSchemaElementAsync(action);
-            await this.ProcessOperationAsync(action);
+            await this.ProcessSchemaElementAsync(action).ConfigureAwait(false);
+            await this.ProcessOperationAsync(action).ConfigureAwait(false);
         }
 
         protected virtual void ProcessFunction(IEdmFunction function)
@@ -1553,8 +1553,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessFunctionAsync(IEdmFunction function)
         {
-            await this.ProcessSchemaElementAsync(function);
-            await this.ProcessOperationAsync(function);
+            await this.ProcessSchemaElementAsync(function).ConfigureAwait(false);
+            await this.ProcessOperationAsync(function).ConfigureAwait(false);
         }
 
         protected virtual void ProcessActionImport(IEdmActionImport actionImport)
@@ -1592,7 +1592,7 @@ namespace Microsoft.OData.Edm
             await this.VisitOperationParametersAsync(operation.Parameters).ConfigureAwait(false);
 
             IEdmOperationReturn operationReturn = operation.GetReturn();
-            await this.ProcessOperationReturnAsync(operationReturn);
+            await this.ProcessOperationReturnAsync(operationReturn).ConfigureAwait(false);
         }
 
         protected virtual void ProcessOperationParameter(IEdmOperationParameter parameter)
@@ -1604,9 +1604,9 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessOperationParameterAsync(IEdmOperationParameter parameter)
         {
-            await this.ProcessVocabularyAnnotatableAsync(parameter);
-            await this.ProcessNamedElementAsync(parameter);
-            await this.VisitTypeReferenceAsync(parameter.Type);
+            await this.ProcessVocabularyAnnotatableAsync(parameter).ConfigureAwait(false);
+            await this.ProcessNamedElementAsync(parameter).ConfigureAwait(false);
+            await this.VisitTypeReferenceAsync(parameter.Type).ConfigureAwait(false);
         }
 
         protected virtual void ProcessOperationReturn(IEdmOperationReturn operationReturn)
@@ -1627,7 +1627,7 @@ namespace Microsoft.OData.Edm
                 return;
             }
 
-            await this.ProcessVocabularyAnnotatableAsync(operationReturn);
+            await this.ProcessVocabularyAnnotatableAsync(operationReturn).ConfigureAwait(false);
             await this.VisitTypeReferenceAsync(operationReturn.Type).ConfigureAwait(false);
         }
         #endregion

--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.Contracts;
 using System.Threading.Tasks;
 using Microsoft.OData.Edm.Vocabularies;
 
@@ -88,7 +89,8 @@ namespace Microsoft.OData.Edm
                 case EdmSchemaElementKind.None:
                     return this.ProcessSchemaElementAsync(element);
                 default:
-                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_SchemaElementKind(element.SchemaElementKind));
+                    Contract.Assert(false, Edm.Strings.UnknownEnumVal_SchemaElementKind(element.SchemaElementKind));
+                    return Task.FromException<InvalidOperationException>(new InvalidOperationException(Edm.Strings.UnknownEnumVal_SchemaElementKind(element.SchemaElementKind)));
             }
         }
 
@@ -458,7 +460,8 @@ namespace Microsoft.OData.Edm
                 case EdmTypeKind.Untyped:
                     return this.ProcessUntypedTypeReferenceAsync(reference as IEdmUntypedTypeReference);
                 default:
-                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_TypeKind(reference.TypeKind().ToString()));
+                    Contract.Assert(false, Edm.Strings.UnknownEnumVal_TypeKind(reference.TypeKind().ToString()));
+                    return Task.FromException<InvalidOperationException>(new InvalidOperationException(Edm.Strings.UnknownEnumVal_TypeKind(reference.TypeKind().ToString())));
             }
         }
 
@@ -564,7 +567,8 @@ namespace Microsoft.OData.Edm
                 case EdmPrimitiveTypeKind.None:
                     return this.ProcessPrimitiveTypeReferenceAsync(reference);
                 default:
-                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_PrimitiveKind(reference.PrimitiveKind().ToString()));
+                    Contract.Assert(false, Edm.Strings.UnknownEnumVal_PrimitiveKind(reference.PrimitiveKind().ToString()));
+                    return Task.FromException<InvalidOperationException>(new InvalidOperationException(Edm.Strings.UnknownEnumVal_PrimitiveKind(reference.PrimitiveKind().ToString())));
             }
         }
 
@@ -611,7 +615,8 @@ namespace Microsoft.OData.Edm
                 case EdmTypeKind.None:
                     return this.VisitSchemaTypeAsync(definition);
                 default:
-                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_TypeKind(definition.TypeKind));
+                    Contract.Assert(false, Edm.Strings.UnknownEnumVal_TypeKind(definition.TypeKind));
+                    return Task.FromException<InvalidOperationException>(new InvalidOperationException(Edm.Strings.UnknownEnumVal_TypeKind(definition.TypeKind)));
             }
         }
 
@@ -654,7 +659,8 @@ namespace Microsoft.OData.Edm
                 case EdmPropertyKind.None:
                     return this.ProcessPropertyAsync(property);
                 default:
-                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_PropertyKind(property.PropertyKind.ToString()));
+                    Contract.Assert(false, Edm.Strings.UnknownEnumVal_PropertyKind(property.PropertyKind.ToString()));
+                    return Task.FromException<InvalidOperationException>(new InvalidOperationException(Edm.Strings.UnknownEnumVal_PropertyKind(property.PropertyKind.ToString())));
             }
         }
 

--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -25,6 +25,11 @@ namespace Microsoft.OData.Edm
             this.ProcessModel(this.Model);
         }
 
+        public Task VisitEdmModelAsync()
+        {
+            return this.ProcessModelAsync(this.Model);
+        }
+
         #region Visit Methods
 
         #region Elements
@@ -32,6 +37,11 @@ namespace Microsoft.OData.Edm
         public void VisitSchemaElements(IEnumerable<IEdmSchemaElement> elements)
         {
             VisitCollection(elements, this.VisitSchemaElement);
+        }
+
+        public Task VisitSchemaElementsAsync(IEnumerable<IEdmSchemaElement> elements)
+        {
+            return VisitCollectionAsync(elements, this.VisitSchemaElementAsync);
         }
 
         public void VisitSchemaElement(IEdmSchemaElement element)
@@ -61,6 +71,27 @@ namespace Microsoft.OData.Edm
             }
         }
 
+        public Task VisitSchemaElementAsync(IEdmSchemaElement element)
+        {
+            switch (element.SchemaElementKind)
+            {
+                case EdmSchemaElementKind.Action:
+                    return this.ProcessActionAsync((IEdmAction)element);
+                case EdmSchemaElementKind.Function:
+                    return this.ProcessFunctionAsync((IEdmFunction)element);
+                case EdmSchemaElementKind.TypeDefinition:
+                    return this.VisitSchemaTypeAsync((IEdmType)element);
+                case EdmSchemaElementKind.Term:
+                    return this.ProcessTermAsync((IEdmTerm)element);
+                case EdmSchemaElementKind.EntityContainer:
+                    return this.ProcessEntityContainerAsync((IEdmEntityContainer)element);
+                case EdmSchemaElementKind.None:
+                    return this.ProcessSchemaElementAsync(element);
+                default:
+                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_SchemaElementKind(element.SchemaElementKind));
+            }
+        }
+
         #endregion
 
         #region Annotations
@@ -70,14 +101,29 @@ namespace Microsoft.OData.Edm
             VisitCollection(annotations, this.VisitAnnotation);
         }
 
+        public Task VisitAnnotationsAsync(IEnumerable<IEdmDirectValueAnnotation> annotations)
+        {
+            return VisitCollectionAsync(annotations, this.VisitAnnotationAsync);
+        }
+
         public void VisitVocabularyAnnotations(IEnumerable<IEdmVocabularyAnnotation> annotations)
         {
             VisitCollection(annotations, this.VisitVocabularyAnnotation);
         }
 
+        public Task VisitVocabularyAnnotationsAsync(IEnumerable<IEdmVocabularyAnnotation> annotations)
+        {
+            return VisitCollectionAsync(annotations, this.VisitVocabularyAnnotationAsync);
+        }
+
         public void VisitAnnotation(IEdmDirectValueAnnotation annotation)
         {
             this.ProcessImmediateValueAnnotation((IEdmDirectValueAnnotation)annotation);
+        }
+
+        public Task VisitAnnotationAsync(IEdmDirectValueAnnotation annotation)
+        {
+            return this.ProcessImmediateValueAnnotationAsync((IEdmDirectValueAnnotation)annotation);
         }
 
         public void VisitVocabularyAnnotation(IEdmVocabularyAnnotation annotation)
@@ -92,9 +138,26 @@ namespace Microsoft.OData.Edm
             }
         }
 
+        public Task VisitVocabularyAnnotationAsync(IEdmVocabularyAnnotation annotation)
+        {
+            if (annotation.Term != null)
+            {
+                return this.ProcessAnnotationAsync(annotation);
+            }
+            else
+            {
+                return this.ProcessVocabularyAnnotationAsync(annotation);
+            }
+        }
+
         public void VisitPropertyValueBindings(IEnumerable<IEdmPropertyValueBinding> bindings)
         {
             VisitCollection(bindings, this.ProcessPropertyValueBinding);
+        }
+
+        public Task VisitPropertyValueBindingsAsync(IEnumerable<IEdmPropertyValueBinding> bindings)
+        {
+            return VisitCollectionAsync(bindings, this.ProcessPropertyValueBindingAsync);
         }
 
         #endregion
@@ -104,6 +167,11 @@ namespace Microsoft.OData.Edm
         public void VisitExpressions(IEnumerable<IEdmExpression> expressions)
         {
             VisitCollection(expressions, this.VisitExpression);
+        }
+
+        public Task VisitExpressionsAsync(IEnumerable<IEdmExpression> expressions)
+        {
+            return VisitCollectionAsync(expressions, this.VisitExpressionAsync);
         }
 
         public void VisitExpression(IEdmExpression expression)
@@ -193,9 +261,75 @@ namespace Microsoft.OData.Edm
             }
         }
 
+        public Task VisitExpressionAsync(IEdmExpression expression)
+        {
+            switch (expression.ExpressionKind)
+            {
+                case EdmExpressionKind.Cast:
+                    return this.ProcessCastExpressionAsync((IEdmCastExpression)expression);
+                case EdmExpressionKind.BinaryConstant:
+                    return this.ProcessBinaryConstantExpressionAsync((IEdmBinaryConstantExpression)expression);
+                case EdmExpressionKind.BooleanConstant:
+                    return this.ProcessBooleanConstantExpressionAsync((IEdmBooleanConstantExpression)expression);
+                case EdmExpressionKind.Collection:
+                    return this.ProcessCollectionExpressionAsync((IEdmCollectionExpression)expression);
+                case EdmExpressionKind.DateConstant:
+                    return this.ProcessDateConstantExpressionAsync((IEdmDateConstantExpression)expression);
+                case EdmExpressionKind.DateTimeOffsetConstant:
+                    return this.ProcessDateTimeOffsetConstantExpressionAsync((IEdmDateTimeOffsetConstantExpression)expression);
+                case EdmExpressionKind.DecimalConstant:
+                    return this.ProcessDecimalConstantExpressionAsync((IEdmDecimalConstantExpression)expression);
+                case EdmExpressionKind.EnumMember:
+                    return this.ProcessEnumMemberExpressionAsync((IEdmEnumMemberExpression)expression);
+                case EdmExpressionKind.FloatingConstant:
+                    return this.ProcessFloatingConstantExpressionAsync((IEdmFloatingConstantExpression)expression);
+                case EdmExpressionKind.FunctionApplication:
+                    return this.ProcessFunctionApplicationExpressionAsync((IEdmApplyExpression)expression);
+                case EdmExpressionKind.GuidConstant:
+                    return this.ProcessGuidConstantExpressionAsync((IEdmGuidConstantExpression)expression);
+                case EdmExpressionKind.If:
+                    return this.ProcessIfExpressionAsync((IEdmIfExpression)expression);
+                case EdmExpressionKind.IntegerConstant:
+                    return this.ProcessIntegerConstantExpressionAsync((IEdmIntegerConstantExpression)expression);
+                case EdmExpressionKind.IsOf:
+                    return this.ProcessIsOfExpressionAsync((IEdmIsOfExpression)expression);
+                case EdmExpressionKind.LabeledExpressionReference:
+                    return this.ProcessLabeledExpressionReferenceExpressionAsync((IEdmLabeledExpressionReferenceExpression)expression);
+                case EdmExpressionKind.Labeled:
+                    return this.ProcessLabeledExpressionAsync((IEdmLabeledExpression)expression);
+                case EdmExpressionKind.Null:
+                    return this.ProcessNullConstantExpressionAsync((IEdmNullExpression)expression);
+                case EdmExpressionKind.Path:
+                    return this.ProcessPathExpressionAsync((IEdmPathExpression)expression);
+                case EdmExpressionKind.PropertyPath:
+                    return this.ProcessPropertyPathExpressionAsync((IEdmPathExpression)expression);
+                case EdmExpressionKind.NavigationPropertyPath:
+                    return this.ProcessNavigationPropertyPathExpressionAsync((IEdmPathExpression)expression);
+                case EdmExpressionKind.AnnotationPath:
+                    return this.ProcessAnnotationPathExpressionAsync((IEdmPathExpression)expression);
+                case EdmExpressionKind.Record:
+                    return this.ProcessRecordExpressionAsync((IEdmRecordExpression)expression);
+                case EdmExpressionKind.StringConstant:
+                    return this.ProcessStringConstantExpressionAsync((IEdmStringConstantExpression)expression);
+                case EdmExpressionKind.TimeOfDayConstant:
+                    return this.ProcessTimeOfDayConstantExpressionAsync((IEdmTimeOfDayConstantExpression)expression);
+                case EdmExpressionKind.DurationConstant:
+                    return this.ProcessDurationConstantExpressionAsync((IEdmDurationConstantExpression)expression);
+                case EdmExpressionKind.None:
+                    return this.ProcessExpressionAsync(expression);
+                default:
+                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_ExpressionKind(expression.ExpressionKind));
+            }
+        }
+
         public void VisitPropertyConstructors(IEnumerable<IEdmPropertyConstructor> constructor)
         {
             VisitCollection(constructor, this.ProcessPropertyConstructor);
+        }
+
+        public Task VisitPropertyConstructorsAsync(IEnumerable<IEdmPropertyConstructor> constructor)
+        {
+            return VisitCollectionAsync(constructor, this.ProcessPropertyConstructorAsync);
         }
 
         #endregion
@@ -299,6 +433,35 @@ namespace Microsoft.OData.Edm
             }
         }
 
+        public Task VisitTypeReferenceAsync(IEdmTypeReference reference)
+        {
+            switch (reference.TypeKind())
+            {
+                case EdmTypeKind.Collection:
+                    return this.ProcessCollectionTypeReferenceAsync(reference.AsCollection());
+                case EdmTypeKind.Complex:
+                    return this.ProcessComplexTypeReferenceAsync(reference.AsComplex());
+                case EdmTypeKind.Entity:
+                    return this.ProcessEntityTypeReferenceAsync(reference.AsEntity());
+                case EdmTypeKind.EntityReference:
+                    return this.ProcessEntityReferenceTypeReferenceAsync(reference.AsEntityReference());
+                case EdmTypeKind.Enum:
+                    return this.ProcessEnumTypeReferenceAsync(reference.AsEnum());
+                case EdmTypeKind.Primitive:
+                    return this.VisitPrimitiveTypeReferenceAsync(reference.AsPrimitive());
+                case EdmTypeKind.TypeDefinition:
+                    return this.ProcessTypeDefinitionReferenceAsync(reference.AsTypeDefinition());
+                case EdmTypeKind.None:
+                    return this.ProcessTypeReferenceAsync(reference);
+                case EdmTypeKind.Path:
+                    return this.ProcessPathTypeReferenceAsync(reference.AsPath());
+                case EdmTypeKind.Untyped:
+                    return this.ProcessUntypedTypeReferenceAsync(reference as IEdmUntypedTypeReference);
+                default:
+                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_TypeKind(reference.TypeKind().ToString()));
+            }
+        }
+
         public void VisitPrimitiveTypeReference(IEdmPrimitiveTypeReference reference)
         {
             switch (reference.PrimitiveKind())
@@ -355,6 +518,56 @@ namespace Microsoft.OData.Edm
             }
         }
 
+        public Task VisitPrimitiveTypeReferenceAsync(IEdmPrimitiveTypeReference reference)
+        {
+            switch (reference.PrimitiveKind())
+            {
+                case EdmPrimitiveTypeKind.Binary:
+                    return this.ProcessBinaryTypeReferenceAsync(reference.AsBinary());
+                case EdmPrimitiveTypeKind.Decimal:
+                    return this.ProcessDecimalTypeReferenceAsync(reference.AsDecimal());
+                case EdmPrimitiveTypeKind.String:
+                    return this.ProcessStringTypeReferenceAsync(reference.AsString());
+                case EdmPrimitiveTypeKind.DateTimeOffset:
+                case EdmPrimitiveTypeKind.Duration:
+                case EdmPrimitiveTypeKind.TimeOfDay:
+                    return this.ProcessTemporalTypeReferenceAsync(reference.AsTemporal());
+                case EdmPrimitiveTypeKind.Geography:
+                case EdmPrimitiveTypeKind.GeographyPoint:
+                case EdmPrimitiveTypeKind.GeographyLineString:
+                case EdmPrimitiveTypeKind.GeographyPolygon:
+                case EdmPrimitiveTypeKind.GeographyCollection:
+                case EdmPrimitiveTypeKind.GeographyMultiPolygon:
+                case EdmPrimitiveTypeKind.GeographyMultiLineString:
+                case EdmPrimitiveTypeKind.GeographyMultiPoint:
+                case EdmPrimitiveTypeKind.Geometry:
+                case EdmPrimitiveTypeKind.GeometryPoint:
+                case EdmPrimitiveTypeKind.GeometryLineString:
+                case EdmPrimitiveTypeKind.GeometryPolygon:
+                case EdmPrimitiveTypeKind.GeometryCollection:
+                case EdmPrimitiveTypeKind.GeometryMultiPolygon:
+                case EdmPrimitiveTypeKind.GeometryMultiLineString:
+                case EdmPrimitiveTypeKind.GeometryMultiPoint:
+                    return this.ProcessSpatialTypeReferenceAsync(reference.AsSpatial());
+                case EdmPrimitiveTypeKind.Boolean:
+                case EdmPrimitiveTypeKind.Byte:
+                case EdmPrimitiveTypeKind.Double:
+                case EdmPrimitiveTypeKind.Guid:
+                case EdmPrimitiveTypeKind.Int16:
+                case EdmPrimitiveTypeKind.Int32:
+                case EdmPrimitiveTypeKind.Int64:
+                case EdmPrimitiveTypeKind.SByte:
+                case EdmPrimitiveTypeKind.Single:
+                case EdmPrimitiveTypeKind.Stream:
+                case EdmPrimitiveTypeKind.Date:
+                case EdmPrimitiveTypeKind.PrimitiveType:
+                case EdmPrimitiveTypeKind.None:
+                    return this.ProcessPrimitiveTypeReferenceAsync(reference);
+                default:
+                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_PrimitiveKind(reference.PrimitiveKind().ToString()));
+            }
+        }
+
         #endregion
 
         #region Type Definitions
@@ -383,9 +596,33 @@ namespace Microsoft.OData.Edm
             }
         }
 
+        public Task VisitSchemaTypeAsync(IEdmType definition)
+        {
+            switch (definition.TypeKind)
+            {
+                case EdmTypeKind.Complex:
+                    return this.ProcessComplexTypeAsync((IEdmComplexType)definition);
+                case EdmTypeKind.Entity:
+                    return this.ProcessEntityTypeAsync((IEdmEntityType)definition);
+                case EdmTypeKind.Enum:
+                    return this.ProcessEnumTypeAsync((IEdmEnumType)definition);
+                case EdmTypeKind.TypeDefinition:
+                    return this.ProcessTypeDefinitionAsync((IEdmTypeDefinition)definition);
+                case EdmTypeKind.None:
+                    return this.VisitSchemaTypeAsync(definition);
+                default:
+                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_TypeKind(definition.TypeKind));
+            }
+        }
+
         public void VisitProperties(IEnumerable<IEdmProperty> properties)
         {
             VisitCollection(properties, this.VisitProperty);
+        }
+
+        public Task VisitPropertiesAsync(IEnumerable<IEdmProperty> properties)
+        {
+            return VisitCollectionAsync(properties, this.VisitPropertyAsync);
         }
 
         public void VisitProperty(IEdmProperty property)
@@ -406,14 +643,39 @@ namespace Microsoft.OData.Edm
             }
         }
 
+        public Task VisitPropertyAsync(IEdmProperty property)
+        {
+            switch (property.PropertyKind)
+            {
+                case EdmPropertyKind.Navigation:
+                    return this.ProcessNavigationPropertyAsync((IEdmNavigationProperty)property);
+                case EdmPropertyKind.Structural:
+                    return this.ProcessStructuralPropertyAsync((IEdmStructuralProperty)property);
+                case EdmPropertyKind.None:
+                    return this.ProcessPropertyAsync(property);
+                default:
+                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_PropertyKind(property.PropertyKind.ToString()));
+            }
+        }
+
         public void VisitEnumMembers(IEnumerable<IEdmEnumMember> enumMembers)
         {
             VisitCollection(enumMembers, this.VisitEnumMember);
         }
 
+        public Task VisitEnumMembersAsync(IEnumerable<IEdmEnumMember> enumMembers)
+        {
+            return VisitCollectionAsync(enumMembers, this.VisitEnumMemberAsync);
+        }
+
         public void VisitEnumMember(IEdmEnumMember enumMember)
         {
             this.ProcessEnumMember(enumMember);
+        }
+
+        public Task VisitEnumMemberAsync(IEdmEnumMember enumMember)
+        {
+            return this.ProcessEnumMemberAsync(enumMember);
         }
 
         #endregion
@@ -425,6 +687,11 @@ namespace Microsoft.OData.Edm
             VisitCollection(parameters, this.ProcessOperationParameter);
         }
 
+        public Task VisitOperationParametersAsync(IEnumerable<IEdmOperationParameter> parameters)
+        {
+            return VisitCollectionAsync(parameters, this.ProcessOperationParameterAsync);
+        }
+
         #endregion
 
         protected static void VisitCollection<T>(IEnumerable<T> collection, Action<T> visitMethod)
@@ -432,6 +699,14 @@ namespace Microsoft.OData.Edm
             foreach (T element in collection)
             {
                 visitMethod(element);
+            }
+        }
+
+        protected static async Task VisitCollectionAsync<T>(IEnumerable<T> collection, Func<T, Task> visitMethod)
+        {
+            foreach (T element in collection)
+            {
+                await visitMethod(element).ConfigureAwait(false);
             }
         }
         #endregion
@@ -447,6 +722,14 @@ namespace Microsoft.OData.Edm
             this.VisitVocabularyAnnotations(model.VocabularyAnnotations);
         }
 
+        protected virtual async Task ProcessModelAsync(IEdmModel model)
+        {
+            await this.ProcessElementAsync(model).ConfigureAwait(false);
+
+            await this.VisitSchemaElementsAsync(model.SchemaElements).ConfigureAwait(false);
+            await this.VisitVocabularyAnnotationsAsync(model.VocabularyAnnotations).ConfigureAwait(false);
+        }
+
         #region Base Element Types
 
         protected virtual void ProcessElement(IEdmElement element)
@@ -457,10 +740,7 @@ namespace Microsoft.OData.Edm
 
         protected virtual Task ProcessElementAsync(IEdmElement element)
         {
-            // TODO: DirectValueAnnotationsInMainSchema (not including those in referenced schemas)
-            this.VisitAnnotations(this.Model.DirectValueAnnotations(element));
-
-            return Task.CompletedTask;
+            return this.VisitAnnotationsAsync(this.Model.DirectValueAnnotations(element));
         }
 
         protected virtual void ProcessNamedElement(IEdmNamedElement element)
@@ -468,9 +748,9 @@ namespace Microsoft.OData.Edm
             this.ProcessElement(element);
         }
 
-        protected virtual async Task ProcessNamedElementAsync(IEdmNamedElement element)
+        protected virtual Task ProcessNamedElementAsync(IEdmNamedElement element)
         {
-            await this.ProcessElementAsync(element);
+            return this.ProcessElementAsync(element);
         }
 
         protected virtual void ProcessSchemaElement(IEdmSchemaElement element)
@@ -503,9 +783,9 @@ namespace Microsoft.OData.Edm
             this.ProcessStructuredTypeReference(reference);
         }
 
-        protected virtual async Task ProcessComplexTypeReferenceAsync(IEdmComplexTypeReference reference)
+        protected virtual Task ProcessComplexTypeReferenceAsync(IEdmComplexTypeReference reference)
         {
-            await this.ProcessStructuredTypeReferenceAsync(reference);
+            return this.ProcessStructuredTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessEntityTypeReference(IEdmEntityTypeReference reference)
@@ -513,9 +793,9 @@ namespace Microsoft.OData.Edm
             this.ProcessStructuredTypeReference(reference);
         }
 
-        protected virtual async Task ProcessEntityTypeReferenceAsync(IEdmEntityTypeReference reference)
+        protected virtual Task ProcessEntityTypeReferenceAsync(IEdmEntityTypeReference reference)
         {
-            await this.ProcessStructuredTypeReferenceAsync(reference);
+            return this.ProcessStructuredTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessEntityReferenceTypeReference(IEdmEntityReferenceTypeReference reference)
@@ -547,9 +827,9 @@ namespace Microsoft.OData.Edm
             this.ProcessTypeReference(reference);
         }
 
-        protected virtual async Task ProcessEnumTypeReferenceAsync(IEdmEnumTypeReference reference)
+        protected virtual Task ProcessEnumTypeReferenceAsync(IEdmEnumTypeReference reference)
         {
-            await this.ProcessTypeReferenceAsync(reference);
+            return this.ProcessTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessTypeDefinitionReference(IEdmTypeDefinitionReference reference)
@@ -557,9 +837,9 @@ namespace Microsoft.OData.Edm
             this.ProcessTypeReference(reference);
         }
 
-        protected virtual async Task ProcessTypeDefinitionReferenceAsync(IEdmTypeDefinitionReference reference)
+        protected virtual Task ProcessTypeDefinitionReferenceAsync(IEdmTypeDefinitionReference reference)
         {
-            await this.ProcessTypeReferenceAsync(reference);
+            return this.ProcessTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessBinaryTypeReference(IEdmBinaryTypeReference reference)
@@ -567,9 +847,9 @@ namespace Microsoft.OData.Edm
             this.ProcessPrimitiveTypeReference(reference);
         }
 
-        protected virtual async Task ProcessBinaryTypeReferenceAsync(IEdmBinaryTypeReference reference)
+        protected virtual Task ProcessBinaryTypeReferenceAsync(IEdmBinaryTypeReference reference)
         {
-            await this.ProcessPrimitiveTypeReferenceAsync(reference);
+            return this.ProcessPrimitiveTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessDecimalTypeReference(IEdmDecimalTypeReference reference)
@@ -577,9 +857,9 @@ namespace Microsoft.OData.Edm
             this.ProcessPrimitiveTypeReference(reference);
         }
 
-        protected virtual async Task ProcessDecimalTypeReferenceAsync(IEdmDecimalTypeReference reference)
+        protected virtual Task ProcessDecimalTypeReferenceAsync(IEdmDecimalTypeReference reference)
         {
-            await this.ProcessPrimitiveTypeReferenceAsync(reference);
+            return this.ProcessPrimitiveTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessSpatialTypeReference(IEdmSpatialTypeReference reference)
@@ -587,9 +867,9 @@ namespace Microsoft.OData.Edm
             this.ProcessPrimitiveTypeReference(reference);
         }
 
-        protected virtual async Task ProcessSpatialTypeReferenceAsync(IEdmSpatialTypeReference reference)
+        protected virtual Task ProcessSpatialTypeReferenceAsync(IEdmSpatialTypeReference reference)
         {
-            await this.ProcessPrimitiveTypeReferenceAsync(reference);
+            return this.ProcessPrimitiveTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessStringTypeReference(IEdmStringTypeReference reference)
@@ -597,9 +877,9 @@ namespace Microsoft.OData.Edm
             this.ProcessPrimitiveTypeReference(reference);
         }
 
-        protected virtual async Task ProcessStringTypeReferenceAsync(IEdmStringTypeReference reference)
+        protected virtual Task ProcessStringTypeReferenceAsync(IEdmStringTypeReference reference)
         {
-            await this.ProcessPrimitiveTypeReferenceAsync(reference);
+            return this.ProcessPrimitiveTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessTemporalTypeReference(IEdmTemporalTypeReference reference)
@@ -607,9 +887,9 @@ namespace Microsoft.OData.Edm
             this.ProcessPrimitiveTypeReference(reference);
         }
 
-        protected virtual async Task ProcessTemporalTypeReferenceAsync(IEdmTemporalTypeReference reference)
+        protected virtual Task ProcessTemporalTypeReferenceAsync(IEdmTemporalTypeReference reference)
         {
-            await this.ProcessPrimitiveTypeReferenceAsync(reference);
+            return this.ProcessPrimitiveTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessPrimitiveTypeReference(IEdmPrimitiveTypeReference reference)
@@ -617,9 +897,9 @@ namespace Microsoft.OData.Edm
             this.ProcessTypeReference(reference);
         }
 
-        protected virtual async Task ProcessPrimitiveTypeReferenceAsync(IEdmPrimitiveTypeReference reference)
+        protected virtual Task ProcessPrimitiveTypeReferenceAsync(IEdmPrimitiveTypeReference reference)
         {
-            await this.ProcessTypeReferenceAsync(reference);
+            return this.ProcessTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessStructuredTypeReference(IEdmStructuredTypeReference reference)
@@ -627,9 +907,9 @@ namespace Microsoft.OData.Edm
             this.ProcessTypeReference(reference);
         }
 
-        protected virtual async Task ProcessStructuredTypeReferenceAsync(IEdmStructuredTypeReference reference)
+        protected virtual Task ProcessStructuredTypeReferenceAsync(IEdmStructuredTypeReference reference)
         {
-            await this.ProcessTypeReferenceAsync(reference);
+            return this.ProcessTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessTypeReference(IEdmTypeReference element)
@@ -637,9 +917,9 @@ namespace Microsoft.OData.Edm
             this.ProcessElement(element);
         }
 
-        protected virtual async Task ProcessTypeReferenceAsync(IEdmTypeReference element)
+        protected virtual Task ProcessTypeReferenceAsync(IEdmTypeReference element)
         {
-            await this.ProcessElementAsync(element);
+            return this.ProcessElementAsync(element);
         }
 
         protected virtual void ProcessPathTypeReference(IEdmPathTypeReference reference)
@@ -647,9 +927,9 @@ namespace Microsoft.OData.Edm
             this.ProcessTypeReference(reference);
         }
 
-        protected virtual async Task ProcessPathTypeReferenceAsync(IEdmPathTypeReference reference)
+        protected virtual Task ProcessPathTypeReferenceAsync(IEdmPathTypeReference reference)
         {
-            await this.ProcessTypeReferenceAsync(reference);
+            return this.ProcessTypeReferenceAsync(reference);
         }
 
         protected virtual void ProcessUntypedTypeReference(IEdmUntypedTypeReference reference)
@@ -657,9 +937,9 @@ namespace Microsoft.OData.Edm
             this.ProcessTypeReference(reference);
         }
 
-        protected virtual async Task ProcessUntypedTypeReferenceAsync(IEdmUntypedTypeReference reference)
+        protected virtual Task ProcessUntypedTypeReferenceAsync(IEdmUntypedTypeReference reference)
         {
-            await this.ProcessTypeReferenceAsync(reference);
+            return this.ProcessTypeReferenceAsync(reference);
         }
 
         #endregion
@@ -674,8 +954,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessTermAsync(IEdmTerm term)
         {
-            await this.ProcessSchemaElementAsync(term);
-            this.VisitTypeReference(term.Type);
+            await this.ProcessSchemaElementAsync(term).ConfigureAwait(false);
+            await this.VisitTypeReferenceAsync(term.Type).ConfigureAwait(false);
         }
 
         #endregion
@@ -691,9 +971,9 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessComplexTypeAsync(IEdmComplexType definition)
         {
-            await this.ProcessSchemaElementAsync(definition);
-            await this.ProcessStructuredTypeAsync(definition);
-            await this.ProcessSchemaTypeAsync(definition);
+            await this.ProcessSchemaElementAsync(definition).ConfigureAwait(false);
+            await this.ProcessStructuredTypeAsync(definition).ConfigureAwait(false);
+            await this.ProcessSchemaTypeAsync(definition).ConfigureAwait(false);
         }
 
         protected virtual void ProcessEntityType(IEdmEntityType definition)
@@ -705,9 +985,9 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessEntityTypeAsync(IEdmEntityType definition)
         {
-            await this.ProcessSchemaElementAsync(definition);
-            await this.ProcessStructuredTypeAsync(definition);
-            await this.ProcessSchemaTypeAsync(definition);
+            await this.ProcessSchemaElementAsync(definition).ConfigureAwait(false);
+            await this.ProcessStructuredTypeAsync(definition).ConfigureAwait(false);
+            await this.ProcessSchemaTypeAsync(definition).ConfigureAwait(false);
         }
 
         protected virtual void ProcessCollectionType(IEdmCollectionType definition)
@@ -719,9 +999,9 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessCollectionTypeAsync(IEdmCollectionType definition)
         {
-            await this.ProcessElementAsync(definition);
-            await this.ProcessTypeAsync(definition);
-            this.VisitTypeReference(definition.ElementType);
+            await this.ProcessElementAsync(definition).ConfigureAwait(false);
+            await this.ProcessTypeAsync(definition).ConfigureAwait(false);
+            await this.VisitTypeReferenceAsync(definition.ElementType).ConfigureAwait(false);
         }
 
         protected virtual void ProcessEnumType(IEdmEnumType definition)
@@ -734,10 +1014,10 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessEnumTypeAsync(IEdmEnumType definition)
         {
-            await this.ProcessSchemaElementAsync(definition);
-            await this.ProcessTypeAsync(definition);
-            await this.ProcessSchemaTypeAsync(definition);
-            this.VisitEnumMembers(definition.Members);
+            await this.ProcessSchemaElementAsync(definition).ConfigureAwait(false);
+            await this.ProcessTypeAsync(definition).ConfigureAwait(false);
+            await this.ProcessSchemaTypeAsync(definition).ConfigureAwait(false);
+            await this.VisitEnumMembersAsync(definition.Members).ConfigureAwait(false);
         }
 
         protected virtual void ProcessTypeDefinition(IEdmTypeDefinition definition)
@@ -749,9 +1029,9 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessTypeDefinitionAsync(IEdmTypeDefinition definition)
         {
-            await this.ProcessSchemaElementAsync(definition);
-            await this.ProcessTypeAsync(definition);
-            await this.ProcessSchemaTypeAsync(definition);
+            await this.ProcessSchemaElementAsync(definition).ConfigureAwait(false);
+            await this.ProcessTypeAsync(definition).ConfigureAwait(false);
+            await this.ProcessSchemaTypeAsync(definition).ConfigureAwait(false);
         }
 
         protected virtual void ProcessEntityReferenceType(IEdmEntityReferenceType definition)
@@ -762,8 +1042,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessEntityReferenceTypeAsync(IEdmEntityReferenceType definition)
         {
-            await this.ProcessElementAsync(definition);
-            await this.ProcessTypeAsync(definition);
+            await this.ProcessElementAsync(definition).ConfigureAwait(false);
+            await this.ProcessTypeAsync(definition).ConfigureAwait(false);
         }
 
         protected virtual void ProcessStructuredType(IEdmStructuredType definition)
@@ -774,8 +1054,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessStructuredTypeAsync(IEdmStructuredType definition)
         {
-            await this.ProcessTypeAsync(definition);
-            this.VisitProperties(definition.DeclaredProperties);
+            await this.ProcessTypeAsync(definition).ConfigureAwait(false);
+            await this.VisitPropertiesAsync(definition.DeclaredProperties).ConfigureAwait(false);
         }
 
         protected virtual void ProcessSchemaType(IEdmSchemaType type)
@@ -833,7 +1113,7 @@ namespace Microsoft.OData.Edm
         {
             await this.ProcessVocabularyAnnotatableAsync(property);
             await this.ProcessNamedElementAsync(property);
-            this.VisitTypeReference(property.Type);
+            await this.VisitTypeReferenceAsync(property.Type).ConfigureAwait(false);
         }
 
         protected virtual void ProcessEnumMember(IEdmEnumMember enumMember)
@@ -865,9 +1145,9 @@ namespace Microsoft.OData.Edm
             this.ProcessNamedElement(annotation);
         }
 
-        protected virtual async Task ProcessImmediateValueAnnotationAsync(IEdmDirectValueAnnotation annotation)
+        protected virtual Task ProcessImmediateValueAnnotationAsync(IEdmDirectValueAnnotation annotation)
         {
-            await this.ProcessNamedElementAsync(annotation);
+            return this.ProcessNamedElementAsync(annotation);
         }
 
         protected virtual void ProcessAnnotation(IEdmVocabularyAnnotation annotation)
@@ -878,13 +1158,18 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessAnnotationAsync(IEdmVocabularyAnnotation annotation)
         {
-            await this.ProcessVocabularyAnnotationAsync(annotation);
-            this.VisitExpression(annotation.Value);
+            await this.ProcessVocabularyAnnotationAsync(annotation).ConfigureAwait(false);
+            await this.VisitExpressionAsync(annotation.Value).ConfigureAwait(false);
         }
 
         protected virtual void ProcessPropertyValueBinding(IEdmPropertyValueBinding binding)
         {
             this.VisitExpression(binding.Value);
+        }
+
+        protected virtual Task ProcessPropertyValueBindingAsync(IEdmPropertyValueBinding binding)
+        {
+            return this.VisitExpressionAsync(binding.Value);
         }
 
         #endregion
@@ -905,9 +1190,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessStringConstantExpressionAsync(IEdmStringConstantExpression expression)
+        protected virtual Task ProcessStringConstantExpressionAsync(IEdmStringConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessBinaryConstantExpression(IEdmBinaryConstantExpression expression)
@@ -915,9 +1200,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessBinaryConstantExpressionAsync(IEdmBinaryConstantExpression expression)
+        protected virtual Task ProcessBinaryConstantExpressionAsync(IEdmBinaryConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessRecordExpression(IEdmRecordExpression expression)
@@ -933,13 +1218,13 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessRecordExpressionAsync(IEdmRecordExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            await this.ProcessExpressionAsync(expression).ConfigureAwait(false);
             if (expression.DeclaredType != null)
             {
-                this.VisitTypeReference(expression.DeclaredType);
+                await this.VisitTypeReferenceAsync(expression.DeclaredType).ConfigureAwait(false);
             }
 
-            this.VisitPropertyConstructors(expression.Properties);
+            await this.VisitPropertyConstructorsAsync(expression.Properties).ConfigureAwait(false);
         }
 
         protected virtual void ProcessPathExpression(IEdmPathExpression expression)
@@ -947,9 +1232,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessPathExpressionAsync(IEdmPathExpression expression)
+        protected virtual Task ProcessPathExpressionAsync(IEdmPathExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessPropertyPathExpression(IEdmPathExpression expression)
@@ -957,9 +1242,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessPropertyPathExpressionAsync(IEdmPathExpression expression)
+        protected virtual Task ProcessPropertyPathExpressionAsync(IEdmPathExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessNavigationPropertyPathExpression(IEdmPathExpression expression)
@@ -967,9 +1252,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessNavigationPropertyPathExpressionAsync(IEdmPathExpression expression)
+        protected virtual Task ProcessNavigationPropertyPathExpressionAsync(IEdmPathExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessAnnotationPathExpression(IEdmPathExpression expression)
@@ -977,9 +1262,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessAnnotationPathExpressionAsync(IEdmPathExpression expression)
+        protected virtual Task ProcessAnnotationPathExpressionAsync(IEdmPathExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessCollectionExpression(IEdmCollectionExpression expression)
@@ -991,7 +1276,7 @@ namespace Microsoft.OData.Edm
         protected virtual async Task ProcessCollectionExpressionAsync(IEdmCollectionExpression expression)
         {
             await this.ProcessExpressionAsync(expression);
-            this.VisitExpressions(expression.Elements);
+            await this.VisitExpressionsAsync(expression.Elements);
         }
 
         protected virtual void ProcessLabeledExpressionReferenceExpression(IEdmLabeledExpressionReferenceExpression expression)
@@ -999,9 +1284,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessLabeledExpressionReferenceExpressionAsync(IEdmLabeledExpressionReferenceExpression expression)
+        protected virtual Task ProcessLabeledExpressionReferenceExpressionAsync(IEdmLabeledExpressionReferenceExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessIsOfExpression(IEdmIsOfExpression expression)
@@ -1014,8 +1299,8 @@ namespace Microsoft.OData.Edm
         protected virtual async Task ProcessIsOfExpressionAsync(IEdmIsOfExpression expression)
         {
             await this.ProcessExpressionAsync(expression);
-            this.VisitTypeReference(expression.Type);
-            this.VisitExpression(expression.Operand);
+            await this.VisitTypeReferenceAsync(expression.Type);
+            await this.VisitExpressionAsync(expression.Operand);
         }
 
         protected virtual void ProcessIntegerConstantExpression(IEdmIntegerConstantExpression expression)
@@ -1023,9 +1308,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessIntegerConstantExpressionAsync(IEdmIntegerConstantExpression expression)
+        protected virtual Task ProcessIntegerConstantExpressionAsync(IEdmIntegerConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessIfExpression(IEdmIfExpression expression)
@@ -1038,10 +1323,10 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessIfExpressionAsync(IEdmIfExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
-            this.VisitExpression(expression.TestExpression);
-            this.VisitExpression(expression.TrueExpression);
-            this.VisitExpression(expression.FalseExpression);
+            await this.ProcessExpressionAsync(expression).ConfigureAwait(false);
+            await this.VisitExpressionAsync(expression.TestExpression).ConfigureAwait(false);
+            await this.VisitExpressionAsync(expression.TrueExpression).ConfigureAwait(false);
+            await this.VisitExpressionAsync(expression.FalseExpression).ConfigureAwait(false);
         }
 
         protected virtual void ProcessFunctionApplicationExpression(IEdmApplyExpression expression)
@@ -1052,8 +1337,8 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessFunctionApplicationExpressionAsync(IEdmApplyExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
-            this.VisitExpressions(expression.Arguments);
+            await this.ProcessExpressionAsync(expression).ConfigureAwait(false);
+            await this.VisitExpressionsAsync(expression.Arguments).ConfigureAwait(false);
         }
 
         protected virtual void ProcessFloatingConstantExpression(IEdmFloatingConstantExpression expression)
@@ -1061,9 +1346,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessFloatingConstantExpressionAsync(IEdmFloatingConstantExpression expression)
+        protected virtual Task ProcessFloatingConstantExpressionAsync(IEdmFloatingConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessGuidConstantExpression(IEdmGuidConstantExpression expression)
@@ -1071,9 +1356,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessGuidConstantExpressionAsync(IEdmGuidConstantExpression expression)
+        protected virtual Task ProcessGuidConstantExpressionAsync(IEdmGuidConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessEnumMemberExpression(IEdmEnumMemberExpression expression)
@@ -1081,9 +1366,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessEnumMemberExpressionAsync(IEdmEnumMemberExpression expression)
+        protected virtual Task ProcessEnumMemberExpressionAsync(IEdmEnumMemberExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessDecimalConstantExpression(IEdmDecimalConstantExpression expression)
@@ -1091,9 +1376,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessDecimalConstantExpressionAsync(IEdmDecimalConstantExpression expression)
+        protected virtual Task ProcessDecimalConstantExpressionAsync(IEdmDecimalConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessDateConstantExpression(IEdmDateConstantExpression expression)
@@ -1101,9 +1386,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessDateConstantExpressionAsync(IEdmDateConstantExpression expression)
+        protected virtual Task ProcessDateConstantExpressionAsync(IEdmDateConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessTimeOfDayConstantExpression(IEdmTimeOfDayConstantExpression expression)
@@ -1111,9 +1396,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessTimeOfDayConstantExpressionAsync(IEdmTimeOfDayConstantExpression expression)
+        protected virtual Task ProcessTimeOfDayConstantExpressionAsync(IEdmTimeOfDayConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessDateTimeOffsetConstantExpression(IEdmDateTimeOffsetConstantExpression expression)
@@ -1121,9 +1406,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessDateTimeOffsetConstantExpressionAsync(IEdmDateTimeOffsetConstantExpression expression)
+        protected virtual Task ProcessDateTimeOffsetConstantExpressionAsync(IEdmDateTimeOffsetConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessDurationConstantExpression(IEdmDurationConstantExpression expression)
@@ -1131,9 +1416,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessDurationConstantExpressionAsync(IEdmDurationConstantExpression expression)
+        protected virtual Task ProcessDurationConstantExpressionAsync(IEdmDurationConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessBooleanConstantExpression(IEdmBooleanConstantExpression expression)
@@ -1141,9 +1426,9 @@ namespace Microsoft.OData.Edm
             this.ProcessExpression(expression);
         }
 
-        protected virtual async Task ProcessBooleanConstantExpressionAsync(IEdmBooleanConstantExpression expression)
+        protected virtual Task ProcessBooleanConstantExpressionAsync(IEdmBooleanConstantExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
+            return this.ProcessExpressionAsync(expression);
         }
 
         protected virtual void ProcessCastExpression(IEdmCastExpression expression)
@@ -1155,9 +1440,9 @@ namespace Microsoft.OData.Edm
 
         protected virtual async Task ProcessCastExpressionAsync(IEdmCastExpression expression)
         {
-            await this.ProcessExpressionAsync(expression);
-            this.VisitTypeReference(expression.Type);
-            this.VisitExpression(expression.Operand);
+            await this.ProcessExpressionAsync(expression).ConfigureAwait(false);
+            await this.VisitTypeReferenceAsync(expression.Type).ConfigureAwait(false);
+            await this.VisitExpressionAsync(expression.Operand).ConfigureAwait(false);
         }
 
 
@@ -1166,11 +1451,9 @@ namespace Microsoft.OData.Edm
             this.VisitExpression(element.Expression);
         }
 
-        protected virtual Task ProcessLabeledExpressionAsync(IEdmLabeledExpression element)
+        protected virtual async Task ProcessLabeledExpressionAsync(IEdmLabeledExpression element)
         {
-            this.VisitExpression(element.Expression);
-
-            return Task.CompletedTask;
+            await this.VisitExpressionAsync(element.Expression).ConfigureAwait(false);
         }
 
         protected virtual void ProcessPropertyConstructor(IEdmPropertyConstructor constructor)
@@ -1178,11 +1461,9 @@ namespace Microsoft.OData.Edm
             this.VisitExpression(constructor.Value);
         }
 
-        protected virtual Task ProcessPropertyConstructorAsync(IEdmPropertyConstructor constructor)
+        protected virtual async Task ProcessPropertyConstructorAsync(IEdmPropertyConstructor constructor)
         {
-            this.VisitExpression(constructor.Value);
-
-            return Task.CompletedTask;
+            await this.VisitExpressionAsync(constructor.Value).ConfigureAwait(false);
         }
 
         protected virtual void ProcessNullConstantExpression(IEdmNullExpression expression)
@@ -1276,9 +1557,9 @@ namespace Microsoft.OData.Edm
             this.ProcessEntityContainerElement(actionImport);
         }
 
-        protected virtual async Task ProcessActionImportAsync(IEdmActionImport actionImport)
+        protected virtual Task ProcessActionImportAsync(IEdmActionImport actionImport)
         {
-            await this.ProcessEntityContainerElementAsync(actionImport);
+            return this.ProcessEntityContainerElementAsync(actionImport);
         }
 
         protected virtual void ProcessFunctionImport(IEdmFunctionImport functionImport)
@@ -1286,9 +1567,9 @@ namespace Microsoft.OData.Edm
             this.ProcessEntityContainerElement(functionImport);
         }
 
-        protected virtual async Task ProcessFunctionImportAsync(IEdmFunctionImport functionImport)
+        protected virtual Task ProcessFunctionImportAsync(IEdmFunctionImport functionImport)
         {
-            await this.ProcessEntityContainerElementAsync(functionImport);
+            return this.ProcessEntityContainerElementAsync(functionImport);
         }
 
         protected virtual void ProcessOperation(IEdmOperation operation)
@@ -1303,7 +1584,7 @@ namespace Microsoft.OData.Edm
         protected virtual async Task ProcessOperationAsync(IEdmOperation operation)
         {
             // Do not visit vocabularyAnnotatable because functions and operation imports are always going to be either a schema element or a container element and will be visited through those paths.
-            this.VisitOperationParameters(operation.Parameters);
+            await this.VisitOperationParametersAsync(operation.Parameters).ConfigureAwait(false);
 
             IEdmOperationReturn operationReturn = operation.GetReturn();
             await this.ProcessOperationReturnAsync(operationReturn);
@@ -1320,7 +1601,7 @@ namespace Microsoft.OData.Edm
         {
             await this.ProcessVocabularyAnnotatableAsync(parameter);
             await this.ProcessNamedElementAsync(parameter);
-            this.VisitTypeReference(parameter.Type);
+            await this.VisitTypeReferenceAsync(parameter.Type);
         }
 
         protected virtual void ProcessOperationReturn(IEdmOperationReturn operationReturn)
@@ -1342,7 +1623,7 @@ namespace Microsoft.OData.Edm
             }
 
             await this.ProcessVocabularyAnnotatableAsync(operationReturn);
-            this.VisitTypeReference(operationReturn.Type);
+            await this.VisitTypeReferenceAsync(operationReturn.Type).ConfigureAwait(false);
         }
         #endregion
 

--- a/src/Microsoft.OData.Edm/EdmModelVisitor.cs
+++ b/src/Microsoft.OData.Edm/EdmModelVisitor.cs
@@ -320,7 +320,8 @@ namespace Microsoft.OData.Edm
                 case EdmExpressionKind.None:
                     return this.ProcessExpressionAsync(expression);
                 default:
-                    throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_ExpressionKind(expression.ExpressionKind));
+                    Contract.Assert(false, Edm.Strings.UnknownEnumVal_ExpressionKind(expression.ExpressionKind));
+                    return Task.FromException<InvalidOperationException>(new InvalidOperationException(Edm.Strings.UnknownEnumVal_ExpressionKind(expression.ExpressionKind)));
             }
         }
 
@@ -365,31 +366,29 @@ namespace Microsoft.OData.Edm
             }
         }
 
-        public virtual async Task VisitEntityContainerElementsAsync(IEnumerable<IEdmEntityContainerElement> elements)
+        public virtual Task VisitEntityContainerElementsAsync(IEnumerable<IEdmEntityContainerElement> elements)
         {
             foreach (IEdmEntityContainerElement element in elements)
             {
                 switch (element.ContainerElementKind)
                 {
                     case EdmContainerElementKind.EntitySet:
-                        await this.ProcessEntitySetAsync((IEdmEntitySet)element);
-                        break;
+                        return this.ProcessEntitySetAsync((IEdmEntitySet)element);
                     case EdmContainerElementKind.Singleton:
-                        await this.ProcessSingletonAsync((IEdmSingleton)element);
-                        break;
+                        return this.ProcessSingletonAsync((IEdmSingleton)element);
                     case EdmContainerElementKind.ActionImport:
-                        await this.ProcessActionImportAsync((IEdmActionImport)element);
-                        break;
+                        return this.ProcessActionImportAsync((IEdmActionImport)element);
                     case EdmContainerElementKind.FunctionImport:
-                        await this.ProcessFunctionImportAsync((IEdmFunctionImport)element);
-                        break;
+                        return this.ProcessFunctionImportAsync((IEdmFunctionImport)element);
                     case EdmContainerElementKind.None:
-                        await this.ProcessEntityContainerElementAsync(element);
-                        break;
+                        return this.ProcessEntityContainerElementAsync(element);
                     default:
-                        throw new InvalidOperationException(Edm.Strings.UnknownEnumVal_ContainerElementKind(element.ContainerElementKind.ToString()));
+                        Contract.Assert(false, Edm.Strings.UnknownEnumVal_ContainerElementKind(element.ContainerElementKind.ToString()));
+                        return Task.FromException<InvalidOperationException>(new InvalidOperationException(Edm.Strings.UnknownEnumVal_ContainerElementKind(element.ContainerElementKind.ToString())));
                 }
             }
+
+            return Task.CompletedTask;
         }
 
         #endregion

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/AsyncYieldStream.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/AsyncYieldStream.cs
@@ -42,7 +42,7 @@ namespace Microsoft.OData.Tests
 
         public override void Flush()
         {
-            this.stream.FlushAsync().Wait();
+            this.stream.Flush();
         }
 
         public override async Task FlushAsync(CancellationToken cancellationToken)
@@ -53,12 +53,14 @@ namespace Microsoft.OData.Tests
 
         public override int Read(byte[] buffer, int offset, int count)
         {
-            return this.stream.ReadAsync(buffer, offset, count).Result;
+            return this.stream.Read(buffer, offset, count);
         }
 
-        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
-            return this.stream.ReadAsync(buffer, offset, count, cancellationToken);
+            await Task.Yield();
+            int result = await this.stream.ReadAsync(buffer, offset, count, cancellationToken);
+            return result;
         }
 
         public override int ReadByte()
@@ -71,9 +73,10 @@ namespace Microsoft.OData.Tests
             this.stream.WriteByte(value);
         }
 
-        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        public override async Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
         {
-            return this.stream.CopyToAsync(destination, bufferSize, cancellationToken);
+            await Task.Yield();
+            await this.stream.CopyToAsync(destination, bufferSize, cancellationToken);
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -88,7 +91,7 @@ namespace Microsoft.OData.Tests
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-            this.stream.WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
+            this.stream.Write(buffer, offset, count);
         }
 
         public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/AsyncYieldStream.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/AsyncYieldStream.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.Tests
+{
+    /// <summary>
+    /// Stream wrapper that yields in every async method
+    /// to ensure the read/write operations complete asynchronously
+    /// even when the operate completely in-memory. This helps simulate
+    /// async I/O in unit tests without making requests out of the process.
+    /// </summary>
+    internal class AsyncYieldStream : Stream
+    {
+        private Stream stream;
+        public AsyncYieldStream(Stream stream)
+        {
+            this.stream = stream;
+        }
+
+        public override bool CanRead => this.stream.CanRead;
+
+        public override bool CanSeek => this.stream.CanSeek;
+
+        public override bool CanWrite => this.stream.CanWrite;
+
+        public override long Length => this.stream.Length;
+
+        public override int ReadTimeout { get => this.stream.ReadTimeout; set => this.stream.ReadTimeout = value; }
+
+        public override int WriteTimeout { get => this.stream.WriteTimeout; set => this.stream.WriteTimeout = value; }
+
+        public override bool CanTimeout => this.stream.CanTimeout;
+
+        public override void Close()
+        {
+            this.stream.Close();
+        }
+
+        public override long Position { get => this.stream.Position; set => this.stream.Position = value; }
+
+        public override void Flush()
+        {
+            this.stream.FlushAsync().Wait();
+        }
+
+        public override async Task FlushAsync(CancellationToken cancellationToken)
+        {
+            await Task.Yield();
+            await base.FlushAsync(cancellationToken);
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return this.stream.ReadAsync(buffer, offset, count).Result;
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return this.stream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override int ReadByte()
+        {
+            return this.stream.ReadByte();
+        }
+
+        public override void WriteByte(byte value)
+        {
+            this.stream.WriteByte(value);
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return this.stream.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return this.stream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            this.stream.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            this.stream.WriteAsync(buffer, offset, count).GetAwaiter().GetResult();
+        }
+
+        public override async ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            await base.WriteAsync(buffer, cancellationToken);
+        }
+
+        public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return this.stream.BeginRead(buffer, offset, count, callback, state);
+        }
+
+        public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+        {
+            return this.stream.BeginWrite(buffer, offset, count, callback, state);
+        }
+
+        public override int EndRead(IAsyncResult asyncResult)
+        {
+            return this.stream.EndRead(asyncResult);
+        }
+
+        public override void EndWrite(IAsyncResult asyncResult)
+        {
+            this.stream.EndWrite(asyncResult);
+        }
+
+        public override string ToString()
+        {
+            return this.stream.ToString();
+        }
+    }
+}

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -1385,7 +1385,7 @@ namespace Microsoft.OData.Tests
                 // Add 300 properties to each entity type
                 for (int j = 0; j < 100; j++)
                 {
-                    entityType.AddProperty(new EdmStructuralProperty(entityType, $"Property{DateTime.Now.Ticks}{j}", EdmCoreModel.Instance.GetString(false)));
+                    entityType.AddProperty(new EdmStructuralProperty(entityType, $"Property638642487961128210{j}", EdmCoreModel.Instance.GetString(false)));
                     entityType.AddProperty(new EdmStructuralProperty(entityType, $"PropertyInt{longString}{j}", EdmCoreModel.Instance.GetInt32(false)));
                     entityType.AddProperty(new EdmStructuralProperty(entityType, $"PropertyBool{j}{longString}{j}", EdmCoreModel.Instance.GetBoolean(false)));
                 }
@@ -1681,11 +1681,7 @@ namespace Microsoft.OData.Tests
             writerSettings.BaseUri = new Uri("http://www.example.com/");
             writerSettings.SetServiceDocumentUri(new Uri("http://www.example.com/"));
 
-#if NETCOREAPP
             await using (var msgWriter = new ODataMessageWriter((IODataResponseMessageAsync)message, writerSettings, edmModel))
-#else
-            using (var msgWriter = new ODataMessageWriter((IODataResponseMessageAsync)message, writerSettings, edmModel))
-#endif
             {
                 await test(msgWriter);
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -901,7 +901,7 @@ namespace Microsoft.OData.Tests
 
             // Act
 
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 10; i++)
             {
                 // Json CSDL generated synchronously
                 string syncPayload = this.WriteAndGetPayload(_largeEdmModel, contentType, omWriter =>
@@ -974,7 +974,7 @@ namespace Microsoft.OData.Tests
             });
 
             // Act - XML
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 10; i++)
             {
                 string payload = await this.WriteAndGetPayloadAsync(_largeEdmModel, "application/xml", async omWriter =>
                 {
@@ -1333,7 +1333,11 @@ namespace Microsoft.OData.Tests
                 var idProperty = new EdmStructuralProperty(entityType, $"Entity{i}Id", EdmCoreModel.Instance.GetInt32(false));
                 entityType.AddProperty(idProperty);
                 entityType.AddKeys(new IEdmStructuralProperty[] { idProperty });
-                entityType.AddProperty(new EdmStructuralProperty(entityType, "Name", EdmCoreModel.Instance.GetString(false)));
+                for (int j = 0; j < 100; j++)
+                {
+                    entityType.AddProperty(new EdmStructuralProperty(entityType, $"Property{j}", EdmCoreModel.Instance.GetString(false)));
+                }
+
                 edmModel.AddElement(entityType);
                 container.AddEntitySet($"Entities{i}", entityType);
             }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -1385,7 +1385,7 @@ namespace Microsoft.OData.Tests
                 // Add 300 properties to each entity type
                 for (int j = 0; j < 100; j++)
                 {
-                    entityType.AddProperty(new EdmStructuralProperty(entityType, $"Property638642487961128210{j}", EdmCoreModel.Instance.GetString(false)));
+                    entityType.AddProperty(new EdmStructuralProperty(entityType, $"PropertyString{longString}{j}", EdmCoreModel.Instance.GetString(false)));
                     entityType.AddProperty(new EdmStructuralProperty(entityType, $"PropertyInt{longString}{j}", EdmCoreModel.Instance.GetInt32(false)));
                     entityType.AddProperty(new EdmStructuralProperty(entityType, $"PropertyBool{j}{longString}{j}", EdmCoreModel.Instance.GetBoolean(false)));
                 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -1061,25 +1061,27 @@ namespace Microsoft.OData.Tests
         public async Task WriteLargeMetadataDocumentPayload_MustEqual_WriteLargeMetadataDocumentAsyncPayload_ForXmlCsdl()
         {
             // Arrange
-            IEdmModel edmModel = GetEdmModel();
-
-            // Act
             var contentType = "application/xml";
 
-            // XML CSDL generated synchronously
-            string syncPayload = this.WriteAndGetPayload(edmModel, contentType, omWriter =>
+            // Act
+            string syncPayload = this.WriteAndGetPayload(_largeEdmModel, contentType, omWriter =>
             {
                 omWriter.WriteMetadataDocument();
             });
 
-            // XML CSDL generated asynchronously
-            string asyncPayload = await this.WriteAndGetPayloadWithAsyncYieldStreamAsync(edmModel, contentType, async omWriter =>
+            string asyncPayload = await this.WriteAndGetPayloadAsync(_largeEdmModel, contentType, async omWriter =>
+            {
+                await omWriter.WriteMetadataDocumentAsync();
+            });
+
+            string asyncPayloadWithAsyncYield = await this.WriteAndGetPayloadWithAsyncYieldStreamAsync(_largeEdmModel, contentType, async omWriter =>
             {
                 await omWriter.WriteMetadataDocumentAsync();
             });
 
             // Assert
-            Assert.Equal(asyncPayload, syncPayload);
+            Assert.Equal(syncPayload, asyncPayload);
+            Assert.Equal(syncPayload, asyncPayloadWithAsyncYield);
         }
 
         #region "DisposeAsync"

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.Async.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.Async.cs
@@ -85,7 +85,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             schema.AddSchemaElement(action);
 
             // Act & Assert for XML
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEdmSchemaAsync(schema, null).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEdmSchemaAsync(schema, null),
                 @"<Schema Namespace=""NS"" xmlns=""http://docs.oasis-open.org/odata/ns/edm"">
   <Action Name=""DoStuff"" IsBound=""true"">
     <Parameter Name=""param1"" Type=""Edm.String"" />
@@ -98,7 +98,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 </Schema>").ConfigureAwait(false);
 
             // Act & Assert for JSON
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEdmSchemaAsync(schema, null).ConfigureAwait(false), @"{
+            await VisitAndVerifyJsonAsync((v) => v.VisitEdmSchemaAsync(schema, null), @"{
   ""NS"": {
     ""DoStuff"": [
       {
@@ -144,7 +144,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             EdmEntitySet entitySet = new EdmEntitySet(container, "Set", entityType);
 
             // Act & Assert for XML
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { entitySet }).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new[] { entitySet }),
                 @"<EntitySet Name=""Set"" EntityType=""NS.EntityType"" />").ConfigureAwait(false);
 
             // Act & Assert for JSON
@@ -157,7 +157,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 }").ConfigureAwait(false);
 
             // Act & Assert for non-indent JSON
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { entitySet }).ConfigureAwait(false),
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new[] { entitySet }),
                 @"{""Set"":{""$Collection"":true,""$Type"":""NS.EntityType""}}", false).ConfigureAwait(false);
         }
 
@@ -224,7 +224,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             model.SetVocabularyAnnotation(annotation);
 
             // Act & Assert for XML
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { people }).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new[] { people }),
                 @"<EntitySet Name=""People"" EntityType=""NS.Person"">
   <NavigationPropertyBinding Path=""Addresses/City"" Target=""City"" />
   <NavigationPropertyBinding Path=""HomeAddress/City"" Target=""City"" />
@@ -233,7 +233,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 </EntitySet>").ConfigureAwait(false);
 
             // Act & Assert for JSON
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { people }).ConfigureAwait(false),
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new[] { people }),
                 @"{
   ""People"": {
     ""$Collection"": true,
@@ -257,16 +257,16 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             IEdmEntityContainer container = new EdmEntityContainer("NS", "Container");
             EdmSingleton singleton = new EdmSingleton(container, "Me", entityType);
 
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { singleton }).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new[] { singleton }),
                 @"<Singleton Name=""Me"" Type=""NS.EntityType"" />").ConfigureAwait(false);
 
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { singleton }).ConfigureAwait(false), @"{
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new[] { singleton }), @"{
   ""Me"": {
     ""$Type"": ""NS.EntityType""
   }
 }").ConfigureAwait(false);
 
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { singleton }).ConfigureAwait(false),
+            await VisitAndVerifyJsonAsync((v) =>  v.VisitEntityContainerElementsAsync(new[] { singleton }),
                 @"{""Me"":{""$Type"":""NS.EntityType""}}", false).ConfigureAwait(false);
         }
 
@@ -291,14 +291,14 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             annotation.SetSerializationLocation(model, EdmVocabularyAnnotationSerializationLocation.Inline);
             this.model.SetVocabularyAnnotation(annotation);
 
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { singleton }).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new[] { singleton }),
                 @"<Singleton Name=""Me"" Type=""NS.EntityType"">
   <Annotation Term=""NS.MyTerm"">
     <EnumMember>NS.Permission/Read NS.Permission/Write</EnumMember>
   </Annotation>
 </Singleton>").ConfigureAwait(false);
 
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new[] { singleton }).ConfigureAwait(false), @"{
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new[] { singleton }), @"{
   ""Me"": {
     ""$Type"": ""NS.EntityType"",
     ""@NS.MyTerm"": ""Read,Write""
@@ -316,11 +316,11 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             var actionImport = new EdmActionImport(defaultContainer, "Checkout", defaultCheckoutAction, null);
 
             // Act & Assert for XML
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport }).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport }),
                 @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" />").ConfigureAwait(false);
 
             // Act & Assert for JSON
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport }).ConfigureAwait(false),
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport }),
                 @"{
   ""Checkout"": {
     ""$Kind"": ""ActionImport"",
@@ -329,7 +329,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 }").ConfigureAwait(false);
 
             // Act & Assert for non-indent JSON
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport }).ConfigureAwait(false),
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport }),
                 @"{""Checkout"":{""$Kind"":""ActionImport"",""$Action"":""Default.NameSpace2.CheckOut""}}", false).ConfigureAwait(false);
         }
 
@@ -341,11 +341,11 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             var actionImport2 = new EdmActionImport(defaultContainer, "Checkout", defaultCheckoutAction, null);
 
             // Act & Assert for XML
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
                 @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" />").ConfigureAwait(false);
 
             // Act & Assert for JSON
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }).ConfigureAwait(false),
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
                 @"{
   ""Checkout"": {
     ""$Kind"": ""ActionImport"",
@@ -362,11 +362,11 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             var actionImport2 = new EdmActionImport(defaultContainer, "Checkout", defaultCheckoutAction, new EdmPathExpression("Set"));
 
             // Act & Assert for XML
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
                 @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""Set"" />").ConfigureAwait(false);
 
             // Act & Assert for JSON
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }).ConfigureAwait(false),
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
                 @"{
   ""Checkout"": {
     ""$Kind"": ""ActionImport"",
@@ -384,11 +384,11 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             var actionImport2 = new EdmActionImport(defaultContainer, "Checkout", defaultCheckoutAction, new EdmPathExpression("path1", "path2"));
 
             // Act & Assert for XML
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
                 @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""path1/path2"" />").ConfigureAwait(false);
 
             // Act & Assert for JSON
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }).ConfigureAwait(false),
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImport, actionImport2 }),
                 @"{
   ""Checkout"": {
     ""$Kind"": ""ActionImport"",
@@ -412,14 +412,14 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
             var actionImportWithUniqueEdmPath = new EdmActionImport(defaultContainer, "Checkout", defaultCheckoutAction, new EdmPathExpression("path1", "path2"));
 
             // Act & Assert for XML
-            await VisitAndVerifyXmlAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImportOnSet, actionImportOnSet2, actionImportWithNoEntitySet, actionImportWithUniqueEdmPath }).ConfigureAwait(false),
+            await VisitAndVerifyXmlAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImportOnSet, actionImportOnSet2, actionImportWithNoEntitySet, actionImportWithUniqueEdmPath }),
                 @"<ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""Set"" />
 <ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""Set2"" />
 <ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" />
 <ActionImport Name=""Checkout"" Action=""Default.NameSpace2.CheckOut"" EntitySet=""path1/path2"" />").ConfigureAwait(false);
 
             // Act & Assert for JSON
-            await VisitAndVerifyJsonAsync(async (v) => await v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImportOnSet, actionImportOnSet2, actionImportWithNoEntitySet, actionImportWithUniqueEdmPath }).ConfigureAwait(false),
+            await VisitAndVerifyJsonAsync((v) => v.VisitEntityContainerElementsAsync(new IEdmEntityContainerElement[] { actionImportOnSet, actionImportOnSet2, actionImportWithNoEntitySet, actionImportWithUniqueEdmPath }),
     @"{
   ""Checkout"": {
     ""$Kind"": ""ActionImport"",


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes [#1320](https://github.com/OData/AspNetCoreOData/issues/1320).*

### Description

*Briefly describe the changes of this pull request.*

Refactors the code to use the asynchronous method `VisitCollectionAsync` instead of the synchronous `VisitCollection`. The **VisitCollectionAsync** method has the second parameter as `Func<T, Task>` as opposed to **VisitCollection** which has the second parameter as `Action<T>`.  This change ensures that the method is awaited properly, maintaining the correct order of execution in an asynchronous context.

The `ProcessEntityContainerAsync` passed as argument to `VisitCollectionAsync` is an asynchronous method that processes the entity container and at the end `WriteEndElementAsync` is called to write the end element. Using **VisitCollectionAsync** ensures that the ProcessEntityContainerAsync method is awaited before the end element is written and thus prevents the exceptions like below:

```cs
System.InvalidOperationException
Token EndAttribute in state Element Start Tag would result in an invalid XML document.
   at System.Xml.XmlWellFormedWriter.ThrowInvalidStateTransition(Token token, State currentState)
   at System.Xml.XmlWellFormedWriter.AdvanceStateAsync(Token token)
   at System.Xml.XmlWellFormedWriter.WriteEndAttributeAsync()
   at System.Xml.XmlWellFormedWriter.AdvanceStateAsync(Token token)
   at System.Xml.XmlWellFormedWriter.WriteEndElementAsync()
   at System.Xml.XmlAsyncCheckWriter.WriteEndElementAsync()
   at Microsoft.OData.Edm.Csdl.Serialization.EdmModelCsdlSchemaXmlWriter.WriteEndElementAsync()
```

```cs
System.InvalidOperationException
An asynchronous operation is already in progress.
   at System.Xml.XmlAsyncCheckWriter.CheckAsync()
   at System.Xml.XmlAsyncCheckWriter.WriteEndElementAsync()
   at Microsoft.OData.Edm.Csdl.Serialization.EdmModelCsdlSchemaXmlWriter.WriteEndElementAsync()
   at Microsoft.OData.Edm.Csdl.Serialization.EdmModelCsdlSerializationVisitor.VisitEdmSchemaAsync(EdmSchema element, IEnumerable`1 mappings)
   at Microsoft.OData.Edm.Csdl.CsdlXmlWriter.WriteSchemasAsync()
   at Microsoft.OData.Edm.Csdl.CsdlXmlWriter.WriteODataCsdlAsync()
   at Microsoft.OData.Edm.Csdl.CsdlXmlWriter.WriteCsdlAsync()
```

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
