### PR TITLE
Cherry-pick: Support parameter aliases in key segments (#3278)

### DIFF
--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/ODataUriParserTests.cs
@@ -11,7 +11,6 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Xml;
-using System.Transactions;
 using Microsoft.OData.Core;
 using Microsoft.OData.Edm;
 using Microsoft.OData.Edm.Csdl;
@@ -21,6 +20,7 @@ using Microsoft.OData.UriParser;
 using Microsoft.OData.UriParser.Aggregation;
 using Microsoft.OData.UriParser.Validation;
 using Xunit;
+using Microsoft.OData.Metadata;
 
 namespace Microsoft.OData.Tests.UriParser
 {
@@ -503,6 +503,69 @@ namespace Microsoft.OData.Tests.UriParser
         }
 
         [Fact]
+        public void ParameterizedKeyShouldWork()
+        {
+            ODataPath pathSegment = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/People(ID = @id)")).ParsePath();
+
+            Assert.Equal(2, pathSegment.Count);
+            pathSegment.FirstSegment.ShouldBeEntitySetSegment(HardCodedTestModel.TestModel.FindDeclaredEntitySet("People"));
+            KeySegment keySegment = pathSegment.LastSegment as KeySegment;
+            Assert.NotNull(keySegment);
+            KeyValuePair<string, object>[] keys = keySegment.Keys.ToArray();
+            Assert.Single(keys);
+            Assert.Equal("ID", keys[0].Key);
+            FunctionParameterAliasToken parameterAliasToken = keys[0].Value as FunctionParameterAliasToken;
+            Assert.NotNull(parameterAliasToken);
+            Assert.Equal("@id", parameterAliasToken.Alias);
+            Assert.True(parameterAliasToken.ExpectedParameterType.IsInt32());
+        }
+
+        [Fact]
+        public void MultiPartParameterizedKeyShouldWork()
+        {
+            ODataPath pathSegment = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/Lions(ID1=@id1,ID2=@id2)")).ParsePath();
+
+            Assert.Equal(2, pathSegment.Count);
+            pathSegment.FirstSegment.ShouldBeEntitySetSegment(HardCodedTestModel.TestModel.FindDeclaredEntitySet("Lions"));
+            KeySegment keySegment = pathSegment.LastSegment as KeySegment;
+            Assert.NotNull(keySegment);
+            KeyValuePair<string, object>[] keys = keySegment.Keys.ToArray();
+            Assert.Equal(2, keys.Length);
+
+            Assert.Equal("ID1", keys[0].Key);
+            FunctionParameterAliasToken parameterAliasToken = keys[0].Value as FunctionParameterAliasToken;
+            Assert.NotNull(parameterAliasToken);
+            Assert.Equal("@id1", parameterAliasToken.Alias);
+            Assert.True(parameterAliasToken.ExpectedParameterType.IsInt32());
+
+            Assert.Equal("ID2", keys[1].Key);
+            parameterAliasToken = keys[1].Value as FunctionParameterAliasToken;
+            Assert.NotNull(parameterAliasToken);
+            Assert.Equal("@id2", parameterAliasToken.Alias);
+            Assert.True(parameterAliasToken.ExpectedParameterType.IsInt32());
+        }
+
+        [Fact]
+        public void MultiPartSemiParameterizedKeyShouldWork()
+        {
+            ODataPath pathSegment = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/Lions(ID1=1,ID2=@id2)")).ParsePath();
+
+            Assert.Equal(2, pathSegment.Count);
+            pathSegment.FirstSegment.ShouldBeEntitySetSegment(HardCodedTestModel.TestModel.FindDeclaredEntitySet("Lions"));
+            KeySegment keySegment = pathSegment.LastSegment as KeySegment;
+            Assert.NotNull(keySegment);
+            KeyValuePair<string, object>[] keys = keySegment.Keys.ToArray();
+            Assert.Equal(2, keys.Length);
+            Assert.Equal("ID1", keys[0].Key);
+            Assert.Equal(1, keys[0].Value);
+            Assert.Equal("ID2", keys[1].Key);
+            FunctionParameterAliasToken parameterAliasToken = keys[1].Value as FunctionParameterAliasToken;
+            Assert.NotNull(parameterAliasToken);
+            Assert.Equal("@id2", parameterAliasToken.Alias);
+            Assert.True(parameterAliasToken.ExpectedParameterType.IsInt32());
+        }
+
+        [Fact]
         public void AlternateKeyShouldWork()
         {
             ODataPath pathSegment = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/People(SocialSN = \'1\')"))
@@ -513,6 +576,80 @@ namespace Microsoft.OData.Tests.UriParser
             Assert.Equal(2, pathSegment.Count);
             pathSegment.FirstSegment.ShouldBeEntitySetSegment(HardCodedTestModel.TestModel.FindDeclaredEntitySet("People"));
             pathSegment.LastSegment.ShouldBeKeySegment(new KeyValuePair<string, object>("SocialSN", "1"));
+        }
+
+        [Fact]
+        public void ParameterizedAlternateKeyShouldWork()
+        {
+            ODataPath pathSegment = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/People(SocialSN = @SocialSN)"))
+            {
+                Resolver = new AlternateKeysODataUriResolver(HardCodedTestModel.TestModel)
+            }.ParsePath();
+
+            Assert.Equal(2, pathSegment.Count);
+            pathSegment.FirstSegment.ShouldBeEntitySetSegment(HardCodedTestModel.TestModel.FindDeclaredEntitySet("People"));
+            KeySegment keySegment = pathSegment.LastSegment as KeySegment;
+            Assert.NotNull(keySegment);
+            KeyValuePair<string,object>[] keys = keySegment.Keys.ToArray();  
+            Assert.Single(keys);
+            Assert.Equal("SocialSN", keys[0].Key);
+            FunctionParameterAliasToken parameterAliasToken = keys[0].Value as FunctionParameterAliasToken;
+            Assert.NotNull(parameterAliasToken);
+            Assert.Equal("@SocialSN", parameterAliasToken.Alias);
+            Assert.True(parameterAliasToken.ExpectedParameterType.IsString());
+        }
+
+        [Fact]
+        public void MultiPartParameterizedAlternateKeyShouldWork()
+        {
+            ODataPath pathSegment = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/People(NameAlias=@nameAlias,FirstNameAlias=@firstNameAlias)"))
+            {
+                Resolver = new AlternateKeysODataUriResolver(HardCodedTestModel.TestModel)
+            }.ParsePath();
+
+            Assert.Equal(2, pathSegment.Count);
+            pathSegment.FirstSegment.ShouldBeEntitySetSegment(HardCodedTestModel.TestModel.FindDeclaredEntitySet("People"));
+            KeySegment keySegment = pathSegment.LastSegment as KeySegment;
+            Assert.NotNull(keySegment);
+            KeyValuePair<string, object>[] keys = keySegment.Keys.ToArray();
+            Assert.Equal(2, keys.Length);
+
+            Assert.Equal("NameAlias", keys[0].Key);
+            FunctionParameterAliasToken parameterAliasToken = keys[0].Value as FunctionParameterAliasToken;
+            Assert.NotNull(parameterAliasToken);
+            Assert.Equal("@nameAlias", parameterAliasToken.Alias);
+            Assert.True(parameterAliasToken.ExpectedParameterType.IsString());
+
+            Assert.Equal("FirstNameAlias", keys[1].Key);
+            parameterAliasToken = keys[1].Value as FunctionParameterAliasToken;
+            Assert.NotNull(parameterAliasToken);
+            Assert.Equal("@firstNameAlias", parameterAliasToken.Alias);
+            Assert.Equal(parameterAliasToken.ExpectedParameterType.Definition, HardCodedTestModel.TestModel.FindType("Fully.Qualified.Namespace.NameType"));
+        }
+
+        [Fact]
+        public void MultiPartSemiParameterizedAlternateKeyShouldWork()
+        {
+            ODataPath pathSegment = new ODataUriParser(HardCodedTestModel.TestModel, new Uri("http://host"), new Uri("http://host/People(NameAlias='name',FirstNameAlias=@firstNameAlias)"))
+            {
+                Resolver = new AlternateKeysODataUriResolver(HardCodedTestModel.TestModel)
+            }.ParsePath();
+
+            Assert.Equal(2, pathSegment.Count);
+            pathSegment.FirstSegment.ShouldBeEntitySetSegment(HardCodedTestModel.TestModel.FindDeclaredEntitySet("People"));
+            KeySegment keySegment = pathSegment.LastSegment as KeySegment;
+            Assert.NotNull(keySegment);
+            KeyValuePair<string, object>[] keys = keySegment.Keys.ToArray();
+            Assert.Equal(2, keys.Length);
+
+            Assert.Equal("NameAlias", keys[0].Key);
+            Assert.Equal("name", keys[0].Value);
+
+            Assert.Equal("FirstNameAlias", keys[1].Key);
+            FunctionParameterAliasToken parameterAliasToken = keys[1].Value as FunctionParameterAliasToken;
+            Assert.NotNull(parameterAliasToken);
+            Assert.Equal("@firstNameAlias", parameterAliasToken.Alias);
+            Assert.Equal(parameterAliasToken.ExpectedParameterType.Definition, HardCodedTestModel.TestModel.FindType("Fully.Qualified.Namespace.NameType"));
         }
 
         [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Cherry-pick: 089572d33aebaa686ca31a358f01d67ca85c1e20

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
