### PR TITLE
Fixes #3094: continue to replace substring in HttpHeaderValueLexer

### DIFF
--- a/src/Microsoft.OData.Core/HttpHeaderValueLexer.cs
+++ b/src/Microsoft.OData.Core/HttpHeaderValueLexer.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.OData
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
@@ -49,13 +50,13 @@ namespace Microsoft.OData
         /// The value of the current parsed item. If the item type is quoted-string, this returns the unescaped and unquoted string value. For other item types,
         /// the value is the same as the original text from the header.
         /// </summary>
-        private readonly string value;
+        private readonly ReadOnlyMemory<char> value;
 
         /// <summary>
         /// The original text of the current parsed item. If the item type is quoted-string, this returns the escaped and quoted string value straight from the header.
         /// For other item types, the original text is the same as the item value.
         /// </summary>
-        private readonly string originalText;
+        private readonly ReadOnlyMemory<char> originalText;
 
         /// <summary>
         /// Constructs a new instance of <see cref="HttpHeaderValueLexer"/>.
@@ -67,7 +68,7 @@ namespace Microsoft.OData
         /// <param name="originalText">The original text of the current parsed item. If the item type is quoted-string, this returns the escaped and quoted string value straight from the header.
         /// For other item types, the original text is the same as the item value.</param>
         /// <param name="startIndexOfNextItem">The start index of the next item to be parsed.</param>
-        private HttpHeaderValueLexer(string httpHeaderName, string httpHeaderValue, string value, string originalText, int startIndexOfNextItem)
+        private HttpHeaderValueLexer(string httpHeaderName, string httpHeaderValue, ReadOnlyMemory<char> value, ReadOnlyMemory<char> originalText, int startIndexOfNextItem)
         {
             this.httpHeaderName = httpHeaderName;
             this.httpHeaderValue = httpHeaderValue;
@@ -114,25 +115,13 @@ namespace Microsoft.OData
         /// The value of the current parsed item. If the item type is quoted-string, this returns the unescaped and unquoted string value. For other item types,
         /// the value is the same as the original text from the header.
         /// </summary>
-        internal string Value
-        {
-            get
-            {
-                return this.value;
-            }
-        }
+        internal ReadOnlyMemory<char> Value => this.value;
 
         /// <summary>
         /// The original text of the current parsed item. If the item type is quoted-string, this returns the escaped and quoted string value straight from the header.
         /// For other item types, the original text is the same as the item value.
         /// </summary>
-        internal string OriginalText
-        {
-            get
-            {
-                return this.originalText;
-            }
-        }
+        internal ReadOnlyMemory<char> OriginalText => this.originalText;
 
         /// <summary>
         /// The type of the current parsed item.
@@ -246,7 +235,7 @@ namespace Microsoft.OData
         {
             Debug.Assert(lexer.Type == HttpHeaderValueItemType.Token, "lexer.Type == HttpHeaderValueItemType.Token");
 
-            string name = lexer.OriginalText;
+            ReadOnlyMemory<char> name = lexer.OriginalText;
             string value = null;
             lexer = lexer.ReadNext();
             if (lexer.Type == HttpHeaderValueItemType.ValueSeparator)
@@ -256,7 +245,7 @@ namespace Microsoft.OData
                     lexer.Type == HttpHeaderValueItemType.Token || lexer.Type == HttpHeaderValueItemType.QuotedString,
                     "lexer.Type == HttpHeaderValueItemType.Token || lexer.Type == HttpHeaderValueItemType.QuotedString");
 
-                value = lexer.OriginalText;
+                value = lexer.OriginalText.ToString();
                 lexer = lexer.ReadNext();
             }
 
@@ -264,7 +253,7 @@ namespace Microsoft.OData
                 lexer.Type == HttpHeaderValueItemType.End || lexer.Type == HttpHeaderValueItemType.ElementSeparator || lexer.Type == HttpHeaderValueItemType.ParameterSeparator,
                 "lexer.Type == HttpHeaderValueItemType.End || lexer.Type == HttpHeaderValueItemType.ElementSeparator || lexer.Type == HttpHeaderValueItemType.ParameterSeparator");
 
