### PR TITLE
Clean #if NETCOREAPP since moved to .NET 8

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataResourceMetadataContext.cs
@@ -279,12 +279,11 @@ namespace Microsoft.OData.Evaluation
 
             if (propertyValue is ODataValue && !(propertyValue is ODataEnumValue))
             {
-#if NETCOREAPP3_1_OR_GREATER
                 if (propertyValue is ODataJsonElementValue)
                 {
                     return propertyValue;
                 }
-#endif
+
                 throw new ODataException(Strings.ODataResourceMetadataContext_KeyOrETagValuesMustBePrimitiveValues(propertyInfo.Name, GetResourceTypeName(resource, entityType)));
             }
 

--- a/src/Microsoft.OData.Core/Json/IJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/IJsonWriter.cs
@@ -10,9 +10,7 @@ namespace Microsoft.OData.Json
     using Microsoft.OData.Edm;
     using System.Threading.Tasks;
     using System.IO;
-#if NETCOREAPP
     using System.Text.Json;
-#endif
 
     /// <summary>
     /// Interface for a class that can write arbitrary JSON.
@@ -161,14 +159,11 @@ namespace Microsoft.OData.Json
         /// <param name="value">TimeOfDay value to be written.</param>
         void WriteValue(TimeOfDay value);
 
-#if NETCOREAPP
-
         /// <summary>
         /// Write a <see cref="JsonElement"/> value.
         /// </summary>
         /// <param name="value">The <see cref="JsonElement"/> value to be written.</param>
         void WriteValue(JsonElement value);
-#endif
 
         /// <summary>
         /// Write a raw value.
@@ -373,15 +368,12 @@ namespace Microsoft.OData.Json
         /// <returns>A task that represents the asynchronous write operation.</returns>
         Task WriteValueAsync(TimeOfDay value);
 
-#if NETCOREAPP
-
         /// <summary>
         /// Asynchronously writes a <see cref="JsonElement"/> value.
         /// </summary>
         /// <param name="value">The <see cref="JsonElement"/> value to be written.</param>
         /// <returns>A task that represents the asynchronous write operation.</returns>
         Task WriteValueAsync(JsonElement value);
-#endif
 
         /// <summary>
         /// Asynchronously writes a raw value.

--- a/src/Microsoft.OData.Core/Json/JsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/JsonReader.cs
@@ -22,11 +22,7 @@ namespace Microsoft.OData.Json
     /// Reader for the JSON format. http://www.json.org
     /// </summary>
     [DebuggerDisplay("{NodeType}: {GetValue()}")]
-#if NETCOREAPP
     internal class JsonReader : IJsonReader, IDisposable, IAsyncDisposable
-#else
-    internal class JsonReader : IJsonReader, IDisposable
-#endif
     {
         /// <summary>
         /// The initial size of the buffer of characters.
@@ -827,13 +823,11 @@ namespace Microsoft.OData.Json
             }
         }
 
-#if NETCOREAPP
         public ValueTask DisposeAsync()
         {
             Dispose();
             return ValueTask.CompletedTask;
         }
-#endif
 
         /// <summary>
         /// Determines if a given character is a whitespace character.
@@ -2148,11 +2142,7 @@ namespace Microsoft.OData.Json
         /// The value of the TResult parameter contains true if a non-whitespace character was found,
         /// in which case the <see cref="tokenStartIndex"/> is pointing at that character;
         /// otherwise false if there are no non-whitespace characters left in the input.</returns>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private async ValueTask<bool> SkipWhitespacesAsync()
-#else
-        private async Task<bool> SkipWhitespacesAsync()
-#endif
         {
             do
             {
@@ -2176,11 +2166,7 @@ namespace Microsoft.OData.Json
         /// <returns>A task that represents the asynchronous operation.
         /// The value of the TResult parameter contains true if at least the required number of characters is available; 
         /// otherwise false if end of input was reached.</returns>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private async ValueTask<bool> EnsureAvailableCharactersAsync(int characterCountAfterTokenStart)
-#else
-        private async Task<bool> EnsureAvailableCharactersAsync(int characterCountAfterTokenStart)
-#endif
         {
             while (this.tokenStartIndex + characterCountAfterTokenStart > this.storedCharacterCount)
             {
@@ -2201,11 +2187,7 @@ namespace Microsoft.OData.Json
         /// otherwise false if end of input was reached.</returns>
         /// <remarks>This may move characters in the <see cref="characterBuffer"/>, so after this is called
         /// all indices to the <see cref="characterBuffer"/> are invalid except for <see cref="tokenStartIndex"/>.</remarks>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private async ValueTask<bool> ReadInputAsync()
-#else
-        private async Task<bool> ReadInputAsync()
-#endif
         {
             Debug.Assert(this.tokenStartIndex >= 0 && this.tokenStartIndex <= this.storedCharacterCount, "The token start is out of stored characters range.");
 

--- a/src/Microsoft.OData.Core/Json/JsonWriter.Async.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.Async.cs
@@ -11,12 +11,10 @@ namespace Microsoft.OData.Json
     using System.Diagnostics;
     using System.Globalization;
     using System.IO;
+    using System.Text.Json;
     using System.Threading.Tasks;
     using Microsoft.OData.Buffers;
     using Microsoft.OData.Edm;
-#if NETCOREAPP
-    using System.Text.Json;
-#endif
     #endregion Namespaces
 
     internal sealed partial class JsonWriter
@@ -242,7 +240,6 @@ namespace Microsoft.OData.Json
             await this.writer.WriteValueAsync(value, this.wrappedBuffer, this.ArrayPool).ConfigureAwait(false);
         }
 
-#if NETCOREAPP
         public Task WriteValueAsync(JsonElement value)
         {
             switch (value.ValueKind)
@@ -358,7 +355,6 @@ namespace Microsoft.OData.Json
             Debug.Fail($"Exhausted all known JSON number types and did not find match.");
             return Task.CompletedTask;
         }
-#endif
 
         /// <inheritdoc/>
         public async Task WriteRawValueAsync(string rawValue)
@@ -373,7 +369,6 @@ namespace Microsoft.OData.Json
             return this.writer.FlushAsync();
         }
 
-#if NETCOREAPP
         public async ValueTask DisposeAsync()
         {
             if (this.ArrayPool != null && this.wrappedBuffer.Value != null)
@@ -395,7 +390,6 @@ namespace Microsoft.OData.Json
                 }
             }
         }
-#endif
 
         /// <inheritdoc/>
         public async Task<Stream> StartStreamValueScopeAsync()
@@ -417,11 +411,8 @@ namespace Microsoft.OData.Json
         public async Task EndStreamValueScopeAsync()
         {
             await this.binaryValueStream.FlushAsync().ConfigureAwait(false);
-#if NETCOREAPP
             await this.binaryValueStream.DisposeAsync().ConfigureAwait(false);
-#else
-            this.binaryValueStream.Dispose();
-#endif
+
             this.binaryValueStream = null;
             await this.writer.FlushAsync().ConfigureAwait(false);
             await this.writer.WriteAsync(JsonConstants.QuoteCharacter).ConfigureAwait(false);

--- a/src/Microsoft.OData.Core/Json/JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/JsonWriter.cs
@@ -13,22 +13,16 @@ namespace Microsoft.OData.Json
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.IO;
+    using System.Text.Json;
     using Microsoft.OData.Buffers;
     using Microsoft.OData.Edm;
-#if NETCOREAPP
-    using System.Text.Json;
-#endif
     #endregion Namespaces
 
     /// <summary>
     /// Writer for the JSON format. http://www.json.org
     /// </summary>
     [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "This class does not own the underlying stream/writer and thus should never dispose it.")]
-#if NETCOREAPP
     internal sealed partial class JsonWriter : IJsonWriter, IDisposable, IAsyncDisposable
-#else
-    internal sealed partial class JsonWriter : IJsonWriter, IDisposable
-#endif
     {
         /// <summary>
         /// Writer to write text into.
@@ -413,7 +407,6 @@ namespace Microsoft.OData.Json
             JsonValueUtils.WriteValue(this.writer, value, this.wrappedBuffer, this.ArrayPool);
         }
 
-#if NETCOREAPP
         public void WriteValue(JsonElement value)
         {
             switch (value.ValueKind)
@@ -542,7 +535,6 @@ namespace Microsoft.OData.Json
                 return;
             }
         }
-#endif
 
         /// <summary>
         /// Write a raw value.
@@ -563,7 +555,7 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
-        /// Start the stream property valuescope.
+        /// Start the stream property value scope.
         /// </summary>
         /// <returns>The stream to write the property value to</returns>
         public Stream StartStreamValueScope()
@@ -589,10 +581,10 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
-        /// Start the TextWriter valuescope.
+        /// Start the TextWriter values cope.
         /// </summary>
         /// <param name="contentType">ContentType of the string being written.</param>
-        /// <returns>The textwriter to write the text property value to</returns>
+        /// <returns>The TextWriter to write the text property value to</returns>
         public TextWriter StartTextWriterValueScope(string contentType)
         {
             this.WriteValueSeparator();
@@ -610,7 +602,7 @@ namespace Microsoft.OData.Json
         }
 
         /// <summary>
-        /// End the TextWriter valuescope.
+        /// End the TextWriter value scope.
         /// </summary>
         public void EndTextWriterValueScope()
         {

--- a/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
@@ -1173,12 +1173,7 @@ namespace Microsoft.OData.Json
         /// 1) true if the annotation name and value is skipped; otherwise false.
         /// 2) The annotation value that was read.
         /// </returns>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
-        private async ValueTask<Tuple<bool, object>> SkipOverUnknownODataAnnotationAsync(
-#else
-        private async Task<Tuple<bool, object>> SkipOverUnknownODataAnnotationAsync(
-#endif
-            string annotationName)
+        private async ValueTask<Tuple<bool, object>> SkipOverUnknownODataAnnotationAsync(string annotationName)
         {
             Debug.Assert(!string.IsNullOrEmpty(annotationName), "!string.IsNullOrEmpty(annotationName)");
             this.AssertJsonCondition(JsonNodeType.Property);

--- a/src/Microsoft.OData.Core/Json/ODataJsonOutputContext.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonOutputContext.cs
@@ -838,7 +838,6 @@ namespace Microsoft.OData.Json
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP
         protected override async ValueTask DisposeAsyncCore()
         {
             try
@@ -880,7 +879,6 @@ namespace Microsoft.OData.Json
                 this.jsonWriter = null;
             }
         }
-#endif
 
         /// <summary>
         /// Creates a new JSON writer of <see cref="IJsonWriter"/>.

--- a/src/Microsoft.OData.Core/Json/ODataJsonPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonPropertySerializer.cs
@@ -224,13 +224,11 @@ namespace Microsoft.OData.Json
                 return;
             }
 
-#if NETCOREAPP
             if (value is ODataJsonElementValue jsonElementValue)
             {
                 this.WriteJsonElementProperty(jsonElementValue);
                 return;
             }
-#endif
         }
 
 
@@ -450,16 +448,13 @@ namespace Microsoft.OData.Json
                 return;
             }
 
-#if NETCOREAPP
             if (value is ODataJsonElementValue jsonElementValue)
             {
                 await this.WriteJsonElementPropertyAsync(jsonElementValue)
                     .ConfigureAwait(false);
                 return;
             }
-#endif
         }
-
 
         /// <summary>
         /// Asynchronously writes the property information for a property.
@@ -532,18 +527,15 @@ namespace Microsoft.OData.Json
             return;
         }
 
-#if NETCOREAPP
         /// <summary>
         /// Writes a <see cref="System.Text.Json.JsonElement"/> property.
         /// </summary>
-        /// <param name="jsonElementvalue">The value to be written.</param>
-        private void WriteJsonElementProperty(ODataJsonElementValue jsonElementvalue)
+        /// <param name="jsonElementValue">The value to be written.</param>
+        private void WriteJsonElementProperty(ODataJsonElementValue jsonElementValue)
         {
             this.JsonWriter.WriteName(this.currentPropertyInfo.WireName);
-            this.JsonWriter.WriteValue(jsonElementvalue.Value);
+            this.JsonWriter.WriteValue(jsonElementValue.Value);
         }
-
-#endif
 
         private void WriteStreamValue(IODataStreamReferenceInfo streamInfo, string propertyName, ODataResourceMetadataBuilder metadataBuilder)
         {
@@ -941,20 +933,17 @@ namespace Microsoft.OData.Json
                 .ConfigureAwait(false);
         }
 
-#if NETCOREAPP
         /// <summary>
         /// Asynchronously writes an <see cref="System.Text.Json.JsonElement"/> value.
         /// </summary>
-        /// <param name="jsonElementvalue">The value to be written.</param>
-        private async Task WriteJsonElementPropertyAsync(ODataJsonElementValue jsonElementvalue)
+        /// <param name="jsonElementValue">The value to be written.</param>
+        private async Task WriteJsonElementPropertyAsync(ODataJsonElementValue jsonElementValue)
         {
             await this.JsonWriter.WriteNameAsync(this.currentPropertyInfo.WireName)
                 .ConfigureAwait(false);
-            await this.JsonWriter.WriteValueAsync(jsonElementvalue.Value)
+            await this.JsonWriter.WriteValueAsync(jsonElementValue.Value)
                 .ConfigureAwait(false);
         }
-
-#endif
 
         /// <summary>
         /// Asynchronosly writes a stream reference value.

--- a/src/Microsoft.OData.Core/Json/ODataJsonReaderCoreUtils.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonReaderCoreUtils.cs
@@ -192,11 +192,7 @@ namespace Microsoft.OData.Json
         /// <returns>true if a null value could be read from the JSON reader; otherwise false.</returns>
         /// <remarks>If the method detects a null value it will read it (position the reader after the null value);
         /// otherwise the reader does not move.</remarks>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         internal static async ValueTask<bool> TryReadNullValueAsync(
-#else
-        internal static async Task<bool> TryReadNullValueAsync(
-#endif
             IJsonReader jsonReader,
             ODataInputContext inputContext,
             IEdmTypeReference expectedTypeReference,

--- a/src/Microsoft.OData.Core/Json/ODataJsonValueSerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonValueSerializer.cs
@@ -328,7 +328,6 @@ namespace Microsoft.OData.Json
         {
             Debug.Assert(value != null, "value != null");
 
-#if NETCOREAPP
             if (value is ODataJsonElementValue jsonElementValue)
             {
                 // We don't perform validation for ODataJsonElementValue.
@@ -336,7 +335,6 @@ namespace Microsoft.OData.Json
                 this.JsonWriter.WriteValue(jsonElementValue.Value);
                 return;
             }
-#endif
 
             if (actualTypeReference == null)
             {
@@ -663,7 +661,6 @@ namespace Microsoft.OData.Json
         {
             Debug.Assert(value != null, "value != null");
 
-#if NETCOREAPP
             if (value is ODataJsonElementValue jsonElementValue)
             {
                 // We don't perform validation for ODataJsonElementValue.
@@ -671,7 +668,6 @@ namespace Microsoft.OData.Json
                 await this.JsonWriter.WriteValueAsync(jsonElementValue.Value).ConfigureAwait(false);
                 return;
             }
-#endif
 
             if (actualTypeReference == null)
             {
@@ -734,20 +730,12 @@ namespace Microsoft.OData.Json
             Stream stream = await this.JsonWriter.StartStreamValueScopeAsync().ConfigureAwait(false);
             await streamValue.Stream.CopyToAsync(stream).ConfigureAwait(false);
             await stream.FlushAsync().ConfigureAwait(false);
-#if NETCOREAPP
             await stream.DisposeAsync();
-#else
-                stream.Dispose();
-#endif
             await this.JsonWriter.EndStreamValueScopeAsync().ConfigureAwait(false);
 
             if (!streamValue.LeaveOpen)
             {
-#if NETCOREAPP
                 await streamValue.Stream.DisposeAsync();
-#else
-                streamValue.Stream.Dispose();
-#endif
             }
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.Stream.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 namespace Microsoft.OData.Json
 {
     using System;
@@ -356,4 +355,3 @@ namespace Microsoft.OData.Json
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.TextWriter.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 namespace Microsoft.OData.Json
 {
     using System;
@@ -533,4 +532,3 @@ namespace Microsoft.OData.Json
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriter.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Diagnostics;
 using System.Globalization;
@@ -1331,4 +1330,3 @@ namespace Microsoft.OData.Json
 
     }
 }
-#endif

--- a/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriterFactory.cs
+++ b/src/Microsoft.OData.Core/Json/ODataUtf8JsonWriterFactory.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.IO;
 using System.Text;
@@ -52,4 +51,3 @@ namespace Microsoft.OData.Json
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
+++ b/src/Microsoft.OData.Core/Json/PooledByteBufferWriter.cs
@@ -4,14 +4,13 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Buffers;
 using System.Diagnostics;
 
 namespace Microsoft.OData.Json
 {
-    // This class has been adapated from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
+    // This class has been adapted from https://github.com/dotnet/runtime/blob/main/src/libraries/Common/src/System/Text/Json/PooledByteBufferWriter.cs
     /// <summary>
     /// An implementation of <see cref="IBufferWriter{T}"/> that rents
     /// buffers from an array pool instead of allocating a new array every time.
@@ -226,4 +225,3 @@ namespace Microsoft.OData.Json
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Core/Json/TranscodingWriteStream.cs
+++ b/src/Microsoft.OData.Core/Json/TranscodingWriteStream.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Buffers;
 using System.Diagnostics;
@@ -425,5 +424,3 @@ namespace Microsoft.OData.Json
         }
     }
 }
- 
-#endif

--- a/src/Microsoft.OData.Core/Metadata/ODataMetadataWriterUtils.cs
+++ b/src/Microsoft.OData.Core/Metadata/ODataMetadataWriterUtils.cs
@@ -32,11 +32,7 @@ namespace Microsoft.OData.Metadata
 
             XmlWriterSettings xmlWriterSettings = CreateXmlWriterSettings(messageWriterSettings, encoding);
 
-#if NETSTANDARD1_1
-            if (stream is AsyncBufferedStream)
-#else
             if (stream is BufferedStream)
-#endif
             {
                 xmlWriterSettings.Async = true;
             }

--- a/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
+++ b/src/Microsoft.OData.Core/MultipartMixed/ODataMultipartMixedBatchWriter.cs
@@ -125,12 +125,8 @@ namespace Microsoft.OData.MultipartMixed
             // then dispose the batch writer (since we are now writing the operation content) and set the corresponding state.
             await this.RawOutputContext.FlushBuffersAsync()
                 .ConfigureAwait(false);
-#if NETCOREAPP
             await this.DisposeBatchWriterAndSetContentStreamRequestedStateAsync()
                 .ConfigureAwait(false);
-#else
-            this.DisposeBatchWriterAndSetContentStreamRequestedState();
-#endif
         }
 
         /// <summary>
@@ -759,7 +755,6 @@ namespace Microsoft.OData.MultipartMixed
             }
         }
 
