### PR TITLE
Fixes #2794: Enable $root path

### DIFF
--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -95,6 +95,7 @@
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\SelectToken.cs" Link="ALinq\UriParser\SyntacticAst\SelectToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\StarToken.cs" Link="ALinq\UriParser\SyntacticAst\StarToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\SystemToken.cs" Link="ALinq\UriParser\SyntacticAst\SystemToken.cs" />
+    <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\RootPathToken.cs" Link="ALinq\UriParser\SyntacticAst\RootPathToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\SyntacticAst\UnaryOperatorToken.cs" Link="ALinq\UriParser\SyntacticAst\UnaryOperatorToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\Aggregation\ApplyTransformationToken.cs" Link="ALinq\UriParser\Aggregation\ApplyTransformationToken.cs" />
     <Compile Include="..\Microsoft.OData.Core\UriParser\Aggregation\EntitySetAggregateToken.cs" Link="ALinq\UriParser\Aggregation\EntitySetAggregateToken.cs" />

--- a/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,7 @@
+Microsoft.OData.Client.ALinq.UriParser.ISyntacticTreeVisitor<T>.Visit(Microsoft.OData.Client.ALinq.UriParser.RootPathToken tokenIn) -> T
+Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind.RootPath = 33 -> Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind
+Microsoft.OData.Client.ALinq.UriParser.RootPathToken
+Microsoft.OData.Client.ALinq.UriParser.RootPathToken.RootPathToken() -> void
+Microsoft.OData.Client.ALinq.UriParser.RootPathToken.Segments.get -> System.Collections.Generic.IList<string>
+override Microsoft.OData.Client.ALinq.UriParser.RootPathToken.Accept<T>(Microsoft.OData.Client.ALinq.UriParser.ISyntacticTreeVisitor<T> visitor) -> T
+override Microsoft.OData.Client.ALinq.UriParser.RootPathToken.Kind.get -> Microsoft.OData.Client.ALinq.UriParser.QueryTokenKind

--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,14 @@
+Microsoft.OData.UriParser.ISyntacticTreeVisitor<T>.Visit(Microsoft.OData.UriParser.RootPathToken tokenIn) -> T
+Microsoft.OData.UriParser.QueryNodeKind.RootPath = 34 -> Microsoft.OData.UriParser.QueryNodeKind
+Microsoft.OData.UriParser.QueryTokenKind.RootPath = 33 -> Microsoft.OData.UriParser.QueryTokenKind
+Microsoft.OData.UriParser.RootPathNode
+Microsoft.OData.UriParser.RootPathNode.Path.get -> Microsoft.OData.UriParser.ODataPath
+Microsoft.OData.UriParser.RootPathNode.RootPathNode(Microsoft.OData.UriParser.ODataPath path, Microsoft.OData.Edm.IEdmTypeReference typeRef) -> void
+Microsoft.OData.UriParser.RootPathToken
+Microsoft.OData.UriParser.RootPathToken.RootPathToken() -> void
+Microsoft.OData.UriParser.RootPathToken.Segments.get -> System.Collections.Generic.IList<string>
+override Microsoft.OData.UriParser.RootPathNode.Accept<T>(Microsoft.OData.UriParser.QueryNodeVisitor<T> visitor) -> T
+override Microsoft.OData.UriParser.RootPathNode.TypeReference.get -> Microsoft.OData.Edm.IEdmTypeReference
+override Microsoft.OData.UriParser.RootPathToken.Accept<T>(Microsoft.OData.UriParser.ISyntacticTreeVisitor<T> visitor) -> T
+override Microsoft.OData.UriParser.RootPathToken.Kind.get -> Microsoft.OData.UriParser.QueryTokenKind
+virtual Microsoft.OData.UriParser.QueryNodeVisitor<T>.Visit(Microsoft.OData.UriParser.RootPathNode nodeIn) -> T

--- a/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/UriQueryExpressionParser.cs
@@ -1064,6 +1064,12 @@ namespace Microsoft.OData.UriParser
                 expr = this.ParsePrimaryStart();
             }
 
