### PR TITLE
Fixes #3174: Enable $select=colProperty/$count query option parser

### DIFF
--- a/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,11 @@
+Microsoft.OData.UriParser.PathCountSelectItem
+Microsoft.OData.UriParser.PathCountSelectItem.Filter.get -> Microsoft.OData.UriParser.FilterClause
+Microsoft.OData.UriParser.PathCountSelectItem.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
+Microsoft.OData.UriParser.PathCountSelectItem.PathCountSelectItem(Microsoft.OData.UriParser.ODataSelectPath selectedPath) -> void
+Microsoft.OData.UriParser.PathCountSelectItem.PathCountSelectItem(Microsoft.OData.UriParser.ODataSelectPath selectedPath, Microsoft.OData.Edm.IEdmNavigationSource navigationSource, Microsoft.OData.UriParser.FilterClause filter, Microsoft.OData.UriParser.SearchClause search) -> void
+Microsoft.OData.UriParser.PathCountSelectItem.Search.get -> Microsoft.OData.UriParser.SearchClause
+Microsoft.OData.UriParser.PathCountSelectItem.SelectedPath.get -> Microsoft.OData.UriParser.ODataSelectPath
+override Microsoft.OData.UriParser.PathCountSelectItem.HandleWith(Microsoft.OData.UriParser.SelectItemHandler handler) -> void
+override Microsoft.OData.UriParser.PathCountSelectItem.TranslateWith<T>(Microsoft.OData.UriParser.SelectItemTranslator<T> translator) -> T
+virtual Microsoft.OData.UriParser.SelectItemHandler.Handle(Microsoft.OData.UriParser.PathCountSelectItem item) -> void
+virtual Microsoft.OData.UriParser.SelectItemTranslator<T>.Translate(Microsoft.OData.UriParser.PathCountSelectItem item) -> T

