### PR TITLE
Fix type casting exceptions in 'isof' and 'cast' calls.

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -240,9 +240,9 @@ namespace Microsoft.OData.UriParser
                 QueryNode argumentNode;
 
                 // If the function is IsOf and the argument is a dotted identifier, we should bind it as a single resource node
-                if ((functionCallToken.Name == ExpressionConstants.UnboundFunctionIsOf || functionCallToken.Name == ExpressionConstants.UnboundFunctionCast) && argument.ValueToken is DottedIdentifierToken dottedIdentifier)
+                if (UnboundFunctionNames.Contains(functionCallToken.Name) && argument.ValueToken is DottedIdentifierToken dottedIdentifier)
                 {
-                    argumentNode = this.TryBindDottedIdentifierAsIsOfFunctionCall(dottedIdentifier);
+                    argumentNode = this.TryBindDottedIdentifierForIsOfOrCastFunctionCall(dottedIdentifier);
                 }
                 else
                 {
@@ -449,7 +449,7 @@ namespace Microsoft.OData.UriParser
         /// <param name="dottedIdentifierToken">The dotted identifier token to bind.</param>
         /// <returns>A <see cref="QueryNode"/> representing the bound single resource node.</returns>
         /// <exception cref="ODataException">Thrown when the token cannot be bound as a single resource node.</exception>
-        private QueryNode TryBindDottedIdentifierAsIsOfFunctionCall(DottedIdentifierToken dottedIdentifierToken)
+        private QueryNode TryBindDottedIdentifierForIsOfOrCastFunctionCall(DottedIdentifierToken dottedIdentifierToken)
         {
             QueryNode parent = null;
             IEdmType parentType = null;

--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -234,7 +234,24 @@ namespace Microsoft.OData.UriParser
 
             // If there isn't, bind as Uri function
             // Bind all arguments
-            List<QueryNode> argumentNodes = new List<QueryNode>(functionCallToken.Arguments.Select(ar => this.bindMethod(ar)));
+            List<QueryNode> argumentNodes = new List<QueryNode>();
+            foreach (FunctionParameterToken argument in functionCallToken.Arguments)
+            {
+                QueryNode argumentNode;
+
+                // If the function is IsOf and the argument is a dotted identifier, we should bind it as a single resource node
+                if ((functionCallToken.Name == ExpressionConstants.UnboundFunctionIsOf || functionCallToken.Name == ExpressionConstants.UnboundFunctionCast) && argument.ValueToken is DottedIdentifierToken dottedIdentifier)
+                {
+                    argumentNode = this.TryBindDottedIdentifierAsIsOfFunctionCall(dottedIdentifier);
+                }
+                else
+                {
+                    argumentNode = this.bindMethod(argument);
+                }
+
+                argumentNodes.Add(argumentNode);
+            }
+
             return BindAsUriFunction(functionCallToken, argumentNodes);
         }
 
@@ -424,6 +441,54 @@ namespace Microsoft.OData.UriParser
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Binds a <see cref="DottedIdentifierToken"/> for the 'isof' and 'cast' function calls.
+        /// </summary>
+        /// <param name="dottedIdentifierToken">The dotted identifier token to bind.</param>
+        /// <returns>A <see cref="QueryNode"/> representing the bound single resource node.</returns>
+        /// <exception cref="ODataException">Thrown when the token cannot be bound as a single resource node.</exception>
+        private QueryNode TryBindDottedIdentifierAsIsOfFunctionCall(DottedIdentifierToken dottedIdentifierToken)
+        {
+            QueryNode parent = null;
+            IEdmType parentType = null;
+
+            if (state.ImplicitRangeVariable != null)
+            {
+                if (dottedIdentifierToken.NextToken == null)
+                {
+                    parent = NodeFactory.CreateRangeVariableReferenceNode(state.ImplicitRangeVariable);
+                    parentType = state.ImplicitRangeVariable.TypeReference.Definition;
+                }
+                else
+                {
+                    parent = this.bindMethod(dottedIdentifierToken.NextToken);
+                    parentType = parent.GetEdmType();
+                }
+            }
+
+            SingleResourceNode parentAsSingleResource = parent as SingleResourceNode;
+            IEdmSchemaType childType = UriEdmHelpers.FindTypeFromModel(state.Model, dottedIdentifierToken.Identifier, this.Resolver);
+            IEdmStructuredType childStructuredType = childType as IEdmStructuredType;
+
+            if (childStructuredType == null)
+            {
+                return this.bindMethod(dottedIdentifierToken);
+            }
+
+            if (parentType != null)
+            {
+                this.state.ParsedSegments.Add(new TypeSegment(childType, parentType, null));
+            }
+
+            CollectionResourceNode parentAsCollection = parent as CollectionResourceNode;
+            if (parentAsCollection != null)
+            {
+                return new CollectionResourceCastNode(parentAsCollection, childStructuredType);
+            }
+
+            return new SingleResourceCastNode(parentAsSingleResource, childStructuredType);
         }
 
         /// <summary>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -844,27 +844,31 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Theory]
-        [InlineData("isof(Fully.Qualified.Namespace.Pet1)", "Fully.Qualified.Namespace.Pet1")]
-        [InlineData("cast(Fully.Qualified.Namespace.HomeAddress)/City eq 'City1'", "Fully.Qualified.Namespace.HomeAddress")]
-        public void IsOfAndCastFunctionsWithSingleParameterWithoutSingleQuotes_WithIncorrectType_ThrowException(string filterQuery, string fullyQualifiedTypeName)
+        [InlineData("isof(Fully.Qualified.Namespace.Pet1)")]
+        [InlineData("isof(MyAddress,Fully.Qualified.Namespace.Pet1)")]
+        [InlineData("isof(null,Fully.Qualified.Namespace.Person)")]
+        [InlineData("isof('',Fully.Qualified.Namespace.Person)")]
+        public void IsOfFunctionsWithUnquotedTypeParameter_WithIncorrectType_DoesNotThrowException(string filterQuery)
         {
             // Arrange & Act
-            Action test = () => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var exception = Record.Exception(() => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()));
 
             // Assert
-            test.Throws<ODataException>(Strings.MetadataBinder_HierarchyNotFollowed(fullyQualifiedTypeName, "Fully.Qualified.Namespace.Person"));
+            Assert.Null(exception);
         }
 
         [Theory]
