### PR TITLE
Add support for top level `JsonElement` values

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataJsonPropertySerializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonPropertySerializer.cs
@@ -388,7 +388,9 @@ namespace Microsoft.OData.Json
                 return;
             }
 
-            if (value is ODataNullValue || value == null)
+            if (value is ODataNullValue
+                || value == null
+                || value is ODataJsonElementValue jsonElement && jsonElement.Value.ValueKind == System.Text.Json.JsonValueKind.Null)
             {
                 await this.WriteNullPropertyAsync(property).ConfigureAwait(false);
                 return;

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataMessageWriterTests.cs
@@ -19,6 +19,7 @@ using Microsoft.OData.UriParser;
 using Microsoft.OData.Edm.Csdl;
 using Xunit;
 using Microsoft.OData.Core;
+using System.Reflection.Metadata;
 
 namespace Microsoft.OData.Tests
 {
@@ -312,14 +313,14 @@ namespace Microsoft.OData.Tests
         [Theory]
         [InlineData("true", "Edm.Boolean")]
         [InlineData("false", "Edm.Boolean")]
-        [InlineData("123", "Edm.Int32")]
+        [InlineData("123", "Edm.Double")]
         [InlineData("\"This is a string\"", "Edm.String")]
-        public async Task SupportsTopLevelPropertyWithPrimitiveJsonElementValue(string rawValue, string expectedType)
+        public async Task SupportsTopLevelPropertyWithPrimitiveJsonElementValueAsync(string rawValue, string expectedType)
         {
             // Arrange
             EdmModel model = new EdmModel();
             JsonElement jsonElement = JsonDocument.Parse(rawValue).RootElement;
-            
+
             // Act
             string output = await WriteAndGetPayloadAsync(
                 model,
@@ -336,6 +337,84 @@ namespace Microsoft.OData.Tests
 
             // Assert
             Assert.Equal($"{{\"@odata.context\":\"http://www.example.com/$metadata#{expectedType}\",\"value\":{rawValue}}}", output);
+        }
+
+        [Theory]
+        [InlineData("[1,2,3]")]
+        [InlineData("{\"foo\":\"bar\"}")]
+        public async Task WritesUntypedContextJsonElementTopLevelPropertyWithArrayOrObject(string rawValue)
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+            JsonElement jsonElement = JsonDocument.Parse(rawValue).RootElement;
+
+            // Act
+            string output = await WriteAndGetPayloadAsync(
+                model,
+                "application/json",
+                (writer) => writer.WritePropertyAsync(new ODataProperty()
+                {
+                    Name = "Name",
+                    Value = new ODataJsonElementValue(jsonElement)
+                }),
+                configureServices: (containerBuilder) =>
+                {
+                    containerBuilder.AddSingleton<IJsonWriterFactory>(sp => ODataUtf8JsonWriterFactory.Default);
+                });
+
+            // Assert
+            Assert.Equal($"{{\"@odata.context\":\"http://www.example.com/$metadata#Edm.Untyped\",\"value\":{rawValue}}}", output);
+        }
+
+        [Theory]
+        [InlineData(true, "Edm.Boolean")]
+        [InlineData(false, "Edm.Boolean")]
+        [InlineData(123, "Edm.Int32")]
+        [InlineData(123.0, "Edm.Double")]
+        [InlineData("\"This is a string\"", "Edm.String")]
+        public async Task SupportsTopLevelPropertyWithPrimitiveValueAsync(object value, string expectedType)
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+
+            // Act
+            string output = await WriteAndGetPayloadAsync(
+                model,
+                "application/json",
+                (writer) => writer.WritePropertyAsync(new ODataProperty()
+                {
+                    Name = "Name",
+                    Value = value
+                }),
+                configureServices: (containerBuilder) =>
+                {
+                    containerBuilder.AddSingleton<IJsonWriterFactory>(sp => ODataUtf8JsonWriterFactory.Default);
+                });
+
+            // Assert
+            Assert.Equal($"{{\"@odata.context\":\"http://www.example.com/$metadata#{expectedType}\",\"value\":{value}}}", output);
+        }
+
+        [Fact]
+        public async Task ThrowsExceptionIfJsonElementValueContainsNullInTopLevelPropertyAsync()
+        {
+            // Arrange
+            EdmModel model = new EdmModel();
+            JsonElement jsonElement = JsonDocument.Parse("null").RootElement;
+
+            // Act
+            var testCode = async () => await WriteAndGetPayloadAsync(
+                model,
+                "application/json",
+                (writer) => writer.WritePropertyAsync(new ODataProperty()
+                {
+                    Name = "Name",
+                    Value = new ODataJsonElementValue(jsonElement)
+                }));
+
+            // Assert
+            var exception = await Assert.ThrowsAsync<ODataException>(testCode);
+            Assert.Equal("Cannot write the value 'null' in top level property; return 204 instead.", exception.Message);
         }
 
         [Theory]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3162*

### Description

The was that we didn't support extracting type name from the `ODataJsonElementValue` for the context URL when writing top-level properties. This PR handles that as follows:

- for primitives, use the corresponding Edm primitive type name. For numbers, this returns `Edm.Double` since we can't be use of the numerical type (int32, double, decimal, etc.?) based on the value kind alone.
- for arrays and objects, return `Edm.Untyped`. This can be problematic and needs to be re-evaluated to see if there's a better option.
- for `null`, throw an exception by default since top-level nulls are not supported by default, but with the right compatibility flag, we can return `Edm.Null` (TODO: add test for the latter case)

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
