### PR TITLE
Cherrypick/support unquoted type params for `isof` and `cast` methods

### DIFF
--- a/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
+++ b/src/Microsoft.OData.Core/UriParser/Binders/FunctionCallBinder.cs
@@ -720,12 +720,19 @@ namespace Microsoft.OData.UriParser
                     Error.Format(SRResources.MetadataBinder_CastOrIsOfExpressionWithWrongNumberOfOperands, args.Count));
             }
 
-            ConstantNode typeArgument = args.Last() as ConstantNode;
+            QueryNode queryNode = args[^1];
 
+            string typeArgumentFullName = null;
             IEdmTypeReference returnType = null;
-            if (typeArgument != null)
+            if (queryNode is SingleResourceCastNode singleResourceCastNode)
             {
-                returnType = TryGetTypeReference(state.Model, typeArgument.Value as string, state.Configuration.Resolver);
+                returnType = singleResourceCastNode.TypeReference;
+                typeArgumentFullName = returnType.FullName();
+            }
+            else if (queryNode is ConstantNode constantNode)
+            {
+                typeArgumentFullName = constantNode.Value as string;
+                returnType = TryGetTypeReference(state.Model, typeArgumentFullName, state.Configuration.Resolver);
             }
 
             if (returnType == null)
@@ -758,7 +765,7 @@ namespace Microsoft.OData.UriParser
             {
                 // throw if cast enum to not-string :
                 if ((args[0].GetEdmTypeReference() is IEdmEnumTypeReference)
-                    && !string.Equals(typeArgument.Value as string, Microsoft.OData.Metadata.EdmConstants.EdmStringTypeName, StringComparison.Ordinal))
+                    && !string.Equals(typeArgumentFullName, Microsoft.OData.Metadata.EdmConstants.EdmStringTypeName, state.Configuration.Resolver?.EnableCaseInsensitive == true ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal))
                 {
                     throw new ODataException(SRResources.CastBinder_EnumOnlyCastToOrFromString);
                 }

--- a/src/Microsoft.OData.Core/UriParser/Resolver/NormalizedModelElementsCache.cs
+++ b/src/Microsoft.OData.Core/UriParser/Resolver/NormalizedModelElementsCache.cs
@@ -20,6 +20,11 @@ namespace Microsoft.OData.Edm
     /// </summary>
     internal sealed class NormalizedModelElementsCache
     {
+        /// <summary>
+        /// Provides a shared, normalized case-insensitive cache of model elements for the EDM core model.
+        /// </summary>
+        public static readonly NormalizedModelElementsCache EdmCoreModelInstance = new NormalizedModelElementsCache(EdmCoreModel.Instance);
+
         // We create different caches for different types of schema elements because all current usage request schema elements
         // of specific types. If we were to use a single dictionary <string, ISchemaElement> we would need
         // to do additional work (and allocations) during lookups to filter the results to the subset that matches the request type.

--- a/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/ScenarioTests/UriParser/FilterAndOrderByFunctionalTests.cs
@@ -15,6 +15,7 @@ using Microsoft.OData.Tests.UriParser;
 using Microsoft.OData.UriParser;
 using Microsoft.Spatial;
 using Microsoft.Test.OData.Utils.Metadata;
+using Microsoft.VisualBasic;
 using Xunit;
 
 namespace Microsoft.OData.Tests.ScenarioTests.UriParser
@@ -761,6 +762,259 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         }
 
         [Fact]
