### PR TITLE
Report line numbers correctly for multi-line elements

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
@@ -652,22 +652,7 @@ namespace Microsoft.OData.Edm.Csdl
         private void ParseSchemaElement()
         {
             Debug.Assert(this.reader.LocalName == CsdlConstants.Element_Schema, "Must call ParseCsdlSchemaElement on Schema Element");
-
-            XmlReaderSettings settings = new XmlReaderSettings();
-            IXmlLineInfo lineInfo = this.reader as IXmlLineInfo;
-            if (lineInfo != null && lineInfo.HasLineInfo())
-            {
-                settings.LineNumberOffset = lineInfo.LineNumber - 1;
-                settings.LinePositionOffset = lineInfo.LinePosition - 2;
-            }
-
-            using (StringReader sr = new StringReader(this.reader.ReadOuterXml()))
-            {
-                using (XmlReader xr = XmlReader.Create(sr, settings))
-                {
-                    this.csdlParser.AddReader(xr, this.source);
-                }
-            }
+            this.csdlParser.AddReader(this.reader, this.source);
         }
 
         private void RaiseEmptyFile()

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/Common/XmlDocumentParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/Common/XmlDocumentParser.cs
@@ -122,6 +122,13 @@ namespace Microsoft.OData.Edm.Csdl.Parsing.Common
                 {
                 }
             }
+            else if (this.reader.ReadState == ReadState.Initial)
+            {
+                // If the state is initial, perform a read to advance
+                // the state to Interactive so that future reads will
+                // correctly advance the reader.
+                this.reader.Read();
+            }
 
             // There must be a root element for all current artifacts
             if (this.reader.EOF)

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -2217,12 +2217,15 @@ namespace Microsoft.OData.Edm.Tests.Csdl
                   <edmx:DataServices>
                     <Schema Namespace="name.space" Alias="self" xmlns="http://docs.oasis-open.org/odata/ns/edm" xmlns:ags="http://aggregator.microsoft.com/internal">
                       <EnumType
+
                         Name="someEnum">
                         <Member Name="notApplicable" Value="0" />
+
                         <Member Name="enabled" Value="1" />
                         <Member Name="disabled" Value="2" />
                         <Member Name="unknownFutureValue" Value="3" />
                       </EnumType>
+
                       <EnumType Name="otherEnum">
                         <Member Name="success" Value="0" />
                         <Member Name="failure" Value="1" />
@@ -2242,7 +2245,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             AssertLineLocation(someEnum, 5, 8);
 
             var otherEnum = model.FindDeclaredType("name.space.otherEnum") as IEdmElement;
-            AssertLineLocation(otherEnum, 12, 8);
+            AssertLineLocation(otherEnum, 15, 8);
         }
 
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderTests.cs
@@ -2241,8 +2241,11 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             using var reader = XmlReader.Create(new StringReader(csdl));
             var model = CsdlReader.Parse(reader);
 
-            var someEnum = model.FindDeclaredType("name.space.someEnum") as IEdmElement;
+            var someEnum = model.FindDeclaredType("name.space.someEnum") as IEdmEnumType;
             AssertLineLocation(someEnum, 5, 8);
+
+            AssertLineLocation(
+                someEnum.Members.FirstOrDefault(m => m.Name == "disabled"), 11, 10);
 
             var otherEnum = model.FindDeclaredType("name.space.otherEnum") as IEdmElement;
             AssertLineLocation(otherEnum, 15, 8);


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3105 .*

### Description

As mentioned in the linked issue, the `CsdlReader` does not report correct line numbers when reading CSDL XML documents with element tags with attributes spanning multiple lines.

Take the following excerpt of a schema (`Edmx` and `DataServices` omitted for brevity). Assuming the snippet starts at Line 1, the `description` property should be line 7. However, if you parse the document using `CsdlReader` and check the `CsdlLocation` of the corresponding `IEdmProperty` element, it will report the line number 4. This is the bug that this PR fixes.

```xml
<Schema Namespace="ns.example" />
  <ComplexType Name="item" />
    <Property
      Name="name"
      Type="Edm.String'
     />
    <Property Name="description" Type="Edm.String" />
  </ComplexType>
</Schema>
```

