### PR TITLE
Cherry-pick: Track DependsOnIds when UseJsonBatch flag is applied to batch requests

### DIFF
--- a/src/Microsoft.OData.Client/BaseSaveResult.cs
+++ b/src/Microsoft.OData.Client/BaseSaveResult.cs
@@ -1048,6 +1048,7 @@ namespace Microsoft.OData.Client
             }
 
             linkDescriptor.State = EntityStates.Unchanged;
+            linkDescriptor.DependsOnIds = null;
         }
 
         /// <summary>
@@ -1226,6 +1227,7 @@ namespace Microsoft.OData.Client
                 {
                     entityDescriptor.ETag = etag;
                     entityDescriptor.State = EntityStates.Unchanged;
+                    entityDescriptor.DependsOnIds = null;
                     entityDescriptor.PropertiesToSerialize.Clear();
                 }
 
@@ -1297,6 +1299,7 @@ namespace Microsoft.OData.Client
                         Debug.Assert(entityDescriptor.State == EntityStates.Modified, "descriptor.State == EntityStates.Modified");
                         entityDescriptor.ETag = etag;
                         entityDescriptor.State = EntityStates.Unchanged;
+                        entityDescriptor.DependsOnIds = null;
                         entityDescriptor.PropertiesToSerialize.Clear();
                     }
                 }
@@ -1306,6 +1309,7 @@ namespace Microsoft.OData.Client
                 if ((EntityStates.Added == descriptor.State) || (EntityStates.Modified == descriptor.State))
                 {
                     descriptor.State = EntityStates.Unchanged;
+                    descriptor.DependsOnIds = null;
                 }
                 else if (EntityStates.Detached != descriptor.State)
                 {   // this link may have been previously detached by a detaching entity
@@ -1317,6 +1321,7 @@ namespace Microsoft.OData.Client
                 Debug.Assert(descriptor.DescriptorKind == DescriptorKind.NamedStream, "it must be named stream");
                 Debug.Assert(descriptor.State == EntityStates.Modified, "named stream must only be in modified state");
                 descriptor.State = EntityStates.Unchanged;
+                descriptor.DependsOnIds = null;
 
                 StreamDescriptor streamDescriptor = (StreamDescriptor)descriptor;
 

--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -2369,6 +2369,7 @@ namespace Microsoft.OData.Client
 
             LinkDescriptor descriptor = new LinkDescriptor(source, sourceProperty, target, this.model);
             this.entityTracker.AddLink(descriptor);
+            UpdateDescriptorWithDependsOnIds(descriptor, new[] { source, target }, this.entityTracker);
             descriptor.State = EntityStates.Added;
             this.entityTracker.IncrementChange(descriptor);
         }
@@ -2477,6 +2478,7 @@ namespace Microsoft.OData.Client
             {
                 relation = new LinkDescriptor(source, sourceProperty, target, this.model);
                 this.entityTracker.AddLink(relation);
+                UpdateDescriptorWithDependsOnIds(relation, new[] { source, target }, this.entityTracker);
             }
 
             Debug.Assert(
@@ -2539,6 +2541,7 @@ namespace Microsoft.OData.Client
 
             LinkDescriptor descriptor = new LinkDescriptor(source, sourceProperty, target, this.model);
             this.entityTracker.AddLink(descriptor);
+            UpdateDescriptorWithDependsOnIds(descriptor, new[] { source, target }, this.entityTracker);
             descriptor.State = EntityStates.Added;
             this.entityTracker.IncrementChange(descriptor);
         }
@@ -2618,13 +2621,13 @@ namespace Microsoft.OData.Client
             var targetResource = new EntityDescriptor(this.model)
             {
                 Entity = target,
-                State = EntityStates.Added,
-                DependsOnIds = new List<string> { sourceResource.ChangeOrder.ToString(CultureInfo.InvariantCulture) }
+                State = EntityStates.Added
             };
 
             targetResource.SetParentForInsert(sourceResource, sourceProperty);
 
             this.EntityTracker.AddEntityDescriptor(targetResource);