+        public void IsOfFunctionWorksWithOrWithoutSingleQuotesOnType()
+        {
+            FilterClause filter = ParseFilter("isof(Shoe, Edm.String)", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonShoeProp());
+            singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode("Edm.String");
+        }
+
+        [Fact]
+        public void IsOfFunctionWithOneParameter_WithSingleQuotesOnTypeParameter_ShouldBeConstantQueryNode()
+        {
+            // Arrange 
+            var filterQuery = "isof('Fully.Qualified.Namespace.Employee')";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            ResourceRangeVariableReferenceNode rangeVariableReference = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
+            Assert.Equal("Fully.Qualified.Namespace.Person", rangeVariableReference.GetEdmTypeReference().FullName()); // $it is of type Person
+
+            var constantNode = singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode("Fully.Qualified.Namespace.Employee");
+            Assert.Equal("Fully.Qualified.Namespace.Employee", constantNode.Value); // 'Fully.Qualified.Namespace.Employee' is the type parameter
+        }
+
+        [Fact]
+        public void IsOfFunctionWithOneParameter_WithoutSingleQuotesOnTypeParameter_ShouldBeSingleResourceCastNode()
+        {
+            // Arrange 
+            var filterQuery = "isof(Fully.Qualified.Namespace.Employee)";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            ResourceRangeVariableReferenceNode rangeVariableReference = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
+            Assert.Equal("Fully.Qualified.Namespace.Person", rangeVariableReference.GetEdmTypeReference().FullName()); // $it is of type Person
+
+            var singleResourceCastNode = singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeSingleResourceCastNode(HardCodedTestModel.GetEmployeeTypeReference());
+            Assert.Equal("Fully.Qualified.Namespace.Employee", singleResourceCastNode.TypeReference.FullName()); // Fully.Qualified.Namespace.Employee is the type parameter
+        }
+
+        [Fact]
+        public void IsOfFunctionWithTwoParameters_WithSingleQuotesOnTypeParameter_ShouldBeConstantQueryNode()
+        {
+            // Arrange
+            var filterQuery = "isof(MyAddress, 'Fully.Qualified.Namespace.HomeAddress')";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            SingleComplexNode singleComplexNode = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleComplexNode(HardCodedTestModel.GetPersonAddressProp());
+            Assert.Equal("MyAddress", singleComplexNode.Property.Name); // MyAddress is the property name
+            Assert.Equal("Fully.Qualified.Namespace.Address", singleComplexNode.GetEdmTypeReference().FullName()); // MyAddress is of type Address
+
+            var constantNode = singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode("Fully.Qualified.Namespace.HomeAddress");
+            Assert.Equal("Fully.Qualified.Namespace.HomeAddress", constantNode.Value); // 'Fully.Qualified.Namespace.Employee' is the type parameter
+        }
+
+        [Fact]
+        public void IsOfFunctionWithTwoParameters_WithoutSingleQuotesOnTypeParameter_ShouldBeSingleResourceCastNode()
+        {
+            // Arrange
+            var filterQuery = "isof(MyAddress, Fully.Qualified.Namespace.HomeAddress)";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            SingleComplexNode singleComplexNode = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleComplexNode(HardCodedTestModel.GetPersonAddressProp());
+            Assert.Equal("MyAddress", singleComplexNode.Property.Name); // MyAddress is the property name
+            Assert.Equal("Fully.Qualified.Namespace.Address", singleComplexNode.GetEdmTypeReference().FullName()); // MyAddress is of type Address
+
+            var singleResourceCastNode = singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeSingleResourceCastNode(HardCodedTestModel.GetHomeAddressReference());
+            Assert.Equal("Fully.Qualified.Namespace.HomeAddress", singleResourceCastNode.TypeReference.FullName()); // Fully.Qualified.Namespace.HomeAddress is the type parameter
+        }
+
+        [Theory]
+        [InlineData("isof(ID, Edm.Int64)", "Edm.Int64")]
+        [InlineData("isof(ID, edm.int64)", "edm.int64")]
+        [InlineData("isof(ID, Edm.int64)", "Edm.int64")]
+        [InlineData("isof(ID, EDM.INT64)", "EDM.INT64")]
+        public void IsOfFunctionWorksWithoutSingleQuotesOnPrimitiveType_CaseInsentive(string queryFilter, string expectedConstantNodeValue)
+        {
+            FilterClause filter = ParseFilter(queryFilter, true, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonIdProp());
+            singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode(expectedConstantNodeValue);
+        }
+
+        [Theory]
+        [InlineData("isof(ID, Edm.Int32)", "Edm.Int32")]
+        [InlineData("isof(ID, edm.int32)", "edm.int32")]
+        [InlineData("isof(ID, Edm.int32)", "Edm.int32")]
+        [InlineData("isof(ID, EDM.INT32)", "EDM.INT32")]
+        public void IsOfFunctionWorksWithoutSingleQuotesOnPrimitiveType_ODataUriParserCaseInsentive(string queryFilter, string expectedConstantNodeValue)
+        {
+            FilterClause filter = ParseFilterODataUriParserCaseInsensitive($"/people?$filter={queryFilter}", HardCodedTestModel.TestModel);
+            var singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonIdProp());
+            singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode(expectedConstantNodeValue);
+        }
+
+        [Theory]
+        [InlineData("isof(Fully.Qualified.Namespace.Employee)")]
+        [InlineData("isof('Fully.Qualified.Namespace.Employee')")]
+        public void IsOfFunctionWithOneParameter_WithOrWithoutSingleQuotesOnTypeParameter_WorksAsExpected(string filterQuery)
+        {
+            // Arrange & Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            ResourceRangeVariableReferenceNode rangeVariableReference = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
+            Assert.Equal("Fully.Qualified.Namespace.Person", rangeVariableReference.GetEdmTypeReference().FullName()); // $it is of type Person
+
+            var secondParameter = singleValueFunctionCallNode.Parameters.ElementAt(1);
+            string fullyQualifiedTypeName = secondParameter switch
+            {
+                SingleResourceCastNode singleResourceCastNode => secondParameter.ShouldBeSingleResourceCastNode(HardCodedTestModel.GetEmployeeTypeReference()).TypeReference.FullName(),
+                ConstantNode constantNode => secondParameter.ShouldBeConstantQueryNode("Fully.Qualified.Namespace.Employee").Value as string,
+                _ => throw new InvalidOperationException("Unexpected node type")
+            };
+
+            Assert.Equal("Fully.Qualified.Namespace.Employee", fullyQualifiedTypeName);
+        }
+
+        [Theory]
+        [InlineData("isof(Fully.Qualified.Namespace.Employee)")]
+        [InlineData("isof(fully.Qualified.namespace.employee)")]
+        [InlineData("isof(FULLY.QUALIFIED.NAMESPACE.EMPLOYEE)")]
+        public void IsOfFunctionWithOneParameter_WithoutSingleQuotesOnTypeParameter_ShouldBeSingleResourceCastNode_CaseInsensitive(string filterQuery)
+        {
+            // Arrange 
+            // Act
+            FilterClause filter = ParseFilterODataUriParserCaseInsensitive($"/people?$filter={filterQuery}", HardCodedTestModel.TestModel);
+
+            // Assert
+            SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            ResourceRangeVariableReferenceNode rangeVariableReference = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
+            Assert.Equal("Fully.Qualified.Namespace.Person", rangeVariableReference.GetEdmTypeReference().FullName()); // $it is of type Person
+
+            var singleResourceCastNode = singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeSingleResourceCastNode(HardCodedTestModel.GetEmployeeTypeReference());
+            Assert.Equal("Fully.Qualified.Namespace.Employee", singleResourceCastNode.TypeReference.FullName()); // Fully.Qualified.Namespace.Employee is the type parameter
+        }
+
+        [Theory]
+        [InlineData("isof(MyAddress, 'Fully.Qualified.Namespace.HomeAddress')")]
+        [InlineData("isof(MyAddress, Fully.Qualified.Namespace.HomeAddress)")]
+        public void IsOfFunctionWithTwoParameters_WithSingleQuotesOnTypeParameter_WorksAsExpected(string filterQuery)
+        {
+            // Arrange & Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            SingleComplexNode singleComplexNode = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleComplexNode(HardCodedTestModel.GetPersonAddressProp());
+            Assert.Equal("MyAddress", singleComplexNode.Property.Name); // MyAddress is the property name
+            Assert.Equal("Fully.Qualified.Namespace.Address", singleComplexNode.GetEdmTypeReference().FullName()); // MyAddress is of type Address
+
+            var secondParameter = singleValueFunctionCallNode.Parameters.ElementAt(1);
+            string fullyQualifiedTypeName = secondParameter switch
+            {
+                SingleResourceCastNode singleResourceCastNode => secondParameter.ShouldBeSingleResourceCastNode(HardCodedTestModel.GetHomeAddressReference()).TypeReference.FullName(),
+                ConstantNode constantNode => secondParameter.ShouldBeConstantQueryNode("Fully.Qualified.Namespace.HomeAddress").Value as string,
+                _ => throw new InvalidOperationException("Unexpected node type")
+            };
+
+            Assert.Equal("Fully.Qualified.Namespace.HomeAddress", fullyQualifiedTypeName);
+        }
+
+        [Theory]
+        [InlineData("isof(MyAddress, Fully.Qualified.Namespace.HomeAddress)")]
+        [InlineData("isof(MyAddress, fully.Qualified.namespace.Homeaddress)")]
+        [InlineData("isof(MyAddress, FULLY.Qualified.Namespace.HOMEAddress)")]
+        public void IsOfFunctionWithTwoParameters_WithoutSingleQuotesOnTypeParameter_ShouldBeSingleResourceCastNode_CaseInsensitive(string filterQuery)
+        {
+            // Arrange
+            // Act
+            FilterClause filter = ParseFilterODataUriParserCaseInsensitive($"/people?$filter={filterQuery}", HardCodedTestModel.TestModel);
+
+            // Assert
+            SingleValueFunctionCallNode singleValueFunctionCallNode = filter.Expression.ShouldBeSingleValueFunctionCallQueryNode("isof");
+            SingleComplexNode singleComplexNode = singleValueFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleComplexNode(HardCodedTestModel.GetPersonAddressProp());
+            Assert.Equal("MyAddress", singleComplexNode.Property.Name); // MyAddress is the property name
+            Assert.Equal("Fully.Qualified.Namespace.Address", singleComplexNode.GetEdmTypeReference().FullName()); // MyAddress is of type Address
+
+            var singleResourceCastNode = singleValueFunctionCallNode.Parameters.ElementAt(1).ShouldBeSingleResourceCastNode(HardCodedTestModel.GetHomeAddressReference());
+            Assert.Equal("Fully.Qualified.Namespace.HomeAddress", singleResourceCastNode.TypeReference.FullName()); // Fully.Qualified.Namespace.HomeAddress is the type parameter
+        }
+
+        [Theory]
+        [InlineData("isof(Fully.Qualified.Namespace.Pet1)", "'Fully.Qualified.Namespace.Pet1' is not assignable from 'Fully.Qualified.Namespace.Person'.")]
+        [InlineData("isof(MyAddress,Fully.Qualified.Namespace.Pet1)", "'Fully.Qualified.Namespace.Pet1' is not assignable from 'Fully.Qualified.Namespace.Address'.")]
+        [InlineData("isof(null,Fully.Qualified.Namespace.Person)", "'Fully.Qualified.Namespace.Person' is not assignable from '<null>'.")]
+        [InlineData("isof('',Fully.Qualified.Namespace.Person)", "'Fully.Qualified.Namespace.Person' is not assignable from 'Edm.String'.")]
+        public void IsOfFunctionsWithUnquotedTypeParameter_WithIncorrectType_ThrowException(string filterQuery, string errorMessage)
+        {
+            // Arrange & Act
+            var exception = Record.Exception(() => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()));
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.IsType<ODataException>(exception);
+            Assert.Equal($"Encountered invalid type cast. {errorMessage}", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("cast(Fully.Qualified.Namespace.HomeAddress)/City eq 'City1'", "'Fully.Qualified.Namespace.HomeAddress' is not assignable from 'Fully.Qualified.Namespace.Person'.")]
+        [InlineData("cast(MyAddress,Fully.Qualified.Namespace.Employee)/WorkID eq 345", "'Fully.Qualified.Namespace.Employee' is not assignable from 'Fully.Qualified.Namespace.Address'.")]
+        [InlineData("cast(null,Fully.Qualified.Namespace.Employee)/WorkID eq 345", "'Fully.Qualified.Namespace.Employee' is not assignable from '<null>'.")]
+        [InlineData("cast('',Fully.Qualified.Namespace.Employee)/WorkID eq 345", "'Fully.Qualified.Namespace.Employee' is not assignable from 'Edm.String'.")]
+        public void CastFunctionWithUnquotedTypeParameter_WithIncorrectType_ThrowException(string filterQuery, string errorMessage)
+        {
+            // Arrange & Act
+            var exception = Record.Exception(() => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet()));
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.IsType<ODataException>(exception);
+            Assert.Equal($"Encountered invalid type cast. {errorMessage}", exception.Message);
+        }
+
+        [Theory]
+        [InlineData("isof(Fully.Qualified.Namespace.Pet1)", "Fully.Qualified.Namespace.Pet1")]
+        [InlineData("cast(Fully.Qualified.Namespace.HomeAddress)/City eq 'City1'", "Fully.Qualified.Namespace.HomeAddress")]
+        public void IsOfAndCastFunctionsWithSingleParameterWithoutSingleQuotes_WithIncorrectType_ThrowException(string filterQuery, string fullyQualifiedTypeName)
+        {
+            // Arrange & Act
+            Action test = () => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            test.Throws<ODataException>(Error.Format(SRResources.MetadataBinder_HierarchyNotFollowed, fullyQualifiedTypeName, "Fully.Qualified.Namespace.Person"));
+        }
+
+        [Theory]
+        [InlineData("isof(MyAddress,Fully.Qualified.Namespace.Pet1)", "Fully.Qualified.Namespace.Pet1")]
+        [InlineData("cast(MyAddress,Fully.Qualified.Namespace.Employee)/WorkID eq 345", "Fully.Qualified.Namespace.Employee")]
+        public void IsOfAndCastFunctionsWithTwoParameterWhereTypeParameterIsWithoutSingleQuotes_WithIncorrectType_ThrowException(string filterQuery, string fullyQualifiedTypeName)
+        {
+            // Arrange & Act
+            Action test = () => ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            test.Throws<ODataException>(Error.Format(SRResources.MetadataBinder_HierarchyNotFollowed, fullyQualifiedTypeName, "Fully.Qualified.Namespace.Address"));
+        }
+
+        [Fact]
         public void CastFunctionWorksWithNoSingleQuotesOnType()
         {
             FilterClause filter = ParseFilter("cast(Shoe, Edm.String) eq 'blue'", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
@@ -770,6 +1024,39 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             singleFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonShoeProp());
             singleFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode("Edm.String");
             bon.Right.ShouldBeConstantQueryNode("blue");
+        }
+
+        [Theory]
+        [InlineData("cast(Shoe, edm.string) eq 'blue'", "edm.string")]
+        [InlineData("cast(Shoe, Edm.string) eq 'blue'", "Edm.string")]
+        [InlineData("cast(Shoe, edm.String) eq 'blue'", "edm.String")]
+        [InlineData("cast(Shoe, Edm.String) eq 'blue'", "Edm.String")]
+        [InlineData("cast(Shoe, EDM.STRING) eq 'blue'", "EDM.STRING")]
+        public void CastFunctionWorksWithNoSingleQuotesOnTypeWithODataUriParserCaseInsensitive(string filterQuery, string expectedConstantQueryNode)
+        {
+            FilterClause filter = ParseFilterODataUriParserCaseInsensitive($"/people?$filter={filterQuery}", HardCodedTestModel.TestModel);
+            var bon = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
+            var convertQueryNode = bon.Left.ShouldBeConvertQueryNode(EdmPrimitiveTypeKind.String);
+            var singleFunctionCallNode = convertQueryNode.Source.ShouldBeSingleValueFunctionCallQueryNode("cast");
+            singleFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonShoeProp());
+            singleFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode(expectedConstantQueryNode);
+            bon.Right.ShouldBeConstantQueryNode("blue");
+        }
+
+        [Theory]
+        [InlineData("cast(ID, edm.int32) lt 10", "edm.int32")]
+        [InlineData("cast(ID, Edm.int32) lt 10", "Edm.int32")]
+        [InlineData("cast(ID, edm.Int32) lt 10", "edm.Int32")]
+        [InlineData("cast(ID, Edm.Int32) lt 10", "Edm.Int32")]
+        [InlineData("cast(ID, EDM.INT32) lt 10", "EDM.INT32")]
+        public void CastFunctionWorksWithNoSingleQuotesOnTypeWithCaseInsensitive(string filterQuery, string expectedConstantQueryNode)
+        {
+            FilterClause filter = ParseFilter(filterQuery, true, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            var bon = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.LessThan);
+            var singleFunctionCallNode = bon.Left.ShouldBeSingleValueFunctionCallQueryNode("cast");
+            singleFunctionCallNode.Parameters.ElementAt(0).ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetPersonIdProp());
+            singleFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode(expectedConstantQueryNode);
+            bon.Right.ShouldBeConstantQueryNode(10);
         }
 
         [Fact]
