### PR TITLE
Improve handling of dynamic properties in expressions

### DIFF
--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.OData.UriParser.CollectionOpenPropertyAccessNode.CollectionOpenPropertyAccessNode(Microsoft.OData.UriParser.SingleValueNode source, string openPropertyName, Microsoft.OData.Edm.IEdmCollectionTypeReference collectionType) -> void
+Microsoft.OData.UriParser.SingleValueOpenPropertyAccessNode.SingleValueOpenPropertyAccessNode(Microsoft.OData.UriParser.SingleValueNode source, string openPropertyName, Microsoft.OData.Edm.IEdmTypeReference typeReference) -> void

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -60,7 +60,7 @@ namespace Microsoft.OData.UriParser
 
             // If the left operand is either an integral or a string type and the right operand is a collection of enums,
             // Calls the MetadataBindingUtils.ConvertToTypeIfNeeded() method to convert the left operand to the same enum type as the right operand.
-            if ((right is CollectionPropertyAccessNode && right.ItemType.IsEnum()) && (left.TypeReference != null && (left.TypeReference.IsString() || left.TypeReference.IsIntegral())))
+            if ((!(right is CollectionConstantNode) && right.ItemType.IsEnum()) && (left.TypeReference != null && (left.TypeReference.IsString() || left.TypeReference.IsIntegral())))
             {
                 left = MetadataBindingUtils.ConvertToTypeIfNeeded(left, right.ItemType);
             }
@@ -151,7 +151,15 @@ namespace Microsoft.OData.UriParser
             }
             else
             {
-                operand = this.bindMethod(queryToken) as CollectionNode;
+                var node = this.bindMethod(queryToken);
+                if (node is SingleValueOpenPropertyAccessNode openNode)
+                {
+                    operand = new CollectionOpenPropertyAccessNode(openNode.Source, openNode.Name, expectedType as IEdmCollectionTypeReference);
+                }
+                else
+                {
+                    operand = node as CollectionNode;
+                }
             }
 
             if (operand == null)

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/CollectionOpenPropertyAccessNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/CollectionOpenPropertyAccessNode.cs
@@ -29,18 +29,33 @@ namespace Microsoft.OData.UriParser
         private readonly string name;
 
         /// <summary>
+        /// The value containing the property.
+        /// </summary>
+        private readonly IEdmCollectionTypeReference collectionType;
+
+        /// <summary>
         /// Constructs a new <see cref="CollectionOpenPropertyAccessNode"/>.
         /// </summary>
         /// <param name="source">The value containing the property.</param>
         /// <param name="openPropertyName">The name of the open collection property to be bound outside the EDM model.</param>
         /// <exception cref="System.ArgumentNullException">Throws if the input source or openPropertyName is null.</exception>
-        public CollectionOpenPropertyAccessNode(SingleValueNode source, string openPropertyName)
+        public CollectionOpenPropertyAccessNode(SingleValueNode source, string openPropertyName) : this(source, openPropertyName, null) { }
+
+        /// <summary>
+        /// Constructs a new <see cref="CollectionOpenPropertyAccessNode"/>.
+        /// </summary>
+        /// <param name="source">The value containing the property.</param>
+        /// <param name="openPropertyName">The name of the open collection property to be bound outside the EDM model.</param>
+        /// <param name="collectionType">The type of the open collection property.</param>
+        /// <exception cref="System.ArgumentNullException">Throws if the input source or openPropertyName is null.</exception>
+        public CollectionOpenPropertyAccessNode(SingleValueNode source, string openPropertyName, IEdmCollectionTypeReference collectionType)
         {
             ExceptionUtils.CheckArgumentNotNull(source, "source");
             ExceptionUtils.CheckArgumentNotNull(openPropertyName, "openPropertyName");
 
             this.source = source;
             this.name = openPropertyName;
+            this.collectionType = collectionType;
         }
 
         /// <summary>
@@ -64,7 +79,7 @@ namespace Microsoft.OData.UriParser
         /// </summary>
         public override IEdmTypeReference ItemType
         {
-            get { return null; }
+            get { return collectionType?.ElementType(); }
         }
 
         /// <summary>