+            // Pase the $root path, for example: '$root/people(12)'
+            if (expr != null && expr.Kind == QueryTokenKind.RootPath)
+            {
+                return ParseRootPath((RootPathToken)expr);
+            }
+
             while (this.lexer.CurrentToken.Kind == ExpressionTokenKind.Slash)
             {
                 this.lexer.NextToken();
@@ -1136,6 +1142,66 @@ namespace Microsoft.OData.UriParser
                         return primitiveLiteralToken;
                     }
             }
+        }
+
+        private RootPathToken ParseRootPath(RootPathToken rootPathToken)
+        {
+            while (this.lexer.CurrentToken.Kind == ExpressionTokenKind.Slash)
+            {
+                this.lexer.NextToken(); // read over the '/'
+
+                // a function call or an entity with key value is treated same as function call.
+                bool identifierIsFunction = this.lexer.ExpandIdentifierAsFunction();
+                if (identifierIsFunction && TryParseIdentifierAsFunction(lexer, out string result))
+                {
+                    rootPathToken.Segments.Add(result);
+                    this.lexer.NextToken();
+                    continue;
+                }
+
+                if (this.lexer.PeekNextToken().Kind == ExpressionTokenKind.Dot)
+                {
+                    ReadOnlySpan<char> dotIdentifier = this.lexer.ReadDottedIdentifier(false);
+                    rootPathToken.Segments.Add(dotIdentifier.ToString());
+                    //lexer.NextToken();
+                    continue;
+                }
+
+                //lexer.ValidateToken(ExpressionTokenKind.Identifier); // could be integerLiteral or others, for example: /people/1234
+                rootPathToken.Segments.Add(this.lexer.CurrentToken.Text.ToString());
+                this.lexer.NextToken();
+            }
+
+            return rootPathToken;
+        }
+
+        private static bool TryParseIdentifierAsFunction(ExpressionLexer lexer, out string result)
+        {
+            result = null;
+            ReadOnlySpan<char> functionName;
+
+            ExpressionLexer.ExpressionLexerPosition position = lexer.SnapshotPosition();
+
+            if (lexer.PeekNextToken().Kind == ExpressionTokenKind.Dot)
+            {
+                // handle the case where we prefix a function with its namespace.
+                functionName = lexer.ReadDottedIdentifier(false);
+            }
+            else
+            {
+                functionName = lexer.CurrentToken.Span;
+                lexer.NextToken();
+            }
+
+            if (lexer.CurrentToken.Kind != ExpressionTokenKind.OpenParen)
+            {
+                lexer.RestorePosition(position);
+                return false;
+            }
+
+            string parameters = lexer.AdvanceThroughBalancedParentheticalExpression();
+            result = $"{functionName}{parameters}";
+            return true;
         }
 
         /// <summary>
