### PR TITLE
Do not force flush when ODataUtf8JsonWriter buffer threshold is reached

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
@@ -83,7 +83,7 @@ namespace Microsoft.OData.Json
                 this.binaryValueStream = null;
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
@@ -282,7 +282,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    this.jsonWriter.FlushIfBufferThresholdReached();
+                    this.jsonWriter.DrainBufferIfThresholdReached();
                 }
             }
 
@@ -328,7 +328,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    await this.jsonWriter.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                    await this.jsonWriter.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
                 }
             }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -119,7 +119,7 @@ namespace Microsoft.OData.Json
                 await this.textWriter.DisposeAsync();
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
 
             CheckIfSeparatorNeeded();
             CheckIfManualValueAtArrayStart();
@@ -337,7 +337,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    this.jsonWriter.FlushIfBufferThresholdReached();
+                    this.jsonWriter.DrainBufferIfThresholdReached();
                 }
             }
 
@@ -387,7 +387,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    await this.jsonWriter.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                    await this.jsonWriter.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
                 }
             }
 
@@ -431,7 +431,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    this.jsonWriter.FlushIfBufferThresholdReached();
+                    this.jsonWriter.DrainBufferIfThresholdReached();
                 }
             }
 
@@ -475,7 +475,7 @@ namespace Microsoft.OData.Json
                     }
 
                     // Flush the writer if the buffer threshold is reached