-#if NETCOREAPP
         /// <summary>
         /// Asynchronously disposes the batch writer and set the 'OperationStreamRequested' batch writer state;
         /// called after the flush operation(s) have completed.
@@ -771,6 +766,5 @@ namespace Microsoft.OData.MultipartMixed
 
             this.SetState(BatchWriterState.OperationStreamRequested);
         }
-#endif
     }
 }

--- a/src/Microsoft.OData.Core/ODataBinaryStreamReader.cs
+++ b/src/Microsoft.OData.Core/ODataBinaryStreamReader.cs
@@ -45,14 +45,8 @@ namespace Microsoft.OData
         /// <summary>Current offset into buffer.</summary>
         private int bytesOffset = 0;
 
-
         /// <summary>Buffer for reading the stream content.</summary>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         private byte[] bytes = Array.Empty<byte>();
-#else
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1825:Avoid zero-length array allocations.", Justification = "<Pending>")]
-        private byte[] bytes = new byte[0];
-#endif
 
         /// <summary>
         /// Constructor.

--- a/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
+++ b/src/Microsoft.OData.Core/ODataBinaryStreamWriter.cs
@@ -26,14 +26,8 @@ namespace Microsoft.OData
         /// <summary>The writer to write to the underlying stream.</summary>
         private readonly TextWriter Writer;
 
-
         /// <summary>Trailing bytes from a previous write to be prepended to the next write.</summary>
-#if NETCOREAPP
         private byte[] trailingBytes = Array.Empty<byte>();
-#else
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1825:Avoid zero-length array allocations.", Justification = "<Pending>")]
-        private byte[] trailingBytes = new byte[0];
-#endif
 
         /// <summary>
         /// The wrapped buffer to help with streaming responses.
@@ -45,19 +39,13 @@ namespace Microsoft.OData
         /// </summary>
         private ICharArrayPool bufferPool;
 
-
         /// <summary>An empty byte[].</summary>
-#if NETCOREAPP
         private byte[] emptyByteArray = Array.Empty<byte>();
-#else
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1825:Avoid zero-length array allocations.", Justification = "<Pending>")]
-        private static byte[] emptyByteArray = new byte[0];
-#endif
 
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="writer">A Textwriter for writing to the stream.</param>
+        /// <param name="writer">A TextWriter for writing to the stream.</param>
         public ODataBinaryStreamWriter(TextWriter writer)
         {
             Debug.Assert(writer != null, "Creating a binary stream writer for a null textWriter.");
@@ -68,7 +56,7 @@ namespace Microsoft.OData
         /// <summary>
         /// Constructor.
         /// </summary>
-        /// <param name="writer">A Textwriter for writing to the stream.</param>
+        /// <param name="writer">A TextWriter for writing to the stream.</param>
         /// <param name="streamingBuffer">A temporary buffer to use when converting binary values.</param>
         /// <param name="bufferPool">Array pool for renting a buffer.</param>
         public ODataBinaryStreamWriter(TextWriter writer, Ref<char[]> wrappedBuffer, ICharArrayPool bufferPool)
@@ -245,7 +233,6 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP
         public override async ValueTask DisposeAsync()
         {
             // write any trailing bytes to stream
@@ -257,7 +244,6 @@ namespace Microsoft.OData
 
             await this.Writer.FlushAsync().ConfigureAwait(false);
         }
-#endif
 
         /// <summary>
         /// Prepares bytes to be written for the particular write event

--- a/src/Microsoft.OData.Core/ODataMessageWriter.cs
+++ b/src/Microsoft.OData.Core/ODataMessageWriter.cs
@@ -22,11 +22,7 @@ namespace Microsoft.OData
     /// <summary>
     /// Writer class used to write all OData payloads (entries, resource sets, metadata documents, service documents, etc.).
     /// </summary>
-#if NETCOREAPP
     public sealed class ODataMessageWriter : IDisposable, IAsyncDisposable
-#else
-    public sealed class ODataMessageWriter : IDisposable
-#endif
     {
         /// <summary>The message for which the message writer was created.</summary>
         private readonly ODataMessage message;
@@ -705,7 +701,6 @@ namespace Microsoft.OData
             GC.SuppressFinalize(this);
         }
 
-#if NETCOREAPP
         /// <summary>
         /// <see cref="System.IAsyncDisposable.DisposeAsync"/> implementation to asynchronously
         /// clean up unmanaged resources of the writer.
@@ -720,7 +715,6 @@ namespace Microsoft.OData
             this.Dispose(false);
             GC.SuppressFinalize(this);
         }
-#endif
 
         /// <summary>
         /// Sets the content-type and OData-Version headers on the message used by the message writer.
@@ -1184,7 +1178,6 @@ namespace Microsoft.OData
             }
         }
 
-#if NETCOREAPP
         /// <summary>
         /// Asynchronously performs the actual cleanup work.
         /// </summary>
@@ -1204,7 +1197,6 @@ namespace Microsoft.OData
                 this.outputContext = null;
             }
         }
-#endif
 
         /// <summary>
         /// Verifies that, if a payload kind has been set via SetHeaders, the payload kind that

--- a/src/Microsoft.OData.Core/ODataMetadataFormat.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataFormat.cs
@@ -62,21 +62,12 @@ namespace Microsoft.OData
 
             bool isJson = IsJsonMetadata(messageInfo.MediaType);
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
             if (isJson)
             {
                 return new ODataMetadataJsonInputContext(messageInfo, messageReaderSettings);
             }
 
             return new ODataMetadataInputContext(messageInfo, messageReaderSettings);
-#else
-            if (isJson)
-            {
-                throw new ODataException(Strings.ODataMetadataOutputContext_NotSupportJsonMetadata);
-            }
-
-            return new ODataMetadataInputContext(messageInfo, messageReaderSettings);
-#endif
         }
 
         /// <summary>
@@ -94,21 +85,12 @@ namespace Microsoft.OData
 
             bool isJson = IsJsonMetadata(messageInfo.MediaType);
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
             if (isJson)
             {
                 return new ODataMetadataJsonOutputContext(messageInfo, messageWriterSettings);
             }
 
             return new ODataMetadataOutputContext(messageInfo, messageWriterSettings);
-#else
-            if (isJson)
-            {
-                throw new ODataException(Strings.ODataMetadataOutputContext_NotSupportJsonMetadata);
-            }
-
-            return new ODataMetadataOutputContext(messageInfo, messageWriterSettings);
-#endif
         }
 
         /// <summary>
@@ -159,21 +141,12 @@ namespace Microsoft.OData
 
             bool isJson = IsJsonMetadata(messageInfo.MediaType);
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
             if (isJson)
             {
                 return Task.FromResult<ODataOutputContext>(new ODataMetadataJsonOutputContext(messageInfo, messageWriterSettings));
             }
 
             return Task.FromResult<ODataOutputContext>(new ODataMetadataOutputContext(messageInfo, messageWriterSettings));
-#else
-            if (isJson)
-            {
-                throw new ODataException(Strings.ODataMetadataOutputContext_NotSupportJsonMetadata);
-            }
-
-            return Task.FromResult<ODataOutputContext>(new ODataMetadataOutputContext(messageInfo, messageWriterSettings));
-#endif
         }
 
         private static bool IsJsonMetadata(ODataMediaType contentType)

--- a/src/Microsoft.OData.Core/ODataMetadataJsonInputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataJsonInputContext.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -110,4 +109,3 @@ namespace Microsoft.OData
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Core/ODataMetadataJsonOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataJsonOutputContext.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -202,7 +201,6 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP
         protected override async ValueTask DisposeAsyncCore()
         {
             try
@@ -230,7 +228,6 @@ namespace Microsoft.OData
 
             await base.DisposeAsyncCore().ConfigureAwait(false);
         }
-#endif
 
         private void WriteMetadataDocumentImplementation()
         {
@@ -283,12 +280,7 @@ namespace Microsoft.OData
 
             await this.jsonWriter.FlushAsync().ConfigureAwait(false);
             await this.jsonWriter.DisposeAsync().ConfigureAwait(false);
-#if NETCOREAPP
             await this.asynchronousOutputStream.DisposeAsync().ConfigureAwait(false);
-#else
-            this.asynchronousOutputStream.Dispose();
-#endif
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataMetadataOutputContext.cs
@@ -30,11 +30,7 @@ namespace Microsoft.OData
         private XmlWriter xmlWriter;
 
         /// <summary>The asynchronous output stream if we're writing asynchronously.</summary>
-#if NETSTANDARD1_1
-        private AsyncBufferedStream asynchronousOutputStream;
-#else
         private Stream asynchronousOutputStream;
-#endif
 
         /// <summary>
         /// Constructor.
@@ -59,11 +55,7 @@ namespace Microsoft.OData
                 }
                 else
                 {
-#if NETSTANDARD1_1
-                    this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
-#else
                     this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, messageWriterSettings.BufferSize);
-#endif
                     outputStream = this.asynchronousOutputStream;
                 }
 
@@ -220,7 +212,6 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP
         protected override async ValueTask DisposeAsyncCore()
         {
             try
@@ -259,7 +250,6 @@ namespace Microsoft.OData
 
             await base.DisposeAsyncCore().ConfigureAwait(false);
         }
-#endif
 
         private void WriteMetadataDocumentImplementation()
         {

--- a/src/Microsoft.OData.Core/ODataNotificationReader.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationReader.cs
@@ -14,11 +14,7 @@ namespace Microsoft.OData
     /// <summary>
     /// Wrapper for TextReader to listen for dispose.
     /// </summary>
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
     internal sealed class ODataNotificationReader : TextReader, IAsyncDisposable
-#else
-    internal sealed class ODataNotificationReader : TextReader
-#endif
     {
         private readonly TextReader textReader;
         private readonly IODataStreamListener listener;
@@ -148,7 +144,6 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
         public async ValueTask DisposeAsync()
         {
             if (!this.disposed)
@@ -161,6 +156,5 @@ namespace Microsoft.OData
             // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
             this.Dispose(false);
         }
-#endif
     }
 }

--- a/src/Microsoft.OData.Core/ODataNotificationStream.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationStream.cs
@@ -15,11 +15,8 @@ namespace Microsoft.OData
     /// <summary>
     /// Wrapper to listen for dispose on a <see cref="Stream"/>.
     /// </summary>
-#if NETSTANDARD2_0
     internal sealed class ODataNotificationStream : Stream, IAsyncDisposable
-#else
-    internal sealed class ODataNotificationStream : Stream
-#endif
+
     {
         private Stream stream;
         private IODataStreamListener listener;
@@ -227,24 +224,12 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP
         /// <inheritdoc/>
         public override ValueTask DisposeAsync()
         {
             return DisposeAsyncCore();
         }
-#elif NETSTANDARD2_0
-        /// <summary>
-        /// Asynchronously releases all resources used by the <see cref="ODataNotificationStream"/> object.
-        /// </summary>
-        /// <returns>A task that represents the asynchronous dispose operation.</returns>
-        public ValueTask DisposeAsync()
-        {
-            return DisposeAsyncCore();
-        }
-#endif
 
-#if NETCOREAPP
         /// <summary>
         /// Asynchronously releases all resources used by the <see cref="ODataNotificationStream"/> object.
         /// </summary>
@@ -265,6 +250,5 @@ namespace Microsoft.OData
             // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
             this.Dispose(false);
         }
-#endif
     }
 }

--- a/src/Microsoft.OData.Core/ODataNotificationWriter.cs
+++ b/src/Microsoft.OData.Core/ODataNotificationWriter.cs
@@ -15,11 +15,8 @@ namespace Microsoft.OData
     /// <summary>
     /// Wrapper for TextWriter to listen for dispose.
     /// </summary>
-#if NETSTANDARD2_0
     internal sealed class ODataNotificationWriter : TextWriter, IAsyncDisposable
-#else
-    internal sealed class ODataNotificationWriter : TextWriter
-#endif
+
     {
         private TextWriter textWriter;
         private IODataStreamListener listener;
@@ -348,24 +345,12 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP
         /// <inheritdoc/>
         public override ValueTask DisposeAsync()
         {
             return DisposeAsyncCore();
         }
-#elif NETSTANDARD2_0
-        /// <summary>
-        /// Asynchronously releases all resources used by the <see cref="ODataNotificationWriter"/> object.
-        /// </summary>
-        /// <returns>A task that represents the asynchronous dispose operation.</returns>
-        public ValueTask DisposeAsync()
-        {
-            return DisposeAsyncCore();
-        }
-#endif
 
-#if NETCOREAPP
         /// <summary>
         /// Asynchronously releases all resources used by the <see cref="ODataNotificationWriter"/> object.
         /// </summary>
@@ -386,6 +371,5 @@ namespace Microsoft.OData
             // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
             this.Dispose(false);
         }
-#endif
     }
 }

--- a/src/Microsoft.OData.Core/ODataOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataOutputContext.cs
@@ -19,11 +19,7 @@ namespace Microsoft.OData
     /// Base class for all output contexts, defines the interface
     /// to be implemented by the specific formats.
     /// </summary>
-#if NETCOREAPP
     public abstract class ODataOutputContext : IDisposable, IAsyncDisposable
-#else
-    public abstract class ODataOutputContext : IDisposable
-#endif
     {
         /// <summary>The format for this output context.</summary>
         private readonly ODataFormat format;
@@ -673,7 +669,6 @@ namespace Microsoft.OData
         {
         }
 
-#if NETCOREAPP
         /// <summary>
         /// IAsyncDisposable.DisposeAsync() implementation to asynchronously cleanup unmanaged resources of the context.
         /// </summary>
@@ -698,7 +693,6 @@ namespace Microsoft.OData
         {
             return default;
         }
-#endif
 
         /// <summary>
         /// Creates an exception which reports that the specified payload kind if not support by this format.

--- a/src/Microsoft.OData.Core/ODataRawOutputContext.cs
+++ b/src/Microsoft.OData.Core/ODataRawOutputContext.cs
@@ -31,11 +31,7 @@ namespace Microsoft.OData
         private Stream messageOutputStream;
 
         /// <summary>The asynchronous output stream if we're writing asynchronously.</summary>
-#if NETSTANDARD1_1
-        private AsyncBufferedStream asynchronousOutputStream;
-#else
         private Stream asynchronousOutputStream;
-#endif
 
         /// <summary>The output stream to write to (both sync and async cases).</summary>
         private Stream outputStream;
@@ -68,11 +64,7 @@ namespace Microsoft.OData
                 }
                 else
                 {
-#if NETSTANDARD1_1
-                    this.asynchronousOutputStream = new AsyncBufferedStream(this.messageOutputStream);
-#else
-	                this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, messageWriterSettings.BufferSize);
-#endif
+                    this.asynchronousOutputStream = new BufferedStream(this.messageOutputStream, messageWriterSettings.BufferSize);
                     this.outputStream = this.asynchronousOutputStream;
                 }
             }
@@ -294,11 +286,7 @@ namespace Microsoft.OData
         {
             if (this.asynchronousOutputStream != null)
             {
-#if NETSTANDARD1_1
-                this.asynchronousOutputStream.FlushSync();
-#else
                 this.asynchronousOutputStream.Flush();
-#endif
             }
         }
 
@@ -318,7 +306,6 @@ namespace Microsoft.OData
             }
         }
 
-#if NETCOREAPP
         /// <summary>
         /// Closes the text writer asynchronously.
         /// </summary>
@@ -330,7 +317,6 @@ namespace Microsoft.OData
             await this.rawValueWriter.DisposeAsync().ConfigureAwait(false);
             this.rawValueWriter = null;
         }
-#endif
 
         /// <summary>
         /// Perform the actual cleanup work.
