### PR TITLE
Fix ArgumentNullException for: $filter=property in ['']

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -104,13 +104,10 @@ namespace Microsoft.OData.UriParser
 
                 if (bracketLiteralText[0] == '(' || bracketLiteralText[0] == '[')
                 {
-                    bool isParenthesesBased = bracketLiteralText[0] == '(' && bracketLiteralText[^1] == ')';
-                    bool isBracketBased = bracketLiteralText[0] == '[' && bracketLiteralText[^1] == ']';
+                    Debug.Assert((bracketLiteralText[0] == '(' && bracketLiteralText[^1] == ')') || (bracketLiteralText[0] == '[' && bracketLiteralText[^1] == ']'),
+                        $"Collection with opening '{bracketLiteralText[0]}' should have corresponding '{(bracketLiteralText[0] == '(' ? ')' : ']')}'");
 
-                    Debug.Assert(isParenthesesBased || isBracketBased,
-                        $"Collection with opening '{bracketLiteralText[0]}' should have corresponding '{bracketLiteralText[^1]}'");
-
-                    if(isParenthesesBased)
+                    if (bracketLiteralText[0] == '(' && bracketLiteralText[^1] == ')')
                     {
                         bracketLiteralText = string.Create(bracketLiteralText.Length, bracketLiteralText, (span, state) =>
                         {

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientQueryTests.cs
@@ -64,34 +64,34 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
         }
 
         [Theory]
-        [InlineData("People?$filter=Name in ('')", 0)]
-        [InlineData("People?$filter=Name in ['']", 0)]
-        [InlineData("People?$filter=Name in ( '' )", 0)]
-        [InlineData("People?$filter=Name in [ '' ]", 0)]
-        [InlineData("People?$filter=Name in (\"\")", 0)]
-        [InlineData("People?$filter=Name in [\"\"]", 0)]
-        [InlineData("People?$filter=Name in ( \"\" )", 0)]
-        [InlineData("People?$filter=Name in [ \"\" ]", 0)]
-        [InlineData("People?$filter=Name in ( ' ' )", 0)]
-        [InlineData("People?$filter=Name in [ ' ' ]", 0)]
-        [InlineData("People?$filter=Name in ( \"  \" )", 0)]
-        [InlineData("People?$filter=Name in [ \"   \"]", 0)]
-        [InlineData("People?$filter=Name in ( '', ' ' )", 0)]
-        [InlineData("People?$filter=Name in [ '', ' ' ]", 0)]
-        [InlineData("People?$filter=Name in ( \"\", \" \" )", 0)]
-        [InlineData("People?$filter=Name in [ \"\", \" \" ]", 0)]
-        [InlineData("People?$filter=Name in ( '', \" \" )", 0)]
-        [InlineData("People?$filter=Name in [ '', \" \" ]", 0)]
-        [InlineData("People?$filter=Name in ( \"\", ' ' )", 0)]
-        [InlineData("People?$filter=Name in [ \"\", ' ' ]", 0)]
-        [InlineData("People?$filter=Name in [ 'null', 'null' ]", 0)]
-        public async Task DollarFilter_WithCollectionWithEmptyString_ExecutesSuccessfully(string query, int expectedCount)
+        [InlineData("People?$filter=Name in ('')")]
+        [InlineData("People?$filter=Name in ['']")]
+        [InlineData("People?$filter=Name in ( '' )")]
+        [InlineData("People?$filter=Name in [ '' ]")]
+        [InlineData("People?$filter=Name in (\"\")")]
+        [InlineData("People?$filter=Name in [\"\"]")]
+        [InlineData("People?$filter=Name in ( \"\" )")]
+        [InlineData("People?$filter=Name in [ \"\" ]")]
+        [InlineData("People?$filter=Name in ( ' ' )")]
+        [InlineData("People?$filter=Name in [ ' ' ]")]
+        [InlineData("People?$filter=Name in ( \"  \" )")]
+        [InlineData("People?$filter=Name in [ \"   \"]")]
+        [InlineData("People?$filter=Name in ( '', ' ' )")]
+        [InlineData("People?$filter=Name in [ '', ' ' ]")]
+        [InlineData("People?$filter=Name in ( \"\", \" \" )")]
+        [InlineData("People?$filter=Name in [ \"\", \" \" ]")]
+        [InlineData("People?$filter=Name in ( '', \" \" )")]
+        [InlineData("People?$filter=Name in [ '', \" \" ]")]
+        [InlineData("People?$filter=Name in ( \"\", ' ' )")]
+        [InlineData("People?$filter=Name in [ \"\", ' ' ]")]
+        [InlineData("People?$filter=Name in [ 'null', 'null' ]")]
+        public async Task DollarFilter_WithCollectionWithEmptyString_ExecutesSuccessfully(string query)
         {
             // Act
             var response = await _context.ExecuteAsync<Common.Clients.EndToEnd.Person>(new Uri(_baseUri.OriginalString + query));
 
             // Assert
-            Assert.Equal(expectedCount, response.ToArray().Length);
+            Assert.Empty(response.ToArray());
         }
 
         [Fact]

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientQueryTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientQueryTests.cs
@@ -63,6 +63,37 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
             Assert.Equal(expectedCount, result.Length);
         }
 
+        [Theory]
+        [InlineData("People?$filter=Name in ('')", 0)]
+        [InlineData("People?$filter=Name in ['']", 0)]
+        [InlineData("People?$filter=Name in ( '' )", 0)]
+        [InlineData("People?$filter=Name in [ '' ]", 0)]
+        [InlineData("People?$filter=Name in (\"\")", 0)]
+        [InlineData("People?$filter=Name in [\"\"]", 0)]
+        [InlineData("People?$filter=Name in ( \"\" )", 0)]
+        [InlineData("People?$filter=Name in [ \"\" ]", 0)]
+        [InlineData("People?$filter=Name in ( ' ' )", 0)]
+        [InlineData("People?$filter=Name in [ ' ' ]", 0)]
+        [InlineData("People?$filter=Name in ( \"  \" )", 0)]
+        [InlineData("People?$filter=Name in [ \"   \"]", 0)]
+        [InlineData("People?$filter=Name in ( '', ' ' )", 0)]
+        [InlineData("People?$filter=Name in [ '', ' ' ]", 0)]
+        [InlineData("People?$filter=Name in ( \"\", \" \" )", 0)]
+        [InlineData("People?$filter=Name in [ \"\", \" \" ]", 0)]
+        [InlineData("People?$filter=Name in ( '', \" \" )", 0)]
+        [InlineData("People?$filter=Name in [ '', \" \" ]", 0)]
+        [InlineData("People?$filter=Name in ( \"\", ' ' )", 0)]
+        [InlineData("People?$filter=Name in [ \"\", ' ' ]", 0)]
+        [InlineData("People?$filter=Name in [ 'null', 'null' ]", 0)]
+        public async Task DollarFilter_WithCollectionWithEmptyString_ExecutesSuccessfully(string query, int expectedCount)
+        {
+            // Act
+            var response = await _context.ExecuteAsync<Common.Clients.EndToEnd.Person>(new Uri(_baseUri.OriginalString + query));
+
+            // Assert
+            Assert.Equal(expectedCount, response.ToArray().Length);
+        }
+
         [Fact]
         public async Task Using_LinqContains_ExecutesSuccessfully()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/FilterAndOrderByBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/FilterAndOrderByBuilderTests.cs
@@ -450,6 +450,16 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.Equal(new Uri("http://gobbledygook/People?$filter=ID%20in%20[1%2C2%2C3]"), actualUri, new UriComparer<Uri>());
         }
 
+        [Theory]
+        [InlineData("People?$filter=Name in ('')", "http://gobbledygook/People?$filter=Name%20in%20(%27%27)")]
+        [InlineData("People?$filter=Name in ['']", "http://gobbledygook/People?$filter=Name%20in%20[%27%27]")]
+        public void BuildFilterWithInOperatorUsingCollectionWithEmptyString(string filterQuery, string expectedQuery)
+        {
+            Uri queryUri = new Uri(filterQuery, UriKind.Relative);
+            Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
+            Assert.Equal(new Uri(expectedQuery), actualUri, new UriComparer<Uri>());
+        }
+
         [Fact]
         public void BuildFilterWithInOperatorUsingSingleConstant()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/SelectExpandBuilderTests.cs
@@ -668,12 +668,16 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString("MyDog($filter=$it/MyAddress/City eq 'Seattle')"), actualUri.OriginalString);
         }
 
