### PR TITLE
Reconfigure issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,21 +4,17 @@ contact_links:
     url: https://github.com/OData/odata.net/discussions
     about: "For general questions, please use GitHub Discussions instead of opening an issue."
 
-  - name: 🔒 Security Issue Reporting
-    url: https://github.com/OData/odata.net/security
-    about: "If you found a security vulnerability, please report it responsibly via our security page."
-    
 issue_templates:
   - name: "🐞 Bug Report"
     description: "Report a problem to help us improve"
     title: "<brief description>"
     labels: ["bug"]
     assignees: []
-    body: .github/ISSUE_TEMPLATE/1_BUG_REPORT.md
+    body: 1_BUG_REPORT.md
     
   - name: "🚀 Feature Request"
     description: "Suggest a new feature or improvement"
     title: "<brief description>"
     labels: ["enhancement", "feature"]
     assignees: []
-    body: .github/ISSUE_TEMPLATE/1_FEATURE_REQUEST.md
+    body: 1_FEATURE_REQUEST.md


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

![image](https://github.com/user-attachments/assets/307fbb7b-7e2b-4496-b4e2-27f708732f7f)

Because the repo already contains a SECURITY.md file, the item for "Report a security vulnerability" is added automatically hence there's no need for "Security Issue Reporting".

In addition, due to previously having full path to the bug and feature request templates, the two items didn't appear. Fixing that in this pull request