@@ -353,11 +339,7 @@ namespace Microsoft.OData
                         // In the async case the underlying stream is the async buffered stream, so we have to flush that explicitly.
                         if (this.asynchronousOutputStream != null)
                         {
-#if NETSTANDARD1_1
-                            this.asynchronousOutputStream.FlushSync();
-#else
                             this.asynchronousOutputStream.Flush();
-#endif
                         }
 
                         // Dispose the message stream (note that we OWN this stream, so we always dispose it).
@@ -376,7 +358,6 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP
         protected override async ValueTask DisposeAsyncCore()
         {
             try
@@ -408,7 +389,6 @@ namespace Microsoft.OData
 
             await base.DisposeAsyncCore().ConfigureAwait(false);
         }
-#endif
 
         /// <summary>
         /// Writes a single value as the message body.

--- a/src/Microsoft.OData.Core/ODataStream.cs
+++ b/src/Microsoft.OData.Core/ODataStream.cs
@@ -18,11 +18,7 @@ namespace Microsoft.OData
     /// or representing a stream value.
     /// This stream communicates status changes to an IODataStreamListener instance.
     /// </summary>
-#if NETSTANDARD2_0
-    internal abstract class ODataStream : Stream, IAsyncDisposable
-#else
     internal abstract class ODataStream : Stream
-#endif
     {
         /// <summary>Listener interface to be notified of operation changes.</summary>
         private IODataStreamListener listener;
@@ -82,7 +78,6 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP
         public override async ValueTask DisposeAsync()
         {
             await DisposeAsyncCore()
@@ -92,19 +87,7 @@ namespace Microsoft.OData
             // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
             this.Dispose(false);
         }
-#elif NETSTANDARD2_0
-        public async ValueTask DisposeAsync()
-        {
-            await DisposeAsyncCore()
-                .ConfigureAwait(false);
 
-            // Dispose unmanaged resources
-            // Pass `false` to ensure functional equivalence with the synchronous dispose pattern
-            this.Dispose(false);
-        }
-#endif
-
-#if NETCOREAPP
         /// <summary>
         /// Encapsulates the common asynchronous cleanup operations.
         /// </summary>
@@ -119,7 +102,6 @@ namespace Microsoft.OData
                 this.listener = null;
             }
         }
-#endif
 
         /// <summary>
         /// Validates that the stream was not already disposed.

--- a/src/Microsoft.OData.Core/ODataUtils.cs
+++ b/src/Microsoft.OData.Core/ODataUtils.cs
@@ -192,11 +192,7 @@ namespace Microsoft.OData
 
         public static T[] GetEmptyArray<T>()
         {
-#if NETCOREAPP
             return Array.Empty<T>();
-#else
-            return new T[0];
-#endif
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataWriteStream.cs
+++ b/src/Microsoft.OData.Core/ODataWriteStream.cs
@@ -164,7 +164,6 @@ namespace Microsoft.OData
             base.Dispose(disposing);
         }
 
-#if NETCOREAPP
         /// <summary>
         /// Encapsulates the common asynchronous cleanup operations.
         /// </summary>
@@ -175,6 +174,5 @@ namespace Microsoft.OData
 
             return base.DisposeAsyncCore();
         }
-#endif
     }
 }

--- a/src/Microsoft.OData.Core/RawValueWriter.cs
+++ b/src/Microsoft.OData.Core/RawValueWriter.cs
@@ -17,11 +17,7 @@ namespace Microsoft.OData
     /// <summary>
     /// Class that handles writing top level raw values to a stream.
     /// </summary>
-#if NETCOREAPP
     internal sealed class RawValueWriter : IDisposable, IAsyncDisposable
-#else
-    internal sealed class RawValueWriter : IDisposable
-#endif
     {
         /// <summary>
         /// Writer settings.
@@ -90,7 +86,6 @@ namespace Microsoft.OData
             this.textWriter = null;
         }
 
-#if NETCOREAPP
         /// <summary>
         /// Asynchronously disposes the <see cref="RawValueWriter"/>.
         /// It flushes itself and then disposes its inner <see cref="System.IO.TextWriter"/>.
@@ -112,7 +107,6 @@ namespace Microsoft.OData
                 this.textWriter = null;
             }
         }
-#endif
 
         /// <summary>
         /// Start writing a raw output. This should only be called once.
@@ -281,11 +275,7 @@ namespace Microsoft.OData
             // We must create the text writer over a stream which will ignore Dispose, since we need to be able to Dispose
             // the writer without disposing the underlying message stream.
             Stream nonDisposingStream;
-#if NETSTANDARD1_1
-            if (MessageStreamWrapper.IsNonDisposingStream(this.stream) || this.stream is AsyncBufferedStream)
-#else
             if (MessageStreamWrapper.IsNonDisposingStream(this.stream))
-#endif
             {
                 // AsyncBufferedStream ignores Dispose
                 nonDisposingStream = this.stream;

--- a/src/Microsoft.OData.Core/TaskUtils.cs
+++ b/src/Microsoft.OData.Core/TaskUtils.cs
@@ -90,13 +90,7 @@ namespace Microsoft.OData.Client
         /// <returns>An already completed task with the specified exception.</returns>
         internal static Task<T> GetFaultedTask<T>(Exception exception)
         {
-#if NETSTANDARD2_0 || NETCOREAPP3_1_OR_GREATER
             return Task.FromException<T>(exception);
-#else
-            TaskCompletionSource<T> taskCompletionSource = new TaskCompletionSource<T>();
-            taskCompletionSource.SetException(exception);
-            return taskCompletionSource.Task;
-#endif
         }
 #endregion
 

--- a/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
+++ b/src/Microsoft.OData.Core/Value/ODataJsonElementValue.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System.Text.Json;
 
 namespace Microsoft.OData
@@ -36,4 +35,3 @@ namespace Microsoft.OData
         public JsonElement Value { get; private set; }
     }
 }
-#endif

--- a/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
+++ b/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
@@ -7,10 +7,8 @@
 #if ODATA_SERVICE
 namespace Microsoft.OData.Service
 #else
-#if NETCOREAPP
 using System;
 using System.Text.Json;
-#endif
 
 namespace Microsoft.OData
 #endif
@@ -50,7 +48,6 @@ namespace Microsoft.OData
                 return new ODataEnumValue(objectToConvert.ToString().Replace(", ", ",", StringComparison.Ordinal));
             }
 
-#if NETCOREAPP
             // Ideally, the JsonElement should be wrapped inside an ODataJsonElementValue
             // when being assigned to an ODataProperty, that will avoid
             // this conversion and avoid boxing the JsonElement.
@@ -58,7 +55,6 @@ namespace Microsoft.OData
             {
                 return new ODataJsonElementValue(jsonElement);
             }
-#endif
 
             // Otherwise treat it as a primitive and wrap in an ODataPrimitiveValue. This includes spatial types.
             return new ODataPrimitiveValue(objectToConvert);

--- a/src/Microsoft.OData.Core/WriterValidator.cs
+++ b/src/Microsoft.OData.Core/WriterValidator.cs
@@ -7,9 +7,7 @@
 namespace Microsoft.OData
 {
     using System.Collections.Generic;
-#if NETCOREAPP
     using Microsoft.Extensions.ObjectPool;
-#endif
     using Microsoft.OData.Edm;
     using Microsoft.OData.Metadata;
 
@@ -23,12 +21,10 @@ namespace Microsoft.OData
         /// </summary>
         private readonly ODataMessageWriterSettings settings;
 
-#if NETCOREAPP
         /// <summary>
         /// Object pool that stores instances of the DuplicatePropertyNameChecker.
         /// </summary>
         private ObjectPool<DuplicatePropertyNameChecker> duplicatePropertyNameCheckerObjectPool;
-#endif
 
         /// <summary>
         /// Creates a WriterValidator instance and binds it to settings.
@@ -46,7 +42,6 @@ namespace Microsoft.OData
 
             if (settings.ThrowOnDuplicatePropertyNames)
             {
-#if NETCOREAPP
                 if (this.duplicatePropertyNameCheckerObjectPool == null)
                 {
                     DefaultObjectPoolProvider poolProvider = new DefaultObjectPoolProvider { MaximumRetained = 8 };
@@ -55,9 +50,6 @@ namespace Microsoft.OData
 
                 duplicatePropertyNameChecker = this.duplicatePropertyNameCheckerObjectPool.Get();
                 duplicatePropertyNameChecker.Reset();
-#else
-                duplicatePropertyNameChecker = new DuplicatePropertyNameChecker();
-#endif
             }
             else
             {
@@ -70,13 +62,11 @@ namespace Microsoft.OData
         /// <inheritdoc/>
         public void ReturnDuplicatePropertyNameChecker(IDuplicatePropertyNameChecker duplicatePropertyNameChecker)
         {
-#if NETCOREAPP
             // We only return the DuplicatePropertyNameChecker to the object pool and ignore the NullDuplicatePropertyNameChecker.
             if (duplicatePropertyNameChecker is DuplicatePropertyNameChecker duplicateChecker)
             {
                 this.duplicatePropertyNameCheckerObjectPool.Return(duplicateChecker);
             }
-#endif
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Csdl/CsdlJsonReaderSettings.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlJsonReaderSettings.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System.Collections.Generic;
 
 namespace Microsoft.OData.Edm.Csdl
@@ -69,4 +68,3 @@ namespace Microsoft.OData.Edm.Csdl
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/CsdlJsonWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlJsonWriter.cs
@@ -4,10 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.OData.Edm.Csdl.Serialization;
@@ -189,4 +186,3 @@ namespace Microsoft.OData.Edm.Csdl
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/CsdlJsonWriterSettings.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlJsonWriterSettings.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 namespace Microsoft.OData.Edm.Csdl
 {
     /// <summary>
@@ -22,4 +21,3 @@ namespace Microsoft.OData.Edm.Csdl
         public bool IsIeee754Compatible { get; set; }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/CsdlReader.Json.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlReader.Json.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -191,4 +190,3 @@ namespace Microsoft.OData.Edm.Csdl
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/CsdlWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/CsdlWriter.cs
@@ -8,14 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
-
-#if NETCOREAPP
 using System.Text.Json;
 using System.Threading.Tasks;
-
-#endif
-
 using System.Xml;
 using Microsoft.OData.Edm.Csdl.Serialization;
 
@@ -47,7 +41,6 @@ namespace Microsoft.OData.Edm.Csdl
             this.edmxVersion = edmxVersion;
         }
 
-#if NETCOREAPP
         /// <summary>
         /// Outputs a CSDL JSON artifact to the provided <see cref="Utf8JsonWriter"/>.
         /// </summary>
@@ -122,7 +115,6 @@ namespace Microsoft.OData.Edm.Csdl
 
             return (true, Enumerable.Empty<EdmError>());
         }
-#endif
 
         /// <summary>
         /// Outputs a CSDL XML artifact to the provided <see cref="XmlWriter"/>.

--- a/src/Microsoft.OData.Edm/Csdl/JsonElementExtensions.cs
+++ b/src/Microsoft.OData.Edm/Csdl/JsonElementExtensions.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -241,4 +240,3 @@ namespace Microsoft.OData.Edm.Csdl
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/AnnotationJsonParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/AnnotationJsonParser.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -513,4 +512,3 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlJsonParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlJsonParser.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -336,4 +335,3 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlJsonParserHelper.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/CsdlJsonParserHelper.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Diagnostics;
 using System.Text.Json;
@@ -142,4 +141,3 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/JsonParserContext.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/JsonParserContext.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -224,4 +223,3 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/Parsing/SchemaJsonParser.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Parsing/SchemaJsonParser.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -1563,4 +1562,3 @@ namespace Microsoft.OData.Edm.Csdl.Parsing
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelCsdlSchemaJsonWriter.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -3277,4 +3276,3 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelReferenceElementsJsonVisitor.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Serialization/EdmModelReferenceElementsJsonVisitor.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using Microsoft.OData.Edm.Vocabularies;
 using System;
 using System.Collections.Generic;
@@ -262,4 +261,3 @@ namespace Microsoft.OData.Edm.Csdl.Serialization
         }
     }
 }
-#endif

--- a/src/Microsoft.OData.Edm/Csdl/Utf8JsonWriterExtensions.cs
+++ b/src/Microsoft.OData.Edm/Csdl/Utf8JsonWriterExtensions.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Text.Json;
 
@@ -194,4 +193,3 @@ namespace Microsoft.OData.Edm.Csdl
         }
     }
 }
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/HttpClientRequestMessageTests.cs
@@ -136,17 +136,10 @@ namespace Microsoft.OData.Client.Tests.Serialization
                         Task.Run(() => Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null));
 
                     // Assert
-#if NETCOREAPP
                     await Assert.ThrowsAsync<DataServiceTransportException>(async () =>
                     {
                         await getResponseTask;
                     });
-#else
-                    await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                    {
-                        await getResponseTask;
-                    });
-#endif
                 }
             }
         }
@@ -195,17 +188,10 @@ namespace Microsoft.OData.Client.Tests.Serialization
 
                     // Assert
                     // Request 1 should fail
-#if NETCOREAPP
                     await Assert.ThrowsAsync<DataServiceTransportException>(async () =>
                     {
                         await getResponse1Task;
                     });
-#else
-                    await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                    {
-                        await getResponse1Task;
-                    });
-#endif
 
                     // Request 2 should succeed
                     var response2 = await getResponse2Task;
@@ -240,17 +226,10 @@ namespace Microsoft.OData.Client.Tests.Serialization
                         Task.Run(() => Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null));
 
                     // Assert
-#if NETCOREAPP
                     await Assert.ThrowsAsync<DataServiceTransportException>(async () =>
                     {
                         await getResponseTask;
                     });
-#else
-                    await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                    {
-                        await getResponseTask;
-                    });
-#endif
                 }
             }
         }
@@ -290,17 +269,10 @@ namespace Microsoft.OData.Client.Tests.Serialization
 
                     // Assert
                     // Request 1 should timeout
-#if NETCOREAPP
                     await Assert.ThrowsAsync<DataServiceTransportException>(async () =>
                     {
                         await getResponse1Task;
                     });
-#else
-                    await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                    {
-                        await getResponse1Task;
-                    });
-#endif
 
                     // Request 2 should succeed;
                     var response2 = await getResponse2Task;
@@ -336,17 +308,10 @@ namespace Microsoft.OData.Client.Tests.Serialization
                         Task.Run(() => Task.Factory.FromAsync(request.BeginGetResponse, request.EndGetResponse, null));
 
                     // Assert
-#if NETCOREAPP
                     await Assert.ThrowsAsync<DataServiceTransportException>(async () =>
                     {
                         await getResponseTask;
                     });
-#else
-                    await Assert.ThrowsAsync<OperationCanceledException>(async () =>
-                    {
-                        await getResponseTask;
-                    });
-#endif
                 }
             }
         }

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/MockDelayedHttpClientHandler.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/MockDelayedHttpClientHandler.cs
@@ -32,11 +32,7 @@ namespace Microsoft.OData.Client.Tests.Serialization
         /// </summary>
         public Action<HttpRequestMessage> OnRequestStarted { get; set; }
 
-#if NETCOREAPP
         protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
-#else
-        public override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
-#endif
         {
             NotifyRequestStart(request);
             Stopwatch stopwatch = new Stopwatch();

--- a/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/MockHttpClientHandler.cs
+++ b/test/FunctionalTests/Microsoft.OData.Client.Tests/Serialization/MockHttpClientHandler.cs
@@ -59,11 +59,7 @@ namespace Microsoft.OData.Client.Tests.Serialization
         /// </summary>
         public bool Disposed { get; private set; } = false;
 
-#if NETCOREAPP
         protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
-#else
-        public virtual HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
-#endif
         {
             _requests.Add($"{request.Method} {request.RequestUri.AbsoluteUri}");
             HttpResponseMessage response = _requestHandler(request);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/AsyncStream.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/AsyncStream.cs
@@ -64,14 +64,7 @@ namespace Microsoft.OData.Tests
 
         public override void Flush()
         {
-#if NETCOREAPP
             throw new SynchronousIOException();
-#else
-            // We allow synchronous flushing in older frameworks
-            // because we also allow synchronous Dispose()
-            // which often calls Flush()
-            this.innerStream.Flush();
-#endif
         }
 
         public override int Read(byte[] buffer, int offset, int count)
@@ -83,47 +76,26 @@ namespace Microsoft.OData.Tests
             throw new SynchronousIOException();
         }
 
-#if NETCOREAPP
         public override int Read(Span<byte> buffer)
         {
             throw new SynchronousIOException();
         }
-#endif
 
         public override void WriteByte(byte value) => throw new SynchronousIOException();
 
         public override void Write(byte[] buffer, int offset, int count)
         {
-#if NETCOREAPP
             throw new SynchronousIOException();
-#else
-            // We allow synchronous flushing in older frameworks
-            // because we also allow synchronous Dispose()
-            // which often calls Flush()
-            this.innerStream.Write(buffer, offset, count);
-#endif
         }
 
-#if NETCOREAPP
         public override void CopyTo(Stream destination, int bufferSize) => throw new SynchronousIOException();
-#endif
 
 
-#if NETCOREAPP
         public override void Write(ReadOnlySpan<byte> buffer) => throw new SynchronousIOException();
-#endif
 
-#if NETCOREAPP
         protected override void Dispose(bool disposing) => throw new SynchronousIOException();
-#else
-        // In .NET Core <= 3.1 we don't support the async alternative DisposeAsync()
-        // So let's allow sync Dispose there cause there's no alternative
-        protected override void Dispose(bool disposing) => this.innerStream.Dispose();
-#endif
 
-#if NETCOREAPP
         public override void Close() => throw new SynchronousIOException();
-#endif
 
         public override long Seek(long offset, SeekOrigin origin)
         {
@@ -135,10 +107,8 @@ namespace Microsoft.OData.Tests
             this.innerStream.SetLength(value);
         }
 
-#if NETCOREAPP
         public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) =>
             this.innerStream.ReadAsync(buffer, cancellationToken);
