### PR TITLE
Add README to NuGet package

### DIFF
--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -4,8 +4,8 @@
     <AssemblyName>Microsoft.OData.Client</AssemblyName>
     <RootNamespace>Microsoft.OData.Client</RootNamespace>
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <DefineConstants>$(DefineConstants);ODATA_CLIENT;SUPPRESS_PORTABLELIB_TARGETFRAMEWORK_ATTRIBUTE;DelaySignKeys</DefineConstants>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -5,6 +5,7 @@
     <RootNamespace>Microsoft.OData.Client</RootNamespace>
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
     <DefineConstants>$(DefineConstants);ODATA_CLIENT;SUPPRESS_PORTABLELIB_TARGETFRAMEWORK_ATTRIBUTE;DelaySignKeys</DefineConstants>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -145,6 +146,10 @@
     <Content Include="Microsoft.OData.Client.Desktop.txt" />
     <Content Include="Microsoft.OData.Client.txt" />
   </ItemGroup>
+
+  <ItemGroup>
+	<None Include="README.md" Pack="true" PackagePath="\"/>
+   </ItemGroup>
 
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -148,8 +148,8 @@
   </ItemGroup>
 
   <ItemGroup>
-	<None Include="README.md" Pack="true" PackagePath="\"/>
-   </ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\"/>
+  </ItemGroup>
 
   <ItemGroup>
     <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -6,8 +6,8 @@
     <RootNamespace>Microsoft.OData.Core</RootNamespace>
 
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <DefineConstants>$(DefineConstants);ODATA_CORE;SUPPRESS_PORTABLELIB_TARGETFRAMEWORK_ATTRIBUTE;DelaySignKeys</DefineConstants>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -7,6 +7,7 @@
 
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
     <DefineConstants>$(DefineConstants);ODATA_CORE;SUPPRESS_PORTABLELIB_TARGETFRAMEWORK_ATTRIBUTE;DelaySignKeys</DefineConstants>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
@@ -42,6 +43,10 @@
   <ItemGroup>
     <None Remove="Microsoft.OData.Core.tt" />
     <None Remove="Parameterized.Microsoft.OData.Core.tt" />
+  </ItemGroup>
+
+  <ItemGroup>
+     <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
+++ b/src/Microsoft.OData.Core/Microsoft.OData.Core.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
 
   <ItemGroup>
-     <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -5,8 +5,8 @@
     <AssemblyName>Microsoft.OData.Edm</AssemblyName>
     <RootNamespace>Microsoft.OData.Edm</RootNamespace>
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <DefineConstants>$(DefineConstants);SUPPRESS_PORTABLELIB_TARGETFRAMEWORK_ATTRIBUTE</DefineConstants>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-	 <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
+++ b/src/Microsoft.OData.Edm/Microsoft.OData.Edm.csproj
@@ -6,6 +6,7 @@
     <RootNamespace>Microsoft.OData.Edm</RootNamespace>
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
     <DefineConstants>$(DefineConstants);SUPPRESS_PORTABLELIB_TARGETFRAMEWORK_ATTRIBUTE</DefineConstants>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
@@ -18,6 +19,10 @@
   
   <ItemGroup>
     <None Remove="Microsoft.OData.Edm.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+	 <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Spatial/Microsoft.Spatial.csproj
+++ b/src/Microsoft.Spatial/Microsoft.Spatial.csproj
@@ -7,6 +7,7 @@
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
     <DefineConstants>TRACE;SPATIAL;SUPPRESS_PORTABLELIB_TARGETFRAMEWORK_ATTRIBUTE;DelaySignKeys</DefineConstants>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+	<PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
   </PropertyGroup>
@@ -23,6 +24,10 @@
     <None Remove="Microsoft.Spatial.tt" />
     <None Remove="Microsoft.Spatial.xml" />
     <None Remove="Parameterized.Microsoft.Spatial.tt" />
+  </ItemGroup>
+
+  <ItemGroup>
+     <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.Spatial/Microsoft.Spatial.csproj
+++ b/src/Microsoft.Spatial/Microsoft.Spatial.csproj
@@ -5,9 +5,9 @@
     <RootNamespace>Microsoft.Spatial</RootNamespace>
 
     <DocumentationFile>$(AssemblyName).xml</DocumentationFile>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <DefineConstants>TRACE;SPATIAL;SUPPRESS_PORTABLELIB_TARGETFRAMEWORK_ATTRIBUTE;DelaySignKeys</DefineConstants>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-	<PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
     <IsShipping>true</IsShipping>
   </PropertyGroup>

--- a/src/Microsoft.Spatial/Microsoft.Spatial.csproj
+++ b/src/Microsoft.Spatial/Microsoft.Spatial.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-     <None Include="README.md" Pack="true" PackagePath="\"/>
+    <None Include="README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

This PR update `csproj` files by adding `README.md` as the package readme file. This is to ensure README.md is package when generating NuGet package.

https://devblogs.microsoft.com/nuget/add-a-readme-to-your-nuget-package/ 
https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packagereadmefile

#### Summary:
1. `<PackageReadmeFile>README.md</PackageReadmeFile>`:
    - This line specifies that the README.md file should be included as the readme file in the NuGet package. When someone views your package on NuGet.org, this README file will be displayed.
2. `<None Include="README.md" Pack="true" PackagePath="\"/>`:
   - This line includes the README.md file in the package. The `Include` attribute specifies the file to include.
   - The `Pack="true"` attribute ensures that the file is included in the NuGet package.
   - The `PackagePath="\"` attribute specifies the path within the package where the file will be placed. In this case, it places the README.md file at the root of the package.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
