### PR TITLE
Cherry-pick: Optimize ODataNullValue Allocations with Singleton Implementation

### DIFF
--- a/src/Microsoft.OData.Client/Serialization/ODataPropertyConverter.cs
+++ b/src/Microsoft.OData.Client/Serialization/ODataPropertyConverter.cs
@@ -665,7 +665,7 @@ namespace Microsoft.OData.Client
         {
             if (propertyValue == null)
             {
-                return new ODataNullValue();
+                return ODataNullValue.Instance;
             }
 
             propertyValue = ConvertPrimitiveValueToRecognizedODataType(propertyValue, property.PropertyType);
@@ -683,7 +683,7 @@ namespace Microsoft.OData.Client
         {
             if (propertyValue == null)
             {
-                return new ODataNullValue();
+                return ODataNullValue.Instance;
             }
 
             object convertedValue = ConvertPrimitiveValueToRecognizedODataType(propertyValue, propertyType);
@@ -837,7 +837,7 @@ namespace Microsoft.OData.Client
                 return true;
             }
 
-            odataValue = new ODataNullValue();
+            odataValue = ODataNullValue.Instance;
             return false;
         }
 

--- a/src/Microsoft.OData.Core/Json/ODataJsonReader.cs
+++ b/src/Microsoft.OData.Core/Json/ODataJsonReader.cs
@@ -2163,7 +2163,7 @@ namespace Microsoft.OData.Json
                             if (resourceType.TypeKind == EdmTypeKind.Primitive || resourceType.TypeKind == EdmTypeKind.Enum)
                             {
                                 // null primitive
-                                this.EnterScope(new JsonPrimitiveScope(new ODataNullValue(),
+                                this.EnterScope(new JsonPrimitiveScope(ODataNullValue.Instance,
                                     this.CurrentNavigationSource, this.CurrentResourceTypeReference, this.CurrentScope.ODataUri));
                             }
                             else
@@ -3637,7 +3637,7 @@ namespace Microsoft.OData.Json
                             {
                                 // null primitive
                                 this.EnterScope(new JsonPrimitiveScope(
-                                    new ODataNullValue(),
+                                    ODataNullValue.Instance,
                                     this.CurrentNavigationSource,
                                     this.CurrentResourceTypeReference,
                                     this.CurrentScope.ODataUri));

--- a/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.OData.Core/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -2289,6 +2289,7 @@ static Microsoft.OData.UriParser.Validation.ODataUrlValidationRules.DeprecatedPr
 static Microsoft.OData.UriParser.Validation.ODataUrlValidationRules.DeprecatedTypeRule -> Microsoft.OData.UriParser.Validation.ODataUrlValidationRule
 static Microsoft.OData.UriParser.Validation.ODataUrlValidationRules.RequireSelectRule -> Microsoft.OData.UriParser.Validation.ODataUrlValidationRule
 static Microsoft.OData.UriParser.Validation.ODataUrlValidationRuleSet.AllRules -> Microsoft.OData.UriParser.Validation.ODataUrlValidationRuleSet
+static readonly Microsoft.OData.ODataNullValue.Instance -> Microsoft.OData.ODataNullValue
 static readonly Microsoft.OData.UriParser.BatchSegment.Instance -> Microsoft.OData.UriParser.BatchSegment
 static readonly Microsoft.OData.UriParser.CountSegment.Instance -> Microsoft.OData.UriParser.CountSegment
 static readonly Microsoft.OData.UriParser.MetadataSegment.Instance -> Microsoft.OData.UriParser.MetadataSegment

--- a/src/Microsoft.OData.Core/Uri/ODataUriUtils.cs
+++ b/src/Microsoft.OData.Core/Uri/ODataUriUtils.cs
@@ -144,7 +144,7 @@ namespace Microsoft.OData
         {
             if (value == null)
             {
-                value = new ODataNullValue();
+                value = ODataNullValue.Instance;
             }
 
             if (model == null)

--- a/src/Microsoft.OData.Core/UriParser/ExpressionLexerLiteralExtensions.cs
+++ b/src/Microsoft.OData.Core/UriParser/ExpressionLexerLiteralExtensions.cs
@@ -79,7 +79,7 @@ namespace Microsoft.OData.UriParser
             Debug.Assert(expressionLexer.CurrentToken.Kind == ExpressionTokenKind.NullLiteral, "this.lexer.CurrentToken.InternalKind == ExpressionTokenKind.NullLiteral");
 
             expressionLexer.NextToken();
-            ODataNullValue nullValue = new ODataNullValue();
+            ODataNullValue nullValue = ODataNullValue.Instance;
             return nullValue;
         }
 

--- a/src/Microsoft.OData.Core/Value/ODataNullValue.cs
+++ b/src/Microsoft.OData.Core/Value/ODataNullValue.cs
@@ -12,6 +12,11 @@ namespace Microsoft.OData
     public sealed class ODataNullValue : ODataValue
     {
         /// <summary>
+        /// Returns a singleton instance of <see cref="ODataNullValue"/>.
+        /// </summary>
+        public static readonly ODataNullValue Instance = new ODataNullValue();
+
+        /// <summary>
         /// Indicates whether the given value is a null value.
         /// </summary>
         /// <value> true, since this object always represents a null value. </value>

--- a/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
+++ b/src/Microsoft.OData.Core/Value/ODataValueUtils.cs
@@ -34,7 +34,7 @@ namespace Microsoft.OData
         {
             if (objectToConvert == null)
             {
-                return new ODataNullValue();
+                return ODataNullValue.Instance;
             }
 
             // If the given object is already an ODataValue, return it as is.

--- a/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Helpers/ODataValueAssertEqualHelper.cs
+++ b/test/EndToEndTests/Common/Microsoft.OData.E2E.TestCommon/Helpers/ODataValueAssertEqualHelper.cs
@@ -91,7 +91,7 @@ public static class ODataValueAssertEqualHelper
     {
         if (value == null)
         {
-            return new ODataNullValue();
+            return ODataNullValue.Instance;
         }
 
         var odataValue = value as ODataValue;

--- a/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/SingletonTests/Tests/SingletonODataValueAssertEqualHelper.cs
+++ b/test/EndToEndTests/Tests/Core/Microsoft.OData.Core.E2E.Tests/SingletonTests/Tests/SingletonODataValueAssertEqualHelper.cs
@@ -107,7 +107,7 @@ public static class SingletonODataValueAssertEqualHelper
     {
         if (value == null)
         {
-            return new ODataNullValue();
+            return ODataNullValue.Instance;
         }
 
         if (value is ODataValue odataValue)

--- a/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/ODataJsonWriterShortSpanIntegrationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/IntegrationTests/Writer/Json/ODataJsonWriterShortSpanIntegrationTests.cs
@@ -306,7 +306,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         [Fact]
         public void ShouldWriteNullPropertyValueForResponseEntryPayloadWithoutUserModel()
         {
-            var entry = new ODataResource { TypeName = "NS.MyDerivedEntityType", Properties = new[] { new ODataProperty { Name = "StringProperty", Value = new ODataNullValue() } } };
+            var entry = new ODataResource { TypeName = "NS.MyDerivedEntityType", Properties = new[] { new ODataProperty { Name = "StringProperty", Value = ODataNullValue.Instance } } };
             const string expectedPayload = "{\"@odata.context\":\"http://odata.org/test/$metadata#MySet/$entity\",\"@odata.type\":\"#NS.MyDerivedEntityType\",\"StringProperty\":null}";
             this.WriteNestedItemsAndValidatePayload(entitySetFullName: "MySet", derivedEntityTypeFullName: null, nestedItemToWrite: new[] { entry }, expectedPayload: expectedPayload, writingResponse: true);
         }
@@ -314,7 +314,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         [Fact]
         public void ShouldWriteNullPropertyValueForResponseEntryPayloadWithUserModel()
         {
-            var entry = new ODataResource { TypeName = "NS.MyDerivedEntityType", Properties = new[] { new ODataProperty { Name = "StringProperty", Value = new ODataNullValue() } } };
+            var entry = new ODataResource { TypeName = "NS.MyDerivedEntityType", Properties = new[] { new ODataProperty { Name = "StringProperty", Value = ODataNullValue.Instance } } };
             const string expectedPayload = "{\"@odata.context\":\"http://odata.org/test/$metadata#MySet/$entity\",\"@odata.type\":\"#NS.MyDerivedEntityType\",\"StringProperty\":null}";
             this.WriteNestedItemsAndValidatePayload(entitySet: this.entitySet, entityType: null, nestedItemToWrite: new[] { entry }, expectedPayload: expectedPayload, writingResponse: true);
         }
@@ -322,7 +322,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         [Fact]
         public void ShouldWriteNullPropertyValueForRequestEntryPayloadWithoutUserModel()
         {
-            var entry = new ODataResource { TypeName = "NS.MyDerivedEntityType", Properties = new[] { new ODataProperty { Name = "StringProperty", Value = new ODataNullValue() } } };
+            var entry = new ODataResource { TypeName = "NS.MyDerivedEntityType", Properties = new[] { new ODataProperty { Name = "StringProperty", Value = ODataNullValue.Instance } } };
             const string expectedPayload = "{\"@odata.type\":\"#NS.MyDerivedEntityType\",\"StringProperty\":null}";
             this.WriteNestedItemsAndValidatePayload(entitySetFullName: null, derivedEntityTypeFullName: null, nestedItemToWrite: new[] { entry }, expectedPayload: expectedPayload, writingResponse: false);
         }
@@ -330,7 +330,7 @@ namespace Microsoft.OData.Tests.IntegrationTests.Writer.Json
         [Fact]
         public void ShouldWriteNullPropertyValueForRequestEntryPayloadWithUserModel()
         {
-            var entry = new ODataResource { TypeName = "NS.MyDerivedEntityType", Properties = new[] { new ODataProperty { Name = "StringProperty", Value = new ODataNullValue() } } };
+            var entry = new ODataResource { TypeName = "NS.MyDerivedEntityType", Properties = new[] { new ODataProperty { Name = "StringProperty", Value = ODataNullValue.Instance } } };
             const string expectedPayload = "{\"@odata.context\":\"http://odata.org/test/$metadata#NS.MyDerivedEntityType\",\"@odata.type\":\"#NS.MyDerivedEntityType\",\"StringProperty\":null}";
             this.WriteNestedItemsAndValidatePayload(entitySet: null, entityType: null, nestedItemToWrite: new[] { entry }, expectedPayload: expectedPayload, writingResponse: false);
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonInstanceAnnotationWriterAsyncTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonInstanceAnnotationWriterAsyncTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.OData.Tests.Json
             {
                 new ODataInstanceAnnotation(
                     "favorite.City",
-                    new ODataNullValue()),
+                    ODataNullValue.Instance),
                 "{\"FunFacts@favorite.City\":null"
             };
 
@@ -176,7 +176,7 @@ namespace Microsoft.OData.Tests.Json
         {
             var instanceAnnotation = new ODataInstanceAnnotation(
                     "favorite.Person",
-                    new ODataNullValue());
+                    ODataNullValue.Instance);
 
             var result = await SetupJsonInstanceAnnotationWriterAndRunTestAsync(
                 (jsonInstanceAnnotationWriter) =>

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonInstanceAnnotationWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonInstanceAnnotationWriterTests.cs
@@ -298,7 +298,7 @@ namespace Microsoft.OData.Tests.Json
                 Assert.Equal(1, verifierCalls);
                 verifierCalls++;
             };
-            this.jsonInstanceAnnotationWriter.WriteInstanceAnnotation(new ODataInstanceAnnotation(term, new ODataNullValue()));
+            this.jsonInstanceAnnotationWriter.WriteInstanceAnnotation(new ODataInstanceAnnotation(term, ODataNullValue.Instance));
             Assert.Equal(2, verifierCalls);
         }
 
@@ -347,7 +347,7 @@ namespace Microsoft.OData.Tests.Json
                 Assert.Equal(1, verifierCalls);
                 verifierCalls++;
             };
-            this.jsonInstanceAnnotationWriter.WriteInstanceAnnotation(new ODataInstanceAnnotation(term, new ODataNullValue()));
+            this.jsonInstanceAnnotationWriter.WriteInstanceAnnotation(new ODataInstanceAnnotation(term, ODataNullValue.Instance));
             Assert.Equal(2, verifierCalls);
         }
 
@@ -361,7 +361,7 @@ namespace Microsoft.OData.Tests.Json
                 EdmCoreModel.Instance.GetInt32(isNullable: false)));
 
             string term = "My.Namespace.NotNullable";
-            Action action = () => this.jsonInstanceAnnotationWriter.WriteInstanceAnnotation(new ODataInstanceAnnotation(term, new ODataNullValue()));
+            Action action = () => this.jsonInstanceAnnotationWriter.WriteInstanceAnnotation(new ODataInstanceAnnotation(term, ODataNullValue.Instance));
             action.Throws<ODataException>(Error.Format(SRResources.JsonInstanceAnnotationWriter_NullValueNotAllowedForInstanceAnnotation, term, "Edm.Int32"));
         }
 

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterAsyncTests.cs
@@ -184,7 +184,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public async Task WriteODataValueAsyncWritesNullValue()
         {
-            var value = new ODataNullValue();
+            var value = ODataNullValue.Instance;
             await this.writer.WriteODataValueAsync(value);
             Assert.Equal("null", this.builder.ToString());
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/JsonWriterTests.cs
@@ -308,7 +308,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public void WriteODataValueWritesNullValue()
         {
-            var value = new ODataNullValue();
+            var value = ODataNullValue.Instance;
             this.writer.WriteODataValue(value);
             Assert.Equal("null", this.builder.ToString());
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonDeserializerTests.cs
@@ -812,7 +812,7 @@ namespace Microsoft.OData.Tests.Json
             this.messageReaderSettings = new ODataMessageReaderSettings();
             ODataJsonPropertyAndValueDeserializer deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"http://odata.org/test/$metadata#Customers(1)/Name\",\"value\":null}", model));
             ODataProperty property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
-            TestUtils.AssertODataValueAreEqual(new ODataNullValue(), property.ODataValue);
+            TestUtils.AssertODataValueAreEqual(ODataNullValue.Instance, property.ODataValue);
         }
 
         [Fact]