-#endif
 
         public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             => this.innerStream.ReadAsync(buffer, offset, count, cancellationToken);
@@ -146,25 +116,20 @@ namespace Microsoft.OData.Tests
         public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             => this.innerStream.WriteAsync(buffer, offset, count, cancellationToken);
 
-#if NETCOREAPP
 
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
             => this.innerStream.WriteAsync(buffer, cancellationToken);
-#endif
 
         public override Task FlushAsync(CancellationToken cancellationToken) => this.innerStream.FlushAsync(cancellationToken);
 
-#if NETCOREAPP
         public override async ValueTask DisposeAsync()
         {
             await this.innerStream.DisposeAsync();
             this.Disposed = true;
         }
-#endif
         public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken) =>
             this.innerStream.CopyToAsync(destination, bufferSize, cancellationToken);
 
-#if NETCOREAPP
         public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state) =>
             this.innerStream.BeginRead(buffer, offset, count, callback, state);
 
@@ -174,7 +139,6 @@ namespace Microsoft.OData.Tests
         public override int EndRead(IAsyncResult asyncResult) => this.innerStream.EndRead(asyncResult);
 
         public override void EndWrite(IAsyncResult asyncResult) => this.innerStream.EndWrite(asyncResult);
-#endif
 
         public override string ToString() => this.innerStream.ToString();
     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/PropertyAndValueJsonWriterIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/PropertyAndValueJsonWriterIntegrationTests.cs
@@ -117,13 +117,8 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
                 "]," +
                 "\"FloatNumbers\":[" +
                 "1," +
-#if NETCOREAPP
                 "-3.4028235E+38," +
                 "3.4028235E+38," +
-#else
-                "-3.40282347E+38," +
-                "3.40282347E+38," +
-#endif
                 "\"INF\"," +
                 "\"-INF\"," +
                 "\"NaN\"" +

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonInstanceAnnotationWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonInstanceAnnotationWriterAsyncTests.cs
@@ -414,11 +414,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 MessageStream = this.stream,
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
                 Encoding = Encoding.GetEncoding(0),
-#else
-                Encoding = Encoding.Default,
-#endif
                 IsResponse = writingResponse,
                 IsAsync = isAsync,
                 Model = model,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncBaseTests.cs
@@ -1,13 +1,17 @@
-﻿using System;
+﻿//---------------------------------------------------------------------
+// <copyright file="JsonWriterAsyncBaseTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Json;
 using Xunit;
-#if NETCOREAPP
-using System.Text.Json;
-#endif
 
 namespace Microsoft.OData.Tests.Json
 {
@@ -230,7 +234,6 @@ namespace Microsoft.OData.Tests.Json
             }
         }
 
-#if NETCOREAPP
         [Fact(Skip ="This test fails intermittently on the release pipeline but works on the build pipeline and locally. Needs investigation.")]
         public async Task WritesJsonElementCorrectly()
         {
@@ -293,7 +296,6 @@ namespace Microsoft.OData.Tests.Json
                 }
             }
         }
-#endif
 
         [Fact]
         public async Task WritesLargeByteArraysCorrectly()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/JsonWriterBaseTests.cs
@@ -1,15 +1,16 @@
-﻿using Microsoft.OData.Edm;
-using Microsoft.OData.Json;
+﻿//---------------------------------------------------------------------
+// <copyright file="JsonWriterBaseTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
 using System;
 using System.IO;
 using System.Text;
-using Xunit;
-using System.Net.Mime;
-
-#if NETCOREAPP
 using System.Text.Json;
-using System.Buffers.Text;
-#endif
+using Microsoft.OData.Edm;
+using Microsoft.OData.Json;
+using Xunit;
 
 namespace Microsoft.OData.Tests.Json
 {
@@ -232,7 +233,6 @@ namespace Microsoft.OData.Tests.Json
             }
         }
 
-#if NETCOREAPP
         public void WritesJsonElementCorrectly()
         {
             using (JsonDocument jsonDoc = JsonDocument.Parse(MixedObjectJson))
@@ -293,7 +293,6 @@ namespace Microsoft.OData.Tests.Json
                 }
             }
         }
-#endif
 
         [Fact]
         public void WritesLargeByteArraysCorrectly()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriter.cs
@@ -5,15 +5,12 @@
 //---------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
+using System.IO;
+using System.Text.Json;
 using Microsoft.OData.Json;
 using Microsoft.OData.Edm;
 using Xunit;
-using System.Threading.Tasks;
-using System.IO;
-
-#if NETCOREAPP
-using System.Text.Json;
-#endif
 
 namespace Microsoft.OData.Tests.Json
 {
@@ -87,9 +84,7 @@ namespace Microsoft.OData.Tests.Json
             this.WriteValueVerifier(Convert.ToBase64String(value));
         }
 
-#if NETCOREAPP
-        public void WriteValue(System.Text.Json.JsonElement value) => throw new NotImplementedException();
-#endif
+        public void WriteValue(JsonElement value) => throw new NotImplementedException();
 
         public void WriteRawValue(string rawValue)
         {
@@ -171,9 +166,7 @@ namespace Microsoft.OData.Tests.Json
 
         public Task FlushAsync() => throw new NotImplementedException();
 
-#if NETCOREAPP
         public Task WriteValueAsync(JsonElement value) => throw new NotImplementedException();
-#endif
 
         public Stream StartStreamValueScope() => throw new NotImplementedException();
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriterFactoryWrapper.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/MockJsonWriterFactoryWrapper.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.IO;
 using System.Text;
@@ -57,4 +56,3 @@ namespace Microsoft.OData.Tests.Json
         public int NumCalls { get; private set; }
     }
 }
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataAnnotationNamesTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataAnnotationNamesTests.cs
@@ -17,15 +17,10 @@ namespace Microsoft.OData.Tests.Json
     {
         private static readonly string[] ReservedODataAnnotationNames =
             typeof(ODataAnnotationNames)
-#if NETCOREAPP1_1
-            .GetFields()
-#else
             .GetFields(BindingFlags.NonPublic | BindingFlags.Static)
-#endif
             .Where(f => f.FieldType == typeof(string))
             .Select(f => (string)f.GetValue(null)).ToArray();
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1&& !NETCOREAPP3_1
         // Not applicable to .NET Core due to changes in framework
         [Fact]
         public void ReservedODataAnnotationNamesHashSetShouldContainAllODataAnnotationNamesSpecialToODataLib()
@@ -39,7 +34,6 @@ namespace Microsoft.OData.Tests.Json
                 Assert.DoesNotContain(annotationName.ToUpperInvariant(), ODataAnnotationNames.KnownODataAnnotationNames);
             }
         }
-#endif
 
         [Fact]
         public void IsODataAnnotationNameShouldReturnTrueForAnnotationNamesUnderODataNamespace()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchReaderTests.cs
@@ -1214,11 +1214,7 @@ namespace Microsoft.OData.Core.Tests.Json
             var messageInfo = new ODataMessageInfo
             {
                 MediaType = this.mediaType,
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = isResponse,
                 IsAsync = isAsync,
                 Model = this.model

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonBatchWriterTests.cs
@@ -108,11 +108,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -145,11 +141,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -183,11 +175,8 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage1 = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
+
                     await using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#else
-                    using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#endif
                     {
                         var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -201,11 +190,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage2 = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Orders"), "2", BatchPayloadUriOption.AbsoluteUri, dependsOnIds);
 
-#if NETCOREAPP
                     await using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#else
-                    using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#endif
                     {
                         var jsonWriter = await messageWriter2.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -244,11 +229,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage1 = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#else
-                    using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#endif
                     {
                         var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -262,11 +243,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage2 = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Orders"), "2", BatchPayloadUriOption.AbsoluteUri, dependsOnIds);
 
-#if NETCOREAPP
                     await using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#else
-                    using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#endif
                     {
                         var jsonWriter = await messageWriter2.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -309,11 +286,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -349,11 +322,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), /*contentId*/ null);
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -385,11 +354,7 @@ namespace Microsoft.OData.Core.Tests.Json
 
                     var operationResponseMessage = await jsonBatchWriter.CreateOperationResponseMessageAsync("1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationResponseMessage, this.settings, this.model))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationResponseMessage, this.settings, this.model))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -421,11 +386,7 @@ namespace Microsoft.OData.Core.Tests.Json
 
                     var operationResponseMessage = await jsonBatchWriter.CreateOperationResponseMessageAsync("1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationResponseMessage, this.settings, this.model))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationResponseMessage, this.settings, this.model))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -497,7 +458,6 @@ namespace Microsoft.OData.Core.Tests.Json
                 result);
         }
 
-#if NETCOREAPP
         [Fact]
         public async Task WriteBatchResponseAsync_WithStreamCopy_UsingODataUtf8JsonWriter()
         {
@@ -552,7 +512,6 @@ namespace Microsoft.OData.Core.Tests.Json
                 "]}",
                 result);
         }
-#endif
 
         [Fact]
         public async Task WriteBatchRequestWithAbsoluteUriUsingHostHeaderAsync()
@@ -565,11 +524,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/odata/Customers"), "1", BatchPayloadUriOption.AbsoluteUriUsingHostHeader);
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -603,11 +558,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri("/odata/Customers", UriKind.Relative), "1", BatchPayloadUriOption.RelativeUri);
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -801,11 +752,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -833,11 +780,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     var operationRequestMessage = await jsonBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionDeserializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionDeserializerTests.cs
@@ -498,11 +498,7 @@ namespace Microsoft.OData.Tests.Json
             var messageInfo = new ODataMessageInfo
             {
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = isResponse,
                 IsAsync = isAsync,
                 Model = new EdmModel()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionReaderTests.cs
@@ -128,11 +128,7 @@ namespace Microsoft.OData.Tests.Json
             var messageInfo = new ODataMessageInfo
             {
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = isResponse,
                 IsAsync = isAsync,
                 Model = this.model

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonCollectionSerializerTests.cs
@@ -209,11 +209,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 MessageStream = this.stream,
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = writingResponse,
                 IsAsync = isAsync,
                 Model = model,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonContextUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonContextUriParserTests.cs
@@ -23,11 +23,7 @@ namespace Microsoft.OData.Tests.Json
             model.AddElement(edmEntityType);
             EdmEntityContainer container = new EdmEntityContainer("NS", "EntityContainer");
             model.AddElement(container);
-#if NETCOREAPP2_0
-            container.AddEntitySet("people", edmEntityType);
-#else
-             container.AddEntitySet("People", edmEntityType);
-#endif
+            container.AddEntitySet("People", edmEntityType);
             return model;
         }
 
@@ -56,16 +52,6 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal(new Uri("https://www.example.com/api/$metadata#People"), parsedContextUrl.ContextUri);
         }
 
-
-#if NETCOREAPP2_0
-        [Fact]
-        public void ParseContextUrlWithEscapedSpecailMeaningCharactersShouldSucceed()
-        {
-            string urlWithUnescapedSpecialMeaningCharacters = "https://www.example.com/api/$metadata#people('i%3A0%23.f%7Cmembership%7Cexample%40example.org')/Dogs";
-            Action parseContextUri = () => ODataJsonContextUriParser.Parse(GetModel(), urlWithUnescapedSpecialMeaningCharacters, ODataPayloadKind.Unsupported, null, true);
-            parseContextUri.DoesNotThrow();
-        }
-#else
         [Fact]
         public void ParseContextUrlWithEscapedSpecailMeaningCharactersShouldSucceed()
         {
@@ -73,6 +59,5 @@ namespace Microsoft.OData.Tests.Json
             Action parseContextUri = () => ODataJsonContextUriParser.Parse(GetModel(), urlWithUnescapedSpecialMeaningCharacters, ODataPayloadKind.Unsupported, null, true);
             parseContextUri.DoesNotThrow();
         }
-#endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeltaReaderTests.cs
@@ -4554,11 +4554,7 @@ namespace Microsoft.OData.Tests.Json
             var messageInfo = new ODataMessageInfo
             {
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = isResponse,
                 IsAsync = isAsync,
                 Model = this.Model,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntityReferenceLinkSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntityReferenceLinkSerializerTests.cs
@@ -171,11 +171,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 MessageStream = this.stream,
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = writingResponse,
                 IsAsync = isAsync,
                 Model = this.model,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextApiTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextApiTests.cs
@@ -89,11 +89,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceSetWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -182,12 +178,7 @@ namespace Microsoft.OData.Tests.Json
             var orderItemResource = CreateOrderItemResource();
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -266,11 +257,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.superEntitySet, this.superEntityType);
 
@@ -507,11 +494,7 @@ namespace Microsoft.OData.Tests.Json
         {
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -553,11 +536,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -609,11 +588,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -663,11 +638,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync();
 
@@ -730,11 +701,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -792,11 +759,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -855,11 +818,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -924,11 +883,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -999,11 +954,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -1066,11 +1017,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataCollectionWriterAsync(EdmCoreModel.Instance.GetString(false));
 
@@ -1117,11 +1064,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings, this.model))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings, this.model))
-#endif
             {
                 var parameterWriter = await messageWriter.CreateODataParameterWriterAsync(rateCustomerAction);
 
@@ -1163,11 +1106,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings, this.model))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings, this.model))
-#endif
             {
                 var parameterWriter = await messageWriter.CreateODataUriParameterResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -1208,11 +1147,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings, this.model))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings, this.model))
-#endif
             {
                 var parameterWriter = await messageWriter.CreateODataUriParameterResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -1257,11 +1192,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -1324,11 +1255,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -1382,11 +1309,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -1438,11 +1361,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -1493,11 +1412,7 @@ namespace Microsoft.OData.Tests.Json
             var deltaDeletedLink = new ODataDeltaDeletedLink(new Uri($"{ServiceUri}/Orders(2)"), new Uri($"{ServiceUri}/Customers(2)"), "Customer");
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -1564,11 +1479,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -1685,11 +1596,7 @@ namespace Microsoft.OData.Tests.Json
         {
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.streamEntitySet, this.streamEntityType);
 
@@ -1741,11 +1648,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceWriterAsync(this.streamEntitySet, this.streamEntityType);
 
@@ -1802,11 +1705,7 @@ namespace Microsoft.OData.Tests.Json
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var batchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await batchWriter.WriteStartBatchAsync();
@@ -1814,11 +1713,7 @@ namespace Microsoft.OData.Tests.Json
                 var operationRequestMessage = await batchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                 {
                     var writer = await nestedMessageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -1884,11 +1779,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var batchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await batchWriter.WriteStartBatchAsync();
@@ -1897,11 +1788,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage = await batchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                 {
                     var writer = await nestedMessageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -1978,11 +1865,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var batchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await batchWriter.WriteStartBatchAsync();
@@ -1991,11 +1874,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage1 = await batchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#else
-                using (var nestedMessageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#endif
                 {
                     var writer = await nestedMessageWriter1.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2008,11 +1887,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage2 = await batchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Orders"), "2", BatchPayloadUriOption.AbsoluteUri, dependsOnIds);
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#else
-                using (var nestedMessageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#endif
                 {
                     var writer = await nestedMessageWriter2.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -2115,22 +1990,14 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var batchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await batchWriter.WriteStartBatchAsync();
 
                 var operationResponseMessage = await batchWriter.CreateOperationResponseMessageAsync("1");
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationResponseMessage, nestedWriterSettings))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationResponseMessage, nestedWriterSettings))
-#endif
                 {
                     var writer = await nestedMessageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2199,11 +2066,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var batchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await batchWriter.WriteStartBatchAsync();
@@ -2211,11 +2074,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
                 var operationResponseMessage = await batchWriter.CreateOperationResponseMessageAsync("1");
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationResponseMessage, nestedWriterSettings))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationResponseMessage, nestedWriterSettings))
-#endif
                 {
                     var writer = await nestedMessageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2288,11 +2147,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var batchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await batchWriter.WriteStartBatchAsync();
@@ -2300,11 +2155,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage = await batchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/odata/Customers"), "1", BatchPayloadUriOption.AbsoluteUriUsingHostHeader);
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                 {
                     var writer = await nestedMessageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2371,11 +2222,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var batchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await batchWriter.WriteStartBatchAsync();
@@ -2383,11 +2230,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage = await batchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri("/odata/Customers", UriKind.Relative), "1", BatchPayloadUriOption.RelativeUri);
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                 {
                     var writer = await nestedMessageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2453,11 +2296,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var batchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await batchWriter.WriteStartBatchAsync();
@@ -2522,11 +2361,7 @@ POST http://tempuri.org/Customers HTTP/1.1
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 await messageWriter.WriteServiceDocumentAsync(serviceDocument);
             }
@@ -2587,11 +2422,7 @@ POST http://tempuri.org/Customers HTTP/1.1
             this.writerSettings.LibraryCompatibility |= libraryCompatibility;
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 await messageWriter.CreateODataResourceWriterAsync();
                 await messageWriter.WriteErrorAsync(nullReferenceError, includeDebugInformation: true);
@@ -2636,11 +2467,7 @@ POST http://tempuri.org/Customers HTTP/1.1
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 await messageWriter.WritePropertyAsync(new ODataProperty { Name = "Count", Value = 5 });
             }
