### PR TITLE
Don't require entityset when writing responses

### DIFF
--- a/src/Microsoft.OData.Client/ConventionalODataEntityMetadataBuilder.cs
+++ b/src/Microsoft.OData.Client/ConventionalODataEntityMetadataBuilder.cs
@@ -68,6 +68,11 @@ namespace Microsoft.OData.Client
         /// </returns>
         internal override Uri GetEditLink()
         {
+            if(this.entitySetName == null)
+            {
+                return null;
+            }
+
             Uri entitySetUri = this.uriBuilder.BuildEntitySetUri(this.baseUri, this.entitySetName);
             Uri editLink = this.uriBuilder.BuildEntityInstanceUri(entitySetUri, this.entityInstance);
             return editLink;

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalEntityMetadataBuilder.cs
@@ -393,6 +393,12 @@ namespace Microsoft.OData.Evaluation
         /// </returns>
         internal override bool TryGetIdForSerialization(out Uri id)
         {
+            if(this.ResourceMetadataContext.TypeContext.NavigationSourceName == null)
+            {
+                id = null;
+                return false;
+            }
+
             id = this.ResourceMetadataContext.Resource.IsTransient ? null : this.GetId();
             return true;
         }
@@ -405,10 +411,13 @@ namespace Microsoft.OData.Evaluation
         {
             Uri uri = this.ResourceMetadataContext.Resource.HasNonComputedId ? this.ResourceMetadataContext.Resource.NonComputedId : this.ComputedId;
 
-            Debug.Assert(this.ResourceMetadataContext != null && this.ResourceMetadataContext.TypeContext != null, "this.resourceMetadataContext != null && this.resourceMetadataContext.TypeContext != null");
-            if (this.ResourceMetadataContext.ActualResourceTypeName != this.ResourceMetadataContext.TypeContext.NavigationSourceEntityTypeName)
+            if (uri != null)
             {
-                uri = this.UriBuilder.AppendTypeSegment(uri, this.ResourceMetadataContext.ActualResourceTypeName);
+                Debug.Assert(this.ResourceMetadataContext != null && this.ResourceMetadataContext.TypeContext != null, "this.resourceMetadataContext != null && this.resourceMetadataContext.TypeContext != null");
+                if (this.ResourceMetadataContext.ActualResourceTypeName != this.ResourceMetadataContext.TypeContext.NavigationSourceEntityTypeName)
+                {
+                    uri = this.UriBuilder.AppendTypeSegment(uri, this.ResourceMetadataContext.ActualResourceTypeName);
+                }
             }
 
             return uri;

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
@@ -131,11 +131,11 @@ namespace Microsoft.OData.Evaluation
                 case EdmNavigationSourceKind.Singleton:
                     uri = this.ComputeIdForSingleton();
                     break;
+                // Treat UnknownEntitySet as a containment
+                case EdmNavigationSourceKind.UnknownEntitySet:
                 case EdmNavigationSourceKind.ContainedEntitySet:
                     uri = this.ComputeIdForContainment();
                     break;
-                case EdmNavigationSourceKind.UnknownEntitySet:
-                    throw new ODataException(Strings.ODataMetadataBuilder_UnknownEntitySet(this.ResourceMetadataContext.TypeContext.NavigationSourceName));
                 default:
                     uri = this.ComputeId();
                     break;
@@ -152,7 +152,7 @@ namespace Microsoft.OData.Evaluation
         /// </returns>
         private Uri ComputeId()
         {
-            if (this.ResourceMetadataContext.KeyProperties.Any())
+            if (this.ResourceMetadataContext.KeyProperties.Any() && this.ResourceMetadataContext.TypeContext.NavigationSourceName != null)
             {
                 Uri uri = this.UriBuilder.BuildBaseUri();
                 uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);

--- a/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataConventionalIdMetadataBuilder.cs
@@ -152,7 +152,7 @@ namespace Microsoft.OData.Evaluation
         /// </returns>
         private Uri ComputeId()
         {
-            if (this.ResourceMetadataContext.KeyProperties.Any() && this.ResourceMetadataContext.TypeContext.NavigationSourceName != null)
+            if (this.ResourceMetadataContext.TypeContext.NavigationSourceName != null && this.ResourceMetadataContext.KeyProperties.Any())
             {
                 Uri uri = this.UriBuilder.BuildBaseUri();
                 uri = this.UriBuilder.BuildEntitySetUri(uri, this.ResourceMetadataContext.TypeContext.NavigationSourceName);

--- a/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
+++ b/src/Microsoft.OData.Core/Evaluation/ODataMetadataContext.cs
@@ -267,8 +267,7 @@ namespace Microsoft.OData.Evaluation
                     IEdmEntityType navigationSourceElementType = this.edmTypeResolver.GetElementType(navigationSource);
                     IODataResourceTypeContext typeContext =
                         ODataResourceTypeContext.Create( /*serializationInfo*/
-                            null, navigationSource, navigationSourceElementType, resourceState.ResourceTypeFromMetadata ?? resourceState.ResourceType,
-                            /*throwIfMissingTypeInfo*/ true);
+                            null, navigationSource, navigationSourceElementType, resourceState.ResourceTypeFromMetadata ?? resourceState.ResourceType);
 
                     IODataResourceMetadataContext resourceMetadataContext = ODataResourceMetadataContext.Create(
                         resource,

--- a/src/Microsoft.OData.Core/Json/ODataJsonWriter.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonWriter.cs
@@ -1838,7 +1838,7 @@ namespace Microsoft.OData.Json
                     string expectedNavigationSource = deltaResourceSetScope?.NavigationSource?.Name;
                     string currentNavigationSource = resource.SerializationInfo?.NavigationSourceName ?? resourceScope.NavigationSource?.Name;
 
-                    if (String.IsNullOrEmpty(currentNavigationSource) || currentNavigationSource != expectedNavigationSource)
+                    if (!String.IsNullOrEmpty(currentNavigationSource) && currentNavigationSource != expectedNavigationSource)
                     {
                         Debug.Assert(this.ScopeLevel <= 3, "Writing a nested deleted resource of the wrong type should already have been caught.");
 

--- a/src/Microsoft.OData.Core/ODataContextUriBuilder.cs
+++ b/src/Microsoft.OData.Core/ODataContextUriBuilder.cs
@@ -172,25 +172,40 @@ namespace Microsoft.OData
             }
             else
             {
-                // No path information
-                switch (info.DeltaKind)
-                {
-                    case ODataDeltaKind.ResourceSet:
-                        return new Uri(ODataConstants.ContextUriFragmentIndicator + ODataConstants.DeltaResourceSet, UriKind.Relative);
-                    case ODataDeltaKind.DeletedEntry:
-                        return new Uri(ODataConstants.ContextUriFragmentIndicator + ODataConstants.DeletedEntry, UriKind.Relative);
-                    case ODataDeltaKind.Link:
-                        return new Uri(ODataConstants.ContextUriFragmentIndicator + ODataConstants.DeltaLink, UriKind.Relative);
-                    case ODataDeltaKind.DeletedLink:
-                        return new Uri(ODataConstants.ContextUriFragmentIndicator + ODataConstants.DeletedLink, UriKind.Relative);
-                }
-
                 if (!string.IsNullOrEmpty(info.TypeName))
                 {   // #TypeName
                     builder.Append(info.TypeName);
+
+                    switch (info.DeltaKind)
+                    {
+                        case ODataDeltaKind.ResourceSet:
+                            builder.Append(ODataConstants.UriSegmentSeparatorChar + ODataConstants.DeltaResourceSet);
+                            break;
+                        case ODataDeltaKind.DeletedEntry:
+                            builder.Append(ODataConstants.UriSegmentSeparatorChar + ODataConstants.DeletedEntry);
+                            break;
+                        case ODataDeltaKind.Link:
+                            builder.Append(ODataConstants.UriSegmentSeparatorChar + ODataConstants.DeltaLink);
+                            break;
+                        case ODataDeltaKind.DeletedLink:
+                            builder.Append(ODataConstants.UriSegmentSeparatorChar + ODataConstants.DeletedLink);
+                            break;
+                    }
                 }
                 else
                 {
+                    switch (info.DeltaKind)
+                    {
+                        case ODataDeltaKind.ResourceSet:
+                            return new Uri(ODataConstants.ContextUriFragmentIndicator + ODataConstants.DeltaResourceSet, UriKind.Relative);
+                        case ODataDeltaKind.DeletedEntry:
+                            return new Uri(ODataConstants.ContextUriFragmentIndicator + ODataConstants.DeletedEntry, UriKind.Relative);
+                        case ODataDeltaKind.Link:
+                            return new Uri(ODataConstants.ContextUriFragmentIndicator + ODataConstants.DeltaLink, UriKind.Relative);
+                        case ODataDeltaKind.DeletedLink:
+                            return new Uri(ODataConstants.ContextUriFragmentIndicator + ODataConstants.DeletedLink, UriKind.Relative);
+                    }
+
                     return null;
                 }
             }

--- a/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
+++ b/src/Microsoft.OData.Core/ODataContextUrlInfo.cs
@@ -238,12 +238,14 @@ namespace Microsoft.OData
         {
             Debug.Assert(typeContext != null, "typeContext != null");
 
+            string typeName = typeContext.NavigationSourceEntityTypeName ?? typeContext.ExpectedResourceTypeName;
+
             ODataContextUrlInfo contextUriInfo = new ODataContextUrlInfo()
             {
                 IsUnknownEntitySet = typeContext.NavigationSourceKind == EdmNavigationSourceKind.UnknownEntitySet,
                 NavigationSource = typeContext.NavigationSourceName,
-                TypeCast = typeContext.NavigationSourceEntityTypeName == typeContext.ExpectedResourceTypeName ? null : typeContext.ExpectedResourceTypeName,
-                TypeName = typeContext.NavigationSourceEntityTypeName,
+                TypeCast = typeName == typeContext.ExpectedResourceTypeName ? null : typeContext.ExpectedResourceTypeName,
+                TypeName = EdmLibraryExtensions.GetCollectionTypeName(typeName),
                 IncludeFragmentItemSelector = kind == ODataDeltaKind.Resource && typeContext.NavigationSourceKind != EdmNavigationSourceKind.Singleton,
                 DeltaKind = kind,
                 NavigationPath = ComputeNavigationPath(typeContext.NavigationSourceKind, null, typeContext.NavigationSourceName),

--- a/src/Microsoft.OData.Core/ODataResourceTypeContext.cs
+++ b/src/Microsoft.OData.Core/ODataResourceTypeContext.cs
@@ -26,53 +26,35 @@ namespace Microsoft.OData
         protected string expectedResourceTypeName;
 
         /// <summary>
-        /// If true, throw if any of the set or type name cannot be determined; if false, return null when any of the set or type name cannot determined.
-        /// </summary>
-        private readonly bool throwIfMissingTypeInfo;
-
-        /// <summary>
         /// Constructs an instance of <see cref="ODataResourceTypeContext"/>.
         /// </summary>
-        /// <param name="throwIfMissingTypeInfo">If true, throw if any of the set or type name cannot be determined; if false, return null when any of the set or type name cannot determined.</param>
-        private ODataResourceTypeContext(bool throwIfMissingTypeInfo)
+        private ODataResourceTypeContext()
         {
-            this.throwIfMissingTypeInfo = throwIfMissingTypeInfo;
         }
 
         /// <summary>
         /// Constructs an instance of <see cref="ODataResourceTypeContext"/>.
         /// </summary>
         /// <param name="expectedResourceType">The expected resource type of resource set or resource.</param>
-        /// <param name="throwIfMissingTypeInfo">If true, throw if any of the set or type name cannot be determined; if false, return null when any of the set or type name cannot determined.</param>
-        private ODataResourceTypeContext(IEdmStructuredType expectedResourceType, bool throwIfMissingTypeInfo)
+        private ODataResourceTypeContext(IEdmStructuredType expectedResourceType)
         {
             this.expectedResourceType = expectedResourceType;
-            this.throwIfMissingTypeInfo = throwIfMissingTypeInfo;
         }
 
         /// <summary>
         /// The navigation source name of the resource set or resource.
         /// </summary>
-        public virtual string NavigationSourceName
-        {
-            get { return default(string); }
-        }
+        public virtual string NavigationSourceName { get; }
 
         /// <summary>
         /// The entity type name of the navigation source of the resource set or resource.
         /// </summary>
-        public virtual string NavigationSourceEntityTypeName
-        {
-            get { return default(string); }
-        }
+        public virtual string NavigationSourceEntityTypeName { get;  }
 
         /// <summary>
         /// The full type name of the navigation source of the resource set or resource.
         /// </summary>
-        public virtual string NavigationSourceFullTypeName
-        {
-            get { return default(string); }
-        }
+        public virtual string NavigationSourceFullTypeName { get; }
 
         /// <summary>
         /// The kind of the navigation source of the resource set or resource.
@@ -133,9 +115,8 @@ namespace Microsoft.OData
         /// <param name="navigationSource">The navigation source of the resource set or resource.</param>
         /// <param name="navigationSourceEntityType">The entity type of the navigation source.</param>
         /// <param name="expectedResourceType">The expected structured type of the resource set or resource.</param>
-        /// <param name="throwIfMissingTypeInfo">If true, throw if any of the set or type name cannot be determined; if false, return null when any of the set or type name cannot determined.</param>
         /// <returns>A new instance of <see cref="ODataResourceTypeContext"/>.</returns>
-        internal static ODataResourceTypeContext Create(ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType navigationSourceEntityType, IEdmStructuredType expectedResourceType, bool throwIfMissingTypeInfo)
+        internal static ODataResourceTypeContext Create(ODataResourceSerializationInfo serializationInfo, IEdmNavigationSource navigationSource, IEdmEntityType navigationSourceEntityType, IEdmStructuredType expectedResourceType)
         {
             if (serializationInfo != null)
             {
@@ -154,7 +135,7 @@ namespace Microsoft.OData
                 return new ODataResourceTypeContextWithModel(navigationSource, navigationSourceEntityType, expectedResourceType);
             }
 
-            return new ODataResourceTypeContext(expectedResourceType, throwIfMissingTypeInfo);
+            return new ODataResourceTypeContext(expectedResourceType);
         }
 
         /// <summary>
@@ -172,7 +153,7 @@ namespace Microsoft.OData
             /// </summary>
             /// <param name="serializationInfo">The serialization info from the resource set or resource instance.</param>
             internal ODataResourceTypeContextWithoutModel(ODataResourceSerializationInfo serializationInfo)
-                : base(/*throwIfMissingTypeInfo*/false)
+                : base()
             {
                 Debug.Assert(serializationInfo != null, "serializationInfo != null");
                 this.serializationInfo = serializationInfo;
@@ -311,7 +292,7 @@ namespace Microsoft.OData
             /// <param name="navigationSourceEntityType">The entity type of the navigation source.</param>
             /// <param name="expectedResourceType">The expected resource type of the resource set or resource.</param>
             internal ODataResourceTypeContextWithModel(IEdmNavigationSource navigationSource, IEdmEntityType navigationSourceEntityType, IEdmStructuredType expectedResourceType)
-                : base(expectedResourceType, /*throwIfMissingTypeInfo*/false)
+                : base(expectedResourceType)
             {
                 Debug.Assert(expectedResourceType != null, "expectedResourceType != null");
                 Debug.Assert(navigationSource != null

--- a/src/Microsoft.OData.Core/ODataResourceTypeContext.cs
+++ b/src/Microsoft.OData.Core/ODataResourceTypeContext.cs
@@ -55,7 +55,7 @@ namespace Microsoft.OData
         /// </summary>
         public virtual string NavigationSourceName
         {
-            get { return this.ValidateAndReturn(default(string)); }
+            get { return default(string); }
         }
 
         /// <summary>
@@ -63,7 +63,7 @@ namespace Microsoft.OData
         /// </summary>
         public virtual string NavigationSourceEntityTypeName
         {
-            get { return this.ValidateAndReturn(default(string)); }
+            get { return default(string); }
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Microsoft.OData
         /// </summary>
         public virtual string NavigationSourceFullTypeName
         {
-            get { return this.ValidateAndReturn(default(string)); }
+            get { return default(string); }
         }
 
         /// <summary>
@@ -155,22 +155,6 @@ namespace Microsoft.OData
             }
 
             return new ODataResourceTypeContext(expectedResourceType, throwIfMissingTypeInfo);
-        }
-
-        /// <summary>
-        /// Validate and return the given value.
-        /// </summary>
-        /// <typeparam name="T">The type of the value to validate.</typeparam>
-        /// <param name="value">The value to validate.</param>
-        /// <returns>The return value.</returns>
-        private T ValidateAndReturn<T>(T value) where T : class
-        {
-            if (this.throwIfMissingTypeInfo && value == null)
-            {
-                throw new ODataException(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
-            }
-
-            return value;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Core/ODataWriterCore.cs
+++ b/src/Microsoft.OData.Core/ODataWriterCore.cs
@@ -4101,17 +4101,11 @@ namespace Microsoft.OData
             {
                 if (this.typeContext == null)
                 {
-                    // For Entity, currently we check the navigation source.
-                    // For Complex, we don't have navigation source, So we shouldn't check it.
-                    // If ResourceType is not provided, serialization info or navigation source info should be provided.
-                    bool throwIfMissingTypeInfo = writingResponse && (this.ResourceType == null || this.ResourceType.TypeKind == EdmTypeKind.Entity);
-
                     this.typeContext = ODataResourceTypeContext.Create(
                         this.serializationInfo,
                         this.NavigationSource,
                         EdmTypeWriterResolver.Instance.GetElementType(this.NavigationSource),
-                        this.ResourceType,
-                        throwIfMissingTypeInfo);
+                        this.ResourceType);
                 }
 
                 return this.typeContext;
@@ -4270,15 +4264,11 @@ namespace Microsoft.OData
                 {
                     IEdmStructuredType expectedResourceType = this.ResourceTypeFromMetadata ?? this.ResourceType;
 
-                    // For entity, we will check the navigation source info
-                    bool throwIfMissingTypeInfo = writingResponse && (expectedResourceType == null || expectedResourceType.TypeKind == EdmTypeKind.Entity);
-
                     this.typeContext = ODataResourceTypeContext.Create(
                         this.serializationInfo,
                         this.NavigationSource,
                         EdmTypeWriterResolver.Instance.GetElementType(this.NavigationSource),
-                        expectedResourceType,
-                        throwIfMissingTypeInfo);
+                        expectedResourceType);
                 }
 
                 return this.typeContext;
@@ -4379,8 +4369,7 @@ namespace Microsoft.OData
                         this.serializationInfo,
                         this.NavigationSource,
                         EdmTypeWriterResolver.Instance.GetElementType(this.NavigationSource),
-                        this.fakeEntityType,
-                        writingResponse);
+                        this.fakeEntityType);
                 }
 
                 return this.typeContext;

--- a/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/ODataPathParser.cs
@@ -1516,7 +1516,7 @@ namespace Microsoft.OData.UriParser
                         segment.TargetKind = RequestTargetKind.Enum;
                         break;
                     default:
-                        Debug.Assert(property.Type.IsPrimitive() || property.Type.IsTypeDefinition(), "must be primitive type or type definition property");
+                        Debug.Assert(property.Type.IsPrimitive() || property.Type.IsTypeDefinition() || property.Type.IsUntyped(), "must be primitive type or type definition property");
                         segment.TargetKind = RequestTargetKind.Primitive;
                         break;
                 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -6,7 +6,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Evaluation/AutoComputePayloadMetadataInJsonIntegrationTests.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -2084,7 +2085,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
         }
 
         [Fact]
-        public void WritingInFullMetadataModeForNavigationPropertyWithoutBindingShouldThrowODataResourceTypeContext_MetadataOrSerializationInfoMissingException()
+        public void WritingInFullMetadataModeForNavigationPropertyWithoutBindingShouldPass()
         {
             ODataItem[] itemsToWrite = new ODataItem[]
             {
@@ -2095,8 +2096,8 @@ namespace Microsoft.OData.Tests.IntegrationTests.Evaluation
             const string selectClause = "UnknownCollectionNavProp";
             const string expandClause = "ExpandedNavLink($expand=UnknownCollectionNavProp)";
 
-            Action test = () => this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=full", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause);
-            test.Throws<ODataException>(Strings.ODataMetadataBuilder_UnknownEntitySet("UnknownCollectionNavProp"));
+            this.GetWriterOutputForContentTypeAndKnobValue("application/json;odata.metadata=full", true, itemsToWrite, Model, EntitySet, EntityType, selectClause, expandClause);
+            Assert.Equal(new Uri("http://example.com/EntitySet(123)/UnknownCollectionNavProp(234)"),this.entryWithOnlyData2.Id);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/ODataJsonWriterIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/ODataJsonWriterIntegrationTests.cs
@@ -37,12 +37,14 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         }
 
         [Fact]
-        public void ShouldNotBeAbleToWriteEntryInResponseWithoutSpecifyingEntitySet()
+        public void ShouldBeAbleToWriteEntryInResponseWithoutSpecifyingEntitySet()
         {
             IEdmEntityType entityType = GetEntityType();
             IEdmEntitySet entitySet = GetEntitySet(entityType);
-            Action writeEmptyEntry = () => WriteJsonEntry(false, new Uri("http://temp.org/"), false, new ODataResource(), entitySet, entityType);
-            writeEmptyEntry.Throws<ODataException>(ErrorStrings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
+            var resource = new ODataResource { Properties = new ODataProperty[] { new ODataProperty { Name = "Key", Value = new ODataPrimitiveValue("abc") } } };
+            const string expected = "{\"@odata.context\":\"http://temp.org/$metadata#Fake.Type\",\"Key\":\"abc\"}";
+            var actual = WriteJsonEntry(false, new Uri("http://temp.org/"), false, resource, entitySet, entityType);
+            Assert.Equal(expected, actual);
         }
 
         [Fact]

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/ODataJsonWriterShortSpanIntegrationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/ODataJsonWriterShortSpanIntegrationTests.cs
@@ -145,10 +145,9 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         }
 
         [Fact]
-        public void ShouldThrowWhenWritingFeedResponseWithoutUserModelAndWithoutSetName()
+        public void ShouldWriteContextUriWhenWritingFeedResponseWithoutUserModelAndWithoutSetName()
         {
-            Action action = () => this.WriteNestedItemsAndValidatePayload(entitySetFullName: null, derivedEntityTypeFullName: "NS.MyDerivedEntityType", nestedItemToWrite: new[] { new ODataResourceSet() }, expectedPayload: "{\"@odata.context\":\"http://odata.org/test/$metadata#MySet/NS.MyDerivedEntityType\",\"value\":[]}", writingResponse: true);
-            action.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
+            this.WriteNestedItemsAndValidatePayload(entitySetFullName: null, derivedEntityTypeFullName: "NS.MyDerivedEntityType", nestedItemToWrite: new[] { new ODataResourceSet() }, expectedPayload: "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(NS.MyDerivedEntityType)\",\"value\":[]}", writingResponse: true);
         }
 
         [Fact]
@@ -170,10 +169,9 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         }
 
         [Fact]
-        public void ShouldThrowWhenWritingEntryResponseWithoutUserModelAndWithoutSetName()
+        public void ShouldWriteContextUriForEntryResponseWithoutUserModelAndWithoutSetName()
         {
-            Action action = () => this.WriteNestedItemsAndValidatePayload(entitySetFullName: null, derivedEntityTypeFullName: "NS.MyDerivedEntityType", nestedItemToWrite: new[] { new ODataResource() }, expectedPayload: "{\"@odata.context\":\"http://odata.org/test/$metadata#MySet/NS.MyDerivedEntityType/$entity\"}", writingResponse: true);
-            action.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
+            this.WriteNestedItemsAndValidatePayload(entitySetFullName: null, derivedEntityTypeFullName: "NS.MyDerivedEntityType", nestedItemToWrite: new[] { new ODataResource() }, expectedPayload: "{\"@odata.context\":\"http://odata.org/test/$metadata#NS.MyDerivedEntityType\"}", writingResponse: true);
         }
 
         [Fact]
@@ -195,10 +193,9 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         }
 
         [Fact]
-        public void ShouldThrowWhenWritingFeedResponseWithUserModelAndWithoutSet()
+        public void ShouldWriteContextUriWhenWritingFeedResponseWithUserModelAndWithoutSet()
         {
-            Action action = () => this.WriteNestedItemsAndValidatePayload(/*entitySet*/ null, this.derivedEntityType, nestedItemToWrite: new[] { new ODataResourceSet() }, expectedPayload: "{\"@odata.context\":\"http://odata.org/test/$metadata#MySet/NS.MyDerivedEntityType\",\"value\":[]}", writingResponse: true);
-            action.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
+            this.WriteNestedItemsAndValidatePayload(/*entitySet*/ null, this.derivedEntityType, nestedItemToWrite: new[] { new ODataResourceSet() }, expectedPayload: "{\"@odata.context\":\"http://odata.org/test/$metadata#Collection(NS.MyDerivedEntityType)\",\"value\":[]}", writingResponse: true);
         }
 
         [Fact]
@@ -214,10 +211,9 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         }
 
         [Fact]
-        public void ShouldThrowWhenWritingEntryResponseWithUserModelAndWithoutSet()
+        public void ShouldWirteContextUriForEntryResponseWithUserModelAndWithoutSet()
         {
-            Action action = () => this.WriteNestedItemsAndValidatePayload(/*entitySet*/ null, this.derivedEntityType, nestedItemToWrite: new[] { new ODataResource() }, expectedPayload: "{\"@odata.context\":\"http://odata.org/test/$metadata#MySet/NS.MyDerivedEntityType/$entity\"}", writingResponse: true);
-            action.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
+            this.WriteNestedItemsAndValidatePayload(/*entitySet*/ null, this.derivedEntityType, nestedItemToWrite: new[] { new ODataResource() }, expectedPayload: "{\"@odata.context\":\"http://odata.org/test/$metadata#NS.MyDerivedEntityType\"}", writingResponse: true);
         }
         #endregion Context Uri tests
 
@@ -1203,9 +1199,12 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
             ODataItem topLevelItem = nestedItemToWrite[0];
             ODataResourceSet topLevelFeed = topLevelItem as ODataResourceSet;
 
-            if (entitySetFullName != null)
+            if (entitySetFullName != null || derivedEntityTypeFullName != null)
             {
-                ODataResourceSerializationInfo serializationInfo = entitySetFullName == null ? null : new ODataResourceSerializationInfo { NavigationSourceName = entitySetFullName, NavigationSourceEntityTypeName = "NS.MyEntityType", ExpectedTypeName = derivedEntityTypeFullName ?? "NS.MyEntityType", NavigationSourceKind = EdmNavigationSourceKind.EntitySet };
+                ODataResourceSerializationInfo serializationInfo = entitySetFullName == null ?
+                  new ODataResourceSerializationInfo { ExpectedTypeName = derivedEntityTypeFullName, IsFromCollection = true } :
+                  new ODataResourceSerializationInfo { NavigationSourceName = entitySetFullName, NavigationSourceEntityTypeName = "NS.MyEntityType", ExpectedTypeName = derivedEntityTypeFullName ?? "NS.MyEntityType", NavigationSourceKind = EdmNavigationSourceKind.EntitySet };
+
                 if (topLevelFeed != null)
                 {
                     topLevelFeed.SetSerializationInfo(serializationInfo);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonResourceSerializerTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/Json/ODataJsonResourceSerializerTests.cs
@@ -325,8 +325,7 @@ namespace Microsoft.OData.Tests.Json
                 CreateCategorySerializationInfo(),
                 /* navigationSource */ null,
                 /* navigationSourceEntityType */ null,
-                /* expectedResourceType */ null,
-                /* throwIfMissingTypeInfo */ true);
+                /* expectedResourceType */ null);
             var contextUrlInfo = ODataContextUrlInfo.Create(
                 typeContext,
                 this.messageWriterSettings.Version ?? ODataVersion.V4,
@@ -417,8 +416,7 @@ namespace Microsoft.OData.Tests.Json
                 /* serializationInfo */ null,
                 this.categoriesEntitySet,
                 this.categoryEntityType,
-                this.categoryEntityType,
-                /* throwIfMissingTypeInfo */ true);
+                this.categoryEntityType);
 
             var result = await SetupJsonResourceSerializerAndRunTestAsync(
                 (jsonResourceSerializer) =>
@@ -439,8 +437,7 @@ namespace Microsoft.OData.Tests.Json
                 CreateCategorySerializationInfo(),
                 /* navigationSource */ null,
                 /* navigationSourceEntityType */ null,
-                /* expectedResourceType */ null,
-                /* throwIfMissingTypeInfo */ true);
+                /* expectedResourceType */ null);
 
             var result = await SetupJsonResourceSerializerAndRunTestAsync(
                 (jsonResourceSerializer) =>
@@ -460,8 +457,7 @@ namespace Microsoft.OData.Tests.Json
                 CreateCategorySerializationInfo(),
                 /* navigationSource */ null,
                 /* navigationSourceEntityType */ null,
-                /* expectedResourceType */ null,
-                /* throwIfMissingTypeInfo */ true);
+                /* expectedResourceType */ null);
 
             var result = await SetupJsonResourceSerializerAndRunTestAsync(
                 (jsonResourceSerializer) =>

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -393,12 +393,12 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
-        public void ShouldThrowIfEntitySetIsMissingWithoutSerializationInfoOnFeedResponse()
+        public void ShouldThrowIfEntitySetAndTypeInfoIsMissingWithoutSerializationInfoOnFeedResponse()
         {
             foreach (ODataVersion version in Versions)
             {
                 Action test = () => this.CreateFeedContextUri(ResponseTypeContextWithoutTypeInfo, version);
-                test.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
+                test.Throws<ODataException>(Strings.ODataContextUriBuilder_NavigationSourceOrTypeNameMissingForResourceOrResourceSet);
             }
         }
 
@@ -455,12 +455,12 @@ namespace Microsoft.OData.Tests
         }
 
         [Fact]
-        public void ShouldThrowIfEntitySetIsMissingOnEntryResponse()
+        public void ShouldThrowIfEntitySetAndTypeInfoIsMissingOnEntryResponse()
         {
             foreach (ODataVersion version in Versions)
             {
                 Action test = () => this.CreateEntryContextUri(ResponseTypeContextWithoutTypeInfo, version);
-                test.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
+                test.Throws<ODataException>(Strings.ODataContextUriBuilder_NavigationSourceOrTypeNameMissingForResourceOrResourceSet);
             }
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataContextUriBuilderTests.cs
@@ -19,8 +19,8 @@ namespace Microsoft.OData.Tests
     {
         private const string ServiceDocumentUriString = "http://odata.org/service/";
         private const string MetadataDocumentUriString = "http://odata.org/service/$metadata";
-        private static readonly ODataResourceTypeContext ResponseTypeContextWithoutTypeInfo = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null, throwIfMissingTypeInfo: true);
-        private static readonly ODataResourceTypeContext RequestTypeContextWithoutTypeInfo = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null, throwIfMissingTypeInfo: false);
+        private static readonly ODataResourceTypeContext ResponseTypeContextWithoutTypeInfo = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null);
+        private static readonly ODataResourceTypeContext RequestTypeContextWithoutTypeInfo = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null);
         private static readonly ODataVersion[] Versions = new ODataVersion[] { ODataVersion.V4, ODataVersion.V401 };
 
         private Uri metadataDocumentBaseUri;
