### PR TITLE
Fix line number reporting when parsing csdl with multiline reference element

### DIFF
--- a/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
@@ -623,7 +623,7 @@ namespace Microsoft.OData.Edm.Csdl
 
             if (referenceParser.HasErrors)
             {
-                foreach (var error in referenceParser.Errors)
+                foreach (EdmError error in referenceParser.Errors)
                 {
                     this.errors.Add(error);
                 }

--- a/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReader.cs
@@ -617,35 +617,21 @@ namespace Microsoft.OData.Edm.Csdl
         {
             Debug.Assert(this.reader.LocalName == CsdlConstants.Element_Reference);
 
-            XmlReaderSettings settings = new XmlReaderSettings();
-            IXmlLineInfo lineInfo = this.reader as IXmlLineInfo;
-            if (lineInfo != null && lineInfo.HasLineInfo())
+            string artifactPath = this.source ?? this.reader.BaseURI;
+            CsdlReferenceParser referenceParser = new CsdlReferenceParser(artifactPath, this.reader);
+            referenceParser.ParseDocumentElement();
+
+            if (referenceParser.HasErrors)
             {
-                settings.LineNumberOffset = lineInfo.LineNumber - 1;
-                settings.LinePositionOffset = lineInfo.LinePosition - 2;
+                foreach (var error in referenceParser.Errors)
+                {
+                    this.errors.Add(error);
+                }
             }
 
-            using (StringReader sr = new StringReader(this.reader.ReadOuterXml()))
+            if (referenceParser.Result != null)
             {
-                using (XmlReader xr = XmlReader.Create(sr, settings))
-                {
-                    string artifactPath = this.source ?? this.reader.BaseURI;
-                    CsdlReferenceParser referenceParser = new CsdlReferenceParser(artifactPath, xr);
-                    referenceParser.ParseDocumentElement();
-
-                    if (referenceParser.HasErrors)
-                    {
-                        foreach (var error in referenceParser.Errors)
-                        {
-                            this.errors.Add(error);
-                        }
-                    }
-
-                    if (referenceParser.Result != null)
-                    {
-                        this.references.Add(referenceParser.Result.Value);
-                    }
-                }
+                this.references.Add(referenceParser.Result.Value);
             }
         }
 


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3105*

### Description

This is a follow up to the PR #3115. I found another case where we're using `ReadOuterXml` when parsing the `edmx:Reference` element, which means we'll get incorrect line number reporting for its children if there are new lines in between the attributes.

I've applied a fix similar to PR #3115 

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