@@ -1250,6 +1316,17 @@ namespace Microsoft.OData.UriParser
         {
             string propertyName = this.lexer.CurrentToken.GetIdentifier().ToString();
             this.lexer.NextToken();
+
+            if (string.Equals(propertyName, "$root", enableCaseInsensitiveBuiltinIdentifier ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
+            {
+                if (parent != null)
+                {
+                    throw new ODataException("$root should be the top-level segment");
+                }
+
+                return new RootPathToken();
+            }
+
             if (this.parameters.Contains(propertyName) && parent == null)
             {
                 return new RangeVariableToken(propertyName);

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/RootPathNode.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/RootPathNode.cs
@@ -1,0 +1,56 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="RootPathNode.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.UriParser
+{
+    using Microsoft.OData.Edm;
+
+    /// <summary>
+    /// The $root literal can be used in expressions to refer to resources of the same service. It can be used as a single-valued expression or within complex or collection literals.
+    /// </summary>
+    public sealed class RootPathNode : SingleValueNode
+    {
+        /// <summary>
+        /// Created a RootPathNode with the given path and the given type.
+        /// </summary>
+        /// <param name="path">The OData path.</param>
+        /// <param name="typeRef">The path type. It could be null if the last segment is dynamic.</param>
+        public RootPathNode(ODataPath path, IEdmTypeReference typeRef)
+        {
+            ExceptionUtils.CheckArgumentNotNull(path, "path");
+            Path = path;
+            TypeReference = typeRef;
+        }
+
+        /// <summary>
+        /// Gets the OData path.
+        /// </summary>
+        public ODataPath Path { get;}
+
+        /// <summary>
+        /// Gets the type of the single value this node represents.
+        /// </summary>
+        public override IEdmTypeReference TypeReference { get; }
+
+        /// <summary>
+        /// Gets the kind of this node.
+        /// </summary>
+        internal override InternalQueryNodeKind InternalKind => InternalQueryNodeKind.RootPath;
+
+        /// <summary>
+        /// Accept a <see cref="QueryNodeVisitor{T}"/> to walk a tree of <see cref="QueryNode"/>s.
+        /// </summary>
+        /// <typeparam name="T">Type that the visitor will return after visiting this token.</typeparam>
+        /// <param name="visitor">An implementation of the visitor interface.</param>
+        /// <returns>An object whose type is determined by the type parameter of the visitor.</returns>
+        /// <exception cref="System.ArgumentNullException">Throws if the input visitor is null.</exception>
+        public override T Accept<T>(QueryNodeVisitor<T> visitor)
+        {
+            ExceptionUtils.CheckArgumentNotNull(visitor, "visitor");
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryTokenKind.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/QueryTokenKind.cs
@@ -159,6 +159,11 @@ namespace Microsoft.OData.UriParser
         /// <summary>
         /// $count segment
         /// </summary>
-        CountSegment = 32
+        CountSegment = 32,
+
+        /// <summary>
+        /// $root path
+        /// </summary>
+        RootPath = 33
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/SyntacticAst/RootPathToken.cs
+++ b/src/Microsoft.OData.Core/UriParser/SyntacticAst/RootPathToken.cs
@@ -1,0 +1,40 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="EndPathToken.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.Generic;
+#if ODATA_CLIENT
+namespace Microsoft.OData.Client.ALinq.UriParser
+#else
+namespace Microsoft.OData.UriParser
+#endif
+{
+    /// <summary>
+    /// Lexical token representing a $root path.
+    /// </summary>
+    public sealed class RootPathToken : QueryToken
+    {
+        /// <summary>
+        /// The kind of the query token.
+        /// </summary>
+        public override QueryTokenKind Kind => QueryTokenKind.RootPath;
+
+        /// <summary>
+        /// Path segments (without the $root leading segment)
+        /// </summary>
+        public IList<string> Segments { get; } = new List<string>();
+
+        /// <summary>
+        /// Accept a <see cref="ISyntacticTreeVisitor{T}"/> to walk a tree of <see cref="QueryToken"/>s.
+        /// </summary>
+        /// <typeparam name="T">Type that the visitor will return after visiting this token.</typeparam>
+        /// <param name="visitor">An implementation of the visitor interface.</param>
+        /// <returns>An object whose type is determined by the type parameter of the visitor.</returns>
+        public override T Accept<T>(ISyntacticTreeVisitor<T> visitor)
+        {
+            return visitor.Visit(this);
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/TreeNodeKinds/QueryNodeKind.cs
+++ b/src/Microsoft.OData.Core/UriParser/TreeNodeKinds/QueryNodeKind.cs
@@ -183,6 +183,11 @@ namespace Microsoft.OData.UriParser
         /// Node that represents a collection of constants.
         /// </summary>
         CollectionConstant = InternalQueryNodeKind.CollectionConstant,
+
+       /// <summary>
+       /// Node that represents a $root path
+       /// </summary>
+        RootPath = InternalQueryNodeKind.RootPath,
     }
 
     /// <summary>
@@ -359,5 +364,10 @@ namespace Microsoft.OData.UriParser
         /// Node that represents a collection of constants.
         /// </summary>
         CollectionConstant = 33,
+
+        /// <summary>
+        /// Node that represetns a $root path
+        /// </summary>
+        RootPath,
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Visitors/ISyntacticTreeVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/ISyntacticTreeVisitor.cs
@@ -192,5 +192,12 @@ namespace Microsoft.OData.UriParser
         /// <param name="tokenIn">The GroupByToken to bind</param>
         /// <returns>A T node bound to this GroupByToken</returns>
         T Visit(GroupByToken tokenIn);
+
+        /// <summary>
+        /// Visits a RootPathToken
+        /// </summary>
+        /// <param name="tokenIn">The RootPathToken to bind</param>
+        /// <returns>A user defined value</returns>
+        T Visit(RootPathToken tokenIn);
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Visitors/QueryNodeVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/QueryNodeVisitor.cs
@@ -313,5 +313,15 @@ namespace Microsoft.OData.UriParser
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Visit an RootPathNode
+        /// </summary>
+        /// <param name="nodeIn">the node to visit</param>
+        /// <returns>Defined by the implementer</returns>
+        public virtual T Visit(RootPathNode nodeIn)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Microsoft.OData.Core/UriParser/Visitors/SyntacticTreeVisitor.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/SyntacticTreeVisitor.cs
@@ -288,5 +288,15 @@ namespace Microsoft.OData.UriParser
         {
             throw new NotImplementedException();
         }
+
+        /// <summary>
+        /// Visits a RootPathToken
+        /// </summary>
+        /// <param name="tokenIn">The RootPathToken to bind</param>
+        /// <returns>A user defined value</returns>
+        public virtual T Visit(RootPathToken tokenIn)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -919,7 +919,58 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             anyOnPrimitiveType.Throws<ODataException>(SRResources.MetadataBinder_LambdaParentMustBeCollection);
         }
 
-#region Custom Functions
+        [Theory]
+        [InlineData("Name eq $root/People(1245)/Name")]
+        [InlineData("Name eq $root/People/1245/Name")]
+        public void ParseDollarRootPath_WithPropertyAccess_InFilter(string filter)
+        {
+            var filterQueryNode = ParseFilter(filter, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            BinaryOperatorNode bod = filterQueryNode.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            bod.Left.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonNameProp());
+            RootPathNode rootPathNode = bod.Right.ShouldBeRootPathNode();
+            Assert.Equal(3, rootPathNode.Path.Count);
+
+            rootPathNode.Path.Segments[0].ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
+            rootPathNode.Path.Segments[1].ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 1245));
+            rootPathNode.Path.Segments[2].ShouldBePropertySegment(HardCodedTestModel.GetPersonNameProp());
+        }
+
+        [Fact]
+        public void ParseDollarRootPath_WithTypeCastAndPropertyAccess_InFilter()
+        {
+            string filter = "Name eq $root/People/1245/Fully.Qualified.Namespace.Employee/WorkEmail";
+
+            var filterQueryNode = ParseFilter(filter, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            BinaryOperatorNode bod = filterQueryNode.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            bod.Left.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonNameProp());
+            RootPathNode rootPathNode = bod.Right.ShouldBeRootPathNode();
+            Assert.Equal(4, rootPathNode.Path.Count);
+
+            rootPathNode.Path.Segments[0].ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
+            rootPathNode.Path.Segments[1].ShouldBeKeySegment(new KeyValuePair<string, object>("ID", 1245));
+            rootPathNode.Path.Segments[2].ShouldBeTypeSegment(HardCodedTestModel.GetEmployeeType(), HardCodedTestModel.GetPersonType());
+            rootPathNode.Path.Segments[3].ShouldBePropertySegment(HardCodedTestModel.GetEmployeeWorkEmailProp());
+        }
+
+        [Fact]
+        public void ParseDollarRootPath_WithDollarCount_InFilter()
+        {
+            string filter = "$root/People/$count lt ID";
+
+            var filterQueryNode = ParseFilter(filter, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            BinaryOperatorNode bod = filterQueryNode.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.LessThan);
+            ConvertNode convertNode = bod.Right.ShouldBeConvertQueryNode(EdmCoreModel.Instance.GetInt32(true));
+            convertNode.Source.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonIdProp());
+
+            RootPathNode rootPathNode = bod.Left.ShouldBeRootPathNode();
+            Assert.Equal(2, rootPathNode.Path.Count);
+
+            rootPathNode.Path.Segments[0].ShouldBeEntitySetSegment(HardCodedTestModel.GetPeopleSet());
+            Assert.Same(CountSegment.Instance, rootPathNode.Path.Segments[1]);
+        }
+
+        #region Custom Functions
 
         [Fact]
         public void FunctionWithASingleOverloadWorksInFilter()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/ParameterAliasFunctionalTests.cs
@@ -237,6 +237,20 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                 });
         }
 
+        [Fact]
+        public void ParsePath_AliasInUnboundFunction_WithinDollarRootPath()
+        {
+            ParseUriAndVerify(
+                new Uri("http://gobbledygook/GetRatings(films=@c)?@c=[$root/Films(1),$root/Films(3)]"),
+                (oDataPath, filterClause, orderByClause, selectExpandClause, aliasNodes) =>
+                {
+                    oDataPath.LastSegment.ShouldBeOperationImportSegment(HardCodedTestModel.GetFunctionImportForGetRatings());
+
+                    var constNode = Assert.IsType<ConstantNode>(aliasNodes["@c"]);
+                    Assert.Equal("[$root/Films(1),$root/Films(3)]", constNode.Value);
+                });
+        }
+
         #endregion
 
         #region alias in filter

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -740,6 +740,7 @@ namespace Microsoft.OData.Tests.UriParser
             var FullyQualifiedNamespaceContextPet4Set = FullyQualifiedNamespaceContext.AddEntitySet("Pet4Set", FullyQualifiedNamespacePet4);
             var FullyQualifiedNamespaceContextPet5Set = FullyQualifiedNamespaceContext.AddEntitySet("Pet5Set", FullyQualifiedNamespacePet5);
             var FullyQualifiedNamespaceContextPet6Set = FullyQualifiedNamespaceContext.AddEntitySet("Pet6Set", FullyQualifiedNamespacePet6);
+            var FullyQualifiedNamespaceContextFilmSet = FullyQualifiedNamespaceContext.AddEntitySet("Films", FullyQualifiedNamespaceFilm);
             var FullyQualifiedNamespaceContextChimera = FullyQualifiedNamespaceContext.AddEntitySet("Chimeras", FullyQualifiedNamespaceChimera);
 
             FullyQualifiedNamespaceContext.AddEntitySet("Shapes", fullyQualifiedNamespaceShape);
@@ -912,6 +913,7 @@ namespace Microsoft.OData.Tests.UriParser
         <EntitySet Name=""Pet4Set"" EntityType=""Fully.Qualified.Namespace.Pet4"" />
         <EntitySet Name=""Pet5Set"" EntityType=""Fully.Qualified.Namespace.Pet5"" />
         <EntitySet Name=""Pet6Set"" EntityType=""Fully.Qualified.Namespace.Pet6"" />
+        <EntitySet Name=""Films"" EntityType=""Fully.Qualified.Namespace.Film"" />
         <EntitySet Name=""Chimeras"" EntityType=""Fully.Qualified.Namespace.Chimera"" />
         <Singleton Name=""Boss"" Type=""Fully.Qualified.Namespace.Person"">
           <NavigationPropertyBinding Path=""MyDog"" Target=""Dogs"" />
@@ -1656,6 +1658,11 @@ namespace Microsoft.OData.Tests.UriParser
         public static IEdmEntitySet GetPet6Set()
         {
             return TestModel.FindEntityContainer("Context").FindEntitySet("Pet6Set");
+        }
+
+        public static IEdmEntitySet GetFilmSet()
+        {
+            return TestModel.FindEntityContainer("Context").FindEntitySet("Films");
         }
 
         public static IEdmEntitySet GetPeopleSet()

--- a/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/NodeAssertions.cs
+++ b/test/FunctionalTests/Microsoft.OData.Core.Tests/UriParser/NodeAssertions.cs
@@ -207,6 +207,14 @@ namespace Microsoft.OData.Tests.UriParser
             return propertyAccessNode;
         }
 
+        public static RootPathNode ShouldBeRootPathNode(this QueryNode node)
+        {
+            Assert.NotNull(node);
+            var rootPathNode = Assert.IsType<RootPathNode>(node);
+            Assert.NotNull(rootPathNode.Path);
+            return rootPathNode;
+        }
+
         public static SingleComplexNode ShouldBeSingleComplexNode(this QueryNode node, IEdmProperty expectedProperty)
         {
             Assert.NotNull(node);


### PR DESCRIPTION
Fixes #2794: Enable $root path

5.1.1.14.5 $root
The $root literal can be used in expressions to refer to resources of the same service. It can be used as a single-valued expression or within complex or collection literals.

Example 108: all employees with the same last name as employee A1235

http://host/service/Employees?$filter=LastName eq $root/Employees('A1245')/LastName

Example 109: products ordered by a set of customers, where the set of customers is passed as a JSON array containing the resource paths from $root to each customer.

http://host/service/ProductsOrderedBy(Customers=@c)?@c=[$root/Customers('ALFKI'),$root/Customers('BLAUS')]