### PR TITLE
#2977 Support more kinds of relative context URIs

### DIFF
--- a/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
@@ -7,17 +7,16 @@
 namespace Microsoft.OData.Json
 {
     #region Namespaces
+    using Microsoft.OData;
+    using Microsoft.OData.Core;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Evaluation;
     using System;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
-    using System.Text.RegularExpressions;
     using System.Threading.Tasks;
-    using Microsoft.OData;
-    using Microsoft.OData.Core;
-    using Microsoft.OData.Edm;
-    using Microsoft.OData.Evaluation;
     #endregion Namespaces
 
     /// <summary>
@@ -25,9 +24,6 @@ namespace Microsoft.OData.Json
     /// </summary>
     internal abstract class ODataJsonDeserializer : ODataDeserializer
     {
-        /// <summary>Regex used to strip unwanted information from the start of a relative contextUriAnnotation value</summary>
-        internal static readonly Regex RelativeContextUriAnnotationRegex = PlatformHelper.CreateCompiled(@"^(\.\.\/)*\$metadata#", RegexOptions.IgnoreCase);
-
         /// <summary>The Json input context to use for reading.</summary>
         private readonly ODataJsonInputContext jsonInputContext;
 
@@ -285,9 +281,12 @@ namespace Microsoft.OData.Json
                 // If the contextUriAnnotation value is Customers(1)/Name, $metadata#Customers(1)/Name, or ../$metadata#Customers(1)/Name
                 // The generated context uri will be http://odata.org/test/$metadata#Customers(1)/Name
                 ODataUri oDataUri = new ODataUri() { ServiceRoot = this.BaseUri };
-                contextUriAnnotationValue = RelativeContextUriAnnotationRegex.Replace(contextUriAnnotationValue, string.Empty);
-                contextUriAnnotationValue = oDataUri.MetadataDocumentUri.ToString()
-                    + ODataConstants.ContextUriFragmentIndicator + contextUriAnnotationValue;
+
+                contextUriAnnotationValue = contextUriAnnotationValue.TrimStart('/', '.');
+
+                contextUriAnnotationValue = contextUriAnnotationValue.StartsWith("$metadata#", StringComparison.OrdinalIgnoreCase)
+                    ? this.BaseUri + contextUriAnnotationValue
+                    : oDataUri.MetadataDocumentUri.ToString() + ODataConstants.ContextUriFragmentIndicator + contextUriAnnotationValue;
             }
 
             ODataJsonContextUriParseResult parseResult = null;

--- a/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonDeserializer.cs
@@ -7,16 +7,16 @@
 namespace Microsoft.OData.Json
 {
     #region Namespaces
-    using Microsoft.OData;
-    using Microsoft.OData.Core;
-    using Microsoft.OData.Edm;
-    using Microsoft.OData.Evaluation;
     using System;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.OData;
+    using Microsoft.OData.Core;
+    using Microsoft.OData.Edm;
+    using Microsoft.OData.Evaluation;
     #endregion Namespaces
 
     /// <summary>

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
@@ -878,6 +878,18 @@ namespace Microsoft.OData.Tests.Json
 
             Assert.NotNull(property);
             Assert.Equal("http://odata.org/test/$metadata#Customers(1)/Name", deserializer.ContextUriParseResult.ContextUri.ToString());
+
+            deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}", model));
+            property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
+
+            Assert.NotNull(property);
+            Assert.Equal("http://odata.org/test/$metadata#Customers(1)/Name", deserializer.ContextUriParseResult.ContextUri.ToString());
+
+            deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}", model));
+            property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
+
+            Assert.NotNull(property);
+            Assert.Equal("http://odata.org/test/$metadata#Customers(1)/Name", deserializer.ContextUriParseResult.ContextUri.ToString());
         }
 
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
@@ -861,33 +861,26 @@ namespace Microsoft.OData.Tests.Json
             TestUtils.AssertODataValueAreEqual(new ODataPrimitiveValue(value), property.ODataValue);
         }
 
-        [Fact]
-        public void TopLevelPropertyShouldReadContextUriAsRelativeUri()
+        [Theory]
+        [InlineData("{\"@odata.context\":\"Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"/Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"./Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"../../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        public void TopLevelPropertyShouldReadContextUriAsRelativeUri(string payload)
         {
+            // Arrange
             var model = this.CreateEdmModelWithEntity();
             var primitiveTypeRef = ((IEdmEntityType)model.SchemaElements.First()).Properties().First().Type;
             this.messageReaderSettings = new ODataMessageReaderSettings() { BaseUri = new Uri("http://odata.org/test/") };
-            ODataJsonPropertyAndValueDeserializer deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"Customers(1)/Name\",\"value\":\"Joe\"}", model));
+
+            // Act
+            ODataJsonPropertyAndValueDeserializer deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext(payload, model));
             ODataProperty property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
 
-            Assert.NotNull(property);
-            Assert.Equal("http://odata.org/test/$metadata#Customers(1)/Name", deserializer.ContextUriParseResult.ContextUri.ToString());
-
-            deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"$metadata#Customers(1)/Name\",\"value\":\"Joe\"}", model));
-            property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
-
-            Assert.NotNull(property);
-            Assert.Equal("http://odata.org/test/$metadata#Customers(1)/Name", deserializer.ContextUriParseResult.ContextUri.ToString());
-
-            deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}", model));
-            property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
-
-            Assert.NotNull(property);
-            Assert.Equal("http://odata.org/test/$metadata#Customers(1)/Name", deserializer.ContextUriParseResult.ContextUri.ToString());
-
-            deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}", model));
-            property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
-
+            // Assert
             Assert.NotNull(property);
             Assert.Equal("http://odata.org/test/$metadata#Customers(1)/Name", deserializer.ContextUriParseResult.ContextUri.ToString());
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
@@ -866,9 +866,15 @@ namespace Microsoft.OData.Tests.Json
         [InlineData("{\"@odata.context\":\"/Customers(1)/Name\",\"value\":\"Joe\"}")]
         [InlineData("{\"@odata.context\":\"./Customers(1)/Name\",\"value\":\"Joe\"}")]
         [InlineData("{\"@odata.context\":\"$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"/$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"./$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
         [InlineData("{\"@odata.context\":\"../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
         [InlineData("{\"@odata.context\":\"../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
         [InlineData("{\"@odata.context\":\"../../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"../../../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"../../../../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"../../../../../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
+        [InlineData("{\"@odata.context\":\"../../../../../../../$metadata#Customers(1)/Name\",\"value\":\"Joe\"}")]
         public void TopLevelPropertyShouldReadContextUriAsRelativeUri(string payload)
         {
             // Arrange


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

This pull request fixes #2977. It is similar to PRs #1208 and #2132

### Description

SAP's OData V4 APIs will return context URI annotations like `"@odata.context": "../$metadata#Customers(1)/Name"` and `"@odata.context": "../../$metadata#Customers(1)/Name"` for certain requests. These are currently unsupported and result in an exception.

The code changes in this PR cover these scenarios.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

`build.cmd` did not work for me... I think I'm missing some build tools, or maybe it's because I don't have VS 2019 Enterprise. However, all tests that I ran in the test explorer passed (21,066 passed, 8 were skipped).