-        [Fact]
-        public void ExpandWithDollarItInFilterInOperatorShouldWork()
+        [Theory]
+        [InlineData("People?$expand=MyDog($filter=$it/ID in ['1', '2', '3'])", "MyDog($filter=$it/ID in ['1', '2', '3'])")]
+        [InlineData("People?$expand=MyDog($filter=$it/ID in ('1', '2', '3'))", "MyDog($filter=$it/ID in ('1', '2', '3'))")]
+        [InlineData("People?$expand=MyDog($filter=$it/Name in (''))", "MyDog($filter=$it/Name in (''))")]
+        [InlineData("People?$expand=MyDog($filter=$it/Name in [''])", "MyDog($filter=$it/Name in [''])")]
+        public void ExpandWithDollarItInFilterInOperatorShouldWork(string filterQuery, string expectedSubQuery)
         {
-            Uri queryUri = new Uri("People?$expand=MyDog($filter=$it/ID in ['1', '2', '3'])", UriKind.Relative);
+            Uri queryUri = new Uri(filterQuery, UriKind.Relative);
             Uri actualUri = UriBuilder(queryUri, ODataUrlKeyDelimiter.Parentheses, settings);
-            Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString("MyDog($filter=$it/ID in ['1', '2', '3'])"), actualUri.OriginalString);
+            Assert.Equal("http://gobbledygook/People?$expand=" + Uri.EscapeDataString(expectedSubQuery), actualUri.OriginalString);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2413,45 +2413,86 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
 
         [Theory]
         [InlineData("('a''bc')", "('a''bc')", 1)]