@@ -427,8 +427,7 @@ namespace Microsoft.OData.Tests
                 },
                 navigationSource: null,
                 navigationSourceEntityType: null,
-                expectedResourceType: null,
-                throwIfMissingTypeInfo: true),
+                expectedResourceType: null),
                 version,
                 isResponse: true);
             }
@@ -478,7 +477,7 @@ namespace Microsoft.OData.Tests
         {
             foreach (ODataVersion version in Versions)
             {
-                var singletonTypeContextWithModel = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.singletonCity, this.cityType, this.cityType, throwIfMissingTypeInfo: true);
+                var singletonTypeContextWithModel = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.singletonCity, this.cityType, this.cityType);
                 Assert.Equal(this.CreateEntryContextUri(singletonTypeContextWithModel, version).OriginalString, BuildExpectedContextUri("#SingletonCity", false));
             }
         }
@@ -487,7 +486,7 @@ namespace Microsoft.OData.Tests
         public void ShouldNotIncludeEntityOnSingletonWithoutModel()
         {
             ODataResourceSerializationInfo serializationInfo = new ODataResourceSerializationInfo() { ExpectedTypeName = "People", NavigationSourceEntityTypeName = "People", NavigationSourceName = "Boss", NavigationSourceKind = EdmNavigationSourceKind.Singleton, };
-            var requestSingletonTypeContextWithoutModel = ODataResourceTypeContext.Create(serializationInfo, /*navigationSource*/null, /*navigationSourceEntityType*/null, /*expectedEntityType*/null, true);
+            var requestSingletonTypeContextWithoutModel = ODataResourceTypeContext.Create(serializationInfo, /*navigationSource*/null, /*navigationSourceEntityType*/null, /*expectedEntityType*/null);
             foreach (ODataVersion version in Versions)
             {
                 Assert.Equal(this.CreateEntryContextUri(requestSingletonTypeContextWithoutModel, version).OriginalString, BuildExpectedContextUri("#Boss", false));
@@ -570,7 +569,7 @@ namespace Microsoft.OData.Tests
         public void BuildResourceContextUriForComplexResource()
         {
             var typeContext = ODataResourceTypeContext.Create( /*serializationInfo*/null,
-                null, null, this.addressType, throwIfMissingTypeInfo: false);
+                null, null, this.addressType);
             ODataResource value = new ODataResource { TypeName = "TestModel.Address" };
             foreach (ODataVersion version in Versions)
             {
@@ -594,7 +593,7 @@ namespace Microsoft.OData.Tests
         public void BuildResourceContextUriForComplexWithNullAnnotation()
         {
             var typeContext = ODataResourceTypeContext.Create( /*serializationInfo*/null,
-                null, null, this.addressType, throwIfMissingTypeInfo: true);
+                null, null, this.addressType);
             ODataResource value = new ODataResource { TypeName = "TestModel.Address" };
             value.TypeAnnotation = new ODataTypeAnnotation();
             foreach (ODataVersion version in Versions)
@@ -783,7 +782,7 @@ namespace Microsoft.OData.Tests
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "MyContainer.MyCities", NavigationSourceEntityTypeName = "TestModel.MyCity", ExpectedTypeName = "TestModel.MyCity" };
             foreach (ODataVersion version in Versions)
             {
-                var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
+                var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null);
                 Assert.Null(this.builderWithNoMetadataDocumentUri.BuildContextUri(ODataPayloadKind.ResourceSet, ODataContextUrlInfo.Create(typeContext, version, false)));
             }
         }
