### PR TITLE
fix(client): Remove HttpMethod restriction in DataServiceContext.ValidateExecuteParameters

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -3836,7 +3836,7 @@ namespace Microsoft.OData.Client
         /// </summary>
         /// <typeparam name="TElement">element type. See Execute method for more details.</typeparam>
         /// <param name="requestUri">request to execute</param>
-        /// <param name="httpMethod">HttpMethod to use. Only GET and POST are supported if operation parameters are not empty.</param>
+        /// <param name="httpMethod">HttpMethod to use</param>
         /// <param name="singleResult">If set to true, indicates that a single result is expected as a response.</param>
         /// <param name="bodyOperationParameters">The list of body operation parameters to be returned.</param>
         /// <param name="uriOperationParameters">The list of uri operation parameters to be returned.</param>
@@ -3849,13 +3849,6 @@ namespace Microsoft.OData.Client
             out List<UriOperationParameter> uriOperationParameters,
             params OperationParameter[] operationParameters)
         {
-            if (string.CompareOrdinal(XmlConstants.HttpMethodGet, httpMethod) != 0 &&
-                string.CompareOrdinal(XmlConstants.HttpMethodPost, httpMethod) != 0 &&
-                string.CompareOrdinal(XmlConstants.HttpMethodDelete, httpMethod) != 0)
-            {
-                throw new ArgumentException(Strings.Context_ExecuteExpectsGetOrPostOrDelete, nameof(httpMethod));
-            }
-
             if (ClientTypeUtil.TypeOrElementTypeIsStructured(typeof(TElement)))
             {
                 singleResult = null;

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.Common.txt
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.Common.txt
@@ -75,7 +75,6 @@ Context_MissingOperationParameterName=The Name property of an OperationParameter
 Context_DuplicateUriOperationParameterName=Multiple uri operation parameters were found with the same name. Uri operation parameter names must be unique.
 Context_DuplicateBodyOperationParameterName=Multiple body operation parameters were found with the same name. Body operation parameter names must be unique.
 Context_NullKeysAreNotSupported=The serialized resource has a null value in key member '{0}'. Null values are not supported in key members.
-Context_ExecuteExpectsGetOrPostOrDelete=The HttpMethod must be GET, POST or DELETE.
 Context_EndExecuteExpectedVoidResponse=EndExecute overload for void service operations and actions received a non-void response from the server.
 Context_NullElementInOperationParameterArray=The operation parameters array contains a null element which is not allowed.
 Context_EntityMetadataBuilderIsRequired=An implementation of ODataEntityMetadataBuilder is required, but a null value was returned from GetEntityMetadataBuilder.

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.cs
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.cs
@@ -85,7 +85,6 @@ namespace Microsoft.OData.Client
         internal const string Context_DuplicateUriOperationParameterName = "Context_DuplicateUriOperationParameterName";
         internal const string Context_DuplicateBodyOperationParameterName = "Context_DuplicateBodyOperationParameterName";
         internal const string Context_NullKeysAreNotSupported = "Context_NullKeysAreNotSupported";
-        internal const string Context_ExecuteExpectsGetOrPostOrDelete = "Context_ExecuteExpectsGetOrPostOrDelete";
         internal const string Context_EndExecuteExpectedVoidResponse = "Context_EndExecuteExpectedVoidResponse";
         internal const string Context_NullElementInOperationParameterArray = "Context_NullElementInOperationParameterArray";
         internal const string Context_EntityMetadataBuilderIsRequired = "Context_EntityMetadataBuilderIsRequired";

--- a/src/Microsoft.OData.Client/Microsoft.OData.Client.txt
+++ b/src/Microsoft.OData.Client/Microsoft.OData.Client.txt
@@ -75,7 +75,6 @@ Context_MissingOperationParameterName=The Name property of an OperationParameter
 Context_DuplicateUriOperationParameterName=Multiple uri operation parameters were found with the same name. Uri operation parameter names must be unique.
 Context_DuplicateBodyOperationParameterName=Multiple body operation parameters were found with the same name. Body operation parameter names must be unique.
 Context_NullKeysAreNotSupported=The serialized resource has a null value in key member '{0}'. Null values are not supported in key members.
-Context_ExecuteExpectsGetOrPostOrDelete=The HttpMethod must be GET, POST or DELETE.
 Context_EndExecuteExpectedVoidResponse=EndExecute overload for void service operations and actions received a non-void response from the server.
 Context_NullElementInOperationParameterArray=The operation parameters array contains a null element which is not allowed.
 Context_EntityMetadataBuilderIsRequired=An implementation of ODataEntityMetadataBuilder is required, but a null value was returned from GetEntityMetadataBuilder.

--- a/src/Microsoft.OData.Client/Parameterized.Microsoft.OData.Client.cs
+++ b/src/Microsoft.OData.Client/Parameterized.Microsoft.OData.Client.cs
@@ -646,17 +646,6 @@ namespace Microsoft.OData.Client {
         }
 
         /// <summary>
-        /// A string like "The HttpMethod must be GET, POST or DELETE."
-        /// </summary>
-        internal static string Context_ExecuteExpectsGetOrPostOrDelete
-        {
-            get
-            {
-                return Microsoft.OData.Client.TextRes.GetString(Microsoft.OData.Client.TextRes.Context_ExecuteExpectsGetOrPostOrDelete);
-            }
-        }
-
-        /// <summary>
         /// A string like "EndExecute overload for void service operations and actions received a non-void response from the server."
         /// </summary>
         internal static string Context_EndExecuteExpectedVoidResponse

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
@@ -60,4 +60,8 @@
       <Version>4.6.0</Version>
     </PackageReference>
    </ItemGroup>
+  
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(TargetFramework)' == 'net452'">
+    <Exec Command="&quot;$([System.Environment]::GetFolderPath(SpecialFolder.ProgramFilesX86))\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe&quot; /Vr $(OutputPath)\Microsoft.OData.Edm.dll" />
+  </Target>
 </Project>

--- a/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
+++ b/test/FunctionalTests/Microsoft.OData.Edm.Tests/Microsoft.OData.Edm.Tests.csproj
@@ -60,8 +60,4 @@
       <Version>4.6.0</Version>
     </PackageReference>
    </ItemGroup>
-  
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent" Condition="'$(TargetFramework)' == 'net452'">
-    <Exec Command="&quot;$([System.Environment]::GetFolderPath(SpecialFolder.ProgramFilesX86))\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\sn.exe&quot; /Vr $(OutputPath)\Microsoft.OData.Edm.dll" />
-  </Target>
 </Project>


### PR DESCRIPTION
### Issues

* Fixes #3249

### Description

Remove any Http method validation in DataServiceContext.ValidateExecuteParameters to allow using valid PUT and PATCH methods.
These methods can be necessary to extend the client and use [Individual Property update](https://learn.microsoft.com/en-us/odata/webapi-8/fundamentals/property-routing).

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary
1. May be an issue to have a full individual property support could be nice
2. Do the same change on release-8.x branch