@@ -2674,11 +2501,7 @@ POST http://tempuri.org/Customers HTTP/1.1
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2716,11 +2539,7 @@ POST http://tempuri.org/Customers HTTP/1.1
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2760,11 +2579,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2800,11 +2615,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2839,11 +2650,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2880,11 +2687,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2925,11 +2728,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -2966,11 +2765,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -3009,11 +2804,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync();
 
@@ -3062,11 +2853,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync();
 
@@ -3107,11 +2894,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -3146,11 +2929,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -3186,11 +2965,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -3230,11 +3005,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -3273,11 +3044,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -3319,11 +3086,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -3372,11 +3135,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataDeltaResourceSetWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -3420,11 +3179,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceSetWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -3463,11 +3218,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 async () =>
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceSetWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -3506,11 +3257,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -3553,11 +3300,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -3601,11 +3344,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataResourceWriterAsync();
 
@@ -3655,11 +3394,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 async () =>
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -3698,11 +3433,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -3739,11 +3470,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -3782,11 +3509,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -3821,11 +3544,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -3862,11 +3581,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -3905,11 +3620,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -3944,11 +3655,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -3985,11 +3692,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4032,11 +3735,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4045,11 +3744,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                         var operationRequestMessage = await writer.CreateOperationRequestMessageAsync(
                             "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                         await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                        using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                         {
                             var nestedWriter = await nestedMessageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -4101,11 +3796,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4114,11 +3805,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                         var operationRequestMessage = await writer.CreateOperationRequestMessageAsync(
                             "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                         await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                        using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                         {
                             var nestedWriter = await nestedMessageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -4164,11 +3851,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4211,11 +3894,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4254,11 +3933,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4301,11 +3976,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4350,11 +4021,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4397,11 +4064,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4446,11 +4109,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 
@@ -4495,11 +4154,7 @@ POST http://tempuri.org/Customers HTTP/1.1
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var writer = await messageWriter.CreateODataBatchWriterAsync();
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonOutputContextTests.cs
@@ -438,11 +438,7 @@ namespace Microsoft.OData.Tests.Json
                     var operationRequestMessage = await batchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Orders"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var resourceWriter = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                         var orderResource = CreateOrderResource();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonParameterReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonParameterReaderTests.cs
@@ -1770,11 +1770,7 @@ namespace Microsoft.OData.Tests.Json
             var messageInfo = new ODataMessageInfo
             {
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = isResponse,
                 IsAsync = isAsync,
                 Model = this.model

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonPropertySerializerAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonPropertySerializerAsyncTests.cs
@@ -273,7 +273,6 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal("{\"@odata.context\":\"http://tempuri.org/$metadata#Edm.Int32\",\"value\":13}", result);
         }
 
-#if NETCOREAPP
         [Fact]
         public async Task WritingJsonElementPropertiesAsync_ShouldSerializeJsonInput()
         {
@@ -334,7 +333,6 @@ namespace Microsoft.OData.Tests.Json
 
             Assert.Equal("{\"JsonProp\":{\"foo\":\"bar\"}}", result);
         }
-#endif
 
         private async Task<string> SetupSerializerAndRunTestAsync(Func<ODataJsonPropertySerializer, Task> func, Action<IServiceCollection> configureServices = null)
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonPropertySerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonPropertySerializerTests.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Text;
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Core.Tests.DependencyInjection;
 using Microsoft.OData.Edm;
@@ -18,10 +19,6 @@ using Microsoft.OData.Edm.Vocabularies.V1;
 using Microsoft.OData.Json;
 using Microsoft.Spatial;
 using Xunit;
-
-#if NETCOREAPP
-using System.Text.Json;
-#endif
 
 namespace Microsoft.OData.Tests.Json
 {
@@ -583,7 +580,6 @@ namespace Microsoft.OData.Tests.Json
                 result);
         }
 
-#if NETCOREAPP
         [Fact]
         public void WritingJsonElementProperties_ShouldSerializeJsonInput()
         {
@@ -620,7 +616,6 @@ namespace Microsoft.OData.Tests.Json
             var result = SerializeProperty(null, property, configureServices);
             Assert.Equal("{\"JsonProp\":{\"foo\":\"bar\"}}", result);
         }
-#endif
 
         /// <summary>
         /// Serialize the given property as a non-top-level property in Json.

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonReaderTests.cs
@@ -2179,11 +2179,7 @@ namespace Microsoft.OData.Tests.Json
             var messageInfo = new ODataMessageInfo
             {
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = isResponse,
                 IsAsync = isAsync,
                 Model = this.model

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonSerializerTests.cs
@@ -476,11 +476,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 MessageStream = stream,
                 MediaType = mediaType,
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = true,
                 IsAsync = isAsync,
                 Model = mainModel,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerAsyncTests.cs
@@ -511,11 +511,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 MessageStream = this.stream,
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = writingResponse,
                 IsAsync = isAsync,
                 Model = this.model,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonValueSerializerTests.cs
@@ -336,7 +336,6 @@ namespace Microsoft.OData.Tests.Json
             Assert.Equal(leaveOpen, !stream.Disposed);
         }
 
-#if NETCOREAPP
         [Fact]
         public void WriteStreamValue_UsingODataUtf8JsonWriter_WritesStreamValue()
         {
@@ -362,7 +361,6 @@ namespace Microsoft.OData.Tests.Json
 
             Assert.Equal("\"CjEyMzQ1Njc4OTA=\"", result);
         }
-#endif
 
         private ODataJsonValueSerializer CreateODataJsonValueSerializer(bool writingResponse, IServiceProvider serviceProvider = null)
         {
@@ -370,11 +368,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 MessageStream = stream,
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = writingResponse,
                 IsAsync = false,
                 Model = model,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterTests.cs
@@ -18,9 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Core.Tests.DependencyInjection;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
-#if NETCOREAPP
 using Microsoft.OData.Json;
-#endif
 using Microsoft.OData.UriParser;
 using Microsoft.OData.Tests;
 using Xunit;
@@ -1233,11 +1231,7 @@ namespace Microsoft.OData.Core.Tests.Json
                     await jsonWriter.WriteStartAsync(addressResource);
                     await jsonWriter.WriteStartAsync(streamProperty);
 
-#if NETCOREAPP
                     await using (var stream = await jsonWriter.CreateBinaryWriteStreamAsync())
-#else
-                    using (var stream = await jsonWriter.CreateBinaryWriteStreamAsync())
-#endif
                     {
                         var bytes = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 0 };
 
@@ -1263,7 +1257,6 @@ namespace Microsoft.OData.Core.Tests.Json
                 result);
         }
 
-#if NETCOREAPP
         [Fact]
         public async Task WriteBinaryValueToStream_WithODataUtf8JsonWriter_Async()
         {
@@ -1360,8 +1353,6 @@ namespace Microsoft.OData.Core.Tests.Json
                 "\"Pangram\":\"The quick brown fox jumps over the lazy dog\"}",
                 result);
         }
-
-#endif
 
         [Fact]
         public async Task WriteRequestPayloadAsync()
@@ -2433,11 +2424,7 @@ namespace Microsoft.OData.Core.Tests.Json
             {
                 MessageStream = messageStream,
                 MediaType = new ODataMediaType("application", "json"),
-#if NETCOREAPP1_1
-                Encoding = Encoding.GetEncoding(0),
-#else
                 Encoding = Encoding.Default,
-#endif
                 IsResponse = !writingRequest,
                 IsAsync = isAsync,
                 Model = this.model,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonTextWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonTextWriterTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using static Microsoft.OData.Json.ODataUtf8JsonWriter;
 using Xunit;
@@ -21,4 +20,3 @@ namespace Microsoft.OData.Core.Tests.Json
         }
     }
 }
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -850,5 +849,3 @@ namespace Microsoft.OData.Tests.Json
         }
     }
 }
-
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterFactoryAsyncTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterFactoryAsyncTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -148,4 +147,3 @@ namespace Microsoft.OData.Tests.Json
         }
     }
 }
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterFactoryTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterFactoryTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -147,4 +146,3 @@ namespace Microsoft.OData.Tests.Json
         }
     }
 }
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterStreamTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using static Microsoft.OData.Json.ODataUtf8JsonWriter;
 using Xunit;
@@ -79,4 +78,3 @@ namespace Microsoft.OData.Core.Tests.Json
         }
     }
 }
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -910,5 +909,3 @@ namespace Microsoft.OData.Tests.Json
         }
     }
 }
-
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/PooledByteBufferWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/PooledByteBufferWriterTests.cs
@@ -4,16 +4,7 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
-
 using System;
-using System.Buffers;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net.NetworkInformation;
-using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.OData.Json;
 using Xunit;
 
@@ -224,5 +215,3 @@ namespace Microsoft.OData.Tests.Json
         }
     }
 }
-
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/TranscodingWriteStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/TranscodingWriteStreamTests.cs
@@ -4,7 +4,6 @@
 // </copyright>
 //---------------------------------------------------------------------
 
-#if NETCOREAPP
 using System;
 using System.IO;
 using System.Linq;
@@ -116,4 +115,3 @@ namespace Microsoft.OData.Tests.Json
         }
     }
 }
-#endif

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataAsynchronousReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataAsynchronousReaderTests.cs
@@ -122,11 +122,7 @@ namespace Microsoft.OData.Tests
 
         private ODataAsynchronousReader CreateAsyncReader(string payload)
         {
-#if NETCOREAPP1_1
-            responseStream = new MemoryStream(Encoding.GetEncoding(0).GetBytes(payload));
-#else
             responseStream = new MemoryStream(Encoding.Default.GetBytes(payload));
-#endif
 
             responseMessage = new InMemoryMessage { Stream = responseStream };
             responseMessage.SetHeader("Content-Type", "application/http");

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderSettingsTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.OData.Tests
             copyOfSettings = settings.Clone();
             this.CompareMessageReaderSettings(settings, copyOfSettings);
         }
-#if NETCOREAPP
+
         [Fact]
         public void ODataMessageReaderSettingsErrorTest()
         {
@@ -210,33 +210,7 @@ namespace Microsoft.OData.Tests
             test = () => new ODataMessageReaderSettings() { MessageQuotas = new ODataMessageQuotas() { MaxReceivedMessageSize = 0 } };
             test.Throws<ArgumentOutOfRangeException>(Strings.ExceptionUtils_CheckLongPositive("0") + " (Parameter 'MaxReceivedMessageSize')");
         }
-#else
-        [Fact]
-        public void ODataMessageReaderSettingsErrorTest()
-        {
-            // MaxPartsPerBatch
-            Action test = () => new ODataMessageReaderSettings() { MessageQuotas = new ODataMessageQuotas() { MaxPartsPerBatch = -1 } };
-            test.Throws<ArgumentOutOfRangeException>(Strings.ExceptionUtils_CheckIntegerNotNegative("-1") + "\r\nParameter name: MaxPartsPerBatch");
 
-            // MaxOperationsPerChangeset
-            test = () => new ODataMessageReaderSettings() { MessageQuotas = new ODataMessageQuotas() { MaxOperationsPerChangeset = -1 } };
-            test.Throws<ArgumentOutOfRangeException>(Strings.ExceptionUtils_CheckIntegerNotNegative("-1") + "\r\nParameter name: MaxOperationsPerChangeset");
-
-            // MaxNestingDepth
-            test = () => new ODataMessageReaderSettings() { MessageQuotas = new ODataMessageQuotas() { MaxNestingDepth = -1 } };
-            test.Throws<ArgumentOutOfRangeException>(Strings.ExceptionUtils_CheckIntegerPositive("-1") + "\r\nParameter name: MaxNestingDepth");
-
-            test = () => new ODataMessageReaderSettings() { MessageQuotas = new ODataMessageQuotas() { MaxNestingDepth = 0 } };
-            test.Throws<ArgumentOutOfRangeException>(Strings.ExceptionUtils_CheckIntegerPositive("0") + "\r\nParameter name: MaxNestingDepth");
-
-            // MaxMessageSize
-            test = () => new ODataMessageReaderSettings() { MessageQuotas = new ODataMessageQuotas() { MaxReceivedMessageSize = -1 } };
-            test.Throws<ArgumentOutOfRangeException>(Strings.ExceptionUtils_CheckLongPositive("-1") + "\r\nParameter name: MaxReceivedMessageSize");
-
-            test = () => new ODataMessageReaderSettings() { MessageQuotas = new ODataMessageQuotas() { MaxReceivedMessageSize = 0 } };
-            test.Throws<ArgumentOutOfRangeException>(Strings.ExceptionUtils_CheckLongPositive("0") + "\r\nParameter name: MaxReceivedMessageSize");
-        }
-#endif
         private void CompareMessageReaderSettings(ODataMessageReaderSettings expected, ODataMessageReaderSettings actual)
         {
             if (expected == null && actual == null)

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageReaderTests.cs
@@ -55,11 +55,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void ReadValueOfTypeDefinitionShouldWork()
         {
-#if NETCOREAPP1_1
-            Stream stream = new MemoryStream(Encoding.GetEncoding(0).GetBytes("123"));
-#else
             Stream stream = new MemoryStream(Encoding.Default.GetBytes("123"));
-#endif
             IODataResponseMessage responseMessage = new InMemoryMessage() { StatusCode = 200, Stream = stream };
             ODataMessageReader reader = new ODataMessageReader(responseMessage, new ODataMessageReaderSettings(), new EdmModel());
             var result = reader.ReadValue(new EdmTypeDefinitionReference(new EdmTypeDefinition("NS", "Length", EdmPrimitiveTypeKind.Int32), true));
@@ -69,11 +65,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void ReadValueOfDateShouldWork()
         {
-#if NETCOREAPP1_1
-            Stream stream = new MemoryStream(Encoding.GetEncoding(0).GetBytes("2014-01-03"));
-#else
             Stream stream = new MemoryStream(Encoding.Default.GetBytes("2014-01-03"));
-#endif
             IODataResponseMessage responseMessage = new InMemoryMessage() { StatusCode = 200, Stream = stream };
             ODataMessageReader reader = new ODataMessageReader(responseMessage, new ODataMessageReaderSettings(), new EdmModel());
             var result = reader.ReadValue(new EdmTypeDefinitionReference(new EdmTypeDefinition("NS", "DateValue", EdmPrimitiveTypeKind.Date), true));
@@ -83,11 +75,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void ReadValueOfAbbreviativeDateShouldWork()
         {
-#if NETCOREAPP1_1
-            Stream stream = new MemoryStream(Encoding.GetEncoding(0).GetBytes("2014-1-3"));
-#else
             Stream stream = new MemoryStream(Encoding.Default.GetBytes("2014-1-3"));
-#endif
             IODataResponseMessage responseMessage = new InMemoryMessage() { StatusCode = 200, Stream = stream };
             ODataMessageReader reader = new ODataMessageReader(responseMessage, new ODataMessageReaderSettings(), new EdmModel());
             var result = reader.ReadValue(new EdmTypeDefinitionReference(new EdmTypeDefinition("NS", "DateValue", EdmPrimitiveTypeKind.Date), true));
@@ -97,11 +85,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void ReadValueOfTimeOfDayShouldWork()
         {
-#if NETCOREAPP1_1
-            Stream stream = new MemoryStream(Encoding.GetEncoding(0).GetBytes("12:30:04.998"));
-#else
             Stream stream = new MemoryStream(Encoding.Default.GetBytes("12:30:04.998"));
-#endif
             IODataResponseMessage responseMessage = new InMemoryMessage() { StatusCode = 200, Stream = stream };
             ODataMessageReader reader = new ODataMessageReader(responseMessage, new ODataMessageReaderSettings(), new EdmModel());
             var result = reader.ReadValue(new EdmTypeDefinitionReference(new EdmTypeDefinition("NS", "TimeOfDayValue", EdmPrimitiveTypeKind.TimeOfDay), true));
@@ -112,11 +96,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void ReadValueOfAbbreviativeTimeOfDayShouldWork()
         {
-#if NETCOREAPP1_1
-            Stream stream = new MemoryStream(Encoding.GetEncoding(0).GetBytes("12:30:4.998"));
-#else
             Stream stream = new MemoryStream(Encoding.Default.GetBytes("12:30:4.998"));
-#endif
             IODataResponseMessage responseMessage = new InMemoryMessage() { StatusCode = 200, Stream = stream };
             ODataMessageReader reader = new ODataMessageReader(responseMessage, new ODataMessageReaderSettings(), new EdmModel());
             var result = reader.ReadValue(new EdmTypeDefinitionReference(new EdmTypeDefinition("NS", "TimeOfDayValue", EdmPrimitiveTypeKind.TimeOfDay), true));
@@ -259,7 +239,6 @@ namespace Microsoft.OData.Tests
             responseMessage.SetHeader("Content-Type", "application/json");
             ODataMessageReader reader = new ODataMessageReader(responseMessage, new ODataMessageReaderSettings(), new EdmModel());
 
-#if NETCOREAPP
             IEdmModel model = reader.ReadMetadataDocument();
 
             IEdmEntityType customerType = model.FindDeclaredType("NS.Customer") as IEdmEntityType;
@@ -276,12 +255,6 @@ namespace Microsoft.OData.Tests
             IEdmEntitySet customers = Assert.Single(model.EntityContainer.EntitySets());
             Assert.Equal("Customers", customers.Name);
             Assert.Same(customerType, customers.EntityType);
-#else
-            Action test = () => reader.ReadMetadataDocument();
-
-            ODataException exception = Assert.Throws<ODataException>(test);
-            Assert.Equal("The JSON metadata is not supported at this platform. It's only supported at platform implementing .NETStardard 2.0.", exception.Message);
-#endif
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -8,6 +8,7 @@ using System;
 using System.IO;
 using System.Text;
 using System.Threading.Tasks;
+using System.Text.Json;
 using System.Xml;
 using System.Xml.Linq;
 using Microsoft.Extensions.DependencyInjection;
@@ -17,10 +18,6 @@ using Microsoft.OData.Tests.Json;
 using Microsoft.OData.UriParser;
 using Microsoft.OData.Edm.Csdl;
 using Xunit;
-
-#if NETCOREAPP
-using System.Text.Json;
-#endif
 
 namespace Microsoft.OData.Tests
 {
@@ -194,7 +191,6 @@ namespace Microsoft.OData.Tests
             write.Throws<ODataException>("The value of type 'System.UInt16' could not be converted to a raw string.");
         }
 
-#if NETCOREAPP
         #region "ODataUtf8JsonWriter support"
         [Fact]
         public void SupportsODataUtf8JsonWriter()
@@ -349,9 +345,7 @@ namespace Microsoft.OData.Tests
         }
 
         #endregion "ODataUtf8JsonWriter support"
-#endif
 
-#if NETCOREAPP
         #region "ODataJsonElementValue support"
         [Fact]
         public void WriteEntityWithJsonElementValues()
@@ -700,7 +694,6 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
         #endregion
-#endif
 
         [Fact]
         public void WriteMetadataDocument_WorksForJsonCsdl()
@@ -710,7 +703,6 @@ namespace Microsoft.OData.Tests
 
             string contentType = "application/json";
 
-#if NETCOREAPP
             // Act
             string payload = this.WriteAndGetPayload(edmModel, contentType, omWriter =>
             {
@@ -741,18 +733,8 @@ namespace Microsoft.OData.Tests
     }
   }
 }", payload);
-#else
-            Action test = () => this.WriteAndGetPayload(edmModel, contentType, omWriter =>
-            {
-                omWriter.WriteMetadataDocument();
-            });
-
-            ODataException exception = Assert.Throws<ODataException>(test);
-            Assert.Equal("The JSON metadata is not supported at this platform. It's only supported at platform implementing .NETStardard 2.0.", exception.Message);
-#endif
         }
 
-#if NETCOREAPP
         [Fact]
         public async Task WriteMetadataDocumentAsync_WorksForJsonCsdl()
         {
@@ -925,7 +907,6 @@ namespace Microsoft.OData.Tests
                 Assert.Null(exception);
             }
         }
-#endif
 
         [Fact]
         public async Task WriteMetadataDocumentAsync_WorksForXmlCsdl()
@@ -1085,7 +1066,6 @@ namespace Microsoft.OData.Tests
         }
 
         #region "DisposeAsync"
-#if NETCOREAPP
 
         [Fact]
         public async Task DisposeAsync_Should_Dispose_Stream_Asynchronously()
@@ -1327,7 +1307,6 @@ namespace Microsoft.OData.Tests
                 "</Schema></edmx:DataServices></edmx:Edmx>", payload);
         }
 
