### PR TITLE
Fix/1744 isof unquoted type params issue

### DIFF
--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -943,22 +943,20 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             ResourceRangeVariableReferenceNode resourceRangeVariable = function.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
             Assert.Equal("Fully.Qualified.Namespace.Person", resourceRangeVariable.GetEdmTypeReference().FullName()); // $it is of type Person
 
+            string fullyQualifiedTypeName;
             QueryNode node = function.Parameters.ElementAt(1);
             if (node is SingleResourceCastNode singleResourceCastNode)
             {
                 node.ShouldBeSingleCastNode(HardCodedTestModel.GetEmployeeTypeReference());
-                Assert.Equal("Fully.Qualified.Namespace.Employee", singleResourceCastNode.TypeReference.FullName()); // Fully.Qualified.Namespace.Employee is the type parameter
-            }
-            else if (node is ConstantNode constantNode)
-            {
-                node.ShouldBeConstantQueryNode("Fully.Qualified.Namespace.Employee");
-                Assert.Equal("Fully.Qualified.Namespace.Employee", constantNode.Value); // Fully.Qualified.Namespace.Employee is the type parameter
+                fullyQualifiedTypeName = singleResourceCastNode.TypeReference.FullName();
             }
             else
             {
-                Assert.True(false, "Expected SingleResourceCastNode or ConstantNode");
+                ConstantNode constantNode = node.ShouldBeConstantQueryNode("Fully.Qualified.Namespace.Employee");
+                fullyQualifiedTypeName = constantNode.Value as string;
             }
 
+            Assert.Equal("Fully.Qualified.Namespace.Employee", fullyQualifiedTypeName); // Fully.Qualified.Namespace.Employee is the type parameter
             Assert.IsType<BinaryOperatorNode>(filter.Expression).Right.ShouldBeConstantQueryNode(345); // 345 is the right operand
         }
 
@@ -979,22 +977,20 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             SingleComplexNode complexNode = function.Parameters.ElementAt(0).ShouldBeSingleComplexNode(HardCodedTestModel.GetPersonAddressProp());
             Assert.Equal("Fully.Qualified.Namespace.Address", complexNode.GetEdmTypeReference().FullName()); // MyAddress is of type Address
 
+            string fullyQualifiedTypeName;
             QueryNode node = function.Parameters.ElementAt(1);
             if (node is SingleResourceCastNode singleResourceCastNode)
             {
                 node.ShouldBeSingleResourceCastNode(HardCodedTestModel.GetHomeAddressReference());
-                Assert.Equal("Fully.Qualified.Namespace.HomeAddress", singleResourceCastNode.TypeReference.FullName()); // Fully.Qualified.Namespace.HomeAddress is the type parameter
-            }
-            else if (node is ConstantNode constantNode)
-            {
-                node.ShouldBeConstantQueryNode("Fully.Qualified.Namespace.HomeAddress");
-                Assert.Equal("Fully.Qualified.Namespace.HomeAddress", constantNode.Value); // Fully.Qualified.Namespace.HomeAddress is the type parameter
+                fullyQualifiedTypeName = singleResourceCastNode.TypeReference.FullName();
             }
             else
             {
-                Assert.True(false, "Expected SingleResourceCastNode or ConstantNode");
+                ConstantNode constantNode = node.ShouldBeConstantQueryNode("Fully.Qualified.Namespace.HomeAddress");
+                fullyQualifiedTypeName = constantNode.Value as string;
             }
 
+            Assert.Equal("Fully.Qualified.Namespace.HomeAddress", fullyQualifiedTypeName); // Fully.Qualified.Namespace.HomeAddress is the type parameter
             Assert.IsType<BinaryOperatorNode>(filter.Expression).Right.ShouldBeConstantQueryNode("H-1234");
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -780,8 +780,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             // Assert
             SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
-            ResourceRangeVariableReferenceNode rangeVariableReferece = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
-            Assert.Equal("Fully.Qualified.Namespace.Person", rangeVariableReferece.GetEdmTypeReference().FullName()); // $it is of type Person
+            ResourceRangeVariableReferenceNode rangeVariableReference = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
+            Assert.Equal("Fully.Qualified.Namespace.Person", rangeVariableReference.GetEdmTypeReference().FullName()); // $it is of type Person
 
             var constantNode = singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode("Fully.Qualified.Namespace.Employee");
             Assert.Equal("Fully.Qualified.Namespace.Employee", constantNode.Value); // 'Fully.Qualified.Namespace.Employee' is the type parameter
@@ -798,8 +798,8 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
             // Assert
             SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
-            ResourceRangeVariableReferenceNode rangeVariableReferece = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
-            Assert.Equal("Fully.Qualified.Namespace.Person", rangeVariableReferece.GetEdmTypeReference().FullName()); // $it is of type Person
+            ResourceRangeVariableReferenceNode rangeVariableReference = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
+            Assert.Equal("Fully.Qualified.Namespace.Person", rangeVariableReference.GetEdmTypeReference().FullName()); // $it is of type Person
 
             var singleResourceCastNode = singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeSingleResourceCastNode(HardCodedTestModel.GetEmployeeTypeReference());
             Assert.Equal("Fully.Qualified.Namespace.Employee", singleResourceCastNode.TypeReference.FullName()); // Fully.Qualified.Namespace.Employee is the type parameter

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -77,6 +77,13 @@ namespace Microsoft.OData.Tests.UriParser
             NonFlagShapeType.AddMember("Triangle", new EdmEnumMemberValue(2));
             NonFlagShapeType.AddMember("foursquare", new EdmEnumMemberValue(3));
             model.AddElement(NonFlagShapeType);