@@ -823,7 +823,7 @@ namespace Microsoft.OData.Tests.Json
             this.messageReaderSettings = new ODataMessageReaderSettings();
             ODataJsonPropertyAndValueDeserializer deserializer = new ODataJsonPropertyAndValueDeserializer(this.CreateJsonInputContext("{\"@odata.context\":\"http://odata.org/test/$metadata#Customers(1)/Name\",\"@odata.null\":true}", model));
             ODataProperty property = deserializer.ReadTopLevelProperty(primitiveTypeRef);
-            TestUtils.AssertODataValueAreEqual(new ODataNullValue(), property.ODataValue);
+            TestUtils.AssertODataValueAreEqual(ODataNullValue.Instance, property.ODataValue);
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedSerializerUndecalredTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonEntryAndFeedSerializerUndecalredTests.cs
@@ -587,7 +587,7 @@ namespace Microsoft.Test.OData.TDD.Tests.Writer.Json
                         new ODataProperty {Name="prop",
                             Value = new ODataPrimitiveValue(1) },       //            "prop": 1,
                         new ODataProperty {Name="nullProp",
-                            Value = new ODataNullValue() },             //            "nullProp": "null",
+                            Value = ODataNullValue.Instance },             //            "nullProp": "null",
                         new ODataProperty {Name="collectionProp",       //            "collectionProp@odata.type":"#Collection(String)"
                             Value = new ODataCollectionValue {          //            "collectionProp":
                                 TypeName="Collection(Edm.String)",      //             [

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsAsyncTests.cs
@@ -267,15 +267,15 @@ namespace Microsoft.OData.Tests.Json
                 Properties = new ODataProperty[]
                 {
                     new ODataProperty { Name = "PropertyName", Value = "PropertyValue" },
-                    new ODataProperty { Name = "NullProperty", Value = new ODataNullValue() }
+                    new ODataProperty { Name = "NullProperty", Value = ODataNullValue.Instance }
                 }
             });