-#endif
         #endregion
 
         private static IEdmModel _edmModel;
@@ -1632,11 +1611,7 @@ namespace Microsoft.OData.Tests
                 };
             }
 
-#if NETCOREAPP
             await using (var msgWriter = new ODataMessageWriter((IODataResponseMessageAsync)message, writerSettings, edmModel))
-#else
-            using (var msgWriter = new ODataMessageWriter((IODataResponseMessageAsync)message, writerSettings, edmModel))
-#endif
             {
                 await test(msgWriter);
             }
@@ -1653,11 +1628,7 @@ namespace Microsoft.OData.Tests
                 string contents = await reader.ReadToEndAsync();
 
                 // Dispose stream manually to avoid synchronous I/O
-#if NETCOREAPP
                 await message.Stream.DisposeAsync();
-#else
-                message.Stream.Dispose();
-#endif
                 return contents;
             }
         }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchOutputContextApiTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchOutputContextApiTests.cs
@@ -53,11 +53,7 @@ namespace Microsoft.OData.Tests
             var orderResource = CreateOrderResource();
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -65,11 +61,7 @@ namespace Microsoft.OData.Tests
                 var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Orders"), "1");
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                 {
                     var writer = await nestedMessageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                     await writer.WriteStartAsync(orderResource);
@@ -134,11 +126,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
             var customerResource = CreateCustomerResource();
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -147,11 +135,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage1 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Orders"), "1");
 
-#if NETCOREAPP
                 await using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#else
-                using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#endif
                 {
                     var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                     await jsonWriter.WriteStartAsync(orderResource);
@@ -162,11 +146,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage2 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Customers"), "2", BatchPayloadUriOption.AbsoluteUri, dependsOnIds);
 
-#if NETCOREAPP
                 await using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#else
-                using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#endif
                 {
                     var jsonWriter = await messageWriter2.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
                     await jsonWriter.WriteStartAsync(customerResource);
@@ -259,11 +239,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
             var customerResource = CreateCustomerResource();
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -272,11 +248,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage1 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                     "PUT", new Uri($"{ServiceUri}/Orders(1)"), "1");
 
-#if NETCOREAPP
                 await using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#else
-                using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#endif
                 {
                     var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                     await jsonWriter.WriteStartAsync(orderResource);
@@ -289,11 +261,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage2 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                     "PUT", new Uri($"{ServiceUri}/Customers(1)"), "2");
 
-#if NETCOREAPP
                 await using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#else
-                using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#endif
                 {
                     var jsonWriter = await messageWriter2.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
                     await jsonWriter.WriteStartAsync(customerResource);
@@ -394,11 +362,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -407,11 +371,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Orders"), "1");
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                 {
                     var jsonWriter = await nestedMessageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                     await jsonWriter.WriteStartAsync(orderResource);
@@ -487,11 +447,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
             var orderResource = CreateOrderResource();
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -499,11 +455,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Orders"), /*contentId*/ null);
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                 {
                     var jsonWriter = await nestedMessageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                     await jsonWriter.WriteStartAsync(orderResource);
@@ -567,11 +519,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -579,11 +527,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri($"{ServiceUri}/Orders"), /*contentId*/ null, BatchPayloadUriOption.AbsoluteUriUsingHostHeader);
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                 {
                     var jsonWriter = await nestedMessageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                     await jsonWriter.WriteStartAsync(orderResource);
@@ -648,11 +592,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
             var orderResource = CreateOrderResource();
 
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -660,11 +600,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                     "POST", new Uri("/Orders", UriKind.Relative), /*contentId*/ null, BatchPayloadUriOption.RelativeUri);
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                 {
                     var jsonWriter = await nestedMessageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                     await jsonWriter.WriteStartAsync(orderResource);
@@ -725,11 +661,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
         public async Task WriteMultipartMixedBatchRequest_APIsYieldSameResultForReportMessageCompleted()
         {
             IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -788,22 +720,14 @@ POST http://tempuri.org/Orders HTTP/1.1
             };
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
 
                 var operationResponseMessage = await multipartMixedBatchWriter.CreateOperationResponseMessageAsync("1");
                 operationResponseMessage.StatusCode = 200;
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(operationResponseMessage, nestedWriterSettings))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(operationResponseMessage, nestedWriterSettings))
-#endif
                 {
                     var jsonWriter = await nestedMessageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                     await jsonWriter.WriteStartAsync(orderResource);
@@ -872,11 +796,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
             };
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, this.writerSettings))
-#endif
             {
                 var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                 await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -885,11 +805,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationResponseMessage1 = await multipartMixedBatchWriter.CreateOperationResponseMessageAsync("1");
                 operationResponseMessage1.StatusCode = 200;
 
-#if NETCOREAPP
                 await using (var messageWriter1 = new ODataMessageWriter(operationResponseMessage1, nestedWriterSettings))
-#else
-                using (var messageWriter1 = new ODataMessageWriter(operationResponseMessage1, nestedWriterSettings))
-#endif
                 {
                     var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
                     await jsonWriter.WriteStartAsync(orderResource);
@@ -902,11 +818,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 var operationResponseMessage2 = await multipartMixedBatchWriter.CreateOperationResponseMessageAsync("2");
                 operationResponseMessage2.StatusCode = 200;
 
-#if NETCOREAPP
                 await using (var messageWriter2 = new ODataMessageWriter(operationResponseMessage2, nestedWriterSettings))
-#else
-                using (var messageWriter2 = new ODataMessageWriter(operationResponseMessage2, nestedWriterSettings))
-#endif
                 {
                     var jsonWriter = await messageWriter2.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
                     await jsonWriter.WriteStartAsync(customerResource);
@@ -1008,11 +920,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 async () =>
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                         await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -1051,11 +959,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 async () =>
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, writerSettings))
-#endif
                     {
                         var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                         await multipartMixedBatchWriter.WriteStartBatchAsync();
@@ -1103,11 +1007,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                 {
                     IODataRequestMessage asyncRequestMessage = new InMemoryMessage { Stream = this.asyncStream };
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(asyncRequestMessage, this.writerSettings))
-#endif
                     {
                         var multipartMixedBatchWriter = await messageWriter.CreateODataBatchWriterAsync();
                         await multipartMixedBatchWriter.WriteStartBatchAsync();

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchReaderTests.cs
@@ -460,7 +460,6 @@ OData-Version: 4.0
             Assert.Equal(expected, contents);
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public async Task ODataBatchReaderStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -507,30 +506,6 @@ OData-Version: 4.0
 
             Assert.Equal("StreamDisposedAsync", contents);
         }
-#else
-        [Fact]
-        public async Task ODataBatchReaderStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
-        {
-            var payload = @"
-
-{""@odata.type"":""NS.Customer"",""Id"":1,""Name"":""Sue""}
---batch_aed653ab--
-";
-            var stream = new MemoryStream();
-            using (Stream batchReaderStream = ODataBatchUtils.CreateBatchOperationReadStream(
-                CreateBatchReaderStream(payload),
-                this.batchOperationHeaders,
-                new MockODataStreamListener(new StreamWriter(stream)),
-                synchronous: false))
-            {
-            }
-
-            stream.Position = 0;
-            var contents = await new StreamReader(stream).ReadToEndAsync();
-
-            Assert.Equal("StreamDisposedAsync", contents);
-        }
-#endif
 
         #endregion BatchOperationReadStream
         #region BatchOperationWriteStream
@@ -576,7 +551,6 @@ OData-Version: 4.0
             Assert.Equal(expected, contents);
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public async Task ODataBatchWriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -611,24 +585,6 @@ OData-Version: 4.0
 
             Assert.Equal("StreamDisposedAsync", contents);
         }
-#else
-        [Fact]
-        public async Task ODataBatchWriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
-        {
-            var stream = new MemoryStream();
-            using (Stream batchWriteStream = ODataBatchUtils.CreateBatchOperationWriteStream(
-                new MemoryStream(),
-                new MockODataStreamListener(new StreamWriter(stream)),
-                synchronous: false))
-            {
-            }
-
-            stream.Position = 0;
-            var contents = await new StreamReader(stream).ReadToEndAsync();
-
-            Assert.Equal("StreamDisposedAsync", contents);
-        }
-#endif
 
         #endregion BatchOperationWriteStream
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataMultipartMixedBatchWriterTests.cs
@@ -79,11 +79,7 @@ POST http://tempuri.org/Orders HTTP/1.1
                     var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Orders"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -123,11 +119,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage1 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Orders"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#else
-                    using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#endif
                     {
                         var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -139,11 +131,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage2 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), "2");
 
-#if NETCOREAPP
                     await using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#else
-                    using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#endif
                     {
                         var jsonWriter = await messageWriter2.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -198,11 +186,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage1 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "PUT", new Uri($"{ServiceUri}/Orders(1)"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#else
-                    using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#endif
                     {
                         var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -217,11 +201,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage2 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "PUT", new Uri($"{ServiceUri}/Customers(1)"), "2");
 
-#if NETCOREAPP
                     await using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#else
-                    using (var messageWriter2 = new ODataMessageWriter(operationRequestMessage2))
-#endif
                     {
                         var jsonWriter = await messageWriter2.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -280,11 +260,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage1 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Customers"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#else
-                    using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage1))
-#endif
                     {
                         var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -298,11 +274,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage2 = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Orders"), "2", BatchPayloadUriOption.AbsoluteUri, dependsOnIds);
 
-#if NETCOREAPP
                     await using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage2))
-#else
-                    using (var messageWriter1 = new ODataMessageWriter(operationRequestMessage2))
-#endif
                     {
                         var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -357,11 +329,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Orders"), "1");
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -407,11 +375,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Orders"), /*contentId*/ null);
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -449,11 +413,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri($"{ServiceUri}/Orders"), /*contentId*/ null, BatchPayloadUriOption.AbsoluteUriUsingHostHeader);
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -494,11 +454,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationRequestMessage = await multipartMixedBatchWriter.CreateOperationRequestMessageAsync(
                         "POST", new Uri("/Orders", UriKind.Relative), /*contentId*/ null, BatchPayloadUriOption.RelativeUri);
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationRequestMessage))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -563,11 +519,7 @@ POST http://tempuri.org/Orders HTTP/1.1
                     var operationResponseMessage = await multipartMixedBatchWriter.CreateOperationResponseMessageAsync("1");
                     operationResponseMessage.StatusCode = 200;
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(operationResponseMessage, this.settings))
-#else
-                    using (var messageWriter = new ODataMessageWriter(operationResponseMessage, this.settings))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -607,11 +559,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationResponseMessage1 = await multipartMixedBatchWriter.CreateOperationResponseMessageAsync("1");
                     operationResponseMessage1.StatusCode = 200;
 
-#if NETCOREAPP
                     await using (var messageWriter1 = new ODataMessageWriter(operationResponseMessage1, this.settings))
-#else
-                    using (var messageWriter1 = new ODataMessageWriter(operationResponseMessage1, this.settings))
-#endif
                     {
                         var jsonWriter = await messageWriter1.CreateODataResourceWriterAsync(this.orderEntitySet, this.orderEntityType);
 
@@ -626,11 +574,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     var operationResponseMessage2 = await multipartMixedBatchWriter.CreateOperationResponseMessageAsync("2");
                     operationResponseMessage2.StatusCode = 200;
 
-#if NETCOREAPP
                     await using (var messageWriter2 = new ODataMessageWriter(operationResponseMessage2, this.settings))
-#else
-                    using (var messageWriter2 = new ODataMessageWriter(operationResponseMessage2, this.settings))
-#endif
                     {
                         var jsonWriter = await messageWriter2.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationReaderTests.cs
@@ -67,7 +67,6 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public async Task NotificationReaderDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -99,23 +98,6 @@ namespace Microsoft.OData.Tests
             // StreamDisposeAsync was written only once
             Assert.Equal("StreamDisposedAsync", result);
         }
-
-#else
-        [Fact]
-        public async Task NotificationReaderDisposeAsyncShouldInvokeStreamDisposedAsync()
-        {
-            using (var notificationReader = new ODataNotificationReader(
-                this.reader,
-                this.streamListener,
-                /*synchronous*/ false))
-            {
-            }
-
-            var result = await this.ReadStreamContentsAsync();
-
-            Assert.Equal("StreamDisposedAsync", result);
-        }
-#endif
 
         public void Dispose() // Fired after every test is ran
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationStreamTests.cs
@@ -64,7 +64,6 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETCOREAPP
         [Fact]
         public async Task NotificationStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -98,23 +97,6 @@ namespace Microsoft.OData.Tests
             // StreamDisposeAsync was written only once
             Assert.Equal("StreamDisposedAsync", result);
         }
-
-#else
-        [Fact]
-        public async Task NotificationStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
-        {
-            using (Stream notificationStream = new ODataNotificationStream(
-                this.stream,
-                this.streamListener,
-                /*synchronous*/ false))
-            {
-            }
-
-            var result = await this.ReadStreamContentsAsync();
-
-            Assert.Equal("StreamDisposedAsync", result);
-        }
-#endif
 
         private string ReadStreamContents()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNotificationWriterTests.cs
@@ -64,7 +64,6 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETCOREAPP
         [Fact]
         public async Task NotificationWriterDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -98,23 +97,6 @@ namespace Microsoft.OData.Tests
             // StreamDisposeAsync was written only once
             Assert.Equal("StreamDisposedAsync", result);
         }
