### PR TITLE
Port transport layer tests

### DIFF
--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.csproj
@@ -27,6 +27,7 @@
   
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.OData.Client.Tests" />
+    <InternalsVisibleTo Include="Microsoft.OData.Client.E2E.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
+++ b/src/Microsoft.OData.Client/Serialization/HttpClientRequestMessage.cs
@@ -14,6 +14,7 @@ namespace Microsoft.OData.Client
     using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.OData;
@@ -410,6 +411,8 @@ namespace Microsoft.OData.Client
                 {
                     _requestMessage.Content.Headers.Add(contentHeader.Key, contentHeader.Value);
                 }
+
+                string contentString = Encoding.UTF8.GetString(messageContent);
             }
 
             _requestMessage.Method = new HttpMethod(_effectiveHttpMethod);

--- a/src/Microsoft.OData.Client/ShippingAssemblyAttributes.cs
+++ b/src/Microsoft.OData.Client/ShippingAssemblyAttributes.cs
@@ -18,4 +18,5 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.Test.Data.Services.DDBasics" + AssemblyRef.TestPublicKey)]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("AstoriaUnitTests.ClientCSharp" + AssemblyRef.TestPublicKey)]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.OData.Client.Tests" + AssemblyRef.TestPublicKey)]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Microsoft.OData.Client.E2E.Tests" + AssemblyRef.TestPublicKey)]
 #pragma warning restore 436

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Microsoft.OData.Client.E2E.Tests.csproj
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Microsoft.OData.Client.E2E.Tests.csproj
@@ -4,9 +4,25 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    
+    <AssemblyName>Microsoft.OData.Client.E2E.Tests</AssemblyName>
+    <RootNamespace>Microsoft.OData.Client.E2E.Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\..\..\..\tools\StrongNamePublicKeys\testkey.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>True</DelaySign>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OutputPath>..\..\..\bin\AnyCPU\Debug\Test\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <OutputPath>..\..\..\bin\AnyCPU\Release\Test\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,6 +55,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\src\Microsoft.OData.Client\Microsoft.OData.Client.csproj" />
     <ProjectReference Include="..\..\..\Common\Microsoft.OData.E2E.TestCommon\Microsoft.OData.E2E.TestCommon.csproj" />
   </ItemGroup>
 

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/HttpClientTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/HttpClientTests.cs
@@ -1,0 +1,213 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="HttpClientTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Batch;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server;
+using Microsoft.OData.E2E.TestCommon;
+using Microsoft.OData.E2E.TestCommon.Common.Client.EndToEnd;
+using Microsoft.OData.E2E.TestCommon.Common.Client.EndToEnd.Default;
+using Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd;
+using Xunit;
+using ClientEndToEndModel = Microsoft.OData.E2E.TestCommon.Common.Client.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests
+{
+    public class HttpClientTests : EndToEndTestBase<HttpClientTests.TestsStartup>
+    {
+        private readonly Uri _baseUri;
+        private readonly Container _context;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(HttpClientController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                    .AddRouteComponents("odata", CommonEndToEndEdmModel.GetEdmModel(), new DefaultODataBatchHandler()));
+            }
+        }
+
+        public HttpClientTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+
+            ResetDataSource();
+        }
+
+        [Fact]
+        public async Task QueryForEntity_ShouldReturnResults()
+        {
+            var results = await _context.CreateQuery<ClientEndToEndModel.Product>("Products").ExecuteAsync();
+            Assert.NotEmpty(results);
+        }
+
+        [Fact]
+        public async Task InsertNewEntity_ShouldInsertEntity()
+        {
+            _context.AddToOrders(new ClientEndToEndModel.Order { OrderId = 993, });
+            await _context.SaveChangesAsync();
+
+            var createdOrderQuery = _context.Orders.ByKey(993);
+            var createdOrder = await createdOrderQuery.GetValueAsync();
+            Assert.Equal(993, createdOrder.OrderId);
+        }
+
+        [Fact]
+        public async Task UpdateEntityWithPatch_ShouldUpdateEntitySuccessfully()
+        {
+            var product = _context.Products.First();
+            var newProductDescription = "Foo " + Guid.NewGuid().ToString();
+            product.Description = newProductDescription;
+            _context.UpdateObject(product);
+
+            await _context.SaveChangesAsync();
+
+            var updatedProduct = _context.Products.First();
+            Assert.Equal(newProductDescription, updatedProduct.Description);
+        }
+
+        [Fact]
+        public async Task UpdateEntityWithReplaceUsingJson_ShouldUpdareTheEntity()
+        {
+            _context.Format.UseJson();
+
+            var product = _context.Products.First();
+            product.Description = "Foo " + Guid.NewGuid().ToString();
+            _context.UpdateObject(product);
+
+            await _context.SaveChangesAsync(SaveChangesOptions.ReplaceOnUpdate);
+            var updateProduct = _context.Products.First();
+            Assert.Equal(product.Description, updateProduct.Description);
+        }
+
+        [Fact]
+        public async Task DeleteEntity_ShouldDeleteTheEntity()
+        {
+            var computer = _context.Computers.First();
+            Assert.Equal(-10, computer.ComputerId);
+            _context.DeleteObject(computer);
+            await _context.SaveChangesAsync();
+
+            var deletedComputer = _context.Computers.FirstOrDefault(c => c.ComputerId == -10);
+            Assert.Null(deletedComputer);
+        }
+
+        [Fact]
+        public async Task DoingMultipleChangesUsingBatch_ShouldExecuteSuccessfully()
+        {
+            _context.AddToOrders(new ClientEndToEndModel.Order { OrderId = 953, });
+            var customerToDelete = _context.Customers.First();
+            Assert.Equal(-10, customerToDelete.CustomerId);
+            _context.DeleteObject(customerToDelete);
+
+            var product = _context.Products.First();
+            product.Description = "Foo " + Guid.NewGuid().ToString();
+            _context.UpdateObject(product);
+
+            await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset);
+
+            //Assert new order was created. 
+            var createdOrder = await _context.Orders.ByKey(953).GetValueAsync();
+            Assert.Equal(953, createdOrder.OrderId);
+
+            //Assert customer was deleted
+            var deletedCustomer = _context.Customers.FirstOrDefault(c => c.CustomerId == -10);
+            Assert.Null(deletedCustomer);
+
+            //Assert product was updated
+            var updatedProduct = _context.Products.First();
+            Assert.Equal(product.Description, updatedProduct.Description);
+        }
+
+        [Fact]
+        public async Task DoingMultipleChangesWithoutBatch_ShouldExecuteSuccessfully()
+        {
+            _context.AddToOrders(new ClientEndToEndModel.Order { OrderId = 953, });
+            _context.DeleteObject(_context.Customers.First());
+
+            var product = _context.Products.First();
+            product.Description = "Foo " + Guid.NewGuid().ToString();
+            _context.UpdateObject(product);
+
+            await _context.SaveChangesAsync();
+
+            //Assert new order was created.
+            var createdOrder = await _context.Orders.ByKey(953).GetValueAsync();
+            Assert.Equal(953, createdOrder.OrderId);
+
+            //Assert customer was deleted
+            var deletedCustomer = _context.Customers.FirstOrDefault(c => c.CustomerId == -10);
+            Assert.Null(deletedCustomer);
+
+            //Assert product was updated
+            var updatedProduct = _context.Products.First();
+            Assert.Equal(product.Description, updatedProduct.Description);
+        }
+
+        [Fact]
+        public async Task LoadProperty_ExecutesSuccessfully()
+        {
+            var product = _context.Products.First();
+
+            var response = await _context.LoadPropertyAsync(product, "Description");
+            Assert.Equal(200, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task BatchUpdatesAsync()
+        {
+            _context.AddObject("Products", new ClientEndToEndModel.Product { ProductId = 55443, Description = "My new product", });
+
+            ClientEndToEndModel.Customer customerWithCustomerInfo = null;
+            var query = _context.Customers.Expand(c => c.Info).Where(c => c.Info != null) as DataServiceQuery<ClientEndToEndModel.Customer>;
+            var queryResult = await query.ExecuteAsync();
+            customerWithCustomerInfo = queryResult.First();
+
+            var customerInfo = customerWithCustomerInfo.Info;
+            customerInfo.Information = "New Information " + Guid.NewGuid().ToString();
+            _context.UpdateObject(customerInfo);
+
+            _context.DetachLink(customerWithCustomerInfo, "Info", customerInfo);
+            _context.UpdateObject(customerWithCustomerInfo);
+
+            var response = await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset);
+
+            Assert.Equal(200, response.BatchStatusCode);
+            Assert.Equal(3, response.Count());
+        }
+
+        [Fact]
+        //Client should not append () to navigation property query URI
+        public async Task ClientShouldNotAppendParenthesisToNavigationPropertyQueryUri()
+        {
+            var product = new ClientEndToEndModel.Product { ProductId = 55445, Description = "My new product" };
+            _context.AddObject("Products", product);
+            await _context.SaveChangesAsync();
+            _context.Detach(product);
+            _context.AttachTo("Products", product);
+            //Collection
+            var response = await _context.LoadPropertyAsync(product, "RelatedProducts");
+            Assert.EndsWith("RelatedProducts", response.Query.RequestUri.AbsolutePath);
+        }
+
+        private void ResetDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "httpclient/Default.ResetDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/RequestMessageArgsTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/RequestMessageArgsTests.cs
@@ -1,0 +1,80 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="RequestMessageArgsTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server;
+using Microsoft.OData.E2E.TestCommon;
+using Microsoft.OData.E2E.TestCommon.Common.Client.EndToEnd.Default;
+using Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd;
+using Xunit;
+using ClientEndToEndModel = Microsoft.OData.E2E.TestCommon.Common.Client.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests
+{
+    public class RequestMessageArgsTests : EndToEndTestBase<RequestMessageArgsTests.TestsStartup>
+    {
+        private readonly Uri _baseUri;
+        private readonly Container _context;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(RequestMessageArgsTestsController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                    .AddRouteComponents("odata", CommonEndToEndEdmModel.GetEdmModel()));
+            }
+        }
+
+        public RequestMessageArgsTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+
+            ResetDataSource();
+        }
+
+        [Fact]
+        public async Task AddingCustomHeaderToRequest_ShouldSucceed()
+        {
+            string headerName = "MyNewHeader";
+            string headerValue = "MyNewHeaderValue";
+            IODataRequestMessage lastRequestMessage = null;
+
+            Func<DataServiceClientRequestMessageArgs, DataServiceClientRequestMessage> configureRequest =
+                args =>
+                {
+                    args.Headers.Add(headerName, headerValue);
+                    return new HttpClientRequestMessage(args);
+                };
+
+            _context.SendingRequest2 += (obj, args) => lastRequestMessage = args.RequestMessage;
+            _context.Configurations.RequestPipeline.OnMessageCreating = configureRequest;
+
+            DataServiceQuery<ClientEndToEndModel.Product> query = _context.Products;
+            await query.ExecuteAsync();
+
+            Assert.NotNull(lastRequestMessage);
+            var header = lastRequestMessage.Headers.SingleOrDefault(h => h.Key == headerName);
+            Assert.Equal(headerValue, header.Value);
+        }
+
+        private void ResetDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "requestmessageargs/Default.ResetDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/Server/HttpClientController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/Server/HttpClientController.cs
@@ -1,0 +1,232 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="HttpClientController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
+{
+    public class HttpClientController : ODataController
+    {
+        private static CommonEndToEndDataSource _dataSource;
+
+        [EnableQuery]
+        [HttpGet("odata/Products")]
+        public IActionResult Get()
+        {
+            var products = _dataSource.Products;
+
+            return Ok(products);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Orders")]
+        public IActionResult GetOrders()
+        {
+            var orders = _dataSource.Orders;
+
+            return Ok(orders);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Customers")]
+        public IActionResult GetCustomers()
+        {
+            var customers = _dataSource.Customers;
+
+            return Ok(customers);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Computers")]
+        public IActionResult GetComputer()
+        {
+            var computers = _dataSource.Computers;
+
+            return Ok(computers);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Login")]
+        public IActionResult GetLogins()
+        {
+            var logins = _dataSource.Logins;
+
+            return Ok(logins);
+        }
+
+        [HttpPost("odata/Orders")]
+        public IActionResult PostOrder([FromBody] Order order)
+        {
+            _dataSource.Orders.Add(order);
+            return Created(order);
+        }
+
+        [HttpPost("odata/Products")]
+        public IActionResult PostProducts([FromBody] Product product)
+        {
+            _dataSource.Products.Add(product);
+            return Created(product);
+        }
+
+        [HttpPatch("odata/Computers({key})")]
+        public IActionResult GetComputer([FromRoute] int key)
+        {
+            var computer = _dataSource.Computers.SingleOrDefault(a => a.ComputerId == key);
+
+            if (computer == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(computer);
+        }
+
+        [HttpGet("odata/Products({key})/Description")]
+        public IActionResult GetProductDescription([FromRoute] int key)
+        {
+            var product = _dataSource.Products.SingleOrDefault(a => a.ProductId == key);
+
+            if (product == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(product.Description);
+        }
+
+        [HttpGet("odata/Orders({key})")]
+        public IActionResult GetOrder([FromRoute] int key)
+        {
+            var order = _dataSource.Orders.SingleOrDefault(a => a.OrderId == key);
+
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order);
+        }
+
+        [HttpGet("odata/Products({key})/RelatedProducts")]
+        public IActionResult GetRelatedProducts([FromRoute] int key)
+        {
+            var product = _dataSource.Products.SingleOrDefault(a => a.ProductId == key);
+
+            if (product == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(product.RelatedProducts);
+        }
+
+        [HttpPatch("odata/Products({key})")]
+        public IActionResult PatchProducts([FromRoute] int key, [FromBody] Delta<Product> delta)
+        {
+            var product = _dataSource.Products.SingleOrDefault(a => a.ProductId == key);
+
+            if (product == null)
+            {
+                return NotFound();
+            }
+
+            var updatedProduct = delta.Patch(product);
+
+            return Updated(updatedProduct);
+        }
+
+        [HttpPatch("odata/CustomerInfos({key})")]
+        public IActionResult PatchCustomerInfos([FromRoute] int key, [FromBody] Delta<CustomerInfo> delta)
+        {
+            var customerInfo = _dataSource.CustomerInfos.SingleOrDefault(a => a.CustomerInfoId == key);
+
+            if (customerInfo == null)
+            {
+                return NotFound();
+            }
+
+            var updatedCustomerInfo = delta.Patch(customerInfo);
+
+            return Updated(updatedCustomerInfo);
+        }
+
+        [HttpPatch("odata/Customers({key})")]
+        public IActionResult PatchCustomers([FromRoute] int key, [FromBody] Delta<Customer> delta)
+        {
+            var customer = _dataSource.Customers.SingleOrDefault(a => a.CustomerId == key);
+
+            if (customer == null)
+            {
+                return NotFound();
+            }
+
+            var updatedCustomer = delta.Patch(customer);
+
+            return Updated(updatedCustomer);
+        }
+
+        [HttpDelete("odata/Customers({key})")]
+        public IActionResult DeleteCustomer([FromRoute] int key)
+        {
+            var customer = _dataSource.Customers?.SingleOrDefault(o => o.CustomerId == key);
+
+            if (customer == null)
+            {
+                return NotFound();
+            }
+
+            _dataSource.Customers.Remove(customer);
+
+            return NoContent();
+        }
+
+        [HttpPut("odata/Products({key})")]
+        public IActionResult PutProduct([FromRoute] int key, [FromBody] Product product)
+        {
+            var existProduct = _dataSource.Products?.SingleOrDefault(o => o.ProductId == key);
+
+            if (existProduct == null)
+            {
+                return NotFound();
+            }
+
+            _dataSource.Products.Remove(existProduct);
+            existProduct.Description = product.Description;
+
+            _dataSource.Products.Add(existProduct);
+
+            return Ok(existProduct);
+        }
+
+        [HttpDelete("odata/Computers({key})")]
+        public IActionResult DeleteComputer([FromRoute] int key)
+        {
+            var computer = _dataSource.Computers?.SingleOrDefault(o => o.ComputerId == key);
+
+            if (computer == null)
+            {
+                return NotFound();
+            }
+
+            _dataSource.Computers.Remove(computer);
+
+            return NoContent();
+        }
+
+        [HttpPost("odata/httpclient/Default.ResetDataSource")]
+        public IActionResult ResetDataSource()
+        {
+            _dataSource = CommonEndToEndDataSource.CreateInstance();
+
+            return Ok();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/Server/RequestMessageArgsTestsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/Server/RequestMessageArgsTestsController.cs
@@ -1,0 +1,52 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="RequestMessageArgsTestsController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
+{
+    public class RequestMessageArgsTestsController : ODataController
+    {
+        private static CommonEndToEndDataSource _dataSource;
+
+        [EnableQuery]
+        [HttpGet("odata/Products")]
+        public IActionResult Get()
+        {
+            var products = _dataSource.Products;
+
+            return Ok(products);
+        }
+
+        [HttpPatch("odata/Products({key})")]
+        public IActionResult PatchProduct([FromRoute] int key, [FromBody] Delta<Product> delta)
+        {
+            var product = _dataSource.Products.SingleOrDefault(a => a.ProductId == key);
+
+            if (product == null)
+            {
+                return NotFound();
+            }
+
+            var updatedProduct = delta.Patch(product);
+
+            return Updated(updatedProduct);
+        }
+
+        [HttpPost("odata/requestmessageargs/Default.ResetDataSource")]
+        public IActionResult ResetDataSource()
+        {
+            _dataSource = CommonEndToEndDataSource.CreateInstance();
+
+            return Ok();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/Server/TransportLayerErrorController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/Server/TransportLayerErrorController.cs
@@ -1,0 +1,68 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TransportLayerErrorController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server
+{
+    public class TransportLayerErrorController : ODataController
+    {
+        private static CommonEndToEndDataSource _dataSource;
+
+        [EnableQuery]
+        [HttpGet("odata/Products")]
+        public IActionResult Get()
+        {
+            var products = _dataSource.Products;
+
+            return Ok(products);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/Customers")]
+        public IActionResult GetCustomers()
+        {
+            var customers = _dataSource.Customers;
+
+            return Ok(customers);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/MessageAttachments")]
+        public IActionResult GetMessageAttachments()
+        {
+            var products = _dataSource.MessageAttachments;
+
+            return Ok(products);
+        }
+
+        [EnableQuery]
+        [HttpGet("odata/MessageAttachments({key})")]
+        public IActionResult GetMessageAttachment(Guid key)
+        {
+            var messageAttachment = _dataSource.MessageAttachments.FirstOrDefault(a => a.AttachmentId == key);
+
+            if (messageAttachment == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(messageAttachment);
+        }
+
+        [HttpPost("odata/transportlayererror/Default.ResetDataSource")]
+        public IActionResult ResetDataSource()
+        {
+            _dataSource = CommonEndToEndDataSource.CreateInstance();
+
+            return Ok();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/TransportLayerErrorTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/TransportLayerTests/TransportLayerErrorTests.cs
@@ -1,0 +1,91 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TransportLayerErrorTests.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.Tests.TransportLayerTests.Server;
+using Microsoft.OData.E2E.TestCommon;
+using Microsoft.OData.E2E.TestCommon.Common.Client.EndToEnd.Default;
+using Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd;
+using Xunit;
+using ClientEndToEndModel = Microsoft.OData.E2E.TestCommon.Common.Client.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.TransportLayerTests
+{
+    public class TransportLayerErrorTests : EndToEndTestBase<TransportLayerErrorTests.TestsStartup>
+    {
+        private readonly Uri _baseUri;
+        private readonly Container _context;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(TransportLayerErrorController), typeof(MetadataController));
+
+                services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
+                    .AddRouteComponents("odata", CommonEndToEndEdmModel.GetEdmModel()));
+            }
+        }
+
+        public TransportLayerErrorTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            _baseUri = new Uri(Client.BaseAddress, "odata/");
+
+            _context = new Container(_baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+
+            ResetDataSource();
+        }
+
+        [Fact]
+        public async Task QueryWithInvalidUri_ShouldThrowADataServiException()
+        {
+            var exception = await Assert.ThrowsAsync<DataServiceQueryException>(async () =>
+                await _context.ExecuteAsync<ClientEndToEndModel.Product>(new Uri("http://var1.svc/Products"))
+            );
+
+            Assert.Equal(404, exception.Response.StatusCode);
+        }
+
+        [Fact]
+        public void QueryForEntryWithInvalidKey_ShouldReturnEmptyResult()
+        {
+            var query = _context.MessageAttachments.Where(ma => ma.AttachmentId == Guid.NewGuid()).ToList();
+            Assert.Empty(query);
+        }
+
+        [Fact]
+        public async Task JsonQueryWithInvalidDataServiceVersion_DoesNotThrowException_ItReturnsTheExpectedResults()
+        {
+            _context.SendingRequest2 += (sender, e) =>
+            {
+                e.RequestMessage.SetHeader("DataServiceVersion", "99.99;NetFx");
+            };
+
+            _context.Format.UseJson();
+
+            var exception = await Record.ExceptionAsync(async () =>
+            {
+                var result = await _context.Customers.ExecuteAsync();
+                Assert.Equal(10, result.Count());
+            });
+
+            Assert.Null(exception);
+        }
+
+        private void ResetDataSource()
+        {
+            var actionUri = new Uri(_baseUri + "transportlayererror/Default.ResetDataSource", UriKind.Absolute);
+            _context.Execute(actionUri, "POST");
+        }
+    }
+}


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

This Pr ports these tests: (https://github.com/OData/odata.net/tree/main/test/EndToEndTests/Tests/Client/Build.Desktop/TransportLayerTests)from using WCF services to using Microsoft.AspNetCore.OData services.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
