### PR TITLE
Fixes #3088: remove the wrong framework in Edm.Lib nuget spec and update metadata for others

### DIFF
--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Nightly.Release.nuspec
@@ -10,8 +10,8 @@
     <projectUrl>http://odata.github.io/</projectUrl>
     <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <summary>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4. </summary>
-    <description>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4. Targets .NET 4.5 and .NET Platform Standard 1.1.
+    <summary>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4 and v4.01. </summary>
+    <description>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4 and v4.01. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>

--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
@@ -10,8 +10,8 @@
     <projectUrl>http://odata.github.io/</projectUrl>
     <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <summary>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4. </summary>
-    <description>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4. Targets .NET 4.5 and .NET Platform Standard 1.1.
+    <summary>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4 and v4.01. </summary>
+    <description>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4 and v4.01. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
     <releaseNotes>https://docs.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Nightly.Release.nuspec
@@ -10,8 +10,8 @@
     <projectUrl>http://odata.github.io/</projectUrl>
     <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <summary>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4.</summary>
-    <description>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4. Enables construction of OData services and clients. Targets .NET Platform Standard 1.1.
+    <summary>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4 and v4.01.</summary>
+    <description>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4 and v4.01. Enables construction of OData services and clients. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>    
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
@@ -10,8 +10,8 @@
     <projectUrl>http://odata.github.io/</projectUrl>
     <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <summary>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4.</summary>
-    <description>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4. Enables construction of OData services and clients. Targets .NET Platform Standard 1.1.
+    <summary>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4 and v4.01.</summary>
+    <description>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4 and v4.01. Enables construction of OData services and clients. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
     <releaseNotes>https://docs.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Nightly.Release.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Nightly.Release.nuspec
@@ -10,12 +10,12 @@
     <projectUrl>http://odata.github.io/</projectUrl>
     <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <summary>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4.</summary>
-    <description>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4. Targets .NET Platform Standard 1.1.
+    <summary>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4 and v4.01.</summary>
+    <description>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4 and v4.01. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <group targetFramework=".NETStandard2.0">
+      <group>
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" />
         <dependency id="System.Text.Encodings.Web" version="4.7.2" />
         <dependency id="System.Text.Json" version="4.6.0" />

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
@@ -10,13 +10,13 @@
     <projectUrl>http://odata.github.io/</projectUrl>
     <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <summary>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4.</summary>
-    <description>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4. Targets .NET Platform Standard 1.1.
+    <summary>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4 and v4.01.</summary>
+    <description>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4 and v4.01. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
     <releaseNotes>https://docs.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <group targetFramework=".NETStandard2.0">
+      <group>
         <dependency id="System.Runtime.CompilerServices.Unsafe" version="4.6.0" />
         <dependency id="System.Text.Encodings.Web" version="4.7.2" />
         <dependency id="System.Text.Json" version="4.6.0" />

--- a/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Nightly.Release.nuspec
+++ b/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Nightly.Release.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <summary>Contains classes and methods that facilitate geography and geometry spatial operations.</summary>
-    <description>Contains classes and methods that facilitate geography and geometry spatial operations. Targets .NET Platform Standard 1.1.
+    <description>Contains classes and methods that facilitate geography and geometry spatial operations. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
   </metadata>

--- a/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Release.nuspec
+++ b/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Release.nuspec
@@ -11,15 +11,13 @@
     <iconUrl>http://static.tumblr.com/hgchgxz/9ualgdf98/icon.png</iconUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <summary>Contains classes and methods that facilitate geography and geometry spatial operations.</summary>
-    <description>Contains classes and methods that facilitate geography and geometry spatial operations. Targets .NET Platform Standard 1.1.
+    <description>Contains classes and methods that facilitate geography and geometry spatial operations. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
     <releaseNotes>https://docs.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
   </metadata>
   <files>
-
-     <file src="$ProductRoot$\Microsoft.Spatial.dll" target="lib" />
-
+    <file src="$ProductRoot$\Microsoft.Spatial.dll" target="lib" />
     <file src="$ProductRoot$\Microsoft.Spatial.pdb" target="lib" />
     <file src="$ProductRoot$\Microsoft.Spatial.xml" target="lib" />
     <file src="$SourcesRoot$\src\Microsoft.Spatial\**\*.cs" target="src\Microsoft.Spatial" />


### PR DESCRIPTION
…ate metadata for others

<!-- markdownlint-disable MD002 MD041 -->

### Issues

Fixes #3088: remove the wrong framework in Edm.Lib nuget spec and update metadata for others

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
