### PR TITLE
Handle null segment type in Validation

### DIFF
--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/ODataUrlValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/ODataUrlValidator.cs
@@ -442,7 +442,7 @@ namespace Microsoft.OData.UriParser.Validation
         private void ValidateProperties(IEdmType edmType, ODataUrlValidationContext context)
         {
             // true if the element is added to the set; false if the element is already in the set.
-            if (edmType.TypeKind != EdmTypeKind.Primitive && context.ValidatedTypes.Add(edmType))
+            if (edmType?.TypeKind != EdmTypeKind.Primitive && context.ValidatedTypes.Add(edmType))
             {
                 IEdmStructuredType structuredType = edmType as IEdmStructuredType;
                 if (structuredType != null)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
@@ -11,6 +11,7 @@ using Microsoft.OData.UriParser;
 using Microsoft.OData.Edm;
 using Xunit;
 using Microsoft.OData.Core;
+using Microsoft.OData.UriParser.Validation;
 
 namespace Microsoft.OData.Tests.UriParser.Parsers
 {
@@ -365,6 +366,20 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 var edmTypeReference = ((IEdmEntityType)keySegment.EdmType).DeclaredKey.Single().Type;
                 keypair.Value.ShouldBeUriTemplateExpression(input, edmTypeReference);
             }
+        }
+
+        [Fact]
+        public void ValidateUntypedTemplateSegment()
+        {
+            // The following URL results in an untyped URI template as the last segment.
+            // Validation needs to handle the untyped segment when validating the URL.
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/People/{myId}/MyDog/{myDogId}"))
+            {
+                EnableUriTemplateParsing = true
+            };
+
+            IEnumerable<ODataUrlValidationMessage> validationMessages;
+            Assert.True(parser.Validate(ODataUrlValidationRuleSet.AllRules, out validationMessages));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3275*

### Description

Handles a null segment type when checking for properties of a structural type during validation.

### Checklist (Uncheck if it is not completed)

- [x] *Test cases added*
- [x] *Build and test with one-click build and test script passed*

### Additional work necessary

None.