+
+            var addressTypeEnum = new EdmEnumType("Fully.Qualified.Namespace", "AddressType");
+            addressTypeEnum.AddMember(new EdmEnumMember(addressTypeEnum, "Home", new EdmEnumMemberValue(0)));
+            addressTypeEnum.AddMember(new EdmEnumMember(addressTypeEnum, "Work", new EdmEnumMemberValue(1)));
+            addressTypeEnum.AddMember(new EdmEnumMember(addressTypeEnum, "Other", new EdmEnumMemberValue(2)));
+            model.AddElement(addressTypeEnum);
+            var addressTypeEnumReference = new EdmEnumTypeReference(addressTypeEnum, false);
             #endregion
 
             #region Structured Types
@@ -349,6 +356,7 @@ namespace Microsoft.OData.Tests.UriParser
             FullyQualifiedNamespaceAddress.AddStructuralProperty("City", EdmCoreModel.Instance.GetString(true));
             FullyQualifiedNamespaceAddress.AddStructuralProperty("NextHome", FullyQualifiedNamespaceAddressTypeReference);
             FullyQualifiedNamespaceAddress.AddStructuralProperty("MyNeighbors", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true))));
+            FullyQualifiedNamespaceAddress.AddStructuralProperty("AddressType", addressTypeEnumReference);
             FullyQualifiedNamespaceAddress.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "PostBoxPainting", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = FullyQualifiedNamespacePainting });
             model.AddElement(FullyQualifiedNamespaceAddress);
 
@@ -975,6 +983,11 @@ namespace Microsoft.OData.Tests.UriParser
         <Member Name=""Triangle"" Value=""2"" />
         <Member Name=""foursquare"" Value=""3"" />
       </EnumType>
+      <EnumType Name=""AddressType"">
+        <Member Name=""Home"" Value=""0"" />
+        <Member Name=""Work"" Value=""1"" />
+        <Member Name=""Other"" Value=""2"" />
+      </EnumType>
       <EntityType Name=""Lion"">
         <Key>
           <PropertyRef Name=""ID1"" />
@@ -1176,6 +1189,7 @@ namespace Microsoft.OData.Tests.UriParser
         <Property Name=""City"" Type=""Edm.String"" />
         <Property Name=""NextHome"" Type=""Fully.Qualified.Namespace.Address"" />
         <Property Name=""MyNeighbors"" Type=""Collection(Edm.String)"" />
+        <Property Name=""AddressType"" Type=""Fully.Qualified.Namespace.AddressType"" Nullable=""false"" />
         <NavigationProperty Name=""PostBoxPainting"" Type=""Fully.Qualified.Namespace.Painting"" />
       </ComplexType>
       <ComplexType Name=""HomeAddress"" BaseType=""Fully.Qualified.Namespace.Address"">
@@ -2000,6 +2014,16 @@ namespace Microsoft.OData.Tests.UriParser
             return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Address")).FindProperty("City");
         }
 
+        public static IEdmStructuralProperty GetMyAddressAddressTypeProperty()
+        {
+            return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Address")).FindProperty("AddressType");
+        }
+
+        public static IEdmStructuralProperty GetAddressHomeNOProperty()
+        {
+            return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.HomeAddress")).FindProperty("HomeNO");
+        }
+
         public static IEdmStructuralProperty GetPet2PetColorPatternProperty()
         {
             return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Pet2")).FindProperty("PetColorPattern");
@@ -2015,6 +2039,11 @@ namespace Microsoft.OData.Tests.UriParser
         public static IEdmNavigationProperty GetAddressMyFavoriteNeighborNavProp()
         {
             return (IEdmNavigationProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Address")).FindProperty("MyFavoriteNeighbor");
+        }
+
+        public static IEdmStructuralProperty GetEmployeeWorkIDProperty()
+        {
+            return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Employee")).FindProperty("WorkID");
         }
 
         public static IEdmNavigationProperty GetDogFastestOwnerNavProp()


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes [#1744](https://github.com/OData/odata.net/issues/1744).*

### Description

According to [OData V4 spec](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_isof) `isof` and `cast` function type parameter can be used without enclosed in quotes. 

The isof function has the following signatures
```
Edm.Boolean isof(type)
Edm.Boolean isof(expression,type)
```

This update supports unquoted type parameters in `isof` and `cast` functions through the following changes:
- Add support to handle `SingleResourceCastNode` in `ValidateIsOfOrCast` method since the unquoted type parameter is bind as **SingleResourceCastNode**
- Update the FunctionCallParser to handle `isof` and `cast` function calls with two parameters, where the second parameter is an unquoted type parameter. For two parameters, the second unquoted type parameter's next token should point to the first parameter. Previously, this was only handled for quoted type parameters. The change has now been made to include unquoted type parameters as well.
  For example,
  - Cast(Location, NS.HomeAddress) -> NS.HomeAddress will be a DottedIdentifierToken, and its NextToken should point to the Location parameter token.
  - Isof(Location, NS.HomeAddress) -> This also applies to the `isof()` function.

With this change, the following queries with unquoted type param are now supported:
```cs
cast(NS.Employee) // cast Person to Employee
cast(Location, NS.WorkAddress) // cast Location property to NS.WorkAddress
isof(NS.Employee) // cast Person to Employee
isof(Location, NS.WorkAddress) // cast Location property to NS.WorkAddress
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