-        [InlineData("isof(MyAddress,Fully.Qualified.Namespace.Pet1)", "Fully.Qualified.Namespace.Pet1")]
-        [InlineData("cast(MyAddress,Fully.Qualified.Namespace.Employee)/WorkID eq 345", "Fully.Qualified.Namespace.Employee")]
-        public void IsOfAndCastFunctionsWithTwoParameterWhereTypeParameterIsWithoutSingleQuotes_WithIncorrectType_ThrowException(string filterQuery, string fullyQualifiedTypeName)
+        [InlineData("cast(Fully.Qualified.Namespace.HomeAddress)/City eq 'City1'")]
+        [InlineData("cast(MyAddress,Fully.Qualified.Namespace.Employee)/WorkID eq 345")]
+        [InlineData("cast(null,Fully.Qualified.Namespace.Employee)/WorkID eq 345")]
+        [InlineData("cast('',Fully.Qualified.Namespace.Employee)/WorkID eq 345")]
+        public void CastFunctionWithUnquotedTypeParameter_WithIncorrectType_DoesNotThrowException(string filterQuery)
         {
             // Arrange & Act
-            Action test = () => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var exception = Record.Exception(() => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()));
 
             // Assert
-            test.Throws<ODataException>(Strings.MetadataBinder_HierarchyNotFollowed(fullyQualifiedTypeName, "Fully.Qualified.Namespace.Address"));
+            Assert.Null(exception);
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes [#1744](https://github.com/OData/odata.net/issues/1744).*

### Description

When using unquoted type parameters in `isof` and `cast`, the operations perform as expected provided that the source type can be cast to the target type. Issues arise when casting is not possible, resulting in the following exception:
```
Encountered invalid type cast. '{source type}' is not assignable from '{target type}'.
```
Lets say you have the following data model:
```cs
namespace NS;

public class Product
{
    public int ProductID { get; set; }
    // Others properties
    public Address SupplierAddress { get; set; }
}

public class DerivedProduct : Product
{
   public string AnotherProperty { get; set; }
    // Others properties
}

public class Address
{
    // Others properties
    public string City { get; set; }
}
```
Executing the query `isof(NS.DerivedCategory)` will throw the exception:
```
"Encountered invalid type cast. 'NS.Category' is not assignable from 'NS.Product'."
```

This occurs because ODL checks if `NS.Product` is related to `NS.Category` using the [CheckRelatedTo ](https://github.com/OData/odata.net/blob/main/src/Microsoft.OData.Core/UriParser/Binders/DottedIdentifierBinder.cs#L104) function and since the types are not related or one is not a derivative of the other, the exception is thrown.

### Main changes
According to the [spec_cast](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_cast) and [spec_isof](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_isof) specifications, there is no indication that an exception should be thrown if casting fails. This pull request introduces the `TryBindDottedIdentifierForIsOfOrCastFunctionCall` method, which handles the binding of `DottedIdentifierToken` specifically for the `isof` and `cast` function calls without performing the `CheckRelatedTo` validation, thereby preventing exceptions when type casting is not possible.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