@@ -794,7 +793,7 @@ namespace Microsoft.OData.Tests
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "MyContainer.MyCities", NavigationSourceEntityTypeName = "TestModel.MyCity", ExpectedTypeName = "TestModel.MyCity" };
             foreach (ODataVersion version in Versions)
             {
-                var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
+                var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null);
                 Assert.Null(this.builderWithNoMetadataDocumentUri.BuildContextUri(ODataPayloadKind.Resource, ODataContextUrlInfo.Create(typeContext, version, true)));
             }
         }
@@ -899,8 +898,8 @@ namespace Microsoft.OData.Tests
 
         private void InitializeTypeContext()
         {
-            this.responseCityTypeContextWithoutSerializationInfo = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.cityType, throwIfMissingTypeInfo: true);
-            this.responseCapitolCityTypeContextWithoutSerializationInfo = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.capitolCityType, throwIfMissingTypeInfo: true);
+            this.responseCityTypeContextWithoutSerializationInfo = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.cityType);
+            this.responseCapitolCityTypeContextWithoutSerializationInfo = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.capitolCityType);
         }
 
         private Uri CreateCollectionContextUri(ODataCollectionStartSerializationInfo serializationInfo, IEdmTypeReference itemTypeReference)
@@ -954,7 +953,7 @@ namespace Microsoft.OData.Tests
             }
 
             
