### PR TITLE
Update nuget release notes changelog URL

### DIFF
--- a/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
+++ b/src/Microsoft.OData.Client/Build.NuGet/Microsoft.OData.Client.Release.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <title>OData Client for .NET</title>
     <id>Microsoft.OData.Client</id>
-    <tags>wcf data services odata odatalib edmlib spatial ado.net ef entity framework open protocol wcfds wcfdataservices dataservices</tags>
+    <tags>wcf data services odata odatalib edmlib spatial ado.net ef efcore entity framework core open protocol wcfds wcfdataservices dataservices</tags>
     <version>$VersionNuGetSemantic$</version>
     <authors>Microsoft</authors>
     <license type="expression">MIT</license>
@@ -14,7 +14,7 @@
     <summary>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4 and v4.01. </summary>
     <description>LINQ-enabled client API for issuing OData queries and consuming OData JSON payloads. Supports OData v4 and v4.01. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
-    <releaseNotes>https://docs.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
+    <releaseNotes>https://learn.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <dependency id="Microsoft.OData.Core" version="[$VersionNuGetSemantic$]" />

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -668,7 +668,7 @@ namespace Microsoft.OData.Client
         /// When true, a Where clause that has only the key property in the predicate generates a $filter query option, otherwise a key segment is generated.
         /// The default value is true.
         /// </summary>
-        [Obsolete("This property will be removed in a future major release.")]
+        [Obsolete("This property will be removed in a future major release. The ByKey method should be used to generate an OData URL with key segment.")]
         public virtual bool KeyComparisonGeneratesFilterQuery
         {
             get { return this.keyComparisonGeneratesFilterQuery; }

--- a/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
+++ b/src/Microsoft.OData.Core/Build.NuGet/Microsoft.OData.Core.Release.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <title>ODataLib</title>
     <id>Microsoft.OData.Core</id>
-    <tags>wcf data services odata odatalib edmlib spatial ado.net ef entity framework open protocol wcfds wcfdataservices dataservices</tags>
+    <tags>wcf data services odata odatalib edmlib spatial ado.net ef efcore entity framework core open protocol wcfds wcfdataservices dataservices</tags>
     <version>$VersionNuGetSemantic$</version>
     <authors>Microsoft</authors>
     <license type="expression">MIT</license>
@@ -14,7 +14,7 @@
     <summary>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4 and v4.01.</summary>
     <description>Classes to serialize, deserialize and validate OData JSON payloads. Supports OData v4 and v4.01. Enables construction of OData services and clients. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
-    <releaseNotes>https://docs.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
+    <releaseNotes>https://learn.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group>

--- a/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
+++ b/src/Microsoft.OData.Edm/Build.NuGet/Microsoft.OData.Edm.Release.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <title>EdmLib</title>
     <id>Microsoft.OData.Edm</id>
-    <tags>wcf data services odata odatalib edmlib spatial ado.net ef entity framework open protocol wcfds wcfdataservices dataservices</tags>
+    <tags>wcf data services odata odatalib edmlib spatial ado.net ef efcore entity framework core open protocol wcfds wcfdataservices dataservices</tags>
     <version>$VersionNuGetSemantic$</version>
     <authors>Microsoft</authors>
     <license type="expression">MIT</license>
@@ -14,7 +14,7 @@
     <summary>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4 and v4.01.</summary>
     <description>Classes to represent, construct, parse, serialize and validate entity data models. Supports OData v4 and v4.01. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
-    <releaseNotes>https://docs.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
+    <releaseNotes>https://learn.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group>

--- a/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Release.nuspec
+++ b/src/Microsoft.Spatial/Build.NuGet/Microsoft.Spatial.Release.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <title>Microsoft.Spatial</title>
     <id>Microsoft.Spatial</id>
-    <tags>wcf data services odata odatalib edmlib spatial ado.net ef entity framework open protocol wcfds wcfdataservices dataservices</tags>
+    <tags>wcf data services odata odatalib edmlib spatial ado.net ef efcore entity framework core open protocol wcfds wcfdataservices dataservices</tags>
     <version>$VersionNuGetSemantic$</version>
     <authors>Microsoft</authors>
     <license type="expression">MIT</license>
@@ -14,7 +14,7 @@
     <summary>Contains classes and methods that facilitate geography and geometry spatial operations.</summary>
     <description>Contains classes and methods that facilitate geography and geometry spatial operations. Targets .NET 8 or above.
 OData .NET library is open source at http://github.com/OData/odata.net. Documentation for the library can be found at https://docs.microsoft.com/en-us/odata/.</description>
-    <releaseNotes>https://docs.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
+    <releaseNotes>https://learn.microsoft.com/en-us/odata/changelog/$VersionFullNumberRelease$</releaseNotes>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
   </metadata>
   <files>

--- a/tools/CustomMSBuild/Versioning.props
+++ b/tools/CustomMSBuild/Versioning.props
@@ -22,8 +22,8 @@
   <PropertyGroup>
     <VersionFullSemantic>$(VersionMajor).$(VersionMinor).$(VersionBuildNumber)</VersionFullSemantic>
     <VersionFull>$(VersionFullSemantic).$(VersionRevision)</VersionFull>
-	<VersionFullNumber>$(VersionMajor)$(VersionMinor)$(VersionBuildNumber)</VersionFullNumber>
-	<VersionFullNumberRelease>odatalib-$(VersionMajor)x#odatalib-$(VersionFullNumber)-release</VersionFullNumberRelease>	
+    <VersionFullNumber>$(VersionMajor)$(VersionMinor)$(VersionBuildNumber)</VersionFullNumber>
+    <VersionFullNumberRelease>odatalib-$(VersionMajor)x#$(VersionFullNumber)</VersionFullNumberRelease> <!-- e.g., odatalib-8x#802 -->
   </PropertyGroup>
 
   <!-- For ADO.NET Provider -->


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes https://github.com/OData/odata.net/issues/2390, fixes https://github.com/OData/odata.net/issues/1971.*

### Description

Currently, the changelog URL on the NuGet package release notes returns a 404:
![image](https://github.com/user-attachments/assets/7a620846-e1cd-4f4f-86d8-81e1f2903b0a)

This pull requests updates the URL to the correct location:
![image](https://github.com/user-attachments/assets/ebc9cc05-7dbe-4e0d-b82e-8bbe1d9e4239)

It also supplements the obsolete message for `KeyComparisonGeneratesFilterQuery` flag.

### Checklist (Uncheck if it is not completed)

- [x] *Build and test with one-click build and test script passed*