### PR TITLE
Fixes #3120: Throws exception if non defined enum member used in `in` operator

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -27,12 +27,19 @@ namespace Microsoft.OData.UriParser
         private readonly Func<QueryToken, QueryNode> bindMethod;
 
         /// <summary>
+        /// Resolver for parsing
+        /// </summary>
+        private readonly ODataUriResolver resolver;
+
+        /// <summary>
         /// Constructs a InBinder with the given method to be used binding the parent token if needed.
         /// </summary>
         /// <param name="bindMethod">Method to use for binding the parent token, if needed.</param>
-        internal InBinder(Func<QueryToken, QueryNode> bindMethod)
+        /// <param name="resolver">Resolver for parsing.</param>
+        internal InBinder(Func<QueryToken, QueryNode> bindMethod, ODataUriResolver resolver)
         {
             this.bindMethod = bindMethod;
+            this.resolver = resolver;
         }
 
         /// <summary>
@@ -64,6 +71,8 @@ namespace Microsoft.OData.UriParser
             {
                 left = MetadataBindingUtils.ConvertToTypeIfNeeded(left, right.ItemType);
             }
+
+            MetadataBindingUtils.VerifyCollectionNode(right, this.resolver.EnableCaseInsensitive);
 
             return new InNode(left, right);
         }

--- a/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/MetadataBinder.cs
@@ -371,7 +371,7 @@ namespace Microsoft.OData.UriParser
                  return this.Bind(queryToken);
              };
 
-            InBinder inBinder = new InBinder(InBinderMethod);
+            InBinder inBinder = new InBinder(InBinderMethod, this.BindingState.Configuration.Resolver);
             return inBinder.BindInOperator(inToken, this.BindingState);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/UriBuilderTestBase.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriBuilder/UriBuilderTestBase.cs
@@ -25,15 +25,20 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriBuilder
             }
         }
 
-        public static Uri UriBuilder(Uri queryUri, ODataUrlKeyDelimiter urlKeyDelimiter, ODataUriParserSettings settings)
+        public static Uri UriBuilder(Uri queryUri, ODataUrlKeyDelimiter urlKeyDelimiter, ODataUriParserSettings settings, ODataUriResolver resolver = null)
         {
             ODataUriParser odataUriParser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, queryUri);
+            if (resolver != null)
+            {
+                odataUriParser.Resolver = resolver;
+            }
+
             SetODataUriParserSettingsTo(settings, odataUriParser.Settings);
             odataUriParser.UrlKeyDelimiter = urlKeyDelimiter;
             ODataUri odataUri = odataUriParser.ParseUri();
 
             return odataUri.BuildUri(urlKeyDelimiter);
         }
-        #endregion  
+        #endregion
     }
 }


### PR DESCRIPTION
… 

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3120.*

### Description

* Should throw exception if the non-defined enum member used in 'in' operator.
* Make sure it's the same behavior comparing to the binary operator.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
