### PR TITLE
Deprecate DataServiceContext KeyComparisonGeneratesFilterQuery

### DIFF
--- a/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
+++ b/src/Microsoft.OData.Client/ALinq/ResourceBinder.cs
@@ -249,51 +249,12 @@ namespace Microsoft.OData.Client
 
                 // Earlier path components must be navigation sources, and navigation sources cannot have query options.
                 Debug.Assert(!target.HasQueryOptions, "Navigation source had query options?");
-
-                target.SetKeyPredicate(keyPredicates);
             }
 
             if (inputPredicates != null)
             {
-                List<Expression> keyPredicates = null;
-                List<Expression> nonKeyPredicates = null;
-
-                // Get the current key predicates
-                List<Expression> currentPredicates = input.KeyPredicateConjuncts.ToList();
-
-                if (input.Filter != null && input.Filter.PredicateConjuncts.Count > 0)
-                {
-                    // Get the filter predicates
-                    currentPredicates = currentPredicates.Union(input.Filter.PredicateConjuncts.Union(inputPredicates)).ToList();
-                }
-                else
-                {
-                    currentPredicates = currentPredicates.Union(inputPredicates).ToList();
-                }
-
-                if (!input.UseFilterAsPredicate && !context.KeyComparisonGeneratesFilterQuery)
-                {
-                    keyPredicates = ExtractKeyPredicate(input, currentPredicates, model, out nonKeyPredicates);
-                }
-
-                if (keyPredicates != null)
-                {
-                    input.SetKeyPredicate(keyPredicates);
-                    input.RemoveFilterExpression();
-                }
-
-                // A key predicate cannot be applied if query options other than 'Expand' are present,
-                // so merge the key predicate into the filter query option instead.
-                if (keyPredicates != null && input.HasSequenceQueryOptions)
-                {
-                    input.ConvertKeyToFilterExpression();
-                }
-
-                if (keyPredicates == null)
-                {
-                    input.ConvertKeyToFilterExpression();
-                    input.AddFilter(inputPredicates);
-                }
+                input.ConvertKeyToFilterExpression();
+                input.AddFilter(inputPredicates);
             }
 
             return input; // No need to adjust this.currentResource - filters are merged in all cases

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -142,9 +142,6 @@ namespace Microsoft.OData.Client
         /// <summary>The HTTP stack to use for requests.</summary>
         private HttpStack httpStack;
 
-        /// <summary>Whether a Where clause that compares only the key property, will generate a $filter query option.</summary>
-        private bool keyComparisonGeneratesFilterQuery;
-
         /// <summary>A factory class to use in selecting the the request message transport mode implementation </summary>
         private IDataServiceRequestMessageFactory requestMessageFactory = new DataServiceRequestMessageFactory();
 
@@ -264,7 +261,6 @@ namespace Microsoft.OData.Client
             this.httpStack = HttpStack.Auto;
             this.UsingDataServiceCollection = false;
             this.UsePostTunneling = false;
-            this.keyComparisonGeneratesFilterQuery = true;
             this.deleteLinkUriOption = DeleteLinkUriOption.IdQueryParam;
         }
 
@@ -663,17 +659,6 @@ namespace Microsoft.OData.Client
         /// Whether enable writing odata annotation without prefix.
         /// </summary>
         public virtual bool EnableWritingODataAnnotationWithoutPrefix { get; set; }
-
-        /// <summary>
-        /// When true, a Where clause that has only the key property in the predicate generates a $filter query option, otherwise a key segment is generated.
-        /// The default value is true.
-        /// </summary>
-        [Obsolete("This property will be removed in a future major release. The ByKey method should be used to generate an OData URL with key segment.")]
-        public virtual bool KeyComparisonGeneratesFilterQuery
-        {
-            get { return this.keyComparisonGeneratesFilterQuery; }
-            set { this.keyComparisonGeneratesFilterQuery = value; }
-        }
 
         /// <summary>Gets or sets the option for the form of Uri to be generated for a delete link request.</summary>
         public virtual DeleteLinkUriOption DeleteLinkUriOption