+        [InlineData("['a''bc']", "['a''bc']", 1)]
         [InlineData("('''def')", "('''def')", 1)]
+        [InlineData("['''def']", "['''def']", 1)]
         [InlineData("('xyz''')", "('xyz''')", 1)]
+        [InlineData("['xyz''']", "['xyz''']", 1)]
         [InlineData("('''pqr''')", "('''pqr''')", 1)]
+        [InlineData("['''pqr''']", "['''pqr''']", 1)]
         [InlineData("('a''bc','''def')", "('a''bc','''def')", 2)]
+        [InlineData("['a''bc','''def']", "['a''bc','''def']", 2)]
         [InlineData("('a''bc','xyz''')", "('a''bc','xyz''')", 2)]
+        [InlineData("['a''bc','xyz''']", "['a''bc','xyz''']", 2)]
         [InlineData("('a''bc','''pqr''')", "('a''bc','''pqr''')", 2)]
+        [InlineData("['a''bc','''pqr''']", "['a''bc','''pqr''']", 2)]
         [InlineData("('''def','a''bc')", "('''def','a''bc')", 2)]
+        [InlineData("['''def','a''bc']", "['''def','a''bc']", 2)]
         [InlineData("('''def','xyz''')", "('''def','xyz''')", 2)]
+        [InlineData("['''def','xyz''']", "['''def','xyz''']", 2)]
         [InlineData("('''def','''pqr''')", "('''def','''pqr''')", 2)]
+        [InlineData("['''def','''pqr''']", "['''def','''pqr''']", 2)]
         [InlineData("('xyz''','a''bc')", "('xyz''','a''bc')", 2)]
+        [InlineData("['xyz''','a''bc']", "['xyz''','a''bc']", 2)]
         [InlineData("('xyz''','''def')", "('xyz''','''def')", 2)]
+        [InlineData("['xyz''','''def']", "['xyz''','''def']", 2)]
         [InlineData("('xyz''','''pqr''')", "('xyz''','''pqr''')", 2)]
+        [InlineData("['xyz''','''pqr''']", "['xyz''','''pqr''']", 2)]
         [InlineData("('''pqr''','a''bc')", "('''pqr''','a''bc')", 2)]
+        [InlineData("['''pqr''','a''bc']", "['''pqr''','a''bc']", 2)]
         [InlineData("('''pqr''','''def')", "('''pqr''','''def')", 2)]
+        [InlineData("['''pqr''','''def']", "['''pqr''','''def']", 2)]
         [InlineData("('''pqr''','xyz''')", "('''pqr''','xyz''')", 2)]
+        [InlineData("['''pqr''','xyz''']", "['''pqr''','xyz''']", 2)]
         [InlineData("('a''bc','''def','xyz''')", "('a''bc','''def','xyz''')", 3)]
+        [InlineData("['a''bc','''def','xyz''']", "['a''bc','''def','xyz''']", 3)]
         [InlineData("('a''bc','''def','''pqr''')", "('a''bc','''def','''pqr''')", 3)]