@@ -783,14 +1070,26 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             bon.Right.ShouldBeEnumNode(HardCodedTestModel.TestModel.FindType("Fully.Qualified.Namespace.ColorPattern") as IEdmEnumType, 2L);
         }
 
-        [Fact]
-        public void CastFunctionWorksForCastFromNullToEnum()
+        [Theory]
+        [InlineData("cast(null, Fully.Qualified.Namespace.ColorPattern) eq Fully.Qualified.Namespace.ColorPattern'blue'")]
+        [InlineData("cast(null, 'Fully.Qualified.Namespace.ColorPattern') eq Fully.Qualified.Namespace.ColorPattern'blue'")]
+        public void CastFunctionWorksForCastFromNullToEnum(string filterQuery)
         {
-            FilterClause filter = ParseFilter("cast(null, Fully.Qualified.Namespace.ColorPattern) eq Fully.Qualified.Namespace.ColorPattern'blue'", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
             var bon = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal);
             var singleFunctionCallNode = bon.Left.ShouldBeSingleValueFunctionCallQueryNode("cast");
             Assert.Null(Assert.IsType<ConstantNode>(singleFunctionCallNode.Parameters.ElementAt(0)).Value);
-            singleFunctionCallNode.Parameters.ElementAt(1).ShouldBeConstantQueryNode("Fully.Qualified.Namespace.ColorPattern");
+
+            QueryNode secondParameterNode = singleFunctionCallNode.Parameters.ElementAt(1);
+            string fullyQualifiedTypeName = secondParameterNode switch
+            {
+                SingleResourceCastNode singleResourceCastNode => singleResourceCastNode.TypeReference.FullName(),
+                ConstantNode constantNode => constantNode.Value as string,
+                _ => throw new InvalidOperationException("Unexpected node type")
+            };
+
+            Assert.Equal("Fully.Qualified.Namespace.ColorPattern", fullyQualifiedTypeName);
+            Assert.Equal("Fully.Qualified.Namespace.ColorPattern'blue'", Assert.IsType<ConstantNode>(bon.Right).LiteralText);
             bon.Right.ShouldBeEnumNode(HardCodedTestModel.TestModel.FindType("Fully.Qualified.Namespace.ColorPattern") as IEdmEnumType, 2L);
         }
 
