### PR TITLE
Remove Obsolete DataserviceContext.Timeout property

### DIFF
--- a/src/Microsoft.OData.Client/DataServiceContext.cs
+++ b/src/Microsoft.OData.Client/DataServiceContext.cs
@@ -112,9 +112,6 @@ namespace Microsoft.OData.Client
         /// <summary>resolve typename from a type</summary>
         private Func<string, Type> resolveType;
 
-        /// <summary>time-out value in seconds, 0 for default</summary>
-        private int timeout;
-
         /// <summary>read or write time-out value in seconds, 0 for default</summary>
         private int readWriteTimeout;
 
@@ -481,34 +478,6 @@ namespace Microsoft.OData.Client
         {
             get { return this.resolveType; }
             set { this.resolveType = value; }
-        }
-
-        /// <summary>Gets or sets the time-out option (in seconds) that is used for the underlying HTTP request to the data service.</summary>
-        /// <returns>An integer that indicates the time interval (in seconds) before time-out of a service request.</returns>
-        /// <remarks>
-        /// A value of 0 will use the default timeout of the underlying HTTP request.
-        /// This value must be set before executing any query or update operations against
-        /// the target data service for it to have effect on the on the request.
-        /// The value may be changed between requests to a data service and the new value
-        /// will be picked up by the next data service request.
-        /// </remarks>
-        [Obsolete("The Timeout property is obsolete. Use IHttpClientFactory to configure the timeout.")]
-        public virtual int Timeout
-        {
-            get
-            {
-                return this.timeout;
-            }
-
-            set
-            {
-                if (value < 0)
-                {
-                    throw Error.ArgumentOutOfRange("Timeout");
-                }
-
-                this.timeout = value;
-            }
         }
 
         /// <summary>Gets or sets the readwrite time-out option (in seconds) that is used for the underlying HTTP request to the data service.</summary>

--- a/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
+++ b/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
@@ -152,7 +152,7 @@ namespace Microsoft.OData.Client
         {
             Debug.Assert(requestMessageArgs != null, "requestMessageArgs != null");
 
-            DataServiceClientRequestMessage requestMessage = requestInfo.CreateRequestMessage(requestMessageArgs);
+            var requestMessage = requestInfo.CreateRequestMessage(requestMessageArgs);
 
             return new TopLevelRequestMessageWrapper(requestMessage, requestInfo, requestMessageArgs.Descriptor);
         }

--- a/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
+++ b/src/Microsoft.OData.Client/ODataRequestMessageWrapper.cs
@@ -152,13 +152,7 @@ namespace Microsoft.OData.Client
         {
             Debug.Assert(requestMessageArgs != null, "requestMessageArgs != null");
 
-            var requestMessage = requestInfo.CreateRequestMessage(requestMessageArgs);
-
-            if (requestInfo.Timeout != 0)
-            {
-                requestMessage.Timeout = requestInfo.Timeout;
-               
-            }
+            DataServiceClientRequestMessage requestMessage = requestInfo.CreateRequestMessage(requestMessageArgs);
 
             return new TopLevelRequestMessageWrapper(requestMessage, requestInfo, requestMessageArgs.Descriptor);
         }

--- a/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.OData.Client/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -920,8 +920,6 @@ virtual Microsoft.OData.Client.DataServiceContext.SetSaveStream(object entity, s
 virtual Microsoft.OData.Client.DataServiceContext.SetSaveStream(object entity, string name, System.IO.Stream stream, bool closeStream, string contentType) -> void
 virtual Microsoft.OData.Client.DataServiceContext.SetSaveStream(object entity, System.IO.Stream stream, bool closeStream, Microsoft.OData.Client.DataServiceRequestArgs args) -> void
 virtual Microsoft.OData.Client.DataServiceContext.SetSaveStream(object entity, System.IO.Stream stream, bool closeStream, string contentType, string slug) -> void
-virtual Microsoft.OData.Client.DataServiceContext.Timeout.get -> int
-virtual Microsoft.OData.Client.DataServiceContext.Timeout.set -> void
 virtual Microsoft.OData.Client.DataServiceContext.TryGetAnnotation<TFunc, TResult>(System.Linq.Expressions.Expression<TFunc> expression, string term, out TResult annotation) -> bool
 virtual Microsoft.OData.Client.DataServiceContext.TryGetAnnotation<TFunc, TResult>(System.Linq.Expressions.Expression<TFunc> expression, string term, string qualifier, out TResult annotation) -> bool
 virtual Microsoft.OData.Client.DataServiceContext.TryGetAnnotation<TResult>(object source, string term, out TResult annotation) -> bool

--- a/src/Microsoft.OData.Client/RequestInfo.cs
+++ b/src/Microsoft.OData.Client/RequestInfo.cs
@@ -133,14 +133,6 @@ namespace Microsoft.OData.Client
         }
 
         /// <summary>
-        /// Get the timeout span in seconds to use for the underlying HTTP request to the data service.
-        /// </summary>
-        internal int Timeout
-        {
-            get { return this.Context.Timeout; }
-        }
-
-        /// <summary>
         /// Whether to use post-tunneling for PUT/DELETE.
         /// </summary>
         internal bool UsePostTunneling

--- a/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ConstructibleModelTests.cs
+++ b/test/EndToEndTests/Tests/Edm/Microsoft.OData.Edm.E2E.Tests/FunctionalTests/ConstructibleModelTests.cs
@@ -1033,7 +1033,7 @@ public class ConstructibleModelTests : EdmLibTestCaseBase
         model.AddElement(bazAction);
         container.AddActionImport("baz", bazAction, null);
 
-        Assert.Equal(bazAction.FindParameter("Betty").Name, "Betty");
+        Assert.Equal("Betty", bazAction.FindParameter("Betty")?.Name);
         Assert.Null(bazAction.FindParameter("Barney"));
 
         this.CompareEdmModelToCsdl(

--- a/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
+++ b/test/UnitTests/Microsoft.OData.Client.Tests/Tracking/DataServiceContextQueryTests.cs
@@ -598,7 +598,7 @@ namespace Microsoft.OData.Client.Tests.Tracking
 
         private void SetupContextWithRequestPipeline(DataServiceContext context, string response, string path)
         {
-            string location = $"{ ServiceRoot}/{path}";
+            string location = $"{ServiceRoot}/{path}";
 
             context.Configurations.RequestPipeline.OnMessageCreating = (args) => new CustomizedRequestMessage(
                 args,


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3182.*

Related to PR: https://github.com/OData/odata.net/pull/3135

### Description

In ODL 8, the `DataserviceContext.Timeout` property was marked as `Obsolete` and recommended using IHttpClientFactory to configure the timeout as outlined in [Configuring HttpClient with IHttpClientFactory in Microsoft.OData.Client](https://learn.microsoft.com/en-us/odata/client/using-dataservice-ihttpclientfactory)

This PR is to remove the DataserviceContext.Timeout property.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