-
-#else
-        [Fact]
-        public async Task NotificationWriterDisposeAsyncShouldInvokeStreamDisposedAsync()
-        {
-            using (TextWriter notificationWriter = new ODataNotificationWriter(
-                this.writer,
-                this.streamListener,
-                /*synchronous*/ false))
-            {
-            }
-
-            var result = await this.ReadStreamContentsAsync();
-
-            Assert.Equal("StreamDisposedAsync", result);
-        }
-#endif
 
         private string ReadStreamContents()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataPreferenceHeaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataPreferenceHeaderTests.cs
@@ -73,21 +73,13 @@ namespace Microsoft.OData.Tests
             Assert.Equal(ReturnRepresentationPreference, this.requestMessage.GetHeader(PreferHeaderName));
         }
 
-#if NETCOREAPP
         [Fact]
         public void SetAnnotationFilterToEmptyShouldThrow()
         {
             Action test = () => this.preferHeader.AnnotationFilter = "";
             test.Throws<ArgumentException>(Strings.ExceptionUtils_ArgumentStringEmpty + " (Parameter 'AnnotationFilter')");
         }
-#else
-        [Fact]
-        public void SetAnnotationFilterToEmptyShouldThrow()
-        {
-            Action test = () => this.preferHeader.AnnotationFilter = "";
-            test.Throws<ArgumentException>(Strings.ExceptionUtils_ArgumentStringEmpty + "\r\nParameter name: AnnotationFilter");
-        }
-#endif
+
         [Fact]
         public void SetAnnotationFilterToNullShouldNoOpIfODataAnnotationPreferenceIsMissing()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataRawOutputContextApiTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataRawOutputContextApiTests.cs
@@ -69,21 +69,13 @@ namespace Microsoft.OData.Tests
             };
 
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { StatusCode = 200, Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, writerSettings))
-#endif
             {
                 var asynchronousWriter = await messageWriter.CreateODataAsynchronousWriterAsync();
                 var responseMessage = await asynchronousWriter.CreateResponseMessageAsync();
                 responseMessage.StatusCode = 200;
 
-#if NETCOREAPP
                 await using (var nestedMessageWriter = new ODataMessageWriter(responseMessage, nestedWriterSettings, this.model))
-#else
-                using (var nestedMessageWriter = new ODataMessageWriter(responseMessage, nestedWriterSettings, this.model))
-#endif
                 {
                     var writer = await nestedMessageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
 
@@ -169,11 +161,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
         public async Task WriteValue_APIsShouldYieldSameResult(object value, string expected)
         {
             IODataResponseMessage asyncResponseMessage = new InMemoryMessage { StatusCode = 200, Stream = this.asyncStream };
-#if NETCOREAPP
             await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, writerSettings))
-#else
-            using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, writerSettings))
-#endif
             {
                 await messageWriter.WriteValueAsync(value);
             }
@@ -211,11 +199,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
             var asyncException = await Assert.ThrowsAsync<ODataException>(async () =>
             {
                 IODataResponseMessage asyncResponseMessage = new InMemoryMessage { StatusCode = 200, Stream = this.asyncStream };
-#if NETCOREAPP
                 await using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, writerSettings))
-#else
-                using (var messageWriter = new ODataMessageWriter(asyncResponseMessage, writerSettings))
-#endif
                 {
                     // Call to CreateODataAsynchronousWriterAsync triggers setting of output in-stream error listener
                     var asynchronousWriter = await messageWriter.CreateODataAsynchronousWriterAsync();
@@ -223,11 +207,7 @@ Content-Type: application/json;odata.metadata=minimal;odata.streaming=true;IEEE7
                     responseMessage.StatusCode = 200;
 
                     // Next section added is to demonstrate that what was already written is flushed to the buffer before exception is thrown
-#if NETCOREAPP
                     await using (var nestedMessageWriter = new ODataMessageWriter(responseMessage, nestedWriterSettings))
-#else
-                    using (var nestedMessageWriter = new ODataMessageWriter(responseMessage, nestedWriterSettings))
-#endif
                     {
                         var writer = await nestedMessageWriter.CreateODataResourceWriterAsync();
                     }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataRawOutputContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataRawOutputContextTests.cs
@@ -69,11 +69,7 @@ namespace Microsoft.OData.Tests
 
                     writerSettings.SetServiceDocumentUri(new Uri(ServiceUri));
 
-#if NETCOREAPP
                     await using (var messageWriter = new ODataMessageWriter(responseMessage, writerSettings, this.model))
-#else
-                    using (var messageWriter = new ODataMessageWriter(responseMessage, writerSettings, this.model))
-#endif
                     {
                         var jsonWriter = await messageWriter.CreateODataResourceWriterAsync(this.customerEntitySet, this.customerEntityType);
                         var customerResponse = new ODataResource

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
@@ -171,21 +171,13 @@ namespace Microsoft.OData.Tests
             this.odataEntry.InstanceAnnotations.Add(new ODataInstanceAnnotation("namespace.name", new ODataPrimitiveValue("value")));
             Assert.Single(this.odataEntry.InstanceAnnotations);
         }
-#if NETCOREAPP
+
         [Fact]
         public void SetNullValueToInstanceAnnotationsPropertyShouldThrow()
         {
             Action test = () => this.odataEntry.InstanceAnnotations = null;
             test.Throws<ArgumentNullException>("Value cannot be null. (Parameter 'value')");
         }
-#else
-        [Fact]
-        public void SetNullValueToInstanceAnnotationsPropertyShouldThrow()
-        {
-            Action test = () => this.odataEntry.InstanceAnnotations = null;
-            test.Throws<ArgumentNullException>("Value cannot be null.\r\nParameter name: value");
-        }
-#endif
 
         [Fact]
         public void SetListValueToInstanceAnnotationsPropertyShouldPass()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataValueUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataValueUtilsTests.cs
@@ -7,9 +7,7 @@
 using System;
 using Xunit;
 using System.IO;
-#if NETCOREAPP3_1_OR_GREATER
 using System.Text.Json;
-#endif
 
 namespace Microsoft.OData.Tests
 {
@@ -54,7 +52,6 @@ namespace Microsoft.OData.Tests
             Feature4 = 8,
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void ConvertsJsonElementToODataValue()
         {
@@ -74,6 +71,5 @@ namespace Microsoft.OData.Tests
 
             Assert.Equal(jsonString, output);
         }
-#endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriteStreamTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataWriteStreamTests.cs
@@ -67,7 +67,6 @@ namespace Microsoft.OData.Tests
             Assert.Equal(expected, result);
         }
 
-#if NETCOREAPP
         [Fact]
         public async Task WriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
         {
@@ -99,23 +98,6 @@ namespace Microsoft.OData.Tests
             // StreamDisposeAsync was written only once
             Assert.Equal("StreamDisposedAsync", result);
         }
-
-#else
-        [Fact]
-        public async Task WriteStreamDisposeAsyncShouldInvokeStreamDisposedAsync()
-        {
-            using (Stream writeStream = new ODataWriteStream(
-                new MemoryStream(),
-                this.streamListener,
-                /*synchronous*/ false))
-            {
-            }
-
-            var result = await this.ReadStreamContentsAsync();
-
-            Assert.Equal("StreamDisposedAsync", result);
-        }
-#endif
 
         private string ReadStreamContents()
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Query/ODataUriUtilsTests.cs
@@ -63,11 +63,7 @@ namespace Microsoft.OData.Tests.Query
         public void TestDecimalConvertFromUriLiteral(string value)
         {
             object dec = ODataUriUtils.ConvertFromUriLiteral(value, ODataVersion.V4);
-#if NETCOREAPP
             Assert.True(dec is double || dec is decimal);
-#else
-            Assert.True(dec is decimal);
-#endif
         }
 
         [Fact]
@@ -97,17 +93,9 @@ namespace Microsoft.OData.Tests.Query
         public void TestSingleConvertToUriLiteral()
         {
             string singleString = ODataUriUtils.ConvertToUriLiteral(float.MaxValue, ODataVersion.V4);
-#if NETCOREAPP
             Assert.Equal("3.4028235E+38", singleString);
-#else
-            Assert.Equal("3.40282347E+38", singleString);
-#endif 
             singleString = ODataUriUtils.ConvertToUriLiteral(float.MinValue, ODataVersion.V4);
-#if NETCOREAPP
             Assert.Equal("-3.4028235E+38", singleString);
-#else
-            Assert.Equal("-3.40282347E+38", singleString);
-#endif
             singleString = ODataUriUtils.ConvertToUriLiteral(1000000000000f, ODataVersion.V4);
             Assert.Equal("1E+12", singleString);
         }
@@ -119,11 +107,7 @@ namespace Microsoft.OData.Tests.Query
         public void TestSingleConvertFromUriLiteral(string value)
         {
             object singleNumber = ODataUriUtils.ConvertFromUriLiteral(value, ODataVersion.V4);
-#if NETCOREAPP
             Assert.True(singleNumber is float || singleNumber is double);
-#else
-            Assert.True(singleNumber is float);
-#endif
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/MetadataReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Reader/MetadataReaderTests.cs
@@ -208,11 +208,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Reader
                 string uriStr = uri.ToString();
                 if (map.ContainsKey(uriStr))
                 {
-#if NETCOREAPP1_1
-                    return XmlReader.Create(new StringReader(map[uriStr]));
-#else
                     return new XmlTextReader(new StringReader(map[uriStr]));
-#endif
                 }
 
                 return null;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/AsyncBatchRoundtripJsonTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/AsyncBatchRoundtripJsonTests.cs
@@ -1030,11 +1030,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
         {
             var requestPayload = this.ClientWriteAsyncBatchRequest(BatchPayloadUriOption.AbsoluteUriUsingHostHeader, batchContentTypeMultipartMixed);
 
-#if NETCOREAPP1_1
-            var payloadString = System.Text.Encoding.GetEncoding(0).GetString(requestPayload);
-#else
             var payloadString = System.Text.Encoding.Default.GetString(requestPayload);
-#endif
             Assert.True(payloadString.Contains("GET /Customers('ALFKI') HTTP/1.1") &&
                 payloadString.Contains("POST /Customers HTTP/1.1") &&
                 payloadString.Contains("PATCH /Customers('ALFKI') HTTP/1.1") &&
@@ -1049,11 +1045,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
         {
             var requestPayload = this.ClientWriteAsyncBatchRequest(BatchPayloadUriOption.RelativeUri, batchContentTypeMultipartMixed);
 
-#if NETCOREAPP1_1
-            var payloadString = System.Text.Encoding.GetEncoding(0).GetString(requestPayload);
-#else
             var payloadString = System.Text.Encoding.Default.GetString(requestPayload);
-#endif
             Assert.Contains("GET Customers('ALFKI') HTTP/1.1", payloadString);
             Assert.Contains("POST Customers HTTP/1.1", payloadString);
             Assert.Contains("PATCH Customers('ALFKI') HTTP/1.1", payloadString);
@@ -1071,11 +1063,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
             var requestPayload = this.ClientWriteAsyncBatchRequest(BatchPayloadUriOption.AbsoluteUriUsingHostHeader, batchContentTypeApplicationJson,
                 SkipBatchWriterStep.None, baseUri);
 
-#if NETCOREAPP1_1
-            var payloadString = System.Text.Encoding.GetEncoding(0).GetString(requestPayload);
-#else
             var payloadString = System.Text.Encoding.Default.GetString(requestPayload);
-#endif
 
             Assert.Contains("\"url\":\"/root/service/Customers('ALFKI')\"", payloadString);
             Assert.Contains("\"url\":\"/root/service/Customers\"", payloadString);
@@ -1093,11 +1081,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
             var requestPayload = this.ClientWriteAsyncBatchRequest(BatchPayloadUriOption.RelativeUri, batchContentTypeApplicationJson,
                 SkipBatchWriterStep.None, baseUri);
 
-#if NETCOREAPP1_1
-            var payloadString = System.Text.Encoding.GetEncoding(0).GetString(requestPayload);
-#else
             var payloadString = System.Text.Encoding.Default.GetString(requestPayload);
-#endif
 
             Assert.Contains("\"url\":\"Customers('ALFKI')\"", payloadString);
             Assert.Contains("\"url\":\"Customers\"", payloadString);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/MetadataUriRoundTripTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/MetadataUriRoundTripTests.cs
@@ -32,7 +32,6 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
             this.organizationsSet = this.defaultContainer.FindEntitySet("Organizations");
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
         [Fact]
         public void EntryMetadataUrlRoundTrip()
         {
@@ -66,6 +65,5 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
             Assert.True(organizationReader.Read());
             Assert.IsType<ODataResource>(organizationReader.Item);
         }
-#endif
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/PrimitiveValuesRoundtripJsonTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/PrimitiveValuesRoundtripJsonTests.cs
@@ -523,11 +523,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
             string payload = reader.ReadToEnd();
             Assert.Equal("{\"@odata.context\":\"http://host/service/$metadata#People/$entity\",\"ID\":\"18446744073709551615\",\"Name\":\"Foo\",\"FavoriteNumber\":250.0,\"Age\":123,\"Guid\":-9223372036854775808,\"Weight\":123.45,\"Money\":79228162514264337593543950335}", payload);
 
-#if NETCOREAPP1_1
-            stream = new MemoryStream(Encoding.GetEncoding(0).GetBytes(payload));
-#else
             stream = new MemoryStream(Encoding.Default.GetBytes(payload));
-#endif
             message = new InMemoryMessage { Stream = stream };
             message.StatusCode = 200;
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/SingletonBatchRoundtripJsonTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/SingletonBatchRoundtripJsonTests.cs
@@ -997,7 +997,6 @@ Content-Type: application/json;odata.metadata=none
             BatchJsonTestUsingBatchFormat(BatchFormat.ApplicationJson, 0);
         }
 
-#if NETCOREAPP3_1_OR_GREATER
         [Fact]
         public void BatchJsonTestUsingMultipartMixed_WithODataUtf8JsonWriter()
         {
@@ -1019,7 +1018,6 @@ Content-Type: application/json;odata.metadata=none
 
             BatchJsonTestUsingBatchFormat(BatchFormat.ApplicationJson, 0, configure);
         }
-#endif
 
         [Fact]
         public void BatchJsonTestChangesetsFollowedByQueryUsingMultipartMixed()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/JsonReaderWriterInjectionTests.cs
@@ -9,9 +9,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-#if NETCOREAPP
 using System.Text.Json;
-#endif
 using System.Threading.Tasks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OData.Core.Tests.DependencyInjection;
@@ -462,9 +460,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
 
             public void WriteValue(TimeOfDay value) => throw new NotImplementedException();
 
-#if NETCOREAPP
             public void WriteValue(System.Text.Json.JsonElement value) => throw new NotImplementedException();
-#endif
 
             public void WriteRawValue(string rawValue) => throw new NotImplementedException();
 
@@ -548,9 +544,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip
                 return this.textWriter.FlushAsync();
             }
 
-#if NETCOREAPP
             public Task WriteValueAsync(JsonElement value) => throw new NotImplementedException();
-#endif
 
             public Stream StartStreamValueScope() => throw new NotImplementedException();
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ExpressionLexerTests.cs
@@ -634,7 +634,6 @@ namespace Microsoft.OData.Tests.UriParser
             EdmValidNamesNotAllowedInUri("_some_name");
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
         [Fact]
         public void EdmValidNamesNotAllowedInUri_Combinations()
         {
@@ -680,7 +679,6 @@ namespace Microsoft.OData.Tests.UriParser
                 EdmValidNamesNotAllowedInUri(propertyNameSB.ToString());
             }
         }
-#endif
 
         [Fact]
         public void ExpressionLexerShouldFailByDefaultForAtSymbol()
@@ -976,7 +974,6 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal("next", lexer.NextToken().Span.ToString());
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1&& !NETCOREAPP3_1
         private char FindMatchingChar(UnicodeCategory category)
         {
             for (int i = 0; i <= 0xffff; i++)
@@ -991,7 +988,6 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.True(false, "Should never get here");
             return (char)0;
         }
-#endif
 
         private void EdmValidNamesNotAllowedInUri(string propertyName)
         {

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -939,11 +939,7 @@ namespace Microsoft.OData.Tests.UriParser
             Uri url = new Uri("http://host/Paintings?$compute=nonsense as");
             ODataUriParser parser = new ODataUriParser(HardCodedTestModel.TestModel, ServiceRoot, url);
             Action action = () => parser.ParseCompute();
-#if NETCOREAPP
             action.Throws<ArgumentNullException>("Value cannot be null or empty. (Parameter 'alias')");
-#else
-             action.Throws<ArgumentNullException>("Value cannot be null or empty.\r\nParameter name: alias");
-#endif
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPathParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriPathParserTests.cs
@@ -31,11 +31,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "One/Two/Three/Four/Five/Six/Seven/Eight/Nine/Ten/Eleven"), this.baseUri);
             string[] expectedListOrder = new[] { "One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten", "Eleven" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -44,11 +40,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "One/Two(1)/Three"), this.baseUri);
             string[] expectedListOrder = new[] { "One", "Two(1)", "Three" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         // TODO: Astoria does this. Not quite sure what the spec says.
@@ -58,11 +50,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "One////Three"), this.baseUri);
             string[] expectedListOrder = new[] { "One", "Three" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -71,11 +59,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "EntitySet('stringkey')"), this.baseUri);
             string[] expectedListOrder = new[] { "EntitySet('stringkey')" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -84,11 +68,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "EntitySet('string/key')"), this.baseUri);
             string[] expectedListOrder = new[] { "EntitySet('string", "key')" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -97,11 +77,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "S p a c e"), this.baseUri);
             string[] expectedListOrder = new[] { "S p a c e" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -113,11 +89,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "Newline\n"), this.baseUri);
             string[] expectedListOrder = new[] { "Newline" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -126,11 +98,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + Uri.EscapeDataString("Space ")), this.baseUri);
             string[] expectedListOrder = new[] { "Space " };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -139,11 +107,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + Uri.EscapeDataString("Tab\t")), this.baseUri);
             string[] expectedListOrder = new[] { "Tab\t" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -152,11 +116,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + Uri.EscapeDataString("Newline\n")), this.baseUri);
             string[] expectedListOrder = new[] { "Newline\n" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -165,11 +125,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + Uri.EscapeDataString("CarriageReturn\r")), this.baseUri);
             string[] expectedListOrder = new[] { "CarriageReturn\r" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -178,11 +134,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "One/Two?query=value"), this.baseUri);
             string[] expectedListOrder = new[] { "One", "Two" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Fact]