@@ -805,17 +1104,151 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
             Assert.Equal("Fully.Qualified.Namespace.ColorPattern'blue'", Assert.IsType<ConstantNode>(bon.Right).LiteralText);
         }
 
-        [Fact]
-        public void CastFunctionProducesAnEntityType()
+        [Theory]
+        [InlineData("cast(MyDog, 'Fully.Qualified.Namespace.Dog')/Color eq 'blue'")]
+        [InlineData("cast(MyDog, Fully.Qualified.Namespace.Dog)/Color eq 'blue'")]
+        public void CastFunctionProducesAnEntityType(string filterQuery)
         {
-            FilterClause filter = ParseFilter("cast(MyDog, 'Fully.Qualified.Namespace.Dog')/Color eq 'blue'", HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
             SingleResourceFunctionCallNode function = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal)
                 .Left.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetDogColorProp())
                 .Source.ShouldBeSingleResourceFunctionCallNode("cast");
             Assert.Equal(2, function.Parameters.Count());
             function.Parameters.ElementAt(0).ShouldBeSingleNavigationNode(HardCodedTestModel.GetPersonMyDogNavProp());
-            function.Parameters.ElementAt(1).ShouldBeConstantQueryNode("Fully.Qualified.Namespace.Dog");
+
+            var secondParameter = function.Parameters.ElementAt(1);
+            string fullyQualifiedTypeName = secondParameter switch
+            {
+                SingleResourceCastNode singleResourceCastNode => secondParameter.ShouldBeSingleResourceCastNode(HardCodedTestModel.GetDogTypeReference()).TypeReference.FullName(),
+                ConstantNode constantNode => secondParameter.ShouldBeConstantQueryNode("Fully.Qualified.Namespace.Dog").Value as string,
+                _ => throw new InvalidOperationException("Unexpected node type")
+            };
+
+            Assert.Equal("Fully.Qualified.Namespace.Dog", fullyQualifiedTypeName);
             Assert.IsType<BinaryOperatorNode>(filter.Expression).Right.ShouldBeConstantQueryNode("blue");