-            ODataResourceTypeContext typeContext = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.cityType, true);
+            ODataResourceTypeContext typeContext = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.cityType);
             ODataUri odataUri = new ODataUri() { SelectAndExpand = selectExpandClause, Apply = applyClause, Compute = computeClause };
             ODataContextUrlInfo info = ODataContextUrlInfo.Create(typeContext, version, false,  odataUri);
             Uri contextUrl = this.responseContextUriBuilder.BuildContextUri(ODataPayloadKind.ResourceSet, info);
@@ -964,7 +963,7 @@ namespace Microsoft.OData.Tests
         private Uri CreateEntryContextUri(string selectClause, string expandClause, ODataVersion version)
         {
             SelectExpandClause selectExpandClause = new ODataQueryOptionParser(edmModel, this.cityType, this.citySet, new Dictionary<string, string> { { "$expand", expandClause }, { "$select", selectClause } }).ParseSelectAndExpand();
-            ODataResourceTypeContext typeContext = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.cityType, true);
+            ODataResourceTypeContext typeContext = ODataResourceTypeContext.Create( /*serializationInfo*/null, this.citySet, this.cityType, this.cityType);
             ODataContextUrlInfo info = ODataContextUrlInfo.Create(typeContext, version, true, new ODataUri() { SelectAndExpand = selectExpandClause });
             Uri contextUrl = this.responseContextUriBuilder.BuildContextUri(ODataPayloadKind.ResourceSet, info);
             return contextUrl;

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNavigationLinkTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataNavigationLinkTests.cs
@@ -34,7 +34,7 @@ namespace Microsoft.OData.Tests
             };
 
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.BaseType", ExpectedTypeName = "ns.BaseType" };
-            var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
+            var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null);
             var metadataContext = new TestMetadataContext();
             var entryMetadataContext = ODataResourceMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree), null);
             var metadataBuilder = new ODataConventionalEntityMetadataBuilder(entryMetadataContext, metadataContext,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataOperationTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataOperationTests.cs
@@ -41,7 +41,7 @@ namespace Microsoft.OData.Tests
             };
 
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.BaseType", ExpectedTypeName = "ns.BaseType" };
-            var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
+            var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null);
             var metadataContext = new TestMetadataContext();
             var entryMetadataContext = ODataResourceMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree), null);
             var fullMetadataBuilder = new ODataConventionalEntityMetadataBuilder(entryMetadataContext, metadataContext,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataReaderDerivedTypeConstraintTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataReaderDerivedTypeConstraintTests.cs
@@ -320,7 +320,7 @@ namespace Microsoft.OData.Tests
                 Assert.Equal(5, resource.Properties.OfType<ODataProperty>().Single().Value);
 
                 ODataNestedResourceInfo nestedResourceInfo = Assert.IsType<ODataNestedResourceInfo>(ms.Pop()); // FriendCustomer Nested resource info
-                Assert.Throws<ODataException>(() => nestedResourceInfo.Url);
+                Assert.Equal(new Uri("http://example.com/Customers(7)/FriendCustomer/FriendCustomer"), nestedResourceInfo.Url);
                 Assert.Equal("FriendCustomer", nestedResourceInfo.Name);
             };
 
