### PR TITLE
Write stream instead of flush (for v7.x)

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
@@ -64,7 +64,7 @@ namespace Microsoft.OData.Json
             this.WriteItemWithSeparatorIfNeeded();
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
 
             this.binaryValueStream = new ODataUtf8JsonWriteStream(this);
 
@@ -83,7 +83,7 @@ namespace Microsoft.OData.Json
                 this.binaryValueStream = null;
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
@@ -282,7 +282,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    this.jsonWriter.FlushIfBufferThresholdReached();
+                    this.jsonWriter.DrainBufferIfThresholdReached();
                 }
             }
 
@@ -328,7 +328,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    await this.jsonWriter.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                    await this.jsonWriter.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
                 }
             }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -121,7 +121,7 @@ namespace Microsoft.OData.Json
                 await this.textWriter.DisposeAsync();
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
 
             CheckIfSeparatorNeeded();
             CheckIfManualValueAtArrayStart();
@@ -347,7 +347,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    this.jsonWriter.FlushIfBufferThresholdReached();
+                    this.jsonWriter.DrainBufferIfThresholdReached();
                 }
             }
 
@@ -397,7 +397,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    await this.jsonWriter.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                    await this.jsonWriter.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
                 }
             }
 
@@ -441,7 +441,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    this.jsonWriter.FlushIfBufferThresholdReached();
+                    this.jsonWriter.DrainBufferIfThresholdReached();
                 }
             }
 