+        }
+
+        [Theory]
+        [InlineData("cast(MyDog, fully.Qualified.Namespace.Dog)/Color eq 'blue'")]
+        [InlineData("cast(MyDog, fully.qualified.namespace.dog)/Color eq 'blue'")]
+        [InlineData("cast(MyDog, fully.Qualified.namespace.dog)/Color eq 'blue'")]
+        [InlineData("cast(MyDog, fully.qualified.Namespace.dog)/Color eq 'blue'")]
+        [InlineData("cast(MyDog, fully.qualified.namespace.Dog)/Color eq 'blue'")]
+        [InlineData("cast(MyDog, FULLY.QUALIFIED.NAMESPACE.DOG)/Color eq 'blue'")]
+        public void CastFunctionProducesAnEntityTypeWorksWithCaseInsensitiveODataUriParser(string filterQuery)
+        {
+            FilterClause filter = ParseFilter(filterQuery, true, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+            SingleResourceFunctionCallNode function = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal)
+                .Left.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetDogColorProp())
+                .Source.ShouldBeSingleResourceFunctionCallNode("cast");
+            Assert.Equal(2, function.Parameters.Count());
+            function.Parameters.ElementAt(0).ShouldBeSingleNavigationNode(HardCodedTestModel.GetPersonMyDogNavProp());
+            var singleResourceCastNode = function.Parameters.ElementAt(1).ShouldBeSingleCastNode(HardCodedTestModel.GetDogTypeReference());
+            Assert.Equal("Fully.Qualified.Namespace.Dog", singleResourceCastNode.TypeReference.FullName());
+            Assert.IsType<BinaryOperatorNode>(filter.Expression).Right.ShouldBeConstantQueryNode("blue");
+        }
+
+        [Theory]
+        [InlineData("cast(MyDog, fully.Qualified.Namespace.Dog)/Color eq 'blue'")]
+        [InlineData("cast(MyDog, fully.qualified.namespace.dog)/Color eq 'blue'")]
+        [InlineData("cast(MyDog, fully.Qualified.namespace.dog)/Color eq 'blue'")]
+        [InlineData("cast(MyDog, fully.qualified.Namespace.dog)/Color eq 'blue'")]
+        [InlineData("cast(MyDog, fully.qualified.namespace.Dog)/Color eq 'blue'")]
+        public void CastFunctionProducesAnEntityTypeWorksWithCaseInsensitive(string filterQuery)
+        {
+            FilterClause filter = ParseFilterODataUriParserCaseInsensitive($"/people?$filter={filterQuery}", HardCodedTestModel.TestModel);
+            SingleResourceFunctionCallNode function = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal)
+                .Left.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetDogColorProp())
+                .Source.ShouldBeSingleResourceFunctionCallNode("cast");
+            Assert.Equal(2, function.Parameters.Count());
+            function.Parameters.ElementAt(0).ShouldBeSingleNavigationNode(HardCodedTestModel.GetPersonMyDogNavProp());
+            var singleResourceCastNode = function.Parameters.ElementAt(1).ShouldBeSingleCastNode(HardCodedTestModel.GetDogTypeReference());
+            Assert.Equal("Fully.Qualified.Namespace.Dog", singleResourceCastNode.TypeReference.FullName());
+            Assert.IsType<BinaryOperatorNode>(filter.Expression).Right.ShouldBeConstantQueryNode("blue");
+        }
+
+        [Theory]
+        [InlineData("cast(Fully.Qualified.Namespace.Employee)/WorkID eq 345")]
+        [InlineData("cast('Fully.Qualified.Namespace.Employee')/WorkID eq 345")]
+        public void CastFunctionWithOneParameter_WithOrWithoutSingleParameterProducesAnEntityType(string filterQuery)
+        {
+            // Arrange & Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            SingleResourceFunctionCallNode function = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal)
+                .Left.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetEmployeeWorkIDProperty())
+                .Source.ShouldBeSingleResourceFunctionCallNode("cast");
+
+            Assert.Equal(2, function.Parameters.Count());
+
+            ResourceRangeVariableReferenceNode resourceRangeVariable = function.Parameters.ElementAt(0).ShouldBeResourceRangeVariableReferenceNode("$it");
+            Assert.Equal("Fully.Qualified.Namespace.Person", resourceRangeVariable.GetEdmTypeReference().FullName()); // $it is of type Person
+
+            QueryNode node = function.Parameters.ElementAt(1);
+            string fullyQualifiedTypeName = node switch
+            {
+                SingleResourceCastNode singleResourceCastNode => node.ShouldBeSingleResourceCastNode(HardCodedTestModel.GetEmployeeTypeReference()).TypeReference.FullName(),
+                ConstantNode constantNode => node.ShouldBeConstantQueryNode("Fully.Qualified.Namespace.Employee").Value as string,
+                _ => throw new InvalidOperationException("Unexpected node type")
+            };
+
+            Assert.Equal("Fully.Qualified.Namespace.Employee", fullyQualifiedTypeName); // Fully.Qualified.Namespace.Employee is the type parameter
+            Assert.IsType<BinaryOperatorNode>(filter.Expression).Right.ShouldBeConstantQueryNode(345); // 345 is the right operand
+        }
+
+        [Theory]
+        [InlineData("cast(MyAddress, 'Fully.Qualified.Namespace.HomeAddress')/HomeNO eq 'H-1234'")]
+        [InlineData("cast(MyAddress, Fully.Qualified.Namespace.HomeAddress)/HomeNO eq 'H-1234'")]
+        public void CastFunctionWithTwoParameters_WithOrWithSingleParameterProducesAnEntityType(string filterQuery)
+        {
+            // Arrange & Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            SingleResourceFunctionCallNode function = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal)
+                .Left.ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetAddressHomeNOProperty())
+                .Source.ShouldBeSingleResourceFunctionCallNode("cast");
+            Assert.Equal(2, function.Parameters.Count()); // There are two parameters
+
+            SingleComplexNode complexNode = function.Parameters.ElementAt(0).ShouldBeSingleComplexNode(HardCodedTestModel.GetPersonAddressProp());
+            Assert.Equal("Fully.Qualified.Namespace.Address", complexNode.GetEdmTypeReference().FullName()); // MyAddress is of type Address
+
+            QueryNode node = function.Parameters.ElementAt(1);
+            string fullyQualifiedTypeName = node switch
+            {
+                SingleResourceCastNode singleResourceCastNode => node.ShouldBeSingleResourceCastNode(HardCodedTestModel.GetHomeAddressReference()).TypeReference.FullName(),
+                ConstantNode constantNode => node.ShouldBeConstantQueryNode("Fully.Qualified.Namespace.HomeAddress").Value as string,
+                _ => throw new InvalidOperationException("Unexpected node type")
+            };
+
+            Assert.Equal("Fully.Qualified.Namespace.HomeAddress", fullyQualifiedTypeName); // Fully.Qualified.Namespace.HomeAddress is the type parameter
+            Assert.IsType<BinaryOperatorNode>(filter.Expression).Right.ShouldBeConstantQueryNode("H-1234");
+        }
+
+        [Theory]
+        [InlineData("cast(MyAddress/AddressType, Edm.String) eq '2'")] // AddressType is Enum
+        [InlineData("cast(MyAddress/AddressType, 'Edm.String') eq '2'")] // AddressType is Enum
+        public void CastFunctionWithTwoParametersWithBuiltInTypeProducesAnEntityType(string filterQuery)
+        {
+            // Arrange
+            string expectedAddressType = "Fully.Qualified.Namespace.AddressType";
+
+            // Act
+            FilterClause filter = ParseFilter(filterQuery, HardCodedTestModel.TestModel, HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet());
+
+            // Assert
+            SingleValueFunctionCallNode function = filter.Expression.ShouldBeBinaryOperatorNode(BinaryOperatorKind.Equal)
+                .Left.ShouldBeConvertQueryNode(EdmCoreModel.Instance.GetString(true))
+                .Source.ShouldBeSingleValueFunctionCallQueryNode("cast");
+
+            Assert.Equal(2, function.Parameters.Count());
+
+            SingleValuePropertyAccessNode singleValuePropertyAccessNode = function.Parameters.ElementAt(0).ShouldBeSingleValuePropertyAccessQueryNode(HardCodedTestModel.GetMyAddressAddressTypeProperty());
+            Assert.Equal(expectedAddressType, singleValuePropertyAccessNode.GetEdmTypeReference().FullName());
+
+            function.Parameters.ElementAt(1).ShouldBeConstantQueryNode("Edm.String");
+            Assert.IsType<BinaryOperatorNode>(filter.Expression).Right.ShouldBeConstantQueryNode("2");
         }
 
         [Fact]
