### PR TITLE
Fix $filter in (collectionofdynamicprimitivevalues)

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -7,13 +7,13 @@
 namespace Microsoft.OData.UriParser
 {
     using System;
+    using System.Buffers;
     using System.Diagnostics;
     using System.Globalization;
     using System.Linq;
     using System.Text;
-    using Microsoft.OData.Edm;
     using Microsoft.OData.Core;
-    using System.Buffers;
+    using Microsoft.OData.Edm;
 
     /// <summary>
     /// Class that knows how to bind the In operator.

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -13,7 +13,6 @@ namespace Microsoft.OData.UriParser
     using System.Text;
     using Microsoft.OData.Edm;
     using Microsoft.OData.Core;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Class that knows how to bind the In operator.

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -427,11 +427,6 @@ namespace Microsoft.OData.UriParser
 
         private static bool IsCollectionEmptyOrWhiteSpace(string bracketLiteralText)
         {
-            if (string.IsNullOrWhiteSpace(bracketLiteralText) || bracketLiteralText.Length < 2)
-            {
-                return true;
-            }
-
             string content = bracketLiteralText[1..^1].Trim();
 
             if (string.IsNullOrWhiteSpace(content))

--- a/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/InBinder.cs
@@ -130,7 +130,7 @@ namespace Microsoft.OData.UriParser
                     Debug.Assert(expectedType.IsCollection());
                     string expectedTypeFullName = expectedType.Definition.AsElementType().FullTypeName();
 
-                    if (expectedTypeFullName.Equals("Edm.String", StringComparison.Ordinal) || (expectedTypeFullName.Equals("Edm.Untyped", StringComparison.Ordinal) && IsCollectionContentEmptyOrSpaces(bracketLiteralText)))
+                    if (expectedTypeFullName.Equals("Edm.String", StringComparison.Ordinal) || (expectedTypeFullName.Equals("Edm.Untyped", StringComparison.Ordinal) && IsCollectionEmptyOrWhiteSpace(bracketLiteralText)))
                     {
                         // For collection of strings, need to convert single-quoted string to double-quoted string,
                         // and also, per ABNF, a single quote within a string literal is "encoded" as two consecutive single quotes in either
@@ -425,7 +425,7 @@ namespace Microsoft.OData.UriParser
             return "[" + String.Join(",", items) + "]";
         }
 
-        private static bool IsCollectionContentEmptyOrSpaces(string bracketLiteralText)
+        private static bool IsCollectionEmptyOrWhiteSpace(string bracketLiteralText)
         {
             if (string.IsNullOrWhiteSpace(bracketLiteralText) || bracketLiteralText.Length < 2)
             {
@@ -439,7 +439,7 @@ namespace Microsoft.OData.UriParser
                 return true;
             }
 
-            bool isEmptyOrHasOnlySpaces = true;
+            bool isEmptyOrWhiteSpace = true;
             bool isCharInsideQuotes = false;
             char quoteChar = '\0';
             char[] buffer = ArrayPool<char>.Shared.Rent(content.Length);
@@ -473,7 +473,7 @@ namespace Microsoft.OData.UriParser
 
                             if (!string.IsNullOrWhiteSpace(item))
                             {
-                                isEmptyOrHasOnlySpaces = false;
+                                isEmptyOrWhiteSpace = false;
                                 break;
                             }
                             bufferIndex = 0;
@@ -491,7 +491,7 @@ namespace Microsoft.OData.UriParser
 
                     if (!string.IsNullOrWhiteSpace(lastItem))
                     {
-                        isEmptyOrHasOnlySpaces = false;
+                        isEmptyOrWhiteSpace = false;
                     }
                 }
             }
@@ -500,7 +500,7 @@ namespace Microsoft.OData.UriParser
                 ArrayPool<char>.Shared.Return(buffer);
             }
 
-            return isEmptyOrHasOnlySpaces;
+            return isEmptyOrWhiteSpace;
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2136,6 +2136,11 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         [InlineData("TestBool", "(true,false)")]
         [InlineData("TestString", "('a','b','c')")]
         [InlineData("TestDecimal", "(1.1,2.2,3.3)")]
+        [InlineData("TestIntInSquareBrackets", "[1,2,3]")]
+        [InlineData("TestDoubleInSquareBrackets", "[1.1,2.2,3.3]")]
+        [InlineData("TestBoolInSquareBrackets", "[true,false]")]
+        [InlineData("TestStringInSquareBrackets", "['a','b','c']")]
+        [InlineData("TestDecimalInSquareBrackets", "[1.1,2.2,3.3]")]
         public void FilterWithInOperationWithParensCollectionConsistingOfDynamicPrimitiveProperties(string propertyName, string values)
         {
             string filterExpression = $"{propertyName} in {values}";

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -2130,6 +2130,22 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal("(1,2,3)", Assert.IsType<CollectionConstantNode>(inNode.Right).LiteralText);
         }
 
+        [Theory]
+        [InlineData("TestInt", "(1,2,3)")]
+        [InlineData("TestDouble", "(1.1,2.2,3.3)")]
+        [InlineData("TestBool", "(true,false)")]
+        [InlineData("TestString", "('a','b','c')")]
+        [InlineData("TestDecimal", "(1.1,2.2,3.3)")]
+        public void FilterWithInOperationWithParensCollectionConsistingOfDynamicPrimitiveProperties(string propertyName, string values)
+        {
+            string filterExpression = $"{propertyName} in {values}";
+            FilterClause filter = ParseFilter(filterExpression, HardCodedTestModel.TestModel, HardCodedTestModel.GetOpenEmployeeType());
+
+            var inNode = Assert.IsType<InNode>(filter.Expression);
+            Assert.IsType<SingleValueOpenPropertyAccessNode>(inNode.Left);
+            Assert.Equal(values, Assert.IsType<CollectionConstantNode>(inNode.Right).LiteralText);
+        }
+
         [Fact]
         public void FilterWithInOperationWithParensCollectionAndLogicalNotOperator()
         {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3098, fixes #2875 *

### Description

This PR (https://github.com/OData/odata.net/pull/2711) introduced a fix to support `$filter=dynamicProperty in ('')`. However, the changes in this PR inadvertently broke the handling of `$filter=dynamicProperty in (primitive collections)`, such as `$filter=dynamicProperty in (1,2,3)`.

To address this, I've added a private method, `IsCollectionContentEmptyOrSpaces`, which checks whether a collection of `Edm.Untyped` is either empty or contains only spaces before further processing. If the collection meets this condition, the logic for ensuring a string collection gets properly formatted gets called. 

Previously, this string formatting logic was executed without verifying whether the `Edm.Untyped` collection contained empty spaces or not. As a result, it was being applied even when the collection contained primitive types (e.g., numbers) that do not require string formatting, leading to exceptions being thrown.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