-            return new KeyValuePair<string, string>(name, value);
+            return new KeyValuePair<string, string>(name.ToString(), value);
         }
 
         /// <summary>
@@ -284,7 +273,7 @@ namespace Microsoft.OData
         {
             int index = this.startIndexOfNextItem;
             bool isQuotedString;
-            string nextValue = HttpUtils.ReadTokenOrQuotedStringValue(this.httpHeaderName, this.httpHeaderValue, ref index, out isQuotedString, message => new ODataException(message));
+            ReadOnlyMemory<char> nextValue = HttpUtils.ReadTokenOrQuotedStringValue(this.httpHeaderName, this.httpHeaderValue, ref index, out isQuotedString, message => new ODataException(message));
 
             // Instead of testing whether result is null or empty, we check to see if the index have moved forward because we can encounter the empty quoted string "".
             if (index == this.startIndexOfNextItem)
@@ -294,7 +283,7 @@ namespace Microsoft.OData
 
             if (isQuotedString)
             {
-                string original = this.httpHeaderValue.Substring(this.startIndexOfNextItem, index - this.startIndexOfNextItem);
+                ReadOnlyMemory<char> original = this.httpHeaderValue.AsMemory(this.startIndexOfNextItem, index - this.startIndexOfNextItem);
                 return new HttpHeaderQuotedString(this.httpHeaderName, this.httpHeaderValue, nextValue, original, index);
             }
 
@@ -323,8 +312,9 @@ namespace Microsoft.OData
         private HttpHeaderSeparator ReadNextSeparator()
         {
             Debug.Assert(this.startIndexOfNextItem < this.httpHeaderValue.Length, "this.startIndexOfNextItem < this.httpHeaderValue.Length");
-            string separator = this.httpHeaderValue.Substring(this.startIndexOfNextItem, 1);
-            if (separator != ElementSeparator && separator != ParameterSeparator && separator != ValueSeparator)
+            ReadOnlyMemory<char> separator = this.httpHeaderValue.AsMemory(this.startIndexOfNextItem, 1);
+            ReadOnlySpan<char> span = separator.Span;
+            if (!span.Equals(ElementSeparator, StringComparison.Ordinal) && !span.Equals(ParameterSeparator, StringComparison.Ordinal) && !span.Equals(ValueSeparator, StringComparison.Ordinal))
             {
                 throw new ODataException(Strings.HttpHeaderValueLexer_UnrecognizedSeparator(this.httpHeaderName, this.httpHeaderValue, this.startIndexOfNextItem, separator));
             }
@@ -343,7 +333,7 @@ namespace Microsoft.OData
             /// <param name="httpHeaderName">The name of the HTTP header being parsed.</param>
             /// <param name="httpHeaderValue">The value of the HTTP header being parsed.</param>
             internal HttpHeaderStart(string httpHeaderName, string httpHeaderValue)
-                : base(httpHeaderName, httpHeaderValue, /*value*/ null, /*originalText*/ null, 0)
+                : base(httpHeaderName, httpHeaderValue, /*value*/ default, /*originalText*/ default, 0)
             {
                 Debug.Assert(!string.IsNullOrEmpty(this.httpHeaderName), "!string.IsNullOrEmpty(this.httpHeaderName)");
                 Debug.Assert(
@@ -354,13 +344,7 @@ namespace Microsoft.OData
             /// <summary>
             /// The type of the current item.
             /// </summary>
-            internal override HttpHeaderValueItemType Type
-            {
-                get
-                {
-                    return HttpHeaderValueItemType.Start;
-                }
-            }
+            internal override HttpHeaderValueItemType Type => HttpHeaderValueItemType.Start;
 
             /// <summary>
             /// Returns an instance of <see cref="HttpHeaderValueLexer"/> to parse the rest of the items on the header value.
@@ -395,25 +379,19 @@ namespace Microsoft.OData
             /// <param name="httpHeaderValue">The value of the HTTP header being parsed.</param>
             /// <param name="value">The value of the token.</param>
             /// <param name="startIndexOfNextItem">The start index of the next item.</param>
-            internal HttpHeaderToken(string httpHeaderName, string httpHeaderValue, string value, int startIndexOfNextItem)
+            internal HttpHeaderToken(string httpHeaderName, string httpHeaderValue, ReadOnlyMemory<char> value, int startIndexOfNextItem)
                 : base(httpHeaderName, httpHeaderValue, value, value, startIndexOfNextItem)
             {
                 Debug.Assert(!string.IsNullOrEmpty(this.httpHeaderName), "!string.IsNullOrEmpty(this.httpHeaderName)");
                 Debug.Assert(!string.IsNullOrEmpty(this.httpHeaderValue), "!string.IsNullOrEmpty(this.httpHeaderValue)");
                 Debug.Assert(this.startIndexOfNextItem <= this.httpHeaderValue.Length, "this.startIndexOfNextItem <= this.httpHeaderValue.Length");
-                Debug.Assert(!string.IsNullOrEmpty(this.value), "!string.IsNullOrEmpty(this.value)");
+                Debug.Assert(!value.IsEmpty, "!value.IsEmpty");
             }
 
             /// <summary>
             /// The type of the current item.
             /// </summary>
-            internal override HttpHeaderValueItemType Type
-            {
-                get
-                {
-                    return HttpHeaderValueItemType.Token;
-                }
-            }
+            internal override HttpHeaderValueItemType Type => HttpHeaderValueItemType.Token;
 
             /// <summary>
             /// Returns an instance of <see cref="HttpHeaderValueLexer"/> to parse the rest of the items on the header value.
@@ -449,25 +427,19 @@ namespace Microsoft.OData
             /// <param name="value">The value of the quoted string, unescaped and without quotes.</param>
             /// <param name="originalText">The original text of the quoted string, escaped and with quotes.</param>
             /// <param name="startIndexOfNextItem">The start index of the next item.</param>
-            internal HttpHeaderQuotedString(string httpHeaderName, string httpHeaderValue, string value, string originalText, int startIndexOfNextItem)
+            internal HttpHeaderQuotedString(string httpHeaderName, string httpHeaderValue, ReadOnlyMemory<char> value, ReadOnlyMemory<char> originalText, int startIndexOfNextItem)
                 : base(httpHeaderName, httpHeaderValue, value, originalText, startIndexOfNextItem)
             {
                 Debug.Assert(!string.IsNullOrEmpty(this.httpHeaderName), "!string.IsNullOrEmpty(this.httpHeaderName)");
                 Debug.Assert(!string.IsNullOrEmpty(this.httpHeaderValue), "!string.IsNullOrEmpty(this.httpHeaderValue)");
                 Debug.Assert(this.startIndexOfNextItem <= this.httpHeaderValue.Length, "this.startIndexOfNextItem <= this.httpHeaderValue.Length");
-                Debug.Assert(!string.IsNullOrEmpty(this.originalText), "!string.IsNullOrEmpty(this.originalText)");
+                Debug.Assert(!originalText.IsEmpty, "!originalText.IsEmpty");
             }
 
             /// <summary>
             /// The type of the current item.
             /// </summary>
-            internal override HttpHeaderValueItemType Type
-            {
-                get
-                {
-                    return HttpHeaderValueItemType.QuotedString;
-                }
-            }
+            internal override HttpHeaderValueItemType Type => HttpHeaderValueItemType.QuotedString;
 
             /// <summary>
             /// Returns an instance of <see cref="HttpHeaderValueLexer"/> to parse the rest of the items on the header value.
@@ -488,7 +460,8 @@ namespace Microsoft.OData
                 HttpHeaderSeparator separator = this.ReadNextSeparator();
 
                 // ',' and ';' can come after a quoted-string.
-                if (separator.Value == ElementSeparator || separator.Value == ParameterSeparator)
+                ReadOnlySpan<char> span = separator.Value.Span;
+                if (span.Equals(ElementSeparator, StringComparison.Ordinal) || span.Equals(ParameterSeparator, StringComparison.Ordinal))
                 {
                     return separator;
                 }
@@ -509,14 +482,18 @@ namespace Microsoft.OData
             /// <param name="httpHeaderValue">The value of the HTTP header being parsed.</param>
             /// <param name="value">The value of the separator.</param>
             /// <param name="startIndexOfNextItem">The start index of the next item.</param>
-            internal HttpHeaderSeparator(string httpHeaderName, string httpHeaderValue, string value, int startIndexOfNextItem)
+            internal HttpHeaderSeparator(string httpHeaderName, string httpHeaderValue, ReadOnlyMemory<char> value, int startIndexOfNextItem)
                 : base(httpHeaderName, httpHeaderValue, value, value, startIndexOfNextItem)
             {
                 Debug.Assert(!string.IsNullOrEmpty(this.httpHeaderName), "!string.IsNullOrEmpty(this.httpHeaderName)");
                 Debug.Assert(!string.IsNullOrEmpty(this.httpHeaderValue), "!string.IsNullOrEmpty(this.httpHeaderValue)");
                 Debug.Assert(this.startIndexOfNextItem <= this.httpHeaderValue.Length, "this.startIndexOfNextItem <= this.httpHeaderValue.Length");
+
+                ReadOnlySpan<char> span = value.Span;
                 Debug.Assert(
-                    this.Value == ElementSeparator || this.Value == ParameterSeparator || this.Value == ValueSeparator,
+                    span.Equals(ElementSeparator, StringComparison.Ordinal) ||
+                    span.Equals(ParameterSeparator, StringComparison.Ordinal) ||
+                    span.Equals(ValueSeparator, StringComparison.Ordinal),
                     "this.Value == CommaSeparator || this.Value == SemicolonSeparator || this.Value == EqualsSeparator");
             }
 
@@ -527,15 +504,19 @@ namespace Microsoft.OData
             {
                 get
                 {
-                    switch (this.Value)
+                    ReadOnlySpan<char> span = Value.Span;
+                    if (span.Equals(ElementSeparator, StringComparison.Ordinal))
                     {
-                        case ElementSeparator:
-                            return HttpHeaderValueItemType.ElementSeparator;
-                        case ParameterSeparator:
-                            return HttpHeaderValueItemType.ParameterSeparator;
-                        default:
-                            Debug.Assert(this.Value == ValueSeparator, "this.Value == ValueSeparator");
-                            return HttpHeaderValueItemType.ValueSeparator;
+                        return HttpHeaderValueItemType.ElementSeparator;
+                    }
+                    else if (span.Equals(ParameterSeparator, StringComparison.Ordinal))
+                    {
+                        return HttpHeaderValueItemType.ParameterSeparator;
+                    }
+                    else
+                    {
+                        Debug.Assert(span.Equals(ValueSeparator, StringComparison.Ordinal), "this.Value == ValueSeparator");
+                        return HttpHeaderValueItemType.ValueSeparator;
                     }
                 }
             }
@@ -557,7 +538,7 @@ namespace Microsoft.OData
                 }
 
                 // Token or quoted-string can come after '='. i.e. token ['=' (token | quoted-string)]
-                if (this.Value == ValueSeparator)
+                if (this.Value.Span.Equals(ValueSeparator, StringComparison.Ordinal))
                 {
                     return this.ReadNextTokenOrQuotedString();
                 }
@@ -581,20 +562,14 @@ namespace Microsoft.OData
             /// Constructs a new instance of <see cref="HttpHeaderEnd"/>.
             /// </summary>
             private HttpHeaderEnd()
-                : base(/*httpHeaderName*/ null, /*httpHeaderValue*/ null, /*value*/ null, /*originalText*/ null, /*startIndexOfNextItem*/ -1)
+                : base(/*httpHeaderName*/ null, /*httpHeaderValue*/ null, /*value*/ default, /*originalText*/ default, /*startIndexOfNextItem*/ -1)
             {
             }
 
             /// <summary>
             /// The type of the current item.
             /// </summary>
-            internal override HttpHeaderValueItemType Type
-            {
-                get
-                {
-                    return HttpHeaderValueItemType.End;
-                }
-            }
+            internal override HttpHeaderValueItemType Type => HttpHeaderValueItemType.End;
 
             /// <summary>
             /// Returns an instance of <see cref="HttpHeaderValueLexer"/> to parse the rest of the items on the header value.

--- a/src/Microsoft.OData.Core/HttpHeaderValueLexer.cs
+++ b/src/Microsoft.OData.Core/HttpHeaderValueLexer.cs
@@ -333,7 +333,7 @@ namespace Microsoft.OData
             /// <param name="httpHeaderName">The name of the HTTP header being parsed.</param>
             /// <param name="httpHeaderValue">The value of the HTTP header being parsed.</param>
             internal HttpHeaderStart(string httpHeaderName, string httpHeaderValue)
-                : base(httpHeaderName, httpHeaderValue, /*value*/ default, /*originalText*/ default, 0)
+                : base(httpHeaderName, httpHeaderValue, default, default, 0)
             {
                 Debug.Assert(!string.IsNullOrEmpty(this.httpHeaderName), "!string.IsNullOrEmpty(this.httpHeaderName)");
                 Debug.Assert(
@@ -562,7 +562,7 @@ namespace Microsoft.OData
             /// Constructs a new instance of <see cref="HttpHeaderEnd"/>.
             /// </summary>
             private HttpHeaderEnd()
-                : base(/*httpHeaderName*/ null, /*httpHeaderValue*/ null, /*value*/ default, /*originalText*/ default, /*startIndexOfNextItem*/ -1)
+                : base(null, null, default, default, -1)
             {
             }
 

--- a/src/Microsoft.OData.Core/HttpUtils.cs
+++ b/src/Microsoft.OData.Core/HttpUtils.cs
@@ -505,12 +505,13 @@ namespace Microsoft.OData
         }
 
         /// <summary>
-        /// Skips whitespace in the specified text by advancing an index to
-        /// the next non-whitespace character.
+        /// Reads a token value from the header.
         /// </summary>
-        /// <param name="text">Text to scan.</param>
-        /// <param name="textIndex">Index to begin scanning from.</param>
-        /// <returns>true if the end of the string was reached, false otherwise.</returns>
+        /// <param name="headerName">Name of the header.</param>
+        /// <param name="headerText">Header text.</param>
+        /// <param name="textIndex">The text index.</param>
+        /// <param name="createException">Func to create the appropriate exception to throw from the given error message.</param>
+        /// <returns>The token that was read from the header.</returns>
         private static ReadOnlyMemory<char> ReadTokenValue(string headerName, string headerText, ref int textIndex, Func<string, Exception> createException)
         {
             int start = textIndex;

--- a/src/Microsoft.OData.Core/HttpUtils.cs
+++ b/src/Microsoft.OData.Core/HttpUtils.cs
@@ -402,7 +402,7 @@ namespace Microsoft.OData
         /// <param name="isQuotedString">Returns true if the value is a quoted-string, false if the value is a token.</param>
         /// <param name="createException">Func to create the appropriate exception to throw from the given error message.</param>
         /// <returns>The token or quoted-string value that was read from the header.</returns>
-        internal static string ReadTokenOrQuotedStringValue(string headerName, string headerText, ref int textIndex, out bool isQuotedString, Func<string, Exception> createException)
+        internal static ReadOnlyMemory<char> ReadTokenOrQuotedStringValue(string headerName, string headerText, ref int textIndex, out bool isQuotedString, Func<string, Exception> createException)
         {
             //// NOTE: See RFC 2616, Sections 3.6 and 2.2 for the full grammar for HTTP parameter values
             ////
@@ -420,8 +420,6 @@ namespace Microsoft.OData
             //// TEXT               = <any OCTET except CTLs, but including LWS>
             //// quoted-pair        = "\" CHAR
 
-            StringBuilder parameterValue = new StringBuilder();
-
             // Check if the value is quoted.
             isQuotedString = false;
             if (textIndex < headerText.Length)
@@ -433,18 +431,22 @@ namespace Microsoft.OData
                 }
             }
 
-            char currentChar = default(char);
+            // if not a quoted string, reading it as Token
+            if (!isQuotedString)
+            {
+                return ReadTokenValue(headerName, headerText, ref textIndex, createException);
+            }
+
+            // Now, we are reading quoted string, since the quoted string could be escaped, using StringBuilder only if the origin string contains the escaped.
+            StringBuilder parameterValue = null;
+            int start = textIndex; // the starting of quoted string (next position of the leading ")
+            char currentChar = default;
             while (textIndex < headerText.Length)
             {
                 currentChar = headerText[textIndex];
 
                 if (currentChar == '\\' || currentChar == '\"')
                 {
-                    if (!isQuotedString)
-                    {
-                        throw createException(Strings.HttpUtils_EscapeCharWithoutQuotes(headerName, headerText, textIndex, currentChar));
-                    }
-
                     textIndex++;
 
                     // End of quoted parameter value.
@@ -453,37 +455,82 @@ namespace Microsoft.OData
                         break;
                     }
 
+                    if (parameterValue == null)
+                    {
+                        parameterValue = new StringBuilder();
+                        int i = start;
+                        while (i < textIndex - 1)
+                        {
+                            parameterValue.Append(headerText[i]); // initial the string builder for the unescaped string
+                            i++;
+                        }
+                    }
+
                     if (textIndex >= headerText.Length)
                     {
                         throw createException(Strings.HttpUtils_EscapeCharAtEnd(headerName, headerText, textIndex, currentChar));
                     }
 
-                    currentChar = headerText[textIndex];
+                    currentChar = headerText[textIndex]; // only save the char after '\'? not unescape it? or it's never used?
                 }
                 else
                 {
-                    if (!isQuotedString && !IsHttpToken(currentChar))
-                    {
-                        // If the given character is special, we stop processing.
-                        break;
-                    }
-
-                    if (isQuotedString && !IsValidInQuotedHeaderValue(currentChar))
+                    if (!IsValidInQuotedHeaderValue(currentChar))
                     {
                         throw createException(Strings.HttpUtils_InvalidCharacterInQuotedParameterValue(headerName, headerText, textIndex, currentChar));
                     }
                 }
 
-                parameterValue.Append(currentChar);
+                if (parameterValue != null)
+                {
+                    parameterValue.Append(currentChar);
+                }
+
                 textIndex++;
             }
 
-            if (isQuotedString && currentChar != '\"')
+            if (currentChar != '\"')
             {
                 throw createException(Strings.HttpUtils_ClosingQuoteNotFound(headerName, headerText, textIndex));
             }
 
-            return parameterValue.ToString();
+            if (parameterValue != null)
+            {
+                return parameterValue.ToString().AsMemory();
+            }
+            else
+            {
+                return headerText.AsMemory(start, textIndex - start - 1);
+            }
+        }
+
+        /// <summary>
+        /// Skips whitespace in the specified text by advancing an index to
+        /// the next non-whitespace character.
+        /// </summary>
+        /// <param name="text">Text to scan.</param>
+        /// <param name="textIndex">Index to begin scanning from.</param>
+        /// <returns>true if the end of the string was reached, false otherwise.</returns>
+        private static ReadOnlyMemory<char> ReadTokenValue(string headerName, string headerText, ref int textIndex, Func<string, Exception> createException)
+        {
+            int start = textIndex;
+            char currentChar = default;
+            while (textIndex < headerText.Length)
+            {
+                currentChar = headerText[textIndex];
+                if (currentChar == '\\' || currentChar == '\"')
+                {
+                    throw createException(Strings.HttpUtils_EscapeCharWithoutQuotes(headerName, headerText, textIndex, currentChar));
+                }
+                else if (!IsHttpToken(currentChar))
+                {
+                    break;
+                }
+
+                textIndex++;
+            }
+
+            return headerText.AsMemory(start, textIndex - start);
         }
 
         /// <summary>
@@ -681,11 +728,11 @@ namespace Microsoft.OData
             textIndex++;
 
             bool isQuotedString;
-            string parameterValue = ReadTokenOrQuotedStringValue(ODataConstants.ContentTypeHeader, text, ref textIndex, out isQuotedString, message => new ODataContentTypeException(message));
+            ReadOnlyMemory<char> parameterValue = ReadTokenOrQuotedStringValue(ODataConstants.ContentTypeHeader, text, ref textIndex, out isQuotedString, message => new ODataContentTypeException(message));
 
             if (CompareMediaTypeParameterNames(ODataConstants.Charset, parameterName))
             {
-                charset = parameterValue;
+                charset = parameterValue.ToString();
             }
             else
             {
@@ -695,7 +742,7 @@ namespace Microsoft.OData
                     parameters = new List<KeyValuePair<string, string>>(1);
                 }
 
-                parameters.Add(new KeyValuePair<string, string>(parameterName, parameterValue));
+                parameters.Add(new KeyValuePair<string, string>(parameterName, parameterValue.ToString()));
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataConventionalEntityMetadataBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataConventionalEntityMetadataBuilderTests.cs
@@ -602,7 +602,7 @@ namespace Microsoft.OData.Tests.Evaluation
             // validates that important uri literal values that OData uses don't change, and that we escape characters when
             // producing the etag for Json
             var escapedStrings = Uri.EscapeDataString(@".:''-");
-            Assert.Equal(@".:''-", escapedStrings);
+            Assert.Equal(@".%3A%27%27-", escapedStrings);
 
             var testSubject = new ODataConventionalEntityMetadataBuilder(new TestEntryMetadataContext { Resource = new ODataResource(), ETagProperties = new[] { new KeyValuePair<string, object>("ETag", "Value ") } }, this.metadataContext, this.uriBuilder);
             Assert.Equal(@"W/""'Value%20'""", testSubject.GetETag());

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataConventionalEntityMetadataBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Evaluation/ODataConventionalEntityMetadataBuilderTests.cs
@@ -601,7 +601,7 @@ namespace Microsoft.OData.Tests.Evaluation
             // .net 45 changed this behavior initially to escape ' to a value, but was changed. below test
             // validates that important uri literal values that OData uses don't change, and that we escape characters when
             // producing the etag for Json
-            var escapedStrings = Uri.EscapeUriString(@".:''-");
+            var escapedStrings = Uri.EscapeDataString(@".:''-");
             Assert.Equal(@".:''-", escapedStrings);
 
             var testSubject = new ODataConventionalEntityMetadataBuilder(new TestEntryMetadataContext { Resource = new ODataResource(), ETagProperties = new[] { new KeyValuePair<string, object>("ETag", "Value ") } }, this.metadataContext, this.uriBuilder);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/HttpUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/HttpUtilsTests.cs
@@ -1,0 +1,135 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="HttpUtilsTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
+using Xunit;
+
+namespace Microsoft.OData.Tests
+{
+    public class HttpUtilsTests
+    {
+        [Theory]
+        [InlineData("token")]
+        [InlineData("token**")]
+        [InlineData("toke$")]
+        public void ReadTokenOrQuotedStringValueShouldReadTokenValue(string headerValue)
+        {
+            int textIndex = 0;
+            bool isQuotedString;
+            ReadOnlyMemory<char> token = HttpUtils.ReadTokenOrQuotedStringValue("any", headerValue, ref textIndex, out isQuotedString, null);
+
+            Assert.False(isQuotedString);
+            Assert.Equal(headerValue.Length, textIndex);
+            Assert.True(token.Span.Equals(headerValue, StringComparison.Ordinal));
+        }
+
+        [Theory]
+        [InlineData("token(Next")]
+        [InlineData("token)Next")]
+        [InlineData("token>Next")]
+        [InlineData("token<Next")]
+        [InlineData("token@Next")]
+        [InlineData("token,Next")]
+        [InlineData("token;Next")]
+        [InlineData("token:Next")]
+        [InlineData("token[Next")]
+        [InlineData("token]Next")]
+        [InlineData("token/Next")]
+        [InlineData("token?Next")]
+        [InlineData("token=Next")]
+        public void ReadTokenOrQuotedStringValueShouldReadTokenValueBeforeSeparator(string headerValue)
+        {
+            int textIndex = 0;
+            bool isQuotedString;
+            ReadOnlyMemory<char> token = HttpUtils.ReadTokenOrQuotedStringValue("any", headerValue, ref textIndex, out isQuotedString, null);
+
+            Assert.False(isQuotedString);
+            Assert.Equal(5, textIndex);
+            Assert.True(token.Span.Equals("token", StringComparison.Ordinal));
+        }
+
+        [Theory]
+        [InlineData("token\\Next", '\\')]
+        [InlineData("token\"Next", '\"')]
+        public void ReadTokenOrQuotedStringValueShouldThrowForEscapeCharInUnquotedString(string headerValue, char ch)
+        {
+            string headerName = "any";
+            int textIndex = 0;
+            bool isQuotedString;
+            Action test = () => HttpUtils.ReadTokenOrQuotedStringValue(headerName, headerValue, ref textIndex, out isQuotedString, (s) => new Exception(s));
+
+            Exception exception = Assert.Throws<Exception>(test);
+            Assert.Equal(Strings.HttpUtils_EscapeCharWithoutQuotes(headerName, headerValue, 5, ch), exception.Message);
+        }
+
+        [Theory]
+        [InlineData("\"token\"")]
+        [InlineData("\"token**\"")]
+        [InlineData("\"toke$\"")]
+        public void ReadTokenOrQuotedStringValueShouldReadQuotedStringWithoutEscaped(string headerValue)
+        {
+            int textIndex = 0;
+            bool isQuotedString;
+            ReadOnlyMemory<char> token = HttpUtils.ReadTokenOrQuotedStringValue("any", headerValue, ref textIndex, out isQuotedString, null);
+
+            Assert.True(isQuotedString);
+            Assert.Equal(headerValue.Length, textIndex);
+            Assert.True(token.Span.Equals(headerValue.Substring(1, headerValue.Length - 2), StringComparison.Ordinal));
+        }
+
+        [Theory]
+        [InlineData("\"\\a_token\"", "a_token")]
+        [InlineData("\"token_\\b\"", "token_b")]
+        [InlineData("\"tok\\den\"", "tokden")]
+        [InlineData("\"to\\t\\\\ken\"", "tot\\ken")]
+        public void ReadTokenOrQuotedStringValueShouldReadQuotedStringWithEscaped(string headerValue, string expect)
+        {
+            int textIndex = 0;
+            bool isQuotedString;
+            ReadOnlyMemory<char> token = HttpUtils.ReadTokenOrQuotedStringValue("any", headerValue, ref textIndex, out isQuotedString, null);
+
+            Assert.True(isQuotedString);
+            Assert.Equal(headerValue.Length, textIndex);
+            Assert.True(token.Span.Equals(expect, StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void ReadTokenOrQuotedStringValueShouldThrowEscapeCharAtEnd()
+        {
+            string headerName = "any";
+            string headerValue = "\"token\\";
+            int textIndex = 0;
+            Action test = () => HttpUtils.ReadTokenOrQuotedStringValue(headerName, headerValue, ref textIndex, out _, (s) => new Exception(s));
+
+            Exception exception = Assert.Throws<Exception>(test);
+            Assert.Equal(Strings.HttpUtils_EscapeCharAtEnd(headerName, headerValue, 7, '\\'), exception.Message);
+        }
+
+        [Fact]
+        public void ReadTokenOrQuotedStringValueShouldThrowInvalidCharacterInQuoted()
+        {
+            string headerName = "any";
+            string headerValue = "\"tok\u001Ben\"";
+            int textIndex = 0;
+            Action test = () => HttpUtils.ReadTokenOrQuotedStringValue(headerName, headerValue, ref textIndex, out _, (s) => new Exception(s));
+
+            Exception exception = Assert.Throws<Exception>(test);
+            Assert.Equal(Strings.HttpUtils_InvalidCharacterInQuotedParameterValue(headerName, headerValue, 4, '\u001b'), exception.Message);
+        }
+
+        [Fact]
+        public void ReadTokenOrQuotedStringValueShouldThrowClosingQuoteNotFound()
+        {
+            string headerName = "any";
+            string headerValue = "\"token";
+            int textIndex = 0;
+            Action test = () => HttpUtils.ReadTokenOrQuotedStringValue(headerName, headerValue, ref textIndex, out _, (s) => new Exception(s));
+
+            Exception exception = Assert.Throws<Exception>(test);
+            Assert.Equal(Strings.HttpUtils_ClosingQuoteNotFound(headerName, headerValue, 6), exception.Message);
+        }
+    }
+}


### PR DESCRIPTION
Add the test cases for HttpUtils

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3094.*

### Description

* This PR focuses on HttpHeaderValueLexer, try to replace 'substring' using ReadOnlyMemory<char> to save the memory allocatioin.
* Add test cases for httpUtils

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
