### PR TITLE
Mark Timeout Property as Obsolete and Recommend IHttpClientFactory for Timeout Config

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -498,7 +498,6 @@ namespace Microsoft.OData.Client
         /// The value may be changed between requests to a data service and the new value
         /// will be picked up by the next data service request.
         /// </remarks>
-        [Obsolete("The Timeout property is obsolete. Use IHttpClientFactory to configure the timeout.")]
         public virtual int Timeout
         {
             get

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -498,6 +498,7 @@ namespace Microsoft.OData.Client
         /// The value may be changed between requests to a data service and the new value
         /// will be picked up by the next data service request.
         /// </remarks>
+        [Obsolete("The Timeout property is obsolete. Use IHttpClientFactory to configure the timeout.")]
         public virtual int Timeout
         {
             get

--- a/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/DataServiceClientRequestMessage.cs
@@ -59,6 +59,7 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Gets or sets the timeout (in seconds) for this request.
         /// </summary>
+        [Obsolete("The Timeout property is obsolete. Use IHttpClientFactory to configure the timeout.")]
         public abstract int Timeout { get; set; }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -165,6 +165,7 @@ namespace Microsoft.OData.Client
         /// <summary>
         /// Gets or sets the timeout (in seconds) for this request.
         /// </summary>
+        [Obsolete("The Timeout property is obsolete. Use IHttpClientFactory to configure the timeout.")]
         public override int Timeout
         {
             get


### PR DESCRIPTION
…r Timeout Config

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes [#3131](https://github.com/OData/odata.net/issues/3131).*

### Description

### Summary
This PR marks the `Timeout` property in the `DataServiceContext` class as obsolete and recommends using `IHttpClientFactory` to configure the timeout. This change is part of our effort to modernize the configuration of HTTP requests and provide more flexible and robust options for users.

### Changes
- Added the `[Obsolete]` attribute to the `Timeout` property with a message indicating the deprecation and suggesting the use of `IHttpClientFactory`.

### Reason for Change
The `Timeout` property is being deprecated to encourage the use of `IHttpClientFactory`, which provides a more flexible and configurable way to manage HTTP client settings, including timeouts. This approach aligns with modern .NET practices and offers better integration with dependency injection and other configuration mechanisms.

### Impact
Users will see a compiler warning when using the `Timeout` property, indicating that it is obsolete and suggesting the use of `IHttpClientFactory` instead. This change does not break existing code but encourages users to migrate to the new approach.

### Next Steps
- Update any relevant documentation to guide users on how to configure timeouts using `IHttpClientFactory`.
- Plan for the eventual removal of the `Timeout` property in a future major release.

### Example Usage of IHttpClientFactory
1. Create CustomHttpClientFactory
```cs
public class CustomHttpClientFactory : IHttpClientFactory
{
    private readonly HttpClient _httpClient;

    public CustomHttpClientFactory(HttpClient httpClient)
    {
        _httpClient = httpClient;
    }

    public HttpClient CreateClient(string name)
    {
        return _httpClient;
    }
}
```

2. Create HttpClient and specify the Timeout
```cs
var httpClient = new HttpClient
{
    Timeout = TimeSpan.FromSeconds(160)
};

var httpClientFactory= new CustomHttpClientFactory(httpClient);

var context = new Container(new Uri("https://localhost:7214/odata"))
{
    HttpClientFactory = httpClientFactory
};
```

3. Using DI:
```cs
var services = new ServiceCollection();
services.AddHttpClient("", client =>  // Note that the httpClient is not named
{
    client.Timeout = TimeSpan.FromSeconds(160);
});

var serviceProvider = services.BuildServiceProvider();
var httpClientFactory = serviceProvider.GetRequiredService<IHttpClientFactory>();

var context = new Container(new Uri("https://localhost:7214/odata"))
{
    HttpClientFactory = httpClientFactory
};
```
### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