--- a/src/Microsoft.OData.Core/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -2489,3 +2489,14 @@ static Microsoft.OData.UriParser.ODataPathExtensions.TrimEndingKeySegment(this M
 static Microsoft.OData.UriParser.ODataPathExtensions.TrimEndingTypeSegment(this Microsoft.OData.UriParser.ODataPath path) -> Microsoft.OData.UriParser.ODataPath
 Microsoft.OData.ODataResourceBase.SkipPropertyVerification.get -> bool
 Microsoft.OData.ODataResourceBase.SkipPropertyVerification.set -> void
+Microsoft.OData.UriParser.PathCountSelectItem
+Microsoft.OData.UriParser.PathCountSelectItem.Filter.get -> Microsoft.OData.UriParser.FilterClause
+Microsoft.OData.UriParser.PathCountSelectItem.NavigationSource.get -> Microsoft.OData.Edm.IEdmNavigationSource
+Microsoft.OData.UriParser.PathCountSelectItem.PathCountSelectItem(Microsoft.OData.UriParser.ODataSelectPath selectedPath) -> void
+Microsoft.OData.UriParser.PathCountSelectItem.PathCountSelectItem(Microsoft.OData.UriParser.ODataSelectPath selectedPath, Microsoft.OData.Edm.IEdmNavigationSource navigationSource, Microsoft.OData.UriParser.FilterClause filter, Microsoft.OData.UriParser.SearchClause search) -> void
+Microsoft.OData.UriParser.PathCountSelectItem.Search.get -> Microsoft.OData.UriParser.SearchClause
+Microsoft.OData.UriParser.PathCountSelectItem.SelectedPath.get -> Microsoft.OData.UriParser.ODataSelectPath
+override Microsoft.OData.UriParser.PathCountSelectItem.HandleWith(Microsoft.OData.UriParser.SelectItemHandler handler) -> void
+override Microsoft.OData.UriParser.PathCountSelectItem.TranslateWith<T>(Microsoft.OData.UriParser.SelectItemTranslator<T> translator) -> T
+virtual Microsoft.OData.UriParser.SelectItemHandler.Handle(Microsoft.OData.UriParser.PathCountSelectItem item) -> void
+virtual Microsoft.OData.UriParser.SelectItemTranslator<T>.Translate(Microsoft.OData.UriParser.PathCountSelectItem item) -> T

--- a/src/Microsoft.OData.Core/SRResources.Designer.cs
+++ b/src/Microsoft.OData.Core/SRResources.Designer.cs
@@ -674,15 +674,6 @@ namespace Microsoft.OData.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to $count is not allowed in $select option..
-        /// </summary>
-        internal static string ExpressionToken_DollarCountNotAllowedInSelect {
-            get {
-                return ResourceManager.GetString("ExpressionToken_DollarCountNotAllowedInSelect", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to An identifier was expected at position {0}..
         /// </summary>
         internal static string ExpressionToken_IdentifierExpected {
@@ -6270,6 +6261,42 @@ namespace Microsoft.OData.Core {
         internal static string SelectExpandBinder_InvalidQueryOptionNestedSelection {
             get {
                 return ResourceManager.GetString("SelectExpandBinder_InvalidQueryOptionNestedSelection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No more segment &apos;{0}&apos; is allowed after &apos;/$count&apos; segment..
+        /// </summary>
+        internal static string SelectExpandBinder_NoSegmentAllowedAfterDollarCount {
+            get {
+                return ResourceManager.GetString("SelectExpandBinder_NoSegmentAllowedAfterDollarCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;/$count&apos; segment is not allowed as first segment..
+        /// </summary>
+        internal static string SelectExpandBinder_NotAllowedDollarCountAsFirstSegment {
+            get {
+                return ResourceManager.GetString("SelectExpandBinder_NotAllowedDollarCountAsFirstSegment", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to In $select query option, &apos;/$count&apos; segment is not allowed on the navigation property segment &apos;{0}&apos;..
+        /// </summary>
+        internal static string SelectExpandBinder_NotAllowedDollarCountOnNavigationPropertyInDollarSelect {
+            get {
+                return ResourceManager.GetString("SelectExpandBinder_NotAllowedDollarCountOnNavigationPropertyInDollarSelect", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;/$count&apos; segment is only allowed on the collection type segment..
+        /// </summary>
+        internal static string SelectExpandBinder_NotAllowedDollarCountOnNonCollection {
+            get {
+                return ResourceManager.GetString("SelectExpandBinder_NotAllowedDollarCountOnNonCollection", resourceCulture);
             }
         }
         

--- a/src/Microsoft.OData.Core/SRResources.resx
+++ b/src/Microsoft.OData.Core/SRResources.resx
@@ -2087,6 +2087,18 @@
   <data name="SelectExpandBinder_SystemTokenInSelect" xml:space="preserve">
     <value>Found a system token, '{0}', while parsing a select clause.</value>
   </data>
+  <data name="SelectExpandBinder_NoSegmentAllowedAfterDollarCount" xml:space="preserve">
+    <value>No more segment '{0}' is allowed after '/$count' segment.</value>
+  </data>
+  <data name="SelectExpandBinder_NotAllowedDollarCountAsFirstSegment" xml:space="preserve">
+    <value>'/$count' segment is not allowed as first segment.</value>
+  </data>
+  <data name="SelectExpandBinder_NotAllowedDollarCountOnNonCollection" xml:space="preserve">
+    <value>'/$count' segment is only allowed on the collection type segment.</value>
+  </data>
+  <data name="SelectExpandBinder_NotAllowedDollarCountOnNavigationPropertyInDollarSelect" xml:space="preserve">
+    <value>In $select query option, '/$count' segment is not allowed on the navigation property segment '{0}'.</value>
+  </data>
   <data name="SelectionItemBinder_NoExpandForSelectedProperty" xml:space="preserve">
     <value>Only properties specified in $expand can be traversed in $select query options. Selected item was '{0}'.</value>
   </data>
@@ -2443,9 +2455,6 @@
   </data>
   <data name="ExpressionToken_OnlyRefAllowWithStarInExpand" xml:space="preserve">
     <value>Only $ref is allowed with star in $expand option.</value>
-  </data>
-  <data name="ExpressionToken_DollarCountNotAllowedInSelect" xml:space="preserve">
-    <value>$count is not allowed in $select option.</value>
   </data>
   <data name="ExpressionToken_NoPropAllowedAfterDollarCount" xml:space="preserve">
     <value>No property is allowed after $count segment.</value>

--- a/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandTermParser.cs
+++ b/src/Microsoft.OData.Core/UriParser/Parsers/SelectExpandTermParser.cs
@@ -136,11 +136,6 @@ namespace Microsoft.OData.UriParser
                 }
             }
 
-            if (this.lexer.CurrentToken.Span.Equals(UriQueryConstants.CountSegment, StringComparison.Ordinal) && isSelect)
-            {
-                // $count is not allowed in $select e.g $select=NavProperty/$count
-                throw new ODataException(SRResources.ExpressionToken_DollarCountNotAllowedInSelect);
-            }
 
             ReadOnlySpan<char> propertyName;
 
@@ -170,6 +165,8 @@ namespace Microsoft.OData.UriParser
                 this.lexer.NextToken();
             }
 
+            // By design, "/$count" or "/$ref" should return using SystemToken, but the existing implementation is using "NonSystemToken".
+            // So far, let's keep it unchanged.
             return new NonSystemToken(propertyName.ToString(), null, previousSegment);
         }
     }

--- a/src/Microsoft.OData.Core/UriParser/SemanticAst/PathCountSelectItem.cs
+++ b/src/Microsoft.OData.Core/UriParser/SemanticAst/PathCountSelectItem.cs
@@ -1,0 +1,86 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="PathCountSelectItem.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Edm;
+
+namespace Microsoft.OData.UriParser
+{
+    /// <summary>
+    /// Class to represent $select=collectionProperty/$count.
+    /// </summary>
+    public sealed class PathCountSelectItem : SelectItem
+    {
+        /// <summary>
+        /// Initializes a new <see cref="PathCountSelectItem"/>.
+        /// </summary>
+        /// <param name="selectedPath">The selected path.</param>
+        public PathCountSelectItem(ODataSelectPath selectedPath)
+            : this(selectedPath, null, null, null)
+        { }
+
+        /// <summary>
+        /// Initializes a new <see cref="PathCountSelectItem"/>.
+        /// </summary>
+        /// <param name="selectedPath">The selected path.</param>
+        /// <param name="navigationSource">The navigation source for this select item.</param>
+        /// <param name="filter">A filter clause for this select (can be null).</param>
+        /// <param name="search">A search clause for this select (can be null).</param>
+        public PathCountSelectItem(ODataSelectPath selectedPath,
+            IEdmNavigationSource navigationSource,
+            FilterClause filter,
+            SearchClause search)
+        {
+            ExceptionUtils.CheckArgumentNotNull(selectedPath, "selectedPath");
+
+            SelectedPath = selectedPath;
+            NavigationSource = navigationSource;
+            Filter = filter;
+            Search = search;
+        }
+
+        /// <summary>
+        /// Gets the selected path.
+        /// </summary>
+        public ODataSelectPath SelectedPath { get; }
+
+        /// <summary>
+        /// Gets the navigation source for this select level.
+        /// </summary>
+        public IEdmNavigationSource NavigationSource { get; }
+
+        /// <summary>
+        /// The filter clause for this select level.
+        /// </summary>
+        public FilterClause Filter { get; }
+
+        /// <summary>
+        /// Gets the search clause for this select level.
+        /// </summary>
+        public SearchClause Search { get; }
+
+        /// <summary>
+        /// Translate using a <see cref="SelectItemTranslator{T}"/>.
+        /// </summary>
+        /// <typeparam name="T">Type that the translator will return after visiting this item.</typeparam>
+        /// <param name="translator">An implementation of the translator interface.</param>
+        /// <returns>An object whose type is determined by the type parameter of the translator.</returns>
+        /// <exception cref="System.ArgumentNullException">Throws if the input translator is null.</exception>
+        public override T TranslateWith<T>(SelectItemTranslator<T> translator)
+        {
+            return translator.Translate(this);
+        }
+
+        /// <summary>
+        /// Handle using a <see cref="SelectItemHandler"/>.
+        /// </summary>
+        /// <param name="handler">An implementation of the handler interface.</param>
+        /// <exception cref="System.ArgumentNullException">Throws if the input handler is null.</exception>
+        public override void HandleWith(SelectItemHandler handler)
+        {
+            handler.Handle(this);
+        }
+    }
+}

--- a/src/Microsoft.OData.Core/UriParser/Visitors/SelectItemHandler.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/SelectItemHandler.cs
@@ -23,6 +23,15 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
+        /// Handle a PathCountSelectItem
+        /// </summary>
+        /// <param name="item">the item to Handle</param>
+        public virtual void Handle(PathCountSelectItem item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Handle a PathSelectItem
         /// </summary>
         /// <param name="item">the item to Handle</param>

--- a/src/Microsoft.OData.Core/UriParser/Visitors/SelectItemTranslator.cs
+++ b/src/Microsoft.OData.Core/UriParser/Visitors/SelectItemTranslator.cs
@@ -35,6 +35,16 @@ namespace Microsoft.OData.UriParser
         }
 
         /// <summary>
+        /// Translate a PathCountSelectItem
+        /// </summary>
+        /// <param name="item">the item to Translate</param>
+        /// <returns>Defined by the implementer</returns>
+        public virtual T Translate(PathCountSelectItem item)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
         /// Translate a ContainerQualifiedWildcardSelectItem
         /// </summary>
         /// <param name="item">the item to Translate</param>


### PR DESCRIPTION
Fixes #3174: Enable $select=colProperty/$count query option parser

See details in #3174 

See related OASIS tc issues at: [Should ABNF support /$count in $Select · Issue #2046 · oasis-tcs/odata-specs](https://github.com/oasis-tcs/odata-specs/issues/2046)