### PR TITLE
OData Client - Do not write @odata.type annotations for declared properties

### DIFF
--- a/src/Microsoft.OData.Client/Serialization/ODataWriterWrapper.cs
+++ b/src/Microsoft.OData.Client/Serialization/ODataWriterWrapper.cs
@@ -49,6 +49,18 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
+        /// Creates the OData entry writer.
+        /// </summary>
+        /// <param name="messageWriter">The message writer.</param>
+        /// <param name="requestPipeline">The request pipeline configuration.</param>
+        /// <param name="resourceType"> The resource type of the entry.</param>
+        /// <returns>The <see cref="ODataWriter"/> wrapper</returns>
+        internal static ODataWriterWrapper CreateForEntry(ODataMessageWriter messageWriter, DataServiceClientRequestPipelineConfiguration requestPipeline, IEdmStructuredType resourceType)
+        {
+            return new ODataWriterWrapper(messageWriter.CreateODataResourceWriter(navigationSource: null, resourceType), requestPipeline);
+        }
+
+        /// <summary>
         /// Creates the OData delta feed writer.
         /// </summary>
         /// <param name="messageWriter">The message writer.</param>

--- a/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/TestHttpInterceptingHandler.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/TestHttpInterceptingHandler.cs
@@ -1,0 +1,74 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="TestHttpInterceptingHandler.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using System.Net;
+using System.Text;
+
+namespace Microsoft.OData.E2E.TestCommon
+{
+    /// <summary>
+    /// This class is used to intercept HTTP requests and provide a controlled response for testing purposes.
+    /// </summary>
+    public class TestHttpInterceptingHandler : DelegatingHandler
+    {
+        private readonly HttpStatusCode httpStatusCode;
+        private readonly Uri? location;
+        private readonly string responseBody;
+
+        public HttpRequestMessage? InterceptedRequest { get; private set; }
+
+        public string? InterceptedBody { get; private set; }
+
+        public TestHttpInterceptingHandler()
+            : this(HttpStatusCode.OK)
+        {
+        }
+
+        public TestHttpInterceptingHandler(HttpStatusCode httpStatusCode)
+            : this(httpStatusCode, location: null)
+        {
+        }
+
+        public TestHttpInterceptingHandler(HttpStatusCode httpStatusCode, Uri? location)
+            : this(httpStatusCode, location, "{}")
+        {
+        }
+
+        public TestHttpInterceptingHandler(HttpStatusCode httpStatusCode, Uri? location, string responseBody)
+            : base(new HttpClientHandler())
+        {
+            this.httpStatusCode = httpStatusCode;
+            this.location = location;
+            this.responseBody = responseBody;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            InterceptedRequest = request;
+
+            if (request.Content != null)
+            {
+                InterceptedBody = await request.Content.ReadAsStringAsync(cancellationToken);
+            }
+
+            // Return dummy response
+            var responseMessage = new HttpResponseMessage(httpStatusCode)
+            {
+                RequestMessage = request,
+                Content = new StringContent(this.responseBody, Encoding.UTF8, "application/json")
+            };
+
+            if (location != null)
+            {
+                responseMessage.Headers.Location = location;
+            }
+
+            return responseMessage;
+        }
+    }
+
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/AnnotationSerializationTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/AnnotationSerializationTests.cs
@@ -1,0 +1,455 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="AnnotationSerializationTests.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.ObjectModel;
+using System.Net;
+using Microsoft.AspNetCore.OData;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Default;
+using Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models;
+using Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server;
+using Microsoft.OData.E2E.TestCommon;
+using Xunit;
+
+namespace Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests
+{
+    public class AnnotationSerializationTests : EndToEndTestBase<AnnotationSerializationTests.TestsStartup>
+    {
+        private readonly Uri baseUri;
+        private readonly Container context;
+
+        public class TestsStartup : TestStartupBase
+        {
+            public override void ConfigureServices(IServiceCollection services)
+            {
+                services.ConfigureControllers(typeof(OrdersController), typeof(MetadataController));
+                services.AddControllers().AddOData(
+                    options => options.EnableQueryFeatures().AddRouteComponents(
+                        AnnotationSerializationEdmModel.GetEdmModel()));
+            }
+        }
+
+        public AnnotationSerializationTests(TestWebApplicationFactory<TestsStartup> fixture)
+            : base(fixture)
+        {
+            if (Client.BaseAddress == null)
+            {
+                throw new ArgumentNullException(nameof(Client.BaseAddress), "Base address cannot be null");
+            }
+
+            baseUri = Client.BaseAddress;
+            context = new Container(baseUri)
+            {
+                HttpClientFactory = HttpClientFactory
+            };
+        }
+
+        [Fact]
+        public void SerializeEntity_ShouldIncludeOnlyRequiredODataAnnotations()
+        {
+            // Arrange
+            var order = InitializeOrderEntity(orderId: 3);
+
+            var httpInterceptingHandler = new TestHttpInterceptingHandler(
+                HttpStatusCode.Created,
+                new Uri(baseUri, "Orders(3)"),
+                $"{{\"@odata.context\": \"{baseUri}/$metadata#Orders/$entity\",\"Id\":3}}");
+            var httpClient = new HttpClient(httpInterceptingHandler)
+            {
+                BaseAddress = baseUri
+            };
+
+            var dataServiceContext = new Container(httpClient.BaseAddress, ODataProtocolVersion.V4);
+            dataServiceContext.HttpClientFactory = new TestHttpClientFactory(httpClient);
+
+            dataServiceContext.AddToOrders(order);
+
+            // Act
+            var dataServiceResponse = dataServiceContext.SaveChanges();
+
+            // Assert
+            var interceptedBody = httpInterceptingHandler.InterceptedBody;
+            Assert.Equal(
+                "{\"Amount\":130.0," +
+                "\"Id\":3," +
+                "\"NextStatus@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.OrderStatus\"," +
+                "\"NextStatus\":\"Processing\"," +
+                "\"ProhibitedStatuses@odata.type\":\"#Collection(Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.OrderStatus)\"," +
+                "\"ProhibitedStatuses\":[\"Returned\"]," +
+                "\"Status\":\"Pending\"," +
+                "\"StatusHistory\":[\"Pending\"]," +
+                "\"Tags\":[\"Urgent\"]," +
+                "\"TagsHistory@odata.type\":\"#Collection(String)\"," +
+                "\"TagsHistory\":[\"Express\"]," +
+                "\"PickupAddress\":{" +
+                "\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.Address\"," +
+                "\"Street\":\"789 Pickup Rd\"," +
+                "\"City\":{" +
+                "\"Name\":\"Houston\"," +
+                "\"State\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Texas\"}}," +
+                "\"NeighborState\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"New Mexico\"}}," +
+                "\"ReturnAddresses@odata.type\":\"#Collection(Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.Address)\"," +
+                "\"ReturnAddresses\":[{" +
+                "\"Street\":\"321 Return St\"," +
+                "\"City\":{" +
+                "\"Name\":\"Miami\"," +
+                "\"State\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Florida\"}}," +
+                "\"NeighborState\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Georgia\"}}]," +
+                "\"ShippingAddress\":{" +
+                "\"Street\":\"123 Main St\"," +
+                "\"City\":{" +
+                "\"Name\":\"Seattle\"," +
+                "\"State\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Washington\"}}," +
+                "\"NeighborState\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Oregon\"}}," +
+                "\"WarehouseAddresses\":[{" +
+                "\"Street\":\"456 Warehouse St\"," +
+                "\"City\":{" +
+                "\"Name\":\"Las Vegas\"," +
+                "\"State\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Nevada\"}}," +
+                "\"NeighborState\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"California\"}}]}",
+                interceptedBody);
+        }
+
+        [Fact]
+        public void SerializeDerivedEntity_ShouldIncludeOnlyRequiredODataAnnotations()
+        {
+            // Arrange
+            var vipOrder = InitializeVipOrderEntity(orderId: 4);
+
+            var httpInterceptingHandler = new TestHttpInterceptingHandler(
+                HttpStatusCode.Created,
+                new Uri(baseUri, "Orders(4)"),
+                $"{{\"@odata.context\": \"{baseUri}/$metadata#Orders/Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipOrder/$entity\",\"Id\":4}}");
+            var httpClient = new HttpClient(httpInterceptingHandler)
+            {
+                BaseAddress = baseUri
+            };
+
+            var dataServiceContext = new Container(httpClient.BaseAddress, ODataProtocolVersion.V4);
+            dataServiceContext.HttpClientFactory = new TestHttpClientFactory(httpClient);
+
+            dataServiceContext.AddToOrders(vipOrder);
+
+            // Act
+            var dataServiceResponse = dataServiceContext.SaveChanges();
+
+            // Assert
+            var interceptedBody = httpInterceptingHandler.InterceptedBody;
+            Assert.Equal(
+                "{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipOrder\"," +
+                "\"Amount\":900.0," +
+                "\"Id\":4," +
+                "\"NextStatus@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.OrderStatus\"," +
+                "\"NextStatus\":\"Pending\"," +
+                "\"ProhibitedStatuses@odata.type\":\"#Collection(Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.OrderStatus)\"," +
+                "\"ProhibitedStatuses\":[]," +
+                "\"Status\":\"Processing\"," +
+                "\"StatusHistory\":[\"Pending\",\"Processing\"]," +
+                "\"Tags\":[\"VIP\",\"Priority\"]," +
+                "\"TagsHistory@odata.type\":\"#Collection(String)\"," +
+                "\"TagsHistory\":[]," +
+                "\"TrackingNumber\":87543," +
+                "\"PickupAddress\":null," +
+                "\"ReturnAddresses@odata.type\":\"#Collection(Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.Address)\"," +
+                "\"ReturnAddresses\":[]," +
+                "\"ShippingAddress\":{" +
+                "\"Street\":\"456 VIP St\"," +
+                "\"City\":{" +
+                "\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipCity\"," +
+                "\"AreaCode\":\"10001\"," +
+                "\"Name\":\"New York\"," +
+                "\"State\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipState\",\"Name\":\"New York\",\"TwoLetterCode\":\"NY\"}}," +
+                "\"NeighborState\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipState\",\"Name\":\"Massachusetts\",\"TwoLetterCode\":\"MA\"}}," +
+                "\"WarehouseAddresses\":[{" +
+                "\"Street\":\"789 VIP Warehouse St\"," +
+                "\"City\":{" +
+                "\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipCity\"," +
+                "\"AreaCode\":\"90001\"," +
+                "\"Name\":\"Los Angeles\"," +
+                "\"State\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipState\",\"Name\":\"California\",\"TwoLetterCode\":\"CA\"}}," +
+                "\"NeighborState\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipState\",\"Name\":\"Arizona\",\"TwoLetterCode\":\"AZ\"}}]}",
+                interceptedBody);
+        }
+
+        [Fact]
+        public void SerializeEntityWithDerivedComplexInCollection_ShouldIncludeOnlyRequiredAnnotations()
+        {
+            var order = InitializedOrderEntityWithDerivedComplexInCollection(orderId: 5);
+
+            var httpInterceptingHandler = new TestHttpInterceptingHandler(
+                HttpStatusCode.Created,
+                new Uri(baseUri, "Orders(5)"),
+                $"{{\"@odata.context\": \"{baseUri}/$metadata#Orders/$entity\",\"Id\":5}}");
+            var httpClient = new HttpClient(httpInterceptingHandler)
+            {
+                BaseAddress = baseUri
+            };
+
+            var dataServiceContext = new Container(httpClient.BaseAddress, ODataProtocolVersion.V4);
+            dataServiceContext.HttpClientFactory = new TestHttpClientFactory(httpClient);
+
+            dataServiceContext.AddToOrders(order);
+
+            // Act
+            var dataServiceResponse = dataServiceContext.SaveChanges();
+
+            // Assert
+            var interceptedBody = httpInterceptingHandler.InterceptedBody;
+            Assert.Equal(
+                "{\"Amount\":170.0," +
+                "\"Id\":5," +
+                "\"NextStatus@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.OrderStatus\"," +
+                "\"NextStatus\":\"Delivered\"," +
+                "\"ProhibitedStatuses@odata.type\":\"#Collection(Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.OrderStatus)\"," +
+                "\"ProhibitedStatuses\":[]," +
+                "\"Status\":\"Shipped\"," +
+                "\"StatusHistory\":[]," +
+                "\"Tags\":[]," +
+                "\"TagsHistory@odata.type\":\"#Collection(String)\"," +
+                "\"TagsHistory\":[]," +
+                "\"PickupAddress\":null," +
+                "\"ReturnAddresses@odata.type\":\"#Collection(Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.Address)\"," +
+                "\"ReturnAddresses\":[]," +
+                "\"ShippingAddress\":{" +
+                "\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipAddress\"," +
+                "\"PostalCode\":\"98101\"," +
+                "\"Street\":\"123 Main St\"," +
+                "\"City\":{" +
+                "\"Name\":\"Seattle\"," +
+                "\"State\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Washington\"}}," +
+                "\"NeighborState\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Oregon\"}}," +
+                "\"WarehouseAddresses\":[{" +
+                "\"Street\":\"456 Warehouse St\"," +
+                "\"City\":{" +
+                "\"Name\":\"Las Vegas\"," +
+                "\"State\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Florida\"}}," +
+                "\"NeighborState\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Georgia\"}}," +
+                "{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.VipAddress\"," +
+                "\"PostalCode\":\"99501\"," +
+                "\"Street\":\"789 VIP Warehouse St\"," +
+                "\"City\":{" +
+                "\"Name\":\"Anchorage\"," +
+                "\"State\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Alaska\"}}," +
+                "\"NeighborState\":{\"@odata.type\":\"#Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State\",\"Name\":\"Hawaii\"}}]}",
+                interceptedBody);
+        }
+
+        [Fact]
+        public void PostEntity_ShouldWorkWithOnlyRequiredODataAnnotations()
+        {
+            var order = InitializeOrderEntity(orderId: 3);
+
+            context.AddToOrders(order);
+
+            var dataServiceResponse = context.SaveChanges();
+
+            var changeOperationResponse = Assert.IsType<ChangeOperationResponse>(Assert.Single(dataServiceResponse));
+            var location = changeOperationResponse.HeaderCollection.GetHeader("Location");
+            Assert.NotNull(location);
+            Assert.Equal(new Uri(baseUri, "Orders(3)").OriginalString, location);
+            Assert.Equal(201, changeOperationResponse.StatusCode);
+        }
+
+        [Fact]
+        public void PostDerivedEntity_ShouldWorkWithOnlyRequiredODataAnnotations()
+        {
+            var order = InitializeVipOrderEntity(orderId: 4);
+
+            context.AddToOrders(order);
+
+            var dataServiceResponse = context.SaveChanges();
+
+            var changeOperationResponse = Assert.IsType<ChangeOperationResponse>(Assert.Single(dataServiceResponse));
+            var location = changeOperationResponse.HeaderCollection.GetHeader("Location");
+            Assert.NotNull(location);
+            Assert.Equal(new Uri(baseUri, "Orders(4)").OriginalString, location);
+            Assert.Equal(201, changeOperationResponse.StatusCode);
+        }
+
+        [Fact]
+        public void PostEntityWithDerivedComplexInCollection_ShouldWorkWithOnlyRequiredODataAnnotations()
+        {
+            var order = InitializeOrderEntity(orderId: 5);
+
+            context.AddToOrders(order);
+
+            var dataServiceResponse = context.SaveChanges();
+
+            var changeOperationResponse = Assert.IsType<ChangeOperationResponse>(Assert.Single(dataServiceResponse));
+            var location = changeOperationResponse.HeaderCollection.GetHeader("Location");
+            Assert.NotNull(location);
+            Assert.Equal(new Uri(baseUri, "Orders(5)").OriginalString, location);
+            Assert.Equal(201, changeOperationResponse.StatusCode);
+        }
+
+        private Order InitializeOrderEntity(int orderId)
+        {
+            return new Order
+            {
+                Id = orderId,
+                Tags = new ObservableCollection<string> { "Urgent" },
+                Status = OrderStatus.Pending,
+                StatusHistory = new ObservableCollection<OrderStatus>
+                {
+                    OrderStatus.Pending
+                },
+                Amount = 130.0m,
+                NextStatus = OrderStatus.Processing,
+                ProhibitedStatuses = new ObservableCollection<OrderStatus>
+                {
+                    OrderStatus.Returned
+                },
+                TagsHistory = new ObservableCollection<string>
+                {
+                    "Express"
+                },
+                ShippingAddress = new Address
+                {
+                    Street = "123 Main St",
+                    City = new City
+                    {
+                        Name = "Seattle",
+                        State = new State { Name = "Washington" }
+                    },
+                    NeighborState = new State { Name = "Oregon" }
+                },
+                WarehouseAddresses = new ObservableCollection<Address>
+                {
+                    new Address
+                    {
+                        Street = "456 Warehouse St",
+                        City = new City
+                        {
+                            Name = "Las Vegas",
+                            State = new State { Name = "Nevada" }
+                        },
+                        NeighborState = new State { Name = "California" }
+                    }
+                },
+                PickupAddress = new Address
+                {
+                    Street = "789 Pickup Rd",
+                    City = new City
+                    {
+                        Name = "Houston",
+                        State = new State { Name = "Texas" }
+                    },
+                    NeighborState = new State { Name = "New Mexico" }
+                },
+                ReturnAddresses = new ObservableCollection<Address>
+                {
+                    new Address
+                    {
+                        Street = "321 Return St",
+                        City = new City
+                        {
+                            Name = "Miami",
+                            State = new State { Name = "Florida" }
+                        },
+                        NeighborState = new State { Name = "Georgia" }
+                    },
+                },
+            };
+        }
+
+        private VipOrder InitializeVipOrderEntity(int orderId)
+        {
+            return new VipOrder
+            {
+                Id = orderId,
+                Status = OrderStatus.Processing,
+                StatusHistory = new ObservableCollection<OrderStatus> { OrderStatus.Pending, OrderStatus.Processing },
+                Tags = new ObservableCollection<string> { "VIP", "Priority" },
+                Amount = 900.0m,
+                ShippingAddress = new Address
+                {
+                    Street = "456 VIP St",
+                    City = new VipCity
+                    {
+                        Name = "New York",
+                        AreaCode = "10001",
+                        State = new VipState { Name = "New York", TwoLetterCode = "NY" }
+                    },
+                    NeighborState = new VipState { Name = "Massachusetts", TwoLetterCode = "MA" }
+                },
+                WarehouseAddresses = new ObservableCollection<Address>
+                {
+                    new Address
+                    {
+                        Street = "789 VIP Warehouse St",
+                        City = new VipCity
+                        {
+                            Name = "Los Angeles",
+                            AreaCode = "90001",
+                            State = new VipState { Name = "California", TwoLetterCode = "CA" }
+                        },
+                        NeighborState = new VipState { Name = "Arizona", TwoLetterCode = "AZ" }
+                    },
+                },
+                TrackingNumber = 87543,
+            };
+        }
+
+        private Order InitializedOrderEntityWithDerivedComplexInCollection(int orderId)
+        {
+            return new Order
+            {
+                Id = orderId,
+                Status = OrderStatus.Shipped,
+                Amount = 170.0m,
+                NextStatus = OrderStatus.Delivered,
+                ShippingAddress = new VipAddress
+                {
+                    Street = "123 Main St",
+                    City = new City
+                    {
+                        Name = "Seattle",
+                        State = new State { Name = "Washington" }
+                    },
+                    NeighborState = new State { Name = "Oregon" },
+                    PostalCode = "98101"
+                },
+                WarehouseAddresses = new ObservableCollection<Address>
+                {
+                    new Address
+                    {
+                        Street = "456 Warehouse St",
+                        City = new City
+                        {
+                            Name = "Las Vegas",
+                            State = new State { Name = "Florida" }
+                        },
+                        NeighborState = new State { Name = "Georgia" }
+                    },
+                    new VipAddress
+                    {
+                        Street = "789 VIP Warehouse St",
+                        City = new City
+                        {
+                            Name = "Anchorage",
+                            State = new State { Name = "Alaska" }
+                        },
+                        NeighborState = new State { Name = "Hawaii" },
+                        PostalCode = "99501"
+                    }
+                }
+            };
+        }
+    }
+
+    public class TestHttpClientFactory : IHttpClientFactory
+    {
+        private readonly HttpClient client;
+
+        public TestHttpClientFactory(HttpClient client)
+        {
+            this.client = client;
+        }
+
+        public HttpClient CreateClient(string name) => client;
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Client/AnnotationSerializationCsdl.xml
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Client/AnnotationSerializationCsdl.xml
@@ -1,0 +1,53 @@
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Order" OpenType="true">
+        <Key>
+          <PropertyRef Name="Id" />
+        </Key>
+        <Property Name="Id" Type="Edm.Int32" Nullable="false" />
+        <Property Name="Status" Type="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.OrderStatus" Nullable="false" />
+        <Property Name="StatusHistory" Type="Collection(Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.OrderStatus)" Nullable="false" />
+        <Property Name="Tags" Type="Collection(Edm.String)" />
+        <Property Name="Amount" Type="Edm.Decimal" Nullable="false" Scale="variable" />
+        <Property Name="ShippingAddress" Type="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.Address" />
+        <Property Name="WarehouseAddresses" Type="Collection(Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.Address)" />
+      </EntityType>
+      <ComplexType Name="Address" OpenType="true">
+        <Property Name="Street" Type="Edm.String" Nullable="false" />
+        <Property Name="City" Type="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.City" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="City" OpenType="true">
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+      </ComplexType>
+      <ComplexType Name="State">
+        <Property Name="Name" Type="Edm.String" Nullable="false" />
+      </ComplexType>
+      <EntityType Name="VipOrder" BaseType="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.Order" OpenType="true">
+        <Property Name="TrackingNumber" Type="Edm.Int32" Nullable="false" />
+      </EntityType>
+      <ComplexType Name="VipAddress" BaseType="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.Address" OpenType="true">
+        <Property Name="PostalCode" Type="Edm.String" />
+      </ComplexType>
+      <ComplexType Name="VipCity" BaseType="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.City" OpenType="true">
+        <Property Name="AreaCode" Type="Edm.String" />
+      </ComplexType>
+      <ComplexType Name="VipState" BaseType="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.State">
+        <Property Name="TwoLetterCode" Type="Edm.String" />
+      </ComplexType>
+      <EnumType Name="OrderStatus">
+        <Member Name="Pending" Value="0" />
+        <Member Name="Processing" Value="1" />
+        <Member Name="Shipped" Value="2" />
+        <Member Name="Delivered" Value="3" />
+        <Member Name="Cancelled" Value="4" />
+        <Member Name="Returned" Value="5" />
+      </EnumType>
+    </Schema>
+    <Schema Namespace="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Default" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityContainer Name="Container">
+        <EntitySet Name="Orders" EntityType="Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.Order" />
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Client/AnnotationSerializationDataModel.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Client/AnnotationSerializationDataModel.cs
@@ -1,0 +1,29 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="AnnotationSerializationDataModel.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.Collections.ObjectModel;
+
+namespace Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models
+{
+    public partial class Order
+    {
+        public OrderStatus NextStatus { get; set; }
+        public ObservableCollection<OrderStatus>? ProhibitedStatuses { get; set; }
+        public ObservableCollection<string>? TagsHistory { get; set; }
+        public Address? PickupAddress { get; set; }
+        public ObservableCollection<Address>? ReturnAddresses { get; set; }
+    }
+
+    public partial class Address
+    {
+        public State? NeighborState { get; set; }
+    }
+
+    public partial class City
+    {
+        public State? State { get; set; }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Client/AnnotationSerializationProxy.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Client/AnnotationSerializationProxy.cs
@@ -1,0 +1,982 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="AnnotationSerializationProxy.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using System.IO;
+
+namespace Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models
+{
+    /// <summary>
+    /// There are no comments for OrderSingle in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("OrderSingle")]
+    public partial class OrderSingle : global::Microsoft.OData.Client.DataServiceQuerySingle<Order>
+    {
+        /// <summary>
+        /// Initialize a new OrderSingle object.
+        /// </summary>
+        public OrderSingle(global::Microsoft.OData.Client.DataServiceContext context, string path)
+            : base(context, path) { }
+
+        /// <summary>
+        /// Initialize a new OrderSingle object.
+        /// </summary>
+        public OrderSingle(global::Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
+            : base(context, path, isComposable) { }
+
+        /// <summary>
+        /// Initialize a new OrderSingle object.
+        /// </summary>
+        public OrderSingle(global::Microsoft.OData.Client.DataServiceQuerySingle<Order> query)
+            : base(query) { }
+
+    }
+    /// <summary>
+    /// There are no comments for Order in the schema.
+    /// </summary>
+    /// <KeyProperties>
+    /// Id
+    /// </KeyProperties>
+    [global::Microsoft.OData.Client.Key("Id")]
+    [global::Microsoft.OData.Client.OriginalNameAttribute("Order")]
+    public partial class Order : global::Microsoft.OData.Client.BaseEntityType, global::System.ComponentModel.INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Create a new Order object.
+        /// </summary>
+        /// <param name="ID">Initial value of Id.</param>
+        /// <param name="status">Initial value of Status.</param>
+        /// <param name="amount">Initial value of Amount.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static Order CreateOrder(int ID, global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderStatus status, decimal amount)
+        {
+            Order order = new Order();
+            order.Id = ID;
+            order.Status = status;
+            order.Amount = amount;
+            return order;
+        }
+        /// <summary>
+        /// There are no comments for Property Id in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Id")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "Id is required.")]
+        public virtual int Id
+        {
+            get
+            {
+                return this._Id;
+            }
+            set
+            {
+                this.OnIdChanging(value);
+                this._Id = value;
+                this.OnIdChanged();
+                this.OnPropertyChanged("Id");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private int _Id;
+        partial void OnIdChanging(int value);
+        partial void OnIdChanged();
+        /// <summary>
+        /// There are no comments for Property Status in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Status")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "Status is required.")]
+        public virtual global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderStatus Status
+        {
+            get
+            {
+                return this._Status;
+            }
+            set
+            {
+                this.OnStatusChanging(value);
+                this._Status = value;
+                this.OnStatusChanged();
+                this.OnPropertyChanged("Status");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderStatus _Status;
+        partial void OnStatusChanging(global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderStatus value);
+        partial void OnStatusChanged();
+        /// <summary>
+        /// There are no comments for Property StatusHistory in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("StatusHistory")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "StatusHistory is required.")]
+        public virtual global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderStatus> StatusHistory
+        {
+            get
+            {
+                return this._StatusHistory;
+            }
+            set
+            {
+                this.OnStatusHistoryChanging(value);
+                this._StatusHistory = value;
+                this.OnStatusHistoryChanged();
+                this.OnPropertyChanged("StatusHistory");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderStatus> _StatusHistory = new global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderStatus>();
+        partial void OnStatusHistoryChanging(global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderStatus> value);
+        partial void OnStatusHistoryChanged();
+        /// <summary>
+        /// There are no comments for Property Tags in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Tags")]
+        public virtual global::System.Collections.ObjectModel.ObservableCollection<string> Tags
+        {
+            get
+            {
+                return this._Tags;
+            }
+            set
+            {
+                this.OnTagsChanging(value);
+                this._Tags = value;
+                this.OnTagsChanged();
+                this.OnPropertyChanged("Tags");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.Collections.ObjectModel.ObservableCollection<string> _Tags = new global::System.Collections.ObjectModel.ObservableCollection<string>();
+        partial void OnTagsChanging(global::System.Collections.ObjectModel.ObservableCollection<string> value);
+        partial void OnTagsChanged();
+        /// <summary>
+        /// There are no comments for Property Amount in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Amount")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "Amount is required.")]
+        public virtual decimal Amount
+        {
+            get
+            {
+                return this._Amount;
+            }
+            set
+            {
+                this.OnAmountChanging(value);
+                this._Amount = value;
+                this.OnAmountChanged();
+                this.OnPropertyChanged("Amount");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private decimal _Amount;
+        partial void OnAmountChanging(decimal value);
+        partial void OnAmountChanged();
+        /// <summary>
+        /// There are no comments for Property ShippingAddress in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("ShippingAddress")]
+        public virtual global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Address ShippingAddress
+        {
+            get
+            {
+                return this._ShippingAddress;
+            }
+            set
+            {
+                this.OnShippingAddressChanging(value);
+                this._ShippingAddress = value;
+                this.OnShippingAddressChanged();
+                this.OnPropertyChanged("ShippingAddress");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Address _ShippingAddress;
+        partial void OnShippingAddressChanging(global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Address value);
+        partial void OnShippingAddressChanged();
+        /// <summary>
+        /// There are no comments for Property WarehouseAddresses in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("WarehouseAddresses")]
+        public virtual global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Address> WarehouseAddresses
+        {
+            get
+            {
+                return this._WarehouseAddresses;
+            }
+            set
+            {
+                this.OnWarehouseAddressesChanging(value);
+                this._WarehouseAddresses = value;
+                this.OnWarehouseAddressesChanged();
+                this.OnPropertyChanged("WarehouseAddresses");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Address> _WarehouseAddresses = new global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Address>();
+        partial void OnWarehouseAddressesChanging(global::System.Collections.ObjectModel.ObservableCollection<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Address> value);
+        partial void OnWarehouseAddressesChanged();
+        /// <summary>
+        /// There are no comments for Property DynamicProperties in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("DynamicProperties")]
+        public virtual global::System.Collections.Generic.IDictionary<string, object> DynamicProperties
+        {
+            get
+            {
+                return this._DynamicProperties;
+            }
+            set
+            {
+                this.OnDynamicPropertiesChanging(value);
+                this._DynamicProperties = value;
+                this.OnDynamicPropertiesChanged();
+                this.OnPropertyChanged("DynamicProperties");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.Collections.Generic.IDictionary<string, object> _DynamicProperties = new global::System.Collections.Generic.Dictionary<string, object>();
+        partial void OnDynamicPropertiesChanging(global::System.Collections.Generic.IDictionary<string, object> value);
+        partial void OnDynamicPropertiesChanged();
+        /// <summary>
+        /// This event is raised when the value of the property is changed
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        /// <summary>
+        /// The value of the property is changed
+        /// </summary>
+        /// <param name="property">property name</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        protected virtual void OnPropertyChanged(string property)
+        {
+            if ((this.PropertyChanged != null))
+            {
+                this.PropertyChanged(this, new global::System.ComponentModel.PropertyChangedEventArgs(property));
+            }
+        }
+    }
+    /// <summary>
+    /// There are no comments for Address in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("Address")]
+    public partial class Address : global::System.ComponentModel.INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Create a new Address object.
+        /// </summary>
+        /// <param name="street">Initial value of Street.</param>
+        /// <param name="city">Initial value of City.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static Address CreateAddress(string street, global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.City city)
+        {
+            Address address = new Address();
+            address.Street = street;
+            if ((city == null))
+            {
+                throw new global::System.ArgumentNullException("city");
+            }
+            address.City = city;
+            return address;
+        }
+        /// <summary>
+        /// There are no comments for Property Street in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Street")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "Street is required.")]
+        public virtual string Street
+        {
+            get
+            {
+                return this._Street;
+            }
+            set
+            {
+                this.OnStreetChanging(value);
+                this._Street = value;
+                this.OnStreetChanged();
+                this.OnPropertyChanged("Street");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _Street;
+        partial void OnStreetChanging(string value);
+        partial void OnStreetChanged();
+        /// <summary>
+        /// There are no comments for Property City in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("City")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "City is required.")]
+        public virtual global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.City City
+        {
+            get
+            {
+                return this._City;
+            }
+            set
+            {
+                this.OnCityChanging(value);
+                this._City = value;
+                this.OnCityChanged();
+                this.OnPropertyChanged("City");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.City _City;
+        partial void OnCityChanging(global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.City value);
+        partial void OnCityChanged();
+        /// <summary>
+        /// There are no comments for Property DynamicProperties in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("DynamicProperties")]
+        public virtual global::System.Collections.Generic.IDictionary<string, object> DynamicProperties
+        {
+            get
+            {
+                return this._DynamicProperties;
+            }
+            set
+            {
+                this.OnDynamicPropertiesChanging(value);
+                this._DynamicProperties = value;
+                this.OnDynamicPropertiesChanged();
+                this.OnPropertyChanged("DynamicProperties");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.Collections.Generic.IDictionary<string, object> _DynamicProperties = new global::System.Collections.Generic.Dictionary<string, object>();
+        partial void OnDynamicPropertiesChanging(global::System.Collections.Generic.IDictionary<string, object> value);
+        partial void OnDynamicPropertiesChanged();
+        /// <summary>
+        /// This event is raised when the value of the property is changed
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        /// <summary>
+        /// The value of the property is changed
+        /// </summary>
+        /// <param name="property">property name</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        protected virtual void OnPropertyChanged(string property)
+        {
+            if ((this.PropertyChanged != null))
+            {
+                this.PropertyChanged(this, new global::System.ComponentModel.PropertyChangedEventArgs(property));
+            }
+        }
+    }
+    /// <summary>
+    /// There are no comments for City in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("City")]
+    public partial class City : global::System.ComponentModel.INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Create a new City object.
+        /// </summary>
+        /// <param name="name">Initial value of Name.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static City CreateCity(string name)
+        {
+            City city = new City();
+            city.Name = name;
+            return city;
+        }
+        /// <summary>
+        /// There are no comments for Property Name in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Name")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "Name is required.")]
+        public virtual string Name
+        {
+            get
+            {
+                return this._Name;
+            }
+            set
+            {
+                this.OnNameChanging(value);
+                this._Name = value;
+                this.OnNameChanged();
+                this.OnPropertyChanged("Name");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _Name;
+        partial void OnNameChanging(string value);
+        partial void OnNameChanged();
+        /// <summary>
+        /// There are no comments for Property DynamicProperties in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("DynamicProperties")]
+        public virtual global::System.Collections.Generic.IDictionary<string, object> DynamicProperties
+        {
+            get
+            {
+                return this._DynamicProperties;
+            }
+            set
+            {
+                this.OnDynamicPropertiesChanging(value);
+                this._DynamicProperties = value;
+                this.OnDynamicPropertiesChanged();
+                this.OnPropertyChanged("DynamicProperties");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::System.Collections.Generic.IDictionary<string, object> _DynamicProperties = new global::System.Collections.Generic.Dictionary<string, object>();
+        partial void OnDynamicPropertiesChanging(global::System.Collections.Generic.IDictionary<string, object> value);
+        partial void OnDynamicPropertiesChanged();
+        /// <summary>
+        /// This event is raised when the value of the property is changed
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        /// <summary>
+        /// The value of the property is changed
+        /// </summary>
+        /// <param name="property">property name</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        protected virtual void OnPropertyChanged(string property)
+        {
+            if ((this.PropertyChanged != null))
+            {
+                this.PropertyChanged(this, new global::System.ComponentModel.PropertyChangedEventArgs(property));
+            }
+        }
+    }
+    /// <summary>
+    /// There are no comments for State in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("State")]
+    public partial class State : global::System.ComponentModel.INotifyPropertyChanged
+    {
+        /// <summary>
+        /// Create a new State object.
+        /// </summary>
+        /// <param name="name">Initial value of Name.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static State CreateState(string name)
+        {
+            State state = new State();
+            state.Name = name;
+            return state;
+        }
+        /// <summary>
+        /// There are no comments for Property Name in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Name")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "Name is required.")]
+        public virtual string Name
+        {
+            get
+            {
+                return this._Name;
+            }
+            set
+            {
+                this.OnNameChanging(value);
+                this._Name = value;
+                this.OnNameChanged();
+                this.OnPropertyChanged("Name");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _Name;
+        partial void OnNameChanging(string value);
+        partial void OnNameChanged();
+        /// <summary>
+        /// This event is raised when the value of the property is changed
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public event global::System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+        /// <summary>
+        /// The value of the property is changed
+        /// </summary>
+        /// <param name="property">property name</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        protected virtual void OnPropertyChanged(string property)
+        {
+            if ((this.PropertyChanged != null))
+            {
+                this.PropertyChanged(this, new global::System.ComponentModel.PropertyChangedEventArgs(property));
+            }
+        }
+    }
+    /// <summary>
+    /// There are no comments for VipOrderSingle in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("VipOrderSingle")]
+    public partial class VipOrderSingle : global::Microsoft.OData.Client.DataServiceQuerySingle<VipOrder>
+    {
+        /// <summary>
+        /// Initialize a new VipOrderSingle object.
+        /// </summary>
+        public VipOrderSingle(global::Microsoft.OData.Client.DataServiceContext context, string path)
+            : base(context, path) { }
+
+        /// <summary>
+        /// Initialize a new VipOrderSingle object.
+        /// </summary>
+        public VipOrderSingle(global::Microsoft.OData.Client.DataServiceContext context, string path, bool isComposable)
+            : base(context, path, isComposable) { }
+
+        /// <summary>
+        /// Initialize a new VipOrderSingle object.
+        /// </summary>
+        public VipOrderSingle(global::Microsoft.OData.Client.DataServiceQuerySingle<VipOrder> query)
+            : base(query) { }
+
+    }
+    /// <summary>
+    /// There are no comments for VipOrder in the schema.
+    /// </summary>
+    /// <KeyProperties>
+    /// Id
+    /// </KeyProperties>
+    [global::Microsoft.OData.Client.Key("Id")]
+    [global::Microsoft.OData.Client.OriginalNameAttribute("VipOrder")]
+    public partial class VipOrder : Order
+    {
+        /// <summary>
+        /// Create a new VipOrder object.
+        /// </summary>
+        /// <param name="ID">Initial value of Id.</param>
+        /// <param name="status">Initial value of Status.</param>
+        /// <param name="amount">Initial value of Amount.</param>
+        /// <param name="trackingNumber">Initial value of TrackingNumber.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static VipOrder CreateVipOrder(int ID, global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderStatus status, decimal amount, int trackingNumber)
+        {
+            VipOrder vipOrder = new VipOrder();
+            vipOrder.Id = ID;
+            vipOrder.Status = status;
+            vipOrder.Amount = amount;
+            vipOrder.TrackingNumber = trackingNumber;
+            return vipOrder;
+        }
+        /// <summary>
+        /// There are no comments for Property TrackingNumber in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("TrackingNumber")]
+        [global::System.ComponentModel.DataAnnotations.RequiredAttribute(ErrorMessage = "TrackingNumber is required.")]
+        public virtual int TrackingNumber
+        {
+            get
+            {
+                return this._TrackingNumber;
+            }
+            set
+            {
+                this.OnTrackingNumberChanging(value);
+                this._TrackingNumber = value;
+                this.OnTrackingNumberChanged();
+                this.OnPropertyChanged("TrackingNumber");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private int _TrackingNumber;
+        partial void OnTrackingNumberChanging(int value);
+        partial void OnTrackingNumberChanged();
+    }
+    /// <summary>
+    /// There are no comments for VipAddress in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("VipAddress")]
+    public partial class VipAddress : Address
+    {
+        /// <summary>
+        /// Create a new VipAddress object.
+        /// </summary>
+        /// <param name="name">Initial value of Name.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static VipAddress CreateVipAddress(string street, global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.City city)
+        {
+            VipAddress vipAddress = new VipAddress();
+            vipAddress.Street = street;
+            if ((city == null))
+            {
+                throw new global::System.ArgumentNullException("city");
+            }
+            vipAddress.City = city;
+            return vipAddress;
+        }
+        /// <summary>
+        /// There are no comments for Property PostalCode in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("PostalCode")]
+        public virtual string PostalCode
+        {
+            get
+            {
+                return this._PostalCode;
+            }
+            set
+            {
+                this.OnPostalCodeChanging(value);
+                this._PostalCode = value;
+                this.OnPostalCodeChanged();
+                this.OnPropertyChanged("PostalCode");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _PostalCode;
+        partial void OnPostalCodeChanging(string value);
+        partial void OnPostalCodeChanged();
+    }
+    /// <summary>
+    /// There are no comments for VipCity in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("VipCity")]
+    public partial class VipCity : City
+    {
+        /// <summary>
+        /// Create a new VipCity object.
+        /// </summary>
+        /// <param name="name">Initial value of Name.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static VipCity CreateVipCity(string name)
+        {
+            VipCity vipCity = new VipCity();
+            vipCity.Name = name;
+            return vipCity;
+        }
+        /// <summary>
+        /// There are no comments for Property AreaCode in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("AreaCode")]
+        public virtual string AreaCode
+        {
+            get
+            {
+                return this._AreaCode;
+            }
+            set
+            {
+                this.OnAreaCodeChanging(value);
+                this._AreaCode = value;
+                this.OnAreaCodeChanged();
+                this.OnPropertyChanged("AreaCode");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _AreaCode;
+        partial void OnAreaCodeChanging(string value);
+        partial void OnAreaCodeChanged();
+    }
+    /// <summary>
+    /// There are no comments for VipState in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("VipState")]
+    public partial class VipState : State
+    {
+        /// <summary>
+        /// Create a new VipState object.
+        /// </summary>
+        /// <param name="name">Initial value of Name.</param>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public static VipState CreateVipState(string name)
+        {
+            VipState vipState = new VipState();
+            vipState.Name = name;
+            return vipState;
+        }
+        /// <summary>
+        /// There are no comments for Property TwoLetterCode in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("TwoLetterCode")]
+        public virtual string TwoLetterCode
+        {
+            get
+            {
+                return this._TwoLetterCode;
+            }
+            set
+            {
+                this.OnTwoLetterCodeChanging(value);
+                this._TwoLetterCode = value;
+                this.OnTwoLetterCodeChanged();
+                this.OnPropertyChanged("TwoLetterCode");
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private string _TwoLetterCode;
+        partial void OnTwoLetterCodeChanging(string value);
+        partial void OnTwoLetterCodeChanged();
+    }
+    /// <summary>
+    /// There are no comments for OrderStatus in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("OrderStatus")]
+    public enum OrderStatus
+    {
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Pending")]
+        Pending = 0,
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Processing")]
+        Processing = 1,
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Shipped")]
+        Shipped = 2,
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Delivered")]
+        Delivered = 3,
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Cancelled")]
+        Cancelled = 4,
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Returned")]
+        Returned = 5
+    }
+    /// <summary>
+    /// Class containing all extension methods
+    /// </summary>
+    public static class ExtensionMethods
+    {
+        /// <summary>
+        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order as global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderSingle specified by key from an entity set
+        /// </summary>
+        /// <param name="_source">source entity set</param>
+        /// <param name="_keys">dictionary with the names and values of keys</param>
+        public static global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order> _source, global::System.Collections.Generic.IDictionary<string, object> _keys)
+        {
+            return new global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
+        }
+        /// <summary>
+        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order as global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderSingle specified by key from an entity set
+        /// </summary>
+        /// <param name="_source">source entity set</param>
+        /// <param name="id">The value of id</param>
+        public static global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order> _source,
+            int id)
+        {
+            global::System.Collections.Generic.IDictionary<string, object> _keys = new global::System.Collections.Generic.Dictionary<string, object>
+            {
+                { "Id", id }
+            };
+            return new global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.OrderSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
+        }
+        /// <summary>
+        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrder as global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrderSingle specified by key from an entity set
+        /// </summary>
+        /// <param name="_source">source entity set</param>
+        /// <param name="_keys">dictionary with the names and values of keys</param>
+        public static global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrder> _source, global::System.Collections.Generic.IDictionary<string, object> _keys)
+        {
+            return new global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrderSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
+        }
+        /// <summary>
+        /// Get an entity of type global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrder as global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrderSingle specified by key from an entity set
+        /// </summary>
+        /// <param name="_source">source entity set</param>
+        /// <param name="id">The value of id</param>
+        public static global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrderSingle ByKey(this global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrder> _source,
+            int id)
+        {
+            global::System.Collections.Generic.IDictionary<string, object> _keys = new global::System.Collections.Generic.Dictionary<string, object>
+            {
+                { "Id", id }
+            };
+            return new global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrderSingle(_source.Context, _source.GetKeyPath(global::Microsoft.OData.Client.Serializer.GetKeyString(_source.Context, _keys)));
+        }
+        /// <summary>
+        /// Cast an entity of type global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order to its derived type global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrder
+        /// </summary>
+        /// <param name="_source">source entity</param>
+        public static global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrderSingle CastToVipOrder(this global::Microsoft.OData.Client.DataServiceQuerySingle<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order> _source)
+        {
+            global::Microsoft.OData.Client.DataServiceQuerySingle<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrder> query = _source.CastTo<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrder>();
+            return new global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.VipOrderSingle(_source.Context, query.GetPath(null));
+        }
+    }
+}
+namespace Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Default
+{
+    /// <summary>
+    /// There are no comments for Container in the schema.
+    /// </summary>
+    [global::Microsoft.OData.Client.OriginalNameAttribute("Container")]
+    public partial class Container : global::Microsoft.OData.Client.DataServiceContext
+    {
+        /// <summary>
+        /// Initialize a new Container object.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public Container(global::System.Uri serviceRoot) :
+                this(serviceRoot, global::Microsoft.OData.Client.ODataProtocolVersion.V4)
+        {
+        }
+
+        /// <summary>
+        /// Initialize a new Container object.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public Container(global::System.Uri serviceRoot, global::Microsoft.OData.Client.ODataProtocolVersion protocolVersion) :
+                base(serviceRoot, protocolVersion)
+        {
+            this.ResolveName = new global::System.Func<global::System.Type, string>(this.ResolveNameFromType);
+            this.ResolveType = new global::System.Func<string, global::System.Type>(this.ResolveTypeFromName);
+            this.OnContextCreated();
+            this.Format.LoadServiceModel = GeneratedEdmModel.GetInstance;
+            this.Format.UseJson();
+        }
+        partial void OnContextCreated();
+        /// <summary>
+        /// Since the namespace configured for this service reference
+        /// in Visual Studio is different from the one indicated in the
+        /// server schema, use type-mappers to map between the two.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        protected global::System.Type ResolveTypeFromName(string typeName)
+        {
+            global::System.Type resolvedType = this.DefaultResolveType(typeName, "Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models", "Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models");
+            if ((resolvedType != null))
+            {
+                return resolvedType;
+            }
+            resolvedType = this.DefaultResolveType(typeName, "Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Default", "Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Default");
+            if ((resolvedType != null))
+            {
+                return resolvedType;
+            }
+            return null;
+        }
+        /// <summary>
+        /// Since the namespace configured for this service reference
+        /// in Visual Studio is different from the one indicated in the
+        /// server schema, use type-mappers to map between the two.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        protected string ResolveNameFromType(global::System.Type clientType)
+        {
+            global::Microsoft.OData.Client.OriginalNameAttribute originalNameAttribute = (global::Microsoft.OData.Client.OriginalNameAttribute)global::System.Linq.Enumerable.SingleOrDefault(global::Microsoft.OData.Client.Utility.GetCustomAttributes(clientType, typeof(global::Microsoft.OData.Client.OriginalNameAttribute), true));
+            if (clientType.Namespace.Equals("Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models", global::System.StringComparison.Ordinal))
+            {
+                if (originalNameAttribute != null)
+                {
+                    return string.Concat("Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.", originalNameAttribute.OriginalName);
+                }
+                return string.Concat("Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models.", clientType.Name);
+            }
+            if (clientType.Namespace.Equals("Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Default", global::System.StringComparison.Ordinal))
+            {
+                if (originalNameAttribute != null)
+                {
+                    return string.Concat("Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Default.", originalNameAttribute.OriginalName);
+                }
+                return string.Concat("Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Default.", clientType.Name);
+            }
+            if (originalNameAttribute != null)
+            {
+                return clientType.Namespace + "." + originalNameAttribute.OriginalName;
+            }
+            return clientType.FullName;
+        }
+        /// <summary>
+        /// There are no comments for Orders in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        [global::Microsoft.OData.Client.OriginalNameAttribute("Orders")]
+        public virtual global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order> Orders
+        {
+            get
+            {
+                if ((this._Orders == null))
+                {
+                    this._Orders = base.CreateQuery<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order>("Orders");
+                }
+                return this._Orders;
+            }
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private global::Microsoft.OData.Client.DataServiceQuery<global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order> _Orders;
+        /// <summary>
+        /// There are no comments for Orders in the schema.
+        /// </summary>
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        public virtual void AddToOrders(global::Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Client.Models.Order order)
+        {
+            base.AddObject("Orders", order);
+        }
+        [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+        private abstract class GeneratedEdmModel
+        {
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+            private static global::Microsoft.OData.Edm.IEdmModel ParsedModel = LoadModelFromString();
+
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+            private const string filePath = @"AnnotationSerializationCsdl.xml";
+
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+            public static global::Microsoft.OData.Edm.IEdmModel GetInstance()
+            {
+                return ParsedModel;
+            }
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+            private static global::Microsoft.OData.Edm.IEdmModel LoadModelFromString()
+            {
+                global::System.Xml.XmlReader reader = CreateXmlReader();
+                try
+                {
+                    global::System.Collections.Generic.IEnumerable<global::Microsoft.OData.Edm.Validation.EdmError> errors;
+                    global::Microsoft.OData.Edm.IEdmModel edmModel;
+
+                    if (!global::Microsoft.OData.Edm.Csdl.CsdlReader.TryParse(reader, true, out edmModel, out errors))
+                    {
+                        global::System.Text.StringBuilder errorMessages = new global::System.Text.StringBuilder();
+                        foreach (var error in errors)
+                        {
+                            errorMessages.Append(error.ErrorMessage);
+                            errorMessages.Append("; ");
+                        }
+                        throw new global::System.InvalidOperationException(errorMessages.ToString());
+                    }
+
+                    return edmModel;
+                }
+                finally
+                {
+                    ((global::System.IDisposable)(reader)).Dispose();
+                }
+            }
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+            private static global::System.Xml.XmlReader CreateXmlReader(string edmxToParse)
+            {
+                return global::System.Xml.XmlReader.Create(new global::System.IO.StringReader(edmxToParse));
+            }
+
+            [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.OData.Client.Design.T4", "#VersionNumber#")]
+            private static global::System.Xml.XmlReader CreateXmlReader()
+            {
+                try
+                {
+                    var assembly = global::System.Reflection.Assembly.GetExecutingAssembly();
+                    // If multiple resource names end with the file name, select the shortest one.
+                    var resourcePath = global::System.Linq.Enumerable.First(
+                        global::System.Linq.Enumerable.OrderBy(
+                            global::System.Linq.Enumerable.Where(assembly.GetManifestResourceNames(), name => name.EndsWith(filePath)),
+                            filteredName => filteredName.Length));
+                    global::System.IO.Stream stream = assembly.GetManifestResourceStream(resourcePath);
+                    return global::System.Xml.XmlReader.Create(new global::System.IO.StreamReader(stream));
+                }
+                catch (global::System.Xml.XmlException e)
+                {
+                    throw new global::System.Xml.XmlException("Failed to create an XmlReader from the stream. Check if the resource exists.", e);
+                }
+            }
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Server/AnnotationSerializationController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Server/AnnotationSerializationController.cs
@@ -1,0 +1,45 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="AnnotationSerializationController.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models;
+
+namespace Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server
+{
+    public class OrdersController : ODataController
+    {
+        [EnableQuery]
+        public ActionResult<IEnumerable<Order>> Get()
+        {
+            return Ok(AnnotationSerializationDataSource.Orders);
+        }
+
+        [EnableQuery]
+        public ActionResult<Order> Get(int key)
+        {
+            var order = AnnotationSerializationDataSource.Orders.FirstOrDefault(o => o.Id == key);
+            if (order == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(order);
+        }
+
+        public ActionResult Post([FromBody] Order order)
+        {
+            if (order == null)
+            {
+                return BadRequest("Order cannot be null.");
+            }
+
+            AnnotationSerializationDataSource.Orders.Add(order);
+            return Created(order);
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Server/AnnotationSerializationDataModel.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Server/AnnotationSerializationDataModel.cs
@@ -1,0 +1,68 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="AnnotationSerializationDataModel.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+namespace Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models
+{
+    public class Address
+    {
+        public string Street { get; set; } = null!;
+        public City City { get; set; } = null!;
+        public Dictionary<string, object>? DynamicProperties { get; set; }
+    }
+
+    public class City
+    {
+        public string Name { get; set; } = null!;
+        public Dictionary<string, object>? DynamicProperties { get; set; }
+    }
+
+    public class State
+    {
+        public string Name { get; set; } = null!;
+    }
+
+    public class VipAddress : Address
+    {
+        public string? PostalCode { get; set; }
+    }
+
+    public class VipCity : City
+    {
+        public string? AreaCode { get; set; }
+    }
+
+    public class VipState : State
+    {
+        public string? TwoLetterCode { get; set; }
+    }
+
+    public class Order
+    {
+        public int Id { get; set; }
+        public OrderStatus Status { get; set; }
+        public List<OrderStatus>? StatusHistory { get; set; }
+        public List<string>? Tags { get; set; }
+        public decimal Amount { get; set; }
+        public Address? ShippingAddress { get; set; }
+        public List<Address>? WarehouseAddresses { get; set; }
+        public Dictionary<string, object>? DynamicProperties { get; set; }
+    }
+
+    public class VipOrder : Order
+    {
+        public int TrackingNumber { get; set; }
+    }
+
+    public enum OrderStatus
+    {
+        Pending,
+        Processing,
+        Shipped,
+        Delivered,
+        Cancelled,
+        Returned
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Server/AnnotationSerializationDataSource.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Server/AnnotationSerializationDataSource.cs
@@ -1,0 +1,124 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="AnnotationSerializationDataSource.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models;
+
+namespace Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server
+{
+    public class AnnotationSerializationDataSource
+    {
+        private static readonly List<Order> orders;
+
+        static AnnotationSerializationDataSource()
+        {
+            orders = new List<Order>
+            {
+                new Order
+                {
+                    Id = 1,
+                    Status = OrderStatus.Pending,
+                    StatusHistory = new List<OrderStatus> { OrderStatus.Pending },
+                    Tags = new List<string> { "Urgent" },
+                    Amount = 130.00m,
+                    ShippingAddress = new Address
+                    {
+                        Street = "123 Main St",
+                        City = new City
+                        {
+                            Name = "Seattle",
+                            DynamicProperties = new Dictionary<string, object> { { "State", new State { Name = "Washington" } } }
+                        },
+                        DynamicProperties = new Dictionary<string, object> { { "NeighborState", new State { Name = "Oregon" } } }
+                    },
+                    WarehouseAddresses = new List<Address>
+                    {
+                        new Address
+                        {
+                            Street = "456 Warehouse St",
+                            City = new City
+                            {
+                                Name = "Las Vegas",
+                                DynamicProperties = new Dictionary<string, object> { { "State", new State { Name = "Nevada" } } }
+                            },
+                            DynamicProperties = new Dictionary<string, object> { { "NeighborState", new State { Name = "California" } } }
+                        },
+                    },
+                    DynamicProperties = new Dictionary<string, object>
+                    {
+                        { "NextStatus", OrderStatus.Processing },
+                        { "ProhibitedStatuses", new List<OrderStatus> { OrderStatus.Returned } },
+                        { "TagsHistory", new List<string> { "Express" } },
+                        {
+                            "PickupAddress",
+                            new Address
+                            {
+                                Street = "789 Pickup Rd",
+                                City = new City
+                                {
+                                    Name = "Houston",
+                                    DynamicProperties = new Dictionary<string, object> { { "State", new State { Name = "Texas" } } }
+                                },
+                                DynamicProperties = new Dictionary<string, object> { { "NeighborState", new State { Name = "New Mexico" } } }
+                            }
+                        },
+                        {
+                            "ReturnAddresses",
+                            new List<Address>
+                            {
+                                new Address
+                                {
+                                    Street = "321 Return St",
+                                    City = new City
+                                    {
+                                        Name = "Miami",
+                                        DynamicProperties = new Dictionary<string, object> { { "State", new State { Name = "Florida" } } }
+                                    },
+                                    DynamicProperties = new Dictionary<string, object> { { "NeighborState", new State { Name = "Georgia" } } }
+                                }
+                            }
+                        }
+                    }
+                },
+                new VipOrder
+                {
+                    Id = 2,
+                    Status = OrderStatus.Processing,
+                    StatusHistory = new List<OrderStatus> { OrderStatus.Pending, OrderStatus.Processing },
+                    Tags = new List<string> { "VIP", "Priority" },
+                    Amount = 900.00m,
+                    ShippingAddress = new Address
+                    {
+                        Street = "456 VIP St",
+                        City = new VipCity
+                        {
+                            Name = "New York",
+                            AreaCode = "10001",
+                            DynamicProperties = new Dictionary<string, object> { { "State", new VipState { Name = "New York", TwoLetterCode = "NY" } } }
+                        },
+                        DynamicProperties = new Dictionary<string, object> { { "NeighborState", new VipState { Name = "Massachusetts", TwoLetterCode = "MA" } } }
+                    },
+                    WarehouseAddresses = new List<Address>
+                    {
+                        new Address
+                        {
+                            Street = "789 VIP Warehouse St",
+                            City = new VipCity
+                            {
+                                Name = "Los Angeles",
+                                AreaCode = "90001",
+                                DynamicProperties = new Dictionary<string, object> { { "State", new VipState { Name = "California", TwoLetterCode = "CA" } } }
+                            },
+                            DynamicProperties = new Dictionary<string, object> { { "NeighborState", new VipState { Name = "Arizona", TwoLetterCode = "AZ" } } }
+                        },
+                    },
+                    TrackingNumber = 87543,
+                }
+            };
+        }
+
+        public static List<Order> Orders  => orders;
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Server/AnnotationSerializationEdmModel.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/AnnotationSerializationTests/Server/AnnotationSerializationEdmModel.cs
@@ -1,0 +1,31 @@
+﻿//---------------------------------------------------------------------
+// <copyright file="AnnotationSerializationEdmModel.cs" company="Microsoft">
+//      Copyright (C) Microsoft Corporation. All rights reserved. See License.txt in the project root for license information.
+// </copyright>
+//---------------------------------------------------------------------
+
+using Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server.Models;
+using Microsoft.OData.Edm;
+using Microsoft.OData.ModelBuilder;
+
+namespace Microsoft.OData.Client.E2E.Tests.AnnotationSerializationTests.Server
+{
+    public class AnnotationSerializationEdmModel
+    {
+        public static IEdmModel GetEdmModel()
+        {
+            var modelBuilder = new ODataConventionModelBuilder();
+            modelBuilder.EntitySet<Order>("Orders");
+            modelBuilder.EnumType<OrderStatus>();
+            modelBuilder.ComplexType<Address>();
+            modelBuilder.ComplexType<City>();
+            modelBuilder.ComplexType<State>();
+            modelBuilder.EntityType<VipOrder>();
+            modelBuilder.ComplexType<VipAddress>();
+            modelBuilder.ComplexType<VipCity>();
+            modelBuilder.ComplexType<VipState>();
+
+            return modelBuilder.GetEdmModel();
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientEntityDescriptorTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/ClientTests/Tests/ClientEntityDescriptorTests.cs
@@ -181,7 +181,7 @@ namespace Microsoft.OData.Client.E2E.Tests.ClientTests.Tests
             var ordersOnMyBirthday = (await ((DataServiceQuery<ClientDefaultModel.Order>)filterByDateTimeQuery).ExecuteAsync()).ToList();
 
             Assert.Single(ordersOnMyBirthday);
-            Assert.Equal("5/29/2011 12:00:00 AM", ordersOnMyBirthday.Single().OrderDate.Date.ToString());
+            Assert.Equal("2011-05-29T00:00:00", ordersOnMyBirthday.Single().OrderDate.Date.ToString("yyyy-MM-dd'T'HH:mm:ss"));
         }
 
         [Fact]

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/KeyAsSegmentTests/Tests/DollarSegmentTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/KeyAsSegmentTests/Tests/DollarSegmentTests.cs
@@ -122,7 +122,7 @@ public class DollarSegmentTests : EndToEndTestBase<DollarSegmentTests.TestsStart
 
         // Assert
         Assert.Equal(5, discontinuedProductDatesQuery.Length);
-        Assert.Single(discontinuedProductDatesQuery.Where(d => d.Discontinued.ToString() == "7/28/2005 1:09:56 PM +00:00"));
+        Assert.Single(discontinuedProductDatesQuery.Where(d => d.Discontinued.ToString("yyyy-MM-dd'T'HH:mm:sszzz") == "2005-07-28T13:09:56+00:00"));
     }
 
     [Fact]
@@ -137,7 +137,7 @@ public class DollarSegmentTests : EndToEndTestBase<DollarSegmentTests.TestsStart
 
         // Assert
         Assert.Equal(5, discontinuedProductDatesQuery.Length);
-        Assert.Single(discontinuedProductDatesQuery.Where(d => d.Discontinued.ToString() == "7/28/2005 1:09:56 PM +00:00"));
+        Assert.Single(discontinuedProductDatesQuery.Where(d => d.Discontinued.ToString("yyyy-MM-dd'T'HH:mm:sszzz") == "2005-07-28T13:09:56+00:00"));
     }
 
     [Fact]

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Microsoft.OData.Client.E2E.Tests.csproj
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Microsoft.OData.Client.E2E.Tests.csproj
@@ -26,11 +26,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="AnnotationSerializationTests\Client\AnnotationSerializationCsdl.xml" />
     <None Remove="ClientWithoutTypeResolverTests\Clients\MismatchedClientModel\MismatchedClientModelCsdl.xml" />
     <None Remove="PayloadValueConverterTests\Client\PayloadValueConverterCsdl.xml" />
   </ItemGroup>
 
   <ItemGroup>
+    <EmbeddedResource Include="AnnotationSerializationTests\Client\AnnotationSerializationCsdl.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </EmbeddedResource>
     <EmbeddedResource Include="ClientWithoutTypeResolverTests\Clients\MismatchedClientModel\MismatchedClientModelCsdl.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </EmbeddedResource>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3064.*

### Description

This pull request addresses unnecessary inclusion of `@odata.type` annotations in payloads generated by the OData client, particularly when serializing entities with declared properties.

### Background

Consider the following sample OData service metadata:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
   <edmx:DataServices>
      <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Ex340.Models">
         <EntityType Name="Order" OpenType="true">
            <Key>
               <PropertyRef Name="Id" />
            </Key>
            <Property Name="Id" Type="Edm.Int32" Nullable="false" />
            <Property Name="Status" Type="Ex340.Models.OrderStatus" Nullable="false" />
            <Property Name="StatusHistory" Type="Collection(Ex340.Models.OrderStatus)" Nullable="false" />
            <Property Name="Tags" Type="Collection(Edm.String)" />
            <Property Name="Amount" Type="Edm.Decimal" Nullable="false" Scale="variable" />
            <Property Name="ShippingAddress" Type="Ex340.Models.Address" />
            <Property Name="WarehouseAddresses" Type="Collection(Ex340.Models.Address)" />
         </EntityType>
         <ComplexType Name="Address" OpenType="true">
            <Property Name="Street" Type="Edm.String" Nullable="false" />
            <Property Name="City" Type="Ex340.Models.City" Nullable="false" />
         </ComplexType>
         <ComplexType Name="City" OpenType="true">
            <Property Name="Name" Type="Edm.String" Nullable="false" />
         </ComplexType>
         <ComplexType Name="State">
            <Property Name="Name" Type="Edm.String" Nullable="false" />
         </ComplexType>
         <EnumType Name="OrderStatus">
            <Member Name="Pending" Value="0" />
            <Member Name="Processing" Value="1" />
            <Member Name="Shipped" Value="2" />
            <Member Name="Delivered" Value="3" />
            <Member Name="Cancelled" Value="4" />
            <Member Name="Returned" Value="5" />
         </EnumType>
      </Schema>
      <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Default">
         <EntityContainer Name="Container">
            <EntitySet Name="Orders" EntityType="Ex340.Models.Order" />
         </EntityContainer>
      </Schema>
   </edmx:DataServices>
</edmx:Edmx>
```

Currently, when an `Order` entity with both declared and dynamic properties is serialized and POSTed to the service, the payload includes redundant `@odata.type` annotations even for declared properties. For example:

```csharp
var order = new Order
{
    Id = 1,
    Tags = new ObservableCollection<string> { "Urgent" },
    Status = OrderStatus.Pending,
    StatusHistory = new ObservableCollection<OrderStatus>
    {
        OrderStatus.Pending
    },
    Amount = 130.00m,
    NextStatus = OrderStatus.Processing,
    ProhibitedStatuses = new ObservableCollection<OrderStatus>
    {
        OrderStatus.Returned
    },
    TagsHistory = new ObservableCollection<string>
    {
        "Express"
    },
    ShippingAddress = new Address
    {
        Street = "123 Main St",
        City = new City
        {
            Name = "Seattle",
            State = new State { Name = "Washington" }
        },
        NeighborState = new State { Name = "Oregon" }
    },
    WarehouseAddresses = new ObservableCollection<Address>
    {
        new Address
        {
            Street = "456 Warehouse St",
            City = new City
            {
                Name = "Las Vegas",
                State = new State { Name = "Nevada" }
            },
            NeighborState = new State { Name = "California" }
        }
    },
    PickupAddress = new Address
    {
        Street = "789 Pickup Rd",
        City = new City
        {
            Name = "Houston",
            State = new State { Name = "Texas" }
        },
        NeighborState = new State { Name = "New Mexico" }
    },
    ReturnAddresses = new ObservableCollection<Address>
    {
        new Address
        {
            Street = "321 Return St",
            City = new City
            {
                Name = "Miami",
                State = new State { Name = "Florida" }
            },
            NeighborState = new State { Name = "Georgia" }
        },
    },
};

var context = new Container(new Uri("http://localhost:5157"));

context.AddToOrders(order);

context.SaveChanges();
```

This results in a verbose payload like:

```json
{
  "@odata.type": "#Ex340.Models.Order",
  "Amount": 130.00,
  "Id": 1,
  "NextStatus@odata.type": "#Ex340.Models.OrderStatus",
  "NextStatus": "Processing",
  "ProhibitedStatuses@odata.type": "#Collection(Ex340.Models.OrderStatus)",
  "ProhibitedStatuses": [
    "Returned"
  ],
  "Status@odata.type": "#Ex340.Models.OrderStatus",
  "Status": "Pending",
  "StatusHistory@odata.type": "#Collection(Ex340.Models.OrderStatus)",
  "StatusHistory": [
    "Pending"
  ],
  "Tags@odata.type": "#Collection(String)",
  "Tags": [
    "Urgent"
  ],
  "TagsHistory@odata.type": "#Collection(String)",
  "TagsHistory": [
    "Express"
  ],
  "PickupAddress": {
    "@odata.type": "#Ex340.Models.Address",
    "Street": "789 Pickup Rd",
    "City": {
      "@odata.type": "#Ex340.Models.City",
      "Name": "Houston",
      "State": {
        "@odata.type": "#Ex340.Models.State",
        "Name": "Texas"
      }
    },
    "NeighborState": {
      "@odata.type": "#Ex340.Models.State",
      "Name": "New Mexico"
    }
  },
  "ReturnAddresses@odata.type": "#Collection(Ex340.Models.Address)",
  "ReturnAddresses": [
    {
      "@odata.type": "#Ex340.Models.Address",
      "Street": "321 Return St",
      "City": {
        "@odata.type": "#Ex340.Models.City",
        "Name": "Miami",
        "State": {
          "@odata.type": "#Ex340.Models.State",
          "Name": "Florida"
        }
      },
      "NeighborState": {
        "@odata.type": "#Ex340.Models.State",
        "Name": "Georgia"
      }
    }
  ],
  "ShippingAddress": {
    "@odata.type": "#Ex340.Models.Address",
    "Street": "123 Main St",
    "City": {
      "@odata.type": "#Ex340.Models.City",
      "Name": "Seattle",
      "State": {
        "@odata.type": "#Ex340.Models.State",
        "Name": "Washington"
      }
    },
    "NeighborState": {
      "@odata.type": "#Ex340.Models.State",
      "Name": "Oregon"
    }
  },
  "WarehouseAddresses@odata.type": "#Collection(Ex340.Models.Address)",
  "WarehouseAddresses": [
    {
      "@odata.type": "#Ex340.Models.Address",
      "Street": "456 Warehouse St",
      "City": {
        "@odata.type": "#Ex340.Models.City",
        "Name": "Las Vegas",
        "State": {
          "@odata.type": "#Ex340.Models.State",
          "Name": "Nevada"
        }
      },
      "NeighborState": {
        "@odata.type": "#Ex340.Models.State",
        "Name": "California"
      }
    }
  ]
}
```

### Issues

The following annotations are unnecessary and inflate the payload:

- `@odata.type` on the `Order` instance (not derived)
- `Status@odata.type` (declared enum property)
- `StatusHistory@odata.type` (declared collection)
- `Tags@odata.type` (declared collection)
- `@odata.type` on `ShippingAddress`, `WarehouseAddresses`, and nested `City` objects (all declared complex types)

While the service accepts the payload, customers have reported that payload size becomes significant for entities with many properties.

### Fix

This PR updates the serialization logic to omit `@odata.type` annotations for declared properties and instances, unless:

- The instance is of a derived type
- The property is dynamic

The resulting payload is more concise:

```json
{
  "Amount": 130.00,
  "Id": 1,
  "NextStatus@odata.type": "#Ex340.Models.OrderStatus",
  "NextStatus": "Processing",
  "ProhibitedStatuses@odata.type": "#Collection(Ex340.Models.OrderStatus)",
  "ProhibitedStatuses": [
    "Returned"
  ],
  "Status": "Pending",
  "StatusHistory": [
    "Pending"
  ],
  "Tags": [
    "Urgent"
  ],
  "TagsHistory@odata.type": "#Collection(String)",
  "TagsHistory": [
    "Express"
  ],
  "PickupAddress": {
    "@odata.type": "#Ex340.Models.Address",
    "Street": "789 Pickup Rd",
    "City": {
      "Name": "Houston",
      "State": {
        "@odata.type": "#Ex340.Models.State",
        "Name": "Texas"
      }
    },
    "NeighborState": {
      "@odata.type": "#Ex340.Models.State",
      "Name": "New Mexico"
    }
  },
  "ReturnAddresses@odata.type": "#Collection(Ex340.Models.Address)",
  "ReturnAddresses": [
    {
      "Street": "321 Return St",
      "City": {
        "Name": "Miami",
        "State": {
          "@odata.type": "#Ex340.Models.State",
          "Name": "Florida"
        }
      },
      "NeighborState": {
        "@odata.type": "#Ex340.Models.State",
        "Name": "Georgia"
      }
    }
  ],
  "ShippingAddress": {
    "Street": "123 Main St",
    "City": {
      "Name": "Seattle",
      "State": {
        "@odata.type": "#Ex340.Models.State",
        "Name": "Washington"
      }
    },
    "NeighborState": {
      "@odata.type": "#Ex340.Models.State",
      "Name": "Oregon"
    }
  },
  "WarehouseAddresses": [
    {
      "Street": "456 Warehouse St",
      "City": {
        "Name": "Las Vegas",
        "State": {
          "@odata.type": "#Ex340.Models.State",
          "Name": "Nevada"
        }
      },
      "NeighborState": {
        "@odata.type": "#Ex340.Models.State",
        "Name": "California"
      }
    }
  ]
}
```

The pull request also ensures that the type annotation is written where the instance is derived, or when the property is dynamic.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