@@ -1294,6 +1727,23 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
                     {"$apply", "aggregate(FavoriteNumber with sum as Total)/compute(Total mul 2 as DoubleTotal)"}
                 });
             odataQueryOptionParser.ParseApply();
+            var orderByClause = odataQueryOptionParser.ParseOrderBy();
+            Assert.Equal(OrderByDirection.Ascending, orderByClause.Direction);
+            orderByClause.Expression.ShouldBeSingleValueOpenPropertyAccessQueryNode("DoubleTotal");
+        }
+
+        [Fact]
+        public void ComputedPropertyTreatedAsOpenPropertyInCastAndOrderBy()
+        {
+            var odataQueryOptionParser = new ODataQueryOptionParser(HardCodedTestModel.TestModel,
+                HardCodedTestModel.GetPersonType(), HardCodedTestModel.GetPeopleSet(),
+                new Dictionary<string, string>()
+                {
+                    {"$orderby", "DoubleTotal asc"},
+                    {"$apply", "aggregate(cast(FavoriteNumber, edm.int64) with sum as Total)/compute(Total mul 2 as DoubleTotal)"}
+                })
+            { Resolver = new ODataUriResolver() { EnableCaseInsensitive = true } };
+            var applyClause = odataQueryOptionParser.ParseApply();
             var orderByClause = odataQueryOptionParser.ParseOrderBy();
             Assert.Equal(OrderByDirection.Ascending, orderByClause.Direction);
             orderByClause.Expression.ShouldBeSingleValueOpenPropertyAccessQueryNode("DoubleTotal");
@@ -3191,6 +3641,31 @@ namespace Microsoft.OData.Tests.ScenarioTests.UriParser
         private static OrderByClause ParseOrderBy(string text, IEdmModel edmModel, IEdmType edmType, IEdmNavigationSource edmEntitySet = null)
         {
             return new ODataQueryOptionParser(edmModel, edmType, edmEntitySet, new Dictionary<string, string>() { { "$orderby", text } }).ParseOrderBy();
+        }
+
+        private static FilterClause ParseFilter(string text, bool caseInsensitive, IEdmModel edmModel, IEdmType edmType, IEdmNavigationSource edmEntitySet = null)
+        {
+            return new ODataQueryOptionParser(edmModel,
+                edmType,
+                edmEntitySet,
+                new Dictionary<string, string>() { { "$filter", text } })
+            { Resolver = new ODataUriResolver() { EnableCaseInsensitive = caseInsensitive } }
+            .ParseFilter();
+        }
+
+        private static FilterClause ParseFilterODataUriParserCaseInsensitive(string text, IEdmModel edmModel)
+        {
+            var parser = new ODataUriParser(edmModel, new Uri(text, UriKind.Relative))
+            {
+                Resolver = new UnqualifiedODataUriResolver()
+                {
+                    EnableCaseInsensitive = true,
+                },
+                UrlKeyDelimiter = ODataUrlKeyDelimiter.Slash,
+            };
+            parser.Settings.MaximumExpansionDepth = 2;
+            parser.ParsePath();
+            return parser.ParseFilter();
         }
     }
 }