+            UpdateDescriptorWithDependsOnIds(targetResource, new[] { source }, this.entityTracker);
 
             // Add the link in the added state.
             LinkDescriptor end = targetResource.GetRelatedEnd();
@@ -2686,6 +2689,7 @@ namespace Microsoft.OData.Client
             targetResource.SetParentForInsert(sourceResource, sourceProperty);
 
             this.EntityTracker.AddEntityDescriptor(targetResource);
+            UpdateDescriptorWithDependsOnIds(targetResource, new[] { source }, this.entityTracker);
 
             // Add the link in the added state.
             LinkDescriptor end = targetResource.GetRelatedEnd();
@@ -2869,7 +2873,7 @@ namespace Microsoft.OData.Client
                 {
                     Entity = target,
                     State = EntityStates.Modified,
-                    EditLink = sourceResource.GetNestedResourceInfo(this.baseUriResolver, property)
+                    EditLink = sourceResource.GetNestedResourceInfo(this.baseUriResolver, property) 
                 };
 
                 targetResource.SetParentForUpdate(sourceResource, sourceProperty);
@@ -4285,6 +4289,43 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
+        /// Updates the <c>DependsOnIds</c> property of the given <see cref="Descriptor"/> to include the change order IDs
+        /// of any related entities that are in the <c>Added</c> state. This is used to ensure correct ordering of operations
+        /// when submitting changes that depend on newly added entities.
+        /// </summary>
+        /// <param name="descriptor">The descriptor (entity or link) to update.</param>
+        /// <param name="dependsOnObjects">An array of related objects that the descriptor depends on.</param>
+        /// <param name="entityTracker">The <see cref="EntityTracker"/> used to resolve descriptors for the related objects.</param>
+        private static void UpdateDescriptorWithDependsOnIds(
+            Descriptor descriptor,
+            object[] dependsOnObjects,
+            EntityTracker entityTracker)
+        {
+            foreach (object dependsOnResource in dependsOnObjects)
+            {
+                if (dependsOnResource == null)
+                {
+                    continue;
+                }
+
+                EntityDescriptor entityDescriptor = entityTracker.TryGetEntityDescriptor(dependsOnResource);
+                if (entityDescriptor != null && entityDescriptor.State == EntityStates.Added)
+                {
+                    if (descriptor.DependsOnIds == null)
+                    {
+                        descriptor.DependsOnIds = new List<string>();
+                    }
+
+                    string dependsOnId = entityDescriptor.ChangeOrder.ToString(CultureInfo.InvariantCulture);
+                    if (!descriptor.DependsOnIds.Contains(dependsOnId))
+                    {
+                        descriptor.DependsOnIds.Add(dependsOnId);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// Sets the entity's state to unchanged.
         /// </summary>
         /// <param name="entity">The entity to set back to unchanged.</param>
@@ -4298,6 +4339,7 @@ namespace Microsoft.OData.Client
             }
 
             descriptor.State = EntityStates.Unchanged;
+            descriptor.DependsOnIds = null;
         }
 
         /// <summary>

--- a/src/Microsoft.OData.Client/EntityTracker.cs
+++ b/src/Microsoft.OData.Client/EntityTracker.cs
@@ -391,6 +391,7 @@ namespace Microsoft.OData.Client
             {
                 LinkDescriptor end = this.bindings[trackedEntityDescriptor.GetRelatedEnd()];
                 end.State = EntityStates.Unchanged;
+                end.DependsOnIds = null;
             }
 
             trackedEntityDescriptor.Identity = entityDescriptorFromMaterializer.Identity; // always attach the identity
@@ -429,6 +430,7 @@ namespace Microsoft.OData.Client
             {
                 LinkDescriptor end = this.bindings[resource.GetRelatedEnd()];
                 end.State = EntityStates.Unchanged;
+                end.DependsOnIds = null;
             }
 
             resource.Identity = identity; // always attach the identity

--- a/src/Microsoft.OData.Client/ObjectMaterializerLog.cs
+++ b/src/Microsoft.OData.Client/ObjectMaterializerLog.cs
@@ -206,6 +206,7 @@ namespace Microsoft.OData.Client
                     {
                         // we should always reset descriptor's state to Unchanged (old v1 behavior)
                         descriptor.State = EntityStates.Unchanged;
+                        descriptor.DependsOnIds = null;
                         descriptor.PropertiesToSerialize.Clear();
                     }
                 }

--- a/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Common/Server/EndToEnd/CommonEndToEndDataSource.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Common/Server/EndToEnd/CommonEndToEndDataSource.cs
@@ -70,7 +70,7 @@ namespace Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd
             PopulatePerson_PersonMetadata();
             PopulateEmployee_Manager();
             PopulateSpecialEmployee_Car();
-            PopulateBank();
+            PopulateBanks();
         }
 
         private void ResetData()
