### PR TITLE
Avoid excessive property verifications when adding resource properties in OData reader

### DIFF
--- a/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
+++ b/src/Microsoft.OData.Core/JsonLight/ODataJsonLightPropertyAndValueDeserializer.cs
@@ -1024,17 +1024,15 @@ namespace Microsoft.OData.JsonLight
             ODataResourceBase resource = resourceState.Resource;
             Debug.Assert(resource != null, "resource != null");
 
-            // The resource.Properties setter would run property verification
-            // each time a property is added to the resource. That is
-            // expensive and scales quadratically with the number of properties + number of items in collection properties.
-            // To avoid this cost, we skip property verification.
+            // To avoid repeated computations for the property verification logic inside the
+            // resource.Properties setter, we update the resource.Properties in-place
+            // without invoking the setter each time.
             // Since the resource and properties are created internally by the reader,
             // we don't need to verify the properties if we can guarantee that we are only
             // adding properties with acceptable values (i.e. not ODataResourceValue).
             // We use debug-time assertions instead to catch such bugs in tests.
 
-            // This is a stop-gap measure to address a performance issue. But
-            // we should rethink the current approach to property verification.
+            // We should rethink the current approach to property verification.
             // See: https://github.com/OData/odata.net/issues/3263
 
             Debug.Assert(!(property.Value is ODataResourceValue), Strings.ODataResource_PropertyValueCannotBeODataResourceValue(property.Name));
@@ -1042,12 +1040,14 @@ namespace Microsoft.OData.JsonLight
                 !(property.Value is ODataCollectionValue collectionValue && collectionValue.Items.Any(item => item is ODataResourceValue)),
                 Strings.ODataResource_PropertyValueCannotBeODataResourceValue(property.Name));
 
-            bool originalSkipPropertyVerificationValue = resource.SkipPropertyVerification;
-            resource.SkipPropertyVerification = true;
-            
-            resource.Properties = resource.Properties.ConcatToReadOnlyEnumerable("Properties", property);
+            if (resource.Properties.IsEmptyReadOnlyEnumerable())
+            {
+                resource.Properties = new ReadOnlyEnumerable<ODataProperty>();
+            }
 
-            resource.SkipPropertyVerification = originalSkipPropertyVerificationValue;
+            // Despite the name the resource.Properties type here is not actually
+            // readonly, it supports appending in-place.
+            resource.Properties.ConcatToReadOnlyEnumerable("Properties", property);
             return property;
         }
 


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request addresses #3264 in ODL 7.x*

If this PR is approved, I'll port the fix to ODL 8.x

### Description

To fix the performance issue caused by excessively running property verification each time the reader adds a property to the resource being deserialized, I update the `resource.Properties` in-place in `ODataJsonLightPropertyAndValueDeserializer.AddResourceProperty()` without invoking the setter each time since the verification logic runs in the setter.

In lieu of running the verification logic, I use `Debug.Assert` statements to perform the equivalent verification during debug builds only, to avoid any runtime impact from the verification. I could have implemented the verification using logic that's executed also in prod builds that would also thrown an exception, this would still improve performance since the properties would be checked in O(n) times instead of O(n^2) times, but I found this unnecessary.

Here's the reasoning for doing debug-time verification only: If the reader stores the `ODataResourceValue` instances inside a resource's properties, then we would be getting exceptions already due to the existing property verification that runs by default. The fact that we don't get exceptions thrown in the reader related to this issue, means that the reader does not add such values. In any case, it would be a bug for the reader to add values in the resource properties which are considered invalid. Which is why I believe a `Debug.Assert` would suffice so we could catch such bugs when testing. Since these resources and properties are created inside the reader, we have full control of the internal behaviour.

The reason I chose this approach (over other alternatives listed in the attached issue) is because it's simple and localized to a single internal method. Every user will benefit from this without having to change their code or opt-in through some new flag. This is a non-breaking change. And we can easily change this implementation in the future without breaking.

Again, I do suggest we revisit the property verification and decide how to address it in a more holistic way since it also affects the writer performance and may affect other scenarios as well (see: https://github.com/OData/odata.net/issues/3263)

### Benchmarks

Benchmark code: 

#### Before

```sh
// * Summary *

BenchmarkDotNet v0.15.1, Windows 11 (10.0.26100.3775/24H2/2024Update/HudsonValley)
Intel Xeon W-2123 CPU 3.60GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK 10.0.100-preview.1.25120.13
  [Host]     : .NET 8.0.17 (8.0.1725.26602), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  DefaultJob : .NET 8.0.17 (8.0.1725.26602), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
```


| Method       | Mean     | Error    | StdDev   | Gen0      | Gen1     | Gen2    | Allocated |
|------------- |---------:|---------:|---------:|----------:|---------:|--------:|----------:|
| ReadResource | 23.16 ms | 0.459 ms | 0.969 ms | 2562.5000 | 562.5000 | 62.5000 |  12.65 MB |

![image](https://github.com/user-attachments/assets/2419b554-c64d-4c5c-b286-772f864c5743)

#### After

```sh
// * Summary *

BenchmarkDotNet v0.15.1, Windows 11 (10.0.26100.3775/24H2/2024Update/HudsonValley)
Intel Xeon W-2123 CPU 3.60GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK 10.0.100-preview.1.25120.13
  [Host]     : .NET 8.0.17 (8.0.1725.26602), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  DefaultJob : .NET 8.0.17 (8.0.1725.26602), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
```


| Method       | Mean     | Error     | StdDev    | Gen0     | Gen1     | Allocated |
|------------- |---------:|----------:|----------:|---------:|---------:|----------:|
| ReadResource | 4.377 ms | 0.0867 ms | 0.1243 ms | 609.3750 | 453.1250 |   3.26 MB |

![image](https://github.com/user-attachments/assets/739481df-7168-4c29-abf3-54b9bb650157)


### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