+        [InlineData("['a''bc','''def','''pqr''']", "['a''bc','''def','''pqr''']", 3)]
         [InlineData("('a''bc','xyz''','''def')", "('a''bc','xyz''','''def')", 3)]
+        [InlineData("['a''bc','xyz''','''def']", "['a''bc','xyz''','''def']", 3)]
         [InlineData("('a''bc','xyz''','''pqr''')", "('a''bc','xyz''','''pqr''')", 3)]
+        [InlineData("['a''bc','xyz''','''pqr''']", "['a''bc','xyz''','''pqr''']", 3)]
         [InlineData("('a''bc','''pqr''','''def')", "('a''bc','''pqr''','''def')", 3)]
+        [InlineData("['a''bc','''pqr''','''def']", "['a''bc','''pqr''','''def']", 3)]
         [InlineData("('a''bc','''pqr''','xyz''')", "('a''bc','''pqr''','xyz''')", 3)]
+        [InlineData("['a''bc','''pqr''','xyz''']", "['a''bc','''pqr''','xyz''']", 3)]
         [InlineData("('''def','a''bc','xyz''')", "('''def','a''bc','xyz''')", 3)]
+        [InlineData("['''def','a''bc','xyz''']", "['''def','a''bc','xyz''']", 3)]
         [InlineData("('''def','a''bc','''pqr''')", "('''def','a''bc','''pqr''')", 3)]
+        [InlineData("['''def','a''bc','''pqr''']", "['''def','a''bc','''pqr''']", 3)]
         [InlineData("('''def','xyz''','a''bc')", "('''def','xyz''','a''bc')", 3)]
+        [InlineData("['''def','xyz''','a''bc']", "['''def','xyz''','a''bc']", 3)]
         [InlineData("('''def','xyz''','''pqr''')", "('''def','xyz''','''pqr''')", 3)]
+        [InlineData("['''def','xyz''','''pqr''']", "['''def','xyz''','''pqr''']", 3)]
         [InlineData("('''def','''pqr''','a''bc')", "('''def','''pqr''','a''bc')", 3)]
+        [InlineData("['''def','''pqr''','a''bc']", "['''def','''pqr''','a''bc']", 3)]
         [InlineData("('''def','''pqr''','xyz''')", "('''def','''pqr''','xyz''')", 3)]
+        [InlineData("['''def','''pqr''','xyz''']", "['''def','''pqr''','xyz''']", 3)]
         [InlineData("('xyz''','a''bc','''def')", "('xyz''','a''bc','''def')", 3)]
+        [InlineData("['xyz''','a''bc','''def']", "['xyz''','a''bc','''def']", 3)]
         [InlineData("('xyz''','a''bc','''pqr''')", "('xyz''','a''bc','''pqr''')", 3)]
+        [InlineData("['xyz''','a''bc','''pqr''']", "['xyz''','a''bc','''pqr''']", 3)]
         [InlineData("('xyz''','''def','''pqr''')", "('xyz''','''def','''pqr''')", 3)]
+        [InlineData("['xyz''','''def','''pqr''']", "['xyz''','''def','''pqr''']", 3)]
         [InlineData("('xyz''','''def','a''bc')", "('xyz''','''def','a''bc')", 3)]
+        [InlineData("['xyz''','''def','a''bc']", "['xyz''','''def','a''bc']", 3)]
         [InlineData("('xyz''','''pqr''','a''bc')", "('xyz''','''pqr''','a''bc')", 3)]
+        [InlineData("['xyz''','''pqr''','a''bc']", "['xyz''','''pqr''','a''bc']", 3)]
         [InlineData("('xyz''','''pqr''','''def')", "('xyz''','''pqr''','''def')", 3)]
+        [InlineData("['xyz''','''pqr''','''def']", "['xyz''','''pqr''','''def']", 3)]
         [InlineData("('''pqr''','a''bc','''def')", "('''pqr''','a''bc','''def')", 3)]
+        [InlineData("['''pqr''','a''bc','''def']", "['''pqr''','a''bc','''def']", 3)]
         [InlineData("('''pqr''','a''bc','xyz''')", "('''pqr''','a''bc','xyz''')", 3)]
+        [InlineData("['''pqr''','a''bc','xyz''']", "['''pqr''','a''bc','xyz''']", 3)]
         [InlineData("('''pqr''','''def','a''bc')", "('''pqr''','''def','a''bc')", 3)]
