### PR TITLE
updating build pipeline and PR template to reflect CI build instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,3 +16,9 @@
 ### Additional work necessary
 
 *If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*
+
+### Repository notes
+
+Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.
+
+Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -11,8 +11,11 @@ trigger:
    
 # Pull request (PR) triggers
 pr:
-- main
-- dev-8.x
+  autoCancel: false
+  brannches:
+    include:
+      - main
+      - dev-8.x
 
 resources:
   repositories:

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -14,8 +14,8 @@ pr:
   autoCancel: false
   brannches:
     include:
-      - main
-      - dev-8.x
+    - main
+    - dev-8.x
 
 resources:
   repositories:

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -12,7 +12,8 @@ trigger:
 # Pull request (PR) triggers
 pr:
   autoCancel: false
-  brannches:
+  branches:
+
     include:
     - main
     - dev-8.x


### PR DESCRIPTION
For security reasons, the CI build does not run automatically for PRs within this repository. The build can be triggered by a team member commenting `/AzurePipelines run` on the PR. I have added these instructions to the PR template so that we can remind ourselves of this mechanism. I have also updated the YAML to not "auto cancel", which, described [here](https://learn.microsoft.com/en-us/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#multiple-pr-updates) current cancels running builds whenever a new commit is pushed to the PR. 

The intent is to make CI builds easier to run and not interfere with the general workflow of the individual developer.