### PR TITLE
Fixing when to add DependsOnIds. Fixes #3150

### DIFF
--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -1047,6 +1047,7 @@ namespace Microsoft.OData.Client
                 Error.ThrowBatchUnexpectedContent(InternalError.LinkNotAddedState);
             }
 
+            linkDescriptor.DependsOnIds = null;
             linkDescriptor.State = EntityStates.Unchanged;
         }
 
@@ -1226,6 +1227,7 @@ namespace Microsoft.OData.Client
                 {
                     entityDescriptor.ETag = etag;
                     entityDescriptor.State = EntityStates.Unchanged;
+                    entityDescriptor.DependsOnIds = null;
                     entityDescriptor.PropertiesToSerialize.Clear();
                 }
 
@@ -1297,6 +1299,7 @@ namespace Microsoft.OData.Client
                         Debug.Assert(entityDescriptor.State == EntityStates.Modified, "descriptor.State == EntityStates.Modified");
                         entityDescriptor.ETag = etag;
                         entityDescriptor.State = EntityStates.Unchanged;
+                        entityDescriptor.DependsOnIds = null;
                         entityDescriptor.PropertiesToSerialize.Clear();
                     }
                 }
@@ -1306,6 +1309,7 @@ namespace Microsoft.OData.Client
                 if ((EntityStates.Added == descriptor.State) || (EntityStates.Modified == descriptor.State))
                 {
                     descriptor.State = EntityStates.Unchanged;
+                    descriptor.DependsOnIds = null;
                 }
                 else if (EntityStates.Detached != descriptor.State)
                 {   // this link may have been previously detached by a detaching entity
@@ -1317,6 +1321,7 @@ namespace Microsoft.OData.Client
                 Debug.Assert(descriptor.DescriptorKind == DescriptorKind.NamedStream, "it must be named stream");
                 Debug.Assert(descriptor.State == EntityStates.Modified, "named stream must only be in modified state");
                 descriptor.State = EntityStates.Unchanged;
+                descriptor.DependsOnIds = null;
 
                 StreamDescriptor streamDescriptor = (StreamDescriptor)descriptor;
 

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -2491,6 +2491,11 @@ namespace Microsoft.OData.Client
             if (relation == null)
             {
                 relation = new LinkDescriptor(source, sourceProperty, target, this.model);
+                EntityDescriptor sourceResource = this.entityTracker.GetEntityDescriptor(source);
+                if (sourceResource.State == EntityStates.Added)
+                {
+                    relation.DependsOnIds = new List<string> { sourceResource.ChangeOrder.ToString(CultureInfo.InvariantCulture) };
+                }
                 this.entityTracker.AddLink(relation);
             }
 
@@ -2633,9 +2638,13 @@ namespace Microsoft.OData.Client
             var targetResource = new EntityDescriptor(this.model)
             {
                 Entity = target,
-                State = EntityStates.Added,
-                DependsOnIds = new List<string> { sourceResource.ChangeOrder.ToString(CultureInfo.InvariantCulture) }
+                State = EntityStates.Added
             };
+
+            if (sourceResource.State == EntityStates.Added)
+            {
+                targetResource.DependsOnIds = new List<string> { sourceResource.ChangeOrder.ToString(CultureInfo.InvariantCulture) };
+            }
 
             targetResource.SetParentForInsert(sourceResource, sourceProperty);
 
@@ -2884,8 +2893,12 @@ namespace Microsoft.OData.Client
                 {
                     Entity = target,
                     State = EntityStates.Modified,
-                    EditLink = sourceResource.GetNestedResourceInfo(this.baseUriResolver, property)
+                    EditLink = sourceResource.GetNestedResourceInfo(this.baseUriResolver, property) 
                 };
+                if (sourceResource.State == EntityStates.Added)
+                {
+                    targetResource.DependsOnIds = new List<string> { sourceResource.ChangeOrder.ToString(CultureInfo.InvariantCulture) };
+                }
 
                 targetResource.SetParentForUpdate(sourceResource, sourceProperty);
                 this.EntityTracker.AddEntityDescriptor(targetResource);
@@ -4313,6 +4326,7 @@ namespace Microsoft.OData.Client
             }
 
             descriptor.State = EntityStates.Unchanged;
+            descriptor.DependsOnIds = null;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/ObjectMaterializerLog.cs
+++ b/src/Microsoft.OData.Client/ObjectMaterializerLog.cs
@@ -206,6 +206,7 @@ namespace Microsoft.OData.Client
                     {
                         // we should always reset descriptor's state to Unchanged (old v1 behavior)
                         descriptor.State = EntityStates.Unchanged;
+                        descriptor.DependsOnIds = null;
                         descriptor.PropertiesToSerialize.Clear();
                     }
                 }

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/Server/BankAccountsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/Server/BankAccountsController.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.OData.Client.E2E.Tests.Batch.Server
+{
+    internal class BankAccountsController : ODataController
+    {
+        // POST: odata/Banks
+        [EnableQuery]
+        [HttpPost("odata/BankAccounts")]
+        public IActionResult Post([FromBody] BankAccount bankAccount)
+        {
+            if (bankAccount == null)
+            {
+                return BadRequest();
+            }
+            BanksController._dataSource.BankAccounts.Add(bankAccount);
+            return Created(bankAccount);
+        }
+
+        // PUT: /odata/$1/Bank
+        [EnableQuery]
+        [HttpPut("odata/BankAccounts({id})/Bank/$ref")]
+        public IActionResult PutBankAccountBank([FromODataUri] int id, [FromBody] Bank bank)
+        {
+            if (bank == null)
+            {
+                return BadRequest();
+            }
+            BankAccount bankAccount = BanksController._dataSource.BankAccounts.First();
+            bankAccount.Bank = bank;
+            return Updated(bankAccount);
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/Server/BanksController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/Server/BanksController.cs
@@ -8,7 +8,7 @@ namespace Microsoft.OData.Client.E2E.Tests.Batch.Server
 {
     public class BanksController : ODataController
     {
-        private static CommonEndToEndDataSource _dataSource = CommonEndToEndDataSource.CreateInstance();
+        internal static CommonEndToEndDataSource _dataSource = CommonEndToEndDataSource.CreateInstance();
 
         [EnableQuery]
         [HttpGet("odata/Banks")]

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Common/Server/EndToEnd/CommonEndToEndDataSource.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Common/Server/EndToEnd/CommonEndToEndDataSource.cs
@@ -140,6 +140,7 @@ namespace Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd
                  }
                 ];
 
+            this.BankAccounts = new List<BankAccount>();
         }
 
         private void PopulateBankAccount()


### PR DESCRIPTION
Resetting DependOnIds Fixes #3150

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3150*

### Description

*Briefly describe the changes of this pull request.*

Resetting DependOnIds in BaseSaveResult and ObjectMaterializerLog. 
Fixing when to add DependsOnIds. 
Add DependOnIds to missing code paths.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