@@ -364,7 +364,7 @@ namespace Microsoft.OData.Tests
                 Assert.Equal("NS.VipCustomer", resource.TypeName);
 
                 ODataNestedResourceInfo nestedResourceInfo = Assert.IsType<ODataNestedResourceInfo>(ms.Pop()); // FriendCustomer Nested resource info
-                Assert.Throws<ODataException>(() => nestedResourceInfo.Url);
+                Assert.Equal(new Uri("http://example.com/Customers(7)/FriendCustomer/NS.VipCustomer/FriendCustomer"), nestedResourceInfo.Url);
                 Assert.Equal("FriendCustomer", nestedResourceInfo.Name);
             };
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.OData.Tests
                 }
             };
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.BaseType", ExpectedTypeName = "ns.BaseType" };
-            var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
+            var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null);
             var metadataContext = new TestMetadataContext();
             var entryMetadataContext = ODataResourceMetadataContext.Create(this.odataEntryWithFullBuilder, typeContext, serializationInfo, null, metadataContext, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree), null);
             this.odataEntryWithFullBuilder.MetadataBuilder =

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTypeContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTypeContextTests.cs
@@ -155,20 +155,6 @@ namespace Microsoft.OData.Tests
 
         #region BaseTypeContextThatThrows
         [Fact]
