### PR TITLE
Fixes #1375 Allows to filter models using Contains with Enum collections

### DIFF
--- a/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
+++ b/src/Microsoft.OData.Core/Evaluation/LiteralFormatter.cs
@@ -267,6 +267,11 @@ namespace Microsoft.OData.Evaluation
                 return enumValue.Value;
             }
 
+            var commonEnum = value as Enum;
+            {
+                return commonEnum.ToString();
+            }
+
             throw SharedUtils.CreateExceptionForUnconvertableType(value);
         }
 
@@ -488,6 +493,11 @@ namespace Microsoft.OData.Evaluation
                 }
 
                 string result = this.FormatAndEscapeLiteral(value);
+
+                if (value is Enum)
+                {
+                    return string.Concat("'", result, "'");
+                }
 
                 if (value is byte[])
                 {


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #1375.*

### Description

OData endpoint can filter models by enum property usng collection Contains method: `$filter=Color in ('Blue','Green')`. But odata client throws exception and dont covert code `requestedColors.Contains(model.Color)` to valid query. 

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*None.*