+        [InlineData("['''pqr''','''def','a''bc']", "['''pqr''','''def','a''bc']", 3)]
         [InlineData("('''pqr''','''def','xyz''')", "('''pqr''','''def','xyz''')", 3)]
+        [InlineData("['''pqr''','''def','xyz''']", "['''pqr''','''def','xyz''']", 3)]
         [InlineData("('''pqr''','xyz''','a''bc')", "('''pqr''','xyz''','a''bc')", 3)]
+        [InlineData("['''pqr''','xyz''','a''bc']", "['''pqr''','xyz''','a''bc']", 3)]
         [InlineData("('''pqr''','xyz''','''def')", "('''pqr''','xyz''','''def')", 3)]
+        [InlineData("['''pqr''','xyz''','''def']", "['''pqr''','xyz''','''def']", 3)]
+
         public void FilterWithInExpressionContainingEscapedSingleQuotes(string inExpr, string parsedExpr, int count)
         {
             FilterClause filter = ParseFilter($"SSN in {inExpr}", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
@@ -2749,7 +2790,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
 
             // A single whitespace or multiple whitespaces are valid literals
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             ConstantNode constantNode = collectionNode.Collection.First();
             Assert.Equal(expectedLiteralText, constantNode.LiteralText);
@@ -2769,7 +2810,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
 
             // A single whitespace or multiple whitespaces are valid literals
-            Assert.Equal(1, collectionNode.Collection.Count);
+            Assert.Single(collectionNode.Collection);
 
             ConstantNode constantNode = collectionNode.Collection.First();
             Assert.Equal(expectedLiteralText, constantNode.LiteralText);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2718,11 +2718,49 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Theory]
+        [InlineData("SSN in ['']")]     // Edm.String
+        [InlineData("SSN in [ '' ]")]     // Edm.String
+        [InlineData("SSN in [\"\"]")]     // Edm.String
+        [InlineData("SSN in [ \"\" ]")]     // Edm.String
+        public void FilterWithInOperationWithEmptyStringInSquareBrackets(string filterClause)
+        {
+            FilterClause filter = ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            var inNode = Assert.IsType<InNode>(filter.Expression);
+
+            CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
+            Assert.Equal(1, collectionNode.Collection.Count);
+
+            ConstantNode constantNode = collectionNode.Collection.First();
+            Assert.Equal("\"\"", constantNode.LiteralText);
+        }
+
+        [Theory]
         [InlineData("SSN in ( ' ' )", " ")]     // 1 space
         [InlineData("SSN in ( '   ' )", "   ")]     // 3 spaces
         [InlineData("SSN in ( \"  \" )", "  ")]     // 2 spaces
         [InlineData("SSN in ( \"    \" )", "    ")]     // 4 spaces
         public void FilterWithInOperationWithWhitespace(string filterClause, string expectedLiteralText)
+        {
+            FilterClause filter = ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            var inNode = Assert.IsType<InNode>(filter.Expression);
+
+            CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
+
+            // A single whitespace or multiple whitespaces are valid literals
+            Assert.Equal(1, collectionNode.Collection.Count);
+
+            ConstantNode constantNode = collectionNode.Collection.First();
+            Assert.Equal(expectedLiteralText, constantNode.LiteralText);
+        }
+
+        [Theory]
+        [InlineData("SSN in [ ' ' ]", " ")]     // 1 space
+        [InlineData("SSN in [ '   ' ]", "   ")]     // 3 spaces
+        [InlineData("SSN in [ \"  \" ]", "  ")]     // 2 spaces
+        [InlineData("SSN in [ \"    \" ]", "    ")]     // 4 spaces
+        public void FilterWithInOperationWithWhitespaceInSquareBrackets(string filterClause, string expectedLiteralText)
         {
             FilterClause filter = ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
 
@@ -2755,9 +2793,29 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Theory]
+        [InlineData("SSN in [ '', ' ' ]")]     // Edm.String
+        [InlineData("SSN in [ \"\", \" \" ]")]     // Edm.String
+        [InlineData("SSN in [ '', \" \" ]")]     // Edm.String
+        [InlineData("SSN in [ \"\", ' ' ]")]     // Edm.String
+        public void FilterWithInOperationWithEmptyStringAndWhitespaceInSquareBrackets(string filterClause)
+        {
+            FilterClause filter = ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
+
+            var inNode = Assert.IsType<InNode>(filter.Expression);
+
+            CollectionConstantNode collectionNode = Assert.IsType<CollectionConstantNode>(inNode.Right);
+
+            // A single whitespace or multiple whitespaces are valid literals
+            Assert.Equal(2, collectionNode.Collection.Count);
+        }
+
+        [Theory]
         [InlineData("MyGuid in ( '' )", "")]  // Edm.Guid
         [InlineData("MyGuid in ( '  ' )", "  ")]  // Edm.Guid
         [InlineData("MyGuid in ( \" \" )", " ")]  // Edm.Guid
+        [InlineData("MyGuid in [ '' ]", "")]  // Edm.Guid
+        [InlineData("MyGuid in [ '  ' ]", "  ")]  // Edm.Guid
+        [InlineData("MyGuid in [ \" \" ]", " ")]  // Edm.Guid
         public void FilterWithInOperationGuidWithEmptyQuotesThrows(string filterClause, string quotedString)
         {
             Action parse = () => ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
@@ -2768,6 +2826,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [InlineData("Birthdate in ( '' )", "")]  // Edm.DateTimeOffset
         [InlineData("Birthdate in ( \" \" )", " ")]  // Edm.DateTimeOffset
         [InlineData("Birthdate in ('   ')", "   ")]  // Edm.DateTimeOffset
+        [InlineData("Birthdate in [ '' ]", "")]  // Edm.DateTimeOffset
+        [InlineData("Birthdate in [ \" \" ]", " ")]  // Edm.DateTimeOffset
+        [InlineData("Birthdate in ['   ']", "   ")]  // Edm.DateTimeOffset
         public void FilterWithInOperationDateTimeOffsetWithEmptyQuotesThrows(string filterClause, string quotedString)
         {
             Action parse = () => ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
@@ -2778,6 +2839,9 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [InlineData("MyDate in ( '' )", "")]  // Edm.Date
         [InlineData("MyDate in ( \" \" )", " ")]  // Edm.Date
         [InlineData("MyDate in ('   ')", "   ")]  // Edm.Date
+        [InlineData("MyDate in [ '' ]", "")]  // Edm.Date
+        [InlineData("MyDate in [ \" \" ]", " ")]  // Edm.Date
+        [InlineData("MyDate in ['   ']", "   ")]  // Edm.Date
         public void FilterWithInOperationDateWithEmptyQuotesThrows(string filterClause, string quotedString)
         {
             Action parse = () => ParseFilter(filterClause, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes [#3092 ](https://github.com/OData/odata.net/issues/3092)*

### Description

This PR addresses an issue where the OData URI parser throws an `ArgumentNullException` when encountering a list with empty string in `square brackets`.

For example, the following query will throw an ArgumentNullException:
- `/People?$filter=Name in ['']`
- `/People?$filter=Name in [ ' ' ]`
- `/People?$filter=Name in [ \"\", ' ' ]`
- `/People?$filter=Name in [ \"\", '' ]`
- `/People?$filter=Name in [\"\"]`
- `/People?$filter=Name in [ \"\", \" \" ]`
- `/People?$filter=Name in [ \"\" ]`
- `/People?$filter=Name in [  '' , ' ' ]`

```
System.InvalidOperationException : An error occurred while processing this request.
---- Microsoft.OData.Client.DataServiceTransportException : System.ArgumentNullException: Value cannot be null or empty. (Parameter 'literalText')
   at Microsoft.OData.ExceptionUtils.CheckArgumentStringNotNullOrEmpty(String value, String parameterName) in C:\Work\odata.net\src\Microsoft.OData.Core\ExceptionUtils.cs:line 101
   .....
```
### Change

This change ensures the Empty String in `square brackets` are handle the same way as `parentheses` when constructing `CollectionNode` in `GetCollectionOperandFromToken` method. This method calls the following methods to handle Single and Double quotes:
 - `ProcessSingleQuotedStringItem` is called to handle single-quoted string items within a collection. This method converts `single-quoted` strings to `double-quoted` strings, ensuring compatibility with JSON format. It manages the escaping of single quotes by unescaping double single quotes and escaping double quotes. For example, it converts ''' to \"\" and 'ghi''' to "ghi'"
 - `ProcessDoubleQuotedStringItem` is then called to process double-quoted string items within a collection. This method ensures that the string is properly escaped for JSON format, handling the escaping of double quotes and backslashes. For example, it converts "" to \"\" to avoid passing an empty string to the `ConstantNode`.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
