### PR TITLE
Fixes #3165: UriParser - Aggregation method Average doesn't support Int16

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -176,6 +176,9 @@ namespace Microsoft.OData.UriParser.Aggregation
                     EdmPrimitiveTypeKind expressionPrimitiveKind = expressionType.PrimitiveKind();
                     switch (expressionPrimitiveKind)
                     {
+                        case EdmPrimitiveTypeKind.SByte:
+                        case EdmPrimitiveTypeKind.Byte:
+                        case EdmPrimitiveTypeKind.Int16:
                         case EdmPrimitiveTypeKind.Int32:
                         case EdmPrimitiveTypeKind.Int64:
                         case EdmPrimitiveTypeKind.Double:

--- a/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Aggregation/ApplyBinder.cs
@@ -176,8 +176,6 @@ namespace Microsoft.OData.UriParser.Aggregation
                     EdmPrimitiveTypeKind expressionPrimitiveKind = expressionType.PrimitiveKind();
                     switch (expressionPrimitiveKind)
                     {
-                        case EdmPrimitiveTypeKind.SByte:
-                        case EdmPrimitiveTypeKind.Byte:
                         case EdmPrimitiveTypeKind.Int16:
                         case EdmPrimitiveTypeKind.Int32:
                         case EdmPrimitiveTypeKind.Int64:

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -838,6 +838,27 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
             Assert.Empty(homeNode.ChildTransformations);
         }
 
+        [Fact]
+        public void BindApplyWithAverageWithInt16PropertyShouldReturnApplyClause()
+        {
+            IEnumerable<QueryToken> tokens = _parser.ParseApply("aggregate(FavoriteNumber with average as AverageFavoriteNumber)");
+
+            ApplyBinder binder = new ApplyBinder(FakeBindMethods.BindMethodReturningASingleFloatPrimitive, _bindingState);
+            ApplyClause actual = binder.BindApply(tokens);
+
+            Assert.NotNull(actual);
+            AggregateTransformationNode aggregate = Assert.IsType<AggregateTransformationNode>(Assert.Single(actual.Transformations));
+
+            Assert.Equal(TransformationNodeKind.Aggregate, aggregate.Kind);
+            Assert.NotNull(aggregate.AggregateExpressions);
+
+            AggregateExpression statement = Assert.IsType<AggregateExpression>(Assert.Single(aggregate.AggregateExpressions));
+            Assert.NotNull(statement.Expression);
+            Assert.Same(FakeBindMethods.FakeSingleFloatPrimitive, statement.Expression);
+            Assert.Equal(AggregationMethod.Average, statement.Method);
+            Assert.Equal("AverageFavoriteNumber", statement.Alias);
+        }
+
         private static ConstantNode _booleanPrimitiveNode = new ConstantNode(true);
 
         private static SingleValueNode BindMethodReturnsBooleanPrimitive(QueryToken token)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Extensions/Binders/ApplyBinderTests.cs
@@ -839,9 +839,30 @@ namespace Microsoft.OData.Tests.UriParser.Extensions.Binders
         }
 
         [Fact]
-        public void BindApplyWithAverageWithInt16PropertyShouldReturnApplyClause()
+        public void BindApplyWithAverageWithUInt16PropertyShouldReturnApplyClause()
         {
             IEnumerable<QueryToken> tokens = _parser.ParseApply("aggregate(FavoriteNumber with average as AverageFavoriteNumber)");
+
+            ApplyBinder binder = new ApplyBinder(FakeBindMethods.BindMethodReturningASingleFloatPrimitive, _bindingState);
+            ApplyClause actual = binder.BindApply(tokens);
+
+            Assert.NotNull(actual);
+            AggregateTransformationNode aggregate = Assert.IsType<AggregateTransformationNode>(Assert.Single(actual.Transformations));
+
+            Assert.Equal(TransformationNodeKind.Aggregate, aggregate.Kind);
+            Assert.NotNull(aggregate.AggregateExpressions);
+
+            AggregateExpression statement = Assert.IsType<AggregateExpression>(Assert.Single(aggregate.AggregateExpressions));
+            Assert.NotNull(statement.Expression);
+            Assert.Same(FakeBindMethods.FakeSingleFloatPrimitive, statement.Expression);
+            Assert.Equal(AggregationMethod.Average, statement.Method);
+            Assert.Equal("AverageFavoriteNumber", statement.Alias);
+        }
+
+        [Fact]
+        public void BindApplyWithAverageWithInt16PropertyShouldReturnApplyClause()
+        {
+            IEnumerable<QueryToken> tokens = _parser.ParseApply("aggregate(SecondFavoriteNumber with average as AverageFavoriteNumber)");
 
             ApplyBinder binder = new ApplyBinder(FakeBindMethods.BindMethodReturningASingleFloatPrimitive, _bindingState);
             ApplyClause actual = binder.BindApply(tokens);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -161,6 +161,7 @@ namespace Microsoft.OData.Tests.UriParser
             FullyQualifiedNamespacePerson.AddStructuralProperty("PreviousAddresses", new EdmCollectionTypeReference(new EdmCollectionType(FullyQualifiedNamespaceAddressTypeReference)));
             FullyQualifiedNamespacePerson.AddStructuralProperty("FavoriteColors", new EdmCollectionTypeReference(new EdmCollectionType(colorTypeReference)));
             FullyQualifiedNamespacePerson.AddStructuralProperty("FavoriteNumber", FullyQualifiedNamespaceUInt16Reference);
+            FullyQualifiedNamespacePerson.AddStructuralProperty("SecondFavoriteNumber", EdmCoreModel.Instance.GetInt16(false));
             FullyQualifiedNamespacePerson.AddStructuralProperty("RelatedIDs", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetInt32(false))));
             FullyQualifiedNamespacePerson.AddStructuralProperty("RelatedSSNs", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true))));
             FullyQualifiedNamespacePerson.AddStructuralProperty("StockQuantity", FullyQualifiedNamespaceUInt32Reference);


### PR DESCRIPTION
### Issues

This pull request fixes [issue](https://github.com/OData/odata.net/issues/3165) where the problem was that during the parsing of average aggregation function the parser could throw an exception saying that it does not support int16. (Or Byte and SByte for that matter)

### Description

Easy fix that required just adding few cases into a switch.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed* (No since I don't have VS 2019 :/ but in VS 2020 no additional tests failed)

### Additional work necessary

None
