### PR TITLE
Cherry-pick: Handle null segment type in Validation

### DIFF
--- a/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/ODataUrlValidator.cs
+++ b/src/Microsoft.OData.Core/UrlValidation/ValidationEngine/ODataUrlValidator.cs
@@ -442,7 +442,7 @@ namespace Microsoft.OData.UriParser.Validation
         private void ValidateProperties(IEdmType edmType, ODataUrlValidationContext context)
         {
             // true if the element is added to the set; false if the element is already in the set.
-            if (edmType.TypeKind != EdmTypeKind.Primitive && context.ValidatedTypes.Add(edmType))
+            if (edmType?.TypeKind != EdmTypeKind.Primitive && context.ValidatedTypes.Add(edmType))
             {
                 IEdmStructuredType structuredType = edmType as IEdmStructuredType;
                 if (structuredType != null)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/Parsers/UriTemplateParserTests.cs
@@ -11,6 +11,7 @@ using Microsoft.OData.UriParser;
 using Microsoft.OData.Edm;
 using Xunit;
 using Microsoft.OData.Core;
+using Microsoft.OData.UriParser.Validation;
 
 namespace Microsoft.OData.Tests.UriParser.Parsers
 {
@@ -365,6 +366,20 @@ namespace Microsoft.OData.Tests.UriParser.Parsers
                 var edmTypeReference = ((IEdmEntityType)keySegment.EdmType).DeclaredKey.Single().Type;
                 keypair.Value.ShouldBeUriTemplateExpression(input, edmTypeReference);
             }
+        }
+
+        [Fact]
+        public void ValidateUntypedTemplateSegment()
+        {
+            // The following URL results in an untyped URI template as the last segment.
+            // Validation needs to handle the untyped segment when validating the URL.
+            var parser = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/People/{myId}/MyDog/{myDogId}"))
+            {
+                EnableUriTemplateParsing = true
+            };
+
+            IEnumerable<ODataUrlValidationMessage> validationMessages;
+            Assert.True(parser.Validate(ODataUrlValidationRuleSet.AllRules, out validationMessages));
         }
 
         [Fact]


### PR DESCRIPTION
Handles a null segment type when checking for properties of a structural type during validation.

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Cherry-pick: 46b2f7e747376881009e665f6222187e3f125e42

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