-        public void BaseTypeContextThatThrowsShouldThrowForEntitySetName()
-        {
-            Action test = () => Assert.Null(BaseTypeContextThatThrows.NavigationSourceName);
-            test.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
-        }
-
-        [Fact]
-        public void BaseTypeContextThatThrowsShouldThrowForEntitySetElementTypeName()
-        {
-            Action test = () => Assert.Null(BaseTypeContextThatThrows.NavigationSourceEntityTypeName);
-            test.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
-        }
-
-        [Fact]
         public void BaseTypeContextThatThrowsShouldReturnNullExpectedEntityTypeName()
         {
             Assert.Null(BaseTypeContextThatThrows.ExpectedResourceTypeName);

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTypeContextTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataResourceTypeContextTests.cs
@@ -47,17 +47,17 @@ namespace Microsoft.OData.Tests
 
             SerializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "MyCustomers", NavigationSourceEntityTypeName = "ns.MyCustomer", ExpectedTypeName = "ns.MyVipCustomer" };
             SerializationInfoWithEdmUnknowEntitySet = new ODataResourceSerializationInfo() { NavigationSourceName = null, NavigationSourceEntityTypeName = "ns.MyCustomer", ExpectedTypeName = "ns.MyVipCustomer", NavigationSourceKind = EdmNavigationSourceKind.UnknownEntitySet };