@@ -485,7 +485,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    await this.jsonWriter.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                    await this.jsonWriter.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
                 }
             }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -28,7 +28,7 @@ namespace Microsoft.OData.Json
     /// </summary>
     internal sealed partial class ODataUtf8JsonWriter : IJsonStreamWriter, IDisposable, IJsonStreamWriterAsync, IAsyncDisposable
     {
-        private const int DefaultBufferSize = 16 * 1024;
+        private const int DefaultBufferSize = 1024 * 1024; // Temporarily set to 1MB to test perf impact (default was 16 * 1024)
         private readonly float bufferFlushThreshold;
         private readonly static ReadOnlyMemory<byte> parentheses = new byte[] { (byte)'(', (byte)')' };
         private readonly static ReadOnlyMemory<byte> itemSeparator = new byte[] { (byte)',' };

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -152,9 +152,7 @@ namespace Microsoft.OData.Json
 
         public void Flush()
         {
-            this.CommitUtf8JsonWriterContentsToBuffer();
-            this.writeStream.Write(this.bufferWriter.WrittenMemory.Span);
-            this.bufferWriter.Clear();
+            this.WriteToStream();
             this.writeStream.Flush();
         }
 
@@ -163,8 +161,15 @@ namespace Microsoft.OData.Json
         {
             if ((this.utf8JsonWriter.BytesPending + this.bufferWriter.WrittenCount) >= this.bufferFlushThreshold)
             {
-                this.Flush();
+                this.WriteToStream();
             }
+        }
+
+        private void WriteToStream()
+        {
+            this.CommitUtf8JsonWriterContentsToBuffer();
+            this.writeStream.Write(this.bufferWriter.WrittenMemory.Span);
+            this.bufferWriter.Clear();
         }
 
         /// <summary>
@@ -435,7 +440,7 @@ namespace Microsoft.OData.Json
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            this.Flush();
+            this.WriteToStream();
 
             int charsNotProcessedFromPreviousChunk = 0;
 
@@ -613,7 +618,7 @@ namespace Microsoft.OData.Json
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            this.Flush();
+            this.WriteToStream();
 
             int bytesNotWrittenFromPreviousChunk = 0;
 
@@ -1136,7 +1141,7 @@ namespace Microsoft.OData.Json
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            await this.FlushAsync();
+            await this.WriteToStreamAsync().ConfigureAwait(false);
 
             int charsNotProcessedFromPreviousChunk = 0;
 
@@ -1204,7 +1209,7 @@ namespace Microsoft.OData.Json
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            await FlushAsync().ConfigureAwait(false);
+            await WriteToStreamAsync().ConfigureAwait(false);
 
             int bytesNotWrittenFromPreviousChunk = 0;
 
@@ -1244,9 +1249,7 @@ namespace Microsoft.OData.Json
 
         public async Task FlushAsync()
         {
-            this.CommitUtf8JsonWriterContentsToBuffer();
-            await this.writeStream.WriteAsync(this.bufferWriter.WrittenMemory).ConfigureAwait(false);
-            this.bufferWriter.Clear();
+            await this.WriteToStreamAsync().ConfigureAwait(false);
             await this.writeStream.FlushAsync().ConfigureAwait(false);
         }
 
@@ -1284,8 +1287,15 @@ namespace Microsoft.OData.Json
         {
             if ((this.utf8JsonWriter.BytesPending + this.bufferWriter.WrittenCount) >= this.bufferFlushThreshold)
             {
-                await this.FlushAsync().ConfigureAwait(false);
+                await this.WriteToStreamAsync().ConfigureAwait(false);
             }
+        }
+
+        private async ValueTask WriteToStreamAsync()
+        {
+            this.CommitUtf8JsonWriterContentsToBuffer();
+            await this.writeStream.WriteAsync(this.bufferWriter.WrittenMemory).ConfigureAwait(false);
+            this.bufferWriter.Clear();
         }
         #endregion
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -640,7 +640,7 @@ namespace Microsoft.OData.Tests.Json
 
             await jsonWriter.WriteValueAsync("foofoo");
 
-            // should have written to stream because we have not reached the writer's buffer threshold
+            // should not have written to stream because we have not reached the writer's buffer threshold
             Assert.Equal(0, bufStream.Position);
             Assert.Equal(0, finalStream.Position);
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -553,7 +553,7 @@ namespace Microsoft.OData.Tests.Json
         #endregion
 
         [Fact]
-        public async Task FlushesWhenBufferThresholdIsReachedAsync()
+        public async Task WritesToStreamWhenBufferThresholdIsReachedAsync()
         {
             using var stream = new MemoryStream();
             // set buffer size to 10, in current implementation, buffer threshold will be 9
@@ -581,7 +581,7 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
-        public async Task FlushesWhenBufferThresholdIsReached_WithRawValues_Async()
+        public async Task WritesToStreamWhenBufferThresholdIsReached_WithRawValues_Async()
         {
             using var stream = new MemoryStream();
             // set buffer size to 10, in current implementation, buffer threshold will be 9
@@ -627,6 +627,34 @@ namespace Microsoft.OData.Tests.Json
             await jsonWriter.EndArrayScopeAsync();
 
             Assert.Equal(@"[""foo"",""fooba""]", await this.ReadStreamAsync(jsonWriter, stream, Encoding.UTF8));
+        }
+
+        [Fact]
+        public async Task WritingWhenBufferIsFullShouldNotForceFlush()
+        {
+            using var finalStream = new MemoryStream();
+            using var bufStream = new BufferedStream(finalStream, bufferSize: 1024);
+
+            using var jsonWriter = new ODataUtf8JsonWriter(bufStream, true, Encoding.UTF8, bufferSize: 16, leaveStreamOpen: true);
+            await jsonWriter.StartArrayScopeAsync();
+
+            await jsonWriter.WriteValueAsync("foofoo");
+
+            // should have written to stream because we have not reached the writer's buffer threshold
+            Assert.Equal(0, bufStream.Position);
+            Assert.Equal(0, finalStream.Position);
+
+            await jsonWriter.WriteValueAsync("foofoofoofoo");
+            await jsonWriter.EndArrayScopeAsync();
+
+            // should write to bufStream since we exceeded the threshold
+            Assert.Equal(24, bufStream.Position);
+            // should not have written to final stream because we have not reached intermediate stream's buffer size
+            Assert.Equal(0, finalStream.Position);
+
+            await jsonWriter.FlushAsync();
+            // should flush content to final stream
+            Assert.Equal(@"[""foofoo"",""foofoofoofoo""]", await this.ReadStreamAsync(jsonWriter, finalStream, Encoding.UTF8));
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -685,7 +685,7 @@ namespace Microsoft.OData.Tests.Json
 
             jsonWriter.WriteValue("foofoo");
 
-            // should have written to stream because we have not reached the writer's buffer threshold
+            // should not have written to stream because we have not reached the writer's buffer threshold
             Assert.Equal(0, bufStream.Position);
             Assert.Equal(0, finalStream.Position);
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3099 .*

This PR is for v7.x. I will create an 8.x port once this is merged.

### Description

This PR removes the "Flush()" call from the `FlushIfBufferThresholdReached` method and renames the method to `DrainBufferIfThresholdReached`. This method no longer forces a flush of the underlying stream, instead it only writes to the stream but leaves the stream to decide whether/when to flush. The user can still force a flush by explicitly calling the `Flush()` method.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