@@ -128,27 +128,83 @@ namespace Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd
         public IList<Bank>? Banks { get; private set; }
         public IList<BankAccount>? BankAccounts { get; private set; }
 
-        private void PopulateBank()
+        private void PopulateBanks()
         {
+            this.BankAccounts = new List<BankAccount>
+            {
+                new ()
+                {
+                    Id = 1001,
+                    AccountNumber = "1001",
+                    BankId = 301
+                },
+                new ()
+                {
+                    Id = 1002,
+                    AccountNumber = "1002",
+                    BankId = 301
+                },
+                new ()
+                {
+                    Id = 1003,
+                    AccountNumber = "1003",
+                    BankId = 302
+                },
+                new ()
+                {
+                    Id = 1004,
+                    AccountNumber = "1004",
+                    BankId = 303
+                },
+                new ()
+                {
+                    Id = 1005,
+                    AccountNumber = "1005",
+                    BankId = 303
+                },
+            };
+
             Banks =
                 [
-                 new (){
-                     Id = 300,
-                     Name = "ICM",
+                 new ()
+                 {
+                     Id = 301,
+                     Name = "ICM1",
                      Location = "KE",
-                     BankAccounts = new List<BankAccount>()
+                     BankAccounts = new List<BankAccount>
+                     {
+                         this.BankAccounts[0],
+                         this.BankAccounts[1],
+                     }
+                 },
+                 new ()
+                 {
+                     Id = 302,
+                     Name = "ICM2",
+                     Location = "KE",
+                     BankAccounts = new List<BankAccount>
+                     {
+                         this.BankAccounts[2],
+                     }
+                 },
+                 new ()
+                 {
+                     Id = 303,
+                     Name = "ICM3",
+                     Location = "KE",
+                     BankAccounts = new List<BankAccount>
+                     {
+                         this.BankAccounts[3],
+                         this.BankAccounts[4]
+                     }
                  }
                 ];
 
-        }
-
-        private void PopulateBankAccount()
-        {
-            AddBankAccountToBank(300, new BankAccount()
-            {
-                AccountNumber = "2002",
-                BankId = 300
-            });
+            this.BankAccounts[0].Bank = Banks[0];
+            this.BankAccounts[1].Bank = Banks[0];
+            this.BankAccounts[2].Bank = Banks[1];
+            this.BankAccounts[3].Bank = Banks[2];
+            this.BankAccounts[4].Bank = Banks[2];
         }
 
         private void PopulateAllTypesSet()

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/AsyncMethodTests.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/AsyncMethodTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.OData.Client.E2E.Tests.Batch
         {
             public override void ConfigureServices(IServiceCollection services)
             {
-                services.ConfigureControllers(typeof(BanksController), typeof(MetadataController));
+                services.ConfigureControllers(typeof(BanksController), typeof(BankAccountsController), typeof(MetadataController));
                 services.AddControllers().AddOData(opt => opt.Count().Filter().Expand().Select().OrderBy().SetMaxTop(null)
                     .AddRouteComponents("odata", CommonEndToEndEdmModel.GetEdmModel(), new DefaultODataBatchHandler()));
             }
@@ -44,7 +44,7 @@ namespace Microsoft.OData.Client.E2E.Tests.Batch
         }
 
         [Fact]
-        public async Task JsonBatchSequencingSingeChangeSetTest()
+        public async Task JsonBatchSequencingSingleChangeSetTest()
         {
             // Create new BankAccounts object
             var bank = new Bank
@@ -85,6 +85,375 @@ namespace Microsoft.OData.Client.E2E.Tests.Batch
 
             Assert.Equal(201, bankResponse.StatusCode);
             Assert.Equal(201, bankAccountResponse.StatusCode);
+        }
+
+        [Fact]
+        // Validating regression reported here: https://github.com/OData/odata.net/issues/3150
+        public async Task BatchSequencingSingleChangeSetWithRelatedAlone()
+        {
+            // Create new Bank object
+            var bank = new Bank
+            {
+                Id = 45,
+                Name = "Test Bank",
+                Location = "KE",
+                BankAccounts = new List<BankAccount>()
+            };
+
+            // Add the Bank entity to the context
+            _context.AddObject("Banks", bank);
+
+            // Save bank
+            var response = await _context.SaveChangesAsync();
+            Assert.Single(response);
+
+            var bankResponse = response.First() as ChangeOperationResponse;
+            Assert.NotNull(bankResponse);
+            Assert.Equal(201, bankResponse.StatusCode);
+
+            // Create new BankAccount object
+            var bankAccount = new BankAccount
+            {
+                Id = 890,
+                AccountNumber = "4567890",
+                BankId = bank.Id,
+                Bank = bank
+            };
+
+            // Establish the relationship between Bank and BankAccount
+            bank.BankAccounts.Add(bankAccount);
+
+            // Add the related BankAccount entity
+            _context.AddRelatedObject(bank, "BankAccounts", bankAccount);
+
+            // Save bankAccount in a single batch request. 
+            response = await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset);
+            Assert.Single(response);
+
+            var bankAccountResponse = response.Last() as ChangeOperationResponse;
+            Assert.NotNull(bankAccountResponse);
+            Assert.Equal(201, bankAccountResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task JsonBatchSequencingSingeChangeSetTest_SetLink()
+        {
+            // Create new BankAccounts object
+            var bank = new Bank
+            {
+                Id = 45,
+                Name = "Test Bank",
+                Location = "KE",
+                BankAccounts = new List<BankAccount>()
+            };
+
+            // Create new BankAccount object
+            var bankAccount = new BankAccount
+            {
+                Id = 890,
+                AccountNumber = "4567890",
+                BankId = bank.Id,
+            };
+
+            // Add the Bank and Account entities to the context
+            _context.AddObject("Banks", bank);
+            _context.AddObject("BankAccounts", bankAccount);
+
+            // Set the link from BankAccount to Bank entity
+            _context.SetLink(bankAccount, "Bank", bank);
+
+            // Save both entities in a single batch request using JSON
+            var response = await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch);
+            Assert.Equal(3, response.Count()); // We get 2 POST's and a PUT for the link
+
+            var bankResponse = response.ElementAt(0) as ChangeOperationResponse;
+            var bankAccountResponse = response.ElementAt(1) as ChangeOperationResponse;
+            var bankAccountBankResponse = response.ElementAt(2) as ChangeOperationResponse;
+
+            Assert.NotNull(bankResponse);
+            Assert.NotNull(bankAccountResponse);
+            Assert.NotNull(bankAccountBankResponse);
+
+            Assert.Equal(201, bankResponse.StatusCode);
+            Assert.Equal(201, bankAccountResponse.StatusCode);
+            Assert.Equal(204, bankAccountBankResponse.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(SaveChangesOptions.BatchWithSingleChangeset, 3001, 10001)]
+        [InlineData(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch, 30001, 100001)]
+        public async Task JsonBatchWithSingleChangesetWithAddLink(SaveChangesOptions saveChangesOptions, int bankId, int bankAccountId)
+        {
+            var bank = new Bank
+            {
+                Id = bankId,
+                Name = $"Bank {bankId}",
+                Location = "Loc 1"
+            };
+            var bankAccount = new BankAccount
+            {
+                Id = bankAccountId,
+                AccountNumber = $"{bankAccountId}",
+                BankId = bank.Id,
+            };
+
+            _context.AddObject("Banks", bank);
+            _context.AddObject("BankAccounts", bankAccount);
+            _context.AddLink(bank, "BankAccounts", bankAccount);
+
+            var dataServiceResponse = await _context.SaveChangesAsync(saveChangesOptions);
+
+            Assert.Equal(3, dataServiceResponse.Count()); // We get 2 POST's and a PUT for the link
+
+            var operationResponseAt0 = dataServiceResponse.ElementAt(0) as ChangeOperationResponse;
+            var operationResponseAt1 = dataServiceResponse.ElementAt(1) as ChangeOperationResponse;
+            var operationResponseAt2 = dataServiceResponse.ElementAt(2) as ChangeOperationResponse;
+
+            Assert.NotNull(operationResponseAt0);
+            Assert.NotNull(operationResponseAt1);
+            Assert.NotNull(operationResponseAt2);
+
+            Assert.Equal(201, operationResponseAt0.StatusCode);
+            Assert.Equal(201, operationResponseAt1.StatusCode);
+            Assert.Equal(204, operationResponseAt2.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(SaveChangesOptions.BatchWithSingleChangeset, 3002, 10002)]
+        [InlineData(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch, 30002, 100002)]
+        public async Task JsonBatchWithSingleChangesetWithSetLink(SaveChangesOptions saveChangesOptions, int bankId, int bankAccountId)
+        {
+            var bank = new Bank
+            {
+                Id = bankId,
+                Name = $"Bank {bankId}",
+                Location = "Loc 1"
+            };
+            var bankAccount = new BankAccount
+            {
+                Id = bankAccountId,
+                AccountNumber = $"{bankAccountId}",
+                BankId = bank.Id,
+            };
+
+            _context.AddObject("Banks", bank);
+            _context.AddObject("BankAccounts", bankAccount);
+            _context.SetLink(bankAccount, "Bank", bank);
+
+            var dataServiceResponse = await _context.SaveChangesAsync(saveChangesOptions);
+
+            Assert.Equal(3, dataServiceResponse.Count()); // We get 2 POST's and a PUT for the link
+
+            var operationResponseAt0 = dataServiceResponse.ElementAt(0) as ChangeOperationResponse;
+            var operationResponseAt1 = dataServiceResponse.ElementAt(1) as ChangeOperationResponse;
+            var operationResponseAt2 = dataServiceResponse.ElementAt(2) as ChangeOperationResponse;
+
+            Assert.NotNull(operationResponseAt0);
+            Assert.NotNull(operationResponseAt1);
+            Assert.NotNull(operationResponseAt2);
+
+            Assert.Equal(201, operationResponseAt0.StatusCode);
+            Assert.Equal(201, operationResponseAt1.StatusCode);
+            Assert.Equal(204, operationResponseAt2.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(SaveChangesOptions.BatchWithSingleChangeset, 3003, 10003)]
+        [InlineData(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch, 30003, 100003)]
+        public async Task JsonBatchWithSingleChangesetWithAddRelatedObject(SaveChangesOptions saveChangesOptions, int bankId, int bankAccountId)
+        {
+            var bank = new Bank
+            {
+                Id = bankId,
+                Name = $"Bank {bankId}",
+                Location = "Loc 1"
+            };
+            var bankAccount = new BankAccount
+            {
+                Id = bankAccountId,
+                AccountNumber = $"{bankAccountId}",
+                BankId = bank.Id,
+            };
+
+            _context.AddObject("Banks", bank);
+            _context.AddRelatedObject(bank, "BankAccounts", bankAccount);
+
+            var dataServiceResponse = await _context.SaveChangesAsync(saveChangesOptions);
+
+            Assert.Equal(2, dataServiceResponse.Count()); // We get 2 POST's and a PUT for the link
+
+            var operationResponseAt0 = dataServiceResponse.ElementAt(0) as ChangeOperationResponse;
+            var operationResponseAt1 = dataServiceResponse.ElementAt(1) as ChangeOperationResponse;
+
+            Assert.NotNull(operationResponseAt0);
+            Assert.NotNull(operationResponseAt1);
+
+            Assert.Equal(201, operationResponseAt0.StatusCode);
+            Assert.Equal(201, operationResponseAt1.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(SaveChangesOptions.BatchWithSingleChangeset, 3004, 10004)]
+        [InlineData(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch, 30004, 100004)]
+        public async Task JsonBatchWithSingleChangesetWithSetRelatedObject(SaveChangesOptions saveChangesOptions, int bankId, int bankAccountId)
+        {
+            var bank = new Bank
+            {
+                Id = bankId,
+                Name = $"Bank {bankId}",
+                Location = "Loc 1"
+            };
+            var bankAccount = new BankAccount
+            {
+                Id = bankAccountId,
+                AccountNumber = $"{bankAccountId}",
+                BankId = bank.Id,
+            };
+
+            _context.AddObject("BankAccounts", bankAccount);
+            _context.SetRelatedObject(bankAccount, "Bank", bank);
+
+            var dataServiceResponse = await _context.SaveChangesAsync(saveChangesOptions);
+
+            Assert.Equal(2, dataServiceResponse.Count());
+
+            var operationResponseAt0 = dataServiceResponse.ElementAt(0) as ChangeOperationResponse;
+            var operationResponseAt1 = dataServiceResponse.ElementAt(1) as ChangeOperationResponse;
+
+            Assert.NotNull(operationResponseAt0);
+            Assert.NotNull(operationResponseAt1);
+
+            Assert.Equal(201, operationResponseAt0.StatusCode);
+            Assert.Equal(201, operationResponseAt1.StatusCode);
+        }
+
+        [Fact]
+        public async Task JsonBatchWithSingleChangesetWithDeleteLink()
+        {
+            var bank = _context.Banks.SingleOrDefault(d => d.Id == 302);
+            var bankAccount = _context.BankAccounts.SingleOrDefault(d => d.Id == 1003);
+            
+            _context.DeleteLink(bank, "BankAccounts", bankAccount);
+            
+            var dataServiceResponse = await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch);
+            
+            var operationResponse = Assert.Single(dataServiceResponse) as ChangeOperationResponse;
+            
+            Assert.NotNull(operationResponse);
+            Assert.Equal(204, operationResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task JsonBatchWithSingleChangesetWithAddLinkToExisting()
+        {
+            var bank = _context.Banks.SingleOrDefault(d => d.Id == 302);
+            var bankAccount = new BankAccount
+            {
+                Id = 10005,
+                AccountNumber = "10005",
+                BankId = bank.Id,
+            };
+            
+            _context.AddObject("BankAccounts", bankAccount);
+            _context.AddLink(bank, "BankAccounts", bankAccount);
+            
+            var dataServiceResponse = await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch);
+            
+            Assert.Equal(2, dataServiceResponse.Count());
+
+            var operationResponseAt0 = dataServiceResponse.ElementAt(0) as ChangeOperationResponse;
+            var operationResponseAt1 = dataServiceResponse.ElementAt(1) as ChangeOperationResponse;
+
+            Assert.NotNull(operationResponseAt0);
+            Assert.NotNull(operationResponseAt1);
+
+            Assert.Equal(201, operationResponseAt0.StatusCode);
+            Assert.Equal(204, operationResponseAt1.StatusCode);
+        }
+
+        [Fact]
+        public async Task JsonBatchWithSingleChangesetWithSetLinkToExisting()
+        {
+            var bank = new Bank
+            {
+                Id = 3005,
+                Name = "Bank 3005",
+                Location = "Loc 1"
+            };
+            var bankAccount = _context.BankAccounts.SingleOrDefault(d => d.Id == 1005);
+
+            _context.AddObject("Banks", bank);
+            _context.SetLink(bankAccount, "Bank", bank);
+
+            var dataServiceResponse = await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch);
+
+            Assert.Equal(2, dataServiceResponse.Count());
+
+            var operationResponseAt0 = dataServiceResponse.ElementAt(0) as ChangeOperationResponse;
+            var operationResponseAt1 = dataServiceResponse.ElementAt(1) as ChangeOperationResponse;
+
+            Assert.NotNull(operationResponseAt0);
+            Assert.NotNull(operationResponseAt1);
+
+            Assert.Equal(201, operationResponseAt0.StatusCode);
+            Assert.Equal(204, operationResponseAt1.StatusCode);
+        }
+
+        [Fact]
+        public async Task JsonBatchWithSingleChangesetWithSetLinkToNull()
+        {
+            var bankAccount = _context.BankAccounts.SingleOrDefault(d => d.Id == 1004);
+            
+            _context.SetLink(bankAccount, "Bank", null);
+
+            var dataServiceResponse = await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch);
+
+            var operationResponse = Assert.Single(dataServiceResponse) as ChangeOperationResponse;
+
+            Assert.NotNull(operationResponse);
+            Assert.Equal(204, operationResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task JsonBatchWithSingleChangesetWithAddRelatedObjectToExisting()
+        {
+            var bank = _context.Banks.SingleOrDefault(d => d.Id == 303);
+            var bankAccount = new BankAccount
+            {
+                Id = 10006,
+                AccountNumber = "10006",
+                BankId = bank.Id,
+            };
+            
+            _context.AddRelatedObject(bank, "BankAccounts", bankAccount);
+            
+            var dataServiceResponse = await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch);
+
+
+            var operationResponse = Assert.Single(dataServiceResponse) as ChangeOperationResponse;
+
+            Assert.NotNull(operationResponse);
+            Assert.Equal(201, operationResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task JsonBatchWithSingleChangesetWithSetRelatedObjectToExisting()
+        {
+            var bank = new Bank
+            {
+                Id = 3006,
+                Name = "Bank 3006",
+                Location = "Loc 1"
+            };
+            var bankAccount = _context.BankAccounts.SingleOrDefault(d => d.Id == 1005);
+
+            _context.SetRelatedObject(bankAccount, "Bank", bank);
+
+            var dataServiceResponse = await _context.SaveChangesAsync(SaveChangesOptions.BatchWithSingleChangeset | SaveChangesOptions.UseJsonBatch);
+            
+            var operationResponse = Assert.Single(dataServiceResponse) as ChangeOperationResponse;
+            Assert.NotNull(operationResponse);
+            Assert.Equal(201, operationResponse.StatusCode);
         }
     }
 

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/Server/Backend.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/Server/Backend.cs
@@ -1,0 +1,36 @@
+﻿//-----------------------------------------------------------------------------
+// <copyright file="BanksController.cs" company=".NET Foundation">
+//      Copyright (c) .NET Foundation and Contributors. All rights reserved.
+//      See License.txt in the project root for license information.
+// </copyright>
+//------------------------------------------------------------------------------
+
+using Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.Batch.Server
+{
+    internal class Backend
+    {
+        public static CommonEndToEndDataSource DataSource { get; } = CommonEndToEndDataSource.CreateInstance();
+
+        public static bool TryGetKeyFromUri(Uri link, out int key)
+        {
+            key = default;
+
+            var segments = link.Segments;
+            if (segments.Length > 1)
+            {
+                var lastSegment = segments[^1].TrimEnd('/');
+                var lastIndexOfLeftParen = lastSegment.LastIndexOf('(');
+                var lastIndexOfRightParen = lastSegment.LastIndexOf(')');
+                if (lastIndexOfLeftParen > 0 && lastIndexOfRightParen > lastIndexOfLeftParen)
+                {
+                    var keyStr = lastSegment.Substring(lastIndexOfLeftParen + 1, lastIndexOfRightParen - lastIndexOfLeftParen - 1);
+                    return int.TryParse(keyStr, out key);
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/Server/BankAccountsController.cs
+++ b/test/EndToEndTests/Tests/Client/Microsoft.OData.Client.E2E.Tests/Batch/Server/BankAccountsController.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Controllers;
+using Microsoft.OData.E2E.TestCommon.Common.Server.EndToEnd;
+
+namespace Microsoft.OData.Client.E2E.Tests.Batch.Server
+{
+    internal class BankAccountsController : ODataController
+    {
+        [EnableQuery]
+        public IActionResult Get()
+        {
+            return Ok(Backend.DataSource.BankAccounts);
+        }
+
+        [EnableQuery]
+        public IActionResult Get(int key)
+        {
+            var bankAccount = Backend.DataSource.BankAccounts.FirstOrDefault(b => b.Id == key);
+            if (bankAccount == null)
+            {
+                return NotFound();
+            }
+
+            return Ok(bankAccount);
+        }
+
+        // POST: odata/Banks
+        [EnableQuery]
+        public IActionResult Post([FromBody] BankAccount bankAccount)
+        {
+            if (bankAccount == null)
+            {
+                return BadRequest();
+            }
+
+            Backend.DataSource.BankAccounts.Add(bankAccount);
+            return Created(bankAccount);
+        }
+
+        // PUT: odata/BankAccounts({key})/Bank/$ref
+        [AcceptVerbs("POST", "PUT")]
+        public IActionResult CreateRefToBank(int key, [FromBody] Uri link)
+        {
+            if (link == null)
+            {
+                return BadRequest();
+            }
+
+            if (!Backend.TryGetKeyFromUri(link, out int relatedKey))
+            {
+                return NotFound();
+            }
+
+            var bankAccount = Backend.DataSource.BankAccounts.FirstOrDefault(b => b.Id == key);
+            var bank = Backend.DataSource.Banks.FirstOrDefault(b => b.Id == relatedKey);
+            bankAccount.Bank = bank;
+
+            return Updated(bankAccount);
+        }
+
+        // POST: odata/BankAccounts({key})/Bank
+        public IActionResult PostToBank(int key, [FromBody] Bank bank)
+        {
+            if (bank == null)
+            {
+                return BadRequest();
+            }
+
+            var bankAccount = Backend.DataSource.BankAccounts.FirstOrDefault(b => b.Id == key);
+
+            if (bankAccount == null)
+            {
+                return NotFound();
+            }
+
+            bankAccount.Bank = bank;
+            Backend.DataSource.Banks.Add(bank);
+
+            return Created(bank);
+        }
+
+        // DELETE: odata/BankAccounts({key})/Bank/$ref
+        public IActionResult DeleteRefToBank(int key)
+        {
+            var bankAccount = Backend.DataSource.BankAccounts.FirstOrDefault(b => b.Id == key);
+            if (bankAccount == null)
+            {
+                return NotFound();
+            }
+
+            bankAccount.Bank = null;
+            return NoContent();
+        }
+    }
+}


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Cherry-pick: 5fcdd1188009585c7d8c80afa1ad42637cfc4e69

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