-            innerError.Properties.Add("NullProperty", new ODataNullValue());
+            innerError.Properties.Add("NullProperty", ODataNullValue.Instance);
             innerError.Properties.Add("CollectionValue", new ODataCollectionValue
             { 
                 Items = new List<object>
                 {
-                    new ODataNullValue(),
+                    ODataNullValue.Instance,
                     new ODataPrimitiveValue("CollectionValue"), new ODataPrimitiveValue(1)
                 }
             });

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataJsonWriterUtilsTests.cs
@@ -232,9 +232,9 @@ namespace Microsoft.OData.Tests.Json
                     { JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue("") },
                     { JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue("") }
                 });
-            innerError.Properties.Add("ResourceValue", new ODataResourceValue() { Properties = new [] { new ODataProperty() { Name = "PropertyName", Value = "PropertyValue" }, new ODataProperty() { Name = "NullProperty", Value = new ODataNullValue() } } });
-            innerError.Properties.Add("NullProperty", new ODataNullValue());
-            innerError.Properties.Add("CollectionValue", new ODataCollectionValue() { Items = new List<object>() { new ODataNullValue(), new ODataPrimitiveValue("CollectionValue"), new ODataPrimitiveValue(1) } });
+            innerError.Properties.Add("ResourceValue", new ODataResourceValue() { Properties = new [] { new ODataProperty() { Name = "PropertyName", Value = "PropertyValue" }, new ODataProperty() { Name = "NullProperty", Value = ODataNullValue.Instance } } });
+            innerError.Properties.Add("NullProperty", ODataNullValue.Instance);
+            innerError.Properties.Add("CollectionValue", new ODataCollectionValue() { Items = new List<object>() { ODataNullValue.Instance, new ODataPrimitiveValue("CollectionValue"), new ODataPrimitiveValue(1) } });
 
             var error = new ODataError
             {
@@ -277,9 +277,9 @@ namespace Microsoft.OData.Tests.Json
         public void ODataInnerErrorToStringTest()
         {
             ODataInnerError innerError = new ODataInnerError();
-            innerError.Properties.Add("ResourceValue", new ODataResourceValue() { Properties = new[] { new ODataProperty { Name = "PropertyName", Value = "PropertyValue" }, new ODataProperty { Name = "NullProperty", Value = new ODataNullValue() } } });
-            innerError.Properties.Add("NullProperty", new ODataNullValue());
-            innerError.Properties.Add("CollectionValue", new ODataCollectionValue() { Items = new List<object>() { new ODataNullValue(), new ODataPrimitiveValue("CollectionValue"), new ODataPrimitiveValue(1) } });
+            innerError.Properties.Add("ResourceValue", new ODataResourceValue() { Properties = new[] { new ODataProperty { Name = "PropertyName", Value = "PropertyValue" }, new ODataProperty { Name = "NullProperty", Value = ODataNullValue.Instance } } });
+            innerError.Properties.Add("NullProperty", ODataNullValue.Instance);
+            innerError.Properties.Add("CollectionValue", new ODataCollectionValue() { Items = new List<object>() { ODataNullValue.Instance, new ODataPrimitiveValue("CollectionValue"), new ODataPrimitiveValue(1) } });
             innerError.Properties.Add(JsonConstants.ODataErrorInnerErrorMessageName, new ODataPrimitiveValue(""));
             innerError.Properties.Add(JsonConstants.ODataErrorInnerErrorTypeNameName, new ODataPrimitiveValue(""));
             innerError.Properties.Add(JsonConstants.ODataErrorInnerErrorStackTraceName, new ODataPrimitiveValue(""));

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterAsyncTests.cs
@@ -374,7 +374,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public async Task WriteODataValueAsync_WritesNullValue()
         {
-            var value = new ODataNullValue();
+            var value = ODataNullValue.Instance;
             await this.writer.WriteODataValueAsync(value);
             Assert.Equal("null", await this.ReadStreamAsync());
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/Json/ODataUtf8JsonWriterTests.cs
@@ -388,7 +388,7 @@ namespace Microsoft.OData.Tests.Json
         [Fact]
         public void WriteODataValueWritesNullValue()
         {
-            var value = new ODataNullValue();
+            var value = ODataNullValue.Instance;
             this.writer.WriteODataValue(value);
             Assert.Equal("null", this.ReadStream());
         }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataErrorTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataErrorTests.cs
@@ -864,7 +864,7 @@ namespace Microsoft.OData.Tests
                             new Dictionary<string, ODataValue>
                             {
                                 { "p1", null },
-                                { "p2", new ODataNullValue() },
+                                { "p2", ODataNullValue.Instance },
                                 { "p3", new ODataPrimitiveValue(true) },
                                 { "p4", new ODataPrimitiveValue((byte)10) },
                                 { "p5", new ODataPrimitiveValue(130M) },

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataInstanceAnnotationTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataInstanceAnnotationTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.OData.Tests
         [Fact]
         public void TheValuePropertyShouldReturnTheAnnotationValue()
         {
-            foreach (ODataValue value in new ODataValue[] { new ODataNullValue(), new ODataPrimitiveValue(1), new ODataResourceValue(), new ODataCollectionValue() })
+            foreach (ODataValue value in new ODataValue[] { ODataNullValue.Instance, new ODataPrimitiveValue(1), new ODataResourceValue(), new ODataCollectionValue() })
             {
                 var annotation = new ODataInstanceAnnotation("namespace.name", value);
                 Assert.Same(value, annotation.Value);

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ODataNullValueTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ODataNullValueTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.OData.Tests
 
         public ODataNullValueTests()
         {
-            this.nullValue = new ODataNullValue();
+            this.nullValue = ODataNullValue.Instance;
         }
 
         [Fact]

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/CustomInstanceAnnotationRoundtripJsonTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/Roundtrip/Json/CustomInstanceAnnotationRoundtripJsonTests.cs
@@ -54,7 +54,7 @@ namespace Microsoft.OData.Tests.ScenarioTests.Roundtrip.Json
             var originalTimeSpan = new KeyValuePair<string, ODataValue>("TimeSpan.error", new ODataPrimitiveValue(timeSpan));
             GeographyPoint geographyPoint = GeographyPoint.Create(32.0, -100.0);
             var originalGeography = new KeyValuePair<string, ODataValue>("Geography.error", new ODataPrimitiveValue(geographyPoint));
-            var originalNull = new KeyValuePair<string, ODataValue>("null.error", new ODataNullValue());
+            var originalNull = new KeyValuePair<string, ODataValue>("null.error", ODataNullValue.Instance);
 
             var resourceValue = new ODataResourceValue
             {

--- a/test/UnitTests/Microsoft.OData.Core.Tests/TestUtils.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/TestUtils.cs
@@ -246,7 +246,7 @@ namespace Microsoft.OData.Tests
         {
             if (value == null)
             {
-                return new ODataNullValue();
+                return ODataNullValue.Instance;
             }
 
             var odataValue = value as ODataValue;


### PR DESCRIPTION

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Cherry-pick: c889ef6f9bb1c79dbbb107bd87ae6c893c9b85c8

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