--- a/test/UnitTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/ALinq/SequenceMethodsTests.cs
@@ -19,9 +19,9 @@ namespace Microsoft.OData.Client.Tests.ALinq
     /// </summary>
     public class SequenceMethodsTests
     {
-        private const string MockCustomer1 = "{\"CustomerID\":\"ALFKI\",\"CompanyName\":\"Alfreds Futterkiste\",\"ContactName\":\"Maria Anders\",\"Address\":\"Obere Str. 57\",\"City\":\"Berlin\"}";
+        private const string MockCustomer1 = "{\"CustomerID\":\"ALFKI\",\"CustomerTypeID\":\"Regular\",\"CompanyName\":\"Alfreds Futterkiste\",\"ContactName\":\"Maria Anders\",\"Address\":\"Obere Str. 57\",\"City\":\"Berlin\"}";
 
-        private const string MockCustomer2 = "{\"CustomerID\":\"CHOPS\",\"CompanyName\":\"Chop-suey Chinese\",\"ContactName\":\"Yang Wang\",\"Address\":\"Hauptstr. 29\",\"City\":\"Bern\"}";
+        private const string MockCustomer2 = "{\"CustomerID\":\"CHOPS\",\"CustomerTypeID\":\"VIP\",\"ContactName\":\"Yang Wang\",\"Address\":\"Hauptstr. 29\",\"City\":\"Bern\"}";
 
         private readonly DataServiceQuery<Customer> _customers;
 
@@ -42,7 +42,6 @@ namespace Microsoft.OData.Client.Tests.ALinq
             EdmModel model = BuildEdmModel();
             _ctx.Format.UseJson(model);
             _ctx.ResolveName = (type) => $"NS.{type.Name}";
-            _ctx.KeyComparisonGeneratesFilterQuery = true;
 
             _ctx.BuildingRequest += (obj, args) =>
             {
@@ -235,6 +234,85 @@ namespace Microsoft.OData.Client.Tests.ALinq
         }
 
         [Fact]
+        public void CombineWhereAndSingleOrDefaultPredicate()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS' and ContactName eq 'Yang%20Wang'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer2 + "]");
+            Customer customer = _customers.Where(c => c.Id == "CHOPS").SingleOrDefault(c => c.Name == "Yang Wang");
+            Assert.Equal("CHOPS", customer.Id);
+            Assert.Equal("Yang Wang", customer.Name);
+            Assert.Equal("Bern", customer.City);
+        }
+
+        [Fact]
+        public void WherePredicateWithCompositeKeys()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS' and CustomerTypeID eq NS.CustomerType'VIP'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer2 + "]");
+            Customer customer = _customers.Where(c => c.Id == "CHOPS" && c.Type == CustomerType.VIP).Single();
+            Assert.Equal("CHOPS", customer.Id);
+            Assert.Equal("Yang Wang", customer.Name);
+            Assert.Equal("Bern", customer.City);
+            Assert.Equal(CustomerType.VIP, customer.Type);
+        }
+
+        [Fact]
+        public void NestedWherePredicateWithCompositeKeys()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS' and CustomerTypeID eq NS.CustomerType'VIP'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer2 + "]");
+            Customer customer = _customers.Where(c => c.Id == "CHOPS").Where(c => c.Type == CustomerType.VIP).SingleOrDefault();
+            Assert.Equal("CHOPS", customer.Id);
+            Assert.Equal("Yang Wang", customer.Name);
+            Assert.Equal("Bern", customer.City);
+            Assert.Equal(CustomerType.VIP, customer.Type);
+        }
+
+        [Fact]
+        public void CombineNestedWhereAndSingleOrDefaultPredicateWithCompositeKeys()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=CustomerID eq 'CHOPS' and CustomerTypeID eq NS.CustomerType'VIP'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer2 + "]");
+            Customer customer = _customers.Where(c => c.Id == "CHOPS").SingleOrDefault(c => c.Type == CustomerType.VIP);
+            Assert.Equal("CHOPS", customer.Id);
+            Assert.Equal("Yang Wang", customer.Name);
+            Assert.Equal("Bern", customer.City);
+            Assert.Equal(CustomerType.VIP, customer.Type);
+        }
+
+        [Fact]
+        public void CombineNestedWhereAndSinglePredicate()
+        {
+            _onRequestUriBuilt = (string builtUri) =>
+            {
+                string expectedUri = BuildUriFromPath("/Customers?$filter=CustomerID eq 'ALFKI' and CustomerTypeID eq NS.CustomerType'Regular' and City eq 'Berlin'&$top=2");
+                Assert.Equal(expectedUri, builtUri);
+            };
+            InterceptRequestAndMockResponseValue("Customers", "[" + MockCustomer1 + "]");
+            Customer customer = _customers.Where(c => c.Id == "ALFKI").Where(c => c.Type == CustomerType.Regular).Single(c => c.City.Equals("Berlin"));
+            Assert.Equal("ALFKI", customer.Id);
+            Assert.Equal("Maria Anders", customer.Name);
+            Assert.Equal("Berlin", customer.City);
+            Assert.Equal(CustomerType.Regular, customer.Type);
+        }
+
+        [Fact]
         public void SingleOrDefaultPredicate_ReturnsNull_WhenNoMatchExists()
         {
             _onRequestUriBuilt = (string builtUri) =>
@@ -291,10 +369,20 @@ namespace Microsoft.OData.Client.Tests.ALinq
         {
             var model = new EdmModel();
 
+            // Define customer type enum
+            var enumType = new EdmEnumType("NS", "CustomerType");
+            enumType.AddMember("None", new EdmEnumMemberValue(0));
+            enumType.AddMember("Regular", new EdmEnumMemberValue(0));
+            enumType.AddMember("Premium", new EdmEnumMemberValue(1));
+            enumType.AddMember("VIP", new EdmEnumMemberValue(2));
+            model.AddElement(enumType);
+
             // Create the Customer entity type
             var customerType = new EdmEntityType("NS", "Customer");
             var customerId = customerType.AddStructuralProperty("CustomerID", EdmPrimitiveTypeKind.String, false);
+            var customerTypeId = customerType.AddStructuralProperty("CustomerTypeID", new EdmEnumTypeReference(enumType, false));
             customerType.AddKeys(customerId);
+            customerType.AddKeys(customerTypeId);
             customerType.AddStructuralProperty("CompanyName", EdmPrimitiveTypeKind.String, false);
             customerType.AddStructuralProperty("ContactName", EdmPrimitiveTypeKind.String, true);
             customerType.AddStructuralProperty("City", EdmPrimitiveTypeKind.String, true);
@@ -316,10 +404,21 @@ namespace Microsoft.OData.Client.Tests.ALinq
             [OriginalName("CustomerID")]
             public string Id { get; set; }
 
+            [OriginalName("CustomerTypeID")]
+            public CustomerType Type { get; set; }
+
             public string City { get; set; }
 
             [OriginalName("ContactName")]
             public string Name { get; set; }
+        }
+
+        public enum CustomerType
+        {
+            None = 0,
+            Regular = 1,
+            Premium = 2,
+            VIP = 3
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Client.Tests/DataServiceContextTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/DataServiceContextTests.cs
@@ -4,11 +4,11 @@ namespace Microsoft.OData.Client.Tests
 {
     public class DataServiceContextTests
     {
-        [Fact]
-        public void KeyComparisonGeneratesFilterQuery_Defaults_To_True()
-        {
-            var context = new DataServiceContext();
-            Assert.True(context.KeyComparisonGeneratesFilterQuery);
-        }
+        //[Fact]
+        //public void KeyComparisonGeneratesFilterQuery_Defaults_To_True()
+        //{
+        //    var context = new DataServiceContext();
+        //    Assert.True(context.KeyComparisonGeneratesFilterQuery);
+        //}
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #2208.*

### Description

Remove `DataServiceContext.KeyComparisonGeneratesFilterQuery` flag. This flag was added so as not to break existing clients. 

In `ODL 8`, `DataServiceContext.KeyComparisonGeneratesFilterQuery` flag is default to true, meaning that we generate a query with `$filter` expression. 

The `KeyComparisonGeneratesFilterQuery` property is marked as `obsolete`. This PR is to remove this flag entirely, requiring users to use `ByKey` for key segment queries.

### Checklist (Uncheck if it is not completed)

- [X] *Test cases added*
- [X] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