--- a/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
+++ b/test/UnitTests/Microsoft.OData.Core.Tests/UriParser/HardCodedTestModel.cs
@@ -77,6 +77,13 @@ namespace Microsoft.OData.Tests.UriParser
             NonFlagShapeType.AddMember("Triangle", new EdmEnumMemberValue(2));
             NonFlagShapeType.AddMember("foursquare", new EdmEnumMemberValue(3));
             model.AddElement(NonFlagShapeType);
+
+            var addressTypeEnum = new EdmEnumType("Fully.Qualified.Namespace", "AddressType");
+            addressTypeEnum.AddMember(new EdmEnumMember(addressTypeEnum, "Home", new EdmEnumMemberValue(0)));
+            addressTypeEnum.AddMember(new EdmEnumMember(addressTypeEnum, "Work", new EdmEnumMemberValue(1)));
+            addressTypeEnum.AddMember(new EdmEnumMember(addressTypeEnum, "Other", new EdmEnumMemberValue(2)));
+            model.AddElement(addressTypeEnum);
+            var addressTypeEnumReference = new EdmEnumTypeReference(addressTypeEnum, false);
             #endregion
 
             #region Structured Types
@@ -350,6 +357,7 @@ namespace Microsoft.OData.Tests.UriParser
             FullyQualifiedNamespaceAddress.AddStructuralProperty("City", EdmCoreModel.Instance.GetString(true));
             FullyQualifiedNamespaceAddress.AddStructuralProperty("NextHome", FullyQualifiedNamespaceAddressTypeReference);
             FullyQualifiedNamespaceAddress.AddStructuralProperty("MyNeighbors", new EdmCollectionTypeReference(new EdmCollectionType(EdmCoreModel.Instance.GetString(true))));