@@ -191,11 +143,7 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
             var list = this.pathParser.ParsePathIntoSegments(new Uri(this.baseUri.AbsoluteUri + "One/Two?query=value/with/slashes"), this.baseUri);
             string[] expectedListOrder = new[] { "One", "Two" };
 
-#if NETCOREAPP1_1
-            Assert.True(list.SequenceEqual(expectedListOrder));
-#else
             list.ContainExactly(expectedListOrder);
-#endif
         }
 
         [Theory]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderJsonTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/CsdlReaderJsonTests.cs
@@ -314,7 +314,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             var setA = model.FindDeclaredNavigationSource("SetA");
             Assert.NotNull(setA);
 
-            var navProp = setA.EntityType().FindProperty("Nav") as IEdmNavigationProperty;
+            var navProp = setA.EntityType.FindProperty("Nav") as IEdmNavigationProperty;
             Assert.NotNull(navProp);
             Assert.Equal(2, setA.NavigationPropertyBindings.Count());
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/EdmValueParserTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/EdmValueParserTests.cs
@@ -429,12 +429,7 @@ namespace Microsoft.OData.Edm.Tests.Csdl
             double? result;
             Assert.True(EdmValueParser.TryParseFloat("1.7976931348623157E+308", out result));
             Assert.Equal(double.MaxValue, result);
-#if NETCOREAPP
             Assert.True(EdmValueParser.TryParseFloat("1.7976931348623157E+309", out result));
-#else
-            Assert.False(EdmValueParser.TryParseFloat("1.7976931348623157E+309", out result));
-            Assert.Null(result);
-#endif
         }
 #endregion Decimal
 

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Csdl/Serialization/EdmModelCsdlSerializationVisitorTests.cs
@@ -1664,15 +1664,9 @@ namespace Microsoft.OData.Edm.Tests.Csdl.Serialization
 
             IEdmVocabularyAnnotation annotation = new EdmVocabularyAnnotation(complexType, term, new EdmFloatingConstant(3.14f));
 
-#if NETCOREAPP
             // Act & Assert for XML
             VisitAndVerifyXml(v => v.VisitVocabularyAnnotation(annotation),
                 @"<Annotation Term=""UI.FloatWidth"" Float=""3.140000104904175"" />");
-#else
-            // Act & Assert for XML
-            VisitAndVerifyXml(v => v.VisitVocabularyAnnotation(annotation),
-                @"<Annotation Term=""UI.FloatWidth"" Float=""3.1400001049041748"" />");
-#endif
 
             // Act & Assert for Json
             VisitAndVerifyJson(v => v.VisitVocabularyAnnotation(annotation), @"{

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/DateAndTimeOfDayTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Schema/DateAndTimeOfDayTests.cs
@@ -54,28 +54,20 @@ namespace Microsoft.OData.Edm.Tests.Library
             Action test = () => date.AddYears(-5000);
 
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
-#else
-            Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
-#endif
         }
 
         [Fact]
-        public void TestDateAddYearsInvalidParmeters()
+        public void TestDateAddYearsInvalidParameters()
         {
             Date date = new Date(2013, 8, 12);
             Action test = () => date.AddYears(12000);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
-#else
-            Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
-#endif
         }
 
         [Fact]
-        public void TesDatetAddMonths()
+        public void TesDateAddMonths()
         {
             Date date = new Date(2013, 8, 12);
             Date result = date.AddMonths(1);
@@ -88,24 +80,16 @@ namespace Microsoft.OData.Edm.Tests.Library
             Date date = new Date(1, 1, 1);
             Action test = () => date.AddMonths(-5000);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
-#else
-            Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
-#endif
         }
 
         [Fact]
-        public void TestDateAddMonthsInvalidParmeters()
+        public void TestDateAddMonthsInvalidParameters()
         {
             Date date = new Date(1, 1, 1);
             Action test = () => date.AddMonths(120001);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
-#else
-            Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
-#endif
         }
 
         [Fact]
@@ -122,24 +106,16 @@ namespace Microsoft.OData.Edm.Tests.Library
             Date date = new Date(1, 1, 1);
             Action test = () => date.AddDays(-2);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
-#else
-            Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
-#endif
         }
 
         [Fact]
-        public void TestDateAddDaysInvalidParmeters()
+        public void TestDateAddDaysInvalidParameters()
         {
             Date date = new Date(1, 1, 1);
             Action test = () => date.AddDays(999999999);
             var exception = Assert.Throws<ArgumentOutOfRangeException>(test);
-#if NETCOREAPP
             Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + " (Parameter 'value')", exception.Message);
-#else
-            Assert.Equal(Strings.Date_InvalidAddedOrSubtractedResults + "\r\nParameter name: value", exception.Message);
-#endif
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/AuthorizationVocabularyTests.Async.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/AuthorizationVocabularyTests.Async.cs
@@ -138,11 +138,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             var (_, errors) = await this._authorizationModel.TryWriteSchemaAsync(xw).ConfigureAwait(false);
             await xw.FlushAsync().ConfigureAwait(false);
 
-#if NETCOREAPP1_1
-            xw.Dispose();
-#else
             xw.Close();
-#endif
             string output = sw.ToString();
 
             Assert.True(!errors.Any(), "No Errors");

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/AuthorizationVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/AuthorizationVocabularyTests.cs
@@ -146,11 +146,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             this._authorizationModel.TryWriteSchema(xw, out errors);
             xw.Flush();
 
-#if NETCOREAPP1_1
-            xw.Dispose();
-#else
             xw.Close();
-#endif
             string output = sw.ToString();
 
             Assert.True(!errors.Any(), "No Errors");

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.Async.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.Async.cs
@@ -847,11 +847,8 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             XmlWriter xw = XmlWriter.Create(sw, settings);
             var (_, errors) = await this.capVocModel.TryWriteSchemaAsync(xw).ConfigureAwait(false);
             await xw.FlushAsync().ConfigureAwait(false);
-#if NETCOREAPP1_1
-            xw.Dispose();
-#else
+
             xw.Close();
-#endif
             string output = sw.ToString();
             Assert.True(!errors.Any(), "No Errors");
             Assert.Equal(expectedText, output);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CapabilitiesVocabularyTests.cs
@@ -856,11 +856,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             XmlWriter xw = XmlWriter.Create(sw, settings);
             this.capVocModel.TryWriteSchema(xw, out errors);
             xw.Flush();
-#if NETCOREAPP1_1
-            xw.Dispose();
-#else
             xw.Close();
-#endif
             string output = sw.ToString();
             Assert.True(!errors.Any(), "No Errors");
             Assert.Equal(expectedText, output);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.Async.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.Async.cs
@@ -73,11 +73,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             XmlWriter xw = XmlWriter.Create(sw, settings);
             var (_, errors) = await coreVocModel.TryWriteSchemaAsync(xw).ConfigureAwait(false);
             await xw.FlushAsync().ConfigureAwait(false);
-#if NETCOREAPP1_1
-            xw.Dispose();
-#else
             xw.Close();
-#endif
             string output = sw.ToString();
             Assert.False(errors.Any(), "No Errors");
             Assert.Equal(expectedText, output);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/CoreVocabularyTests.cs
@@ -465,11 +465,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             XmlWriter xw = XmlWriter.Create(sw, settings);
             coreVocModel.TryWriteSchema(xw, out errors);
             xw.Flush();
-#if NETCOREAPP1_1
-            xw.Dispose();
-#else
             xw.Close();
-#endif
             string output = sw.ToString();
             Assert.False(errors.Any(), "No Errors");
             Assert.Equal(expectedText, output);

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.Async.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.Async.cs
@@ -123,11 +123,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             XmlWriter xw = XmlWriter.Create(sw, settings);
             var (_, errors) = await this._validationModel.TryWriteSchemaAsync(xw).ConfigureAwait(false);
             await xw.FlushAsync().ConfigureAwait(false);
-#if NETCOREAPP1_1
-            xw.Dispose();
-#else
             xw.Close();
-#endif
             string output = sw.ToString();
 
             Assert.True(!errors.Any(), "No Errors");

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Vocabularies/ValidationVocabularyTests.cs
@@ -128,11 +128,7 @@ namespace Microsoft.OData.Edm.Tests.Vocabularies
             XmlWriter xw = XmlWriter.Create(sw, settings);
             this._validationModel.TryWriteSchema(xw, out errors);
             xw.Flush();
-#if NETCOREAPP1_1
-            xw.Dispose();
-#else
             xw.Close();
-#endif
             string output = sw.ToString();
 
             Assert.True(!errors.Any(), "No Errors");

--- a/test/FunctionalTests/Microsoft.OData.TestCommon/DebugAssertTraceListener.cs
+++ b/test/FunctionalTests/Microsoft.OData.TestCommon/DebugAssertTraceListener.cs
@@ -1,5 +1,4 @@
-﻿#if !NETCOREAPP1_1
-namespace Microsoft.OData.TestCommon
+﻿namespace Microsoft.OData.TestCommon
 {
     using System;
     using System.Diagnostics;
@@ -81,4 +80,3 @@ namespace Microsoft.OData.TestCommon
         }
     }
 }
-#endif

--- a/test/FunctionalTests/Microsoft.OData.TestCommon/Fake.cs
+++ b/test/FunctionalTests/Microsoft.OData.TestCommon/Fake.cs
@@ -1,5 +1,4 @@
-﻿#if !NETCOREAPP1_1
-namespace Microsoft.OData.TestCommon
+﻿namespace Microsoft.OData.TestCommon
 {
     /// <summary>
     /// A fake <see cref="System.Delegate"/> that is defined to refer to some construct in Microsoft.OData.TestCommon
@@ -19,4 +18,3 @@ namespace Microsoft.OData.TestCommon
     /// </remarks>
     internal delegate void Fake(DebugAssertTraceListener listener);
 }
-#endif

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/ForwardingSegmentTests.cs
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/ForwardingSegmentTests.cs
@@ -75,10 +75,8 @@ namespace Microsoft.Spatial.Tests
             Exception ex = SpatialTestUtils.RunCatching(() => this.testSubject.GeographyPipeline.SetCoordinateSystem(coordinateSystem));
             Assert.True(ex.GetType() == typeof(InvalidOperationException), "got the exception we threw");
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
             // .NET Core does not appear to generate this stack trace
             Assert.True(ex.StackTrace.Contains("DoWhenNotCall"), "Lost the original stack trace");
-#endif
             AssertResetCalledLastOnCurrentAndDownstream();
         }
 
@@ -89,10 +87,8 @@ namespace Microsoft.Spatial.Tests
             Exception ex = SpatialTestUtils.RunCatching(() => this.testSubject.GeographyPipeline.EndFigure());
             Assert.True(ex.GetType() == typeof(InvalidOperationException), "got the exception we threw");
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
             // .NET Core does not appear to generate this stack trace
             Assert.True(ex.StackTrace.Contains("DoWhenCall"), "Lost the original stack trace");
-#endif
             AssertResetCalledLastOnCurrentAndDownstream();
         }
 

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/GmlWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/GmlWriterTests.cs
@@ -370,11 +370,7 @@ namespace Microsoft.Spatial.Tests
 
             pipelineCalls(gw.GeographyPipeline);
             w.Flush();
-#if NETCOREAPP1_1
-            w.Dispose();
-#else
             w.Close();
-#endif
 
             // use XElement to validate basic XML integrity
             ms.Seek(0, SeekOrigin.Begin);
@@ -739,11 +735,7 @@ namespace Microsoft.Spatial.Tests
 
             pipelineCalls(gw.GeometryPipeline);
             w.Flush();
-#if NETCOREAPP1_1
-            w.Dispose();
-#else
             w.Close();
-#endif
 
             // use XElement to validate basic XML integrity
             ms.Seek(0, SeekOrigin.Begin);

--- a/test/FunctionalTests/Microsoft.Spatial.Tests/SpatialReaderTests.cs
+++ b/test/FunctionalTests/Microsoft.Spatial.Tests/SpatialReaderTests.cs
@@ -49,11 +49,7 @@ namespace Microsoft.Spatial.Tests
         public void ErrorOnNullDestinationInCtor()
         {
             Action act = () => new TrivialReader(null);
-#if NETCOREAPP            
             SpatialTestUtils.VerifyExceptionThrown<ArgumentNullException>(act, "Value cannot be null. (Parameter 'destination')");
-#else
-            SpatialTestUtils.VerifyExceptionThrown<ArgumentNullException>(act, "Value cannot be null.\r\nParameter name: destination");
-#endif
         }
 
         [Fact]
@@ -62,17 +58,10 @@ namespace Microsoft.Spatial.Tests
             var reader = new TrivialReader(new CallSequenceLoggingPipeline());
             Action[] acts = { () => reader.ReadGeography(null), () => reader.ReadGeometry(null) };
 
-#if NETCOREAPP
             foreach (var act in acts)
             {
                 SpatialTestUtils.VerifyExceptionThrown<ArgumentNullException>(act, "Value cannot be null. (Parameter 'input')");
             }
-#else
-            foreach (var act in acts)
-            {
-                SpatialTestUtils.VerifyExceptionThrown<ArgumentNullException>(act, "Value cannot be null.\r\nParameter name: input");
-            }
-#endif
         }
 
         private static void ShouldFindOneShape(string input, string expectedUnusedInput)

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Common/ExceptionUtilities.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Common/ExceptionUtilities.cs
@@ -163,12 +163,10 @@ namespace Microsoft.Test.OData.Utils.Common
         /// </returns>
         public static bool IsCatchable(Exception exception)
         {
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
             if (exception is ThreadAbortException)
             {
                 return false;
             }
-#endif
 
             return true;
         }

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/MetadataUtils.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/MetadataUtils.cs
@@ -734,11 +734,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
         {
             ExceptionUtilities.CheckArgumentNotNull(type, "type");
             bool isGenericType = false;
-#if NETCOREAPP1_1
-            isGenericType = type.GetTypeInfo().IsGenericType;
-#else
             isGenericType = type.IsGenericType;
-#endif
             return isGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
         }
 
@@ -765,11 +761,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
         {
             ExceptionUtilities.CheckArgumentNotNull(type, "type");
             bool isValueType = false;
-#if NETCOREAPP1_1
-            isValueType = type.GetTypeInfo().IsValueType;
-#else
             isValueType = type.IsValueType;
-#endif
             return !isValueType || IsNullableType(type);
         }
 
@@ -806,11 +798,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
             }
 
             bool isGenericType = false;
-#if NETCOREAPP1_1
-            isGenericType = seqType.GetTypeInfo().IsGenericType;
-#else
             isGenericType = seqType.IsGenericType;
-#endif
 
             if (isGenericType)
             {
@@ -835,11 +823,7 @@ namespace Microsoft.Test.OData.Utils.Metadata
             }
 
             Type baseType = null;
-#if NETCOREAPP1_1
-            baseType = seqType.GetTypeInfo().BaseType;
-#else
             baseType = seqType.BaseType;
-#endif
 
             if (baseType != null && baseType != typeof(object))
             {

--- a/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/TestModels.cs
+++ b/test/FunctionalTests/Tests/TestUtils/Common/Microsoft.Test.OData.Utils/Metadata/TestModels.cs
@@ -255,10 +255,8 @@ namespace Microsoft.Test.OData.Utils.Metadata
             // Model with OData-specific attribute annotations
             yield return BuildODataAnnotationTestModel(true);
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
             // Astoria Default Test Model
             yield return BuildDefaultAstoriaTestModel();
-#endif
         }
 
         /// <summary>
@@ -339,7 +337,6 @@ namespace Microsoft.Test.OData.Utils.Metadata
             return model;
         }
 
-#if !NETCOREAPP1_1 && !NETCOREAPP2_1 && !NETCOREAPP3_1
         /// <summary>
         /// Builds the Astoria default test model and applies necessary fixups for use in OData tests.
         /// </summary>
@@ -365,7 +362,6 @@ namespace Microsoft.Test.OData.Utils.Metadata
                 return model;
             }
         }
-#endif
 
         /// <summary>
         /// Creates a test model to test our conversion of OData instances into EDM values.


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Since  the ODat library targets on .NET 8, the #if NETCOREAPP is no longer needed. 
Simply clean them.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