This `CsdlReader` uses an `XmlReader` passed by the user to read the elements of the XML file. It uses the `XmlReader` to determine the line number and position of each element. However, once the `CsdlReader` reached the `<Schema>` element, it does continue to read it with the same reader, instead it reads out the `<Schema>` element's outer XML content into a string, then creates a new reader to handle it:

```c#
XmlReaderSettings settings = new XmlReaderSettings();
IXmlLineInfo lineInfo = this.reader as IXmlLineInfo;
if (lineInfo != null && lineInfo.HasLineInfo())
{
    settings.LineNumberOffset = lineInfo.LineNumber - 1;
    settings.LinePositionOffset = lineInfo.LinePosition - 2;
}

using (StringReader sr = new StringReader(this.reader.ReadOuterXml()))
{
    using (XmlReader xr = XmlReader.Create(sr, settings))
    {
        this.csdlParser.AddReader(xr, this.source);
    }
}
```

I'm not sure why we do this. I don't know what we gain from doing this or what we lose by continuing to use the current reader (`this.reader`) to process the `<Schema>` node. But this is the source of the issue. It happens that the `this.reader.ReadOuterXml()` returns a string serialization of the XML element that does not preserve whitespace and new lines between attributes. It preserves whitespace between elements, but not attributes. Conceptually, the XML string that's returned would look like:

```xml
<Schema Namespace="ns.example" />
  <ComplexType Name="item" />
    <Property Name="name" Type="Edm.String' />
    <Property Name="description" Type="Edm.String" />
  </ComplexType>
</Schema>
```

This is what will be passed to the new reader (`xr` in the sample code above) that will be used to parse the `<Schema>` node and its children. Since we have lost track of whitespace between attributes, line numbers of elements below will be incorrect.
Unfortunately, the `ReadOuterXml()` method is a standard library method, we can't change its behaviour unless we go through complicated hoops of overriding the behaviour with layers of custom `XmlReader` and related implementations.

I fixed the issue by avoiding creating a new reader here and using the current reader to read the `<Schema>` element:

```c#
this.csdlParser.AddReader(this.reader, this.source);
```

Making this change caused another issue: It also happens that `XmlDocumentParser.ParseDocumentElement` creates a new reader on top of the current reader:

```c#
this.reader = this.InitializeReader(this.reader);
```

This reader is a wrapper on top of the current reader and does not affect line number and position information. It appears that this wrapper is used to activate some preferences like skipping comments and whitespace (see `EdmXmlDocumentParser.InitializeReader`). However, the fact that it's a new reader means that its internal read state is set to `ReadState.Initial`. As a result, if we call `Read()` the first time, it will not advance the node, but it will set the state to `ReadState.Interactive`. After that, calls to `Read()` will advance the reader to the next node as expected.

Before this PR, the `ParseDocumentElement()` had the following block:

```c#
// To make life simpler, we skip down to the first/root element, unless we're
// already there
if (this.reader.NodeType != XmlNodeType.Element)
{
    while (this.reader.Read() && this.reader.NodeType != XmlNodeType.Element)
    {
    }
}
```

If the reader is not at an element, it will call `Read()` until the reader advances to an element. Since this reader is a wrapper to the newly created reader for the schema element, for which `Read()` had not yet been called, the initial node type is `None`, so this block gets called. It also has the side effect of moving the state from `Initial` to `Interactive`.

However, this did not work with the new PR: while the wrapper reader is at state `Initial`, the wrapped reader is already at an `Element` node since it had just reached the `<Schema` element. Since the state does not move to interactive, the parser will not be at a correct state and causes element mismatch errors. I fixed this with the following adjustment:

```c#
this.reader = this.InitializeReader(this.reader);
this.xmlLineInfo = this.reader as IXmlLineInfo;

// To make life simpler, we skip down to the first/root element, unless we're
// already there
if (this.reader.NodeType != XmlNodeType.Element)
{
    while (this.reader.Read() && this.reader.NodeType != XmlNodeType.Element)
    {
    }
}
else if (this.reader.ReadState == ReadState.Initial)
{
    // If the state is initial, perform a read to advance
    // the state to Interactive so that future reads will
    // correctly advance the reader.
    this.reader.Read();
}
```

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
