### PR TITLE
Port QueryCount and CancellationToken tests

### DIFF
--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Server/CancellationTokenTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Server/CancellationTokenTestsController.cs
@@ -1,0 +1,148 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="CancellationTokenTestsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.IO;
+using System.Net.Mime;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Net.Http.Headers;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.DeltaTests.Server;
+
+public class CancellationTokenTestsController : ODataController
+{
+    private static CommonEndToEndDataSource _dataSource;
+
+    [EnableQuery(PageSize = 5)]
+    [HttpGet("odata/Customers")]
+    public IActionResult GetCustomers(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Ok(_dataSource.Customers);
+    }
+
+    [EnableQuery]
+    [HttpGet("odata/Customers({key})")]
+    public IActionResult GetCustomer([FromODataUri] int key, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var customer = _dataSource.Customers?.FirstOrDefault(c => c.CustomerId == key);
+        if (customer == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(customer);
+    }
+
+    [HttpPost("odata/Customers")]
+    public IActionResult AddCustomer([FromBody] Customer customer, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _dataSource.Customers?.Add(customer);
+        return Created(customer);
+    }
+
+    [HttpPost("odata/Customers({key})/Default.ChangeCustomerAuditInfo")]
+    public IActionResult ChangeCustomerAuditInfo([FromODataUri] int key, [FromBody] AuditInfo auditInfo, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var customer = _dataSource.Customers?.FirstOrDefault(c => c.CustomerId == key);
+        if (customer == null)
+        {
+            return NotFound();
+        }
+
+        customer.Auditing = auditInfo;
+        return Created(auditInfo);
+    }
+
+    [HttpPost("odata/Customers({key})/Orders/$ref")]
+    public IActionResult AddOrderRefToCustomer([FromODataUri] int key, [FromBody] Uri orderUri, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (orderUri == null)
+        {
+            return BadRequest();
+        }
+
+        // Extract the order ID from the URI
+        var lastSegment = orderUri.Segments.Last();
+        var orderId = int.Parse(Regex.Match(lastSegment, @"\d+").Value);
+
+        // Find the order by ID
+        var order = _dataSource.Orders?.SingleOrDefault(d => d.OrderId == orderId);
+        if (order == null)
+        {
+            return NotFound();
+        }
+
+        // Add the order reference to the customer
+        var customer = _dataSource.Customers?.SingleOrDefault(c => c.CustomerId == key);
+        if (customer == null)
+        {
+            return NotFound();
+        }
+
+        customer.Orders ??= [];
+        customer.Orders.Add(order);
+
+        return Ok(customer);
+    }
+
+    [HttpPost("odata/Orders")]
+    public IActionResult AddOrder([FromBody] Order order, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _dataSource.Orders?.Add(order);
+        return Created(order);
+    }
+
+    [HttpPost("odata/Cars")]
+    public async Task<IActionResult> AddCar([FromBody] Car car, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        _dataSource.Cars?.Add(car);
+        return Created(car);
+    }
+
+    [HttpPut("odata/Cars({key})/Photo")]
+    public IActionResult UpdateCarPhoto([FromODataUri] int key, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var car = _dataSource.Cars?.FirstOrDefault(c => c.VIN == key);
+        if (car == null)
+        {
+            return NotFound();
+        }
+
+        var photo = Request.Body;
+        car.Photo = photo;
+        return Ok();
+    }
+
+    [HttpPost("odata/cancellationtokentests/Default.ResetDefaultDataSource")]
+    public IActionResult ResetDefaultDataSource()
+    {
+        _dataSource = CommonEndToEndDataSource.CreateInstance();
+
+        return Ok();
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Server/CancellationTokenTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Server/CancellationTokenTestsController.cs
@@ -5,16 +5,11 @@
 // </copyright>
 //------------------------------------------------------------------------------
 
-using System.IO;
-using System.Net.Mime;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OData.Formatter;
 using Microsoft.AspNetCore.OData.Query;
 using Microsoft.AspNetCore.OData.Routing.Controllers;
-using Microsoft.AspNetCore.WebUtilities;
-using Microsoft.Extensions.Primitives;
-using Microsoft.Net.Http.Headers;
 using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
 
 namespace Microsoft.OData.Client.E2E.Tests.DeltaTests.Server;

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Tests/CancellationTokenTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/CancellationTokenTests/Tests/CancellationTokenTests.cs
@@ -1,0 +1,341 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="CancellationTokenTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Batch;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.TestCommon;
+using Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd;
+using Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
+using Microsoft.OData.Client.E2E.Tests.DeltaTests.Server;
+using Microsoft.OData.Edm;
+using Xunit;
+using AuditInfo = Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.AuditInfo;
+using Car = Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Car;
+using Customer = Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Customer;
+using Order = Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Order;
+
+namespace Microsoft.OData.Client.E2E.Tests.DeltaTests.Tests;
+
+
+/// <summary>
+/// CancellationToken tests using asynchronous APIs
+/// </summary>
+public class CancellationTokenTests : EndToEndTestBase<CancellationTokenTests.TestsStartup>
+{
+    private readonly Uri _baseUri;
+    private readonly Container _context;
+    private readonly IEdmModel _model;
+
+    public class TestsStartup : TestStartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.ConfigureControllers(typeof(CancellationTokenTestsController), typeof(MetadataController));
+
+            services.AddControllers().AddOData(opt =>
+                opt.EnableQueryFeatures().AddRouteComponents("odata", CommonEndToEndEdmModel.GetEdmModel(), batchHandler: new DefaultODataBatchHandler()));
+        }
+    }
+
+    public CancellationTokenTests(TestWebApplicationFactory<TestsStartup> fixture) : base(fixture)
+    {
+        if (Client.BaseAddress == null)
+        {
+            throw new ArgumentNullException(nameof(Client.BaseAddress), "Base address cannot be null");
+        }
+
+        _baseUri = new Uri(Client.BaseAddress, "odata/");
+
+        _context = new Container(_baseUri)
+        {
+            HttpClientFactory = HttpClientFactory
+        };
+
+        _model = CommonEndToEndEdmModel.GetEdmModel();
+        ResetDefaultDataSource();
+    }
+
+    #region SaveChangesAsync with CancellationToken
+
+    [Fact]
+    public async Task SaveChangesAsyncCancellationTokenTest()
+    {
+        // Arrange
+        var source = new CancellationTokenSource();
+        var c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+
+        // Act & Assert
+        _context.AddToCustomers(c1);
+
+        Task response() => _context.SaveChangesAsync(source.Token);
+        source.Cancel();
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+        Assert.Equal("The operation was canceled.", exception.Message);
+
+        // SaveChangesAsync with SaveChangesOptions
+        var c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
+        var c3 = new Customer { CustomerId = 33, Name = "customerThree" };
+        _context.AddToCustomers(c2);
+        _context.AddToCustomers(c3);
+
+        Task response2() => _context.SaveChangesAsync(SaveChangesOptions.BatchWithIndependentOperations, source.Token);
+        source.Cancel();
+        var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
+        Assert.Equal("The operation was canceled.", exception2.Message);
+    }
+
+    #endregion
+
+    #region GetValueAsync with CancellationToken
+
+    [Fact]
+    public async Task GetValueAsyncCancellationTokenTest()
+    {
+        // Arrange
+        var source = new CancellationTokenSource();
+        var c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+        _context.AddToCustomers(c1);
+        await _context.SaveChangesAsync();
+
+        // Act & Assert
+        Task response() => _context.Customers.ByKey(11).GetValueAsync(source.Token);
+        source.Cancel();
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+        Assert.Equal("The operation was canceled.", exception.Message);
+    }
+
+    #endregion
+
+    #region ExecuteAsync with CancellationToken
+
+    [Fact]
+    public async Task ExecuteAsyncCancellationTokenTest()
+    {
+        // Arrange
+        var source = new CancellationTokenSource();
+        var c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+
+        // Act & Assert
+        _context.AddToCustomers(c1);
+        var c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
+        _context.AddToCustomers(c2);
+        await _context.SaveChangesAsync();
+
+        Task response() => _context.Customers.ExecuteAsync(source.Token);
+        source.Cancel();
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+        Assert.Equal("The operation was canceled.", exception.Message);
+
+        // ExecuteAsync by continuation
+        var customers = (await _context.Customers.ExecuteAsync()) as QueryOperationResponse<Customer>;
+        // continuation is only available when the result has been enumerated. Hence we call Count()
+        Assert.NotNull(customers);
+        var count = customers.Count(); 
+        var continuation = customers.GetContinuation();
+
+        Task response2() => _context.ExecuteAsync(continuation, source.Token);
+        source.Cancel();
+        var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
+        Assert.Equal("The operation was canceled.", exception2.Message);
+
+        // ExecuteAsync by nextLink
+        var customers2 = (await _context.Customers.ExecuteAsync()) as QueryOperationResponse<Customer>;
+        // continuation is only available when the result has been enumerated. Hence we call Count()
+        Assert.NotNull(customers2);
+        var count2 = customers2.Count(); 
+        var continuation2 = customers2.GetContinuation();
+
+        Task response3() => _context.ExecuteAsync<Customer>(continuation2.NextLinkUri, source.Token);
+        source.Cancel();
+        var exception3 = await Assert.ThrowsAsync<OperationCanceledException>(response3);
+        Assert.Equal("The operation was canceled.", exception3.Message);
+    }
+
+    #endregion
+
+    #region GetAllPagesAsync with CancellationToken
+
+    [Fact]
+    public async Task GetAllPagesAsyncCancellationTokenTest()
+    {
+        // Arrange
+        var source = new CancellationTokenSource();
+
+        // Act & Assert
+        var c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+        _context.AddToCustomers(c1);
+        var c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
+        _context.AddToCustomers(c2);
+        await _context.SaveChangesAsync();
+
+        Task response() => _context.Customers.GetAllPagesAsync(source.Token);
+        source.Cancel();
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+        Assert.Equal("The operation was canceled.", exception.Message);
+    }
+
+    #endregion
+
+    #region LoadPropertyAsyn with CancellationToken
+
+    [Fact]
+    public async Task LoadPropertyAsyncCancellationTokenTest()
+    {
+        // Arrange
+        var source = new CancellationTokenSource();
+        _context.MergeOption = MergeOption.OverwriteChanges;
+
+        // Act & Assert
+        var c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+        _context.AddToCustomers(c1);
+        await _context.SaveChangesAsync();
+
+        for (int i = 1; i <= 9; i++)
+        {
+            Order order = new Order() { OrderId = 1000 + i };
+            _context.AddToOrders(order);
+            _context.AddLink(c1, "Orders", order);
+        }
+
+        await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset);
+
+        Task response() => _context.LoadPropertyAsync(c1, "Orders", source.Token);
+        source.Cancel();
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+        Assert.Equal("The operation was canceled.", exception.Message);
+
+        //Get Entity by DataServiceQuery.ExecuteAsync
+        var query = _context.Customers.Expand(c => c.Orders).Where(c => c.CustomerId == 11) as DataServiceQuery<Customer>;
+        Assert.NotNull(query);
+        var resp = (await query.ExecuteAsync()) as QueryOperationResponse<Customer>;
+        Assert.NotNull(resp);
+        var customer = resp.First();
+
+        //Load navigation property by using continuation
+        var continuation = resp.GetContinuation(customer.Orders);
+        Task response2() => _context.LoadPropertyAsync(customer, "Orders", continuation, source.Token);
+        source.Cancel();
+        var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
+        Assert.Equal("The operation was canceled.", exception2.Message);
+
+        Task response3() => _context.LoadPropertyAsync(customer, "Orders", continuation.NextLinkUri, source.Token);
+        source.Cancel();
+        var exception3 = await Assert.ThrowsAsync<OperationCanceledException>(response3);
+        Assert.Equal("The operation was canceled.", exception3.Message);
+    }
+
+    #endregion
+
+    #region ReadStreamAsync with CancellationToken
+
+    [Fact]
+    public async Task GetReadStreamAsyncCancellationTokenTest()
+    {
+        // Arrange
+        var source = new CancellationTokenSource();
+        var car = new Car { VIN = 1000 };
+
+        var mediaEntry = new MemoryStream(new byte[] { 64, 65, 66 });
+
+        // Act & Assert
+        _context.AddToCars(car);
+
+        //_context.SetSaveStream(car, mediaEntry, true, "image/png", "UnitTestLogo.png");
+        //await _context.SaveChangesAsync();
+
+        //Task response() => _context.GetReadStreamAsync(car, new DataServiceRequestArgs(), source.Token);
+        //source.Cancel();
+        //var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+        //Assert.Equal("The operation was canceled.", exception.Message);
+
+        _context.SetSaveStream(car, "Photo", mediaEntry, true, new DataServiceRequestArgs { ContentType = "application/binary" });
+        await _context.SaveChangesAsync();
+
+        Task response2() => _context.GetReadStreamAsync(car, "Photo", new DataServiceRequestArgs { AcceptContentType = "application/binary" }, source.Token);
+        source.Cancel();
+        var exception2 = await Assert.ThrowsAsync<OperationCanceledException>(response2);
+        Assert.Equal("The operation was canceled.", exception2.Message);
+    }
+
+    #endregion
+
+    #region ExecuteBatchAsync with CancellationToken
+
+    [Fact]
+    public async Task ExecuteBatchAsyncCancellationTokenTest()
+    {
+        // Arrange
+        var source = new CancellationTokenSource();
+        var c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+        var c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
+
+        // Act & Assert
+        _context.AddToCustomers(c1);
+        _context.AddToCustomers(c2);
+        await _context.SaveChangesAsync();
+
+        Task response() => _context.ExecuteBatchAsync(
+            SaveChangesOptions.BatchWithIndependentOperations | SaveChangesOptions.UseRelativeUri,
+            source.Token,
+            new DataServiceRequest[]
+            {
+                    new DataServiceRequest<Customer>(((_context.Customers.Where(c => c.CustomerId == 11)) as DataServiceQuery<Customer>)?.RequestUri),
+                    new DataServiceRequest<Customer>(((_context.Customers.Where(c => c.CustomerId == 22)) as DataServiceQuery<Customer>)?.RequestUri)
+            });
+
+        source.Cancel();
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+        Assert.Equal("The operation was canceled.", exception.Message);
+    }
+
+    #endregion
+
+    #region DataServiceActionQuery.ExecuteAsync with CancellationToken
+
+    [Fact]
+    public async Task DataServiceActionQueryExecuteAsyncCancellationTokenTest()
+    {
+        // Arrange
+        var source = new CancellationTokenSource();
+        var c1 = new Customer { CustomerId = 11, Name = "customerOne" };
+        var c2 = new Customer { CustomerId = 22, Name = "customerTwo" };
+
+        // Act & Assert
+        _context.AddToCustomers(c1);
+        _context.AddToCustomers(c2);
+        await _context.SaveChangesAsync();
+
+        var auditInfo = new AuditInfo()
+        {
+            ModifiedDate = new DateTimeOffset()
+        };
+
+        DataServiceQuerySingle<Customer> customer = _context.Customers.ByKey(11);
+        DataServiceActionQuery getComputerAction = customer.ChangeCustomerAuditInfo(auditInfo);
+
+        Task response() => getComputerAction.ExecuteAsync(source.Token);
+
+        source.Cancel();
+        var exception = await Assert.ThrowsAsync<OperationCanceledException>(response);
+        Assert.Equal("The operation was canceled.", exception.Message);
+    }
+
+    #endregion
+
+    #region Private
+
+    private void ResetDefaultDataSource()
+    {
+        var actionUri = new Uri(_baseUri + "cancellationtokentests/Default.ResetDefaultDataSource", UriKind.Absolute);
+        _context.Execute(actionUri, "POST");
+    }
+
+    #endregion
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/QueryCountTests/Server/QueryCountTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/QueryCountTests/Server/QueryCountTestsController.cs
@@ -1,0 +1,108 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="QueryCountTestsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Formatter;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.QueryCountTests.Server;
+
+public class QueryCountTestsController : ODataController
+{
+    private static CommonEndToEndDataSource _dataSource;
+
+    [EnableQuery]
+    [HttpGet("odata/Customers")]
+    public IActionResult GetCustomers()
+    {
+        var result = _dataSource.Customers;
+        return Ok(result);
+    }
+
+    [EnableQuery]
+    [HttpGet("odata/Customers({key})")]
+    public IActionResult GetCustomer([FromODataUri] int key)
+    {
+        var result = _dataSource.Customers?.SingleOrDefault(a => a.CustomerId == key);
+
+        if (result == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(result);
+    }
+
+    [EnableQuery]
+    [HttpGet("odata/Customers({key})/Orders")]
+    public IActionResult GetCustomerOrders([FromODataUri] int key)
+    {
+        var result = _dataSource.Customers?.SingleOrDefault(a => a.CustomerId == key);
+
+        if (result == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(result?.Orders);
+    }
+
+    [EnableQuery]
+    [HttpGet("odata/Computers")]
+    public IActionResult GetComputers()
+    {
+        var result = _dataSource.Computers;
+        return Ok(result);
+    }
+
+    [EnableQuery]
+    [HttpGet("odata/Computers({key})")]
+    public IActionResult GetComputer([FromODataUri] int key)
+    {
+        var result = _dataSource.Computers?.SingleOrDefault(a => a.ComputerId == key);
+
+        if (result == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(result);
+    }
+
+    [EnableQuery]
+    [HttpGet("odata/Computers/$count")]
+    public IActionResult GetComputersCount()
+    {
+        var result = _dataSource.Computers;
+        return Ok(result?.Count);
+    }
+
+    [EnableQuery]
+    [HttpGet("odata/Computers({key})/ComputerDetail/Manufacturer")]
+    public IActionResult GetComputerManufacturer([FromODataUri] int key)
+    {
+        var result = _dataSource.Computers?.SingleOrDefault(a => a.ComputerId == key);
+
+        if (result == null)
+        {
+            return NotFound();
+        }
+
+        return Ok(result?.ComputerDetail?.Manufacturer);
+    }
+
+    [HttpPost("odata/querycounttests/Default.ResetDefaultDataSource")]
+    public IActionResult ResetDefaultDataSource()
+    {
+        _dataSource = CommonEndToEndDataSource.CreateInstance();
+
+        return Ok();
+    }
+}
+

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/QueryCountTests/Tests/QueryCountTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/QueryCountTests/Tests/QueryCountTests.cs
@@ -1,0 +1,326 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="QueryCountTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.TestCommon;
+using Microsoft.OData.Client.E2E.TestCommon.Common;
+using Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Default;
+using Microsoft.OData.Client.E2E.Tests.Common.Server.EndToEnd;
+using Microsoft.OData.Client.E2E.Tests.QueryCountTests.Server;
+using Microsoft.OData.Edm;
+using Xunit;
+using Customer = Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Customer;
+using Computer = Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Computer;
+using Order = Microsoft.OData.Client.E2E.Tests.Common.Clients.EndToEnd.Order;
+
+namespace Microsoft.OData.Client.E2E.Tests.QueryCountTests.Tests;
+
+public class QueryCountTests : EndToEndTestBase<QueryCountTests.TestsStartup>
+{
+    private readonly Uri _baseUri;
+    private readonly Container _context;
+    private readonly IEdmModel _model;
+
+    public class TestsStartup : TestStartupBase
+    {
+        public override void ConfigureServices(IServiceCollection services)
+        {
+            services.ConfigureControllers(typeof(QueryCountTestsController), typeof(MetadataController));
+
+            services.AddControllers().AddOData(opt =>
+                opt.EnableQueryFeatures().AddRouteComponents("odata", CommonEndToEndEdmModel.GetEdmModel()));
+        }
+    }
+
+    public QueryCountTests(TestWebApplicationFactory<TestsStartup> fixture) : base(fixture)
+    {
+        if (Client.BaseAddress == null)
+        {
+            throw new ArgumentNullException(nameof(Client.BaseAddress), "Base address cannot be null");
+        }
+
+        _baseUri = new Uri(Client.BaseAddress, "odata/");
+
+        _context = new Container(_baseUri)
+        {
+            HttpClientFactory = HttpClientFactory
+        };
+
+        _model = CommonEndToEndEdmModel.GetEdmModel();
+        ResetDefaultDataSource();
+    }
+
+    // Constants
+    private const string MimeTypeApplicationAtomXml = MimeTypes.ApplicationAtomXml;
+    private const string MimeTypeODataParameterFullMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterFullMetadata;
+    private const string MimeTypeODataParameterMinimalMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterMinimalMetadata;
+    private const string MimeTypeODataParameterIEEE754Compatible = MimeTypes.ApplicationJson + MimeTypes.ODataParameterIEEE754Compatible;
+    private const string MimeTypeODataParameterNoMetadata = MimeTypes.ApplicationJson + MimeTypes.ODataParameterNoMetadata;
+
+    #region Positive tests
+
+    /// <summary>
+    /// IncludeCount Test
+    /// </summary>
+    [Fact]
+    public void CountLinqTest()
+    {
+        // Arrange & Act
+        var query = _context.Customers.IncludeCount();
+
+        // Assert
+        Assert.Contains("$count=true", query.ToString());
+
+        var response = query.Execute() as QueryOperationResponse<Customer>;
+        Assert.NotNull(response);
+        Assert.Equal(10, response.Count);
+    }
+
+    /// <summary>
+    /// IncludeCount(true) Test
+    /// </summary>
+    [Fact]
+    public void CountWithBoolTrueParamLinqTest()
+    {
+        // Arrange & Act
+        var query = _context.Customers.IncludeCount(true);
+
+        // Assert
+        Assert.Contains("$count=true", query.ToString());
+
+        var response = query.Execute() as QueryOperationResponse<Customer>;
+        Assert.NotNull(response);
+        Assert.Equal(10, response.Count);
+    }
+
+    /// <summary>
+    /// Query Entity Set  With Server Driven Paging
+    /// </summary>
+    [Fact]
+    public void CountLinqTestWithServerDrivenPaging()
+    {
+        // Arrange & Act
+        var query = _context.Computers.IncludeCount();
+
+        // Assert
+        Assert.Contains("$count=true", query.ToString());
+
+        var response = query.Execute() as QueryOperationResponse<Computer>;
+        Assert.NotNull(response);
+        Assert.Equal(10, response.Count);
+    }
+
+    /// <summary>
+    /// Normal $count request
+    /// </summary>
+    [Theory]
+    [InlineData("Computers?$count=true")]
+    [InlineData("Computers?$expand=ComputerDetail&$count=true")]
+    [InlineData("Computers?$top=5&$count=true")]
+    [InlineData("Computers?$count=true&$skip=5")]
+    [InlineData("Computers?$skip=5&$count=true&$top=10")]
+    public void CountUriTest(string queryText)
+    {
+        // Arrange & Act
+        var response = _context.Execute<Computer>(new Uri(this._baseUri.AbsoluteUri + queryText)) as QueryOperationResponse<Computer>;
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(10, response.Count);
+    }
+
+    /// <summary>
+    /// Normal $count request With Server Driven Paging
+    /// </summary>
+    [Theory]
+    [InlineData("Customers?$count=true")]
+    [InlineData("Customers?$Count=true")]
+    [InlineData("Customers?$COUNT=true")]
+    [InlineData("Customers?$expand=Orders&$count=true")]
+    [InlineData("Customers?$top=5&$count=true")]
+    [InlineData("Customers?$count=true&$skip=5")]
+    [InlineData("Customers?$skip=5&$count=true&$top=10")]
+    public void CountUriTestWithServerDrivenPaging(string queryText)
+    {
+        // Arrange & Act
+        var response = _context.Execute<Customer>(new Uri(this._baseUri.AbsoluteUri + queryText)) as QueryOperationResponse<Customer>;
+
+        // Assert
+        Assert.NotNull(response);
+        Assert.Equal(10, response.Count);
+
+        var orders = _context.Execute<Order>(new Uri(this._baseUri.AbsoluteUri + "Customers(-10)/Orders?$count=true")) as QueryOperationResponse<Order>;
+        Assert.NotNull(orders);
+        Assert.Equal(3, orders.Count);
+    }
+
+    /// <summary>
+    /// when $count=true results 
+    /// odata.count in json payload 
+    /// and 
+    /// m:count in atom payload
+    /// </summary>
+    [Theory]
+    [InlineData(MimeTypeApplicationAtomXml)]
+    [InlineData(MimeTypeODataParameterFullMetadata)]
+    [InlineData(MimeTypeODataParameterMinimalMetadata)]
+    [InlineData(MimeTypeODataParameterIEEE754Compatible)]
+    [InlineData(MimeTypeODataParameterNoMetadata)]
+    public async Task CountPayloadVerification(string mimeType)
+    {
+        // Arrange
+        ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+        var requestUrl = new Uri(_baseUri.AbsoluteUri + "Customers?$count=true", UriKind.Absolute);
+
+        var requestMessage = new TestHttpClientRequestMessage(requestUrl, Client);
+        requestMessage.SetHeader("Accept", mimeType);
+
+        // Act
+        var responseString = await ReadResponseMessageAsync(requestMessage);
+
+        // Assert
+        if (mimeType.Contains(MimeTypes.ODataParameterIEEE754Compatible))
+        {
+            Assert.Contains("\"@odata.count\":\"10\"", responseString);
+        }
+        else
+        {
+            Assert.Contains("\"@odata.count\":10", responseString);
+        }
+    }
+
+    /// <summary>
+    /// $count=false is the default value 
+    /// payload should be same with specifying nothing
+    /// </summary>
+    [Theory]
+    [InlineData(MimeTypeApplicationAtomXml)]
+    [InlineData(MimeTypeODataParameterFullMetadata)]
+    [InlineData(MimeTypeODataParameterMinimalMetadata)]
+    [InlineData(MimeTypeODataParameterIEEE754Compatible)]
+    [InlineData(MimeTypeODataParameterNoMetadata)]
+    public async Task FalseCountIsDefaultValue(string mimeType)
+    {
+        // Arrange
+        ODataMessageReaderSettings readerSettings = new() { BaseUri = _baseUri };
+
+        var requestMessage = new TestHttpClientRequestMessage(new Uri(_baseUri.AbsoluteUri + "Computers", UriKind.Absolute), Client);
+        requestMessage.SetHeader("Accept", mimeType);
+
+        // Act
+        var defaultResponseString = await ReadResponseMessageAsync(requestMessage);
+
+        var requestMessage2 = new TestHttpClientRequestMessage(new Uri(_baseUri.AbsoluteUri + "Computers?$count=false", UriKind.Absolute), Client);
+        requestMessage2.SetHeader("Accept", mimeType);
+
+        var responseString = await ReadResponseMessageAsync(requestMessage2);
+
+        // Assert
+        if (mimeType == MimeTypes.ApplicationAtomXml)
+        {
+            // resulting atom payloads with/without model should be the same except for the updated time stamps
+            const string pattern = @"<updated>([A-Za-z0-9\-\:]{20})\</updated>";
+            const string replacement = "<updated>0000-00-00T00:00:00Z</updated>";
+            defaultResponseString = Regex.Replace(defaultResponseString, pattern, (match) => replacement);
+            responseString = Regex.Replace(responseString, pattern, (match) => replacement);
+        }
+
+        Assert.Equal(defaultResponseString, responseString);
+    }
+
+    #endregion
+
+    #region Negative tests
+
+    [Theory]
+    [InlineData("Computers?$count", "'$count' cannot be empty.")]
+    [InlineData("Computers/$count=true", "NotFound")]
+    [InlineData("Computers/$count?$count=true", "The query specified in the URI is not valid. The requested resource is not a collection.")]
+    [InlineData("Computers?$count=True", "'True' is not a valid count option.")]
+    [InlineData("Computers?$count=true&$count=true", "'true,true' is not a valid count option.")]
+    [InlineData("Computers?$count=invalidValue", "'invalidValue' is not a valid count option.")]
+    [InlineData("Computers?$count='true'", "''true'' is not a valid count option.")]
+    [InlineData("Computers?$count=true/$count", "'true/$count' is not a valid count option.")]
+    [InlineData("Computers(-10)?$count=true", "The query specified in the URI is not valid. The requested resource is not a collection.")]
+    [InlineData("Computers(-10)/ComputerDetail/Manufacturer?$count=true", "The query specified in the URI is not valid. The requested resource is not a collection.")]
+    public async Task CountUriInvalidTest(string queryText, string errorString)
+    {
+        // Arrange & Act
+        var task = _context.ExecuteAsync<Computer>(new Uri(this._baseUri.AbsoluteUri + queryText));
+
+        var exception = await Assert.ThrowsAsync<DataServiceQueryException>(async () => await task);
+
+        // Assert
+        Assert.NotNull(exception.InnerException);
+        Assert.IsType<DataServiceClientException>(exception.InnerException);
+        Assert.Contains(errorString, exception.InnerException.Message);
+    }
+
+    /// <summary>
+    /// Invalid getting count when $count=false
+    /// </summary>
+    [Theory]
+    [InlineData("Customers")]
+    [InlineData("Customers?$count=false")]
+    public void GetTotalCountInvalidTest(string queryText)
+    {
+        // Arrange & Act
+        var response = _context.Execute<Customer>(new Uri(this._baseUri.AbsoluteUri + queryText)) as QueryOperationResponse<Customer>;
+        Assert.NotNull(response);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => response.Count);
+
+        // Assert
+        Assert.NotNull(exception);
+        Assert.Contains("Count value is not part of the response stream", exception.Message);
+    }
+
+    /// <summary>
+    /// Invalid getting count when IncludeCount(false)
+    /// </summary>
+    [Fact]
+    public void CountWithBoolFalseParamLinqTest()
+    {
+        // Arrange & Act
+        var query = _context.Customers.IncludeCount(false);
+
+        var response = query.Execute() as QueryOperationResponse<Customer>;
+        Assert.NotNull(response);
+
+        var exception = Assert.Throws<InvalidOperationException>(() => response.Count);
+
+        // Assert
+        Assert.Contains("Count value is not part of the response stream", exception.Message);
+    }
+
+    #endregion
+
+    #region Private
+
+    private static async Task<string> ReadResponseMessageAsync(TestHttpClientRequestMessage requestMessage)
+    {
+        var responseMessage = await requestMessage.GetResponseAsync();
+
+        // Assert
+        Assert.Equal(200, responseMessage.StatusCode);
+
+        var stream = await responseMessage.GetStreamAsync();
+        using var streamReader = new StreamReader(stream);
+        return await streamReader.ReadToEndAsync();
+    }
+
+    private void ResetDefaultDataSource()
+    {
+        var actionUri = new Uri(_baseUri + "querycounttests/Default.ResetDefaultDataSource", UriKind.Absolute);
+        _context.Execute(actionUri, "POST");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Port `Batch Request Tests` from [`WCF`](https://learn.microsoft.com/en-us/dotnet/framework/wcf/whats-wcf) to use `AspNetCoreOData`

- [test/EndToEndTests/Tests/Client/Build.Desktop/QueryCountTests](https://github.com/OData/odata.net/blob/main/test/EndToEndTests/Tests/Client/Build.Desktop/QueryCountTests.cs)
- [test/EndToEndTests/Tests/Client/Build.Desktop/CancellationTokenTests](https://github.com/OData/odata.net/blob/main/test/EndToEndTests/Tests/Client/Build.Desktop/CancellationTokenTests.cs)

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