-            TypeContextWithoutModel = ODataResourceTypeContext.Create(SerializationInfo, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null, throwIfMissingTypeInfo: true);
-            TypeContextWithModel = ODataResourceTypeContext.Create(/*serializationInfo*/null, EntitySet, EntitySetElementType, ExpectedEntityType, throwIfMissingTypeInfo: true);
-            TypeContextWithEdmUnknowEntitySet = ODataResourceTypeContext.Create(SerializationInfoWithEdmUnknowEntitySet, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null, throwIfMissingTypeInfo: true);
-            BaseTypeContextThatThrows = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null, throwIfMissingTypeInfo: true);
-            BaseTypeContextThatWillNotThrow = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null, throwIfMissingTypeInfo: false);
+            TypeContextWithoutModel = ODataResourceTypeContext.Create(SerializationInfo, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null);
+            TypeContextWithModel = ODataResourceTypeContext.Create(/*serializationInfo*/null, EntitySet, EntitySetElementType, ExpectedEntityType);
+            TypeContextWithEdmUnknowEntitySet = ODataResourceTypeContext.Create(SerializationInfoWithEdmUnknowEntitySet, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null);
+            BaseTypeContextThatThrows = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null);
+            BaseTypeContextThatWillNotThrow = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null);
         }
 
         [Fact]
         public void ShouldCreateSubclassWithoutModelWhenSerializationInfoIsGiven()
         {
-            var typeContext = ODataResourceTypeContext.Create(SerializationInfo, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null, throwIfMissingTypeInfo: true);
+            var typeContext = ODataResourceTypeContext.Create(SerializationInfo, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null);
             Assert.NotNull(typeContext);
             Assert.EndsWith("WithoutModel", typeContext.GetType().Name);
         }
