### PR TITLE
Cherry-pick: (PR 3234) FunctionCallBinder returning SingleValueFunctionCallNode for complex types

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -403,9 +403,9 @@ namespace Microsoft.OData.UriParser
 
             string functionName = function.FullName();
 
-            if (returnType.IsEntity())
+            if (returnType.IsStructured())
             {
-                boundFunction = new SingleResourceFunctionCallNode(functionName, new[] { function }, boundArguments, (IEdmEntityTypeReference)returnType.Definition.ToTypeReference(), returnSet, parent);
+                boundFunction = new SingleResourceFunctionCallNode(functionName, new[] { function }, boundArguments, returnType.AsStructured(), returnSet, parent);
             }
             else if (returnType.IsStructuredCollection())
             {

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -1998,7 +1998,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         {
             FilterClause filter = ParseFilter("Fully.Qualified.Namespace.GetPriorAddress in Fully.Qualified.Namespace.GetPriorAddresses", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
             var inNode = Assert.IsType<InNode>(filter.Expression);
-            Assert.Equal("Fully.Qualified.Namespace.GetPriorAddress", Assert.IsType<SingleValueFunctionCallNode>(inNode.Left).Name);
+            Assert.Equal("Fully.Qualified.Namespace.GetPriorAddress", Assert.IsType<SingleResourceFunctionCallNode>(inNode.Left).Name);
             Assert.Equal("Fully.Qualified.Namespace.GetPriorAddresses", Assert.IsType<CollectionResourceFunctionCallNode>(inNode.Right).Name);
         }
 
@@ -2874,7 +2874,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             OrderByClause orderby = ParseOrderBy("Fully.Qualified.Namespace.GetPriorAddress in Fully.Qualified.Namespace.GetPriorAddresses", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType());
 
             var inNode = Assert.IsType<InNode>(orderby.Expression);
-            Assert.Equal("Fully.Qualified.Namespace.GetPriorAddress", Assert.IsType<SingleValueFunctionCallNode>(inNode.Left).Name);
+            Assert.Equal("Fully.Qualified.Namespace.GetPriorAddress", Assert.IsType<SingleResourceFunctionCallNode>(inNode.Left).Name);
             Assert.Equal("Fully.Qualified.Namespace.GetPriorAddresses", Assert.IsType<CollectionResourceFunctionCallNode>(inNode.Right).Name);
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Binders/FunctionCallBinderTests.cs
@@ -1167,6 +1167,16 @@ namespace Microsoft.OData.Tests.UriParser.Binders
         }
 
         [Fact]
+        public void BindSingleComplexFunctionCallReturnsSingleResourceFunctionCallNode()
+        {
+            QueryNode functionCallNode;
+            Assert.True(RunBindEndPathAsFunctionCall("Fully.Qualified.Namespace.GetSomeAddressFromPerson", out functionCallNode));
+            IEdmFunction function = HardCodedTestModel.GetFunctionForGetMyDogGetSomeAddressFromPerson();
+            SingleResourceFunctionCallNode SingleResourceCallNode = functionCallNode.ShouldBeSingleResourceFunctionCallNode(function);
+            Assert.Empty(SingleResourceCallNode.Parameters);
+        }
+
+        [Fact]
         public void EntityCollectionFunctionDoesNotHaveResultEntitySetIfFunctionImportDidntSpecifyOne()
         {
             QueryNode functionCallNode;

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -2228,6 +2228,11 @@ namespace Microsoft.OData.Tests.UriParser
             return TestModel.FindOperations("Fully.Qualified.Namespace.GetMyDog").Single() as IEdmFunction;
         }
 
+        public static IEdmFunction GetFunctionForGetMyDogGetSomeAddressFromPerson()
+        {
+            return TestModel.FindOperations("Fully.Qualified.Namespace.GetSomeAddressFromPerson").Single() as IEdmFunction;
+        }
+
         public static IEdmFunctionImport GetFunctionImportIsAddressGood()
         {
             return TestModel.EntityContainer.FindOperationImports("IsAddressGood").Single() as IEdmFunctionImport;


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

Cherry-pick: 00d4c772d048573d6b3b9ffd85836e217979a4e5

### Description

*Briefly describe the changes of this pull request.*

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