@@ -75,7 +90,7 @@ namespace Microsoft.OData.UriParser
         /// </remarks>
         public override IEdmCollectionTypeReference CollectionType
         {
-            get { return null; }
+            get { return collectionType; }
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/SingleValueOpenPropertyAccessNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/SingleValueOpenPropertyAccessNode.cs
@@ -24,18 +24,33 @@ namespace Microsoft.OData.UriParser
         private readonly string name;
 
         /// <summary>
+        /// The name of the open property to be bound outside the EDM model.
+        /// </summary>
+        private readonly IEdmTypeReference typeReference;
+
+        /// <summary>
         /// Constructs a <see cref="SingleValueOpenPropertyAccessNode"/>.
         /// </summary>
         /// <param name="source">The value containing this property.</param>
         /// <param name="openPropertyName">The name of the open property to be bound outside the EDM model.</param>
         /// <exception cref="System.ArgumentNullException">Throws if the input source or openPropertyName is null.</exception>
-        public SingleValueOpenPropertyAccessNode(SingleValueNode source, string openPropertyName)
+        public SingleValueOpenPropertyAccessNode(SingleValueNode source, string openPropertyName) : this(source, openPropertyName, null) { }
+
+        /// <summary>
+        /// Constructs a <see cref="SingleValueOpenPropertyAccessNode"/>.
+        /// </summary>
+        /// <param name="source">The value containing this property.</param>
+        /// <param name="openPropertyName">The name of the open property to be bound outside the EDM model.</param>
+        /// <param name="typeReference">They type of the open property.</param>
+        /// <exception cref="System.ArgumentNullException">Throws if the input source or openPropertyName is null.</exception>
+        public SingleValueOpenPropertyAccessNode(SingleValueNode source, string openPropertyName, IEdmTypeReference typeReference)
         {
             ExceptionUtils.CheckArgumentNotNull(source, "source");
             ExceptionUtils.CheckArgumentStringNotNullOrEmpty(openPropertyName, "openPropertyName");
 
             this.name = openPropertyName;
             this.source = source;
+            this.typeReference = typeReference;
         }
 
         /// <summary>
@@ -62,7 +77,7 @@ namespace Microsoft.OData.UriParser
         /// </remarks>
         public override IEdmTypeReference TypeReference
         {
-            get { return null; }
+            get { return typeReference; }
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2944,6 +2944,26 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Theory]
+        [InlineData("'a'", "Edm.String")]
+        [InlineData("1", "Edm.Int32")]
+        [InlineData("true", "Edm.Boolean")]
+        [InlineData("Artist","Edm.String")]
+        [InlineData("Value", "Edm.Decimal")]
+        [InlineData("ArtistAddress","Fully.Qualified.Namespace.Address")]
+        [InlineData("Owner", "Fully.Qualified.Namespace.Person")]
+        [InlineData("undefined","Edm.Untyped")]
+        public void FilterWithInOperationWithDynamicRightOperand(string lOperand, string typeName)
+        {
+            FilterClause filter = ParseFilter(String.Format("{0} in dynamicCollection",lOperand),
+                HardCodedTestModel.TestModel, HardCodedTestModel.GetPaintingType());
+
+            var inNode = Assert.IsType<InNode>(filter.Expression);
+            var rNode = Assert.IsType<CollectionOpenPropertyAccessNode>(inNode.Right);
+            Assert.Equal("dynamicCollection", rNode.Name);
+            Assert.Equal(typeName, rNode.ItemType.FullName());
+        }
+
+        [Theory]
         [InlineData("example in ('')", "\"\"")] // No space
         [InlineData("example in (' ')", " ")] // 1 space
         [InlineData("example in ( '   ' )", "   ")] // 3 spaces

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/EndPathBinderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Binders/EndPathBinderTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         // GeneratePropertyAccessQueryNodeForOpenTypes tests
 
         [Fact]
-        public void ShouldThrowNotImplementedIfTypeIsOpen()
+        public void ShouldSucceedIfTypeIsOpen()
         {
             const string OpenPropertyName = "Style";
             var token = new EndPathToken(OpenPropertyName, new RangeVariableToken("a"));


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3090.*

### Description

Allows open property access nodes to be created with a type when the type can be inferred from the context.
Supports creating an In expression with a CollectionOpenPropertyAccessNode as the right-hand operand, using the type of the left-hand operand

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

None