### PR TITLE
Deprecate IEdmOperation.ReturnType in v8.x; recommend using GetReturn() extension method

### DIFF
--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperation.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperation.cs
@@ -6,6 +6,7 @@
 
 namespace Microsoft.OData.Edm
 {
+    using System;
     using System.Collections.Generic;
 
     /// <summary>
@@ -16,6 +17,7 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Gets the return type of this operation.
         /// </summary>
+        [Obsolete("Use 'GetReturn()' extension method to get the 'IEdmOperationReturn' instead. This will be dropped in the 9.x release.: https://github.com/OData/odata.net/issues/3085", false)]
         IEdmTypeReference ReturnType { get; }
 
         /// <summary>

--- a/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperation.cs
+++ b/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperation.cs
@@ -17,7 +17,7 @@ namespace Microsoft.OData.Edm
         /// <summary>
         /// Gets the return type of this operation.
         /// </summary>
-        [Obsolete("Use 'GetReturn()' extension method to get the 'IEdmOperationReturn' instead. This will be dropped in the 9.x release.: https://github.com/OData/odata.net/issues/3085", false)]
+        [Obsolete("Use 'GetReturn()' to get 'IEdmOperationReturn'. This will be dropped in the 9.x release when 'IEdmOperation' exposes 'IEdmOperationReturn' directly. See: https://github.com/OData/odata.net/issues/3085", false)]
         IEdmTypeReference ReturnType { get; }
 
         /// <summary>


### PR DESCRIPTION
<!-- markdownlint-disable MD002 MD041 -->

### Issues

*This pull request fixes #3085.*

### Description

#### **Context**
In version **7.x**, [`IEdmOperationReturn`](https://github.com/OData/odata.net/blob/main/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperationReturn.cs) was introduced to represent return types without modifying [`IEdmOperation`](https://github.com/OData/odata.net/blob/main/src/Microsoft.OData.Edm/Schema/Interfaces/IEdmOperation.cs), in order to avoid breaking changes.
Introduced by PR: https://github.com/OData/odata.net/pull/1414

#### **Change in 8.x**
Mark `IEdmOperation.ReturnType` as `[Obsolete]` and provide guidance to use the [`GetReturn()`](https://github.com/OData/odata.net/blob/main/src/Microsoft.OData.Edm/ExtensionMethods/ExtensionMethods.cs#L2722) extension method instead. This method returns an `IEdmOperationReturn` instance

#### **Forward plan for 9.x**
Change `IEdmOperation` to expose `IEdmOperationReturn` directly and remove `ReturnType`.

### Checklist (Uncheck if it is not completed)

- [ ] *Test cases added*
- [ ] *Build and test with one-click build and test script passed*

### Additional work necessary

*If documentation update is needed, please add "Docs Needed" label to the issue and provide details about the required document change in the issue.*

### Repository notes

Team members can start a CI build by adding a comment with the text `/AzurePipelines run` to a PR. A bot may respond indicating that there is no pipeline associated with the pull request. This can be ignored if the build is triggered.

Team members should **not** trigger a build this way for pull requests coming from forked repositories. They should instead trigger the build manually by setting the "branch" to `refs/pull/{prId}/merge` where `{prId}` is the ID of the PR. 