+            FullyQualifiedNamespaceAddress.AddStructuralProperty("AddressType", addressTypeEnumReference);
             FullyQualifiedNamespaceAddress.AddUnidirectionalNavigation(new EdmNavigationPropertyInfo { Name = "PostBoxPainting", TargetMultiplicity = EdmMultiplicity.ZeroOrOne, Target = FullyQualifiedNamespacePainting });
             model.AddElement(FullyQualifiedNamespaceAddress);
 
@@ -978,6 +986,11 @@ namespace Microsoft.OData.Tests.UriParser
         <Member Name=""Triangle"" Value=""2"" />
         <Member Name=""foursquare"" Value=""3"" />
       </EnumType>
+      <EnumType Name=""AddressType"">
+        <Member Name=""Home"" Value=""0"" />
+        <Member Name=""Work"" Value=""1"" />
+        <Member Name=""Other"" Value=""2"" />
+      </EnumType>
       <EntityType Name=""Lion"">
         <Key>
           <PropertyRef Name=""ID1"" />
@@ -1180,6 +1193,7 @@ namespace Microsoft.OData.Tests.UriParser
         <Property Name=""City"" Type=""Edm.String"" />
         <Property Name=""NextHome"" Type=""Fully.Qualified.Namespace.Address"" />
         <Property Name=""MyNeighbors"" Type=""Collection(Edm.String)"" />
+        <Property Name=""AddressType"" Type=""Fully.Qualified.Namespace.AddressType"" Nullable=""false"" />
         <NavigationProperty Name=""PostBoxPainting"" Type=""Fully.Qualified.Namespace.Painting"" />
       </ComplexType>
       <ComplexType Name=""HomeAddress"" BaseType=""Fully.Qualified.Namespace.Address"">
@@ -1770,6 +1784,16 @@ namespace Microsoft.OData.Tests.UriParser
             return new EdmEntityTypeReference(GetDogType(), false);
         }
 
+        public static IEdmComplexType GetColorPatternType()
+        {
+            return TestModel.FindType("Fully.Qualified.Namespace.ColorPattern") as IEdmComplexType;
+        }
+
+        public static IEdmComplexTypeReference GetColorPatternTypeReference()
+        {
+            return new EdmComplexTypeReference(GetColorPatternType(), false);
+        }
+
         public static IEdmEntityType GetPaintingType()
         {
             return TestModel.FindType("Fully.Qualified.Namespace.Painting") as IEdmEntityType;
@@ -2009,6 +2033,16 @@ namespace Microsoft.OData.Tests.UriParser
             return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Address")).FindProperty("City");
         }
 
+        public static IEdmStructuralProperty GetMyAddressAddressTypeProperty()
+        {
+            return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Address")).FindProperty("AddressType");
+        }
+
+        public static IEdmStructuralProperty GetAddressHomeNOProperty()
+        {
+            return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.HomeAddress")).FindProperty("HomeNO");
+        }
+
         public static IEdmStructuralProperty GetPet2PetColorPatternProperty()
         {
             return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Pet2")).FindProperty("PetColorPattern");
@@ -2024,6 +2058,11 @@ namespace Microsoft.OData.Tests.UriParser
         public static IEdmNavigationProperty GetAddressMyFavoriteNeighborNavProp()
         {
             return (IEdmNavigationProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Address")).FindProperty("MyFavoriteNeighbor");
+        }
+
+        public static IEdmStructuralProperty GetEmployeeWorkIDProperty()
+        {
+            return (IEdmStructuralProperty)((IEdmStructuredType)TestModel.FindType("Fully.Qualified.Namespace.Employee")).FindProperty("WorkID");
         }
 
         public static IEdmNavigationProperty GetDogFastestOwnerNavProp()


### PR DESCRIPTION
* Add support for unquoted type params in `isof` and `cast` methods

---------

<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #xxx.*

### Description

Cherrypic: 4985a41245889f99ca777affeb3ef5652b698b65

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