@@ -65,7 +65,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void ShouldCreateSubclassWithModelWhenMetadataIsGiven()
         {
-            var typeContext = ODataResourceTypeContext.Create(/*serializationInfo*/null, EntitySet, EntitySetElementType, ExpectedEntityType, throwIfMissingTypeInfo: true);
+            var typeContext = ODataResourceTypeContext.Create(/*serializationInfo*/null, EntitySet, EntitySetElementType, ExpectedEntityType);
             Assert.NotNull(typeContext);
             Assert.EndsWith("WithModel", typeContext.GetType().Name);
         }
@@ -74,7 +74,7 @@ namespace Microsoft.OData.Tests
         public void ShouldCreateSubclassWithModelWhenExpectedTypeisGiven()
         {
             var typeContext = ODataResourceTypeContext.Create(null, navigationSource: null,
-                navigationSourceEntityType: null, expectedResourceType: ComplexType, throwIfMissingTypeInfo: false);
+                navigationSourceEntityType: null, expectedResourceType: ComplexType);
             Assert.NotNull(typeContext);
             Assert.EndsWith("WithModel", typeContext.GetType().Name);
         }
@@ -82,7 +82,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void ShouldCreateSubclassWithoutModelWhenBothSerializationInfoAndMetadataAreGiven()
         {
-            var typeContext = ODataResourceTypeContext.Create(SerializationInfo, EntitySet, EntitySetElementType, ExpectedEntityType, throwIfMissingTypeInfo: true);
+            var typeContext = ODataResourceTypeContext.Create(SerializationInfo, EntitySet, EntitySetElementType, ExpectedEntityType);
             Assert.NotNull(typeContext);
             Assert.EndsWith("WithoutModel", typeContext.GetType().Name);
         }
@@ -90,14 +90,14 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void ShouldCreateBaseClassWhenSerializationInfoAndUserModelAreBothMissingAndThrowIfMissingTypeInfoIsTrue()
         {
-            var typeContext = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null, throwIfMissingTypeInfo: true);
+            var typeContext = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null);
             Assert.IsType<ODataResourceTypeContext>(typeContext);
         }
 
         [Fact]
         public void ShouldCreateBaseClassWhenSerializationInfoAndUserModelAreBothMissingAndThrowIfMissingTypeInfoIsFalse()
         {
-            var typeContext = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null, throwIfMissingTypeInfo: false);
+            var typeContext = ODataResourceTypeContext.Create(serializationInfo: null, navigationSource: null, navigationSourceEntityType: null, expectedResourceType: null);
             Assert.IsType<ODataResourceTypeContext>(typeContext);
         }
 

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataStreamReferenceValueTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ODataStreamReferenceValueTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.OData.Tests
             };
 
             var serializationInfo = new ODataResourceSerializationInfo { NavigationSourceName = "Set", NavigationSourceEntityTypeName = "ns.BaseType", ExpectedTypeName = "ns.BaseType" };
-            var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null, true);
+            var typeContext = ODataResourceTypeContext.Create(serializationInfo, null, null, null);
             var metadataContext = new TestMetadataContext();
             var entryMetadataContext = ODataResourceMetadataContext.Create(entry, typeContext, serializationInfo, null, metadataContext, new SelectedPropertiesNode(SelectedPropertiesNode.SelectionType.EntireSubtree), null);
             var fullMetadataBuilder = new ODataConventionalEntityMetadataBuilder(entryMetadataContext, metadataContext,

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/Writer/Json/ODataJsonInheritComplexCollectionWriterTests.cs
@@ -117,7 +117,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
         {
             Action sync = () => WriteAndValidateSync(/*itemTypeReference*/ null, this.collectionStartWithoutSerializationInfo, items, "", writingResponse: true);
           //  Action async = () => WriteAndValidateAsync(/*itemTypeReference*/ null, this.collectionStartWithoutSerializationInfo, items, "", writingResponse: true);
-            sync.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
+            sync.Throws<ODataException>(Strings.ODataContextUriBuilder_NavigationSourceOrTypeNameMissingForResourceOrResourceSet);
            // Assert.Throws<AggregateException>(async);
         }
 
@@ -186,7 +186,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Writer.Json
         {
             Action sync = () => WriteAndValidateSync(/*itemTypeReference*/ null, this.collectionStartWithoutSerializationInfo, derivedItems, "", writingResponse: true);
             //Action async = () => WriteAndValidateAsync(/*itemTypeReference*/ null, this.collectionStartWithoutSerializationInfo, derivedItems, "", writingResponse: true);
-            sync.Throws<ODataException>(Strings.ODataResourceTypeContext_MetadataOrSerializationInfoMissing);
+            sync.Throws<ODataException>(Strings.ODataContextUriBuilder_NavigationSourceOrTypeNameMissingForResourceOrResourceSet);
             //Assert.Throws<AggregateException>(async);
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Enables writing responses without specifying an entityset.

### Description

UnknownEntitySet is treated as containment -- path becomes path through parent
Id of entities in unknown entity set is path if known, otherwise null
ContextUrl is path, if known, otherwise type

### Checklist (Uncheck if it is not completed)

- [x ] *Test cases added*
- [x ] *Build and test with one-click build and test script passed*

### Additional Work
-Might be able to get rid of ThrowIfMissingTypeInfo (or validate that it relates only to type info, not entity set info)