-                    await this.jsonWriter.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                    await this.jsonWriter.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
                 }
             }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -152,19 +152,28 @@ namespace Microsoft.OData.Json
 
         public void Flush()
         {
-            this.CommitUtf8JsonWriterContentsToBuffer();
-            this.writeStream.Write(this.bufferWriter.WrittenMemory.Span);
-            this.bufferWriter.Clear();
+            this.WriteToStream();
             this.writeStream.Flush();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void FlushIfBufferThresholdReached()
+        private void DrainBufferIfThresholdReached()
         {
             if ((this.utf8JsonWriter.BytesPending + this.bufferWriter.WrittenCount) >= this.bufferFlushThreshold)
             {
-                this.Flush();
+                this.WriteToStream();
             }
+        }
+
+        /// <summary>
+        /// If buffer threshold is reached, writes the buffered data
+        /// to the stream and clears the buffer.
+        /// </summary>
+        private void WriteToStream()
+        {
+            this.CommitUtf8JsonWriterContentsToBuffer();
+            this.writeStream.Write(this.bufferWriter.WrittenMemory.Span);
+            this.bufferWriter.Clear();
         }
 
         /// <summary>
@@ -182,21 +191,21 @@ namespace Microsoft.OData.Json
         {
             this.CommitUtf8JsonWriterContentsToBuffer();
             this.bufferWriter.Write(parentheses[..1].Span);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WritePaddingFunctionName(string functionName)
         {
             this.CommitUtf8JsonWriterContentsToBuffer();
             this.bufferWriter.Write(Encoding.UTF8.GetBytes(functionName));
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void EndPaddingFunctionScope()
         {
             this.CommitUtf8JsonWriterContentsToBuffer();
             this.bufferWriter.Write(parentheses[1..2].Span);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void StartObjectScope()
@@ -204,14 +213,14 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             this.EnterObjectScope();
             this.utf8JsonWriter.WriteStartObject();
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void EndObjectScope()
         {
             this.utf8JsonWriter.WriteEndObject();
             this.ExitScope();
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void StartArrayScope()
@@ -219,35 +228,35 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             this.EnterArrayScope();
             this.utf8JsonWriter.WriteStartArray();
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void EndArrayScope()
         {
             this.utf8JsonWriter.WriteEndArray();
             this.ExitScope();
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteName(string name)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WritePropertyName(name);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(bool value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteBooleanValue(value);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(int value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteNumberValue(value);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(float value)
@@ -270,14 +279,14 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteNumberValue(value);
             }
 
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(short value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteNumberValue(value);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(long value)
@@ -292,7 +301,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteNumberValue(value);
             }
 
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(double value)
@@ -326,14 +335,14 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: true);
             }
 
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(Guid value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteStringValue(value);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(decimal value)
@@ -348,7 +357,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteNumberValue(value);
             }
 
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(DateTimeOffset value)
@@ -369,7 +378,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteStringValue(value);
             }
 
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(TimeSpan value)
@@ -377,35 +386,35 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             string stringValue = EdmValueWriter.DurationAsXml(value);
             this.utf8JsonWriter.WriteStringValue(stringValue);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(Date value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteStringValue(value.ToString());
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(TimeOfDay value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteStringValue(value.ToString());
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(byte value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteNumberValue(value);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(sbyte value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteNumberValue(value);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteValue(string value)
@@ -425,7 +434,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteStringValue(value);
             }
 
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         /// <summary>
@@ -445,7 +454,7 @@ namespace Microsoft.OData.Json
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            this.Flush();
+            this.WriteToStream();
 
             int charsNotProcessedFromPreviousChunk = 0;
 
@@ -468,7 +477,7 @@ namespace Microsoft.OData.Json
                 }
 
                 // Flush the buffer if needed
-                this.FlushIfBufferThresholdReached();
+                this.DrainBufferIfThresholdReached();
             }
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
@@ -608,7 +617,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteBase64StringValue(value);
             }
 
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         /// <summary>
@@ -623,7 +632,7 @@ namespace Microsoft.OData.Json
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            this.Flush();
+            this.WriteToStream();
 
             int bytesNotWrittenFromPreviousChunk = 0;
 
@@ -636,7 +645,7 @@ namespace Microsoft.OData.Json
 
                 Base64EncodeAndWriteChunk(chunk, isFinalBlock, out bytesNotWrittenFromPreviousChunk);
 
-                this.FlushIfBufferThresholdReached();
+                this.DrainBufferIfThresholdReached();
             }
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
@@ -673,13 +682,13 @@ namespace Microsoft.OData.Json
         {
             this.WriteSeparatorIfNecessary();
             value.WriteTo(this.utf8JsonWriter);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         public void WriteRawValue(string rawValue)
         {
             this.WriteRawValueCore(rawValue);
-            this.FlushIfBufferThresholdReached();
+            this.DrainBufferIfThresholdReached();
         }
 
         /// <summary>
@@ -893,21 +902,21 @@ namespace Microsoft.OData.Json
         {
             this.CommitUtf8JsonWriterContentsToBuffer();
             this.bufferWriter.Write(parentheses[..1].Span);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WritePaddingFunctionNameAsync(string functionName)
         {
             this.CommitUtf8JsonWriterContentsToBuffer();
             this.bufferWriter.Write(Encoding.UTF8.GetBytes(functionName));
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task EndPaddingFunctionScopeAsync()
         {
             this.CommitUtf8JsonWriterContentsToBuffer();
             this.bufferWriter.Write(parentheses[1..2].Span);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task StartObjectScopeAsync()
@@ -915,14 +924,14 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             this.EnterObjectScope();
             this.utf8JsonWriter.WriteStartObject();
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task EndObjectScopeAsync()
         {
             this.utf8JsonWriter.WriteEndObject();
             this.ExitScope();
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task StartArrayScopeAsync()
@@ -930,35 +939,35 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             this.EnterArrayScope();
             this.utf8JsonWriter.WriteStartArray();
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task EndArrayScopeAsync()
         {
             this.utf8JsonWriter.WriteEndArray();
             this.ExitScope();
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteNameAsync(string name)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WritePropertyName(name);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(bool value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteBooleanValue(value);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(int value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteNumberValue(value);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(float value)
@@ -981,14 +990,14 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteNumberValue(value);
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(short value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteNumberValue(value);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(long value)
@@ -1003,7 +1012,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteNumberValue(value);
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(double value)
@@ -1037,14 +1046,14 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteRawValue(needsFractionalPart ? $"{valueToWrite}.0" : valueToWrite, skipInputValidation: true);
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(Guid value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteStringValue(value);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(decimal value)
@@ -1059,7 +1068,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteNumberValue(value);
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(DateTimeOffset value)
@@ -1081,7 +1090,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteStringValue(value);
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(TimeSpan value)
@@ -1089,35 +1098,35 @@ namespace Microsoft.OData.Json
             this.WriteSeparatorIfNecessary();
             string stringValue = EdmValueWriter.DurationAsXml(value);
             this.utf8JsonWriter.WriteStringValue(stringValue);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(Date value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteStringValue(value.ToString());
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(TimeOfDay value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteStringValue(value.ToString());
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(byte value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteNumberValue(value);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(sbyte value)
         {
             this.WriteSeparatorIfNecessary();
             this.utf8JsonWriter.WriteNumberValue(value);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteValueAsync(string value)
@@ -1137,7 +1146,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteStringValue(value.ToString());
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1157,7 +1166,7 @@ namespace Microsoft.OData.Json
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            await this.FlushAsync();
+            await this.WriteToStreamAsync().ConfigureAwait(false);
 
             int charsNotProcessedFromPreviousChunk = 0;
 
@@ -1181,7 +1190,7 @@ namespace Microsoft.OData.Json
                 }
 
                 // Flush the buffer if needed
-                await this.FlushIfBufferThresholdReachedAsync();
+                await this.DrainBufferIfThresholdReachedAsync();
             }
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
@@ -1210,7 +1219,7 @@ namespace Microsoft.OData.Json
                 this.utf8JsonWriter.WriteBase64StringValue(value);
             }
 
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         /// <summary>
@@ -1225,7 +1234,7 @@ namespace Microsoft.OData.Json
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
 
-            await FlushAsync().ConfigureAwait(false);
+            await WriteToStreamAsync().ConfigureAwait(false);
 
             int bytesNotWrittenFromPreviousChunk = 0;
 
@@ -1238,7 +1247,7 @@ namespace Microsoft.OData.Json
 
                 Base64EncodeAndWriteChunk(chunk.Span, isFinalBlock, out bytesNotWrittenFromPreviousChunk);
 
-                await FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+                await DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
             }
 
             this.bufferWriter.Write(this.DoubleQuote.Slice(0, 1).Span);
@@ -1254,20 +1263,18 @@ namespace Microsoft.OData.Json
         {
             this.WriteSeparatorIfNecessary();
             value.WriteTo(utf8JsonWriter);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task WriteRawValueAsync(string rawValue)
         {
             this.WriteRawValueCore(rawValue);
-            await this.FlushIfBufferThresholdReachedAsync().ConfigureAwait(false);
+            await this.DrainBufferIfThresholdReachedAsync().ConfigureAwait(false);
         }
 
         public async Task FlushAsync()
         {
-            this.CommitUtf8JsonWriterContentsToBuffer();
-            await this.writeStream.WriteAsync(this.bufferWriter.WrittenMemory).ConfigureAwait(false);
-            this.bufferWriter.Clear();
+            await this.WriteToStreamAsync().ConfigureAwait(false);
             await this.writeStream.FlushAsync().ConfigureAwait(false);
         }
 
@@ -1301,12 +1308,24 @@ namespace Microsoft.OData.Json
             this.Dispose(false);
         }
 
-        private async ValueTask FlushIfBufferThresholdReachedAsync()
+        /// <summary>
+        /// If the buffer threshold is reached, write the buffered data
+        /// to the underlying stream asynchronously, then clear the buffer.
+        /// </summary>
+        /// <returns>ValueTask representing the eventual completion of the asynchronous operation.</returns>
+        private async ValueTask DrainBufferIfThresholdReachedAsync()
         {
             if ((this.utf8JsonWriter.BytesPending + this.bufferWriter.WrittenCount) >= this.bufferFlushThreshold)
             {
-                await this.FlushAsync().ConfigureAwait(false);
+                await this.WriteToStreamAsync().ConfigureAwait(false);
             }
+        }
+
+        private async ValueTask WriteToStreamAsync()
+        {
+            this.CommitUtf8JsonWriterContentsToBuffer();
+            await this.writeStream.WriteAsync(this.bufferWriter.WrittenMemory).ConfigureAwait(false);
+            this.bufferWriter.Clear();
         }
         #endregion
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -601,7 +601,7 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
-        public async Task FlushesWhenBufferThresholdIsReached_WithRawValues_Async()
+        public async Task WritesToStreamWhenBufferThresholdIsReached_WithRawValues_Async()
         {
             using var stream = new MemoryStream();
             // set buffer size to 10, in current implementation, buffer threshold will be 9
@@ -656,6 +656,34 @@ namespace Microsoft.OData.Tests.Json
             using var jsonWriter = new ODataUtf8JsonWriter(stream, true, Encoding.UTF8, leaveStreamOpen: true);
             await jsonWriter.FlushAsync();
             Assert.Equal(0, stream.Length);
+        }
+
+        [Fact]
+        public async Task WritingWhenBufferIsFullShouldNotForceFlush()
+        {
+            using var finalStream = new MemoryStream();
+            using var bufStream = new BufferedStream(finalStream, bufferSize: 1024);
+
+            using var jsonWriter = new ODataUtf8JsonWriter(bufStream, true, Encoding.UTF8, bufferSize: 16, leaveStreamOpen: true);
+            await jsonWriter.StartArrayScopeAsync();
+
+            await jsonWriter.WriteValueAsync("foofoo");
+
+            // should not have written to stream because we have not reached the writer's buffer threshold
+            Assert.Equal(0, bufStream.Position);
+            Assert.Equal(0, finalStream.Position);
+
+            await jsonWriter.WriteValueAsync("foofoofoofoo");
+            await jsonWriter.EndArrayScopeAsync();
+
+            // should write to bufStream since we exceeded the threshold
+            Assert.Equal(24, bufStream.Position);
+            // should not have written to final stream because we have not reached intermediate stream's buffer size
+            Assert.Equal(0, finalStream.Position);
+
+            await jsonWriter.FlushAsync();
+            // should flush content to final stream
+            Assert.Equal(@"[""foofoo"",""foofoofoofoo""]", await this.ReadStreamAsync(jsonWriter, finalStream, Encoding.UTF8));
         }
 
         [Theory]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -615,7 +615,7 @@ namespace Microsoft.OData.Tests.Json
         }
 
         [Fact]
-        public void FlushesWhenBufferThresholdIsReached_WithRawValues()
+        public void WritesToStreamWhenBufferThresholdIsReached_WithRawValues()
         {
             using var stream = new MemoryStream();
             // set buffer size to 10, in current implementation, buffer threshold will be 9
@@ -670,6 +670,34 @@ namespace Microsoft.OData.Tests.Json
             using var jsonWriter = new ODataUtf8JsonWriter(stream, true, Encoding.UTF8, leaveStreamOpen: true);
             jsonWriter.Flush();
             Assert.Equal(0, stream.Length);
+        }
+
+        [Fact]
+        public void WritingWhenBufferIsFullShouldNotForceFlush()
+        {
+            using var finalStream = new MemoryStream();
+            using var bufStream = new BufferedStream(finalStream, bufferSize: 1024);
+
+            using var jsonWriter = new ODataUtf8JsonWriter(bufStream, true, Encoding.UTF8, bufferSize: 16, leaveStreamOpen: true);
+            jsonWriter.StartArrayScope();
+
+            jsonWriter.WriteValue("foofoo");
+
+            // should not have written to stream because we have not reached the writer's buffer threshold
+            Assert.Equal(0, bufStream.Position);
+            Assert.Equal(0, finalStream.Position);
+
+            jsonWriter.WriteValue("foofoofoofoo");
+            jsonWriter.EndArrayScope();
+
+            // should write to bufStream since we exceeded the threshold
+            Assert.Equal(24, bufStream.Position);
+            // should not have written to final stream because we have not reached intermediate stream's buffer size
+            Assert.Equal(0, finalStream.Position);
+
+            jsonWriter.Flush();
+            // should flush content to final stream
+            Assert.Equal(@"[""foofoo"",""foofoofoofoo""]", this.ReadStream(jsonWriter, finalStream, Encoding.UTF8));
         }
 
         [Theory]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #3099  .

This PR is an 8.x port of the following 7.x PR: https://github.com/OData/odata.net/pull/3101

### Description

This PR removes the "Flush()" call from the `FlushIfBufferThresholdReached` method and renames the method to `DrainBufferIfThresholdReached`. This method no longer forces a flush of the underlying stream, instead it only writes to the stream but leaves the stream to decide whether/when to flush. The user can still force a flush by explicitly calling the `Flush()` method.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*
